### PR TITLE
Replace array->timestamp() with array->open_timestamp_end()

### DIFF
--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -77,7 +77,7 @@ SOMAReader::SOMAReader(
         LOG_DEBUG(fmt::format("[SOMAReader] opening array '{}'", uri_));
         auto array = std::make_shared<Array>(*ctx_, uri_, TILEDB_READ);
         mq_ = std::make_unique<ManagedQuery>(array, name);
-        LOG_DEBUG(fmt::format("timestamp = {}", array->timestamp()));
+        LOG_DEBUG(fmt::format("timestamp = {}", array->open_timestamp_end()));
     } catch (const std::exception& e) {
         throw TileDBSOMAError(
             fmt::format("Error opening array: {}\n  {}", uri_, e.what()));


### PR DESCRIPTION
The `timestamp()` accessor is deprecated, replacing it with `open_timestamp_end()` is recommended in the header.