### PR TITLE
[c++] Do not require query condition columns in column_names

### DIFF
--- a/apis/python/src/tiledbsoma/query_condition.py
+++ b/apis/python/src/tiledbsoma/query_condition.py
@@ -140,6 +140,8 @@ class QueryCondition:
                 "be made up of one or more Boolean expressions."
             )
 
+        return query_attrs
+
 
 @dataclass
 class QueryConditionTree(ast.NodeVisitor):
@@ -323,10 +325,7 @@ class QueryConditionTree(ast.NodeVisitor):
             raise tiledb.TileDBError(f"Attribute `{att}` not found in schema.")
 
         if att not in self.query_attrs:
-            raise tiledb.TileDBError(
-                f"Attribute `{att}` given to filter in query's `attr_cond` "
-                "arg but not found in `attr` arg."
-            )
+            self.query_attrs.append(att)
 
         return att
 

--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -131,6 +131,36 @@ PYBIND11_MODULE(libtiledbsoma, m) {
                         std::string_view batch_size,
                         std::string_view result_order,
                         std::map<std::string, std::string> platform_config) {
+                // Handle query condition based on
+                // TileDB-Py::PyQuery::set_attr_cond()
+                QueryCondition* qc = nullptr;
+                if (!py_query_condition.is(py::none())) {
+                    py::object init_pyqc = py_query_condition.attr(
+                        "init_query_condition");
+
+                    try {
+                        // Column names will be updated with columns present in
+                        // the query condition
+                        auto new_column_names =
+                            init_pyqc(py_schema, column_names)
+                                .cast<std::vector<std::string>>();
+
+                        // Update the column_names list if it was not empty,
+                        // otherwise continue selecting all columns with an
+                        // empty column_names list
+                        if (!column_names.empty()) {
+                            column_names = new_column_names;
+                        }
+                    } catch (const std::exception& e) {
+                        throw TileDBSOMAError(e.what());
+                    }
+
+                    qc = py_query_condition.attr("c_obj")
+                             .cast<tiledbpy::PyQueryCondition>()
+                             .ptr()
+                             .get();
+                }
+
                 auto reader = SOMAReader::open(
                     uri,
                     name,
@@ -139,21 +169,8 @@ PYBIND11_MODULE(libtiledbsoma, m) {
                     batch_size,
                     result_order);
 
-                // Handle query condition based on
-                // TileDB-Py::PyQuery::set_attr_cond()
-                if (!py_query_condition.is(py::none())) {
-                    py::object init_pyqc = py_query_condition.attr(
-                        "init_query_condition");
-
-                    try {
-                        init_pyqc(py_schema, column_names);
-                    } catch (const std::exception& e) {
-                        throw TileDBSOMAError(e.what());
-                    }
-
-                    auto pyqc = (py_query_condition.attr("c_obj"))
-                                    .cast<tiledbpy::PyQueryCondition>();
-                    auto qc = pyqc.ptr().get();
+                // Set query condition if present
+                if (qc) {
                     reader->set_condition(*qc);
                 }
 

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -93,5 +93,20 @@ def test_query_condition_and_or():
     assert len(pandas.index) == soma_arrow.num_rows
 
 
+def test_query_condition_select_columns():
+    uri = os.path.join(SOMA_URI, "obs")
+    condition = "percent_mito > 0.02"
+
+    qc = QueryCondition(condition)
+    schema = tiledb.open(uri).schema
+
+    sr = sc.SOMAReader(uri, query_condition=qc, schema=schema, column_names=["n_genes"])
+    sr.submit()
+    arrow_table = sr.read_next()
+
+    assert sr.results_complete()
+    assert arrow_table.num_rows == 1332
+
+
 if __name__ == "__main__":
     test_query_condition_and_or()

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -106,7 +106,24 @@ def test_query_condition_select_columns():
 
     assert sr.results_complete()
     assert arrow_table.num_rows == 1332
+    assert arrow_table.num_columns == 2
+
+
+def test_query_condition_all_columns():
+    uri = os.path.join(SOMA_URI, "obs")
+    condition = "percent_mito > 0.02"
+
+    qc = QueryCondition(condition)
+    schema = tiledb.open(uri).schema
+
+    sr = sc.SOMAReader(uri, query_condition=qc, schema=schema)
+    sr.submit()
+    arrow_table = sr.read_next()
+
+    assert sr.results_complete()
+    assert arrow_table.num_rows == 1332
+    assert arrow_table.num_columns == 7
 
 
 if __name__ == "__main__":
-    test_query_condition_and_or()
+    test_query_condition_select_columns()

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -26,13 +26,11 @@ def pandas_query(uri, condition):
     return arrow_table.to_pandas().query(condition)
 
 
-def soma_query(uri, column_names, condition):
+def soma_query(uri, condition):
     qc = QueryCondition(condition)
     schema = tiledb.open(uri).schema
 
-    sr = sc.SOMAReader(
-        uri, column_names=column_names, query_condition=qc, schema=schema
-    )
+    sr = sc.SOMAReader(uri, query_condition=qc, schema=schema)
     sr.submit()
     arrow_table = sr.read_next()
     assert sr.results_complete()
@@ -46,8 +44,7 @@ def test_query_condition_int():
 
     pandas = pandas_query(uri, condition)
 
-    column_names = ["n_genes"]
-    soma_arrow = soma_query(uri, column_names, condition)
+    soma_arrow = soma_query(uri, condition)
 
     assert len(pandas.index) == soma_arrow.num_rows
 
@@ -58,8 +55,7 @@ def test_query_condition_string():
 
     pandas = pandas_query(uri, condition)
 
-    column_names = ["louvain"]
-    soma_arrow = soma_query(uri, column_names, condition)
+    soma_arrow = soma_query(uri, condition)
 
     assert len(pandas.index) == soma_arrow.num_rows
 
@@ -70,8 +66,7 @@ def test_query_condition_float():
 
     pandas = pandas_query(uri, condition)
 
-    column_names = ["percent_mito"]
-    soma_arrow = soma_query(uri, column_names, condition)
+    soma_arrow = soma_query(uri, condition)
 
     assert len(pandas.index) == soma_arrow.num_rows
 
@@ -82,8 +77,7 @@ def test_query_condition_and():
 
     pandas = pandas_query(uri, condition)
 
-    column_names = ["percent_mito", "n_genes"]
-    soma_arrow = soma_query(uri, column_names, condition)
+    soma_arrow = soma_query(uri, condition)
 
     assert len(pandas.index) == soma_arrow.num_rows
 
@@ -94,8 +88,7 @@ def test_query_condition_and_or():
 
     pandas = pandas_query(uri, condition)
 
-    column_names = ["percent_mito", "n_genes", "louvain"]
-    soma_arrow = soma_query(uri, column_names, condition)
+    soma_arrow = soma_query(uri, condition)
 
     assert len(pandas.index) == soma_arrow.num_rows
 


### PR DESCRIPTION
Based on https://github.com/TileDB-Inc/TileDB-Py/pull/1333, remove the requirement to add attributes used in query conditions to the `SOMAReader` `column_names`.