### PR TITLE
fix index in pandas read all

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_dataframe.py
@@ -304,7 +304,8 @@ class SOMADataFrame(TileDBArray):
                 value_filter=value_filter,
                 column_names=column_names,
                 result_order=result_order,
-            )
+            ),
+            ignore_index=True,
         )
 
     def write_from_pandas(self, dataframe: pd.DataFrame) -> None:

--- a/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/soma_indexed_dataframe.py
@@ -301,7 +301,8 @@ class SOMAIndexedDataFrame(TileDBArray):
                 value_filter=value_filter,
                 column_names=column_names,
                 result_order=result_order,
-            )
+            ),
+            ignore_index=True,
         )
 
     def write_from_pandas(


### PR DESCRIPTION
the SOMADataFrame and SOMAIndexedDataFrame `read_as_pandas_all` was returning a malformed index with repeated values. It should be a simple range index from [0, len), but was in instead the original (partial read) dataframe indices concatenated.

End result was that the index had repeated values (eg, index zero would show up many times).  Here is an example - note how the index and soma_rowid (and total number of rows) are not consistent:
```
In [15]: %time census['human'].obs.read_as_pandas_all(column_names=['soma_rowid', 'soma_joinid', 'dataset_id', 'assay_ontology_term_id', 'cell_type_ontology_term_id', 'development_stage_ontology_term_id', 'disease_ontology_term_id', 'et
    ...: hnicity_ontology_term_id', 'organism_ontology_term_id', 'sex_ontology_term_id', 'tissue_ontology_term_id'])                                                                                                                        
CPU times: user 3min 43s, sys: 27.2 s, total: 4min 10s                                                                                                                                                                                      
Wall time: 12.2 s                                                                                                                                                                                                                           
Out[15]:                                                                                                                                                                                                                                    
        soma_rowid  soma_joinid                            dataset_id assay_ontology_term_id  ... ethnicity_ontology_term_id organism_ontology_term_id sex_ontology_term_id tissue_ontology_term_id                                         
0                0            0  a43aa46b-bd16-47fe-bc3e-19a052624e79            EFO:0009899  ...                    unknown            NCBITaxon:9606         PATO:0000384          UBERON:0002107                                         
1                1            1  a43aa46b-bd16-47fe-bc3e-19a052624e79            EFO:0009899  ...                    unknown            NCBITaxon:9606         PATO:0000384          UBERON:0002107                                         
2                2            2  a43aa46b-bd16-47fe-bc3e-19a052624e79            EFO:0009899  ...                    unknown            NCBITaxon:9606         PATO:0000384          UBERON:0002107                                         
3                3            3  a43aa46b-bd16-47fe-bc3e-19a052624e79            EFO:0009899  ...                    unknown            NCBITaxon:9606         PATO:0000384          UBERON:0002107                                         
4                4            4  a43aa46b-bd16-47fe-bc3e-19a052624e79            EFO:0009899  ...                    unknown            NCBITaxon:9606         PATO:0000384          UBERON:0002107                                         
...            ...          ...                                   ...                    ...  ...                        ...                       ...                  ...                     ...                                         
162947    22590814     22590814  90d4a63b-5c02-43eb-acde-c49345681601            EFO:0009922  ...             HANCESTRO:0005            NCBITaxon:9606         PATO:0000383          UBERON:8410010                                         
162948    22590815     22590815  90d4a63b-5c02-43eb-acde-c49345681601            EFO:0009922  ...             HANCESTRO:0005            NCBITaxon:9606         PATO:0000383          UBERON:8410010                                         
162949    22590816     22590816  90d4a63b-5c02-43eb-acde-c49345681601            EFO:0009922  ...             HANCESTRO:0005            NCBITaxon:9606         PATO:0000383          UBERON:8410010                                         
162950    22590817     22590817  90d4a63b-5c02-43eb-acde-c49345681601            EFO:0009922  ...             HANCESTRO:0005            NCBITaxon:9606         PATO:0000383          UBERON:8410010                                         
162951    22590818     22590818  90d4a63b-5c02-43eb-acde-c49345681601            EFO:0009922  ...             HANCESTRO:0005            NCBITaxon:9606         PATO:0000383          UBERON:8410010                                         
                                                                                                                                                                                                                                            
[22590819 rows x 11 columns]                                                                                                                                                                                                                
                                                                                                                                                                                                                                            

```

As the index has no actual information in it, the fix is to concat while ignoring the index.