### PR TITLE
Handle leading/trailing whitespace in value_filter

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -157,7 +157,7 @@ class DataFrame(TileDBArray):
         with self._tiledb_open("r") as A:
             query_condition = None
             if value_filter is not None:
-                query_condition = QueryCondition(value_filter)
+                query_condition = QueryCondition(value_filter.strip())
 
             sr = clib.SOMAReader(
                 self._uri,

--- a/apis/python/src/tiledbsoma/indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/indexed_dataframe.py
@@ -189,7 +189,7 @@ class IndexedDataFrame(TileDBArray):
         with self._tiledb_open("r") as A:
             query_condition = None
             if value_filter is not None:
-                query_condition = QueryCondition(value_filter)
+                query_condition = QueryCondition(value_filter.strip())
 
             sr = clib.SOMAReader(
                 self._uri,

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -105,8 +105,8 @@ def test_dataframe_non_indexed(tmp_path):
     assert sorted([e.as_py() for e in list(table["baz"])]) == ["ball", "dog"]
 
     # ----------------------------------------------------------------
-    # Read by value_filter
-    table = sdf.read_all(value_filter='baz == "ball" or baz == "dog"')
+    # Read by value_filter; also check leading/trailing whitespace is handled
+    table = sdf.read_all(value_filter=' baz == "ball" or baz == "dog" ')
     assert table.num_rows == 2
 
     # We should be getting back the soma_rowid & soma_joind column as well


### PR DESCRIPTION
Works around https://github.com/TileDB-Inc/TileDB-Py/issues/1396