### PR TITLE
SOMACollection: fix loose check in create logic

### DIFF
--- a/apis/python/src/tiledbsoma/soma_collection.py
+++ b/apis/python/src/tiledbsoma/soma_collection.py
@@ -89,7 +89,7 @@ class SOMACollectionBase(TileDBObject, MutableMapping[str, CollectionElementType
                 self,
                 ctx=self._ctx,
             )
-            if member:
+            if member is not None:
                 self._cached_members[member_name] = member
 
         if member_name in self._cached_members:


### PR DESCRIPTION
The SOMACollection __getitem__ will raise a KeyError incorrectly whencreating any object that is specialized from SOMACollection (eg, SOMAExperiment).

This is due to a bug in the __getitem__ logic checking for create failures in _construct_factory.  It checked for a falsey value, rather than check explicitly for None.  Any SOMACollection or SOMACollection subclass will now tests falsey if it is empty, as it obeys the Colleciton ABC API (empty collections are falsey)