### PR TITLE
Fix MacOS build with local TileDB core

### DIFF
--- a/libtiledbsoma/src/pyapi/CMakeLists.txt
+++ b/libtiledbsoma/src/pyapi/CMakeLists.txt
@@ -24,7 +24,9 @@ target_include_directories(libtiledbsoma
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
     ${TILEDB_SOMA_EXPORT_HEADER_DIR}
+    $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
 if(DEFINED ENV{LIBTILEDBSOMA_DEBUG_BUILD})
   message(STATUS "END libtiledbsoma/src/pyapi/CMakeLists.txt")
   message(STATUS "")


### PR DESCRIPTION
Up until now:

* On Linux, without core in `/usr/local`, builds fine
* On Mac, without core in `/usr/local`, builds fine
* On Linux, with core in `/usr/local`, builds fine
* On Mac, with core in `/usr/local`, build fails with
```
/Users/johnkerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/pyapi/../../include/tiledbsoma/logger_public.h:41:10: fatal error: 'spdlog/spdlog.h' file not found
#include <spdlog/spdlog.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
```

This is a crucial ability for any developers on MacOS (which is several of us).

Fixed after long debug with the incomparable @ihnorton :D 