### PR TITLE
[r] Make SOMAs and X layers selectable when converting to a Seurat object

### DIFF
--- a/apis/python/examples/soco-batch-query.py
+++ b/apis/python/examples/soco-batch-query.py
@@ -33,7 +33,7 @@ print("cell_type_ontology_term_id count =", n)
 for i, ctot_id in enumerate(ctot_ids):
     soma_slices = soco.query(
         obs_attrs=["cell_type_ontology_term_id"],
-        obs_query_string=f'cell_type_ontology_term_id == {ctot_id!r}',
+        obs_query_string=f"cell_type_ontology_term_id == {ctot_id!r}",
     )
     if soma_slices == []:
         continue

--- a/apis/python/examples/soco-batch-query.py
+++ b/apis/python/examples/soco-batch-query.py
@@ -33,7 +33,7 @@ print("cell_type_ontology_term_id count =", n)
 for i, ctot_id in enumerate(ctot_ids):
     soma_slices = soco.query(
         obs_attrs=["cell_type_ontology_term_id"],
-        obs_query_string=f'cell_type_ontology_term_id == "{ctot_id}"',
+        obs_query_string=f'cell_type_ontology_term_id == {ctot_id!r}',
     )
     if soma_slices == []:
         continue

--- a/apis/python/examples/uniformizer.py
+++ b/apis/python/examples/uniformizer.py
@@ -67,7 +67,7 @@ def main() -> int:
         return uniformizer.add_soma(args.dataset_id, args.soma)
     else:
         raise Exception(
-            f'Internal coding error: handler for "{args.func_name}" not found.'
+            f'Internal coding error: handler for {args.func_name!r} not found.'
         )
 
 

--- a/apis/python/examples/uniformizer.py
+++ b/apis/python/examples/uniformizer.py
@@ -67,7 +67,7 @@ def main() -> int:
         return uniformizer.add_soma(args.dataset_id, args.soma)
     else:
         raise Exception(
-            f'Internal coding error: handler for {args.func_name!r} not found.'
+            f"Internal coding error: handler for {args.func_name!r} not found."
         )
 
 

--- a/apis/python/src/tiledbsoma/annotation_dataframe.py
+++ b/apis/python/src/tiledbsoma/annotation_dataframe.py
@@ -94,7 +94,7 @@ class AnnotationDataFrame(TileDBArray):
         """
         Default display of soma.obs and soma.var.
         """
-        return ", ".join(f"'{key}'" for key in self.keys())
+        return ", ".join(f"{key!r}" for key in self.keys())
 
     # ----------------------------------------------------------------
     def __len__(self) -> int:

--- a/apis/python/src/tiledbsoma/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix_group.py
@@ -47,7 +47,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         """
         Default display of soma.obsm and soma.varm.
         """
-        return ", ".join(f"'{key}'" for key in self.keys())
+        return ", ".join(f"{key!r}" for key in self.keys())
 
     # ----------------------------------------------------------------
     def __iter__(self) -> Iterator[AnnotationMatrix]:
@@ -68,7 +68,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         with self._open() as G:
             if name not in G:
                 raise AttributeError(
-                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                    f"{self.__class__.__name__!r} object has no attribute {name!r}"
                 )
         return self[name]
 

--- a/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
@@ -57,7 +57,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         """
         Default display of soma.obsp and soma.varp.
         """
-        return ", ".join(f"'{key}'" for key in self.keys())
+        return ", ".join(f"{key!r}" for key in self.keys())
 
     # ----------------------------------------------------------------
     def __getattr__(self, name: str) -> Optional[AssayMatrix]:
@@ -68,7 +68,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         with self._open() as G:
             if name not in G:
                 raise AttributeError(
-                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                    f"{self.__class__.__name__!r} object has no attribute {name!r}"
                 )
         return self[name]
 

--- a/apis/python/src/tiledbsoma/assay_matrix_group.py
+++ b/apis/python/src/tiledbsoma/assay_matrix_group.py
@@ -54,7 +54,7 @@ class AssayMatrixGroup(TileDBGroup):
         """
         Default display of soma.X.
         """
-        return ", ".join(f"'{key}'" for key in self.keys())
+        return ", ".join(f"{key!r}" for key in self.keys())
 
     # ----------------------------------------------------------------
     def __getattr__(self, name: str) -> Optional[AssayMatrix]:
@@ -65,7 +65,7 @@ class AssayMatrixGroup(TileDBGroup):
         with self._open() as G:
             if name not in G:
                 raise AttributeError(
-                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                    f"{self.__class__.__name__!r} object has no attribute {name!r}"
                 )
         return self[name]
 

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -89,7 +89,7 @@ def show_tiledb_group_array_schemas(uri: str, ctx: Optional[tiledb.Ctx] = None) 
 
 # ----------------------------------------------------------------
 def list_fragments(array_uri: str) -> None:
-    print(f"Listing fragments for array: '{array_uri}'")
+    print(f"Listing fragments for array: {array_uri!r}")
     vfs = tiledb.VFS()
 
     fragments = []

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.22.9000
+Version: 0.1.22.9001
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,7 +2,8 @@
 
 ## Features
 
-* New function `dataset_seurat_pbmc3k()` to download the pbmc3k dataset from 10X and import as a `Seurat` object without requiring any extra dependencies.
+- The `SOMACollection`'s `to_seurat()` method gains a `somas` argument that makes it possible to select a subset of `SOMA`s and `X` layers to be retrieved (#571).
+- New function `dataset_seurat_pbmc3k()` to download the pbmc3k dataset from 10X and import as a `Seurat` object without requiring any extra dependencies.
 
 # tiledbsoma 0.1.19
 
@@ -14,7 +15,7 @@
 
 ## Features
 
-- The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods.
+- The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods (#548).
 
 ## Changes
 
@@ -22,7 +23,7 @@
 
 ## Fixes
 
-- Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire)
+- Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire).
 
 # tiledbsoma 0.1.12
 

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -105,7 +105,8 @@ file_path <- function(..., fsep = .Platform$file.sep) {
   file.path(..., fsep = fsep)
 }
 
-#' Assert all values of `x` are a subset of `y`. @param x,y vectors of values
+#' Assert all values of `x` are a subset of `y`.
+#' @param x,y vectors of values
 #' @param type A character vector of length 1 used in the error message
 #' @return `TRUE` if all values of `x` are present in `y`, otherwise an
 #' informative error is thrown with the missing values.

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -175,7 +175,11 @@ dimensionality reduction method (e.g., \code{"pca"}).
 \subsection{Method \code{to_seurat()}}{
 Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(project = "SeuratProject", batch_mode = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(
+  project = "SeuratProject",
+  somas = NULL,
+  batch_mode = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -183,8 +187,14 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \describe{
 \item{\code{project}}{\code{\link[SeuratObject:Project]{SeuratObject::Project}} name for the \code{Seurat} object}
 
+\item{\code{somas}}{character vector, names of \code{SOMA}s to include as
+\code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}}s in the \code{Seurat} object. If \code{NULL}, all \code{SOMA}s
+are included. Can also be a named list of character vectors, where each
+element corresponds to a \code{SOMA} name and the value is a character vector
+of \code{X} layers from that \code{SOMA} to include as assays (e.g., \code{list("RNA" = c("counts", "logcounts"))}).}
+
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X}, \code{obsm}/\code{varm}, and \code{obsp}/\code{varp} layers. See
+retrieving \code{X} layers. See
 \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}

--- a/apis/r/tests/testthat/helpers.R
+++ b/apis/r/tests/testthat/helpers.R
@@ -16,3 +16,18 @@ with_allocation_size_preference <- function(value, .local_envir = parent.frame()
   )
   tiledb::set_allocation_size_preference(value)
 }
+
+
+#' Compare data.frames or matrices after sorting dimensions
+#' Useful for comparing objects were numerically or lexicographically sorted
+#' after being reconstituted from TileDB.
+#' @noRd
+expect_equal_after_ordering_dims <- function(object, expected, ...) {
+  stopifnot(
+    is.data.frame(object) || is_matrix(object),
+    is.data.frame(expected) || is_matrix(expected)
+  )
+
+  object <- object[rownames(expected), colnames(expected)]
+  testthat::expect_equal(object, expected, ...)
+}


### PR DESCRIPTION
This PR adds a `somas` argument to `SOMACollection`'s `to_seurat()` method that allows you to select a subset of `SOMA`s and, optionally, `X` layers when converting to a `Seurat` object. 

You can pass either a vector of `SOMA` names

```r
soco$to_seurat(somas = c("SOMA1", "SOMA2"))
```

_or_ a named list of character vectors, where each element corresponds to a `SOMA` name and the value is a character vector of `X` layers from that `SOMA` to include in the corresponding Seurat `Assay`:

```r
soco$to_seurat(somas = list(SOMA1 = c("counts", "data"), SOMA2 = "counts"))
```
