### PR TITLE
improve column_name handling in dataframe read operations

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_dataframe.py
@@ -202,7 +202,7 @@ class SOMADataFrame(TileDBArray):
         )
 
         with self._tiledb_open("r") as A:
-            dims_names, attrs_names = util_tiledb.split_column_names(
+            dim_names, attr_names = util_tiledb.split_column_names(
                 A.schema, column_names
             )
             if value_filter is None:
@@ -210,8 +210,8 @@ class SOMADataFrame(TileDBArray):
                     return_arrow=True,
                     return_incomplete=True,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
             else:
                 qc = tiledb.QueryCondition(value_filter)
@@ -220,8 +220,8 @@ class SOMADataFrame(TileDBArray):
                     return_incomplete=True,
                     attr_cond=qc,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
 
             if ids is None:
@@ -349,15 +349,15 @@ class SOMADataFrame(TileDBArray):
         )
 
         with self._tiledb_open() as A:
-            dims_names, attrs_names = util_tiledb.split_column_names(
+            dim_names, attr_names = util_tiledb.split_column_names(
                 A.schema, column_names
             )
             if value_filter is None:
                 query = A.query(
                     return_incomplete=True,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
             else:
                 qc = tiledb.QueryCondition(value_filter)
@@ -365,8 +365,8 @@ class SOMADataFrame(TileDBArray):
                     return_incomplete=True,
                     attr_cond=qc,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
 
             if ids is None:

--- a/apis/python/src/tiledbsoma/soma_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_dataframe.py
@@ -202,11 +202,16 @@ class SOMADataFrame(TileDBArray):
         )
 
         with self._tiledb_open("r") as A:
+            dims_names, attrs_names = util_tiledb.split_column_names(
+                A.schema, column_names
+            )
             if value_filter is None:
                 query = A.query(
                     return_arrow=True,
                     return_incomplete=True,
                     order=tiledb_result_order,
+                    dims=dims_names,
+                    attrs=attrs_names,
                 )
             else:
                 qc = tiledb.QueryCondition(value_filter)
@@ -215,16 +220,14 @@ class SOMADataFrame(TileDBArray):
                     return_incomplete=True,
                     attr_cond=qc,
                     order=tiledb_result_order,
+                    dims=dims_names,
+                    attrs=attrs_names,
                 )
 
             if ids is None:
                 iterator = query.df[:]
-                if column_names is not None:
-                    iterator = query.df[:][column_names]
             else:
                 iterator = query.df[ids]
-                if column_names is not None:
-                    iterator = query.df[ids][column_names]
 
             for df in iterator:
                 batches = df.to_batches()
@@ -346,11 +349,15 @@ class SOMADataFrame(TileDBArray):
         )
 
         with self._tiledb_open() as A:
+            dims_names, attrs_names = util_tiledb.split_column_names(
+                A.schema, column_names
+            )
             if value_filter is None:
                 query = A.query(
                     return_incomplete=True,
                     order=tiledb_result_order,
-                    attrs=column_names,
+                    dims=dims_names,
+                    attrs=attrs_names,
                 )
             else:
                 qc = tiledb.QueryCondition(value_filter)
@@ -358,7 +365,8 @@ class SOMADataFrame(TileDBArray):
                     return_incomplete=True,
                     attr_cond=qc,
                     order=tiledb_result_order,
-                    attrs=column_names,
+                    dims=dims_names,
+                    attrs=attrs_names,
                 )
 
             if ids is None:
@@ -378,7 +386,11 @@ class SOMADataFrame(TileDBArray):
                     df.set_index(id_column_name, inplace=True)
 
                 # Don't materialize soma_rowid on read
-                if ROWID in df.columns:
+                if (
+                    ROWID in df.columns
+                    and column_names is not None
+                    and ROWID not in column_names
+                ):
                     yield df.drop(ROWID, axis=1)
                 else:
                     yield df

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -242,7 +242,7 @@ class SOMAIndexedDataFrame(TileDBArray):
 
         # TODO: more about index_column_names
         with self._tiledb_open("r") as A:
-            dims_names, attrs_names = util_tiledb.split_column_names(
+            dim_names, attr_names = util_tiledb.split_column_names(
                 A.schema, column_names
             )
             if value_filter is None:
@@ -250,8 +250,8 @@ class SOMAIndexedDataFrame(TileDBArray):
                     return_arrow=True,
                     return_incomplete=True,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
             else:
                 qc = tiledb.QueryCondition(value_filter)
@@ -260,8 +260,8 @@ class SOMAIndexedDataFrame(TileDBArray):
                     return_incomplete=True,
                     attr_cond=qc,
                     order=tiledb_result_order,
-                    dims=dims_names,
-                    attrs=attrs_names,
+                    dims=dim_names,
+                    attrs=attr_names,
                 )
 
             if ids is None:

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -19,7 +19,7 @@ class SOMAIndexedDataFrame(TileDBArray):
     """
     Represents ``obs``, ``var``, and others.
 
-    All `SOMAIndexedDataFrame` must contain a column called `soma_joinid`, of type `uint64`. The `soma_joinid` column contains a unique value for each row in the `SOMAIndexedDataFrame`, and intended to act as a joint key for other objects, such as `SOMASparseNdArray`.
+    All ``SOMAIndexedDataFrame`` must contain a column called ``soma_joinid``, of type ``uint64``. The ``soma_joinid`` column contains a unique value for each row in the ``SOMAIndexedDataFrame``, and intended to act as a joint key for other objects, such as ``SOMASparseNdArray``.
     """
 
     _index_column_names: Optional[List[str]]

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -145,11 +145,27 @@ def split_column_names(
     array_schema: tiledb.ArraySchema, column_names: Optional[Sequence[str]]
 ) -> Tuple[Union[Sequence[str], None], Union[Sequence[str], None]]:
     """
-    Given a tiledb ArraySchema and a list of dim or column names, split
-    them into a tuple of (dim_names, column_nanes).
+    Given a tiledb ArraySchema and a list of dim or attr names, split
+    them into a tuple of (dim_names, attr_names).
 
     This helper is used to turn the SOMA `column_names` parameter into a
-    form that can be used by tiledb.Array.query.
+    form that can be natively used by tiledb.Array.query, which requires
+    that the list of names be separated into `dims` and `attrs`.
+
+    Parameters
+    ----------
+    array_schema : tiledb.Array
+        An array schema which will be used to determine whether a
+        column name is a dim or attr.
+    column_names : Optional[Sequence[str]]
+        List of column names to split into `dim` and `attr` names.
+
+    Returns
+    -------
+    Tuple[Union[Sequence[str], None], Union[Sequence[str], None]]
+        If column_names is `None`, the tuple `(None, None)` will be returned.
+        Otherwise, returns a tuple of (dim_names, attr_names), with any unknown
+        names, ie, not present in the array schema, ignored (dropped).
     """
     if column_names is None:
         return (None, None)

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, TypeVar, List, Tuple, Union
+from typing import List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -139,3 +139,26 @@ def list_fragments(array_uri: str) -> None:
 
     frags_df = pd.DataFrame(fragments)
     print(frags_df)
+
+
+def split_column_names(
+    array_schema: tiledb.ArraySchema, column_names: Optional[List[str]]
+) -> Tuple[Union[List[str], None], Union[List[str], None]]:
+    """
+    Given a tiledb ArraySchema and a list of dim or column names, split
+    them into a tuple of (dim_names, column_nanes).
+
+    This helper is used to turn the SOMA `column_names` parameter into a
+    form that can be used by tiledb.Array.query.
+    """
+    if column_names is None:
+        return (None, None)
+
+    dim_names = [
+        array_schema.domain.dim(i).name for i in range(array_schema.domain.ndim)
+    ]
+    attr_names = [array_schema.attr(i).name for i in range(array_schema.nattr)]
+    return (
+        [c for c in column_names if c in dim_names],
+        [c for c in column_names if c in attr_names],
+    )

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Tuple, TypeVar, Union
+from typing import Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -142,8 +142,8 @@ def list_fragments(array_uri: str) -> None:
 
 
 def split_column_names(
-    array_schema: tiledb.ArraySchema, column_names: Optional[List[str]]
-) -> Tuple[Union[List[str], None], Union[List[str], None]]:
+    array_schema: tiledb.ArraySchema, column_names: Optional[Sequence[str]]
+) -> Tuple[Union[Sequence[str], None], Union[Sequence[str], None]]:
     """
     Given a tiledb ArraySchema and a list of dim or column names, split
     them into a tuple of (dim_names, column_nanes).

--- a/apis/python/tests/test_soma_dataframe.py
+++ b/apis/python/tests/test_soma_dataframe.py
@@ -1,4 +1,7 @@
+import pytest
+
 import pyarrow as pa
+import pandas as pd
 
 import tiledbsoma as t
 
@@ -136,3 +139,102 @@ def test_soma_dataframe_non_indexed(tmp_path):
     assert sorted([e.as_py() for e in list(batch["foo"])]) == [20, 40]
     assert sorted([e.as_py() for e in list(batch["bar"])]) == [5.2, 7.4]
     assert sorted([e.as_py() for e in list(batch["baz"])]) == ["ball", "dog"]
+
+
+@pytest.fixture
+def simple_soma_data_frame(tmp_path):
+    """
+    A pytest fixture which creates a simple SOMADataFrame for use in tests below.
+    """
+    schema = pa.schema(
+        [
+            ("soma_rowid", pa.uint64()),
+            ("A", pa.int64()),
+            ("B", pa.float64()),
+            ("C", pa.string()),
+        ]
+    )
+    sdf = t.SOMADataFrame(uri=tmp_path.as_posix())
+
+    # TODO: see issue #324 - create will not accept 'soma_rowid' in the schema,
+    # even if the type of that field is correctly specified as a uint64.
+    sdf.create(schema=schema.remove(schema.get_field_index("soma_rowid")))
+
+    data = {
+        "soma_rowid": [0, 1, 2, 3],
+        "A": [10, 11, 12, 13],
+        "B": [100.1, 200.2, 300.3, 400.4],
+        "C": ["this", "is", "a", "test"],
+    }
+    n_data = len(data["soma_rowid"])
+    rb = pa.RecordBatch.from_pydict(data)
+    sdf.write(rb)
+    return (schema, sdf, n_data)
+
+
+@pytest.mark.parametrize(
+    "ids",
+    [
+        None,
+        [
+            0,
+        ],
+        [1, 3],
+    ],
+)
+@pytest.mark.parametrize(
+    "col_names",
+    [
+        ["A"],
+        ["B"],
+        ["A", "B"],
+        ["soma_rowid"],
+        ["soma_rowid", "A", "B", "C"],
+        None,
+    ],
+)
+def test_SOMADataFrame_read_column_names(simple_soma_data_frame, ids, col_names):
+    """
+    Issue #312 - `column_names` parameter not correctly handled.
+
+    While the bug report was only against SOMADataFrame.read,this
+    test covers all of the read* methods.
+    """
+
+    schema, sdf, n_data = simple_soma_data_frame
+    assert sdf.exists()
+
+    def _check_tbl(tbl, col_names, ids):
+        assert tbl.num_columns == (
+            len(schema.names) if col_names is None else len(col_names)
+        )
+        assert tbl.num_rows == (n_data if ids is None else len(ids))
+        assert tbl.schema == pa.schema(
+            [
+                schema.field(f)
+                for f in (col_names if col_names is not None else schema.names)
+            ]
+        )
+
+    _check_tbl(
+        pa.Table.from_batches(sdf.read(ids=ids, column_names=col_names)),
+        col_names,
+        ids,
+    )
+    _check_tbl(
+        pa.Table.from_batches([sdf.read_all(column_names=col_names)]),
+        col_names,
+        None,
+    )
+    _check_tbl(
+        pa.Table.from_pandas(
+            pd.concat(sdf.read_as_pandas(ids=ids, column_names=col_names))
+        ),
+        col_names,
+        ids,
+    )
+    _check_tbl(
+        pa.Table.from_pandas(sdf.read_as_pandas_all(column_names=col_names)),
+        col_names,
+        None,
+    )

--- a/apis/python/tests/test_soma_dataframe.py
+++ b/apis/python/tests/test_soma_dataframe.py
@@ -1,7 +1,6 @@
-import pytest
-
-import pyarrow as pa
 import pandas as pd
+import pyarrow as pa
+import pytest
 
 import tiledbsoma as t
 

--- a/apis/python/tests/test_soma_indexed_dataframe.py
+++ b/apis/python/tests/test_soma_indexed_dataframe.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pyarrow as pa
 import pytest
 

--- a/apis/python/tests/test_soma_indexed_dataframe.py
+++ b/apis/python/tests/test_soma_indexed_dataframe.py
@@ -1,4 +1,6 @@
+import pandas as pd
 import pyarrow as pa
+import pytest
 
 import tiledbsoma as t
 
@@ -35,9 +37,7 @@ def test_soma_indexed_dataframe(tmp_path):
     # * If you thought `for record in record_batch` would print records ... you would be wrong -- it
     #   loops over columns
     assert batch.num_rows == 5
-    # We should be getting back the soma_rowid column as well
-    assert batch.num_columns == 4
-    assert [e.as_py() for e in list(batch["soma_rowid"])] == [0, 1, 2, 3, 4]
+    assert batch.num_columns == 3
     assert [e.as_py() for e in list(batch["foo"])] == pydict["foo"]
     assert [e.as_py() for e in list(batch["bar"])] == pydict["bar"]
     assert [e.as_py() for e in list(batch["baz"])] == pydict["baz"]
@@ -51,9 +51,110 @@ def test_soma_indexed_dataframe(tmp_path):
     # * If you thought `for record in record_batch` would print records ... you would be wrong -- it
     #   loops over columns
     assert batch.num_rows == 2
-    # We should be getting back the soma_rowid column as well
-    assert batch.num_columns == 4
-    assert sorted([e.as_py() for e in list(batch["soma_rowid"])]) == [0, 2]
+    assert batch.num_columns == 3
     assert sorted([e.as_py() for e in list(batch["foo"])]) == [10, 30]
     assert sorted([e.as_py() for e in list(batch["bar"])]) == [4.1, 6.3]
     assert sorted([e.as_py() for e in list(batch["baz"])]) == ["apple", "cat"]
+
+
+@pytest.fixture
+def simple_soma_indexed_data_frame(tmp_path):
+    """
+    A pytest fixture which creates a simple SOMAIndexedDataFrame for use in tests below.
+    """
+    schema = pa.schema(
+        [
+            ("index", pa.uint64()),
+            ("A", pa.int64()),
+            ("B", pa.float64()),
+            ("C", pa.string()),
+        ]
+    )
+    index_column_names = ["index"]
+    sdf = t.SOMAIndexedDataFrame(uri=tmp_path.as_posix())
+    sdf.create(schema=schema, index_column_names=index_column_names)
+
+    data = {
+        "index": [0, 1, 2, 3],
+        "A": [10, 11, 12, 13],
+        "B": [100.1, 200.2, 300.3, 400.4],
+        "C": ["this", "is", "a", "test"],
+    }
+    n_data = len(data["index"])
+    rb = pa.RecordBatch.from_pydict(data)
+    sdf.write(rb)
+    return (schema, sdf, n_data, index_column_names)
+
+
+@pytest.mark.parametrize(
+    "ids",
+    [
+        None,
+        [
+            0,
+        ],
+        [1, 3],
+    ],
+)
+@pytest.mark.parametrize(
+    "col_names",
+    [
+        ["A"],
+        ["B"],
+        ["A", "B"],
+        ["index"],
+        ["index", "A", "B", "C"],
+        None,
+    ],
+)
+def test_SOMAIndexedDataFrame_read_column_names(
+    simple_soma_indexed_data_frame, ids, col_names
+):
+    schema, sdf, n_data, index_column_names = simple_soma_indexed_data_frame
+    assert sdf.exists()
+
+    print(schema)
+    print(sdf)
+    print(n_data)
+    print(index_column_names)
+    print(col_names)
+    print(ids)
+
+    def _check_tbl(tbl, col_names, ids):
+        print(tbl)
+        assert tbl.num_columns == (
+            len(schema.names) if col_names is None else len(col_names)
+        )
+        assert tbl.num_rows == (n_data if ids is None else len(ids))
+        assert tbl.schema == pa.schema(
+            [
+                schema.field(f)
+                for f in (col_names if col_names is not None else schema.names)
+            ]
+        )
+
+    _check_tbl(
+        pa.Table.from_batches(sdf.read(ids=ids, column_names=col_names)),
+        col_names,
+        ids,
+    )
+    _check_tbl(
+        pa.Table.from_batches([sdf.read_all(column_names=col_names)]),
+        col_names,
+        None,
+    )
+
+    # TODO: currently unimplemented. Enable tests when issue #329 is resolved.
+    #
+    # _check_tbl(
+    #     pa.Table.from_pandas(
+    #         pd.concat(sdf.read_as_pandas(ids=ids, column_names=col_names))
+    #     ),
+    #     col_names,
+    #     ids,
+    # )
+    # _check_tbl(
+    #     pa.Table.from_pandas(sdf.read_as_pandas_all(column_names=col_names)),
+    #     col_names,
+    #     None,
+    # )


### PR DESCRIPTION
Fixes #312 

Changes:
* add unit test exercising expected behavior for SOMADataFrame and SOMAIndexedDataFrame read ops
* add utility function to split column names into dims / attrs so that they may be correctly passed to the underlying tiledb.Array query
* remove the `soma_rowid` column suppression in SOMADataFrame.read_as_pandas*
* remove the `soma_rowid` attribute creation in SOMAIndexedDataframe create

*Note:* SOMAIndexedDataFrame read_as_pandas/read_as_pandas_all is unimplemented, and the corresponding tests are disabled until such time as the methods exist.
