### PR TITLE
[r] Support build against external artifact and system library

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -48,6 +48,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Suggests:
     rmarkdown,
+    jsonlite,
     knitr,
     withr,
     testthat (>= 3.0.0)

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -48,7 +48,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Suggests:
     rmarkdown,
-    jsonlite,
     knitr,
     withr,
     testthat (>= 3.0.0)

--- a/apis/r/cleanup
+++ b/apis/r/cleanup
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-rm -f  src/*.o src/*.so src/*.dylib */*~ *~
+rm -r -f \
+   src/*.o src/*.so src/*.dylib */*~ *~ \
+   src/Makevars \
+   tiledb.tar.gz \
+   tiledb/ \
+   inst/tiledb/

--- a/apis/r/configure
+++ b/apis/r/configure
@@ -1,20 +1,48 @@
 #!/bin/sh
 
+## for single-cell-data/apis/r repo, consider completing sources
 if test -d inst/include/tiledbsoma && test -f src/soma_reader.cc; then
-   echo "** Seeing files present, nothing to configure, exiting."
-   exit 0
+    echo "** Source files present, no adjustments needed."
+else
+
+    if ! test -d ../../libtiledbsoma; then
+        echo "** Not all source files present but no repo layout. Hm. Exiting."
+        exit 1
+    fi
+
+    if ! test -d inst/include/tiledbsoma; then
+        mkdir -p inst/include/tiledbsoma
+        echo "** copying C++ header files"
+        cp -vax ../../libtiledbsoma/include/tiledbsoma/* inst/include/tiledbsoma/
+        echo "** copying C++ source and header files"
+        cp -vax ../../libtiledbsoma/src/* src/
+    fi
 fi
 
-if ! test -d ../../libtiledbsoma; then
-   echo "** Not all source files present but not repo layout. Hm. Exiting."
-   exit 1
-fi   
+## look for tiledb core library and either use system library or download build
+have_tiledb="false"
 
-if ! test -d inst/include/tiledbsoma; then
-   mkdir -p inst/include/tiledbsoma
-   echo "** copying C++ header files"
-   cp -vax ../../libtiledbsoma/include/tiledbsoma/* inst/include/tiledbsoma/
-   echo "** copying C++ source and header files"
-   cp -vax ../../libtiledbsoma/src/* src/
+## check for pkg-config and use it to inquire about tiledb build options
+pkg-config --version >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+    pkg-config --exists tiledb
+    if [ $? -eq 0 ]; then
+        pkgcflags=`pkg-config --cflags tiledb`
+        pkglibs=`pkg-config --libs tiledb`
+        archincl=`${R_HOME}/bin/Rscript -e 'cat("-I", system.file("include", package="arch"), sep="")'`
+
+        ## substitute them in (leaving @tiledb_rpath@ and @cxx20_macos@ alone for now)
+        sed -e "s|@tiledb_include@|$pkgcflags $archincl|" \
+            -e "s|@tiledb_libs@|$pkglibs|" \
+            -e "s|@tiledb_rpath@||" \
+            -e "s|@cxx20_macos@||" \
+            src/Makevars.in > src/Makevars
+
+        have_tiledb="true"
+        echo "*** updated src/Makevars for system library via pkg-config"
+    fi
 fi
 
+if [ x"${have_tiledb}" = x"false" ]; then
+    ${R_HOME}/bin/Rscript tools/get_tarball.R
+fi

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -1,0 +1,15 @@
+CXX_STD = CXX20
+
+## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 10.14 for macOS
+PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ -DR_BUILD @cxx20_macos@
+
+## We also need the TileDB library
+PKG_LIBS = @cxx20_macos@ @tiledb_libs@ @tiledb_rpath@
+
+all: $(SHLIB)
+        # if we are
+        #  - not on Window NT (a tip from data.table)
+        #  - on macOS aka Darwin which needs this
+        #  - the library is present (implying non-system library use)
+        # then let us call install_name_tool
+	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ] && [ -f ../inst/tiledb/lib/libtiledb.dylib ] && [ -f tiledb.so ]; then install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; fi

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -12,4 +12,4 @@ all: $(SHLIB)
         #  - on macOS aka Darwin which needs this
         #  - the library is present (implying non-system library use)
         # then let us call install_name_tool
-	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ] && [ -f ../inst/tiledb/lib/libtiledb.dylib ] && [ -f tiledb.so ]; then install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; fi
+	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ] && [ -f ../inst/tiledb/lib/libtiledb.dylib ] && [ -f tiledbsoma.so ]; then install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; install_name_tool -add_rpath @loader_path/../tiledb/lib tiledbsoma.so; fi

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -1,8 +1,5 @@
 #!/usr/bin/env Rscript
 
-res <- jsonlite::fromJSON("https://api.github.com/repos/tiledb-inc/tiledb/releases/latest")
-cat("Seeing", res$name, "\n")
-
 ## todo: chipset for macOS to detect arm
 isX86 <- Sys.info()["machine"] == "x86_64"
 isMac <- Sys.info()['sysname'] == "Darwin"
@@ -11,14 +8,13 @@ macosver <- ""
 
 if (isMac) {
     if (isX86) {
-        url <- res$assets$browser_download_url[grepl("macos-x86", res$assets$browser_download_url)]
+        url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-macos-x86_64-2.11.1-15a1161.tar.gz"
         macosver <- "-mmacosx-version-min=10.14"
     } else {
-        url <- res$assets$browser_download_url[grepl("macos-arm64", res$assets$browser_download_url)]
+        url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-macos-arm64-2.11.1-15a1161.tar.gz"
     }
 } else if (isLinux) {
-    ## use [1] as [2] is the noavx2 one
-    url <- res$assets$browser_download_url[grepl("linux", res$assets$browser_download_url)][1]
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-linux-x86_64-2.11.1-15a1161.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -1,0 +1,37 @@
+#!/usr/bin/env Rscript
+
+res <- jsonlite::fromJSON("https://api.github.com/repos/tiledb-inc/tiledb/releases/latest")
+cat("Seeing", res$name, "\n")
+
+## todo: chipset for macOS to detect arm
+isX86 <- Sys.info()["machine"] == "x86_64"
+isMac <- Sys.info()['sysname'] == "Darwin"
+isLinux <- Sys.info()[["sysname"]] == "Linux"
+macosver <- ""
+
+if (isMac) {
+    if (isX86) {
+        url <- res$assets$browser_download_url[grepl("macos-x86", res$assets$browser_download_url)]
+        macosver <- "-mmacosx-version-min=10.14"
+    } else {
+        url <- res$assets$browser_download_url[grepl("macos-arm64", res$assets$browser_download_url)]
+    }
+} else if (isLinux) {
+    ## use [1] as [2] is the noavx2 one
+    url <- res$assets$browser_download_url[grepl("linux", res$assets$browser_download_url)][1]
+} else {
+    stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
+}
+
+tarball <- "tiledb.tar.gz"
+if (!file.exists(tarball)) download.file(url, tarball, quiet=TRUE)
+if (!dir.exists("tiledb")) untar(tarball, exdir="tiledb")
+if (!dir.exists("inst/tiledb")) untar(tarball, exdir="inst/tiledb")
+archincl <- paste0("-I", system.file("include", package="arch"))
+
+mkvar <- readLines("src/Makevars.in")
+mkvar <- gsub("@cxx20_macos@", macosver, mkvar)
+mkvar <- gsub("@tiledb_include@", paste("-I../inst/tiledb/include", archincl), mkvar)
+mkvar <- gsub("@tiledb_libs@", "-ltiledb -L../inst/tiledb/lib", mkvar)
+mkvar <- gsub("@tiledb_rpath@", "-Wl,-rpath,'$$ORIGIN/../tiledb/lib'", mkvar)
+writeLines(mkvar, "src/Makevars")

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -48,6 +48,7 @@ else()
     endif()
 
     # Try to download prebuilt artifacts unless the user specifies to build from source
+    # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
           SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-windows-x86_64-2.11.1-15a1161.zip")


### PR DESCRIPTION
This PR generalizes the build setup for the R package to use _either_ a system-wide installation of TileDB Core for the C++ headers and library, and a dowloaded artifact.  

This (loosely) follows the behavior of the `tiledb` R package on CRAN.  

It has been tested with system-wide TileDB and without (in Docker and on CI).  Tests in CI for macOS are not yet feasible as that setup appears to lack sufficient C++20 support.  Actual CI support may be added in a subsequent PR.