### PR TITLE
Check for errors on scripts/setup

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # cd to the top level directory of the repo
 cd $(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
I got an error while running this with a missing dependency -- we should die at the right time to give the right error, rather than failing less clearly later on.

This PR is for the `main` branch; #284 is for the `main-v0` branch.