### PR TITLE
Correct element names on to_anndata for tiledb-cloud URIs

### DIFF
--- a/apis/python/src/tiledbsoma/annotation_dataframe.py
+++ b/apis/python/src/tiledbsoma/annotation_dataframe.py
@@ -342,7 +342,7 @@ class AnnotationDataFrame(TileDBArray):
         attr_filters = tiledb.FilterList([tiledb.ZstdFilter(level=-1)])
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.nested_name}")
 
         # Make the row-names column (barcodes for obs, gene names for var) explicitly named.
         # Otherwise it'll be called '__tiledb_rows'.
@@ -372,7 +372,7 @@ class AnnotationDataFrame(TileDBArray):
         mode = "ingest"
         if self.exists():
             mode = "append"
-            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.nested_name}")
 
         # ISSUE:
         # TileDB attributes can be stored as Unicode but they are not yet queryable via the TileDB
@@ -427,5 +427,5 @@ class AnnotationDataFrame(TileDBArray):
 
         log_io(
             f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.nested_name}"),
         )

--- a/apis/python/src/tiledbsoma/annotation_matrix.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix.py
@@ -113,7 +113,7 @@ class AnnotationMatrix(TileDBArray):
         :param dim_values: ``anndata.obs_names``, ``anndata.var_names``, or ``anndata.raw.var_names``.
         """
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.nested_name}")
 
         if isinstance(matrix, pd.DataFrame):
             self._from_pandas_dataframe(matrix, dim_values)
@@ -124,7 +124,7 @@ class AnnotationMatrix(TileDBArray):
 
         log_io(
             f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.nested_name}"),
         )
 
     # ----------------------------------------------------------------
@@ -139,7 +139,7 @@ class AnnotationMatrix(TileDBArray):
 
         # Ingest annotation matrices as 1D/multi-attribute sparse arrays
         if self.exists():
-            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.nested_name}")
         else:
             self._create_empty_array([matrix.dtype] * nattr, attr_names)
 
@@ -153,7 +153,7 @@ class AnnotationMatrix(TileDBArray):
 
         # Ingest annotation matrices as 1D/multi-attribute sparse arrays
         if self.exists():
-            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.nested_name}")
         else:
             self._create_empty_array(list(df.dtypes), attr_names)
 

--- a/apis/python/src/tiledbsoma/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix_group.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Iterator, Optional, Sequence, Union
 
 import numpy as np
@@ -180,32 +179,34 @@ class AnnotationMatrixGroup(TileDBGroup):
         """
         if not self.exists():
             # Not all groups have all four of obsm, obsp, varm, and varp.
-            log_io(None, f"{self._indent}{self.uri} not found")
+            log_io(None, f"{self._indent}{self.nested_name} not found")
             return {}
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.nested_name}")
 
         with self._open() as G:
             matrices_in_group = {}
             for element in G:
                 s2 = util.get_start_stamp()
-                log_io(None, f"{self._indent}START  read {element.uri}")
+                log_io(None, f"{self._indent}START  read {element.name}")
 
                 with tiledb.open(element.uri, ctx=self._ctx) as A:
                     df = pd.DataFrame(A[:])
                     df.set_index(self.dim_name, inplace=True)
-                    matrix_name = os.path.basename(element.uri)  # e.g. 'X_pca'
+                    matrix_name = element.name
                     matrices_in_group[matrix_name] = df.to_numpy()
 
                 log_io(
                     None,
-                    util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}"),
+                    util.format_elapsed(
+                        s2, f"{self._indent}FINISH read {element.name}"
+                    ),
                 )
 
         log_io(
             f"Read {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH read {self.nested_name}"),
         )
 
         return matrices_in_group

--- a/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Iterator, Optional, Sequence
 
 import scipy.sparse as sp
@@ -217,32 +216,34 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         except tiledb.TileDBError:
             pass
         if grp is None:
-            log_io(None, f"{self._indent}{self.uri} not found")
+            log_io(None, f"{self._indent}{self.nested_name} not found")
             return {}
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.nested_name}")
 
         matrices_in_group = {}
         for element in self:
             s2 = util.get_start_stamp()
-            log_io(None, f"{self._indent}START  read {element.uri}")
+            log_io(None, f"{self._indent}START  read {element.nested_name}")
 
-            matrix_name = os.path.basename(element.uri)  # TODO: fix for tiledb cloud
+            matrix_name = element.name
             matrices_in_group[matrix_name] = element.to_csr_matrix(
                 obs_df_index, var_df_index
             )
 
             log_io(
                 None,
-                util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}"),
+                util.format_elapsed(
+                    s2, f"{self._indent}FINISH read {element.nested_name}"
+                ),
             )
 
         grp.close()
 
         log_io(
             f"Read {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH READING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH READING {self.nested_name}"),
         )
 
         return matrices_in_group

--- a/apis/python/src/tiledbsoma/assay_matrix.py
+++ b/apis/python/src/tiledbsoma/assay_matrix.py
@@ -1,5 +1,4 @@
 import math
-import os
 import time
 from typing import Optional, Tuple, Union
 
@@ -173,7 +172,7 @@ class AssayMatrix(TileDBArray):
         s = util.get_start_stamp()
         log_io(
             f"Writing {self.nested_name} ...",
-            f"{self._indent}START  WRITING {self.uri}",
+            f"{self._indent}START  WRITING {self.nested_name}",
         )
 
         assert len(row_names) == matrix.shape[0]
@@ -188,7 +187,7 @@ class AssayMatrix(TileDBArray):
             col_names = np.asarray(col_names)
 
         if self.exists():
-            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.nested_name}")
         else:
             self._create_empty_array(matrix_dtype=matrix.dtype)
 
@@ -204,7 +203,7 @@ class AssayMatrix(TileDBArray):
             self.ingest_data_dense_rows_chunked(matrix, row_names, col_names)
         log_io(
             f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.nested_name}"),
         )
 
     # ----------------------------------------------------------------
@@ -636,13 +635,13 @@ class AssayMatrix(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.nested_name}")
 
         csr = self.csr()
 
         log_io(
-            os.path.basename(self.uri),
-            util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"),
+            f"Read {self.nested_name}",
+            util.format_elapsed(s, f"{self._indent}FINISH read {self.nested_name}"),
         )
 
         return csr

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -22,7 +22,9 @@ def from_h5ad_unless_exists(
     so users don't need to replicate the if-test.
     """
     if tiledbsoma.util.is_soma(soma.uri, ctx=soma._ctx):
-        tiledbsoma.logging.logger.info(f"Already exists, skipping ingest: {soma.uri}")
+        tiledbsoma.logging.logger.info(
+            f"Already exists, skipping ingest: {soma.nested_name}"
+        )
     else:
         from_h5ad(soma, input_path, X_layer_name)
 
@@ -59,7 +61,7 @@ def _from_h5ad_common(
     Common code for things we do when processing a .h5ad file for ingest/update.
     """
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"START  SOMA.from_h5ad {input_path} -> {soma.uri}")
+    log_io(None, f"START  SOMA.from_h5ad {input_path} -> {soma.nested_name}")
 
     s = tiledbsoma.util.get_start_stamp()
     log_io(None, f"{soma._indent}START  READING {input_path}")
@@ -76,7 +78,7 @@ def _from_h5ad_common(
     log_io(
         None,
         tiledbsoma.util.format_elapsed(
-            s, f"FINISH SOMA.from_h5ad {input_path} -> {soma.uri}"
+            s, f"FINISH SOMA.from_h5ad {input_path} -> {soma.nested_name}"
         ),
     )
 
@@ -88,7 +90,9 @@ def from_10x_unless_exists(soma: tiledbsoma.SOMA, input_path: Path) -> None:
     so users don't need to replicate the if-test.
     """
     if tiledbsoma.util.is_soma(soma.uri):
-        tiledbsoma.logging.logger.info(f"Already exists, skipping ingest: {soma.uri}")
+        tiledbsoma.logging.logger.info(
+            f"Already exists, skipping ingest: {soma.nested_name}"
+        )
     else:
         from_10x(soma, input_path)
 
@@ -100,7 +104,7 @@ def from_10x(
     Reads a 10X file and writes to a TileDB group structure.
     """
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"START  SOMA.from_10x {input_path} -> {soma.uri}")
+    log_io(None, f"START  SOMA.from_10x {input_path} -> {soma.nested_name}")
 
     log_io(None, f"{soma._indent}START  READING {input_path}")
 
@@ -116,7 +120,7 @@ def from_10x(
     log_io(
         None,
         tiledbsoma.util.format_elapsed(
-            s, f"FINISH SOMA.from_10x {input_path} -> {soma.uri}"
+            s, f"FINISH SOMA.from_10x {input_path} -> {soma.nested_name}"
         ),
     )
 
@@ -130,7 +134,9 @@ def from_anndata_unless_exists(
     so users don't need to replicate the if-test.
     """
     if tiledbsoma.util.is_soma(soma.uri):
-        tiledbsoma.logging.logger.info(f"Already exists, skipping ingest: {soma.uri}")
+        tiledbsoma.logging.logger.info(
+            f"Already exists, skipping ingest: {soma.nested_name}"
+        )
     else:
         _from_anndata_aux(soma, anndata, X_layer_name)
 
@@ -177,7 +183,7 @@ def _from_anndata_aux(
     )
 
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"{soma._indent}START  WRITING {soma.uri}")
+    log_io(None, f"{soma._indent}START  WRITING {soma.nested_name}")
 
     # Must be done first, to create the parent directory
     soma.create_unless_exists()
@@ -249,7 +255,9 @@ def _from_anndata_aux(
 
     log_io(
         f"Wrote {soma.nested_name}",
-        tiledbsoma.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}"),
+        tiledbsoma.util.format_elapsed(
+            s, f"{soma._indent}FINISH WRITING {soma.nested_name}"
+        ),
     )
 
 
@@ -279,7 +287,7 @@ def from_anndata_update_obs_and_var(
     )
 
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"{soma._indent}START  WRITING {soma.uri}")
+    log_io(None, f"{soma._indent}START  WRITING {soma.nested_name}")
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     soma._remove_object(soma.obs)
@@ -296,7 +304,9 @@ def from_anndata_update_obs_and_var(
 
     log_io(
         None,
-        tiledbsoma.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}"),
+        tiledbsoma.util.format_elapsed(
+            s, f"{soma._indent}FINISH WRITING {soma.nested_name}"
+        ),
     )
 
 
@@ -308,7 +318,7 @@ def to_h5ad(soma: tiledbsoma.SOMA, h5ad_path: Path, X_layer_name: str = "data") 
     """
 
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"START  SOMA.to_h5ad {soma.uri} -> {h5ad_path}")
+    log_io(None, f"START  SOMA.to_h5ad {soma.nested_name} -> {h5ad_path}")
 
     anndata = to_anndata(soma, X_layer_name=X_layer_name)
 
@@ -325,7 +335,7 @@ def to_h5ad(soma: tiledbsoma.SOMA, h5ad_path: Path, X_layer_name: str = "data") 
     log_io(
         None,
         tiledbsoma.util.format_elapsed(
-            s, f"FINISH SOMA.to_h5ad {soma.uri} -> {h5ad_path}"
+            s, f"FINISH SOMA.to_h5ad {soma.nested_name} -> {h5ad_path}"
         ),
     )
 
@@ -342,7 +352,7 @@ def to_anndata(soma: tiledbsoma.SOMA, X_layer_name: str = "data") -> ad.AnnData:
     """
 
     s = tiledbsoma.util.get_start_stamp()
-    log_io(None, f"START  SOMA.to_anndata {soma.uri}")
+    log_io(None, f"START  SOMA.to_anndata {soma.nested_name}")
 
     obs_df = soma.obs.df()
     var_df = soma.var.df()
@@ -396,7 +406,8 @@ def to_anndata(soma: tiledbsoma.SOMA, X_layer_name: str = "data") -> ad.AnnData:
     )
 
     log_io(
-        None, tiledbsoma.util.format_elapsed(s, f"FINISH SOMA.to_anndata {soma.uri}")
+        None,
+        tiledbsoma.util.format_elapsed(s, f"FINISH SOMA.to_anndata {soma.nested_name}"),
     )
 
     return anndata

--- a/apis/python/src/tiledbsoma/raw_group.py
+++ b/apis/python/src/tiledbsoma/raw_group.py
@@ -65,7 +65,7 @@ class RawGroup(TileDBGroup):
         Writes ``anndata.raw`` to a TileDB group structure.
         """
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.nested_name}")
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
@@ -88,7 +88,10 @@ class RawGroup(TileDBGroup):
             )
         self._add_object(self.varm)
 
-        log_io(None, util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
+        log_io(
+            None,
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.nested_name}"),
+        )
 
     # ----------------------------------------------------------------
     def to_anndata_raw(

--- a/apis/python/src/tiledbsoma/tiledb_group.py
+++ b/apis/python/src/tiledbsoma/tiledb_group.py
@@ -52,7 +52,7 @@ class TileDBGroup(TileDBObject):
         Creates the TileDB group data structure on disk/S3/cloud, unless it already exists.
         """
         if not self.exists():
-            logger.debug(f"{self._indent}Creating TileDB group {self.uri}")
+            logger.debug(f"{self._indent}Creating TileDB group {self.nested_name}")
             tiledb.group_create(uri=self.uri, ctx=self._ctx)
             self._set_object_type_metadata()
 

--- a/apis/python/src/tiledbsoma/uns_array.py
+++ b/apis/python/src/tiledbsoma/uns_array.py
@@ -32,7 +32,9 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING PANDAS.DATAFRAME {self.uri}")
+        log_io(
+            None, f"{self._indent}START  WRITING PANDAS.DATAFRAME {self.nested_name}"
+        )
 
         tiledb.from_pandas(
             uri=self.uri,
@@ -45,7 +47,7 @@ class UnsArray(TileDBArray):
         log_io(
             None,
             util.format_elapsed(
-                s, f"{self._indent}FINISH WRITING PANDAS.DATAFRAME {self.uri}"
+                s, f"{self._indent}FINISH WRITING PANDAS.DATAFRAME {self.nested_name}"
             ),
         )
 
@@ -84,7 +86,9 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING FROM NUMPY.NDARRAY {self.uri}")
+        log_io(
+            None, f"{self._indent}START  WRITING FROM NUMPY.NDARRAY {self.nested_name}"
+        )
 
         if "numpy" in str(type(arr)) and str(arr.dtype).startswith("<U"):
             # Note arr.astype('str') does not lead to a successfuly tiledb.from_numpy.
@@ -92,7 +96,7 @@ class UnsArray(TileDBArray):
 
         if self.exists():
             tiledbsoma.logging.logger.info(
-                f"{self._indent}Updating existing array {self.uri}"
+                f"{self._indent}Updating existing array {self.nested_name}"
             )
             tiledb.from_numpy(
                 uri=self.uri, array=arr, mode="append", start_idx=0, ctx=self._ctx
@@ -103,7 +107,7 @@ class UnsArray(TileDBArray):
         log_io(
             None,
             util.format_elapsed(
-                s, f"{self._indent}FINISH WRITING FROM NUMPY.NDARRAY {self.uri}"
+                s, f"{self._indent}FINISH WRITING FROM NUMPY.NDARRAY {self.nested_name}"
             ),
         )
 
@@ -116,11 +120,14 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING FROM SCIPY.SPARSE.CSR {self.uri}")
+        log_io(
+            None,
+            f"{self._indent}START  WRITING FROM SCIPY.SPARSE.CSR {self.nested_name}",
+        )
 
         nrows, ncols = csr.shape
         if self.exists():
-            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.nested_name}")
         else:
             self.create_empty_array_for_csr("data", csr.dtype, nrows, ncols)
 
@@ -129,7 +136,8 @@ class UnsArray(TileDBArray):
         log_io(
             None,
             util.format_elapsed(
-                s, f"{self._indent}FINISH WRITING FROM SCIPY.SPARSE.CSR {self.uri}"
+                s,
+                f"{self._indent}FINISH WRITING FROM SCIPY.SPARSE.CSR {self.nested_name}",
             ),
         )
 

--- a/apis/python/src/tiledbsoma/uns_group.py
+++ b/apis/python/src/tiledbsoma/uns_group.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 
 import numpy as np
@@ -138,7 +137,7 @@ class UnsGroup(TileDBGroup):
         """
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.nested_name}")
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
@@ -214,7 +213,7 @@ class UnsGroup(TileDBGroup):
 
         log_io(
             f"Wrote {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.nested_name}"),
         )
 
     # ----------------------------------------------------------------
@@ -225,18 +224,18 @@ class UnsGroup(TileDBGroup):
         """
         if not self.exists():
             log_io(
-                f"{self._indent}{self.uri} not found",
-                f"{self._indent}{self.uri} not found",
+                f"{self._indent}{self.nested_name} not found",
+                f"{self._indent}{self.nested_name} not found",
             )
             return {}
 
         s = util.get_start_stamp()
-        log_io(None, f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.nested_name}")
 
         with self._open() as G:
             retval = {}
             for element in G:
-                name = os.path.basename(element.uri)  # TODO: update for tiledb cloud
+                name = element.name
 
                 if element.type == tiledb.tiledb.Group:
                     child_group = UnsGroup(uri=element.uri, name=name, parent=self)
@@ -253,7 +252,7 @@ class UnsGroup(TileDBGroup):
 
         log_io(
             f"Read {self.nested_name}",
-            util.format_elapsed(s, f"{self._indent}FINISH READING {self.uri}"),
+            util.format_elapsed(s, f"{self._indent}FINISH READING {self.nested_name}"),
         )
 
         return retval

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -167,6 +167,10 @@ def test_export_anndata(adata):
     tiledbsoma.io.from_anndata(soma, orig)
 
     readback = tiledbsoma.io.to_anndata(soma)
+    print("================================================================")
+    print("READBACK")
+    print(readback)
+    print("================================================================")
 
     assert readback.obs.shape == orig.obs.shape
     assert readback.var.shape == orig.var.shape

--- a/apis/python/tools/outgestor
+++ b/apis/python/tools/outgestor
@@ -35,6 +35,9 @@ def main():
         "-q", "--quiet", help="decrease output verbosity", action="store_true"
     )
     parser.add_argument(
+        "--debug", help="increase output verbosity", action="store_true"
+    )
+    parser.add_argument(
         "-o",
         help="Specify output directory to contain the somas: default ./anndata-readback",
         type=str,
@@ -65,11 +68,12 @@ def main():
         parser.print_help(file=sys.stderr)
         sys.exit(1)
 
-    vfs = tiledb.VFS()
-    if not vfs.is_dir(input_path):
-        # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
-        logging.error(f"Input path not found: {input_path}")
-        sys.exit(1)
+    if not input_path.startswith("tiledb://"):
+        vfs = tiledb.VFS()
+        if not vfs.is_dir(input_path):
+            # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
+            logging.error(f"Input path not found: {input_path}")
+            sys.exit(1)
 
     # This is for local-disk use only -- for S3-backed tiledb://... URIs we should
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.


### PR DESCRIPTION
Before:

```
>>> tiledbsoma.io.to_anndata(tiledbsoma.SOMA('tiledb://johnkerl-tiledb/pbmc-small'))
9c04b575-3e82-4b2b-b92b-cc2a5bad15bc
Read pbmc-small/obsm
Read pbmc-small/varm
dcfab2d6-b62a-4854-abf5-47652c305b25
Read pbmc-small/obsp
Read pbmc-small/varp
651eec7e-64ff-400c-91d3-66edb8133ff7
Read pbmc-small/raw/varm
Read pbmc-small/uns/eb28e180-dc88-43d2-8eaa-020cd08716ad/0ef47a66-077f-46b6-8c31-3cb36c518c34
Read pbmc-small/uns/eb28e180-dc88-43d2-8eaa-020cd08716ad
Read pbmc-small/uns
AnnData object with n_obs × n_vars = 80 × 20
    obs: 'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'RNA_snn_res.0.8', 'letter.idents', 'groups', 'RNA_snn_res.1'
    var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
    uns: 'eb28e180-dc88-43d2-8eaa-020cd08716ad'
    obsm: '66082acf-5934-4616-a284-730f8698d663', 'c2bc1e57-b22e-48bf-8c8f-bb6adbbd5fa0'
    varm: '4823f451-2d9d-4009-82e1-71abf1fb4f77'
    obsp: 'dcfab2d6-b62a-4854-abf5-47652c305b25'
```

After:

```
>>> tiledbsoma.io.to_anndata(tiledbsoma.SOMA('tiledb://johnkerl-tiledb/pbmc-small'))
Read pbmc-small/X/data
Read pbmc-small/obsm
Read pbmc-small/varm
Read pbmc-small/obsp/distances
Read pbmc-small/obsp
Read pbmc-small/varp
Read pbmc-small/raw/X/data
Read pbmc-small/raw/varm
Read pbmc-small/uns/neighbors/params
Read pbmc-small/uns/neighbors
Read pbmc-small/uns
AnnData object with n_obs × n_vars = 80 × 20
    obs: 'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'RNA_snn_res.0.8', 'letter.idents', 'groups', 'RNA_snn_res.1'
    var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
    uns: 'neighbors'
    obsm: 'X_pca', 'X_tsne'
    varm: 'PCs'
    obsp: 'distances'
```

The reason this wasn't caught in unit tests is that `TileDB-SOMA` is an open-source-only package with zero tiledb-cloud dependencies. Existing unit tests are unbroken by this PR; the tiledb-cloud experience is improved by this PR.