### PR TITLE
Shorten class constants using `Final` typing thing.

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -123,6 +123,7 @@ if __name__ == "__main__":
             "scanpy",
             "scipy",
             "tiledb>=0.19.0",
+            "typing_extensions",
         ],
         python_requires=">=3.7",
         ext_modules=get_ext_modules(),

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -7,7 +7,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Literal,
     MutableMapping,
     Optional,
     Tuple,
@@ -18,6 +17,7 @@ from typing import (
 )
 
 import tiledb
+from typing_extensions import Final
 
 from .exception import DoesNotExistError, SOMAError
 from .tiledb_object import TileDBObject
@@ -384,6 +384,4 @@ class Collection(CollectionBase[TileDBObject]):
     A persistent collection of SOMA objects, mapping string keys to any SOMA object.
     """
 
-    @property
-    def soma_type(self) -> Literal["SOMACollection"]:
-        return "SOMACollection"
+    soma_type: Final = "SOMACollection"

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -1,20 +1,11 @@
 import collections.abc
-from typing import (
-    Any,
-    Iterator,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    get_args,
-)
+from typing import Any, Iterator, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import tiledb
+from typing_extensions import Final, get_args
 
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
@@ -54,9 +45,7 @@ class DataFrame(TileDBArray):
         self._index_column_names = ()
         self._is_sparse = None
 
-    @property
-    def soma_type(self) -> Literal["SOMADataFrame"]:
-        return "SOMADataFrame"
+    soma_type: Final = "SOMADataFrame"
 
     def create(
         self,

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -1,8 +1,9 @@
-from typing import Any, List, Literal, Optional, Union, cast
+from typing import Any, List, Optional, Union, cast
 
 import numpy as np
 import pyarrow as pa
 import tiledb
+from typing_extensions import Final
 
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
@@ -41,9 +42,7 @@ class DenseNDArray(TileDBArray):
             ctx=ctx,
         )
 
-    @property
-    def soma_type(self) -> Literal["SOMADenseNDArray"]:
-        return "SOMADenseNDArray"
+    soma_type: Final = "SOMADenseNDArray"
 
     def create(
         self,
@@ -136,12 +135,7 @@ class DenseNDArray(TileDBArray):
         with self._tiledb_open() as A:
             return cast(int, A.schema.domain.ndim)
 
-    @property
-    def is_sparse(self) -> Literal[False]:
-        """
-        Returns ``False``.
-        """
-        return False
+    is_sparse: Final = False
 
     def read_tensor(
         self,

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Literal, Optional, Tuple, cast
+from typing import Any, Dict, Optional, Tuple, cast
 
 import tiledb
+from typing_extensions import Final
 
 from .collection import CollectionBase
 from .dataframe import DataFrame
@@ -44,9 +45,7 @@ class Experiment(CollectionBase[TileDBObject]):
             ctx=ctx,
         )
 
-    @property
-    def soma_type(self) -> Literal["SOMAExperiment"]:
-        return "SOMAExperiment"
+    soma_type: Final = "SOMAExperiment"
 
     def create(self) -> "Experiment":
         """

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -332,7 +332,7 @@ def create_from_matrix(
         platform_config=platform_config,
     )
 
-    if soma_ndarray.soma_type == "SOMADenseNDArray":
+    if isinstance(soma_ndarray, DenseNDArray):
         _write_matrix_to_denseNDArray(soma_ndarray, src_matrix)
     else:  # SOMmASparseNDArray
         _write_matrix_to_sparseNDArray(soma_ndarray, src_matrix)
@@ -571,13 +571,15 @@ def to_anndata(
     X_data = measurement.X["data"]
     assert X_data is not None
     X_dtype = None  # some datasets have no X
-    if type(X_data) == DenseNDArray:
+    if isinstance(X_data, DenseNDArray):
         X_ndarray = X_data.read_numpy((slice(None), slice(None)))
         X_dtype = X_ndarray.dtype
-    elif type(X_data) == SparseNDArray:
+    elif isinstance(X_data, SparseNDArray):
         X_mat = X_data.read_as_pandas_all()  # TODO: CSR/CSC options ...
         X_csr = util_scipy.csr_from_tiledb_df(X_mat, nobs, nvar)
         X_dtype = X_csr.dtype
+    else:
+        raise TypeError(f"Unexpected NDArray type {type(X_data)}")
 
     # XXX FIX OBSM/VARM SHAPES
 

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Literal, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import tiledb
+from typing_extensions import Final
 
 from .collection import CollectionBase
 from .dataframe import DataFrame
@@ -68,9 +69,7 @@ class Measurement(CollectionBase[TileDBObject]):
             ctx=ctx,
         )
 
-    @property
-    def soma_type(self) -> Literal["SOMAMeasurement"]:
-        return "SOMAMeasurement"
+    soma_type: Final = "SOMAMeasurement"
 
     def create(self) -> "Measurement":
         """

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -1,11 +1,12 @@
 import collections.abc
-from typing import Any, Iterator, List, Literal, Optional, Union, cast
+from typing import Any, Iterator, List, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
 import tiledb
+from typing_extensions import Final, Literal
 
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
@@ -41,9 +42,7 @@ class SparseNDArray(TileDBArray):
             ctx=ctx,
         )
 
-    @property
-    def soma_type(self) -> Literal["SOMASparseNDArray"]:
-        return "SOMASparseNDArray"
+    soma_type: Final = "SOMASparseNDArray"
 
     def create(
         self,
@@ -137,12 +136,7 @@ class SparseNDArray(TileDBArray):
         """
         return len(self.shape)
 
-    @property
-    def is_sparse(self) -> Literal[True]:
-        """
-        Returns ``True``.
-        """
-        return True
+    is_sparse: Final = True
 
     @property
     def nnz(self) -> int:

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -1,10 +1,11 @@
 import pathlib
-from typing import Any, List, Literal, Mapping, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Sequence, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
+from typing_extensions import Literal
 
 Path = Union[str, pathlib.Path]
 


### PR DESCRIPTION
It turns out you can fulfil the requirements of abstract properties using just members. `Final` gives users some static analysis hints that maybe they shouldn't be writing to that field.

---

As seen in somabase: https://github.com/single-cell-data/SOMA/pull/59