### PR TITLE
Support half-slices in SOMAReader

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -259,8 +259,7 @@ class DataFrame(TileDBArray):
                         sr.set_dim_points(dim_name, dim_ids)
                     elif isinstance(dim_ids, slice):
                         ned = A.nonempty_domain()
-                        lo_hi = util.slice_to_range(
-                            dim_ids, ned[i]) if ned else None
+                        lo_hi = util.slice_to_range(dim_ids, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi
                             if lo < 0 or hi < 0:

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -258,7 +258,9 @@ class DataFrame(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, dim_ids)
                     elif isinstance(dim_ids, slice):
-                        lo_hi = util.slice_to_range(dim_ids)
+                        ned = A.nonempty_domain()
+                        lo_hi = util.slice_to_range(
+                            dim_ids, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi
                             if lo < 0 or hi < 0:

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -258,7 +258,7 @@ class DataFrame(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, dim_ids)
                     elif isinstance(dim_ids, slice):
-                        ned = A.nonempty_domain() # None iff the array has no data
+                        ned = A.nonempty_domain()  # None iff the array has no data
                         lo_hi = util.slice_to_range(dim_ids, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -258,7 +258,7 @@ class DataFrame(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, dim_ids)
                     elif isinstance(dim_ids, slice):
-                        ned = A.nonempty_domain()
+                        ned = A.nonempty_domain() # None iff the array has no data
                         lo_hi = util.slice_to_range(dim_ids, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -290,7 +290,7 @@ class SparseNdArray(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, coord)
                     elif isinstance(coord, slice):
-                        ned = A.nonempty_domain() # None iff the array has no data
+                        ned = A.nonempty_domain()  # None iff the array has no data
                         lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -291,8 +291,7 @@ class SparseNdArray(TileDBArray):
                         sr.set_dim_points(dim_name, coord)
                     elif isinstance(coord, slice):
                         ned = A.nonempty_domain()
-                        lo_hi = util.slice_to_range(
-                            coord, ned[i]) if ned else None
+                        lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi
                             if lo < 0 or hi < 0:

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -277,7 +277,7 @@ class SparseNdArray(TileDBArray):
 
                 for i, coord in enumerate(coords):
                     #                # Example: coords = [None, 3, slice(4,5)]
-                    #                # coor takes on values None, 3, and slice(4,5) in this loop body.
+                    #                # coord takes on values None, 3, and slice(4,5) in this loop body.
                     dim_name = A.schema.domain.dim(i).name
                     if coord is None:
                         pass  # No constraint; select all in this dimension
@@ -290,7 +290,9 @@ class SparseNdArray(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, coord)
                     elif isinstance(coord, slice):
-                        lo_hi = util.slice_to_range(coord)
+                        ned = A.nonempty_domain()
+                        lo_hi = util.slice_to_range(
+                            coord, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi
                             if lo < 0 or hi < 0:

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -290,7 +290,7 @@ class SparseNdArray(TileDBArray):
                             )
                         sr.set_dim_points(dim_name, coord)
                     elif isinstance(coord, slice):
-                        ned = A.nonempty_domain()
+                        ned = A.nonempty_domain() # None iff the array has no data
                         lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
                         if lo_hi is not None:
                             lo, hi = lo_hi

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -1,7 +1,7 @@
 import pathlib
 import time
 import urllib.parse
-from typing import Tuple, TypeVar
+from typing import Optional, Tuple, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -113,7 +113,9 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(ids: slice, nonempty_domain: Tuple[int, int]) -> Tuple[int, int]:
+def slice_to_range(
+    ids: slice, nonempty_domain: Tuple[int, int]
+) -> Optional[Tuple[int, int]]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -113,17 +113,22 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(ids: slice) -> Optional[Tuple[int, int]]:
+def slice_to_range(ids: slice, nonempty_domain) -> Optional[Tuple[int, int]]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """
-    if ids.start is None and ids.stop is None:
-        return None
-    if ids.start is None or ids.stop is None:
-        # TODO: https://github.com/single-cell-data/TileDB-SOMA/issues/457
-        raise ValueError("slice start and stop must be both specified, or neither")
-    if ids.start > ids.stop:
-        raise ValueError("slice start must be <= slice stop")
     if ids.step is not None and ids.step != 1:
         raise ValueError("slice step must be 1 or None")
-    return (ids.start, ids.stop)  # XXX TEMP
+    if ids.start is None and ids.stop is None:
+        return None
+    start = ids.start
+    stop = ids.stop
+
+    if start is None:
+        start = nonempty_domain[0]
+    if stop is None:
+        stop = nonempty_domain[1]
+
+    if start > stop:
+        raise ValueError("slice start must be <= slice stop")
+    return (start, stop)  # XXX TEMP

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -113,7 +113,9 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(ids: slice, nonempty_domain) -> Optional[Tuple[int, int]]:
+def slice_to_range(
+    ids: slice, nonempty_domain: Tuple[int, int]
+) -> Optional[Tuple[int, int]]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -1,7 +1,7 @@
 import pathlib
 import time
 import urllib.parse
-from typing import Optional, Tuple, TypeVar
+from typing import Tuple, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -113,9 +113,7 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(
-    ids: slice, nonempty_domain: Tuple[int, int]
-) -> Tuple[int, int]:
+def slice_to_range(ids: slice, nonempty_domain: Tuple[int, int]) -> Tuple[int, int]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """
@@ -123,7 +121,7 @@ def slice_to_range(
         raise ValueError("slice step must be 1 or None")
     if ids.start is None and ids.stop is None:
         return None
-    
+
     start = ids.start
     stop = ids.stop
 

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -115,7 +115,7 @@ def uri_joinpath(base: str, path: str) -> str:
 
 def slice_to_range(
     ids: slice, nonempty_domain: Tuple[int, int]
-) -> Optional[Tuple[int, int]]:
+) -> Tuple[int, int]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """
@@ -123,9 +123,11 @@ def slice_to_range(
         raise ValueError("slice step must be 1 or None")
     if ids.start is None and ids.stop is None:
         return None
+    
     start = ids.start
     stop = ids.stop
 
+    # TODO: with future C++ improvements, move half-slice logic to SOMAReader
     if start is None:
         start = nonempty_domain[0]
     if stop is None:

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -501,15 +501,15 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
         },
         {
             "index_column_names": ["index1"],
-            "ids": [slice(None, 3)],  # Half-slices are not supported yet
-            "A": None,
-            "throws": ValueError,
+            "ids": [slice(None, 3)],  # Half-slice
+            "A": [10, 11, 12, 13],
+            "throws": None,
         },
         {
             "index_column_names": ["index1"],
-            "ids": [slice(1, None)],  # Half-slices are not supported yet
-            "A": None,
-            "throws": ValueError,
+            "ids": [slice(2, None)],  # Half-slice
+            "A": [12, 13, 14, 15],
+            "throws": None,
         },
         {
             "index_column_names": ["index1"],

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -483,6 +483,16 @@ def test_csr_csc_2d_read(tmp_path, read_format, shape):
             },
             "throws": None,
         },
+        # Coords has None in a slot and int in a slot
+        {
+            "shape": (3, 4),
+            "coords": (slice(None,2), slice(2,None)),
+            "dims": {
+                "soma_dim_0": [0, 0, 1, 1, 2, 2],
+                "soma_dim_1": [2, 3, 2, 3, 2, 3],
+            },
+            "throws": None,
+        },
         # Coords doesn't specify all dimensions, so the rest are implicit-all
         {
             "shape": (4, 6),

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -486,7 +486,7 @@ def test_csr_csc_2d_read(tmp_path, read_format, shape):
         # Coords has None in a slot and int in a slot
         {
             "shape": (3, 4),
-            "coords": (slice(None,2), slice(2,None)),
+            "coords": (slice(None, 2), slice(2, None)),
             "dims": {
                 "soma_dim_0": [0, 0, 1, 1, 2, 2],
                 "soma_dim_1": [2, 3, 2, 3, 2, 3],


### PR DESCRIPTION
Use `nonempty_domain` to convert half-slices of `(None, int)` or `(int, None)` to valid ranges interpreted by the SOMAReader.