### PR TITLE
Use MacOS 12 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,22 +9,30 @@ on:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-11, windows-2019]
-        python-version: ['3.8']
+        # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
+        os: [ubuntu-22.04, macos-12]
+        # os: [ubuntu-22.04, macos-12, windows-2019]
+        python-version: ['3.8', '3.9', '3.10']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
-          - runs-on: macos-11
+          - runs-on: macos-12
             cc: gcc-11
             cxx: g++-11
 
     steps:
+    - name: Select XCode version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        # Pending https://github.com/actions/runner-images/issues/6350
+        xcode-version: '13.4'
+      if: ${{ runner.os == 'macOS' }}
+
     - name: Checkout TileDB-SOMA
       uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
         os: [ubuntu-22.04, macos-12]
         # os: [ubuntu-22.04, macos-12, windows-2019]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-22.04, macos-12]
         python-version: ['3.8']
         include:
           - runs-on: ubuntu-22.04
@@ -19,11 +19,18 @@ jobs:
             cxx: g++-11
           # Pending https://github.com/actions/runner-images/issues/6350
           # - runs-on: macos-12
-          - runs-on: macos-11
+          - runs-on: macos-12
             cc: gcc-11
             cxx: g++-11
 
     steps:
+    - name: Select XCode version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        # Pending https://github.com/actions/runner-images/issues/6350
+        xcode-version: '13.4'
+      if: ${{ runner.os == 'macOS' }}
+
     - name: 'Print env'
       run: |
         echo "'uname -s' is:"

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-12]
-        python-version: ['3.8']
+        python-version: ['3.9']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11


### PR DESCRIPTION
On #354 we got MacOS CI working in the presence of an XCode 14 linker bug by downgrading to MacOS 11. As discussed at https://github.com/actions/runner-images/issues/6350, we can stay on MacOS 12 but force XCode 13.4 (non-buggy).

Also, it's not a bad idea or a bad time to use Python 3.9 for CI (we have been using 3.8, which is now in a 'security fixes only' phase).

Note that if/when this PR is accepted, I'll switch the required builds in the branch-protection rules for this repo to require 3.9 passes rather than 3.8 (as now).