### PR TITLE
Suppress C++ build for old branch

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -130,10 +130,4 @@ if __name__ == "__main__":
             "tiledb>=0.17.0",
         ],
         python_requires=">=3.7",
-        ext_modules=get_ext_modules(),
-        cmdclass={
-            "build_ext": BuildExtCmd,
-            "bdist_egg": BdistEggCmd,
-            "bdist_wheel": BdistWheelCmd,
-        },
     )


### PR DESCRIPTION
The `main` branch has C++ working well with `pip install`.

On the `main-old` branch though this does not succeed. This in turn is one reason we have a doc-build fail at https://readthedocs.com/projects/tiledb-inc-tiledb-soma/builds/.