### PR TITLE
[r] Ignore directory with TileDB Core headers in coverage analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 coverage:
   range: "90...95"
+
+ignore:
+  - "apis/r/inst/tiledb/"


### PR DESCRIPTION
The code coverage analysis also descends into a directory containing headers from TileDB Core which are not part of this repo, and should be excluded from coverage analysis.  Setting an `ignore:` directive achieves this.

No code changes in this PR.

