### PR TITLE
Update to TileDB 2.13 [main-old branch]

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,18 +15,28 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Check Python Black Format
+        with:
+          python-version: "3.8"
         run: |
           python -m pip install black
           python -m black --check --diff . tools/[a-z]*
       - name: Check for unsorted / unformatted Python imports with isort
+        with:
+          python-version: "3.8"
         run: |
           python -m pip install isort
           python -m isort --check --diff .
       - name: Check Python style guide enforcement with flake8
+        with:
+          python-version: "3.8"
         run: |
           python -m pip install flake8-bugbear
+          python --version
+          python -m flake8 --version
           python -m flake8 . tools/[a-z]*
       - name: Check type annotations with mypy
+        with:
+          python-version: "3.8"
         run: |
           # mypy 0.990 has false positives on `import anndata as ad` and `Module has no attribute
           # "read_h5ad"` etc :(

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,28 +15,20 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Check Python Black Format
-        with:
-          python-version: "3.8"
         run: |
           python -m pip install black
           python -m black --check --diff . tools/[a-z]*
       - name: Check for unsorted / unformatted Python imports with isort
-        with:
-          python-version: "3.8"
         run: |
           python -m pip install isort
           python -m isort --check --diff .
       - name: Check Python style guide enforcement with flake8
-        with:
-          python-version: "3.8"
         run: |
           python -m pip install flake8-bugbear
           python --version
           python -m flake8 --version
           python -m flake8 . tools/[a-z]*
       - name: Check type annotations with mypy
-        with:
-          python-version: "3.8"
         run: |
           # mypy 0.990 has false positives on `import anndata as ad` and `Module has no attribute
           # "read_h5ad"` etc :(

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyarrow
     scanpy
     scipy
-    tiledb>=0.18.1
+    tiledb>=0.19.0
 python_requires = >3.7
 
 [options.extras_require]

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyarrow
     scanpy
     scipy
-    tiledb>=0.19.0
+    tiledb>=0.19.1
 python_requires = >3.7
 
 [options.extras_require]

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
             "pyarrow",
             "scanpy",
             "scipy",
-            "tiledb>=0.18.1",
+            "tiledb>=0.19.0",
         ],
         python_requires=">=3.7",
     )

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
             "pyarrow",
             "scanpy",
             "scipy",
-            "tiledb>=0.19.0",
+            "tiledb>=0.19.1",
         ],
         python_requires=">=3.7",
     )

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     R6,
     methods,
     Matrix,
+    tiledb,
     SeuratObject,
     jsonlite,
     glue,

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -36,7 +36,6 @@ Imports:
     R6,
     methods,
     Matrix,
-    tiledb (>= 0.17.0),
     SeuratObject,
     jsonlite,
     glue,

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     R6,
     methods,
     Matrix,
-    tiledb (>= 0.14.0),
+    tiledb (>= 0.17.0),
     SeuratObject,
     jsonlite,
     glue,

--- a/tools/ci/install-r-dependencies.sh
+++ b/tools/ci/install-r-dependencies.sh
@@ -2,7 +2,21 @@
 set -euo pipefail
 # Context: .github/workflows/*.yaml
 export R_REMOTES_NO_ERRORS_FROM_WARNINGS='true'
+
+# TODO: Remove this once we have either a TileDB-R 0.17.1 depending on core 2.13.1, or, a TileDB-R
+# 0.18 depending on core 2.14.
+#
+# See also https://github.com/single-cell-data/TileDB-SOMA/issues/654
+#
+# * Enable repository from tiledb-inc
+# * Download and install tiledb in R
+Rscript -e '
+    options(repos = c(tiledbinc = "https://tiledb-inc.r-universe.dev", CRAN = "https://cloud.r-project.org"));
+    install.packages("tiledb")
+'
+
 Rscript -e 'install.packages("remotes")'
+
 cd apis/r
 Rscript -e 'remotes::install_deps(dependencies = TRUE)'
 cd ../..

--- a/tools/ci/install-r-dependencies.sh
+++ b/tools/ci/install-r-dependencies.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 # Context: .github/workflows/*.yaml
 export R_REMOTES_NO_ERRORS_FROM_WARNINGS='true'
 
+Rscript -e 'install.packages("remotes")'
+
 # TODO: Remove this once we have either a TileDB-R 0.17.1 depending on core 2.13.1, or, a TileDB-R
 # 0.18 depending on core 2.14.
 #
@@ -10,12 +12,7 @@ export R_REMOTES_NO_ERRORS_FROM_WARNINGS='true'
 #
 # * Enable repository from tiledb-inc
 # * Download and install tiledb in R
-Rscript -e '
-    options(repos = c(tiledbinc = "https://tiledb-inc.r-universe.dev", CRAN = "https://cloud.r-project.org"));
-    install.packages("tiledb")
-'
-
-Rscript -e 'install.packages("remotes")'
+Rscript -e 'options(repos = c(tiledbinc = "https://tiledb-inc.r-universe.dev", CRAN = "https://cloud.r-project.org")); install.packages("tiledb")'
 
 cd apis/r
 Rscript -e 'remotes::install_deps(dependencies = TRUE)'


### PR DESCRIPTION
Core 2.13 aligns with TileDB-Py 0.19 and TileDB-R 0.17. Those are already released.

After this we can tag TileDB-SOMA 0.1.19.

Once TileDB Cloud is updated to 2.13 (REST server) then we can include TileDB-SOMA 0.1.19 in the UDF/notebook-image repos.