### PR TITLE
Do not rewrite pre-creation URI to post-creation URI

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_group.py
+++ b/apis/python/src/tiledbsoma/tiledb_group.py
@@ -234,14 +234,6 @@ class TileDBGroup(TileDBObject):
         with self._open("w") as G:
             if not exists:
                 G.add(uri=child_uri, relative=relative, name=obj.name)
-        # See _get_child_uri. Key point is that, on TileDB Cloud, URIs change from pre-creation to
-        # post-creation. Example:
-        # * Upload to pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname
-        # * Results will be at post-creation URI tiledb://namespace/somaname
-        # * Note people can still use the pre-creation URI to read the data if they like.
-        # * Member pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname/obs
-        # * Member post-creation URI tiledb://somaname/e4de581a-1353-4150-b1f4-6ed12548e497
-        obj.uri = self._get_child_uri(obj.name)
 
     def _remove_object(self, obj: TileDBObject) -> None:
         self._remove_object_by_name(obj.name)


### PR DESCRIPTION
See the comments at
https://github.com/single-cell-data/TileDB-SOMA/blob/0f9aac4c5e2f9eb939262e210fca68895b1d7fb8/apis/python/src/tiledbsoma/tiledb_group.py#L237-L244
which tell the whole story:

```
# See _get_child_uri. Key point is that, on TileDB Cloud, URIs change from pre-creation to
# post-creation. Example:
# * Upload to pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname
# * Results will be at post-creation URI tiledb://namespace/somaname
# * Note people can still use the pre-creation URI to read the data if they like.
# * Member pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname/obs
# * Member post-creation URI tiledb://somaname/e4de581a-1353-4150-b1f4-6ed12548e497
```

Re-writing the URIs here was a convenience; however, for append-mode ingests, it can be error-prone -- when the soma object is already instantiated, and a schema-only ingest has been done with `schema_only=True`, the user will need to come back and ingest data with `schema_only=False` and the pre-creation URI needs to still be in place.