### PR TITLE
[r] Update logging code utilizing templated interface

### DIFF
--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -69,7 +69,7 @@ bool export_column(const std::string& uri, const std::string& colname,
 // [[Rcpp::export]]
 SEXP export_column_direct(const std::string& uri, const std::vector<std::string>& colnames) {
 
-    spdl::info(fmt::format("Reading from {}", uri));
+    spdl::info("Reading from {}", uri);
 
     // Read selected columns from the uri array (return is unique_ptr<SOMAReader>)
     auto sr = tdbs::SOMAReader::open(uri, "", {}, colnames);
@@ -80,8 +80,8 @@ SEXP export_column_direct(const std::string& uri, const std::vector<std::string>
     if (!sr->results_complete()) {
         Rcpp::warning("Read of '%s' incomplete", uri);
     }
-    spdl::info(fmt::format("Read complete with {} rows and {} cols",
-                           sr_data->get()->num_rows(), sr_data->get()->names().size()));
+    spdl::info("Read complete with {} rows and {} cols",
+               sr_data->get()->num_rows(), sr_data->get()->names().size());
 
     auto ncol = sr_data->get()->names().size();
     Rcpp::List reslist(ncol);
@@ -95,7 +95,7 @@ SEXP export_column_direct(const std::string& uri, const std::vector<std::string>
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = sr_data->get()->at(colnames[i]);
 
-        spdl::info(fmt::format("Accessing {} at {}", colnames[i], i));
+        spdl::info("Accessing {} at {}", colnames[i], i);
 
         // this is pair of array and schema pointer
         auto pp = tdbs::ArrowAdapter::to_arrow(buf);
@@ -149,10 +149,9 @@ Rcpp::List soma_reader(const std::string& uri,
                        Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
                        const std::string& loglevel = "warn") {
 
-    tdbs::LOG_SET_LEVEL(loglevel);
     spdl::set_level(loglevel);
 
-    spdl::info(fmt::format("[soma_reader] Reading from {}", uri));
+    spdl::info("[soma_reader] Reading from {}", uri);
 
     // Read selected columns from the uri (return is unique_ptr<SOMAReader>)
     auto sr = tdbs::SOMAReader::open(uri);
@@ -162,22 +161,22 @@ Rcpp::List soma_reader(const std::string& uri,
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim: dims) {
-        spdl::info(fmt::format("[soma_reader] Dimension {} type {} domain {} extent {}",
-                               dim.name(), tiledb::impl::to_str(dim.type()),
-                               dim.domain_to_str(), dim.tile_extent_to_str()));
+        spdl::info("[soma_reader] Dimension {} type {} domain {} extent {}",
+                   dim.name(), tiledb::impl::to_str(dim.type()),
+                   dim.domain_to_str(), dim.tile_extent_to_str());
         name2type.emplace(std::make_pair(dim.name(), dim.type()));
     }
 
     // If we have column names, select them
     if (!colnames.isNull()) {
         std::vector<std::string> cn = Rcpp::as<std::vector<std::string>>(colnames);
-        spdl::info(fmt::format("[soma_reader] Selecting {} columns", cn.size()));
+        spdl::info("[soma_reader] Selecting {} columns", cn.size());
         sr->select_columns(cn);
     }
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdl::info(fmt::format("[soma_reader] Applying query condition"));
+        spdl::info("[soma_reader] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         sr->set_condition(*qcxp);
     }
@@ -203,9 +202,8 @@ Rcpp::List soma_reader(const std::string& uri,
     if (!sr->results_complete()) {
         Rcpp::warning("Read of '%s' incomplete", uri);
     }
-    spdl::info(fmt::format("[soma_reader] Read complete with {} rows and {} cols",
-                               sr_data->get()->num_rows(),
-                               sr_data->get()->names().size()));
+    spdl::info("[soma_reader] Read complete with {} rows and {} cols",
+               sr_data->get()->num_rows(), sr_data->get()->names().size());
 
     const std::vector<std::string> names = sr_data->get()->names();
     auto ncol = names.size();
@@ -216,7 +214,7 @@ Rcpp::List soma_reader(const std::string& uri,
         SEXP schemaxp = arch_c_allocate_schema();
         SEXP arrayxp = arch_c_allocate_array_data();
 
-        spdl::info(fmt::format("[soma_reader] Accessing {} at {}", names[i], i));
+        spdl::info("[soma_reader] Accessing {} at {}", names[i], i);
 
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = sr_data->get()->at(names[i]);
@@ -227,7 +225,7 @@ Rcpp::List soma_reader(const std::string& uri,
         memcpy((void*) R_ExternalPtrAddr(schemaxp), pp.second.get(), sizeof(ArrowSchema));
         memcpy((void*) R_ExternalPtrAddr(arrayxp), pp.first.get(), sizeof(ArrowArray));
 
-        spdl::info(fmt::format("[soma_reader] Incoming name {}", std::string(pp.second->name)));
+        spdl::info("[soma_reader] Incoming name {}", std::string(pp.second->name));
 
         schlst[i] = schemaxp;
         arrlst[i] = arrayxp;
@@ -256,7 +254,7 @@ Rcpp::List soma_reader(const std::string& uri,
 //' @noRd
 // [[Rcpp::export]]
 void set_log_level(const std::string& level) {
-    tdbs::LOG_SET_LEVEL(level);
+    spdl::set_level(level);
 }
 
 //' @noRd

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -139,7 +139,7 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
     check_xptr_tag<tiledb::Context>(ctx);
     spdl::set_level(loglevel);
 
-    spdl::info(fmt::format("[sr_setup] Setting up {}", uri));
+    spdl::info("[sr_setup] Setting up {}", uri);
 
     //std::map<std::string, std::string> platform_config;
     std::string_view name = "unnamed";
@@ -161,15 +161,15 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim: dims) {
-        spdl::info(fmt::format("[soma_reader] Dimension {} type {} domain {} extent {}",
-                               dim.name(), tiledb::impl::to_str(dim.type()),
-                               dim.domain_to_str(), dim.tile_extent_to_str()));
+        spdl::info("[soma_reader] Dimension {} type {} domain {} extent {}",
+                   dim.name(), tiledb::impl::to_str(dim.type()),
+                   dim.domain_to_str(), dim.tile_extent_to_str());
         name2type.emplace(std::make_pair(dim.name(), dim.type()));
     }
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdl::info(fmt::format("[soma_reader] Applying query condition"));
+        spdl::info("[soma_reader] Applying query condition") ;
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         ptr->set_condition(*qcxp);
     }
@@ -197,7 +197,7 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
 // [[Rcpp::export]]
 bool sr_complete(Rcpp::XPtr<tdbs::SOMAReader> sr) {
    check_xptr_tag<tdbs::SOMAReader>(sr);
-   spdl::info(fmt::format("[sr_complete] Complete test is {}", sr->is_complete()));
+   spdl::info("[sr_complete] Complete test is {}", sr->is_complete());
    return sr->is_complete();
 }
 
@@ -209,10 +209,10 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAReader> sr) {
 
    auto sr_data = sr->read_next();
    if (!sr->results_complete()) {
-       tdbs::LOG_TRACE(fmt::format("[sr_next] Read is incomplete"));
+       spdl::trace("[sr_next] Read is incomplete");
    }
-   spdl::info(fmt::format("[sr_next] Read {} rows and {} cols",
-                          sr_data->get()->num_rows(), sr_data->get()->names().size()));
+   spdl::info("[sr_next] Read {} rows and {} cols",
+              sr_data->get()->num_rows(), sr_data->get()->names().size()) ;
 
    const std::vector<std::string> names = sr_data->get()->names();
    auto ncol = names.size();
@@ -223,7 +223,7 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAReader> sr) {
        SEXP schemaxp = arch_c_allocate_schema();
        SEXP arrayxp = arch_c_allocate_array_data();
 
-       tdbs::LOG_TRACE(fmt::format("[sr_next] Accessing {} at {}", names[i], i));
+       spdl::trace("[sr_next] Accessing {} at {}", names[i], i);
 
        // now buf is a shared_ptr to ColumnBuffer
        auto buf = sr_data->get()->at(names[i]);

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -19,33 +19,33 @@ void apply_dim_points(tdbs::SOMAReader *sr,
             for (size_t i=0; i<iv.size(); i++) {
                 uv[i] = static_cast<uint64_t>(iv[i]);
                 sr->set_dim_point<uint64_t>(nm, uv[i]);  // bonked when use with vector
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {}", uv[i], nm));
+                spdl::info("[export_arrow_array] Applying dim point {} on {}", uv[i], nm);
             }
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericVector payload = lst[nm];
             std::vector<int64_t> iv = getInt64Vector(payload);
             for (size_t i=0; i<iv.size(); i++) {
                 sr->set_dim_point<int64_t>(nm, iv[i]);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {}", iv[i], nm));
+                spdl::info("[export_arrow_array] Applying dim point {} on {}", iv[i], nm) ;
             }
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericVector payload = lst[nm];
             for (R_xlen_t i=0; i<payload.size(); i++) {
                 float v = static_cast<uint64_t>(payload[i]);
                 sr->set_dim_point<float>(nm, v);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {}", v, nm));
+                spdl::info("[export_arrow_array] Applying dim point {} on {}", v, nm) ;
             }
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericVector payload = lst[nm];
             for (R_xlen_t i=0; i<payload.size(); i++) {
                 sr->set_dim_point<double>(nm,payload[i]);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {}", payload[i], nm));
+                spdl::info("[export_arrow_array] Applying dim point {} on {}", payload[i], nm) ;
             }
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerVector payload = lst[nm];
             for (R_xlen_t i=0; i<payload.size(); i++) {
                 sr->set_dim_point<int32_t>(nm,payload[i]);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {}", payload[i], nm));
+                spdl::info("[export_arrow_array] Applying dim point {} on {}", payload[i], nm) ;
             }
         } else {
             Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));
@@ -68,7 +68,7 @@ void apply_dim_ranges(tdbs::SOMAReader* sr,
                 uint64_t h = static_cast<uint64_t>(makeScalarInteger64(hi[i]));
                 std::vector<std::pair<uint64_t, uint64_t>> vp{std::make_pair(l,h)};
                 sr->set_dim_ranges<uint64_t>(nm, vp);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h));
+                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
             }
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericMatrix mm = lst[nm];
@@ -77,7 +77,7 @@ void apply_dim_ranges(tdbs::SOMAReader* sr,
             for (int i=0; i<mm.nrow(); i++) {
                 std::vector<std::pair<int64_t, int64_t>> vp{std::make_pair(lo[i], hi[i])};
                 sr->set_dim_ranges<int64_t>(nm, vp);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]));
+                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
             }
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericMatrix mm = lst[nm];
@@ -88,7 +88,7 @@ void apply_dim_ranges(tdbs::SOMAReader* sr,
                 float h = static_cast<float_t>(hi[i]);
                 std::vector<std::pair<float, float>> vp{std::make_pair(l,h)};
                 sr->set_dim_ranges<float>(nm, vp);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h));
+                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
             }
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericMatrix mm = lst[nm];
@@ -97,7 +97,7 @@ void apply_dim_ranges(tdbs::SOMAReader* sr,
             for (int i=0; i<mm.nrow(); i++) {
                 std::vector<std::pair<double, double>> vp{std::make_pair(lo[i],hi[i])};
                 sr->set_dim_ranges<double>(nm, vp);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]));
+                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
             }
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerMatrix mm = lst[nm];
@@ -108,7 +108,7 @@ void apply_dim_ranges(tdbs::SOMAReader* sr,
                 int32_t h = static_cast<int32_t>(hi[i]);
                 std::vector<std::pair<int32_t, int32_t>> vp{std::make_pair(l,h)};
                 sr->set_dim_ranges<int32_t>(nm, vp);
-                spdl::info(fmt::format("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm[i], l, h));
+                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm[i], l, h) ;
             }
         } else {
             Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));


### PR DESCRIPTION
This PR updates the logging code to using the recently-enhanced versions offering templated access which alleviates the (explicit but wordier) use of the `fmt::format()` layer. 

No code changes in this PR.