### PR TITLE
Correct configure by ensuring R_HOME is set early

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+## Ensure R_HOME is set either explicitly or implicitly from the running R instance
+: ${R_HOME=`R RHOME`}
+
 ## for single-cell-data/apis/r repo, consider completing sources
 if test -d inst/include/tiledbsoma && test -f src/soma_reader.cc; then
     echo "** Source files present, no adjustments needed."
@@ -47,7 +50,6 @@ fi
 if [ x"${have_tiledb}" = x"false" ]; then
     ## allow for standard CRAN override preference for settable R_HOME
     ## with fallback to query R in $PATH for its value
-    : ${R_HOME=`R RHOME`}
     if test -z "${R_HOME}"; then
         echo Could not determine R_HOME.
         exit 1

--- a/apis/r/configure
+++ b/apis/r/configure
@@ -1,7 +1,13 @@
 #!/bin/sh
 
-## Ensure R_HOME is set either explicitly or implicitly from the running R instance
+## This allow for standard CRAN override preference for both a settable R_HOME
+## with fallback to query R in $PATH for the value it has so it works both
+## explicitly or implicitly from the running R instance
 : ${R_HOME=`R RHOME`}
+if test -z "${R_HOME}"; then
+    echo Could not determine R_HOME.
+    exit 1
+fi
 
 ## for single-cell-data/apis/r repo, consider completing sources
 if test -d inst/include/tiledbsoma && test -f src/soma_reader.cc; then
@@ -48,12 +54,5 @@ if [ $? -eq 0 ]; then
 fi
 
 if [ x"${have_tiledb}" = x"false" ]; then
-    ## allow for standard CRAN override preference for settable R_HOME
-    ## with fallback to query R in $PATH for its value
-    if test -z "${R_HOME}"; then
-        echo Could not determine R_HOME.
-        exit 1
-    fi
-
     ${R_HOME}/bin/Rscript tools/get_tarball.R
 fi


### PR DESCRIPTION
This PR corrects an oversight and ensure `R_HOME` is always set whereever `configure` may need it.  