### PR TITLE
NdArray implementation work (create, props)

### DIFF
--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -131,7 +131,7 @@ def from_anndata(
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # MS
     measurement = SOMAMeasurement(
-        uri=f"{experiment.ms.get_uri()}/{measurement_name}", ctx=ctx
+        uri=f"{experiment.ms.uri}/{measurement_name}", ctx=ctx
     )
     measurement.create()
     experiment.ms.set(measurement)
@@ -150,12 +150,12 @@ def from_anndata(
 
     # TODO: more types to check?
     if isinstance(anndata.X, np.ndarray):
-        ddata = SOMADenseNdArray(uri=f"{measurement.X.get_uri()}/data", ctx=ctx)
+        ddata = SOMADenseNdArray(uri=f"{measurement.X.uri}/data", ctx=ctx)
         # Code here and in else-block duplicated for linter appeasement
         ddata.from_matrix(anndata.X)
         measurement.X.set(ddata)
     else:
-        sdata = SOMASparseNdArray(uri=f"{measurement.X.get_uri()}/data", ctx=ctx)
+        sdata = SOMASparseNdArray(uri=f"{measurement.X.uri}/data", ctx=ctx)
         sdata.from_matrix(anndata.X)
         measurement.X.set(sdata)
 
@@ -165,7 +165,7 @@ def from_anndata(
     if len(anndata.obsm.keys()) > 0:  # do not create an empty collection
         measurement.obsm.create()
         for key in anndata.obsm.keys():
-            arr = SOMADenseNdArray(uri=f"{measurement.obsm.get_uri()}/{key}", ctx=ctx)
+            arr = SOMADenseNdArray(uri=f"{measurement.obsm.uri}/{key}", ctx=ctx)
             arr.from_matrix(anndata.obsm[key])
             measurement.obsm.set(arr)
         measurement.set(measurement.obsm)
@@ -173,7 +173,7 @@ def from_anndata(
     if len(anndata.varm.keys()) > 0:  # do not create an empty collection
         measurement.varm.create()
         for key in anndata.varm.keys():
-            darr = SOMADenseNdArray(uri=f"{measurement.varm.get_uri()}/{key}", ctx=ctx)
+            darr = SOMADenseNdArray(uri=f"{measurement.varm.uri}/{key}", ctx=ctx)
             darr.from_matrix(anndata.varm[key])
             measurement.varm.set(darr)
         measurement.set(measurement.varm)
@@ -181,7 +181,7 @@ def from_anndata(
     if len(anndata.obsp.keys()) > 0:  # do not create an empty collection
         measurement.obsp.create()
         for key in anndata.obsp.keys():
-            sarr = SOMASparseNdArray(uri=f"{measurement.obsp.get_uri()}/{key}", ctx=ctx)
+            sarr = SOMASparseNdArray(uri=f"{measurement.obsp.uri}/{key}", ctx=ctx)
             sarr.from_matrix(anndata.obsp[key])
             measurement.obsp.set(sarr)
         measurement.set(measurement.obsp)
@@ -189,7 +189,7 @@ def from_anndata(
     if len(anndata.varp.keys()) > 0:  # do not create an empty collection
         measurement.varp.create()
         for key in anndata.varp.keys():
-            sarr = SOMASparseNdArray(uri=f"{measurement.varp.get_uri()}/{key}", ctx=ctx)
+            sarr = SOMASparseNdArray(uri=f"{measurement.varp.uri}/{key}", ctx=ctx)
             sarr.from_matrix(anndata.varp[key])
             measurement.varp.set(sarr)
         measurement.set(measurement.varp)
@@ -197,7 +197,7 @@ def from_anndata(
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # RAW
     if anndata.raw is not None:
-        raw_measurement = SOMAMeasurement(uri=f"{experiment.ms.get_uri()}/raw", ctx=ctx)
+        raw_measurement = SOMAMeasurement(uri=f"{experiment.ms.uri}/raw", ctx=ctx)
         raw_measurement.create()
         experiment.ms.set(raw_measurement)
 
@@ -209,7 +209,7 @@ def from_anndata(
         raw_measurement.X.create()
         raw_measurement.set(raw_measurement.X)
 
-        rawXdata = SOMASparseNdArray(uri=f"{raw_measurement.X.get_uri()}/data", ctx=ctx)
+        rawXdata = SOMASparseNdArray(uri=f"{raw_measurement.X.uri}/data", ctx=ctx)
         rawXdata.from_matrix(anndata.raw.X)
         raw_measurement.X.set(rawXdata)
 

--- a/apis/python/src/tiledbsoma/soma_collection.py
+++ b/apis/python/src/tiledbsoma/soma_collection.py
@@ -119,7 +119,7 @@ class SOMACollection(TileDBObject):
         Adds a member to the collection.
         """
         self._add_object(member, relative)
-        self._cached_members[member.get_name()] = member
+        self._cached_members[member.name] = member
 
     def delete(self, member_name: str) -> None:
         """
@@ -186,7 +186,7 @@ class SOMACollection(TileDBObject):
             key, lines = future.result()
             lines_per_key[key] = lines
 
-        lines = [f"{self.get_name()} {self.__class__.__name__}:"]
+        lines = [f"{self.name} {self.__class__.__name__}:"]
         for key in self.keys():
             for line in lines_per_key[key]:
                 lines.append("  " + line)
@@ -311,8 +311,8 @@ class SOMACollection(TileDBObject):
         if self._cached_member_names_to_uris is None:
             self._create_unless_exists()
 
-        child_uri = obj.get_uri()
-        child_name = obj.get_name()
+        child_uri = obj.uri
+        child_name = obj.name
         if relative is None:
             relative = self._tiledb_platform_config.member_uris_are_relative
         if relative is None:
@@ -332,7 +332,7 @@ class SOMACollection(TileDBObject):
         obj._uri = self._get_child_uri(child_name)
 
     def _remove_object(self, obj: TileDBObject) -> None:
-        self._remove_object_by_name(obj.get_name())
+        self._remove_object_by_name(obj.name)
 
     def _remove_object_by_name(self, member_name: str) -> None:
         self._cached_member_names_to_uris = None  # invalidate on remove-member

--- a/apis/python/src/tiledbsoma/soma_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_dense_nd_array.py
@@ -1,6 +1,6 @@
 import math
 import time
-from typing import Any, List, Optional, Sequence, Tuple, Union, Literal
+from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/apis/python/src/tiledbsoma/soma_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_dense_nd_array.py
@@ -229,7 +229,7 @@ class SOMADenseNdArray(TileDBArray):
                 # Make this opt-in only.  For large arrays, this df.set_index is time-consuming
                 # so we should not do it without direction.
                 if set_index:
-                    df.set_index(self.dim_names(), inplace=True)
+                    df.set_index(self._tiledb_dim_names(), inplace=True)
                 yield df
 
     def read_all(

--- a/apis/python/src/tiledbsoma/soma_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_dense_nd_array.py
@@ -372,6 +372,9 @@ class SOMADenseNdArray(TileDBArray):
 
         tiledb.Array.create(self.uri, sch, ctx=self._ctx)
 
+    def _ingest_data_whole(self, matrix: np.ndarray) -> None:
+        raise NotImplementedError()
+
     def _ingest_data_dense_rows_chunked(
         self,
         matrix: np.ndarray,

--- a/apis/python/src/tiledbsoma/soma_experiment.py
+++ b/apis/python/src/tiledbsoma/soma_experiment.py
@@ -79,6 +79,6 @@ class SOMAExperiment(SOMACollection):
         for element in self.ms:
             if not isinstance(element, SOMAMeasurement):
                 raise Exception(
-                    f"element {element.name} of {self.get_type()}.ms should be SOMAMeasurement; got {element.__class__.__name__}"
+                    f"element {element.name} of {self.type}.ms should be SOMAMeasurement; got {element.__class__.__name__}"
                 )
             element.constrain()

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, List, Optional, Sequence, TypeVar
+from typing import Any, Iterator, List, Literal, Optional, Sequence, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -146,27 +146,14 @@ class SOMAIndexedDataFrame(TileDBArray):
         if not self.exists():
             return ["Unpopulated"]
         lines = [
-            self.get_name()
+            self.name
             + " "
             + self.__class__.__name__
             # Pending https://github.com/single-cell-data/TileDB-SOMA/issues/302
             # + " "
-            # + str(self._get_shape())
+            # + str(self.shape)
         ]
         return lines
-
-    def __getattr__(self, name: str) -> Any:
-        """
-        Implements ``.shape``, etc. which are really method calls.
-        """
-        if name == "shape":
-            return self._get_shape()
-        elif name == "ndims":
-            return self._get_ndims()
-        else:
-            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
-            # resolvable. So raising here is the right thing to do.
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
 
     def keys(self) -> Sequence[str]:
         """
@@ -174,7 +161,8 @@ class SOMAIndexedDataFrame(TileDBArray):
         """
         return self._tiledb_attr_names()
 
-    def _get_shape(self) -> NTuple:
+    @property
+    def shape(self) -> NTuple:
         """
         Return length of each dimension, always a list of length ``ndims``.
         """
@@ -183,14 +171,16 @@ class SOMAIndexedDataFrame(TileDBArray):
                 self._shape = A.shape
         return self._shape
 
-    def _get_ndims(self) -> int:
+    @property
+    def ndims(self) -> int:
         """
         Return number of index columns.
         """
         return len(self.get_index_column_names())
 
-    def get_indexed(self) -> bool:
-        return False
+    @property
+    def is_indexed(self) -> Literal[True]:
+        return True
 
     def get_index_column_names(self) -> Sequence[str]:
         """

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -189,15 +189,14 @@ class SOMAIndexedDataFrame(TileDBArray):
         # If we've cached the answer, skip the storage read. Especially if the storage is on the
         # cloud, where we'll avoid an HTTP request.
         if self._index_column_names is None:
-            if self.is_indexed:
-                names = []
-                with self._tiledb_open() as A:
-                    dom = A.domain
-                    for i in range(dom.ndim):
-                        names.append(dom.dim(i).name)
-                self._index_column_names = names
-            else:
-                self._index_column_names = []
+            assert self.is_indexed
+            names = []
+            with self._tiledb_open() as A:
+                dom = A.domain
+                for i in range(dom.ndim):
+                    names.append(dom.dim(i).name)
+            self._index_column_names = names
+
         return self._index_column_names
 
     def read(

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -189,7 +189,7 @@ class SOMAIndexedDataFrame(TileDBArray):
         # If we've cached the answer, skip the storage read. Especially if the storage is on the
         # cloud, where we'll avoid an HTTP request.
         if self._index_column_names is None:
-            if self.get_is_indexed():
+            if self.is_indexed:
                 names = []
                 with self._tiledb_open() as A:
                     dom = A.domain

--- a/apis/python/src/tiledbsoma/soma_measurement.py
+++ b/apis/python/src/tiledbsoma/soma_measurement.py
@@ -106,7 +106,7 @@ class SOMAMeasurement(SOMACollection):
         #            # TODO: make this a SOMACollection method
         #            if not isinstance(element, SOMASparseNdArray):
         #                raise Exception(
-        #                    f"element {element.name} of {self.get_type()}.{attr} should be SOMASparseNdArray; got {element.__class__.__name__}"
+        #                    f"element {element.name} of {self.type}.{attr} should be SOMASparseNdArray; got {element.__class__.__name__}"
         #                )
 
         # for attr in ["obsm", "varm"]:
@@ -116,7 +116,7 @@ class SOMAMeasurement(SOMACollection):
         #            # TODO: make this a SOMACollection method
         #            if not isinstance(element, SOMADenseNdArray):
         #                raise Exception(
-        #                    f"element {element.name} of {self.get_type()}.{attr} should be SOMADenseNdArray; got {element.__class__.__name__}"
+        #                    f"element {element.name} of {self.type}.{attr} should be SOMADenseNdArray; got {element.__class__.__name__}"
         #                )
 
     # ``X`` collection values

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -1,6 +1,6 @@
 import math
 import time
-from typing import Any, Iterator, List, Optional, Sequence, Union, Literal
+from typing import Iterator, List, Literal, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -212,7 +212,7 @@ class SOMASparseNdArray(TileDBArray):
         """
         dim_names = None
         if set_index:
-            dim_names = self.dim_names()
+            dim_names = self._tiledb_dim_names()
 
         with self._tiledb_open() as A:
             query = A.query(return_incomplete=True)

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -1,6 +1,6 @@
 import math
 import time
-from typing import Any, Iterator, List, Optional, Sequence, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union, Literal
 
 import numpy as np
 import pandas as pd
@@ -52,6 +52,11 @@ class SOMASparseNdArray(TileDBArray):
         assert len(shape) > 0
         for e in shape:
             assert e >= 0
+
+        if not pa.types.is_primitive(type):
+            raise TypeError(
+                "Unsupported type - SOMADenseNdArray only supports primtive Arrow types"
+            )
 
         level = self._tiledb_platform_config.string_dim_zstd_level
 
@@ -111,29 +116,17 @@ class SOMASparseNdArray(TileDBArray):
 
     def _repr_aux(self) -> Sequence[str]:
         lines = [
-            self.get_name()
+            self.name
             + " "
             + self.__class__.__name__
             # Pending https://github.com/single-cell-data/TileDB-SOMA/issues/302
             # + " "
-            # + str(self._get_shape())
+            # + str(self.shape)
         ]
         return lines
 
-    def __getattr__(self, name: str) -> Any:
-        """
-        Implements ``.shape``, etc. which are really method calls.
-        """
-        if name == "shape":
-            return self._get_shape()
-        elif name == "ndims":
-            return self._get_ndims()
-        else:
-            # Unlike __getattribute__ this is _only_ called when the member isn't otherwise
-            # resolvable. So raising here is the right thing to do.
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{name}'")
-
-    def _get_shape(self) -> NTuple:
+    @property
+    def shape(self) -> NTuple:
         """
         Return length of each dimension, always a list of length ``ndims``
         """
@@ -142,13 +135,15 @@ class SOMASparseNdArray(TileDBArray):
                 self._shape = A.shape
         return self._shape
 
-    def _get_ndims(self) -> int:
+    @property
+    def ndims(self) -> int:
         """
         Return number of index columns
         """
         return len(self._get_shape())
 
-    def get_is_sparse(self) -> bool:
+    @property
+    def is_sparse(self) -> Literal[True]:
         """
         Returns ``True``.
         """
@@ -411,7 +406,7 @@ class SOMASparseNdArray(TileDBArray):
             ctx=self._ctx,
         )
 
-        tiledb.Array.create(self.get_uri(), sch, ctx=self._ctx)
+        tiledb.Array.create(self.uri, sch, ctx=self._ctx)
 
     # ----------------------------------------------------------------
     def _ingest_data_whole(
@@ -429,7 +424,7 @@ class SOMASparseNdArray(TileDBArray):
 
         mat_coo = sp.coo_matrix(matrix)
 
-        with tiledb.open(self.get_uri(), mode="w", ctx=self._ctx) as A:
+        with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
             A[mat_coo.row, mat_coo.col] = mat_coo.data
 
     # ----------------------------------------------------------------
@@ -450,7 +445,7 @@ class SOMASparseNdArray(TileDBArray):
         nrow = matrix.shape[0]
 
         eta_tracker = eta.Tracker()
-        with tiledb.open(self.get_uri(), mode="w", ctx=self._ctx) as A:
+        with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
 
             i = 0
             while i < nrow:
@@ -529,7 +524,7 @@ class SOMASparseNdArray(TileDBArray):
         ncol = matrix.shape[1]
 
         eta_tracker = eta.Tracker()
-        with tiledb.open(self.get_uri(), mode="w", ctx=self._ctx) as A:
+        with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
 
             j = 0
             while j < ncol:
@@ -611,7 +606,7 @@ class SOMASparseNdArray(TileDBArray):
         )
 
         eta_tracker = eta.Tracker()
-        with tiledb.open(self.get_uri(), mode="w", ctx=self._ctx) as A:
+        with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
 
             i = 0
             while i < nrow:

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -140,7 +140,7 @@ class SOMASparseNdArray(TileDBArray):
         """
         Return number of index columns
         """
-        return len(self._get_shape())
+        return len(self.shape)
 
     @property
     def is_sparse(self) -> Literal[True]:

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -27,11 +27,12 @@ class TileDBArray(TileDBObject):
         """
         super().__init__(uri, name=name, parent=parent, ctx=ctx)
 
-    def get_schema(self) -> pa.Schema:
+    @property
+    def schema(self) -> pa.Schema:
         """
         Return data schema, in the form of an Arrow Schema.
         """
-        return util_arrow.get_arrow_schema_from_tiledb_uri(self.get_uri(), self._ctx)
+        return util_arrow.get_arrow_schema_from_tiledb_uri(self.uri, self._ctx)
 
     # TODO
     #    def delete(uri: str) -> None

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -64,7 +64,8 @@ class TileDBArray(TileDBObject):
         Reads the dimension names from the schema: for example, ['obs_id', 'var_id'].
         """
         with self._tiledb_open() as A:
-            return [A.schema.domain.dim(i).name for i in range(A.schema.domain.ndim)]
+            dom = A.dom
+            return [dom.dim(i).name for i in range(dom.ndim)]
 
     def _tiledb_attr_names(self) -> Sequence[str]:
         """

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -69,13 +69,16 @@ class TileDBObject(ABC):
     def _repr_aux(self) -> Sequence[str]:
         raise Exception("Must be overridden by inherting classes.")
 
-    def get_name(self) -> str:
+    @property
+    def name(self) -> str:
         return self._name
 
-    def get_uri(self) -> str:
+    @property
+    def uri(self) -> str:
         return self._uri
 
-    def get_type(self) -> str:
+    @property
+    def type(self) -> str:
         return type(self).__name__
 
     def exists(self) -> bool:
@@ -92,7 +95,7 @@ class TileDBObject(ABC):
         # before a third, successful HTTP request for group-open.  Instead, we directly attempt the
         # group-open request, checking for an exception.
         try:
-            return self._get_object_type_from_metadata() == self.get_type()
+            return self._get_object_type_from_metadata() == self.type
         except tiledb.cc.TileDBError:
             return False
 
@@ -114,7 +117,7 @@ class TileDBObject(ABC):
         with self._tiledb_open("w") as obj:
             obj.meta.update(
                 {
-                    util.SOMA_OBJECT_TYPE_METADATA_KEY: self.get_type(),
+                    util.SOMA_OBJECT_TYPE_METADATA_KEY: self.type,
                     util.SOMA_ENCODING_VERSION_METADATA_KEY: util.SOMA_ENCODING_VERSION,
                 }
             )

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -13,4 +13,4 @@ Labels = Union[Sequence[str], pd.Index]
 
 Matrix = Union[np.ndarray, sp.csr_matrix, sp.csc_matrix]
 
-NTuple = Union[Tuple[int], Tuple[int, int]]
+NTuple = Tuple[int, ...]

--- a/apis/python/src/tiledbsoma/util_arrow.py
+++ b/apis/python/src/tiledbsoma/util_arrow.py
@@ -4,7 +4,6 @@ import numpy as np
 import pyarrow as pa
 import tiledb
 
-
 """
 Conversion to/from Arrow and TileDB type systems. Must be capable
 of representing full type semantics, and correctly performing a

--- a/apis/python/src/tiledbsoma/util_arrow.py
+++ b/apis/python/src/tiledbsoma/util_arrow.py
@@ -5,19 +5,83 @@ import pyarrow as pa
 import tiledb
 
 
+"""
+Conversion to/from Arrow and TileDB type systems. Must be capable
+of representing full type semantics, and correctly performing a
+round trip conversion (eg, T == to_arrow(to_tiledb(T)))
+
+Most primitive types are simple - eg, uint8. Of particular challenge
+are datetime/timestamps as TileDB has no distinction between a "datetime" and
+a "timedelta". The best Arrow match is TimestampType, as long as that
+TimestampType instance does NOT have a timezone set.
+
+Because of our round-trip requirement, all other Arrow temporal types
+are unsupported (even though they are just int64 under the covers).
+"""
+ARROW_TO_TDB = {
+    # Dict of types unsupported by to_pandas_dtype, which require overrides.
+    # If the value is an instance of Exception, it will be raised.
+    #
+    # IMPORTANT: ALL non-primitive types supported by TileDB must be in this table.
+    #
+    pa.string(): np.dtype(
+        "S"
+    ),  # XXX TODO: temporary work-around until UTF8 support is native. GH #338.
+    pa.binary(): np.dtype("S"),
+    pa.timestamp("s"): "datetime64[s]",
+    pa.timestamp("ms"): "datetime64[ms]",
+    pa.timestamp("us"): "datetime64[us]",
+    pa.timestamp("ns"): "datetime64[ns]",
+    #
+    # Unsupported types in TileDB type system
+    pa.float16(): TypeError("float16 - unsupported type (use float32)"),
+    pa.date32(): TypeError("32-bit date - unsupported type (use TimestampType)"),
+    pa.date64(): TypeError("64-bit date - unsupported type (use TimestampType)"),
+}
+
+
 def tiledb_type_from_arrow_type(t: pa.DataType) -> Union[type, np.dtype]:
     """
+    Given an Arrow type, return the corresponding TileDB type as a Numpy dtype.
     Building block for Arrow-to-TileDB schema translation.
+
+    If type is unsupported, with raise a TypeError exception.
+
+    Parameters
+    ----------
+    t : pyarrow.DataType
+        Arrow DataType instance, eg, pyarrow.int8()
+
+    Returns
+    -------
+    numpy.dtype
+        The numpy dtype corresponding to the ``t`` parameter. ``TypeError`` will
+        be raised for unsupported types.
     """
-    if t == pa.string():
-        # pyarrow's to_pandas_dtype maps pa.string() to dtype object which
-        # isn't acceptable to tiledb -- we must say str.
-        # XXX COMMENT return str
-        return np.dtype("S")
-    else:
-        # mypy says:
-        # Returning Any from function declared to return "type"  [no-any-return]
-        return t.to_pandas_dtype()
+    if t in ARROW_TO_TDB:
+        arrow_type = ARROW_TO_TDB[t]
+        if isinstance(arrow_type, Exception):
+            raise arrow_type
+        return np.dtype(arrow_type)
+
+    if not pa.types.is_primitive(t):
+        raise TypeError(f"Type {str(t)} - unsupported type")
+    if pa.types.is_timestamp(t):
+        raise TypeError("TimeStampType - unsupported type (timezone not supported)")
+    if pa.types.is_time32(t):
+        raise TypeError("Time64Type - unsupported type (use TimestampType)")
+    if pa.types.is_time64(t):
+        raise TypeError("Time32Type - unsupported type (use TimestampType)")
+    if pa.types.is_duration(t):
+        raise TypeError("DurationType - unsupported type (use TimestampType)")
+
+    # else lets try the default conversion path
+    try:
+        # Must force into a dtype to catch places where the Pandas type
+        # system has extra information that can't be expressed
+        return np.dtype(t.to_pandas_dtype())
+    except NotImplementedError as exc:
+        raise TypeError("Unsupported Arrow type") from exc
 
 
 def get_arrow_type_from_tiledb_dtype(tiledb_dtype: np.dtype) -> pa.DataType:
@@ -25,6 +89,7 @@ def get_arrow_type_from_tiledb_dtype(tiledb_dtype: np.dtype) -> pa.DataType:
     TODO: COMMENT
     """
     if tiledb_dtype.name == "bytes":
+        # XXX TODO: temporary work-around until UTF8 support is native. GH #338.
         return pa.string()
     else:
         return pa.from_numpy_dtype(tiledb_dtype)

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -1,3 +1,45 @@
+import pyarrow as pa
 from typeguard.importhook import install_import_hook
 
 install_import_hook("tiledbsoma")
+
+"""Types supported in a SOMA*NdArray """
+NDARRAY_ARROW_TYPES_SUPPORTED = [
+    pa.bool_(),
+    pa.int8(),
+    pa.int16(),
+    pa.int32(),
+    pa.int16(),
+    pa.uint8(),
+    pa.uint16(),
+    pa.uint32(),
+    pa.uint64(),
+    pa.float32(),
+    pa.float64(),
+    pa.timestamp("s"),
+    pa.timestamp("ms"),
+    pa.timestamp("us"),
+    pa.timestamp("ns"),
+]
+
+"""Primitive types NOT supported in a SOMA*NdArray """
+NDARRAY_ARROW_TYPES_NOT_SUPPORTED = [
+    pa.float16(),
+    pa.date32(),
+    pa.time32("s"),
+    pa.duration("s"),
+    pa.date64(),
+    pa.time64("us"),
+    pa.time64("ns"),
+    pa.binary(),
+    pa.binary(10),
+    pa.large_binary(),
+    pa.large_string(),
+    pa.decimal128(1),
+    pa.decimal128(38),
+    pa.list_(pa.int8()),
+    pa.large_list(pa.bool_()),
+    pa.map_(pa.string(), pa.int32()),
+    pa.struct([("f1", pa.int32()), ("f2", pa.string())]),
+    pa.dictionary(pa.int32(), pa.string()),
+]

--- a/apis/python/tests/test_soma_collection_basic.py
+++ b/apis/python/tests/test_soma_collection_basic.py
@@ -64,7 +64,7 @@ def test_soma_collection_basic(tmp_path):
     collection.set(sparse_nd_array)
 
     # ----------------------------------------------------------------
-    readback_collection = t.SOMACollection(collection.get_uri())
+    readback_collection = t.SOMACollection(collection.uri)
     assert len(readback_collection) == 2
 
     readback_dataframe = readback_collection.get("sdf")

--- a/apis/python/tests/test_soma_dense_nd_array.py
+++ b/apis/python/tests/test_soma_dense_nd_array.py
@@ -84,7 +84,7 @@ def test_soma_dense_nd_array_delete(tmp_path):
     assert not a.exists()
 
 
-# XXX obsolete - remove
+# TODO - remove when full test refactoring is complete
 def test_soma_dense_nd_array(tmp_path):
     nr = 10
     nc = 20

--- a/apis/python/tests/test_soma_dense_nd_array.py
+++ b/apis/python/tests/test_soma_dense_nd_array.py
@@ -9,6 +9,7 @@ import tiledbsoma as soma
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
 
 """
+comment will be removed when test rework is complete
 TODO:
 - [X] create
 - [-] delete

--- a/apis/python/tests/test_soma_dense_nd_array.py
+++ b/apis/python/tests/test_soma_dense_nd_array.py
@@ -1,19 +1,97 @@
+from typing import Tuple
+
 import numpy as np
 import pyarrow as pa
+import pytest
 
-import tiledbsoma
+import tiledbsoma as soma
+
+from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+
+
+"""
+TODO:
+- [X] create
+- [-] delete
+- [X] exists
+- [X] get type
+- [X] get shape
+- [X] get ndims
+- [X] get schema
+- [X] get is_sparse
+- [ ] get metadata
+- [ ] read
+- [ ] write
+- [ ] reshape
+"""
 
 
 def test_soma_dense_nd_array_ok_no_storage():
-    arr = tiledbsoma.SOMASparseNdArray(uri="/foo/bar")
-    assert arr.get_uri() == "/foo/bar"
-    assert arr.get_name() == "bar"
+    arr = soma.SOMADenseNdArray(uri="/foo/bar")
+    assert arr.uri == "/foo/bar"
+    assert arr.name == "bar"
+    assert not arr.exists()
+    assert arr.type == "SOMADenseNdArray"
 
 
+@pytest.mark.parametrize(
+    "shape", [(10,), (1, 100), (10, 1, 100), (2, 4, 6, 8), [1], (1, 2, 3, 4, 5)]
+)
+@pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
+def test_soma_dense_nd_array_create_ok(
+    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+):
+    """
+    Test all cases we expect "create" to succeed.
+    """
+    assert pa.types.is_primitive(element_type)  # sanity check incoming params
+
+    a = soma.SOMADenseNdArray(uri=tmp_path.as_posix())
+    a.create(element_type, shape)
+    assert a.type == "SOMADenseNdArray"
+    assert a.uri == tmp_path.as_posix()
+    assert a.ndims == len(shape)
+    assert a.shape == tuple(shape)
+    assert a.is_sparse is False
+    assert a.exists()
+
+    assert a.schema is not None
+    expected_field_names = ["data"] + [f"__dim_{d}" for d in range(len(shape))]
+    assert set(a.schema.names) == set(expected_field_names)
+    for d in range(len(shape)):
+        assert a.schema.field(f"__dim_{d}").type == pa.uint64()
+    assert a.schema.field("data").type == element_type
+
+
+@pytest.mark.parametrize("shape", [(10,)])
+@pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
+def test_soma_dense_nd_array_create_fail(
+    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+):
+    a = soma.SOMADenseNdArray(uri=tmp_path.as_posix())
+    with pytest.raises(TypeError):
+        a.create(element_type, shape)
+    assert not a.exists()
+
+
+# TODO: implement test when operation is implemented
+@pytest.mark.xfail(reason="Unimplemented operation")
+def test_soma_dense_nd_array_delete(tmp_path):
+    a = soma.SOMADenseNdArray(uri=tmp_path.as_posix())
+    a.create(pa.int8(), (100, 100))
+    assert a.exists()
+
+    a.delete()
+    assert not a.exists()
+
+
+
+
+""" XXX obsolete - remove """
 def test_soma_dense_nd_array(tmp_path):
     nr = 10
     nc = 20
-    a = tiledbsoma.SOMADenseNdArray(tmp_path.as_posix())
+    a = soma.SOMADenseNdArray(tmp_path.as_posix())
 
     a.create(pa.float64(), [nr, nc])
 

--- a/apis/python/tests/test_soma_dense_nd_array.py
+++ b/apis/python/tests/test_soma_dense_nd_array.py
@@ -8,7 +8,6 @@ import tiledbsoma as soma
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
 
-
 """
 TODO:
 - [X] create
@@ -85,9 +84,7 @@ def test_soma_dense_nd_array_delete(tmp_path):
     assert not a.exists()
 
 
-
-
-""" XXX obsolete - remove """
+# XXX obsolete - remove
 def test_soma_dense_nd_array(tmp_path):
     nr = 10
     nc = 20

--- a/apis/python/tests/test_soma_experiment_basic.py
+++ b/apis/python/tests/test_soma_experiment_basic.py
@@ -83,7 +83,7 @@ def test_soma_experiment_basic(tmp_path):
     experiment.ms.create()
     experiment.set(experiment.ms)
 
-    measurement = t.SOMAMeasurement(uri=f"{experiment.ms.get_uri()}/mRNA")
+    measurement = t.SOMAMeasurement(uri=f"{experiment.ms.uri}/mRNA")
     measurement.create()
     experiment.ms.set(measurement)
 
@@ -93,7 +93,7 @@ def test_soma_experiment_basic(tmp_path):
     measurement.X.create()
     measurement.set(measurement.X)
 
-    nda = t.SOMASparseNdArray(uri=f"{measurement.X.get_uri()}/data")
+    nda = t.SOMASparseNdArray(uri=f"{measurement.X.uri}/data")
     create_and_populate_sparse_nd_array(nda)
     measurement.X.set(nda)
 
@@ -135,8 +135,8 @@ def test_soma_experiment_basic(tmp_path):
     assert experiment.ms["mRNA"].X["data"].exists()
 
     # Paths exist but are not of the right type
-    assert not t.SOMADataFrame(experiment.get_uri()).exists()
-    assert not t.SOMACollection(experiment.obs.get_uri()).exists()
+    assert not t.SOMADataFrame(experiment.uri).exists()
+    assert not t.SOMACollection(experiment.obs.uri).exists()
 
     # Paths do not exist
     assert not t.SOMAExperiment("/nonesuch/no/nope/nope/never").exists()

--- a/apis/python/tests/test_soma_sparse_nd_array.py
+++ b/apis/python/tests/test_soma_sparse_nd_array.py
@@ -1,19 +1,92 @@
-# import pytest
+from typing import Tuple
 
 import numpy as np
 import pyarrow as pa
+import pytest
 
-import tiledbsoma
+import tiledbsoma as soma
+
+from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+
+"""
+TODO:
+- [X] create
+- [-] delete
+- [X] exists
+- [-] get metadata
+- [X] get type
+- [X] get shape
+- [X] get ndims
+- [X] get schema
+- [X] get is_sparse
+- [ ] read
+- [ ] write
+- [ ] reshape
+"""
 
 
 def test_soma_sparse_nd_array_ok_no_storage():
-    arr = tiledbsoma.SOMASparseNdArray(uri="/foo/bar")
-    assert arr.get_uri() == "/foo/bar"
-    assert arr.get_name() == "bar"
+    arr = soma.SOMASparseNdArray(uri="/foo/bar")
+    assert arr.uri == "/foo/bar"
+    assert arr.name == "bar"
+    assert not arr.exists()
+    assert arr.type == "SOMASparseNdArray"
 
 
+@pytest.mark.parametrize(
+    "shape", [(10,), (1, 100), (10, 1, 100), (2, 4, 6, 8), [1], (1, 2, 3, 4, 5)]
+)
+@pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
+def test_soma_sparse_nd_array_create_ok(
+    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+):
+    """
+    Test all cases we expect "create" to succeed.
+    """
+    assert pa.types.is_primitive(element_type)  # sanity check incoming params
+
+    a = soma.SOMASparseNdArray(uri=tmp_path.as_posix())
+    a.create(element_type, shape)
+    assert a.type == "SOMASparseNdArray"
+    assert a.uri == tmp_path.as_posix()
+    assert a.ndims == len(shape)
+    assert a.shape == tuple(shape)
+    assert a.is_sparse is True
+    assert a.exists()
+
+    assert a.schema is not None
+    expected_field_names = ["data"] + [f"__dim_{d}" for d in range(len(shape))]
+    assert set(a.schema.names) == set(expected_field_names)
+    for d in range(len(shape)):
+        assert a.schema.field(f"__dim_{d}").type == pa.uint64()
+    assert a.schema.field("data").type == element_type
+
+
+@pytest.mark.parametrize("shape", [(10,)])
+@pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
+def test_soma_sparse_nd_array_create_fail(
+    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+):
+    a = soma.SOMASparseNdArray(uri=tmp_path.as_posix())
+    with pytest.raises(TypeError):
+        a.create(element_type, shape)
+    assert not a.exists()
+
+
+# TODO: implement test when operation is implemented
+@pytest.mark.xfail(reason="Unimplemented operation")
+def test_soma_sparse_nd_array_delete(tmp_path):
+    a = soma.SOMASparseNdArray(uri=tmp_path.as_posix())
+    a.create(pa.int8(), (100, 100))
+    assert a.exists()
+
+    a.delete()
+    assert not a.exists()
+
+
+# TODO XXX - obsolete cleanup
 def test_soma_sparse_nd_array(tmp_path):
-    arr = tiledbsoma.SOMASparseNdArray(uri=tmp_path.as_posix())
+    arr = soma.SOMASparseNdArray(uri=tmp_path.as_posix())
 
     nr = 10
     nc = 20

--- a/apis/python/tests/test_soma_sparse_nd_array.py
+++ b/apis/python/tests/test_soma_sparse_nd_array.py
@@ -9,6 +9,7 @@ import tiledbsoma as soma
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
 
 """
+comment will be removed when test rework is complete
 TODO:
 - [X] create
 - [-] delete

--- a/apis/python/tests/test_soma_sparse_nd_array.py
+++ b/apis/python/tests/test_soma_sparse_nd_array.py
@@ -13,12 +13,12 @@ TODO:
 - [X] create
 - [-] delete
 - [X] exists
-- [-] get metadata
 - [X] get type
 - [X] get shape
 - [X] get ndims
 - [X] get schema
 - [X] get is_sparse
+- [ ] get metadata
 - [ ] read
 - [ ] write
 - [ ] reshape
@@ -84,7 +84,7 @@ def test_soma_sparse_nd_array_delete(tmp_path):
     assert not a.exists()
 
 
-# TODO XXX - obsolete cleanup
+# TODO - cleanup when test refactoring is complete
 def test_soma_sparse_nd_array(tmp_path):
     arr = soma.SOMASparseNdArray(uri=tmp_path.as_posix())
 

--- a/apis/python/tests/test_soma_sparse_nd_array.py
+++ b/apis/python/tests/test_soma_sparse_nd_array.py
@@ -20,6 +20,7 @@ TODO:
 - [X] get schema
 - [X] get is_sparse
 - [ ] get metadata
+- [ ] get nnz
 - [ ] read
 - [ ] write
 - [ ] reshape

--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -62,7 +62,7 @@ UNSUPPORTED_ARROW_TYPES = [
 def test_supported_types_supported(arrow_type):
     """Verify round-trip conversion of types"""
     if pa.types.is_binary(arrow_type):
-        pytest.xfail("Awaiting UTF-8 support - issue #338")
+        pytest.xfail("Awaiting UTF-8 support - see issue #338")
 
     tdb_dtype = tiledb_type_from_arrow_type(arrow_type)
     assert isinstance(tdb_dtype, np.dtype)

--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -3,10 +3,9 @@ import pyarrow as pa
 import pytest
 
 from tiledbsoma.util_arrow import (
-    tiledb_type_from_arrow_type,
     get_arrow_type_from_tiledb_dtype,
+    tiledb_type_from_arrow_type,
 )
-
 
 """Arrow types we expect to work"""
 SUPPORTED_ARROW_TYPES = [

--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from tiledbsoma.util_arrow import (
+    tiledb_type_from_arrow_type,
+    get_arrow_type_from_tiledb_dtype,
+)
+
+
+"""Arrow types we expect to work"""
+SUPPORTED_ARROW_TYPES = [
+    pa.bool_(),
+    pa.int8(),
+    pa.int16(),
+    pa.int32(),
+    pa.int16(),
+    pa.uint8(),
+    pa.uint16(),
+    pa.uint32(),
+    pa.uint64(),
+    pa.float32(),
+    pa.float64(),
+    pa.timestamp("s"),
+    pa.timestamp("ms"),
+    pa.timestamp("us"),
+    pa.timestamp("ns"),
+    pa.string(),
+    pa.binary(),
+]
+
+
+"""Arrow types we expect to fail"""
+UNSUPPORTED_ARROW_TYPES = [
+    pa.null(),
+    pa.date64(),
+    pa.time64("us"),
+    pa.time64("ns"),
+    pa.float16(),
+    pa.date32(),
+    pa.time32("s"),
+    pa.time32("ms"),
+    pa.duration("s"),
+    pa.duration("ms"),
+    pa.duration("us"),
+    pa.duration("ns"),
+    pa.month_day_nano_interval(),
+    pa.binary(),
+    pa.binary(10),
+    pa.large_binary(),
+    pa.large_string(),
+    pa.decimal128(1),
+    pa.decimal128(38),
+    pa.list_(pa.int8()),
+    pa.large_list(pa.bool_()),
+    pa.map_(pa.string(), pa.int32()),
+    pa.struct([("f1", pa.int32()), ("f2", pa.string())]),
+    pa.dictionary(pa.int32(), pa.string()),
+]
+
+
+@pytest.mark.parametrize("arrow_type", SUPPORTED_ARROW_TYPES)
+def test_supported_types_supported(arrow_type):
+    """Verify round-trip conversion of types"""
+    if pa.types.is_binary(arrow_type):
+        pytest.xfail("Awaiting UTF-8 support - issue #338")
+
+    tdb_dtype = tiledb_type_from_arrow_type(arrow_type)
+    assert isinstance(tdb_dtype, np.dtype)
+    rt_arrow_type = get_arrow_type_from_tiledb_dtype(tdb_dtype)
+    assert isinstance(rt_arrow_type, pa.DataType)
+    assert arrow_type == rt_arrow_type
+
+
+@pytest.mark.parametrize("arrow_type", UNSUPPORTED_ARROW_TYPES)
+def test_supported_types_unsupported(arrow_type):
+    """Verify correct error for unsupported types"""
+    with pytest.raises(TypeError):
+        tiledb_type_from_arrow_type(arrow_type, match=r".*unsupported type.*")

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -253,7 +253,7 @@ def ingest_one(
 
         tiledbsoma.logging.logger.info("")
         tiledbsoma.logging.logger.info(
-            f"Added SOMAExperiment {exp.get_name()} to SOMACollection {soco_dir}"
+            f"Added SOMAExperiment {exp.name} to SOMACollection {soco_dir}"
         )
 
 


### PR DESCRIPTION
First of several PRs to update NdArray to match the spec. Breaking into smaller PRs for easier review.

This PR focuses on create/schema issues and the mapping between Arrow and TileDB type systems. It also cleans up the property API (eg, `shape`) to be more pythonic and fix issues preventing static code analysis by mypy.

Fixes #337
Partial fix for #330 (more work to be done)

Changes:
* Revised utility `get_arrow_type_from_tiledb_dtype` to correctly handle Arrow types which can be expressed in TileDB, but which were not correctly being handled by the previous implementation.
* Added test case for the type system conversion (anndata->tiledb and tiledb->anndata)
* Various properties (shape, ndim, etc) were implemented with a specialized __getattr__ method, rather than the more Python use of `@property`.  This was modified to use @property, which allows for correct typing, docstrings, etc. This has the added benefit of not hiding errors from static analyzers (like mypy).
* Fixed many cases of lint found once mypy could peform static analysis (due to removal of __getattr__ in most classes)

**Still WIP:**
* Remainder of SOMA*NdArray implementation refinement and corresponding test cases