### PR TITLE
Add the `platform_config` parameter to create methods.

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_platform_config.py
+++ b/apis/python/src/tiledbsoma/tiledb_platform_config.py
@@ -1,5 +1,20 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import tiledb
+
+from .types import PlatformConfig
 
 
 @dataclass(frozen=True)
@@ -34,3 +49,131 @@ class TileDBPlatformConfig:
     # TODO: remove when SOMA/Arrow path is known to be working well.
     #
     from_anndata_write_pandas_using_arrow: bool = True
+
+
+def from_param(pc: Optional[PlatformConfig]) -> "ParamWrapper":
+    """Extracts the TileDB-specific platform config key."""
+    pc = pc or {}
+    return ParamWrapper(pc.get("tiledb", {}))
+
+
+@dataclass(frozen=True)
+class ParamWrapper(Mapping[str, Any]):
+    """Wrapper for the TileDB key of the ``platform_config`` parameter.
+
+    Provides some methods and proxies to the config dict itself.
+    """
+
+    _config: PlatformConfig
+
+    def create_options(self) -> "CreateWrapper":
+        return CreateWrapper(self.get("create", {}))
+
+    # Mapping implementation:
+
+    def __getitem__(self, it: str) -> Any:
+        return self._config[it]
+
+    def __len__(self) -> int:
+        return len(self._config)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._config)
+
+
+StrOrMap = Union[str, Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class CreateWrapper(Mapping[str, Any]):
+
+    _config: Mapping[str, Any]
+
+    def offsets_filters(
+        self,
+        default: Sequence[StrOrMap] = (
+            "DoubleDeltaFilter",
+            "BitWidthReductionFilter",
+            "ZstdFilter",
+        ),
+    ) -> Sequence[tiledb.Filter]:
+        return _build_filters(self.get("offsets_filters", default))
+
+    def cell_tile_orders(
+        self,
+        default_cell: Optional[str] = "row-major",
+        default_tile: Optional[str] = "row-major",
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Returns the cell and tile orders that should be used.
+
+        If *neither* ``cell_order`` nor ``tile_order`` is present, only in this
+        case will we use the default values provided.
+        """
+        if "cell_order" in self or "tile_order" in self:
+            return self.get("cell_order"), self.get("tile_order")
+
+        return default_cell, default_tile
+
+    def dim_filters(
+        self, dim: str, default: Sequence[StrOrMap] = ()
+    ) -> Sequence[tiledb.Filter]:
+        return _build_filters(self._dim(dim).get("filters", default))
+
+    def dim_tile(self, dim: str, default: int = 2048) -> int:
+        return self._dim(dim).get("tile", default)
+
+    def attr_filters(
+        self, attr: str, default: Sequence[StrOrMap] = ()
+    ) -> Sequence[tiledb.Filter]:
+        return _build_filters(self._attr(attr).get("filters", default))
+
+    def _dim(self, dim: str) -> Dict[str, Any]:
+        return cast(Dict[str, Any], self.get("dims", {}).get(dim, {}))
+
+    def _attr(self, attr: str) -> Dict[str, Any]:
+        return cast(Dict[str, Any], self.get("attrs", {}).get(attr, {}))
+
+    # Mapping implementation:
+
+    def __getitem__(self, it: str) -> Any:
+        return self._config[it]
+
+    def __len__(self) -> int:
+        return len(self._config)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._config)
+
+
+_FILTERS: Mapping[str, Type[tiledb.Filter]] = {
+    cls.__name__: cls for cls in tiledb.FilterList.filter_type_cc_to_python.values()
+}
+
+
+def _build_filters(items: Any) -> Sequence[tiledb.Filter]:
+    return tuple(map(_build_filter, items))
+
+
+def _build_filter(item: Any) -> tiledb.Filter:
+    kwargs: Dict[str, Any]
+    if isinstance(item, str):
+        cls_name = item
+        kwargs = {}
+    elif isinstance(item, Mapping):
+        kwargs = dict(item)
+        try:
+            cls_name = kwargs.pop("_type")
+        except KeyError as ke:
+            raise ValueError(
+                "filter specification must include a `_type` key with the filter type"
+            ) from ke
+    else:
+        raise TypeError(
+            f"filter specification must be a string name or a dict, not {type(item)}"
+        )
+
+    try:
+        cls = _FILTERS[cls_name]
+    except KeyError as ke:
+        raise ValueError(f"no filter named {cls_name!r}") from ke
+    return cls(**kwargs)

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Literal, Sequence, Tuple, Union
+from typing import Any, List, Literal, Mapping, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -57,3 +57,6 @@ SparseNdCoordinates = Union[
     None,
     Sequence[Union[None, DenseCoordinates, Sequence[int], np.ndarray, pa.IntegerArray]],
 ]
+
+PlatformConfig = Mapping[str, Any]
+"""The platform-configuration dictionary. May contain a ``tiledb`` key."""

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import anndata
 import pytest
+import tiledb
 
 import tiledbsoma
 import tiledbsoma.io
@@ -26,25 +27,37 @@ def adata(h5ad_file):
 def test_platform_config(adata):
 
     # Set up anndata input path and tiledb-group output path
-    tempdir = tempfile.TemporaryDirectory()
-    output_path = tempdir.name
+    with tempfile.TemporaryDirectory() as output_path:
+        # Ingest
+        exp = tiledbsoma.Experiment(output_path)
+        tiledbsoma.io.from_anndata(
+            exp,
+            adata,
+            "mRNA",
+            platform_config={
+                "tiledb": {
+                    "create": {
+                        "capacity": 8888,
+                        "offsets_filters": ["RleFilter", "NoOpFilter"],
+                        "dims": {
+                            "soma_dim_0": {"tile": 6},
+                            "soma_dim_1": {"filters": []},
+                        },
+                        "attrs": {"soma_data": {"filters": ["NoOpFilter"]}},
+                        "cell_order": "row-major",
+                        "tile_order": "col-major",
+                    },
+                },
+            },
+        )
 
-    # platform_config = {"tiledb": TileDBPlatformConfig(X_capacity=8888))
-    # platform_config = {"tiledb": {"X_capacity":8888}}
-    # platform_config = {"tiledb": {"capacity":8888}}
-    # Hi Paul! Two notes:
-    # * In `main-old` we had `X_capacity` separate from capacities for every array. Might be worth
-    #   doing here in `main`.
-    # * The above three commented-out attempts didn't work for me until I read the code.
-    #   This is PEBKAC for sure, however, we might do a bit more aggressive shape-checking
-    #   to warn others users, who may be as careless as myself, earlier than later.
-    platform_config = {"tiledb": {"create": {"capacity": 8888}}}
-
-    # Ingest
-    exp = tiledbsoma.Experiment(output_path)
-    tiledbsoma.io.from_anndata(exp, adata, "mRNA", platform_config=platform_config)
-
-    with exp.ms["mRNA"].X["data"]._tiledb_open() as X:
-        assert X.schema.capacity == 8888
-
-    # soma.TileDBPlatformConfig(obs_extent=999, X_capacity=8888)
+        with exp.ms["mRNA"].X["data"]._tiledb_open() as arr:
+            sch = arr.schema
+            assert sch.capacity == 8888
+            assert sch.cell_order == "row-major"
+            assert sch.tile_order == "col-major"
+            assert sch.offsets_filters == [tiledb.RleFilter(), tiledb.NoOpFilter()]
+            assert arr.attr("soma_data").filters == [tiledb.NoOpFilter()]
+            assert arr.dim("soma_dim_0").tile == 6
+            assert arr.dim("soma_dim_1").filters == []
+            print(sch)

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -1,0 +1,50 @@
+import tempfile
+from pathlib import Path
+
+import anndata
+import pytest
+
+import tiledbsoma
+import tiledbsoma.io
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def h5ad_file(request):
+    # pbmc-small is faster for automated unit-test / CI runs.
+    # input_path = HERE.parent / "anndata/pbmc3k_processed.h5ad"
+    input_path = HERE.parent / "anndata/pbmc-small.h5ad"
+    return input_path
+
+
+@pytest.fixture
+def adata(h5ad_file):
+    return anndata.read_h5ad(h5ad_file)
+
+
+def test_platform_config(adata):
+
+    # Set up anndata input path and tiledb-group output path
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+
+    # platform_config = {"tiledb": TileDBPlatformConfig(X_capacity=8888))
+    # platform_config = {"tiledb": {"X_capacity":8888}}
+    # platform_config = {"tiledb": {"capacity":8888}}
+    # Hi Paul! Two notes:
+    # * In `main-old` we had `X_capacity` separate from capacities for every array. Might be worth
+    #   doing here in `main`.
+    # * The above three commented-out attempts didn't work for me until I read the code.
+    #   This is PEBKAC for sure, however, we might do a bit more aggressive shape-checking
+    #   to warn others users, who may be as careless as myself, earlier than later.
+    platform_config = {"tiledb": {"create": {"capacity": 8888}}}
+
+    # Ingest
+    exp = tiledbsoma.Experiment(output_path)
+    tiledbsoma.io.from_anndata(exp, adata, "mRNA", platform_config=platform_config)
+
+    with exp.ms["mRNA"].X["data"]._tiledb_open() as X:
+        assert X.schema.capacity == 8888
+
+    # soma.TileDBPlatformConfig(obs_extent=999, X_capacity=8888)


### PR DESCRIPTION
This adds a `platform_config` parameter, which allows a user to tune options relating to the creation of their TileDB array.

The structure of the data it expects can be described with this TypeScript specification:

```typescript
interface PlatformConfig {
  tiledb?: TDBConfig;
}

interface TDBConfig {
  create?: TDBCreateOptions;
}

interface TDBCreateOptions {
  dims?: { [dim: string]: TDBDimension };
  attrs?: { [attr: string]: TDBAttr };
  offsets_filters?: TDBFilter[];
  capacity?: number;
  cell_order?: string;
  tile_order?: string;
}

interface TDBDimension {
  filters?: TDBFilter[];
  tile?: number;
}

interface TDBAttr {
  filters?: TDBFilter[];
}

/**
 * Either the name of a filter (in which case it will use
 * the default arguments) or a specification with filter args.
 */
type TDBFilter = string | TDBFilterSpec;

interface TDBFilterSpec {
  /** The name of the filter. */
  _name: string;
  /** kwargs that are passed when constructing the filter. */
  [kwarg: string]: any;
}
```