### PR TITLE
Add documentation for `platform_config` to the Python README.

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -10,20 +10,20 @@ This branch, `main`, implements the [updated specfication](https://github.com/si
 
 This code is hosted at [PyPI](https://pypi.org/project/tiledbsoma/), so you can do
 
-```
-python -m pip install tiledbsoma
+```shell
+$ python -m pip install tiledbsoma
 ```
 
 To install a specific version:
 
-```
-python -m pip install git+https://github.com/single-cell-data/TileDB-SOMA.git@0.0.6#subdirectory=apis/python
+```shell
+$ python -m pip install git+https://github.com/single-cell-data/TileDB-SOMA.git@0.0.6#subdirectory=apis/python
 ```
 
 To update to the latest version:
 
-```
-python -m pip install --upgrade tiledbsoma
+```shell
+$ python -m pip install --upgrade tiledbsoma
 ```
 
 ## From source
@@ -34,17 +34,62 @@ python -m pip install --upgrade tiledbsoma
 * `python -m pip install .`
 * Or, if you wish to modify the code and run it, `python setup.py develop`
 * Optionally, if you prefer, you can run that inside `venv`:
-```
-python -m venv venv
-. ./venv/bin/activate
-python -m pip install .
-```
+  ```shell
+  $ python -m venv venv
+  $ . ./venv/bin/activate
+  $ python -m pip install .
+  ```
 * In either case:
-
-```
-python -m pytest tests
-```
+  ```shell
+  python -m pytest tests
+  ```
 
 # Status
 
 Please see [https://github.com/single-cell-data/TileDB-SOMA/issues](https://github.com/single-cell-data/TileDB-SOMA/issues).
+
+# `platform_config` format
+
+When accessing SOMA APIs, TileDB-specific settings can be configured with the `platform_config` parameter.
+The options accepted by TileDB SOMA are described here, using [TypeScript interface syntax](https://www.typescriptlang.org/docs/handbook/2/objects.html):
+
+```typescript
+interface PlatformConfig {
+  tiledb?: TDBConfig;
+}
+
+interface TDBConfig {
+  create?: TDBCreateOptions;
+}
+
+interface TDBCreateOptions {
+  dims?: { [dim: string]: TDBDimension };
+  attrs?: { [attr: string]: TDBAttr };
+  offsets_filters?: TDBFilter[];
+  capacity?: number;
+  cell_order?: string;
+  tile_order?: string;
+}
+
+interface TDBDimension {
+  filters?: TDBFilter[];
+  tile?: number;
+}
+
+interface TDBAttr {
+  filters?: TDBFilter[];
+}
+
+/**
+ * Either the name of a filter (in which case it will use
+ * the default arguments) or a specification with filter args.
+ */
+type TDBFilter = string | TDBFilterSpec;
+
+interface TDBFilterSpec {
+  /** The name of the filter. */
+  _name: string;
+  /** kwargs that are passed when constructing the filter. */
+  [kwarg: string]: any;
+}
+```


### PR DESCRIPTION
Based on a note I left on #562, I figured the `platform_config` format should probably be documented someplace more visible and durable than the contents of a single commit message.