### PR TITLE
[r] Tweak logging default value enabling easier use

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -49,7 +49,7 @@ LinkingTo:
     arch
 Additional_repositories: https://ghrr.github.io/drat
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Suggests:
     rmarkdown,
     knitr,

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -17,7 +17,8 @@
 #' for the given dimension. Each dimension can be one entry in the list.
 #' @param batch_size Character value with the desired batch size, defaults to \sQuote{auto}
 #' @param result_order Character value with the desired result order, defaults to \sQuote{auto}
-#' @param loglevel Character value with the desired logging level, defaults to \sQuote{warn}
+#' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
+#' which lets prior setting prevail, any other value is set as new logging level.
 #' @param arrlst A list containing the pointers to an Arrow data structure
 #' @return An Arrow data structure is returned
 #' @examples
@@ -27,7 +28,7 @@
 #' tb <- arrow::as_arrow_table(arch::from_arch_array(z, arrow::RecordBatch))
 #' }
 #' @export
-soma_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "warn") {
+soma_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto") {
     .Call(`_tiledbsoma_soma_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel)
 }
 
@@ -68,7 +69,8 @@ nnz <- function(uri) {
 #' for the given dimension. Each dimension can be one entry in the list.
 #' @param config Optional named chracter vector with \sQuote{key} and \sQuote{value} pairs
 #' used as TileDB config parameters. If unset default configuration is used.
-#' @param loglevel Character value with the desired logging level, defaults to \sQuote{warn}
+#' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
+#' which lets prior setting prevail, any other value is set as new logging level.
 #' @param sr An external pointer to a TileDB SOMAReader object
 #'
 #' @return \code{sr_setup} returns an external pointer to a SOMAReader. \code{sr_complete}
@@ -93,7 +95,7 @@ nnz <- function(uri) {
 #' summary(rl)
 #' }
 #' @export
-sr_setup <- function(ctx, uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, config = NULL, loglevel = "warn") {
+sr_setup <- function(ctx, uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, config = NULL, loglevel = "auto") {
     .Call(`_tiledbsoma_sr_setup`, ctx, uri, colnames, qc, dim_points, dim_ranges, config, loglevel)
 }
 

--- a/apis/r/man/SOMADenseNdArray.Rd
+++ b/apis/r/man/SOMADenseNdArray.Rd
@@ -94,7 +94,7 @@ Read as an 'arrow::Table'
 length equal to the number of values to read. If \code{NULL}, all values are
 read. List elements can be named when specifying a subset of dimensions.}
 
-\item{\code{result_order}}{Order of read results. This can be one of either
+\item{\code{result_order}}{Optional order of read results. This can be one of either
 \verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
 
 \item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}

--- a/apis/r/man/soma_reader.Rd
+++ b/apis/r/man/soma_reader.Rd
@@ -14,7 +14,7 @@ soma_reader(
   dim_ranges = NULL,
   batch_size = "auto",
   result_order = "auto",
-  loglevel = "warn"
+  loglevel = "auto"
 )
 
 nnz(uri)
@@ -39,7 +39,8 @@ for the given dimension. Each dimension can be one entry in the list.}
 
 \item{result_order}{Character value with the desired result order, defaults to \sQuote{auto}}
 
-\item{loglevel}{Character value with the desired logging level, defaults to \sQuote{warn}}
+\item{loglevel}{Character value with the desired logging level, defaults to \sQuote{auto}
+which lets prior setting prevail, any other value is set as new logging level.}
 
 \item{arrlst}{A list containing the pointers to an Arrow data structure}
 }

--- a/apis/r/man/sr_setup.Rd
+++ b/apis/r/man/sr_setup.Rd
@@ -14,7 +14,7 @@ sr_setup(
   dim_points = NULL,
   dim_ranges = NULL,
   config = NULL,
-  loglevel = "warn"
+  loglevel = "auto"
 )
 
 sr_complete(sr)
@@ -40,7 +40,8 @@ for the given dimension. Each dimension can be one entry in the list.}
 \item{config}{Optional named chracter vector with \sQuote{key} and \sQuote{value} pairs
 used as TileDB config parameters. If unset default configuration is used.}
 
-\item{loglevel}{Character value with the desired logging level, defaults to \sQuote{warn}}
+\item{loglevel}{Character value with the desired logging level, defaults to \sQuote{auto}
+which lets prior setting prevail, any other value is set as new logging level.}
 
 \item{sr}{An external pointer to a TileDB SOMAReader object}
 }

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -21,7 +21,8 @@ namespace tdbs = tiledbsoma;
 //' for the given dimension. Each dimension can be one entry in the list.
 //' @param batch_size Character value with the desired batch size, defaults to \sQuote{auto}
 //' @param result_order Character value with the desired result order, defaults to \sQuote{auto}
-//' @param loglevel Character value with the desired logging level, defaults to \sQuote{warn}
+//' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
+//' which lets prior setting prevail, any other value is set as new logging level.
 //' @param arrlst A list containing the pointers to an Arrow data structure
 //' @return An Arrow data structure is returned
 //' @examples
@@ -39,10 +40,12 @@ Rcpp::List soma_reader(const std::string& uri,
                        Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
                        std::string batch_size = "auto",
                        std::string result_order = "auto",
-                       const std::string& loglevel = "warn") {
+                       const std::string& loglevel = "auto") {
 
-    spdl::set_level(loglevel);
-    tdbs::LOG_SET_LEVEL(loglevel);
+    if (loglevel != "auto") {
+        spdl::set_level(loglevel);
+        tdbs::LOG_SET_LEVEL(loglevel);
+    }
 
     spdl::info("[soma_reader] Reading from {}", uri);
 

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -105,7 +105,8 @@ template<typename T> void check_xptr_tag(Rcpp::XPtr<T> ptr) {
 //' for the given dimension. Each dimension can be one entry in the list.
 //' @param config Optional named chracter vector with \sQuote{key} and \sQuote{value} pairs
 //' used as TileDB config parameters. If unset default configuration is used.
-//' @param loglevel Character value with the desired logging level, defaults to \sQuote{warn}
+//' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
+//' which lets prior setting prevail, any other value is set as new logging level.
 //' @param sr An external pointer to a TileDB SOMAReader object
 //'
 //' @return \code{sr_setup} returns an external pointer to a SOMAReader. \code{sr_complete}
@@ -138,10 +139,12 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
                                       Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
                                       Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
                                       Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue,
-                                      const std::string& loglevel = "warn") {
+                                      const std::string& loglevel = "auto") {
     check_xptr_tag<tiledb::Context>(ctx);
-    spdl::set_level(loglevel);
-    tdbs::LOG_SET_LEVEL(loglevel);
+    if (loglevel != "auto") {
+        spdl::set_level(loglevel);
+        tdbs::LOG_SET_LEVEL(loglevel);
+    }
 
     spdl::info("[sr_setup] Setting up {}", uri);
 


### PR DESCRIPTION
This PR sets the default value of the logging level to `"auto"` and changes logging levels only on a different value.  This allows us ti 'chain' tests with an earlier logger setup without having to (explicitly) set the level in these functions:

```sh
$ Rscript -e 'spdl::setup("tst", "debug"); library(tiledbsoma); testthat::test_dir("tests/testthat/")'
```

This works well along with a in the logger (unlrelease, but coming 'soon') to also support file-based logging meaning we can pick up logs from test runs where console output is generally hidden or suppressed.

No new code.