### PR TITLE
[c++] Accept dim_points as pyarrow.Array

### DIFF
--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -209,8 +209,16 @@ PYBIND11_MODULE(libtiledbsoma, m) {
                py::object py_arrow_array,
                int partition_index,
                int partition_count) {
-                for (auto& array :
-                     py_arrow_array.attr("chunks").cast<py::list>()) {
+                // Create a list of array chunks
+                py::list array_chunks;
+                if (py::hasattr(py_arrow_array, "chunks")) {
+                    array_chunks = py_arrow_array.attr("chunks")
+                                       .cast<py::list>();
+                } else {
+                    array_chunks.append(py_arrow_array);
+                }
+
+                for (auto& array : array_chunks) {
                     ArrowSchema arrow_schema;
                     ArrowArray arrow_array;
                     uintptr_t arrow_schema_ptr = (uintptr_t)(&arrow_schema);
@@ -229,7 +237,7 @@ PYBIND11_MODULE(libtiledbsoma, m) {
                             dim, data, partition_index, partition_count);
                     } else {
                         throw TileDBSOMAError(fmt::format(
-                            "[libtiledbsoma] set_dim_arrow: type={} not "
+                            "[libtiledbsoma] set_dim_points: type={} not "
                             "supported",
                             arrow_schema.format));
                     }

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -79,6 +79,25 @@ def test_soma_reader_dim_points():
     assert arrow_table.num_rows == len(obs_id_points)
 
 
+def test_soma_reader_dim_points_arrow_array():
+    """Read scalar dimension slice from obs array into an arrow table."""
+
+    name = "obs"
+    uri = os.path.join(SOMA_URI, name)
+    sr = clib.SOMAReader(uri)
+
+    obs_id_points = pa.array([0, 2, 4, 6, 8])
+
+    sr.set_dim_points("soma_rowid", obs_id_points)
+
+    sr.submit()
+    arrow_table = sr.read_next()
+
+    # test that all results are present in the arrow table (no incomplete queries)
+    assert sr.results_complete()
+    assert arrow_table.num_rows == len(obs_id_points)
+
+
 def test_soma_reader_dim_ranges():
     """Read range dimension slice from obs array into an arrow table."""
 


### PR DESCRIPTION
Accept dim_points as `pyarrow.Array`, not just `pyarrow.ChunkedArray`.

Closes #497.