### PR TITLE
Enable option for enhancing debug-log visibility

### DIFF
--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -117,7 +117,7 @@ if (CMAKE_IDE)
 endif()
 
 if (SUPERBUILD)
-  project(TileDB-SC-Superbuild)
+  project(TileDB-SOMA-Superbuild)
   message(STATUS "Starting TileDB-SingleCell superbuild.")
   include("cmake/Superbuild.cmake")
   if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
@@ -127,8 +127,8 @@ if (SUPERBUILD)
   return()
 endif()
 
-project(TileDB-SC)
-message(STATUS "Starting TileDB-SC regular build.")
+project(TileDB-SOMA)
+message(STATUS "Starting TileDB-SOMA regular build.")
 
 # Paths to locate the installed external projects.
 set(EP_SOURCE_DIR "${EP_BASE}/src")

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -30,6 +30,11 @@
 ############################################################
 
 cmake_minimum_required(VERSION 3.21)
+
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "")
+  message(STATUS "START libtiledbsoma/CMakeLists.txt")
+endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # TileDB-SOMA Options
@@ -115,6 +120,10 @@ if (SUPERBUILD)
   project(TileDB-SC-Superbuild)
   message(STATUS "Starting TileDB-SingleCell superbuild.")
   include("cmake/Superbuild.cmake")
+  if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+    message(STATUS "END libtiledbsoma/CMakeLists.txt")
+    message(STATUS "")
+  endif()
   return()
 endif()
 
@@ -199,3 +208,7 @@ enable_testing()
 
 add_subdirectory(src)
 add_subdirectory(test)
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "END libtiledbsoma/CMakeLists.txt")
+  message(STATUS "")
+endif()

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -1,4 +1,9 @@
-message(STATUS "Starting TileDB-SC build.")
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "")
+  message(STATUS "START libtiledbsoma/src/CMakeLists.txt")
+else()
+  message(STATUS "Starting TileDB-SC build.")
+endif()
 
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
@@ -248,3 +253,7 @@ install(
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tiledbsoma
 )
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "END libtiledbsoma/src/CMakeLists.txt")
+  message(STATUS "")
+endif()

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -2,7 +2,7 @@ if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
   message(STATUS "")
   message(STATUS "START libtiledbsoma/src/CMakeLists.txt")
 else()
-  message(STATUS "Starting TileDB-SC build.")
+  message(STATUS "Starting TileDB-SOMA build.")
 endif()
 
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
@@ -94,7 +94,7 @@ if (SANITIZER)
   if (NOT SANITIZER MATCHES "^(address|memory|leak|thread|undefined)$")
     message(FATAL_ERROR "Unknown clang sanitizer: ${SANITIZER})")
   else()
-    message(STATUS "The TileDB-SC library is compiled with sanitizer ${SANITIZER} enabled")
+    message(STATUS "The TileDB-SOMA library is compiled with sanitizer ${SANITIZER} enabled")
   endif()
   target_compile_options(TILEDB_SOMA_OBJECTS
           PRIVATE

--- a/libtiledbsoma/src/pyapi/CMakeLists.txt
+++ b/libtiledbsoma/src/pyapi/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "")
+  message(STATUS "START libtiledbsoma/src/pyapi/CMakeLists.txt")
+endif()
 find_package(pybind11 REQUIRED)
 
 pybind11_add_module(libtiledbsoma
@@ -21,3 +25,7 @@ target_include_directories(libtiledbsoma
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
     ${TILEDB_SOMA_EXPORT_HEADER_DIR}
 )
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "END libtiledbsoma/src/pyapi/CMakeLists.txt")
+  message(STATUS "")
+endif()

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -1,6 +1,10 @@
 ############################################################
 # Definitions
 ############################################################
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "")
+  message(STATUS "START libtiledbsoma/test/CMakeLists.txt")
+endif()
 
 # Set root source directory as compiler definition for use in tests
 get_filename_component(TILEDBSOMA_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE)
@@ -72,4 +76,9 @@ if (TILEDBSOMA_TESTING)
         build_tests
     )
 
+endif()
+
+if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
+  message(STATUS "END libtiledbsoma/test/CMakeLists.txt")
+  message(STATUS "")
 endif()

--- a/scripts/bld
+++ b/scripts/bld
@@ -9,17 +9,51 @@
 # * Coverage
 
 BUILD_TYPE=${1:-Release} # default to Release build
-echo "Building ${BUILD_TYPE} build"
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD BUILD_TYPE ${BUILD_TYPE}
+  echo ================================================================
+else
+  echo "Building ${BUILD_TYPE} build"
+fi
+
+# Convert these from unset to "" before we flip on `set -u`.
+if [ -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  export LIBTILEDBSOMA_DEBUG_BUILD=""
+fi
+if [ -z "$LIBTILEDBSOMA_NO_PARALLEL_BUILD" ]; then
+  export LIBTILEDBSOMA_NO_PARALLEL_BUILD=""
+fi
 
 set -eu -o pipefail
 
 # cd to the top level directory of the repo
 cd $(git rev-parse --show-toplevel)
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD PWD
+  pwd
+  echo ================================================================
+fi
 
 # set env for pybind11 cmake
 export pybind11_DIR=$(python -m pybind11 --cmakedir)
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD PYBIND11 DIR=$pybind11_DIR
+  echo ================================================================
+fi
 
 # remove existing build files
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD CLEAN
+  echo ================================================================
+fi
 rm -rf build dist
 rm -f apis/python/src/tiledbsoma/libtiledb.*
 rm -f apis/python/src/tiledbsoma/libtiledbsoma.*
@@ -41,12 +75,46 @@ else
   # Debug note: this is _incredibly_ helpful in that it reveals the actual compile lines etc which
   # make itself shows by default but which cmake-driven make hides by default. Use this for any
   # non-trivial cmake debugging.
-  #
+  if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+    EXTRA_OPTS="-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+  fi
   # Also (pro-tip), set nproc=1 to get a more deterministic ordering of output lines.
-  # EXTRA_OPTS="-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+  if [ ! -z "$LIBTILEDBSOMA_NO_PARALLEL_BUILD" ]; then
+    nproc=1
+  fi
 fi
 
 mkdir -p build
+
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD GENERATE MAKEFILES
+  echo cmake -B build -S libtiledbsoma -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${EXTRA_OPTS}
+fi
 cmake -B build -S libtiledbsoma -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${EXTRA_OPTS}
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo ================================================================
+fi
+
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA EXECUTE MAKEFILES
+  echo cmake --build build -j $nproc
+fi
 cmake --build build -j $nproc
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo ================================================================
+fi
+
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo
+  echo ================================================================
+  echo LIBTILEDBSOMA SCRIPTS/BLD EXECUTE TESTS
+  echo cmake --build build --target install-libtiledbsoma
+fi
 cmake --build build --target install-libtiledbsoma
+if [ ! -z "$LIBTILEDBSOMA_DEBUG_BUILD" ]; then
+  echo ================================================================
+fi


### PR DESCRIPTION
This is in the context of SC 21583. After an extended debug session, these are mods worth keeping, as quality-of-life improvements. This is opt-in via the two environment variables checked at the top of `scripts/bld`.