### PR TITLE
add temporary configuration to SOMAReader instances

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -166,6 +166,7 @@ class DataFrame(TileDBArray):
                 schema=A.schema,  # query_condition needs this
                 column_names=column_names,
                 query_condition=query_condition,
+                platform_config={} if self._ctx is None else self._ctx.config().dict(),
             )
 
             if ids is not None:

--- a/apis/python/src/tiledbsoma/indexed_dataframe.py
+++ b/apis/python/src/tiledbsoma/indexed_dataframe.py
@@ -212,6 +212,7 @@ class IndexedDataFrame(TileDBArray):
                 schema=A.schema,  # query_condition needs this
                 column_names=column_names,
                 query_condition=query_condition,
+                platform_config={} if self._ctx is None else self._ctx.config().dict(),
             )
 
             if ids is not None:

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -146,7 +146,13 @@ class SparseNdArray(TileDBArray):
         """
         Return the number of stored values in the array, including explicitly stored zeros.
         """
-        return cast(int, clib.SOMAReader(self.uri).nnz())
+        return cast(
+            int,
+            clib.SOMAReader(
+                self.uri,
+                platform_config={} if self._ctx is None else self._ctx.config().dict(),
+            ).nnz(),
+        )
 
     def read_sparse_tensor(
         self,
@@ -253,6 +259,7 @@ class SparseNdArray(TileDBArray):
                 self._uri,
                 name=self.__class__.__name__,
                 schema=A.schema,
+                platform_config={} if self._ctx is None else self._ctx.config().dict(),
             )
 
             if coords is not None:


### PR DESCRIPTION
For the Python package, add a temporary means of configuring the SOMAReader via the `ctx` support.

This enables configuration to be passed to the C++ reader:
```
    df = soma.IndexedDataFrame(uri, ctx=tiledb.Ctx({"vfs.s3.region": "us-west-2"})
    df.read_as_pandas_all()
```

This will be superseded by the upcoming context/platform_config work.