### PR TITLE
No readthedocs build on main for now

### DIFF
--- a/.readthedocs.yml.pending
+++ b/.readthedocs.yml.pending
@@ -1,3 +1,8 @@
+# ================================================================
+# The main branch is not published to readthedocs at present.
+# We only publish from main-old for now (2022-09-26).
+# ================================================================
+
 # Note: builds at
 # https://readthedocs.com/projects/tiledb-inc-tiledb-soma/builds/
 # (permissioned)


### PR DESCRIPTION
Currently readthedocs should publish from `main-old` (there will be a separate PR on that branch for fixups).