### PR TITLE
Check for errors on scripts/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: TileDB-SingleCell Python CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main-v0]
   release:
     types: [published]
 

--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -2,6 +2,8 @@
 
 This is a POC Python implementation of the proposed [Unified Single-cell Data Model](https://github.com/single-cell-data/SOMA).
 
+This branch conforms to [this version](https://github.com/single-cell-data/TileDB-SOMA/blob/main/spec/specification.md) of the specification -- for the [latest version](https://github.com/single-cell-data/SOMA/blob/spec-revision/brainstorming.md) please see the `main` branch of this repository.
+
 # Installation
 
 ## Using pip
@@ -15,7 +17,7 @@ python -m pip install tiledbsc
 To install a specific version:
 
 ```
-python -m pip install git+https://github.com/single-cell-data/TileDB-SingleCell.git@0.0.6#subdirectory=apis/python
+python -m pip install git+https://github.com/single-cell-data/TileDB-SOMA.git@0.0.6#subdirectory=apis/python
 ```
 
 To update to the latest version:
@@ -27,7 +29,7 @@ python -m pip install --upgrade tiledbsc
 ## From source
 
 * This requires [`tiledb`](https://github.com/TileDB-Inc/TileDB-Py) (see [./setup.cfg](setup.cfg) for version), in addition to other dependencies in [setup.cfg](./setup.cfg).
-* Clone [this repo](https://github.com/single-cell-data/TileDB-SingleCell)
+* Clone [this repo](https://github.com/single-cell-data/TileDB-SOMA)
 * `cd` into your checkout and then `cd apis/python`
 * `python -m pip install .`
 * Or, if you wish to modify the code and run it, `python setup.py develop`
@@ -45,4 +47,4 @@ python -m pytest tests
 
 # Status
 
-Please see [https://github.com/single-cell-data/TileDB-SingleCell/issues](https://github.com/single-cell-data/TileDB-SingleCell/issues).
+Please see [https://github.com/single-cell-data/TileDB-SOMA/issues](https://github.com/single-cell-data/TileDB-SOMA/issues).

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # cd to the top level directory of the repo
 cd $(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
I got an error while running this with a missing dependency -- we should die at the right time to give the right error, rather than failing less clearly later on.

I am trying to get this to be a PR on the `main-v0` branch.

In my sandbox checkout I do have

```
$ git log -n 2

commit 0a06dae318965d93c1a3ce5d4e8205ae91232c2c (HEAD -> kerl/v0/script-setup-error-check, origin/kerl/v0/script-setup-error-check)
Author: John Kerl <kerl.john.r@gmail.com>
Date:   Wed Sep 14 07:56:22 2022 -0400

    Check for errors on scripts/setup

commit ab4f99c4c1a844d36ba9b7c6369717a7e46a6e7a (origin/main-v0, main-v0)
Author: John Kerl <kerl.john.r@gmail.com>
Date:   Tue Sep 13 17:38:26 2022 -0400

    run CI on main-v0 branch
```

so it's not clear to me what I'm doing wrong.