### PR TITLE
Wording-neaten for to_anndata with logging

### DIFF
--- a/apis/python/src/tiledbsoma/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix_group.py
@@ -204,7 +204,7 @@ class AnnotationMatrixGroup(TileDBGroup):
                 )
 
         log_io(
-            f"Wrote {self.nested_name}",
+            f"Read {self.nested_name}",
             util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"),
         )
 

--- a/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
@@ -241,8 +241,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         grp.close()
 
         log_io(
-            f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            f"Read {self.nested_name}",
+            util.format_elapsed(s, f"{self._indent}FINISH READING {self.uri}"),
         )
 
         return matrices_in_group

--- a/apis/python/src/tiledbsoma/uns_group.py
+++ b/apis/python/src/tiledbsoma/uns_group.py
@@ -252,8 +252,8 @@ class UnsGroup(TileDBGroup):
                     )
 
         log_io(
-            f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            f"Read {self.nested_name}",
+            util.format_elapsed(s, f"{self._indent}FINISH READING {self.uri}"),
         )
 
         return retval


### PR DESCRIPTION
The `to_anndata` method says "writing" or "wrote" when it should say "reading" or "read". With this PR:

```
>>> soma = tiledbsoma.SOMA('/Users/johnkerl/s/t/pbmc-small')
```

```
>>> tiledbsoma.logging.info()

>>> tiledbsoma.io.to_anndata(soma)
data
Read pbmc-small/obsm
Read pbmc-small/varm
distances
Read pbmc-small/obsp
Read pbmc-small/varp
data
Read pbmc-small/raw/varm
Read pbmc-small/uns/neighbors/params
Read pbmc-small/uns/neighbors
Read pbmc-small/uns
AnnData object with n_obs × n_vars = 80 × 20
    obs: 'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'RNA_snn_res.0.8', 'letter.idents', 'groups', 'RNA_snn_res.1'
    var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
    uns: 'neighbors'
    obsm: 'X_tsne', 'X_pca'
    varm: 'PCs'
    obsp: 'distances'
```

```
>>> tiledbsoma.logging.debug()

>>> tiledbsoma.io.to_anndata(soma)
START  SOMA.to_anndata /Users/johnkerl/s/t/pbmc-small/
    START  read file:///Users/johnkerl/s/t/pbmc-small/X/data
    FINISH read file:///Users/johnkerl/s/t/pbmc-small/X/data TIME 0.077 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/obsm
  START  read file:///Users/johnkerl/s/t/pbmc-small/obsm/X_tsne
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/obsm/X_tsne TIME 0.017 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/obsm/X_pca
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/obsm/X_pca TIME 0.032 seconds
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/obsm TIME 0.051 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/varm
  START  read file:///Users/johnkerl/s/t/pbmc-small/varm/PCs
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/varm/PCs TIME 0.034 seconds
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/varm TIME 0.035 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/obsp
  START  read file:///Users/johnkerl/s/t/pbmc-small/obsp/distances
    START  read file:///Users/johnkerl/s/t/pbmc-small/obsp/distances
    FINISH read file:///Users/johnkerl/s/t/pbmc-small/obsp/distances TIME 0.060 seconds
  FINISH read file:///Users/johnkerl/s/t/pbmc-small/obsp/distances TIME 0.060 seconds
  FINISH READING file:///Users/johnkerl/s/t/pbmc-small/obsp TIME 0.060 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/varp
  FINISH READING file:///Users/johnkerl/s/t/pbmc-small/varp TIME 0.000 seconds
      START  read file:///Users/johnkerl/s/t/pbmc-small/raw/X/data
      FINISH read file:///Users/johnkerl/s/t/pbmc-small/raw/X/data TIME 0.057 seconds
    START  read file:///Users/johnkerl/s/t/pbmc-small/raw/varm
    FINISH read file:///Users/johnkerl/s/t/pbmc-small/raw/varm TIME 0.001 seconds
  START  read file:///Users/johnkerl/s/t/pbmc-small/uns
    START  read file:///Users/johnkerl/s/t/pbmc-small/uns/neighbors
      START  read file:///Users/johnkerl/s/t/pbmc-small/uns/neighbors/params
      FINISH READING file:///Users/johnkerl/s/t/pbmc-small/uns/neighbors/params TIME 0.020 seconds
    FINISH READING file:///Users/johnkerl/s/t/pbmc-small/uns/neighbors TIME 0.021 seconds
  FINISH READING file:///Users/johnkerl/s/t/pbmc-small/uns TIME 0.023 seconds
FINISH SOMA.to_anndata /Users/johnkerl/s/t/pbmc-small/ TIME 0.496 seconds
AnnData object with n_obs × n_vars = 80 × 20
    obs: 'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'RNA_snn_res.0.8', 'letter.idents', 'groups', 'RNA_snn_res.1'
    var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
    uns: 'neighbors'
    obsm: 'X_tsne', 'X_pca'
    varm: 'PCs'
    obsp: 'distances'
```