### PR TITLE
[r] Arrow conversion utilities

### DIFF
--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -82,9 +82,10 @@ TileDBArray <- R6::R6Class(
     },
 
     #' @description Retrieve the array dimensions
-    #' @return A list of [`tiledb::tiledb_dim`] objects
+    #' @return A named list of [`tiledb::tiledb_dim`] objects
     dimensions = function() {
-      tiledb::dimensions(self$schema())
+      dims <- tiledb::dimensions(self$schema())
+      setNames(dims, nm = vapply_char(dims, tiledb::name))
     },
 
     #' @description Retrieve the array attributes

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -100,7 +100,8 @@ TileDBArray <- R6::R6Class(
       vapply(
         self$dimensions(),
         FUN = tiledb::name,
-        FUN.VALUE = vector("character", 1L)
+        FUN.VALUE = vector("character", 1L),
+        USE.NAMES = FALSE
       )
     },
 

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -6,6 +6,10 @@ is_arrow_data_type <- function(x) {
   is_arrow_object(x) && inherits(x, "DataType")
 }
 
+is_arrow_field <- function(x) {
+  is_arrow_object(x) && inherits(x, "Field")
+}
+
 is_arrow_record_batch <- function(x) {
   is_arrow_object(x) && inherits(x, "RecordBatch")
 }

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -145,3 +145,14 @@ arrow_field_from_tiledb_attr <- function(x) {
     nullable = tiledb::tiledb_attribute_get_nullable(x)
   )
 }
+
+#' Create an Arrow schema from a TileDB array schema
+#' @noRd
+arrow_schema_from_tiledb_schema <- function(x) {
+  stopifnot(inherits(x, "tiledb_array_schema"))
+  fields <- c(
+    lapply(tiledb::dimensions(x), arrow_field_from_tiledb_dim),
+    lapply(tiledb::attrs(x), arrow_field_from_tiledb_attr)
+  )
+  arrow::schema(fields)
+}

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -73,6 +73,25 @@ tiledb_type_from_arrow_type <- function(x) {
   )
 }
 
+arrow_type_from_tiledb_type <- function(x) {
+  stopifnot(is.character(x))
+  switch(x,
+    INT8 = arrow::int8(),
+    INT16 = arrow::int16(),
+    INT32 = arrow::int32(),
+    INT64 = arrow::int64(),
+    UINT8 = arrow::uint8(),
+    UINT16 = arrow::uint16(),
+    UINT32 = arrow::uint32(),
+    UINT64 = arrow::uint64(),
+    FLOAT32 = arrow::float32(),
+    FLOAT64 = arrow::float64(),
+    BOOL = arrow::boolean(),
+    ASCII = arrow::utf8(),
+    stop("Unsupported data type", call. = FALSE)
+  )
+}
+
 #' Retrieve limits for Arrow types
 #' @importFrom bit64 lim.integer64
 #' @noRd
@@ -98,5 +117,27 @@ arrow_type_range <- function(x) {
     utf8 = NULL,
     string = NULL,
     stop("Unsupported data type", call. = FALSE)
+  )
+}
+
+#' Create an Arrow field from a TileDB dimension
+#' @noRd
+arrow_field_from_tiledb_dim <- function(x) {
+  stopifnot(inherits(x, "tiledb_dim"))
+  arrow::field(
+    name = tiledb::name(x),
+    type = arrow_type_from_tiledb_type(tiledb::datatype(x)),
+    nullable = FALSE
+  )
+}
+
+#' Create an Arrow field from a TileDB attribute
+#' @noRd
+arrow_field_from_tiledb_attr <- function(x) {
+  stopifnot(inherits(x, "tiledb_attr"))
+  arrow::field(
+    name = tiledb::name(x),
+    type = arrow_type_from_tiledb_type(tiledb::datatype(x)),
+    nullable = tiledb::tiledb_attribute_get_nullable(x)
   )
 }

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -1,0 +1,70 @@
+test_that("TileDB classes can be converted to Arrow equivalents", {
+
+  # Dimension to Arrow field
+  dim0 <- tiledb::tiledb_dim(
+    name = "dim0",
+    domain = NULL,
+    tile = NULL,
+    type = "ASCII"
+  )
+
+  dim1 <- tiledb::tiledb_dim(
+    name = "dim1",
+    domain = bit64::as.integer64(c(0, 100)),
+    tile = bit64::as.integer64(10),
+    type = "INT64"
+  )
+
+  # Error if not a dimension
+  expect_error(arrow_field_from_tiledb_attr(dim0))
+
+  # String dimension
+  dim0_field <- arrow_field_from_tiledb_dim(dim0)
+  expect_true(is_arrow_field(dim0_field))
+  expect_equal(dim0_field$name, tiledb::name(dim0))
+  expect_equal(
+    tiledb_type_from_arrow_type(dim0_field$type),
+    tiledb::datatype(dim0)
+  )
+
+  # Integer dimension
+  dim1_field <- arrow_field_from_tiledb_dim(dim1)
+  expect_true(is_arrow_field(dim1_field))
+  expect_equal(dim1_field$name, tiledb::name(dim1))
+  expect_equal(
+    tiledb_type_from_arrow_type(dim1_field$type),
+    tiledb::datatype(dim1)
+  )
+
+  # Attribute to Arrow field
+  attr0 <- tiledb::tiledb_attr(
+    name = "attr0",
+    type = "ASCII"
+  )
+
+  attr1 <- tiledb::tiledb_attr(
+    name = "attr1",
+    type = "INT64"
+  )
+
+  # Error if not an attribute
+  expect_error(arrow_field_from_tiledb_attr(dim0))
+
+  # String attribute
+  attr0_field <- arrow_field_from_tiledb_attr(attr0)
+  expect_true(is_arrow_field(attr0_field))
+  expect_equal(attr0_field$name, tiledb::name(attr0))
+  expect_equal(
+    tiledb_type_from_arrow_type(attr0_field$type),
+    tiledb::datatype(attr0)
+  )
+
+  # Integer attribute
+  attr1_field <- arrow_field_from_tiledb_attr(attr1)
+  expect_true(is_arrow_field(attr1_field))
+  expect_equal(attr1_field$name, tiledb::name(attr1))
+  expect_equal(
+    tiledb_type_from_arrow_type(attr1_field$type),
+    tiledb::datatype(attr1)
+  )
+})

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -67,4 +67,16 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
     tiledb_type_from_arrow_type(attr1_field$type),
     tiledb::datatype(attr1)
   )
+
+  # TileDB schema to Arrow schema
+  tdb_schema <- tiledb::tiledb_array_schema(
+    domain = tiledb::tiledb_domain(c(dim0, dim1)),
+    attrs = c(attr0, attr1),
+    sparse = TRUE
+  )
+
+  arrow_schema <- arrow_schema_from_tiledb_schema(tdb_schema)
+  expect_true(is_arrow_schema(arrow_schema))
+  expect_equal(length(arrow_schema$fields), 4)
+  expect_equal(names(arrow_schema), c("dim0", "dim1", "attr0", "attr1"))
 })


### PR DESCRIPTION
This adds internal helpers for converting TileDB dimensions, attributes, and schemas to their Arrow equivalents. We'll use these in a future PR to return Arrow schemas from the foundational classes.

Also tweaked `TileDBArray$dimensions()` to return a named list, which matches the behavior of `TileDBArray$attributes()`.