### PR TITLE
add error check for zero length dimensions in ndarray

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_dense_nd_array.py
@@ -51,10 +51,11 @@ class SOMADenseNdArray(TileDBArray):
         :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the uint64 range.
         """
 
-        # checks on shape
-        assert len(shape) > 0
-        for e in shape:
-            assert e > 0
+        # check on shape
+        if len(shape) == 0 or any(e <= 0 for e in shape):
+            raise ValueError(
+                "DenseNdArray shape must be non-zero length tuple of ints > 0"
+            )
 
         if not pa.types.is_primitive(type):
             raise TypeError(

--- a/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/soma_sparse_nd_array.py
@@ -48,10 +48,11 @@ class SOMASparseNdArray(TileDBArray):
         :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the uint64 range.
         """
 
-        # checks on shape
-        assert len(shape) > 0
-        for e in shape:
-            assert e >= 0
+        # check on shape
+        if len(shape) == 0 or any(e <= 0 for e in shape):
+            raise ValueError(
+                "DenseNdArray shape must be non-zero length tuple of ints > 0"
+            )
 
         if not pa.types.is_primitive(type):
             raise TypeError(
@@ -62,15 +63,10 @@ class SOMASparseNdArray(TileDBArray):
 
         dims = []
         for e in shape:
-            upper = e - 1
-            tile = min(e, 2048)  # TODO: parameterize
-            if e == 0:
-                upper = 1
-                tile = 1
             dim = tiledb.Dim(
                 # Use tiledb default names like ``__dim_0``
-                domain=(0, upper),
-                tile=tile,
+                domain=(0, e - 1),
+                tile=min(e, 2048),  # TODO: PARAMETERIZE,
                 dtype=np.uint64,
                 filters=[tiledb.ZstdFilter(level=level)],
             )

--- a/apis/python/tests/test_soma_dense_nd_array.py
+++ b/apis/python/tests/test_soma_dense_nd_array.py
@@ -116,3 +116,11 @@ def test_soma_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...])
     data[(0,) * len(shape)] = 0.0
     t = b.read_tensor((slice(None),) * ndim)
     assert t.equals(pa.Tensor.from_numpy(data))
+
+
+@pytest.mark.parametrize("shape", [(), (0,), (10, 0), (0, 10), (1, 2, 0)])
+def test_zero_length_fail(tmp_path, shape):
+    """Zero length dimensions are expected to fail"""
+    a = soma.SOMADenseNdArray(tmp_path.as_posix())
+    with pytest.raises(ValueError):
+        a.create(type=pa.float32(), shape=shape)

--- a/apis/python/tests/test_soma_sparse_nd_array.py
+++ b/apis/python/tests/test_soma_sparse_nd_array.py
@@ -316,3 +316,11 @@ def test_soma_sparse_nd_array_read_as_pandas(
     assert df.sort_values(by=dim_names, ignore_index=True).equals(
         data.to_pandas().sort_values(by=dim_names, ignore_index=True)
     )
+
+
+@pytest.mark.parametrize("shape", [(), (0,), (10, 0), (0, 10), (1, 2, 0)])
+def test_zero_length_fail(tmp_path, shape):
+    """Zero length dimensions are expected to fail"""
+    a = soma.SOMASparseNdArray(tmp_path.as_posix())
+    with pytest.raises(ValueError):
+        a.create(type=pa.float32(), shape=shape)


### PR DESCRIPTION
Fixes #297 

TileDB does not support zero-length domains for a dimension.  Add error check and raise a meaningful exception.
