### PR TITLE
Expose a faster method for member-URI enumeration

### DIFF
--- a/apis/python/README-ingestion.md
+++ b/apis/python/README-ingestion.md
@@ -228,7 +228,7 @@ VDAC3            1.1250     30.971519               8.986513                   2
 ```
 
 ```
->>> soma.obsm._get_member_names()
+>>> soma.obsm.get_member_names()
 ['X_tsne', 'X_pca']
 >>> soma.obsm['X_pca'].df()
                  X_pca_1   X_pca_2  ...  X_pca_18  X_pca_19
@@ -268,11 +268,11 @@ TTTAGCTGTACTCT TYMP     4.693411
 ```
 
 ```
->>> soma.uns._get_member_names()
+>>> soma.uns.get_member_names()
 ['neighbors']
->>> soma.uns['neighbors']._get_member_names()
+>>> soma.uns['neighbors'].get_member_names()
 ['params']
->>> soma.uns['neighbors']['params']._get_member_names()
+>>> soma.uns['neighbors']['params'].get_member_names()
 ['method']
 >>> arr = soma.uns['neighbors']['params']['method'].open_array()
 >>> arr.df[:]

--- a/apis/python/src/tiledbsoma/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix_group.py
@@ -39,9 +39,9 @@ class AnnotationMatrixGroup(TileDBGroup):
     def keys(self) -> Sequence[str]:
         """
         For ``obsm`` and ``varm``, ``.keys()`` is a keystroke-saver for the more general group-member
-        accessor ``._get_member_names()``.
+        accessor ``.get_member_names()``.
         """
-        return self._get_member_names()
+        return self.get_member_names()
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -55,7 +55,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         """
         Implements ``for matrix in soma.obsm: ...`` and ``for matrix in soma.varm: ...``
         """
-        for name, uri in self._get_member_names_to_uris().items():
+        for name, uri in self.get_member_names_to_uris().items():
             yield AnnotationMatrix(
                 uri=uri, name=name, dim_name=self.dim_name, parent=self
             )

--- a/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
@@ -49,9 +49,9 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
     def keys(self) -> Sequence[str]:
         """
         For obsp and varp, ``.keys()`` is a keystroke-saver for the more general group-member
-        accessor ``._get_member_names()``.
+        accessor ``.get_member_names()``.
         """
-        return self._get_member_names()
+        return self.get_member_names()
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -134,7 +134,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         """
         Implements ``for matrix in soma.obsp: ...`` and ``for matrix in soma.varp: ...``
         """
-        for name, uri in self._get_member_names_to_uris().items():
+        for name, uri in self.get_member_names_to_uris().items():
             yield AssayMatrix(
                 uri=uri,
                 name=name,

--- a/apis/python/src/tiledbsoma/assay_matrix_group.py
+++ b/apis/python/src/tiledbsoma/assay_matrix_group.py
@@ -44,9 +44,9 @@ class AssayMatrixGroup(TileDBGroup):
     def keys(self) -> Sequence[str]:
         """
         For ``obsm`` and ``varm``, ``.keys()`` is a keystroke-saver for the more general group-member
-        accessor ``._get_member_names()``.
+        accessor ``.get_member_names()``.
         """
-        return self._get_member_names()
+        return self.get_member_names()
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -126,7 +126,7 @@ class AssayMatrixGroup(TileDBGroup):
         """
         Implements ``for matrix in soma.obsm: ...`` and ``for matrix in soma.varm: ...``
         """
-        for name, uri in self._get_member_names_to_uris().items():
+        for name, uri in self.get_member_names_to_uris().items():
             yield AssayMatrix(
                 uri=uri,
                 name=name,

--- a/apis/python/src/tiledbsoma/soma_collection.py
+++ b/apis/python/src/tiledbsoma/soma_collection.py
@@ -86,7 +86,7 @@ class SOMACollection(TileDBGroup):
         """
         Implements ``len(soco)``. Returns the number of elements in the collection.
         """
-        return len(self._get_member_names())
+        return len(self.get_member_names())
 
     # ----------------------------------------------------------------
     def add(self, soma: SOMA, relative: Optional[bool] = None) -> None:
@@ -130,7 +130,7 @@ class SOMACollection(TileDBGroup):
         """
         Returns the names of the SOMAs in the collection.
         """
-        return self._get_member_names()
+        return self.get_member_names()
 
     # ----------------------------------------------------------------
     def __iter__(self) -> Iterator[SOMA]:
@@ -169,7 +169,7 @@ class SOMACollection(TileDBGroup):
         with ThreadPoolExecutor(
             max_workers=self._soma_options.max_thread_pool_workers
         ) as executor:
-            for name, uri in self._get_member_names_to_uris().items():
+            for name, uri in self.get_member_names_to_uris().items():
                 if name not in self._somas:
                     future = executor.submit(self._populate_aux, name=name, uri=uri)
                     futures.append(future)

--- a/apis/python/src/tiledbsoma/tiledb_group.py
+++ b/apis/python/src/tiledbsoma/tiledb_group.py
@@ -106,7 +106,7 @@ class TileDBGroup(TileDBObject):
             # the member URIs involve UUIDs which are known to the server.
             answer = {}
 
-            mapping = self._get_member_names_to_uris()
+            mapping = self.get_member_names_to_uris()
             for member_name in member_names:
                 if member_name in mapping:
                     answer[member_name] = mapping[member_name]
@@ -152,7 +152,7 @@ class TileDBGroup(TileDBObject):
         if not self.exists():
             # TODO: comment
             return self.uri + "/" + member_name
-        mapping = self._get_member_names_to_uris()
+        mapping = self.get_member_names_to_uris()
         if member_name in mapping:
             return mapping[member_name]
         else:
@@ -242,7 +242,7 @@ class TileDBGroup(TileDBObject):
     def _remove_object_by_name(self, member_name: str) -> None:
         self._cached_member_names_to_uris = None  # invalidate on remove-member
         if self.uri.startswith("tiledb://"):
-            mapping = self._get_member_names_to_uris()
+            mapping = self.get_member_names_to_uris()
             if member_name not in mapping:
                 raise Exception(f"name {member_name} not present in group {self.uri}")
             member_uri = mapping[member_name]
@@ -252,23 +252,23 @@ class TileDBGroup(TileDBObject):
             with self._open("w") as G:
                 G.remove(member_name)
 
-    def _get_member_names(self) -> Sequence[str]:
+    def get_member_names(self) -> Sequence[str]:
         """
         Returns the names of the group elements. For a SOMACollection, these will SOMA names;
         for a SOMA, these will be matrix/group names; etc.
         """
-        return list(self._get_member_names_to_uris().keys())
+        return list(self.get_member_names_to_uris().keys())
 
-    def _get_member_uris(self) -> Sequence[str]:
+    def get_member_uris(self) -> Sequence[str]:
         """
         Returns the URIs of the group elements. For a SOMACollection, these will SOMA URIs;
         for a SOMA, these will be matrix/group URIs; etc.
         """
-        return list(self._get_member_names_to_uris().values())
+        return list(self.get_member_names_to_uris().values())
 
-    def _get_member_names_to_uris(self) -> Dict[str, str]:
+    def get_member_names_to_uris(self) -> Dict[str, str]:
         """
-        Like ``_get_member_names()`` and ``_get_member_uris``, but returns a dict mapping from
+        Like ``get_member_names()`` and ``get_member_uris``, but returns a dict mapping from
         member name to member URI.
         """
         if self._cached_member_names_to_uris is None:

--- a/apis/python/src/tiledbsoma/uns_group.py
+++ b/apis/python/src/tiledbsoma/uns_group.py
@@ -31,9 +31,9 @@ class UnsGroup(TileDBGroup):
     def keys(self) -> Sequence[str]:
         """
         For uns, ``.keys()`` is a keystroke-saver for the more general group-member
-        accessor ``._get_member_names()``.
+        accessor ``.get_member_names()``.
         """
-        return self._get_member_names()
+        return self.get_member_names()
 
     # At the tiledb-py API level, *all* groups are name-indexable.  But here at the tiledbsoma-py
     # level, we implement name-indexing only for some groups:

--- a/apis/python/tests/test_soco_ops.py
+++ b/apis/python/tests/test_soco_ops.py
@@ -35,21 +35,21 @@ def test_import_anndata(tmp_path):
         assert G.meta[tiledbsoma.util.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
 
     soco.create_unless_exists()
-    assert len(soco._get_member_names()) == 0
+    assert len(soco.get_member_names()) == 0
 
     soco.add(soma1)
-    assert len(soco._get_member_names()) == 1
+    assert len(soco.get_member_names()) == 1
     soco.add(soma2)
-    assert len(soco._get_member_names()) == 2
+    assert len(soco.get_member_names()) == 2
     soco.add(soma3)
-    assert len(soco._get_member_names()) == 3
+    assert len(soco.get_member_names()) == 3
 
     soco.remove(soma1)
-    assert len(soco._get_member_names()) == 2
+    assert len(soco.get_member_names()) == 2
     del soco["soma2"]
-    assert len(soco._get_member_names()) == 1
+    assert len(soco.get_member_names()) == 1
     del soco.soma3
-    assert len(soco._get_member_names()) == 0
+    assert len(soco.get_member_names()) == 0
 
     assert tiledbsoma.util.is_soma(soma1.uri)
     assert tiledbsoma.util.is_soma(soma2.uri)

--- a/apis/python/tests/test_soma_group_indexing.py
+++ b/apis/python/tests/test_soma_group_indexing.py
@@ -45,10 +45,10 @@ def test_soma_group_indexing(h5ad_file):
     #   raw/var
     #   raw/varm/PCs
 
-    assert set(soma._get_member_names()) == set(
+    assert set(soma.get_member_names()) == set(
         ["uns", "varm", "X", "raw", "obsp", "varp", "var", "obsm", "obs"]
     )
-    assert set(soma.X._get_member_names()) == set(["data"])
+    assert set(soma.X.get_member_names()) == set(["data"])
     assert soma.X["data"].dim_names() == ["obs_id", "var_id"]
     assert soma.X["data"].shape() == (80, 20)
 
@@ -207,7 +207,7 @@ def test_soma_group_indexing(h5ad_file):
     ]
 
     assert soma.obsm.exists()
-    assert set(soma.obsm._get_member_names()) == set(["X_pca", "X_tsne"])
+    assert set(soma.obsm.get_member_names()) == set(["X_pca", "X_tsne"])
     assert set(soma.obsm.keys()) == set(["X_pca", "X_tsne"])
     assert soma.obsm["X_pca"].exists()
     assert isinstance(soma.obsm["X_pca"], tiledbsoma.AnnotationMatrix)
@@ -237,16 +237,16 @@ def test_soma_group_indexing(h5ad_file):
         np.dtype("float64"),
     ]
 
-    assert set(soma.varm._get_member_names()) == set(["PCs"])
+    assert set(soma.varm.get_member_names()) == set(["PCs"])
     assert soma.varm["PCs"].exists()
     assert isinstance(soma.varm["PCs"], tiledbsoma.AnnotationMatrix)
     assert soma.varm["nonesuch"] is None
-    assert soma.varm._get_member_names() == ["PCs"]
+    assert soma.varm.get_member_names() == ["PCs"]
     assert soma.varm["PCs"].dim_names() == ["var_id"]
     assert soma.varm["PCs"].shape() == (20, 19)
     assert soma.varm["PCs"].df().shape == (20, 19)
 
-    assert set(soma.obsp._get_member_names()) == set(["distances"])
+    assert set(soma.obsp.get_member_names()) == set(["distances"])
     assert soma.obsp["distances"].exists()
     assert soma.obsp["distances"].dim_names() == ["obs_id_i", "obs_id_j"]
     assert soma.obsp["distances"].shape() == (80, 80)
@@ -255,13 +255,13 @@ def test_soma_group_indexing(h5ad_file):
     assert soma.varp["nonesuch"] is None
 
     assert soma.uns.exists()
-    assert set(soma.uns._get_member_names()) == set(["neighbors"])
+    assert set(soma.uns.get_member_names()) == set(["neighbors"])
     assert soma.uns["neighbors"].exists()
     assert soma.uns.exists()
     assert isinstance(soma.uns["neighbors"], tiledbsoma.UnsGroup)
-    assert set(soma.uns["neighbors"]._get_member_names()) == set(["params"])
+    assert set(soma.uns["neighbors"].get_member_names()) == set(["params"])
     assert isinstance(soma.uns["neighbors"]["params"], tiledbsoma.UnsGroup)
-    assert set(soma.uns["neighbors"]["params"]._get_member_names()) == set(["method"])
+    assert set(soma.uns["neighbors"]["params"].get_member_names()) == set(["method"])
     assert isinstance(soma.uns["neighbors"]["params"]["method"], tiledbsoma.UnsArray)
     assert soma.uns["nonesuch"] is None
 


### PR DESCRIPTION
The idiom `[soma.uri for soma in soco]` is marvelously expressive but instantiates each `SOMA`. This is parallelized via `TheadPoolExecutor` but even then with remotely stored data the overhead can be undesirable.

There is a `soco._get_member_uris` which _only_ consults the group meta for the parent `SOMACollection`, and is almost instantaneous. This should be made a first-class citizen, as it does only what the user wants (no more) and is much more performant.