### PR TITLE
Work around recent Mac GHA issue

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -17,7 +17,9 @@ jobs:
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
-          - runs-on: macos-12
+          # Pending https://github.com/actions/runner-images/issues/6350
+          # - runs-on: macos-12
+          - runs-on: macos-11
             cc: gcc-11
             cxx: g++-11
 


### PR DESCRIPTION
As detailed at
https://github.com/actions/runner-images/issues/6350

There don't appear (in my googling so far anyway) to be good options besides 'downgrade' :disappointed: so this is my best attempt at present