### PR TITLE
[c++] Add fast nnz

### DIFF
--- a/libtiledbsoma/include/tiledbsoma/managed_query.h
+++ b/libtiledbsoma/include/tiledbsoma/managed_query.h
@@ -230,6 +230,15 @@ class ManagedQuery {
      */
     std::shared_ptr<ArrayBuffers> results();
 
+    /**
+     * @brief Get the schema of the array.
+     *
+     * @return std::shared_ptr<ArraySchema> Schema
+     */
+    std::shared_ptr<ArraySchema> schema() {
+        return schema_;
+    }
+
    private:
     //===================================================================
     //= private non-static
@@ -256,7 +265,7 @@ class ManagedQuery {
     std::string name_;
 
     // Array schema
-    ArraySchema schema_;
+    std::shared_ptr<ArraySchema> schema_;
 
     // TileDB query being managed.
     std::unique_ptr<Query> query_;

--- a/libtiledbsoma/include/tiledbsoma/soma_reader.h
+++ b/libtiledbsoma/include/tiledbsoma/soma_reader.h
@@ -56,15 +56,35 @@ class SOMAReader {
      *
      * @param uri URI of the array
      * @param name Name of the array
+     * @param platform_config Config parameter dictionary
+     * @param column_names Columns to read
      * @param batch_size Read batch size
      * @param result_order Read result order
-     * @param platform_config Config parameter dictionary
      * @return std::unique_ptr<SOMAReader> SOMAReader
      */
     static std::unique_ptr<SOMAReader> open(
         std::string_view uri,
         std::string_view name = "unnamed",
         std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> column_names = {},
+        std::string_view batch_size = "auto",
+        std::string_view result_order = "auto");
+
+    /**
+     * @brief Open an array at the specified URI and return SOMAReader object.
+     *
+     * @param ctx TileDB context
+     * @param uri URI of the array
+     * @param name Name of the array
+     * @param column_names Columns to read
+     * @param batch_size Read batch size
+     * @param result_order Read result order
+     * @return std::unique_ptr<SOMAReader> SOMAReader
+     */
+    static std::unique_ptr<SOMAReader> open(
+        std::shared_ptr<Context> ctx,
+        std::string_view uri,
+        std::string_view name = "unnamed",
         std::vector<std::string> column_names = {},
         std::string_view batch_size = "auto",
         std::string_view result_order = "auto");
@@ -226,6 +246,13 @@ class SOMAReader {
     bool results_complete() {
         return mq_->results_complete();
     }
+
+    /**
+     * @brief Get the total number of unique cells in the array.
+     *
+     * @return uint64_t Total number of unique cells
+     */
+    uint64_t nnz();
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/managed_query.cc
+++ b/libtiledbsoma/src/managed_query.cc
@@ -45,9 +45,9 @@ using namespace tiledb;
 ManagedQuery::ManagedQuery(std::shared_ptr<Array> array, std::string_view name)
     : array_(array)
     , name_(name)
-    , schema_(array->schema()) {
-    query_ = std::make_unique<Query>(schema_.context(), *array);
-    subarray_ = std::make_unique<Subarray>(schema_.context(), *array);
+    , schema_(std::make_shared<ArraySchema>(array->schema())) {
+    query_ = std::make_unique<Query>(schema_->context(), *array);
+    subarray_ = std::make_unique<Subarray>(schema_->context(), *array);
 
     if (array->schema().array_type() == TILEDB_SPARSE) {
         query_->set_layout(TILEDB_UNORDERED);
@@ -66,8 +66,8 @@ void ManagedQuery::select_columns(
 
     for (auto& name : names) {
         // Name is not an attribute or dimension.
-        if (!schema_.has_attribute(name) &&
-            !schema_.domain().has_dimension(name)) {
+        if (!schema_->has_attribute(name) &&
+            !schema_->domain().has_dimension(name)) {
             LOG_WARN(fmt::format(
                 "[TileDB-SOMA::ManagedQuery] [{}] Invalid column selected: {}",
                 name_,

--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -231,16 +231,21 @@ PYBIND11_MODULE(libtiledbsoma, m) {
         .def("submit", &SOMAReader::submit)
         .def("results_complete", &SOMAReader::results_complete)
 
-        .def("read_next", [](SOMAReader& reader) -> std::optional<py::object> {
-            // Try to read more data
-            auto buffers = reader.read_next();
+        .def(
+            "read_next",
+            [](SOMAReader& reader) -> std::optional<py::object> {
+                // Try to read more data
+                auto buffers = reader.read_next();
 
-            // If more data was read, convert it to an arrow table and return
-            if (buffers.has_value()) {
-                return to_table(*buffers);
-            }
+                // If more data was read, convert it to an arrow table and
+                // return
+                if (buffers.has_value()) {
+                    return to_table(*buffers);
+                }
 
-            // No data was read, the query is complete, return nullopt
-            return std::nullopt;
-        });
+                // No data was read, the query is complete, return nullopt
+                return std::nullopt;
+            })
+
+        .def("nnz", &SOMAReader::nnz);
 }

--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -193,6 +193,12 @@ uint64_t SOMAReader::nnz() {
 
     //===============================================================
     // Found overlapping fragments, count cells
+    if (mq_->schema()->allows_dups()) {
+        throw TileDBSOMAError(
+            "[SOMAReader] nnz not supported for overlapping fragments with "
+            "duplicates");
+    }
+
     LOG_WARN("[SOMAReader] Found overlapping fragments, counting cells...");
 
     // TODO[perf]: Reuse "this" object to read, then reset the state of "this"

--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -57,6 +57,17 @@ std::unique_ptr<SOMAReader> SOMAReader::open(
         result_order);
 }
 
+std::unique_ptr<SOMAReader> SOMAReader::open(
+    std::shared_ptr<Context> ctx,
+    std::string_view uri,
+    std::string_view name,
+    std::vector<std::string> column_names,
+    std::string_view batch_size,
+    std::string_view result_order) {
+    return std::make_unique<SOMAReader>(
+        uri, name, ctx, column_names, batch_size, result_order);
+}
+
 //===================================================================
 //= public non-static
 //===================================================================
@@ -116,6 +127,89 @@ std::optional<std::shared_ptr<ArrayBuffers>> SOMAReader::read_next() {
 
     // Return the results, possibly incomplete
     return mq_->results();
+}
+
+uint64_t SOMAReader::nnz() {
+    // Verify array is sparse
+    if (mq_->schema()->array_type() != TILEDB_SPARSE) {
+        throw TileDBSOMAError(
+            "[SOMAReader] nnz is only supported for sparse arrays");
+    }
+
+    // Load fragment info
+    FragmentInfo fragment_info(*ctx_, uri_);
+    fragment_info.load();
+
+    LOG_DEBUG(fmt::format("[SOMAReader] Fragment info for array '{}'", uri_));
+    if (LOG_DEBUG_ENABLED()) {
+        fragment_info.dump();
+    }
+
+    //===============================================================
+    // If only one fragment, return total_cell_num
+    auto fragment_count = fragment_info.fragment_num();
+    if (fragment_count == 1) {
+        return fragment_info.total_cell_num();
+    }
+
+    //===============================================================
+    // Check for overlapping fragments on the first dimension
+    std::vector<std::array<uint64_t, 2>> non_empty_domains(fragment_count);
+
+    // Get all non-empty domains for first dimension
+    for (uint32_t i = 0; i < fragment_count; i++) {
+        // TODO[perf]: Reading fragment info is not supported on TileDB Cloud
+        // yet, but reading one fragment at a time will be slow. Is there
+        // another way?
+        fragment_info.get_non_empty_domain(i, 0, &non_empty_domains[i]);
+        LOG_DEBUG(fmt::format(
+            "[SOMAReader] fragment {} non-empty domain = [{}, {}]",
+            i,
+            non_empty_domains[i][0],
+            non_empty_domains[i][1]));
+    }
+
+    // Sort non-empty domains by the start of their ranges
+    std::sort(non_empty_domains.begin(), non_empty_domains.end());
+
+    // After sorting, if the end of a non-empty domain is >= the beginning of
+    // the next non-empty domain, there is an overlap
+    bool overlap = false;
+    for (uint32_t i = 0; i < fragment_count - 1; i++) {
+        LOG_DEBUG(fmt::format(
+            "[SOMAReader] Checking {} < {}",
+            non_empty_domains[i][1],
+            non_empty_domains[i + 1][0]));
+        if (non_empty_domains[i][1] >= non_empty_domains[i + 1][0]) {
+            overlap = true;
+            break;
+        }
+    }
+
+    // If multiple fragments do not overlap, return the total_cell_num
+    if (!overlap) {
+        return fragment_info.total_cell_num();
+    }
+
+    //===============================================================
+    // Found overlapping fragments, count cells
+    LOG_WARN("[SOMAReader] Found overlapping fragments, counting cells...");
+
+    // TODO[perf]: Reuse "this" object to read, then reset the state of "this"
+    // so it could be used to read again (for TileDB Cloud)
+    auto sr = SOMAReader::open(
+        ctx_,
+        uri_,
+        "count_cells",
+        {mq_->schema()->domain().dimension(0).name()});
+    sr->submit();
+
+    uint64_t total_cell_num = 0;
+    while (auto batch = sr->read_next()) {
+        total_cell_num += (*batch)->num_rows();
+    }
+
+    return total_cell_num;
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -28,6 +28,7 @@ if (TILEDBSOMA_TESTING)
         $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
         unit_column_buffer.cc
         unit_managed_query.cc
+        unit_soma_reader.cc
         unit_thread_pool.cc
     )
 

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -8,7 +8,7 @@ import tiledb
 from tiledbsoma.query_condition import QueryCondition
 
 
-VERBOSE = True
+VERBOSE = False
 
 TEST_DIR = os.path.dirname(__file__)
 SOMA_URI = f"{TEST_DIR}/../../test/soco/pbmc3k_processed"

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python
+
 import os
 import pandas as pd
 import pyarrow as pa
 import tiledbsoma.libtiledbsoma as sc
 
-VERBOSE = True
+VERBOSE = False
 
 TEST_DIR = os.path.dirname(__file__)
 SOMA_URI = f"{TEST_DIR}/../../test/soco/pbmc3k_processed"
@@ -139,22 +141,15 @@ def test_soma_reader_column_names():
     assert arrow_table.num_columns == 2
 
 
-# TODO: implement value filter
-def todo_soma_reader_value_filter():
-    """Read obs array into an arrow table with value filter applied."""
-
+def test_nnz():
     name = "obs"
     uri = os.path.join(SOMA_URI, name)
     sr = sc.SOMAReader(uri)
 
-    sr.set_value_filter("foo > 1")
+    total_cell_count = sr.nnz()
 
-    sr.submit()
-    arrow_table = sr.read_next()
-
-    # test that all results are present in the arrow table (no incomplete queries)
-    assert sr.results_complete()
+    assert total_cell_count == 2638
 
 
 if __name__ == "__main__":
-    test_soma_reader_var()
+    test_nnz()

--- a/libtiledbsoma/test/unit_managed_query.cc
+++ b/libtiledbsoma/test/unit_managed_query.cc
@@ -56,6 +56,8 @@ const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
 
 namespace {
 
+bool VERBOSE = false;
+
 auto create_array(const std::string& uri, Context& ctx) {
     // Delete array if it exists
     auto vfs = VFS(ctx);
@@ -104,7 +106,9 @@ auto create_array(const std::string& uri, Context& ctx) {
 };  // namespace
 
 TEST_CASE("ManagedQuery: Basic execution test") {
-    LOG_CONFIG("debug");
+    if (VERBOSE) {
+        LOG_CONFIG("debug");
+    }
 
     std::string uri = "mem://unit-test-array";
     auto ctx = Context();

--- a/libtiledbsoma/test/unit_soma_reader.cc
+++ b/libtiledbsoma/test/unit_soma_reader.cc
@@ -132,7 +132,7 @@ uint64_t create_array(
 };  // namespace
 
 TEST_CASE("SOMAReader: nnz") {
-    auto num_fragments = GENERATE(1, 10, 10);
+    auto num_fragments = GENERATE(1, 10);
     auto overlap = GENERATE(false, true);
     auto allow_duplicates = GENERATE(false, true);
     int num_cells_per_fragment = 128;

--- a/libtiledbsoma/test/unit_soma_reader.cc
+++ b/libtiledbsoma/test/unit_soma_reader.cc
@@ -1,0 +1,166 @@
+/**
+ * @file   unit_soma_reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for the SOMAReader class
+ */
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_predicate.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+#include <random>
+
+#include <tiledbsoma/util.h>
+#include <tiledb/tiledb>
+#include <tiledbsoma/tiledbsoma>
+
+using namespace tiledb;
+using namespace tiledbsoma;
+using namespace Catch::Matchers;
+
+#ifndef TILEDBSOMA_SOURCE_ROOT
+#define TILEDBSOMA_SOURCE_ROOT "not_defined"
+#endif
+
+const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
+
+namespace {
+
+uint64_t create_array(
+    const std::string& uri,
+    Context& ctx,
+    int num_cells_per_fragment = 10,
+    int num_fragments = 1,
+    bool overlap = false) {
+    // Delete array if it exists
+    auto vfs = VFS(ctx);
+    if (vfs.is_dir(uri)) {
+        vfs.remove_dir(uri);
+    }
+
+    // Create schema
+    ArraySchema schema(ctx, TILEDB_SPARSE);
+
+    auto dim = Dimension::create<int64_t>(
+        ctx, "d0", {0, std::numeric_limits<int64_t>::max()});
+
+    Domain domain(ctx);
+    domain.add_dimension(dim);
+    schema.set_domain(domain);
+
+    auto attr = Attribute::create<int>(ctx, "a0");
+    schema.add_attribute(attr);
+    schema.set_allows_dups(false);
+    schema.check();
+
+    // Create array and open for writing
+    Array::create(uri, schema);
+    Array array(ctx, uri, TILEDB_WRITE);
+    if (LOG_DEBUG_ENABLED()) {
+        array.schema().dump();
+    }
+
+    // Generate fragments in random order
+    std::vector<int> frags(num_fragments);
+    std::iota(frags.begin(), frags.end(), 0);
+    std::shuffle(frags.begin(), frags.end(), std::random_device{});
+
+    for (auto i : frags) {
+        std::vector<int64_t> d0(num_cells_per_fragment);
+        for (int j = 0; j < num_cells_per_fragment; j++) {
+            // Overlap odd fragments when generating overlaps
+            if (overlap && i & 1) {
+                d0[j] = j + num_cells_per_fragment * (i - 1);
+            } else {
+                d0[j] = j + num_cells_per_fragment * i;
+            }
+        }
+        std::vector<int> a0(num_cells_per_fragment, i);
+
+        // Write data to array
+        Query query(ctx, array);
+        query.set_layout(TILEDB_UNORDERED)
+            .set_data_buffer("d0", d0)
+            .set_data_buffer("a0", a0);
+        query.submit();
+    }
+
+    array.close();
+
+    uint64_t nnz = num_fragments * num_cells_per_fragment;
+
+    // Adjust nnz when overlap is enabled
+    if (overlap) {
+        nnz = (num_fragments + 1) / 2 * num_cells_per_fragment;
+    }
+
+    return nnz;
+}
+
+};  // namespace
+
+TEST_CASE("SOMAReader: nnz, one fragment") {
+    // Create array
+    std::string uri = "mem://unit-test-array";
+    auto ctx = std::make_shared<Context>();
+    auto expected_nnz = create_array(uri, *ctx);
+
+    // Get total cell num
+    auto sr = SOMAReader::open(ctx, uri);
+    auto nnz = sr->nnz();
+    REQUIRE(nnz == expected_nnz);
+}
+
+TEST_CASE("SOMAReader: nnz, multiple fragments") {
+    // Create array
+    std::string uri = "mem://unit-test-array";
+    auto ctx = std::make_shared<Context>();
+    auto expected_nnz = create_array(uri, *ctx, 10, 10);
+
+    // Get total cell num
+    auto sr = SOMAReader::open(ctx, uri);
+    auto nnz = sr->nnz();
+    REQUIRE(nnz == expected_nnz);
+}
+
+TEST_CASE("SOMAReader: nnz, overlapping fragments") {
+    // Create array
+    std::string uri = "mem://unit-test-array";
+    auto ctx = std::make_shared<Context>();
+    auto expected_nnz = create_array(uri, *ctx, 100, 21, true);
+
+    // Get total cell num
+    auto sr = SOMAReader::open(ctx, uri);
+    auto nnz = sr->nnz();
+    REQUIRE(nnz == expected_nnz);
+}


### PR DESCRIPTION
Add fast nnz to C++ API, as discussed in #383:
* if one fragment, there are no dups, so use cell_num
* if multiple, non-overlapping fragments, sum fragment cell_num
* if overlapping fragments, read/count the overlapping fragments

Closes #383.