### PR TITLE
Depend on TileDB-Py 0.17.4

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyarrow
     scanpy
     scipy
-    tiledb>=0.17.3
+    tiledb>=0.17.4
 python_requires = >3.7
 
 [options.extras_require]


### PR DESCRIPTION
For the `main` branch.