### PR TITLE
Depend on TileDB-Py 0.18.1 [main-old]

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyarrow
     scanpy
     scipy
-    tiledb>=0.18.0
+    tiledb>=0.18.1
 python_requires = >3.7
 
 [options.extras_require]

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
             "pyarrow",
             "scanpy",
             "scipy",
-            "tiledb>=0.18.0",
+            "tiledb>=0.18.1",
         ],
         python_requires=">=3.7",
     )


### PR DESCRIPTION
Not to be merged until `TileDB-Py` 0.18.1 appears in Conda:
https://anaconda.org/conda-forge/tiledb-py