### PR TITLE
[ci] Update to checkout/actions@v3 to suppress nag about node.js 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
 
     - name: Checkout TileDB-SOMA
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -44,7 +44,7 @@ jobs:
       if: ${{ runner.os != 'Windows' }}
 
     - name: Checkout TileDB-SOMA
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # TODO: add clang-format check
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: apis/python
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - name: Check Python Black Format
         run: |

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap


### PR DESCRIPTION
This PR update the yml files from version two to version three of the core checkout action and thereby suppresses a nag displayed about node.js version 12 soon going away.  