### PR TITLE
[r] Use X_capacity=1000 to optimize reads

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.16
+Version: 0.1.16.9000
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/AssayMatrix.R
+++ b/apis/r/R/AssayMatrix.R
@@ -175,7 +175,7 @@ AssayMatrix <- R6::R6Class(
       index_cols = c("obs_id", "var_id"),
       cell_order = "ROW_MAJOR",
       tile_order = "ROW_MAJOR",
-      capacity = 100000) {
+      capacity = 1000) {
 
       # determine appropriate type for each attribute
       value_cols <- setdiff(colnames(x), index_cols)

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -33,9 +33,7 @@ TileDBObject <- R6::R6Class(
       }
 
       if (is.null(self$ctx)) {
-        config <- tiledb_config()
-        config["sm.mem.reader.sparse_global_order.ratio_array_data"] = "0.3"
-        self$ctx <- tiledb::tiledb_ctx(config)
+        self$ctx <- tiledb::tiledb_get_context()
       }
     },
 

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -33,7 +33,9 @@ TileDBObject <- R6::R6Class(
       }
 
       if (is.null(self$ctx)) {
-        self$ctx <- tiledb::tiledb_ctx(c("sm.mem.reader.sparse_global_order.ratio_array_data" = "0.3"))
+        config <- tiledb_config()
+        config["sm.mem.reader.sparse_global_order.ratio_array_data"] = "0.3"
+        self$ctx <- tiledb::tiledb_ctx(config)
       }
     },
 

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -33,7 +33,7 @@ TileDBObject <- R6::R6Class(
       }
 
       if (is.null(self$ctx)) {
-        self$ctx <- tiledb::tiledb_get_context()
+        self$ctx <- tiledb::tiledb_ctx(c("sm.mem.reader.sparse_global_order.ratio_array_data" = "0.3"))
       }
     },
 


### PR DESCRIPTION
Larger-scale queries (in the megacell range) have revealed an opportunity to more closely align tile capacity with remote-read performance.

This PR ports #533 from Python to R on `main-old`.