### PR TITLE
Disambiguate bytes/ascii on tiledb schema -> arrow schema

### DIFF
--- a/apis/python/src/tiledbsoma/util_scipy.py
+++ b/apis/python/src/tiledbsoma/util_scipy.py
@@ -4,7 +4,7 @@ import scipy.sparse as sp
 
 def csr_from_tiledb_df(df: pd.DataFrame, num_rows: int, num_cols: int) -> sp.csr_matrix:
     """
-    TODO: COMMENT
+    Given a tiledb dataframe, return a ``scipy.sparse.csr_matrx``.
     """
     return sp.csr_matrix(
         (df["soma_data"], (df["soma_dim_0"], df["soma_dim_1"])),


### PR DESCRIPTION
Context: #405

Fantastic unit-testing was added by @bkmartinjr on #407 which was merged into this PR.

Issue (for the record): `bytes` and `ascii` both read back with `np.dtype("S") == "bytes"`. We need to use either `attr._tiledb_dtype` or `attr.isascii` when reading TileDB schema, to determine which Arrow schema type (`large_binary` or `large_string`) to report.