### PR TITLE
Make __getattr__ Pythonic on key-not-found

### DIFF
--- a/apis/python/src/tiledbsoma/soma_collection.py
+++ b/apis/python/src/tiledbsoma/soma_collection.py
@@ -83,7 +83,14 @@ class SOMACollection(TileDBObject):
                 member_name, member_uri, self
             )
 
-        return self._cached_members[member_name]
+        if member_name in self._cached_members:
+            return self._cached_members[member_name]
+        else:
+            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
+            # resolvable. So raising here is the right thing to do.
+            raise AttributeError(
+                f"{self.__class__.__name__} has no attribute '{member_name}'"
+            )
 
     def keys(self) -> Sequence[str]:
         """

--- a/apis/python/src/tiledbsoma/soma_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_dataframe.py
@@ -147,6 +147,10 @@ class SOMADataFrame(TileDBArray):
             return self._get_shape()
         elif name == "ndims":
             return self._get_ndims()
+        else:
+            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
+            # resolvable. So raising here is the right thing to do.
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def keys(self) -> Sequence[str]:
         """

--- a/apis/python/src/tiledbsoma/soma_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_dense_nd_array.py
@@ -126,6 +126,10 @@ class SOMADenseNdArray(TileDBArray):
             return self._get_shape()
         elif name == "ndims":
             return self._get_ndims()
+        else:
+            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
+            # resolvable. So raising here is the right thing to do.
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def _get_shape(self) -> NTuple:
         """

--- a/apis/python/src/tiledbsoma/soma_experiment.py
+++ b/apis/python/src/tiledbsoma/soma_experiment.py
@@ -68,7 +68,7 @@ class SOMAExperiment(SOMACollection):
         else:
             # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
             # resolvable. So raising here is the right thing to do.
-            raise AttributeError(f"unrecognized attribute: {name}")
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def constrain(self) -> None:
         """

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -171,6 +171,10 @@ class SOMAIndexedDataFrame(TileDBArray):
             return self._get_shape()
         elif name == "ndims":
             return self._get_ndims()
+        else:
+            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
+            # resolvable. So raising here is the right thing to do.
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def keys(self) -> Sequence[str]:
         """

--- a/apis/python/src/tiledbsoma/soma_measurement.py
+++ b/apis/python/src/tiledbsoma/soma_measurement.py
@@ -87,11 +87,10 @@ class SOMAMeasurement(SOMACollection):
                     uri=child_uri, name=name, parent=self
                 )
             return self._cached_members[name]
-
         else:
             # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
             # resolvable. So raising here is the right thing to do.
-            raise AttributeError(f"unrecognized attribute: {name}")
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def constrain(self) -> None:
         """

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -124,6 +124,10 @@ class SOMASparseNdArray(TileDBArray):
             return self._get_shape()
         elif name == "ndims":
             return self._get_ndims()
+        else:
+            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
+            # resolvable. So raising here is the right thing to do.
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def _get_shape(self) -> NTuple:
         """


### PR DESCRIPTION
Found by @gspowley while he was working hard on C++/`libtiledbsoma` which is a priority, and the bug caused him some confusion. Let's make better use of developer time by behaving in a Pythonic way.

Before: inconsistent:

```
>>> exp = tiledbsoma.SOMAExperiment('tiledb-data/pbmc-small')

>>> exp.nonesuch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_experiment.py", line 71, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
AttributeError: unrecognized attribute: nonesuch

>>> type(exp.obs.nonesuch)
<class 'NoneType'>

>>> exp.ms.nonesuch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_collection.py", line 104, in __getattr__

  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_collection.py", line 82, in get
    self._cached_members[member_name] = _construct_member(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/factory.py", line 43, in _construct_member
    raise Exception(f"URI {member_uri} not found")
Exception: URI tiledb-data/pbmc-small/ms/nonesuch not found
```

After: consistent:

```
>>> exp = tiledbsoma.SOMAExperiment('tiledb-data/pbmc-small')

>>> exp.nonesuch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_experiment.py", line 71, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
AttributeError: SOMAExperiment has no attribute 'nonesuch'

>>> exp.obs.nonesuch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_dataframe.py", line 153, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
AttributeError: SOMADataFrame has no attribute 'nonesuch'

>>> exp.ms.nonesuch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_collection.py", line 109, in __getattr__
    return self.get(member_name)
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_collection.py", line 82, in get
    self._cached_members[member_name] = _construct_member(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/factory.py", line 43, in _construct_member
    raise Exception(f"URI {member_uri} not found")
Exception: URI file:///home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/tiledbsoma-data/pbmc-small/ms/nonesuch not found
```
