### PR TITLE
[c++] Map 8-bit TILEDB_BOOL to 1-bit Arrow boolean

### DIFF
--- a/libtiledbsoma/include/tiledbsoma/arrow_adapter.h
+++ b/libtiledbsoma/include/tiledbsoma/arrow_adapter.h
@@ -3,6 +3,7 @@
 
 #include <tiledbsoma/tiledbsoma>
 #include "carrow.h"
+#include <stdio.h>
 
 // https://arrow.apache.org/docs/format/CDataInterface.html
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-listing-for-each-layout
@@ -100,14 +101,68 @@ class ArrowAdapter {
         array->buffers = (const void**)malloc(sizeof(void*) * n_buffers);
         assert(array->buffers != nullptr);
         array->buffers[0] = nullptr;  // validity
+        bool boolean_column_type = column->type() == 41 ? true : false;
+
         if (n_buffers == 2) {
-            array->buffers[1] = column->data<void*>().data();
+            if (boolean_column_type) {
+                out_bitmap(column, array.get(), 1);
+            } else {
+                array->buffers[1] = column->data<void*>().data();
+            }
         } else if (n_buffers == 3) {
             array->buffers[1] = column->offsets().data();
-            array->buffers[2] = column->data<void*>().data();
+            if (boolean_column_type) {
+                out_bitmap(column, array.get(), 2);
+            } else {
+                array->buffers[2] = column->data<void*>().data();
+            }
         }
 
         return std::pair(std::move(array), std::move(schema));
+    }
+
+    static void out_bitmap(
+            std::shared_ptr<ColumnBuffer> column, 
+            ArrowArray* array, 
+            int buffer_index) {
+        auto in_bytemap = column->data<bool>().data();
+        int in_byte_length = column->size();
+        
+        // If the array length is not byte-aligned, get the difference
+        int byte_align = in_byte_length % 8 == 0 ? 0 : 
+            8 - (in_byte_length % 8);
+        int out_bit_length = in_byte_length + byte_align;
+        uint8_t out_bitmap[out_bit_length / 8];
+        
+        // Pad input array with 0s so it's byte-aligned
+        if (byte_align != 0) {
+            for (int i = 0; i < byte_align; i++) {
+                in_bytemap[in_byte_length + i] = 0;
+                in_byte_length++;
+            }
+        }
+
+        for (int in_byte_idx = 0; in_byte_idx < out_bit_length; in_byte_idx++) {
+            int out_byte_idx = in_byte_idx / 8;
+            // If it's the start of the byte, set the dest byte to 0
+            if (in_byte_idx % 8 == 0) {
+                out_bitmap[out_byte_idx] = 0;
+            }
+            for (int ob_idx = 0; ob_idx < 8; ob_idx++) {
+                // Retrieve the source bit from the input bytemap array
+                auto in_bitset = std::bitset<8>(in_bytemap[in_byte_idx]);
+                auto source_bit = in_bitset[7-ob_idx];
+                
+                // this works, the translation to Arrow bool is what's failing
+                out_bitmap[out_byte_idx] |= 
+                    0b00000000 | source_bit << (7 - (in_byte_idx % 8));
+                
+                // Sanity check: Print the bitmap
+                if(ob_idx == 7 && in_byte_idx != 0 && in_byte_idx % 7 == 0)
+                    std::cerr<<out_byte_idx<<": "<<std::bitset<8>(out_bitmap[out_byte_idx])<<std::endl;
+            }
+        }
+        array->buffers[buffer_index] = (bool*)out_bitmap;
     }
 
     /**
@@ -125,7 +180,8 @@ class ArrowAdapter {
             case TILEDB_BLOB:
                 return "Z";  // large because TileDB uses 64bit offsets
             case TILEDB_BOOL:
-                return "C";  // TILEDB_BOOL is 8bit but arrow BOOL is 1bit
+                //return "C";  // TILEDB_BOOL is 8bit but arrow BOOL is 1bit
+                return "b";
             case TILEDB_INT32:
                 return "i";
             case TILEDB_INT64:


### PR DESCRIPTION
Problem: `TILEDB_BOOL` is stored as a `uint8_t`, while Arrow uses 1-bit `bool`. 
Solution: Overwrite the `ColumnBuffer`'s bytemap in-place with its corresponding byte-aligned bitmap.


Test case:
```python
#!/usr/bin/env python

import os
import shutil

import numpy as np
import pandas as pd
import pyarrow as pa
import tiledbsoma as soma
import tiledbsoma.libtiledbsoma as clib

uri = "489"
if os.path.exists(uri):
    shutil.rmtree(uri)

df = pd.DataFrame(
    {
        "soma_joinid": np.asarray([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], dtype=np.int64),
        "b": np.array([False,True,True,False,True,False,True, False,False,False,True,False,True,False,False,False,True,False,True,False], dtype=bool),
    }
)
tbl = pa.Table.from_pandas(df)
sdf = soma.DataFrame(uri)
sdf.create(schema=tbl.schema, index_column_names=['soma_joinid'])
sdf.write(tbl)

print("DataFrame.schema:")
print(sdf.schema)

print()
print("PANDAS")
read_df = sdf.read_as_pandas_all()
for k in read_df:
  print(k, read_df[k].dtype)
assert sdf.read_as_pandas_all().b.dtype == bool

print()
print("ARROW")
read_df = sdf.read_all()
for v in read_df:
  print(v.to_pylist())
  print(v.type)

print()
print("SOMAReader")
sr = clib.SOMAReader('489')
sr.submit()
t = sr.read_next()
print(t.to_pylist())
print(t['b'].type)
```

Results:
```bash
DataFrame.schema:
soma_joinid: int64
b: bool

PANDAS
soma_joinid int64
b bool

ARROW
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
int64
[False, True, True, False, True, False, True, False, False, False, True, False, True, False, False, False, True, False, True, False]
bool

SOMAReader
[{'soma_joinid': 1, 'b': False}, {'soma_joinid': 2, 'b': True}, {'soma_joinid': 3, 'b': True}, {'soma_joinid': 4, 'b': False}, {'soma_joinid': 5, 'b': True}, {'soma_joinid': 6, 'b': False}, {'soma_joinid': 7, 'b': True}, {'soma_joinid': 8, 'b': False}, {'soma_joinid': 9, 'b': False}, {'soma_joinid': 10, 'b': False}, {'soma_joinid': 11, 'b': True}, {'soma_joinid': 12, 'b': False}, {'soma_joinid': 13, 'b': True}, {'soma_joinid': 14, 'b': False}, {'soma_joinid': 15, 'b': False}, {'soma_joinid': 16, 'b': False}, {'soma_joinid': 17, 'b': True}, {'soma_joinid': 18, 'b': False}, {'soma_joinid': 19, 'b': True}, {'soma_joinid': 20, 'b': False}]
bool
```