### PR TITLE
Don't use default assay name for Seurat objects

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.12
+Version: 0.1.12.9000
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,8 @@
+# tiledbsoma (development version)
+
+## Fixes
+* Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire)
+
 # tiledbsoma 0.1.12
 
  ## Package name

--- a/apis/r/R/SOMACollection.R
+++ b/apis/r/R/SOMACollection.R
@@ -215,16 +215,17 @@ SOMACollection <- R6::R6Class(
       obs_df <- self$somas[[1]]$obs$to_dataframe()
 
       # retain cell identities before restoring cell-level metadata
-  idents <- obs_df$active_ident
+      idents <- obs_df$active_ident
       if (!is.null(idents)) {
-        idents <- setNames(idents, rownames(obs_df))
+        idents <- stats::setNames(idents, rownames(obs_df))
         obs_df$active_ident <- NULL
       }
 
       object <- SeuratObject::CreateSeuratObject(
         counts = assays[[1]],
         project = project,
-        meta.data = obs_df
+        meta.data = obs_df,
+        assay = names(assays)[1]
       )
 
       if (!is.null(idents)) {


### PR DESCRIPTION
This implements @dan11mcguire's fix for https://github.com/TileDB-Inc/tiledbsc/issues/82. Previously we were implicitly using Seurat's default name for the first assay created by `to_seurat()`. Now we always explicitly supply an assay name from the corresponding SOMA.