### PR TITLE
Fix scripts/test for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, macos-11, windows-2019]
         python-version: ['3.8']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
-          - runs-on: macos-12
+          - runs-on: macos-11
             cc: gcc-11
             cxx: g++-11
 

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-11]
         python-version: ['3.8']
         include:
           - runs-on: ubuntu-22.04

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_compile_definitions(TILEDBSOMA_SOURCE_ROOT="${TILEDBSOMA_SOURCE_ROOT}")
 ############################################################
 
 find_package(TileDB_EP REQUIRED)
+find_package(Spdlog_EP REQUIRED)
 
 ############################################################
 # SC unit test
@@ -41,6 +42,7 @@ if (TILEDBSOMA_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src
         ${CMAKE_CURRENT_SOURCE_DIR}/../include
         ${pybind11_INCLUDE_DIRS}
+        $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
     )
 
     target_compile_definitions(unit_sc PRIVATE CATCH_CONFIG_MAIN)


### PR DESCRIPTION
Follow-on from #354 

For MacOS with TileDB in `/usr/local`,  #354 makes `pip install -e apis/python` succeed.

This PR makes `./scripts/test` succeed.