### PR TITLE
Apply ctx to tiledb.array_exists

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -41,7 +41,8 @@ class TileDBArray(TileDBObject):
         object has not yet been populated, e.g. before calling ``from_anndata`` --- or, if the
         SOMA has been populated but doesn't have this member (e.g. not all SOMAs have a ``varp``).
         """
-        return bool(tiledb.array_exists(self.uri))
+        with tiledb.scope_ctx(self._ctx):
+            return bool(tiledb.array_exists(self.uri))
 
     def tiledb_array_schema(self) -> tiledb.ArraySchema:
         """


### PR DESCRIPTION
Scenario:

* Append-to-single-soma ingestion contexts
* Some configs are present only in `ctx` and not in the shell environment
* After successful schema-only ingest, the data-ingest fails [here](https://github.com/single-cell-data/TileDB-SOMA/blob/93855155949ee97b222877bdb9e1268bbaf474a2/apis/python/src/tiledbsoma/annotation_dataframe.py#L378) because the array-exists method [here](https://github.com/single-cell-data/TileDB-SOMA/blob/93855155949ee97b222877bdb9e1268bbaf474a2/apis/python/src/tiledbsoma/tiledb_array.py#L44) is not using the `self._ctx` as it should

This PR fixes that.