### PR TITLE
Basic client-side stats

### DIFF
--- a/apis/python/src/tiledbsoma/annotation_dataframe.py
+++ b/apis/python/src/tiledbsoma/annotation_dataframe.py
@@ -32,7 +32,9 @@ class AnnotationDataFrame(TileDBArray):
         """
         assert name in ["obs", "var"]
         super().__init__(uri=uri, name=name, parent=parent)
+        s0 = self.timing_start("__init__", "total")
         self.dim_name = name + "_id"
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def shape(self) -> Tuple[int, int]:
@@ -41,7 +43,10 @@ class AnnotationDataFrame(TileDBArray):
         The row-count is the number of obs_ids (for ``obs``) or the number of var_ids (for ``var``).
         The column-count is the number of columns/attributes in the dataframe.
         """
+        s0 = self.timing_start("shape", "total")
+        s1 = self.timing_start("shape", "open")
         with self._open("r") as A:
+            self.timing_end(s1)
             self.dim_name = A.domain.dim(0).name
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
@@ -67,6 +72,7 @@ class AnnotationDataFrame(TileDBArray):
                         ].tolist()
                     )
             num_cols = A.schema.nattr
+            self.timing_end(s0)
             return (num_rows, num_cols)
 
     # ----------------------------------------------------------------
@@ -74,12 +80,24 @@ class AnnotationDataFrame(TileDBArray):
         """
         Returns the ``obs_ids`` in the matrix (for ``obs``) or the ``var_ids`` (for ``var``).
         """
+        s0 = self.timing_start("ids", "total")
+        s1 = self.timing_start("ids", "open")
         with self._open("r") as A:
+            self.timing_end(s1)
             self.dim_name = A.domain.dim(0).name
+
             # TileDB string dims are ASCII not UTF-8. Decode them so they readback
             # not like `b"AKR1C3"` but rather like `"AKR1C3"`.
+            s2 = self.timing_start("ids", "tiledb_query")
             retval = A.query(attrs=[], dims=[self.dim_name])[:][self.dim_name].tolist()
-            return [e.decode() for e in retval]
+            self.timing_end(s2)
+
+            s3 = self.timing_start("ids", "decode")
+            retval = [e.decode() for e in retval]
+            self.timing_end(s3)
+
+            self.timing_end(s0)
+            return list(retval)  # coerce to list to appease the linter
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -101,7 +119,10 @@ class AnnotationDataFrame(TileDBArray):
         Returns the column names for the ``obs`` or ``var`` dataframe.  For obs and varp, ``.keys()`` is a
         keystroke-saver for the more general array-schema accessor ``attr_names``.
         """
-        return self.attr_names()
+        s0 = self.timing_start("keys", "total")
+        retval = self.attr_names()
+        self.timing_end(s0)
+        return retval
 
     # ----------------------------------------------------------------
     def keyset(self) -> Set[str]:
@@ -123,13 +144,18 @@ class AnnotationDataFrame(TileDBArray):
         ``var``).  If ``ids`` is ``None``, the entire dataframe is returned.  Similarly, if ``attrs`` are
         provided, they're used for the query; else, all attributes are returned.
         """
+        s0 = self.timing_start("dim_select", "total")
+        s1 = self.timing_start("dim_select", "open")
         with self._open("r") as A:
+            self.timing_end(s1)
             self.dim_name = A.domain.dim(0).name
+            s2 = self.timing_start("dim_select", "tiledb_query")
             query = A.query(return_arrow=return_arrow, attrs=attrs)
             if ids is None:
                 df = query.df[:]
             else:
                 df = query.df[ids]
+            self.timing_end(s2)
 
         # We do not need this:
         #   df.set_index(self.dim_name, inplace=True)
@@ -140,17 +166,24 @@ class AnnotationDataFrame(TileDBArray):
         # so the set_index is already done for us.
         #
         # However if the data was written somehow else (e.g. by tiledbsoma-r) then we do.
+        s3 = self.timing_start("dim_select", "set_index")
         if not return_arrow:
             if isinstance(df.index, pd.RangeIndex) and self.dim_name in df.columns:
                 df.set_index(self.dim_name, inplace=True)
+        self.timing_end(s3)
 
         # TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
         # This is the 'decode on read' part of our logic; in from_dataframe we have the 'encode on write' part.
         # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
+        s4 = self.timing_start("dim_select", "ascii_to_unicode")
         if return_arrow:
-            return self._ascii_to_unicode_arrow_readback(df)
+            retval = self._ascii_to_unicode_arrow_readback(df)
         else:
-            return self._ascii_to_unicode_pandas_readback(df)
+            retval = self._ascii_to_unicode_pandas_readback(df)
+        self.timing_end(s4)
+
+        self.timing_end(s0)
+        return retval
 
     # ----------------------------------------------------------------
     def df(
@@ -185,8 +218,31 @@ class AnnotationDataFrame(TileDBArray):
         if query_string is None:
             return self.dim_select(ids, attrs=attrs, return_arrow=return_arrow)
 
+        s0 = self.timing_start("query", "total")
+        retval = self._query_aux(
+            query_string=query_string, ids=ids, attrs=attrs, return_arrow=return_arrow
+        )
+        self.timing_end(s0)
+        return retval
+
+    def _query_aux(
+        self,
+        query_string: Optional[str],
+        ids: Optional[Ids] = None,
+        attrs: Optional[Sequence[str]] = None,
+        *,
+        return_arrow: bool = False,
+    ) -> Union[pd.DataFrame, pa.Table]:
+        """
+        Helper method for `query`: as this has multiple `return` statements, it's easiest to track
+        elapsed-time stats in a call to this helper.
+        """
+
+        s1 = self.timing_start("query", "open")
         with self._open() as A:
+            self.timing_end(s1)
             self.dim_name = A.domain.dim(0).name
+            s2 = self.timing_start("query", "tiledb_query")
             qc = tiledb.QueryCondition(query_string)
             if attrs is None:
                 slice_query = A.query(attr_cond=qc, return_arrow=return_arrow)
@@ -202,6 +258,7 @@ class AnnotationDataFrame(TileDBArray):
                     df = slice_query.df[:]
                 else:
                     df = slice_query.df[ids]
+            self.timing_end(s2)
 
             # We do not need this:
             #   df.set_index(self.dim_name, inplace=True)
@@ -211,17 +268,29 @@ class AnnotationDataFrame(TileDBArray):
             #   (('__pandas_index_dims', '{"obs_id": "<U0"}'),)
             # so the set_index is already done for us.
             #
+<<<<<<< HEAD:apis/python/src/tiledbsoma/annotation_dataframe.py
             # However if the data was written somehow else (e.g. by tiledbsoma-r) then we do.
+||||||| parent of 19963aa (tiledbsc-py stats experiment):apis/python/src/tiledbsc/annotation_dataframe.py
+            # However if the data was written somehow else (e.g. by tiledbscr-r) then we do.
+=======
+            # However if the data was written somehow else (e.g. by tiledbscr-r) then we do.
+            s3 = self.timing_start("query", "set_index")
+>>>>>>> 19963aa (tiledbsc-py stats experiment):apis/python/src/tiledbsc/annotation_dataframe.py
             if not return_arrow:
                 if isinstance(df.index, pd.RangeIndex) and self.dim_name in df.columns:
                     df.set_index(self.dim_name, inplace=True)
                 # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.
                 # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
+            self.timing_end(s3)
 
+            s4 = self.timing_start("query", "ascii_to_unicode")
             if return_arrow:
-                return self._ascii_to_unicode_arrow_readback(df)
+                retval = self._ascii_to_unicode_arrow_readback(df)
             else:
-                return self._ascii_to_unicode_pandas_readback(df)
+                retval = self._ascii_to_unicode_pandas_readback(df)
+            self.timing_end(s4)
+
+            return retval
 
     # ----------------------------------------------------------------
     def _ascii_to_unicode_pandas_series_readback(
@@ -310,6 +379,7 @@ class AnnotationDataFrame(TileDBArray):
         :param dataframe: ``anndata.obs``, ``anndata.var``, ``anndata.raw.var``.
         :param extent: TileDB ``extent`` parameter for the array schema.
         """
+        s0 = self.timing_start("from_dataframe", "total")
 
         offsets_filters = tiledb.FilterList(
             [tiledb.PositiveDeltaFilter(), tiledb.ZstdFilter(level=-1)]
@@ -405,3 +475,5 @@ class AnnotationDataFrame(TileDBArray):
             f"Wrote {self.nested_name}",
             util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
         )
+
+        self.timing_end(s0)

--- a/apis/python/src/tiledbsoma/annotation_dataframe.py
+++ b/apis/python/src/tiledbsoma/annotation_dataframe.py
@@ -268,14 +268,8 @@ class AnnotationDataFrame(TileDBArray):
             #   (('__pandas_index_dims', '{"obs_id": "<U0"}'),)
             # so the set_index is already done for us.
             #
-<<<<<<< HEAD:apis/python/src/tiledbsoma/annotation_dataframe.py
             # However if the data was written somehow else (e.g. by tiledbsoma-r) then we do.
-||||||| parent of 19963aa (tiledbsc-py stats experiment):apis/python/src/tiledbsc/annotation_dataframe.py
-            # However if the data was written somehow else (e.g. by tiledbscr-r) then we do.
-=======
-            # However if the data was written somehow else (e.g. by tiledbscr-r) then we do.
             s3 = self.timing_start("query", "set_index")
->>>>>>> 19963aa (tiledbsc-py stats experiment):apis/python/src/tiledbsc/annotation_dataframe.py
             if not return_arrow:
                 if isinstance(df.index, pd.RangeIndex) and self.dim_name in df.columns:
                     df.set_index(self.dim_name, inplace=True)

--- a/apis/python/src/tiledbsoma/annotation_matrix.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix.py
@@ -42,6 +42,7 @@ class AnnotationMatrix(TileDBArray):
 
         Note: currently implemented via data scan --- will be optimized in an upcoming TileDB Core release.
         """
+        s0 = self.timing_start("shape", "total")
         with self._open() as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
@@ -64,6 +65,7 @@ class AnnotationMatrix(TileDBArray):
                         ].tolist()
                     )
             num_cols = A.schema.nattr
+            self.timing_end(s0)
             return (num_rows, num_cols)
 
     # ----------------------------------------------------------------
@@ -77,6 +79,7 @@ class AnnotationMatrix(TileDBArray):
         Selects a slice out of the array with specified ``obs_ids`` (for ``obsm`` elements) or
         ``var_ids`` (for ``varm`` elements).  If ``ids`` is ``None``, the entire array is returned.
         """
+        s0 = self.timing_start("dim_select", "total")
         if ids is None:
             with self._open() as A:
                 query = A.query(return_arrow=return_arrow)
@@ -87,6 +90,7 @@ class AnnotationMatrix(TileDBArray):
                 df = query.df[ids]
         if not return_arrow:
             df.set_index(self.dim_name, inplace=True)
+        self.timing_end(s0)
         return df
 
     # ----------------------------------------------------------------
@@ -112,6 +116,7 @@ class AnnotationMatrix(TileDBArray):
         :param matrix: ``anndata.obsm['foo']``, ``anndata.varm['foo']``, or ``anndata.raw.varm['foo']``.
         :param dim_values: ``anndata.obs_names``, ``anndata.var_names``, or ``anndata.raw.var_names``.
         """
+        s0 = self.timing_start("from_matrix_and_dim_values", "total")
 
         s = util.get_start_stamp()
         log_io(None, f"{self._indent}START  WRITING {self.uri}")
@@ -127,11 +132,13 @@ class AnnotationMatrix(TileDBArray):
             f"Wrote {self.nested_name}",
             util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
         )
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def _numpy_ndarray_or_scipy_sparse_csr_matrix(
         self, matrix: Matrix, dim_values: Labels
     ) -> None:
+        s0 = self.timing_start("_numpy_ndarray_or_scipy_sparse_csr_matrix", "total")
         # We do not have column names for anndata-provenance annotation matrices.
         # So, if say we're looking at anndata.obsm['X_pca'], we create column names
         # 'X_pca_1', 'X_pca_2', etc.
@@ -147,9 +154,11 @@ class AnnotationMatrix(TileDBArray):
         df = pd.DataFrame(matrix, columns=attr_names)
         with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
             A[dim_values] = df.to_dict(orient="list")
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def _from_pandas_dataframe(self, df: pd.DataFrame, dim_values: Labels) -> None:
+        s0 = self.timing_start("_from_pandas_dataframe", "total")
         attr_names = df.columns.values.tolist()
 
         # Ingest annotation matrices as 1D/multi-attribute sparse arrays
@@ -160,6 +169,7 @@ class AnnotationMatrix(TileDBArray):
 
         with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
             A[dim_values] = df.to_dict(orient="list")
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def _create_empty_array(
@@ -172,6 +182,7 @@ class AnnotationMatrix(TileDBArray):
         repeated once per column. For pandas.DataFrame, there is a dtype per column.
         :param attr_names: column names for the dataframe
         """
+        s0 = self.timing_start("_create_empty_array", "total")
 
         # Nominally 'obs_id' or 'var_id'
         level = self._soma_options.string_dim_zstd_level
@@ -214,3 +225,5 @@ class AnnotationMatrix(TileDBArray):
         )
 
         tiledb.Array.create(self.uri, sch, ctx=self._ctx)
+
+        self.timing_end(s0)

--- a/apis/python/src/tiledbsoma/assay_matrix.py
+++ b/apis/python/src/tiledbsoma/assay_matrix.py
@@ -53,12 +53,14 @@ class AssayMatrix(TileDBArray):
         * For reading from an already-populated SOMA, we wish to avoid cache-coherency issues.
         """
         super().__init__(uri=uri, name=name, parent=parent)
+        s0 = self.timing_start("__init__", "total")
 
         self.row_dim_name = row_dim_name
         self.col_dim_name = col_dim_name
         self.attr_name = "value"
         self.row_dataframe = row_dataframe
         self.col_dataframe = col_dataframe
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def shape(self) -> Tuple[int, int]:
@@ -69,12 +71,15 @@ class AssayMatrix(TileDBArray):
 
         Note: currently implemented via data scan --- will be optimized for TileDB core 2.10.
         """
+        s1 = self.timing_start("shape", "total")
         with self._open():
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
             num_rows = self.row_dataframe.shape()[0]
             num_cols = self.col_dataframe.shape()[0]
-            return (num_rows, num_cols)
+            retval = (num_rows, num_cols)
+            self.timing_end(s1)
+            return retval
 
     # ----------------------------------------------------------------
     def dim_select(
@@ -89,7 +94,13 @@ class AssayMatrix(TileDBArray):
         Either or both of the ID lists may be ``None``, meaning, do not subselect along
         that dimension. If both ID lists are ``None``, the entire matrix is returned.
         """
+        s0 = self.timing_start("dim_select", "open")
+
+        s1 = self.timing_start("dim_select", "open")
         with tiledb.open(self.uri, ctx=self._ctx) as A:
+            self.timing_end(s1)
+
+            s2 = self.timing_start("dim_select", "tiledb_query")
             query = A.query(return_arrow=return_arrow)
             if obs_ids is None:
                 if var_ids is None:
@@ -101,8 +112,14 @@ class AssayMatrix(TileDBArray):
                     df = query.df[obs_ids, :]
                 else:
                     df = query.df[obs_ids, var_ids]
+            self.timing_end(s2)
+
+        s3 = self.timing_start("dim_select", "set_index")
         if not return_arrow:
             df.set_index([self.row_dim_name, self.col_dim_name], inplace=True)
+        self.timing_end(s3)
+
+        self.timing_end(s0)
         return df
 
     # ----------------------------------------------------------------
@@ -126,7 +143,10 @@ class AssayMatrix(TileDBArray):
         """
         Like ``.df()`` but returns results in ``scipy.sparse.csr_matrix`` format.
         """
-        return self._csr_or_csc("csr", obs_ids, var_ids)
+        s0 = self.timing_start("csr", "total")
+        retval = self._csr_or_csc("csr", obs_ids, var_ids)
+        self.timing_end(s0)
+        return retval
 
     def csc(
         self, obs_ids: Optional[Ids] = None, var_ids: Optional[Ids] = None
@@ -134,7 +154,10 @@ class AssayMatrix(TileDBArray):
         """
         Like ``.df()`` but returns results in ``scipy.sparse.csc_matrix`` format.
         """
-        return self._csr_or_csc("csc", obs_ids, var_ids)
+        s0 = self.timing_start("csc", "total")
+        retval = self._csr_or_csc("csc", obs_ids, var_ids)
+        self.timing_end(s0)
+        return retval
 
     def _csr_or_csc(
         self,
@@ -168,6 +191,7 @@ class AssayMatrix(TileDBArray):
         ``scipy.sparse.csr_matrix``, ``scipy.sparse.csc_matrix``, ``numpy.ndarray``, etc.
         For ingest from ``AnnData``, these should be ``ann.obs_names`` and ``ann.var_names``.
         """
+        s0 = self.timing_start("from_matrix_and_dim_values", "total")
 
         s = util.get_start_stamp()
         log_io(
@@ -206,11 +230,14 @@ class AssayMatrix(TileDBArray):
             util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
         )
 
+        self.timing_end(s0)
+
     # ----------------------------------------------------------------
     def _create_empty_array(self, matrix_dtype: np.dtype) -> None:
         """
         Create a TileDB 2D sparse array with string dimensions and a single attribute.
         """
+        s0 = self.timing_start("_create_empty_array", "total")
 
         dom = tiledb.Domain(
             tiledb.Dim(
@@ -248,6 +275,7 @@ class AssayMatrix(TileDBArray):
         )
 
         tiledb.Array.create(self.uri, sch, ctx=self._ctx)
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def ingest_data_whole(
@@ -264,6 +292,7 @@ class AssayMatrix(TileDBArray):
         :param row_names: List of row names.
         :param col_names: List of column names.
         """
+        s0 = self.timing_start("ingest_data_whole", "total")
 
         assert len(row_names) == matrix.shape[0]
         assert len(col_names) == matrix.shape[1]
@@ -274,6 +303,7 @@ class AssayMatrix(TileDBArray):
 
         with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
             A[d0, d1] = mat_coo.data
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     # Example: suppose this 4x3 is to be written in two chunks of two rows each
@@ -321,6 +351,7 @@ class AssayMatrix(TileDBArray):
         :param row_names: List of row names.
         :param col_names: List of column names.
         """
+        s0 = self.timing_start("ingest_data_rows_chunked", "total")
 
         assert len(row_names) == matrix.shape[0]
         assert len(col_names) == matrix.shape[1]
@@ -408,6 +439,7 @@ class AssayMatrix(TileDBArray):
                 f"{self._indent}FINISH __ingest_coo_data_string_dims_rows_chunked",
             ),
         )
+        self.timing_end(s0)
 
     # This method is very similar to ingest_data_rows_chunked. The code is largely repeated,
     # and this is intentional. The algorithm here is non-trivial (among the most non-trivial
@@ -427,6 +459,7 @@ class AssayMatrix(TileDBArray):
         :param row_names: List of row names.
         :param col_names: List of column names.
         """
+        s0 = self.timing_start("ingest_data_cols_chunked", "total")
 
         assert len(row_names) == matrix.shape[0]
         assert len(col_names) == matrix.shape[1]
@@ -514,6 +547,7 @@ class AssayMatrix(TileDBArray):
                 f"{self._indent}FINISH __ingest_coo_data_string_dims_rows_chunked",
             ),
         )
+        self.timing_end(s0)
 
     # This method is very similar to ingest_data_rows_chunked. The code is largely repeated,
     # and this is intentional. The algorithm here is non-trivial (among the most non-trivial
@@ -533,6 +567,7 @@ class AssayMatrix(TileDBArray):
         :param row_names: List of row names.
         :param col_names: List of column names.
         """
+        s0 = self.timing_start("ingest_data_dense_rows_chunked", "total")
 
         assert len(row_names) == matrix.shape[0]
         assert len(col_names) == matrix.shape[1]
@@ -622,6 +657,7 @@ class AssayMatrix(TileDBArray):
                 f"{self._indent}FINISH __ingest_coo_data_string_dims_dense_rows_chunked",
             ),
         )
+        self.timing_end(s0)
 
     # ----------------------------------------------------------------
     def to_csr_matrix(self, row_labels: Labels, col_labels: Labels) -> sp.csr_matrix:
@@ -633,6 +669,7 @@ class AssayMatrix(TileDBArray):
         be in the same order as they were in any anndata object which was used to create the
         TileDB storage.
         """
+        s0 = self.timing_start("to_csr_matrix", "total")
 
         s = util.get_start_stamp()
         log_io(None, f"{self._indent}START  read {self.uri}")
@@ -644,4 +681,5 @@ class AssayMatrix(TileDBArray):
             util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"),
         )
 
+        self.timing_end(s0)
         return csr

--- a/apis/python/src/tiledbsoma/perf.py
+++ b/apis/python/src/tiledbsoma/perf.py
@@ -1,0 +1,136 @@
+# ----------------------------------------------------------------
+# in some foo class:
+#     s = self.startfunc({'foo': 'bar'}) # uri=self.uri implicit in there
+#     self.endfunc(s)
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+
+class Entry:
+    """
+    A simple container for a single labeled elapsed-time stat.
+    """
+
+    t1: float
+    t2: Optional[float] = None
+
+    def __init__(self, **kwargs: Any):
+        self.t1 = time.time()
+        self.t2 = None
+        self.state = {}
+        for k, v in kwargs.items():
+            self.state[k] = v
+
+    def finish(self) -> None:
+        self.t2 = time.time()
+
+    def as_line(self) -> str:
+        line = ",".join([f"{k}={v}" for k, v in self.state.items()])
+        if self.t2 is None:
+            return line
+
+        dt = "%.6f" % (self.t2 - self.t1)
+        if len(self.state.items()) > 0:
+            return f"seconds={dt},{line}"
+        else:
+            return f"seconds={dt}"
+
+    def as_dict(self) -> Dict[str, Any]:
+        retval = {}
+        if self.t1 is not None and self.t2 is not None:
+            retval["seconds"] = "%.6f" % (self.t2 - self.t1)
+        for k, v in self.state.items():
+            retval[k] = v
+        return retval
+
+
+# ----------------------------------------------------------------
+class Tracker:
+    """
+    A simple container for a multiple labeled elapsed-time stats.
+    """
+
+    _entries: List[Entry]
+
+    def __init__(self) -> None:
+        self._entries = []
+
+    def reset(self) -> None:
+        self._entries = []
+
+    def track(self, entry: Entry) -> None:
+        self._entries.append(entry)
+
+    def as_json(self) -> str:
+        return json.dumps([entry.as_dict() for entry in self._entries], indent=2)
+
+    def show_as_lines(self) -> None:
+        """
+        Displays the stats in key1=value1,key2=value2,... format which is splendid
+        for when the key-list varies from one row to the next.
+        """
+        for entry in self._entries:
+            print(entry.as_line())
+
+    def show(self) -> None:
+        """
+        Displays the stats in pretty-printed tabular format, starting a new pretty-printed batch
+        whenever the key-list changes.
+        """
+        homogeneous_batch = []
+        last_header: List[str] = []
+        printed_a_batch = False
+        for entry in self._entries:
+            row = entry.as_dict()
+            # Build up a list of rows all having the same key-list, then format them
+            # using column alignment.
+            current_header = list(row.keys())
+            if (last_header == []) or (current_header == last_header):
+                homogeneous_batch.append(row)
+            else:
+                if printed_a_batch:
+                    print()
+                self._show_tabular_batch(homogeneous_batch, last_header)
+                printed_a_batch = True
+                homogeneous_batch = []
+            last_header = current_header
+        if len(homogeneous_batch) > 0:
+            if printed_a_batch:
+                print()
+            self._show_tabular_batch(homogeneous_batch, last_header)
+
+    def _show_tabular_batch(
+        self, batch: List[Dict[str, Any]], header: List[str]
+    ) -> None:
+        """
+        Helper method for `show`. Prints a list of perf entries all having the
+        same key-list, using column alignment.
+        """
+        # Find the widths of the keys in the header line.
+        assert len(batch) > 0
+        max_widths = {}
+        for key in header:
+            max_widths[key] = len(key)
+
+        # Find the widths of the values in the data lines, taking the max length
+        # down columns.
+        for row in batch:
+            for key in header:
+                value = str(row[key])
+                max_widths[key] = max(max_widths[key], len(value))
+
+        aligned_header = " ".join(["%-*s" % (max_widths[key], key) for key in header])
+        print(aligned_header)
+
+        for row in batch:
+            aligned_data = " ".join(
+                ["%-*s" % (max_widths[key], value) for key, value in row.items()]
+            )
+            print(aligned_data)
+
+
+# ----------------------------------------------------------------
+# Canonical singleton, although others can be instantiated if desired
+tracker = Tracker()

--- a/apis/python/src/tiledbsoma/perf.py
+++ b/apis/python/src/tiledbsoma/perf.py
@@ -128,7 +128,7 @@ class Tracker:
             aligned_data = " ".join(
                 ["%-*s" % (max_widths[key], value) for key, value in row.items()]
             )
-            print(aligned_data)
+            print(aligned_data.rstrip())
 
 
 # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -5,7 +5,7 @@ import tiledb
 
 import tiledbsoma
 
-from . import util
+from . import perf, util
 from .soma_options import SOMAOptions
 
 
@@ -114,3 +114,35 @@ class TileDBObject(ABC):
     @abstractmethod
     def _open(self, mode: str = "r") -> Union[tiledb.Array, tiledb.Group]:
         """Open the underlying TileDB array or Group"""
+
+    def timing_start(
+        self, func_name: str, phase_name: str, **kwargs: Any
+    ) -> perf.Entry:
+        return perf.Entry(
+            element_name=self.nested_name,
+            element_class=self.__class__.__name__,
+            func_name=func_name,
+            phase_name=phase_name,
+            **kwargs,
+        )
+
+    def timing_end(self, entry: perf.Entry) -> None:
+        entry.finish()
+        perf.tracker.track(entry)
+
+    @classmethod
+    def cls_timing_start(
+        cls, func_name: str, phase_name: str, **kwargs: Any
+    ) -> perf.Entry:
+        return perf.Entry(
+            element_name="N/A",
+            element_class=cls.__name__,
+            func_name=func_name,
+            phase_name=phase_name,
+            **kwargs,
+        )
+
+    @classmethod
+    def cls_timing_end(cls, entry: perf.Entry) -> None:
+        entry.finish()
+        perf.tracker.track(entry)

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -198,10 +198,10 @@ select `relative=True`. (This is the default.)
             sys.exit(1)
 
     if args.stats:
-        tiledbsc.perf.tracker.show()
-    if args.stats and args.corestats:
         print()
+        tiledbsc.perf.tracker.show()
     if args.corestats:
+        print()
         tiledb.stats_dump()
 
 

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -199,7 +199,7 @@ select `relative=True`. (This is the default.)
 
     if args.stats:
         print()
-        tiledbsc.perf.tracker.show()
+        tiledbsoma.perf.tracker.show()
     if args.corestats:
         print()
         tiledb.stats_dump()

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -63,6 +63,16 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--stats",
+        help="For internal use, to collect performance-optimization stats",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--corestats",
+        help="For internal use, to collect performance-optimization stats",
+        action="store_true",
+    )
+    parser.add_argument(
         "-r",
         "--relative",
         help="""
@@ -126,6 +136,9 @@ select `relative=True`. (This is the default.)
     soma_options = tiledbsoma.SOMAOptions(member_uris_are_relative=rel_member_uris)
     outdir = args.o.rstrip("/")
 
+    if args.corestats:
+        tiledb.stats_enable()
+
     if args.n:
         if len(args.paths) < 1:
             parser.print_help(file=sys.stderr)
@@ -183,6 +196,13 @@ select `relative=True`. (This is the default.)
         else:
             parser.print_help(file=sys.stderr)
             sys.exit(1)
+
+    if args.stats:
+        tiledbsc.perf.tracker.show()
+    if args.stats and args.corestats:
+        print()
+    if args.corestats:
+        tiledb.stats_dump()
 
 
 # ================================================================


### PR DESCRIPTION
# Context

Very much inspired by, and in the spirit of, `tiledb.stats_enable` and `tiledb.stats_dump`.

`tiledbsc-py` profiling up to this point has been timestamp-difference-printing outside of this repo. It is high time that we standardize such stats and make them more user-accessible.

# Differences

* For `tiledb` stats there is a lot of looping over tiles and cells; data-reduction by sums and averages is appropriate
* Here the looping is coarser (handled by core, not handled at this application level) and the components are heterogeneous; straight narrative is appropriate
* The stats being accumulated and are lightweight; no need to explicitly enable -- a `tracker.show()` and `tracker.reset()` are sufficient

# Similarities

* We simply compute seconds
* Just as `tiledb`'s outer `do_work.sum` includes times for inner bits, here too, a `total` time includes times which may be refined out by inner bits

# Examples

## SOMA-query example

```
#!/usr/bin/env python

import tiledb
import tiledbsc
import tiledbsc.io

# uri = "kv0"
# uri = s3://tiledb-singlecell-data/soco/soco3/Krasnow
uri = "tiledb://johnkerl-tiledb/Krasnow"

query_string = 'cell_type == "pulmonary ionocyte"'

cfg = tiledb.Config()
cfg["py.init_buffer_bytes"] = 4 * 1024**3
cfg["rest.use_refactored_array_open"] = True
ctx = tiledb.Ctx(cfg)

soma = tiledbsc.SOMA(uri, ctx=ctx)
if not soma.exists():
    print("Does not exist yet:", uri)

slice = soma.query(
    #obs_attrs=['cell_type','manually_annotated','is_primary_data'],
    obs_query_string=query_string,
)

print(slice)
print()
tiledbsc.perf.tracker.show()
```

Script output:

```
X/data: (65200, 1)
obs: (22, 29)
var: (24857, 4)

seconds  element_name    element_class       func_name            phase_name
0.000007 Krasnow/obs     AnnotationDataFrame __init__             total
0.000002 Krasnow/var     AnnotationDataFrame __init__             total
0.000006 Krasnow/raw/var AnnotationDataFrame __init__             total
0.733203 Krasnow         SOMA                __init__             total
1.088516 Krasnow/obs     AnnotationDataFrame query                open
2.214017 Krasnow/obs     AnnotationDataFrame query                tiledb_query
0.000588 Krasnow/obs     AnnotationDataFrame query                set_index
0.006811 Krasnow/obs     AnnotationDataFrame query                ascii_to_unicode
3.309994 Krasnow/obs     AnnotationDataFrame query                total
0.417870 Krasnow/var     AnnotationDataFrame dim_select           open
1.931505 Krasnow/var     AnnotationDataFrame dim_select           tiledb_query
0.000548 Krasnow/var     AnnotationDataFrame dim_select           set_index
0.015925 Krasnow/var     AnnotationDataFrame dim_select           ascii_to_unicode
2.365893 Krasnow/var     AnnotationDataFrame dim_select           total
0.000009 Krasnow/X/data  AssayMatrix         __init__             total
0.607492 Krasnow/X/data  AssayMatrix         dim_select           open
2.199090 Krasnow/X/data  AssayMatrix         dim_select           tiledb_query
0.016846 Krasnow/X/data  AssayMatrix         dim_select           set_index
2.823472 Krasnow/X/data  AssayMatrix         dim_select           open
3.474640 Krasnow         SOMA                _assemble_soma_slice total
9.150593 Krasnow         SOMA                query                total
```

## Data-ingest example

```
tiledbsc.__version__       0.1.11.dev4
tiledb.cloud.__version__   0.7.45
tiledb.__version__         0.17.2
core version               2.11.0

>>> soma = tiledbsc.SOMA('example')

>>> tiledbsc.io.from_h5ad(soma, '/Users/johnkerl/s/a/Krasnow.h5ad')
Wrote example/obs
Wrote example/var
Writing example/X/data ...
... example/X/data  16.079% done, ETA 1.94 minutes
... example/X/data  33.959% done, ETA 1.28 minutes
... example/X/data  48.392% done, ETA 1.09 minutes
... example/X/data  63.691% done, ETA 47.40 seconds
... example/X/data  76.041% done, ETA 31.12 seconds
... example/X/data  93.057% done, ETA 10.42 seconds
Wrote example/X/data
Wrote example/obsm/X_Compartment_tSNE
Wrote example/obsm/X_tSNE
Wrote example/raw/var
Writing example/raw/X/data ...
... example/raw/X/data  16.079% done, ETA 1.88 minutes
... example/raw/X/data  33.959% done, ETA 1.33 minutes
... example/raw/X/data  48.392% done, ETA 1.12 minutes
... example/raw/X/data  63.691% done, ETA 48.44 seconds
... example/raw/X/data  76.041% done, ETA 31.76 seconds
... example/raw/X/data  93.057% done, ETA 10.74 seconds
Wrote example/raw/X/data
Wrote example/uns/layer_descriptions
Wrote example/uns
Wrote example

>>> tiledbsc.perf.tracker.show()
seconds    element_name                    element_class       func_name                                 phase_name
0.000009   example/obs                     AnnotationDataFrame __init__                                  total
0.000127   example/var                     AnnotationDataFrame __init__                                  total
0.000004   example/raw/var                 AnnotationDataFrame __init__                                  total
0.012278   example                         SOMA                __init__                                  total
0.212238   example/obs                     AnnotationDataFrame from_dataframe                            total
0.068891   example/var                     AnnotationDataFrame from_dataframe                            total
0.000014   example/X/data                  AssayMatrix         __init__                                  total
0.001988   example/X/data                  AssayMatrix         _create_empty_array                       total
131.961346 example/X/data                  AssayMatrix         ingest_data_rows_chunked                  total
132.023129 example/X/data                  AssayMatrix         from_matrix_and_dim_values                total
0.001547   example/obsm/X_Compartment_tSNE AnnotationMatrix    _create_empty_array                       total
0.073877   example/obsm/X_Compartment_tSNE AnnotationMatrix    _numpy_ndarray_or_scipy_sparse_csr_matrix total
0.075479   example/obsm/X_Compartment_tSNE AnnotationMatrix    from_matrix_and_dim_values                total
0.000963   example/obsm/X_tSNE             AnnotationMatrix    _create_empty_array                       total
0.060634   example/obsm/X_tSNE             AnnotationMatrix    _numpy_ndarray_or_scipy_sparse_csr_matrix total
0.061879   example/obsm/X_tSNE             AnnotationMatrix    from_matrix_and_dim_values                total
0.033895   example/raw/var                 AnnotationDataFrame from_dataframe                            total
0.000005   example/raw/X/data              AssayMatrix         __init__                                  total
0.000947   example/raw/X/data              AssayMatrix         _create_empty_array                       total
132.724781 example/raw/X/data              AssayMatrix         ingest_data_rows_chunked                  total
132.792822 example/raw/X/data              AssayMatrix         from_matrix_and_dim_values                total
```
