### PR TITLE
[c++] Improve build experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,46 +2,34 @@
 
 MAKEFLAGS += --no-print-directory
 
-# - incrementally compile and install the c++ code
-# - copy the shared objects on top of the python dev build
-.PHONY: update
-update:
-	@cd build && make -j && make install-libtiledbsoma
-	cp dist/lib/* apis/python/src/tiledbsoma/
+# print help by default
+help:
 
-# - run the clean rule
-# - build the c++ code using the environment's cmake (not the python build-system cmake)
-#   - builds a Release build
-# - install the python in editable mode (dev build)
+# install 
+# -------------------------------------------------------------------
 .PHONY: install
 install: clean
-	./scripts/bld
-	pip install -v -e apis/python
+	@./scripts/bld --prefix=${prefix} --tiledb=${tiledb} --build=${build}
+	@pip install -v -e apis/python
 
-# - run the clean rule
-# - build the c++ code using the environment's cmake (not the python build-system cmake)
-#   - builds a Debug build
-# - install the python in editable mode (dev build)
-.PHONY: install-debug
-install-debug: clean
-	BUILD_TYPE=Debug ./scripts/bld
-	pip install -v -e apis/python
-
-# - run the clean rule
-# - build the c++ static library for r
 .PHONY: r-build
 r-build: clean
-	./scripts/bld --prefix=${prefix} --r-build
+	@./scripts/bld --prefix=${prefix} --tiledb=${tiledb} --r-build
 
-# - run the data rule
-# - run c++ unit tests
-# - run pytests
+# incremental compile and update python install
+# -------------------------------------------------------------------
+.PHONY: update
+update:
+	cd build && make -j && make install-libtiledbsoma
+	cp dist/lib/* apis/python/src/tiledbsoma/
+
+# test
+# -------------------------------------------------------------------
 .PHONY: test
 test: data
 	ctest --test-dir build/libtiledbsoma -C Release --verbose
 	pytest
 
-# install the test data
 .PHONY: data
 data:
 	./apis/python/tools/ingestor \
@@ -52,13 +40,58 @@ data:
 		data/pbmc3k_processed.h5ad \
 		data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
 
-# - remove the c++ build and dist, and the test data
+# clean
+# -------------------------------------------------------------------
 .PHONY: clean
 clean:
-	rm -rf build dist
+	@rm -rf build dist
 
-# - run git clean (in dry-run mode)
 .PHONY: cleaner
 cleaner:
-	@echo "*** dry-run mode: remove -n to actually remove files"
+	@printf "*** dry-run mode: remove -n to actually remove files\n"
 	git clean -ffdx -e .vscode -e test/tiledbsoma -n
+
+# help
+# -------------------------------------------------------------------
+define HELP
+Usage: make rule [options]
+
+Rules:
+  install [options]   Build C++ library and install python module
+  r-build [options]   Build C++ static library for R
+  update              Incrementally build C++ library and update python module
+  test                Run tests
+  clean               Remove build artifacts
+
+Options:
+  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
+  prefix=PREFIX       Install location [${PWD}/dist]
+  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
+
+Examples:
+  Install Release build
+
+    make install
+
+  Install Debug build of libtiledbsoma and libtiledb
+
+    make install build=Debug
+
+  Install Release build with custom libtiledb
+
+    make install tiledb=$$PWD/../TileDB/dist
+    export LD_LIBRARY_PATH=$$PWD/../TileDB/dist/lib:$$LD_LIBRARY_PATH     # linux
+    export DYLD_LIBRARY_PATH=$$PWD/../TileDB/dist/lib:$$DYLD_LIBRARY_PATH # macos
+
+  Incrementally build C++ changes and update the python module
+
+    make update
+
+
+endef 
+export HELP
+
+.PHONY: help
+help:
+	@printf "$${HELP}"
+

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ Usage: make rule [options]
 
 Rules:
   install [options]   Build C++ library and install python module
-  r-build [options]   Build C++ static library for R
+  r-build [options]   Build C++ static library with "#define R_BUILD" for R
   update              Incrementally build C++ library and update python module
   test                Run tests
   clean               Remove build artifacts

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -72,6 +72,13 @@ if (TILEDBSOMA_BUILD_R)
   add_compile_options(-DR_BUILD)
 endif()
 
+# Enable compiler cache to speed up recompilation
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif()
+
 # Set C++17 as required standard for all C++ targets (C++17 minimum is required to use the TileDB C++ API).
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/libtiledbsoma/README.md
+++ b/libtiledbsoma/README.md
@@ -3,7 +3,7 @@
 ## System Dependencies
 
 * C++17 compiler
-* Python 3.7+
+* Python 3.8+
 
 Run these commands to setup a fresh Ubuntu 22.04 instance (tested on x86 and Arm):
 ```
@@ -55,28 +55,42 @@ make test
 
 ### Developer Makefile
 
-The [Makefile](../Makefile) automates common developer use cases and promotes sharing of consistent build flows, including the following:
+The [Makefile](../Makefile) automates common developer use cases and promotes sharing of consistent build flows.
 
 ```
-# Build libtiledbsoma, install the project in editable mode
-make install
+Usage: make rule [options]
 
-# Run the tests, installing test data if needed
-make test
+Rules:
+  install [options]   Build C++ library and install python module
+  r-build [options]   Build C++ static library for R
+  update              Incrementally build C++ library and update python module
+  test                Run tests
+  clean               Remove build artifacts
 
-# Build debug versions libtiledbsoma and libtiledb, install the project in editable mode
-make install-debug
+Options:
+  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
+  prefix=PREFIX       Install location [/home/gspowley/work/TileDB-SOMA/dist]
+  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
 
-# Remove the C++ build, dist, and test data directories
-make clean
+Examples:
+  Install Release build
 
-# Build a static libtiledbsoma library for R
-make r-build
+    make install
 
-# Incrementally compile modified C++ code and install in the editable python project
-make
+  Install Debug build of libtiledbsoma and libtiledb
+
+    make install build=Debug
+
+  Install Release build with custom libtiledb
+
+    make install tiledb=$PWD/../TileDB/dist
+    export LD_LIBRARY_PATH=$PWD/../TileDB/dist/lib:$LD_LIBRARY_PATH     # linux
+    export DYLD_LIBRARY_PATH=$PWD/../TileDB/dist/lib:$DYLD_LIBRARY_PATH # macos
+
+  Incrementally build C++ changes and update the python module
+
+    make update test
 ```
-> **Note** - Please update the `Makefile` to share new build flows with other developers.
 
 ---
 

--- a/libtiledbsoma/README.md
+++ b/libtiledbsoma/README.md
@@ -62,14 +62,14 @@ Usage: make rule [options]
 
 Rules:
   install [options]   Build C++ library and install python module
-  r-build [options]   Build C++ static library for R
+  r-build [options]   Build C++ static library with "#define R_BUILD" for R
   update              Incrementally build C++ library and update python module
   test                Run tests
   clean               Remove build artifacts
 
 Options:
   build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
-  prefix=PREFIX       Install location [/home/gspowley/work/TileDB-SOMA/dist]
+  prefix=PREFIX       Install location [dist]
   tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
 
 Examples:
@@ -89,7 +89,7 @@ Examples:
 
   Incrementally build C++ changes and update the python module
 
-    make update test
+    make update
 ```
 
 ---

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -37,8 +37,10 @@ endif()
 
 if (TILEDB_FOUND)
   get_target_property(TILEDB_LIB TileDB::tiledb_shared IMPORTED_LOCATION_RELEASE)
-  # NOTE: TILEDB_LIB-NOTFOUND here is not indicative of error.
-  #       TODO maybe needs fix in TileDBConfig? Check actual linkage.
+  # If release build location not found, check for debug build location
+  if (TILEDB_LIB MATCHES "NOTFOUND")
+    get_target_property(TILEDB_LIB TileDB::tiledb_shared IMPORTED_LOCATION_DEBUG)
+  endif()
   message(STATUS "Found TileDB: ${TILEDB_LIB}")
 else()
   if (SUPERBUILD)

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -173,7 +173,7 @@ def test_soma_reader_obs_slice_x():
     assert sr.results_complete()
     assert obs.num_rows == 60
 
-    clib.stats_dump()
+    # clib.stats_dump()
     clib.stats_reset()
 
     # read X/data
@@ -193,7 +193,7 @@ def test_soma_reader_obs_slice_x():
 
     assert total_num_rows == 110280
 
-    clib.stats_dump()
+    # clib.stats_dump()
     clib.stats_disable()
 
 

--- a/scripts/bld
+++ b/scripts/bld
@@ -8,15 +8,17 @@ set -eu -o pipefail
 # -------------------------------------------------------------------
 arg() { echo "$1" | sed "s/^${2-[^=]*=}//" | sed "s/:/;/g"; }
 
+build="Release"
 prefix=""
-build_type="Release"
 r_build="OFF"
+tiledb=""
 
 while test $# != 0; do
   case "$1" in
+  --build=*) build=$(arg "$1");;
   --prefix=*) prefix=$(arg "$1");;
-  --enable-debug) build_type="Debug";;
   --r-build) r_build="ON";;
+  --tiledb=*) tiledb=$(arg "$1");;
   esac
   shift
 done
@@ -32,11 +34,13 @@ fi
 # set extra cmake options
 # -------------------------------------------------------------------
 extra_opts=""
-if [ "${build_type}" == "Debug" ]; then
+if [ "${build}" == "Debug" ] && [ -z "${tiledb}" ]; then
   # Debug build: build TileDB from source with debug enabled
   extra_opts+=" -DFORCE_EXTERNAL_TILEDB=ON -DDOWNLOAD_TILEDB_PREBUILT=OFF"
-elif [ "$(uname -m)" == "aarch64" ]; then
-  # build on arm: build TileDB from source
+fi
+
+# build on arm: build TileDB from source
+if [ "$(uname -m)" == "aarch64" ]; then
   extra_opts=+" -DFORCE_EXTERNAL_TILEDB=ON -DDOWNLOAD_TILEDB_PREBUILT=OFF"
 fi
 
@@ -50,29 +54,43 @@ if false; then
   # TILEDB_WERROR=OFF is necessary to build core with XCode 14; doesn't hurt for XCode 13.
   extra_opts+=" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DTILEDB_WERROR=OFF -DTILEDBSOMA_ENABLE_WERROR=OFF"
   
+  # Debug cmake find commands
+  extra_opts+=" --debug-find"
+
   # Also (pro-tip), set nproc=1 to get a more deterministic ordering of output lines.
   nproc=1
 fi
 
+# set installation path
 if [ -n "${prefix}"  ]; then 
   extra_opts+=" -DCMAKE_INSTALL_PREFIX=${prefix} -DOVERRIDE_INSTALL_PREFIX=OFF"
 fi
 
+# build for R only
 if [ "${r_build}" == "ON" ]; then 
   extra_opts+=" -DTILEDBSOMA_BUILD_R=${r_build}"
 fi
 
+# build with custom tiledb
+if [ -n "${tiledb}"  ]; then
+  printf "Build with TileDB: ${tiledb}\n"
+  export TileDB_DIR="${tiledb}"
+  export LD_LIBRARY_PATH="${tiledb}"
+  export DYLD_LIBRARY_PATH="${tiledb}"
+fi
+
 # run cmake
 # -------------------------------------------------------------------
-echo "Building ${build_type} build"
-echo -e "${extra_opts}"
+printf "Building ${build} build\n"
 
 # cd to the top level directory of the repo
-cd "$(git rev-parse --show-toplevel)"
+if [ "${r_build}" == "OFF" ]; then 
+  cd "$(git rev-parse --show-toplevel)"
+fi
 
 rm -rf build
 mkdir -p build
-cmake -B build -S libtiledbsoma -DCMAKE_BUILD_TYPE=${build_type} ${extra_opts}
+cmake -B build -S libtiledbsoma -DCMAKE_BUILD_TYPE=${build} ${extra_opts}
 cmake --build build -j ${nproc}
 cmake --build build --target install-libtiledbsoma
 


### PR DESCRIPTION
Update build scripts based on more feedback, including better support for building with a custom build of TileDB.

```
Usage: make rule [options]

Rules:
  install [options]   Build C++ library and install python module
  r-build [options]   Build C++ static library with "#define R_BUILD" for R
  update              Incrementally build C++ library and update python module
  test                Run tests
  clean               Remove build artifacts

Options:
  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
  prefix=PREFIX       Install location [dist]
  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 

Examples:
  Install Release build

    make install

  Install Debug build of libtiledbsoma and libtiledb

    make install build=Debug

  Install Release build with custom libtiledb

    make install tiledb=$PWD/../TileDB/dist
    export LD_LIBRARY_PATH=$PWD/../TileDB/dist/lib:$LD_LIBRARY_PATH     # linux
    export DYLD_LIBRARY_PATH=$PWD/../TileDB/dist/lib:$DYLD_LIBRARY_PATH # macos

  Incrementally build C++ changes and update the python module

    make update

```