### PR TITLE
[r] Convert arrow::large_utf8() to ascii

### DIFF
--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -47,7 +47,6 @@ tiledb_type_from_arrow_type <- function(x) {
     double = "FLOAT64",
     boolean = "BOOL",
     bool = "BOOL",
-    # large_utf8 = "large_string",
     # large_string = "large_string",
     # binary = "binary",
     # large_binary = "large_binary",
@@ -56,6 +55,7 @@ tiledb_type_from_arrow_type <- function(x) {
     # not yet queryable so we use ASCII for now
     utf8 = "ASCII",
     string = "ASCII",
+    large_utf8 = "ASCII",
     # date32 = "date32",
     # date64 = "date64",
     # time32 = "time32",

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -1,9 +1,9 @@
 test_that("SOMADataFrame creation", {
   uri <- withr::local_tempdir("soma-indexed-dataframe4")
   asch <- arrow::schema(
-    foo = arrow::int32(),
-    bar = arrow::float64(),
-    baz = arrow::string()
+    arrow::field("foo", arrow::int32(), nullable = FALSE),
+    arrow::field("bar", arrow::float64(), nullable = FALSE),
+    arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
   )
   sidf <- SOMADataFrame$new(uri)
   expect_error(
@@ -33,9 +33,7 @@ test_that("SOMADataFrame creation", {
   tbl0 <- arrow::arrow_table(foo = 1L:10L,
                              bar = 1.1:10.1,
                              baz = letters[1:10],
-                             schema=arrow::schema(arrow::field("foo", arrow::int32(), nullable=FALSE),
-                                                  arrow::field("bar", arrow::float64(), nullable=FALSE),
-                                                  arrow::field("baz", arrow::large_utf8(), nullable=FALSE)))
+                             schema=asch)
 
   sidf$write(tbl0)
 

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -81,9 +81,8 @@ test_that("SOMADataFrame read", {
     columns <- c("n_counts", "n_genes", "louvain")
     sdf <- SOMADataFrame$new(uri)
     z <- sdf$read(column_names=columns)
-    tbl <- tibble::as_tibble(z)
-    expect_equal(ncol(tbl), 3L)
-    expect_equal(colnames(tbl), columns)
+    expect_equal(z$num_columns, 3L)
+    expect_equal(z$ColumnNames(), columns)
 
     columns <- c("n_counts", "does_not_exist")
     sdf <- SOMADataFrame$new(uri)
@@ -93,5 +92,4 @@ test_that("SOMADataFrame read", {
     sdf <- SOMADataFrame$new(uri)
     z <- sdf$read(ids = list(soma_joinid=ids))
     expect_equal(z$num_rows, 10L)
-
 })


### PR DESCRIPTION
This updates the internal `tiledb_type_from_arrow_type()` utility to convert Arrow `large_utf8` to TileDB `STRING_ASCII`, just as it does for the `utf8` and `string` types. 

These conversions are temporary until utf8 filtering support is added to core.