### PR TITLE
[python/ci] Include Python 3.11 in CI matrix

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -21,7 +21,7 @@ jobs:
         # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
         os: [ubuntu-22.04, macos-12]
         # os: [ubuntu-22.04, macos-12, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04]
-        python-version: ['3.10', '3.7']
+        # XXX TEMP ONLY FOR PRE-MERGE
+        # python-version: ['3.10', '3.7']
+        python-version: ['3.11']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -18,9 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04]
-        # XXX TEMP ONLY FOR PRE-MERGE
-        # python-version: ['3.10', '3.7']
-        python-version: ['3.11']
+        python-version: ['3.10', '3.7']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -278,8 +278,6 @@ setuptools.setup(
         # with less-particular numpy version constraints, or if we decide we no
         # longer need to support the old pip solver (default on ubuntu 20.04).
         #
-        # "numba==0.56.4",
-        #
         # Also: numba doesn't support Python 3.11 until 0.57.0rc1.
         # It' not preferable to pin to an RC dependency, so we only do this
         # when we must, which is for 3.11.

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -277,7 +277,14 @@ setuptools.setup(
         # These pins can be removed either when there's a new numba release
         # with less-particular numpy version constraints, or if we decide we no
         # longer need to support the old pip solver (default on ubuntu 20.04).
-        "numba==0.56.4",
+        #
+        # "numba==0.56.4",
+        #
+        # WIP
+        # https://github.com/single-cell-data/TileDB-SOMA/pull/599
+        # https://github.com/numba/numba/issues/8304
+        "numba==0.57.0rc1",
+        #
         "numpy>=1.18,<1.24",
         "pandas",
         "pyarrow>=9.0.0",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -280,11 +280,11 @@ setuptools.setup(
         #
         # "numba==0.56.4",
         #
-        # WIP
-        # https://github.com/single-cell-data/TileDB-SOMA/pull/599
-        # https://github.com/numba/numba/issues/8304
-        "numba==0.57.0rc1",
-        #
+        # Also: numba doesn't support Python 3.11 until 0.57.0rc1.
+        # It' not preferable to pin to an RC dependency, so we only do this
+        # when we must, which is for 3.11.
+        "numba==0.56.4; python_version<'3.11'",
+        "numba==0.57.0rc1; python_version=='3.11'",
         "numpy>=1.18,<1.24",
         "pandas",
         "pyarrow>=9.0.0",


### PR DESCRIPTION
This is a trial balloon for #544, to see what we would need to do to support Python 3.11.

First result: at https://github.com/single-cell-data/TileDB-SOMA/actions/runs/3661926647/jobs/6190605155 we see `numba` is not yet supported in Python 3.11. cc @thetorpedodog @bkmartinjr @Shelnutt2 .

```
Collecting numba>=0.41.0
  Downloading numba-0.56.4.tar.gz (2.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.4/2.4 MB 146.6 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/tmp/pip-install-0tpo_aju/numba_b1ec8a6b557b450ea19a316e9668617a/setup.py", line 51, in <module>
      _guard_py_ver()
    File "/tmp/pip-install-0tpo_aju/numba_b1ec8a6b557b450ea19a316e9668617a/setup.py", line 48, in _guard_py_ver
      raise RuntimeError(msg.format(cur_py, min_py, max_py))
  RuntimeError: Cannot install on Python version 3.11.0; only versions >=3.7,<3.11 are supported.
```

See also https://github.com/numba/numba/issues/8304

Looks like they're hoping for a release candidate by end of 2022: https://github.com/numba/numba/issues/8304#issuecomment-1336218610