### PR TITLE
Include Python 3.10 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
         os: [ubuntu-22.04, macos-12]
         # os: [ubuntu-22.04, macos-12, windows-2019]
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11


### PR DESCRIPTION
Part of #544.

Note 3.11 may take a bit more work, and 3.7 quite a bit more (due to `typing` changes). This PR just takes a quick and easy step, as the first of more to come.

With this PR we'll have Python 3.8 through 3.10 covered in CI testing.