### PR TITLE
[c++] Enable internal TileDB stats collection

### DIFF
--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -53,6 +53,8 @@ using namespace tiledbsoma;
 namespace py = pybind11;
 using namespace py::literals;
 
+namespace tiledbsoma {
+
 /**
  * @brief Convert ColumnBuffer to Arrow array.
  *
@@ -89,6 +91,13 @@ py::object to_table(std::shared_ptr<ArrayBuffers> array_buffers) {
     return pa_table_from_arrays(arrays, names);
 }
 
+std::string version() {
+    int major, minor, patch;
+    tiledb_version(&major, &minor, &patch);
+    return fmt::format(
+        "libtiledbsoma={}\nlibtiledb={}.{}.{}", VERSION, major, minor, patch);
+}
+
 /**
  * @brief pybind11 bindings
  *
@@ -98,16 +107,7 @@ PYBIND11_MODULE(libtiledbsoma, m) {
 
     m.doc() = "SOMA acceleration library";
 
-    m.def("version", []() {
-        int major, minor, patch;
-        tiledb_version(&major, &minor, &patch);
-        return fmt::format(
-            "libtiledbsoma={} libtiledb={}.{}.{}",
-            VERSION,
-            major,
-            minor,
-            patch);
-    });
+    m.def("version", []() { return version(); });
 
     m.def(
         "config_logging",
@@ -119,6 +119,15 @@ PYBIND11_MODULE(libtiledbsoma, m) {
 
     m.def("info", &LOG_INFO, "message"_a = "");
     m.def("debug", &LOG_DEBUG, "message"_a = "");
+
+    m.def("stats_enable", []() { tiledb::Stats::enable(); });
+    m.def("stats_disable", []() { tiledb::Stats::disable(); });
+    m.def("stats_reset", []() { tiledb::Stats::reset(); });
+    m.def("stats_dump", []() {
+        std::string stats;
+        tiledb::Stats::dump(&stats);
+        std::cout << version() << "\n" << stats;
+    });
 
     py::class_<SOMAReader>(m, "SOMAReader")
         .def(
@@ -278,3 +287,4 @@ PYBIND11_MODULE(libtiledbsoma, m) {
 
         .def("nnz", &SOMAReader::nnz);
 }
+}  // namespace tiledbsoma

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -148,6 +148,8 @@ def test_soma_reader_dim_mixed():
 def test_soma_reader_obs_slice_x():
     """Read X/data sliced by obs."""
 
+    clib.stats_enable()
+
     # read obs
     # ---------------------------------------------------------------1
     name = "obs"
@@ -171,6 +173,9 @@ def test_soma_reader_obs_slice_x():
     assert sr.results_complete()
     assert obs.num_rows == 60
 
+    clib.stats_dump()
+    clib.stats_reset()
+
     # read X/data
     # ---------------------------------------------------------------1
     name = "X/data"
@@ -187,6 +192,9 @@ def test_soma_reader_obs_slice_x():
         total_num_rows += x_data.num_rows
 
     assert total_num_rows == 110280
+
+    clib.stats_dump()
+    clib.stats_disable()
 
 
 def test_soma_reader_column_names():


### PR DESCRIPTION
This PR provides python/C++ bindings to control the internal TileDB stats collection.
* The python bindings should be wrapped with python functions/docstrings for inclusion in the API docs.
* Similar functions can be implemented in R.

New libtiledbsoma python functions:
```python
import tiledbsoma.libtiledbsoma as clib

# Enable TileDB internal statistics
clib.stats_enable()

# Disable TileDB internal statistics
clib.stats_disable()

# Reset all TileDB internal statistics to 0
clib.stats_reset()

# Print TileDB internal statistics to cout
clib.stats_dump()
```

Example output:
```
libtiledbsoma=faa9021-modified
libtiledb=2.12.0
[
  {
    "timers": {
      "Context.StorageManager.subSubarray.read_load_relevant_rtrees.sum": 0.000191879,
      "Context.StorageManager.subSubarray.read_load_relevant_rtrees.avg": 2.74113e-05,
      "Context.StorageManager.subSubarray.read_compute_tile_overlap.sum": 0.00102588,
      "Context.StorageManager.subSubarray.read_compute_tile_overlap.avg": 0.00102588,
      "Context.StorageManager.subSubarray.read_compute_relevant_tile_overlap.sum": 0.000636366,
      "Context.StorageManager.subSubarray.read_compute_relevant_tile_overlap.avg": 9.09094e-05,
      "Context.StorageManager.subSubarray.read_compute_relevant_frags.sum": 0.000158146,
      "Context.StorageManager.subSubarray.read_compute_relevant_frags.avg": 2.25923e-05,
      "Context.StorageManager.sm_load_array_schemas_and_fragment_metadata.sum": 0.000246897,
      "Context.StorageManager.sm_load_array_schemas_and_fragment_metadata.avg": 0.000246897,
      "Context.StorageManager.sm_load_array_schema_from_uri.sum": 0.000176006,
      "Context.StorageManager.sm_load_array_schema_from_uri.avg": 0.000176006,
      "Context.StorageManager.sm_load_all_array_schemas.sum": 0.000191461,
      "Context.StorageManager.sm_load_all_array_schemas.avg": 0.000191461,
      "Context.StorageManager.load_fragment_metadata.sum": 4.8723e-05,
      "Context.StorageManager.load_fragment_metadata.avg": 4.8723e-05,
      "Context.StorageManager.array_open_for_reads.sum": 0.000249576,
      "Context.StorageManager.array_open_for_reads.avg": 0.000249576,
      "Context.StorageManager.Subarray.read_compute_tile_coords.sum": 3.414e-06,
      "Context.StorageManager.Subarray.read_compute_tile_coords.avg": 3.414e-06,
      "Context.StorageManager.Query.Reader.unfilter_attr_tiles.sum": 0.0102394,
      "Context.StorageManager.Query.Reader.unfilter_attr_tiles.avg": 0.0102394,
      "Context.StorageManager.Query.Reader.read_tiles.sum": 0.0127017,
      "Context.StorageManager.Query.Reader.read_tiles.avg": 0.0127017,
      "Context.StorageManager.Query.Reader.read_attribute_tiles.sum": 0.0127047,
      "Context.StorageManager.Query.Reader.read_attribute_tiles.avg": 0.0127047,
      "Context.StorageManager.Query.Reader.load_tile_offsets.sum": 0.000135991,
      "Context.StorageManager.Query.Reader.load_tile_offsets.avg": 0.000135991,
      "Context.StorageManager.Query.Reader.init_state.sum": 0.000134403,
      "Context.StorageManager.Query.Reader.init_state.avg": 0.000134403,
      "Context.StorageManager.Query.Reader.fill_dense_coords.sum": 0.000887103,
      "Context.StorageManager.Query.Reader.fill_dense_coords.avg": 0.000887103,
      "Context.StorageManager.Query.Reader.dowork.sum": 0.0266873,
      "Context.StorageManager.Query.Reader.dowork.avg": 0.0266873,
      "Context.StorageManager.Query.Reader.copy_fixed_tiles.sum": 0.000182665,
      "Context.StorageManager.Query.Reader.copy_fixed_tiles.avg": 0.000182665,
      "Context.StorageManager.Query.Reader.copy_attribute.sum": 0.00018627,
      "Context.StorageManager.Query.Reader.copy_attribute.avg": 0.00018627,
      "Context.StorageManager.Query.Reader.apply_query_condition.sum": 5.15e-07,
      "Context.StorageManager.Query.Reader.apply_query_condition.avg": 5.15e-07,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.sum": 0.00114635,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.avg": 0.00114635
    },
    "counters": {
      "Context.StorageManager.subSubarray.precompute_tile_overlap.tile_overlap_byte_size": 3328,
      "Context.StorageManager.subSubarray.precompute_tile_overlap.relevant_fragment_num": 1,
      "Context.StorageManager.subSubarray.precompute_tile_overlap.ranges_requested": 52,
      "Context.StorageManager.subSubarray.precompute_tile_overlap.ranges_computed": 52,
      "Context.StorageManager.subSubarray.precompute_tile_overlap.fragment_num": 1,
      "Context.StorageManager.read_unfiltered_byte_num": 319,
      "Context.StorageManager.read_tile_offsets_size": 24,
      "Context.StorageManager.read_rtree_size": 8,
      "Context.StorageManager.read_frag_meta_size": 510,
      "Context.StorageManager.read_array_schema_size": 287,
      "Context.StorageManager.VFS.read_ops_num": 12,
      "Context.StorageManager.VFS.read_byte_num": 15066569,
      "Context.StorageManager.VFS.ls_num": 5,
      "Context.StorageManager.VFS.file_size_num": 1,
      "Context.StorageManager.Query.Reader.read_unfiltered_byte_num": 15056896,
      "Context.StorageManager.Query.Reader.num_tiles_read": 1,
      "Context.StorageManager.Query.Reader.num_tiles": 1,
      "Context.StorageManager.Query.Reader.loop_num": 1,
      "Context.StorageManager.Query.Reader.dim_num": 2,
      "Context.StorageManager.Query.Reader.dim_fixed_num": 2,
      "Context.StorageManager.Query.Reader.attr_num": 1,
      "Context.StorageManager.Query.Reader.attr_fixed_num": 1,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.ranges": 52,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.found": 1,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.adjusted_ranges": 52
    }
  }
]
```