### PR TITLE
[r] Add coverage reports in script and yaml

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    
 jobs:
   ci:
     strategy:
@@ -29,3 +32,7 @@ jobs:
 
       - name: Test
         run: cd apis/r && ./configure && tools/r-ci.sh run_tests
+
+      - name: Coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: cd apis/r && tools/r-ci.sh coverage

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [main]
 
-env:
-  COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
 jobs:
   ci:
     strategy:

--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -32,6 +32,8 @@ TRIM_APT_SOURCES=${TRIM_APT_SOURCES:-"TRUE"}
 
 ## Optional setting of type argument in covr::coverage() call below, defaults to "tests"
 COVERAGE_TYPE=${COVERAGE_TYPE:-"tests"}
+COVERAGE_FLAGS=${COVERAGE_FLAGS:-"r"}
+COVERAGE_TOKEN=${COVERAGE_TOKEN:-"missing_please_access_in_yaml_file_from_repo_settings"}
 
 R_BUILD_ARGS=${R_BUILD_ARGS-"--no-build-vignettes --no-manual"}
 R_CHECK_ARGS=${R_CHECK_ARGS-"--no-vignettes --no-manual --as-cran"}
@@ -372,7 +374,7 @@ Coverage() {
     ## assumes that the Rutter PPAs are in fact known, which is a given here
     AptGetInstall r-cran-covr
 
-    Rscript -e "covr::codecov(type = '${COVERAGE_TYPE}', quiet = FALSE)"
+    Rscript -e "covr::codecov(type = '${COVERAGE_TYPE}', quiet = FALSE, token = '${COVERAGE_TOKEN}', flags = '${COVERAGE_FLAGS}')"
 }
 
 RunTests() {

--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -33,7 +33,6 @@ TRIM_APT_SOURCES=${TRIM_APT_SOURCES:-"TRUE"}
 ## Optional setting of type argument in covr::coverage() call below, defaults to "tests"
 COVERAGE_TYPE=${COVERAGE_TYPE:-"tests"}
 COVERAGE_FLAGS=${COVERAGE_FLAGS:-"r"}
-COVERAGE_TOKEN=${COVERAGE_TOKEN:-"missing_please_access_in_yaml_file_from_repo_settings"}
 
 R_BUILD_ARGS=${R_BUILD_ARGS-"--no-build-vignettes --no-manual"}
 R_CHECK_ARGS=${R_CHECK_ARGS-"--no-vignettes --no-manual --as-cran"}
@@ -374,7 +373,7 @@ Coverage() {
     ## assumes that the Rutter PPAs are in fact known, which is a given here
     AptGetInstall r-cran-covr
 
-    Rscript -e "covr::codecov(type = '${COVERAGE_TYPE}', quiet = FALSE, token = '${COVERAGE_TOKEN}', flags = '${COVERAGE_FLAGS}')"
+    Rscript -e "covr::codecov(type = '${COVERAGE_TYPE}', quiet = FALSE, flags = '${COVERAGE_FLAGS}')"
 }
 
 RunTests() {


### PR DESCRIPTION
This PR enables code coverage for the R package and submits the report under flag 'r' with the repo token for codecov.io.

The actual coverage analysis is provided by the widely-used CRAN package [covr](https://cloud.r-project.org/package=covr) which is loaded when coverage is requested (when running on Linux).