### PR TITLE
Test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,32 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python packages
-      run: python -m pip install pytest apis/python
+      run: python -m pip install pytest-cov apis/python
 
-    - name: Run pytests
-      run: python -m pytest apis/python/tests
+    - name: Run pytest
+      if: matrix.os != 'ubuntu-latest'
+      run: python -m pytest
+
+    - name: Run pytest with coverage
+      if: matrix.os == 'ubuntu-latest'
+      id: pytest
+      run: |
+        python -m pytest --cov=tiledbsc --cov-report=term-missing > coverage.txt
+        cat coverage.txt
+        COVERAGE="$(grep '^TOTAL' coverage.txt | awk -v N=4 '{print $N}')"
+        echo "::set-output name=COVERAGE::$COVERAGE"
+
+    - name: Create Test Coverage Badge
+      if: matrix.os == 'ubuntu-latest'
+      uses: schneegans/dynamic-badges-action@v1.1.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: 1c6cd065142bbb77359f210cce9bcc43
+        filename: TileDB-SingleCell-coverage-badge.json
+        label: Test Coverage
+        message: ${{ steps.pytest.outputs.COVERAGE }}
+        color: green
+        namedLogo: pytest
 
     - name: Build wheel distribution
       run: python -m pip wheel --no-deps --wheel-dir=dist apis/python

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -1,6 +1,9 @@
 name: TileDB-SingleCell C++ CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
 [![TileDB-SingleCell CI](https://github.com/single-cell-data/TileDB-SingleCell/actions/workflows/ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SingleCell/actions/workflows/ci.yml)
+![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gsakkis/1c6cd065142bbb77359f210cce9bcc43/raw/TileDB-SingleCell-coverage-badge.json)
 
 # TileDB-SingleCell
 


### PR DESCRIPTION
Add test coverage for running CI tests and publish a coverage badge to the README.

To configure it follow the instructions [here](https://github.com/marketplace/actions/dynamic-badges#configuration). In short:
- Create a new Github action token with the gist scope and name it `GIST_SECRET`.
- Create a new gist named `TileDB-SingleCell-coverage-badge.json` and any initial content (it will be overwritten).
- Update this PR with the new gist info:
  - username (`gsakkis` in this draft).
  - id (`1c6cd065142bbb77359f210cce9bcc43` in this draft). Note this is referenced in two files.
