### PR TITLE
Fix for SOMAIndexedDataFrames with float dims

### DIFF
--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -88,8 +88,14 @@ class SOMAIndexedDataFrame(TileDBArray):
             lo = None
             hi = None
             if dtype != str:
-                lo = np.iinfo(dtype).min
-                hi = np.iinfo(dtype).max - 1
+                if np.issubdtype(dtype, np.integer):
+                    lo = np.iinfo(dtype).min
+                    hi = np.iinfo(dtype).max - 1
+                elif np.issubdtype(dtype, np.floating):
+                    lo = np.finfo(dtype).min
+                    hi = np.finfo(dtype).max
+                else:
+                    raise TypeError(f"Unsupported dtype {dtype}")
             dim = tiledb.Dim(
                 name=index_column_name,
                 domain=(lo, hi),

--- a/apis/python/tests/test_soma_indexed_dataframe.py
+++ b/apis/python/tests/test_soma_indexed_dataframe.py
@@ -3,15 +3,20 @@ import pytest
 
 import tiledbsoma as t
 
+
 @pytest.fixture
 def arrow_schema():
     def _schema():
-        return pa.schema([
-            pa.field("foo", pa.int64()),
-            pa.field("bar", pa.float64()),
-            pa.field("baz", pa.string())
-        ])
+        return pa.schema(
+            [
+                pa.field("foo", pa.int64()),
+                pa.field("bar", pa.float64()),
+                pa.field("baz", pa.string()),
+            ]
+        )
+
     return _schema
+
 
 def test_soma_indexed_dataframe(tmp_path, arrow_schema):
     sdf = t.SOMAIndexedDataFrame(uri=tmp_path.as_posix())
@@ -49,11 +54,13 @@ def test_soma_indexed_dataframe(tmp_path, arrow_schema):
     assert sorted([e.as_py() for e in list(table["bar"])]) == [4.1, 6.3]
     assert sorted([e.as_py() for e in list(table["baz"])]) == ["apple", "cat"]
 
+
 def test_soma_indexed_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = t.SOMAIndexedDataFrame(uri=tmp_path.as_posix())
     asch = arrow_schema()
     sdf.create(schema=asch, index_column_names=["bar"])
     assert sdf.get_index_column_names() == ["bar"]
+
 
 @pytest.fixture
 def simple_soma_indexed_data_frame(tmp_path):

--- a/apis/python/tests/test_soma_indexed_dataframe.py
+++ b/apis/python/tests/test_soma_indexed_dataframe.py
@@ -3,19 +3,21 @@ import pytest
 
 import tiledbsoma as t
 
+@pytest.fixture
+def arrow_schema():
+    def _schema():
+        return pa.schema([
+            pa.field("foo", pa.int64()),
+            pa.field("bar", pa.float64()),
+            pa.field("baz", pa.string())
+        ])
+    return _schema
 
-def test_soma_indexed_dataframe(tmp_path):
+def test_soma_indexed_dataframe(tmp_path, arrow_schema):
     sdf = t.SOMAIndexedDataFrame(uri=tmp_path.as_posix())
 
-    asch = pa.schema(
-        [
-            ("foo", pa.int32()),
-            ("bar", pa.float64()),
-            ("baz", pa.string()),
-        ]
-    )
-
     # Create
+    asch = arrow_schema()
     sdf.create(schema=asch, index_column_names=["foo"])
 
     # Write
@@ -47,6 +49,11 @@ def test_soma_indexed_dataframe(tmp_path):
     assert sorted([e.as_py() for e in list(table["bar"])]) == [4.1, 6.3]
     assert sorted([e.as_py() for e in list(table["baz"])]) == ["apple", "cat"]
 
+def test_soma_indexed_dataframe_with_float_dim(tmp_path, arrow_schema):
+    sdf = t.SOMAIndexedDataFrame(uri=tmp_path.as_posix())
+    asch = arrow_schema()
+    sdf.create(schema=asch, index_column_names=["bar"])
+    assert sdf.get_index_column_names() == ["bar"]
 
 @pytest.fixture
 def simple_soma_indexed_data_frame(tmp_path):


### PR DESCRIPTION
Previously `numpy.iinfo` was used to retrieve the range of all non-string dtypes when constructing a `SOMAIndexedDataFrame`. Now `numpy.iinfo` is only used for integer dtypes and `numpy.finfo` is used for floating point dtypes. 
