### PR TITLE
[r] Extend iterated reader interface with platform_config

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -78,6 +78,8 @@ nnz <- function(uri) {
 #' dimension(s). Each dimension can be one entry in the list.
 #' @param dim_ranges Optional named list with two-column matrix where each row select a range
 #' for the given dimension. Each dimension can be one entry in the list.
+#' @param config Optional named chracter vector with \sQuote{key} and \sQuote{value} pairs
+#' used as TileDB config parameters. If unset default configuration is used.
 #' @param loglevel Character value with the desired logging level, defaults to \sQuote{warn}
 #' @param sr An external pointer to a TileDB SOMAReader object
 #'
@@ -103,8 +105,8 @@ nnz <- function(uri) {
 #' summary(rl)
 #' }
 #' @export
-sr_setup <- function(ctx, uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, loglevel = "warn") {
-    .Call(`_tiledbsoma_sr_setup`, ctx, uri, colnames, qc, dim_points, dim_ranges, loglevel)
+sr_setup <- function(ctx, uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, config = NULL, loglevel = "warn") {
+    .Call(`_tiledbsoma_sr_setup`, ctx, uri, colnames, qc, dim_points, dim_ranges, config, loglevel)
 }
 
 #' @rdname sr_setup

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -76,7 +76,7 @@ Write
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{values}}{An \code{\link[arrow:Table]{arrow::Table}} containing all columns, including
-the \code{soma_rowid} index column. The schema for \code{values} must match the
+any index columns. The schema for \code{values} must match the
 schema for the \code{SOMADataFrame}.}
 }
 \if{html}{\out{</div>}}

--- a/apis/r/man/sr_setup.Rd
+++ b/apis/r/man/sr_setup.Rd
@@ -13,6 +13,7 @@ sr_setup(
   qc = NULL,
   dim_points = NULL,
   dim_ranges = NULL,
+  config = NULL,
   loglevel = "warn"
 )
 
@@ -35,6 +36,9 @@ dimension(s). Each dimension can be one entry in the list.}
 
 \item{dim_ranges}{Optional named list with two-column matrix where each row select a range
 for the given dimension. Each dimension can be one entry in the list.}
+
+\item{config}{Optional named chracter vector with \sQuote{key} and \sQuote{value} pairs
+used as TileDB config parameters. If unset default configuration is used.}
 
 \item{loglevel}{Character value with the desired logging level, defaults to \sQuote{warn}}
 

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -98,8 +98,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // sr_setup
-Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx, const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, const std::string& loglevel);
-RcppExport SEXP _tiledbsoma_sr_setup(SEXP ctxSEXP, SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP loglevelSEXP) {
+Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx, const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, Rcpp::Nullable<Rcpp::CharacterVector> config, const std::string& loglevel);
+RcppExport SEXP _tiledbsoma_sr_setup(SEXP ctxSEXP, SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP configSEXP, SEXP loglevelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -109,8 +109,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> >::type qc(qcSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type dim_points(dim_pointsSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type dim_ranges(dim_rangesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type loglevel(loglevelSEXP);
-    rcpp_result_gen = Rcpp::wrap(sr_setup(ctx, uri, colnames, qc, dim_points, dim_ranges, loglevel));
+    rcpp_result_gen = Rcpp::wrap(sr_setup(ctx, uri, colnames, qc, dim_points, dim_ranges, config, loglevel));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -145,7 +146,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_set_log_level", (DL_FUNC) &_tiledbsoma_set_log_level, 1},
     {"_tiledbsoma_get_column_types", (DL_FUNC) &_tiledbsoma_get_column_types, 2},
     {"_tiledbsoma_nnz", (DL_FUNC) &_tiledbsoma_nnz, 1},
-    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 7},
+    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 8},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_sr_next", (DL_FUNC) &_tiledbsoma_sr_next, 1},
     {NULL, NULL, 0}


### PR DESCRIPTION
This PR extend the 'iterating reader' to accept an optional argument `config`: a (standard R) named character vector for `key=value` pairs used to seed the `platform_config` map.  This now permits to set configuration values.  Here is an example of turning logging one by passing `config=c("config.logging_level" = "5")`:

```sh
$ ./quickCheck.R 
[2022-11-18 17:24:38.034] [Process: 2773728] [info] [1668813877360419015-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:24:38.274] [Process: 2773728] [info] [1668813877360419015-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:24:38.355] [Process: 2773728] [info] [1668813877360419015-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:24:38.543] [Process: 2773728] [info] [1668813877360419015-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:24:38.543] [Process: 2773728] [info] [1668813877360419015-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:24:38.765] [Process: 2773728] [trace] [1668813878010788925-Global] malloc_trim did unmap memory
$ 
```

We can combine this with the existing logging support from R which, when set to `debug`, also shows the value being set (see second line):

```sh
$ ./quickCheck.R 
[2022-11-18 17:49:39.119] [default] [Process: 2837302] [info] [sr_setup] Setting up ~/git/tiledb-soma/test/soco/pbmc3k_processed/ms/mRNA/X/data/
[2022-11-18 17:49:39.119] [default] [Process: 2837302] [debug] [sr_setup] config map adding 'config.logging_level' = '5'
[2022-11-18 17:49:39.119] [default] [Process: 2837302] [debug] [sr_setup] creating ctx object with supplied config
[2022-11-18 17:49:39.122] [default] [Process: 2837302] [info] [soma_reader] Dimension soma_dim_0 type INT64 domain [0,2637] extent 2048
[2022-11-18 17:49:39.122] [default] [Process: 2837302] [info] [soma_reader] Dimension soma_dim_1 type INT64 domain [0,1837] extent 1838
[2022-11-18 17:49:39.137] [Process: 2837302] [info] [1668815378482964946-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:49:39.186] [default] [Process: 2837302] [info] [sr_complete] Complete test is false
[2022-11-18 17:49:39.186] [default] [Process: 2837302] [info] [sr_next] Read 1213080 rows and 3 cols
[2022-11-18 17:49:39.354] [default] [Process: 2837302] [info] [sr_complete] Complete test is false
[2022-11-18 17:49:39.365] [Process: 2837302] [info] [1668815378482964946-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:49:39.403] [default] [Process: 2837302] [info] [sr_next] Read 1211242 rows and 3 cols
[2022-11-18 17:49:39.436] [default] [Process: 2837302] [info] [sr_complete] Complete test is false
[2022-11-18 17:49:39.449] [Process: 2837302] [info] [1668815378482964946-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:49:39.493] [default] [Process: 2837302] [info] [sr_next] Read 1213080 rows and 3 cols
[2022-11-18 17:49:39.618] [default] [Process: 2837302] [info] [sr_complete] Complete test is false
[2022-11-18 17:49:39.633] [Process: 2837302] [info] [1668815378482964946-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:49:39.633] [Process: 2837302] [info] [1668815378482964946-Context: 2] [Query: 1] [DenseReader: 1] using cache
[2022-11-18 17:49:39.681] [default] [Process: 2837302] [info] [sr_next] Read 1211242 rows and 3 cols
[2022-11-18 17:49:39.835] [default] [Process: 2837302] [info] [sr_complete] Complete test is true
[2022-11-18 17:49:39.838] [Process: 2837302] [trace] [1668815379114681381-Global] malloc_trim did unmap memory
$ 
```

No other code change.  No test added as there is currently no way to return a config so hard to check that values are set.  We can address this later, as we can extending the other (simpler) SOMAReader interface.

I had accidentally pushed this same commit to `main` a few minutes ago, but have undo that as `main` should only change after reviews of pull requests.