### PR TITLE
[c++] Support empty range query

### DIFF
--- a/libtiledbsoma/include/tiledbsoma/column_buffer.h
+++ b/libtiledbsoma/include/tiledbsoma/column_buffer.h
@@ -78,8 +78,8 @@ class ColumnBuffer {
      *
      * @param name Column name
      * @param type TileDB datatype
-     * @param num_cells Number of cells
-     * @param data View of data
+     * @param num_cells Number of cells to allocate for offsets and validity
+     * @param num_bytes Number of bytes to allocate for data
      * @param is_var Column type is variable length
      * @param is_nullable Column can contain null values
      */
@@ -87,7 +87,7 @@ class ColumnBuffer {
         std::string_view name,
         tiledb_datatype_t type,
         size_t num_cells,
-        size_t data,
+        size_t num_bytes,
         bool is_var = false,
         bool is_nullable = false);
 

--- a/libtiledbsoma/include/tiledbsoma/soma_reader.h
+++ b/libtiledbsoma/include/tiledbsoma/soma_reader.h
@@ -304,6 +304,9 @@ class SOMAReader {
 
     // True if this is the first call to read_next()
     bool first_read_next_ = true;
+
+    // True if the query was submitted
+    bool submitted_ = false;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/column_buffer.cc
+++ b/libtiledbsoma/src/column_buffer.cc
@@ -95,7 +95,7 @@ ColumnBuffer::ColumnBuffer(
     : name_(name)
     , type_(type)
     , type_size_(tiledb::impl::type_size(type))
-    , num_cells_(num_cells)
+    , num_cells_(0)
     , is_var_(is_var)
     , is_nullable_(is_nullable) {
     LOG_DEBUG(fmt::format(
@@ -124,10 +124,11 @@ void ColumnBuffer::attach(Query& query) {
     query.set_data_buffer(
         name_, (void*)data_.data(), data_.capacity() / type_size_);
     if (is_var_) {
-        query.set_offsets_buffer(name_, offsets_.data(), num_cells_);
+        query.set_offsets_buffer(name_, offsets_.data(), offsets_.capacity());
     }
     if (is_nullable_) {
-        query.set_validity_buffer(name_, validity_.data(), num_cells_);
+        query.set_validity_buffer(
+            name_, validity_.data(), validity_.capacity());
     }
 }
 
@@ -203,11 +204,9 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
     //   from the type size.
     size_t num_cells = is_var ? num_bytes / sizeof(uint64_t) :
                                 num_bytes / tiledb::impl::type_size(type);
-    size_t num_offsets = is_var ? num_cells + 1 : 0;  // + 1 for arrow
-    size_t num_validity = is_nullable ? num_cells : 0;
 
     return std::make_shared<ColumnBuffer>(
-        name, type, num_cells, num_bytes, num_offsets, num_validity);
+        name, type, num_cells, num_bytes, is_var, is_nullable);
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/managed_query.cc
+++ b/libtiledbsoma/src/managed_query.cc
@@ -104,7 +104,7 @@ void ManagedQuery::submit() {
                 0, non_empty_domain.first, non_empty_domain.second);
 
             LOG_DEBUG(fmt::format(
-                "[ManagedQuery] Add full NDE range to dense subarray = (0, {}, "
+                "[ManagedQuery] Add full NED range to dense subarray = (0, {}, "
                 "{})",
                 non_empty_domain.first,
                 non_empty_domain.second));
@@ -139,11 +139,19 @@ void ManagedQuery::submit() {
     // Submit query
     LOG_DEBUG(fmt::format("[ManagedQuery] [{}] Submit query", name_));
 
-    query_->submit();
+    // Do not submit if the query contains only empty ranges
+    if (!is_empty_query()) {
+        query_->submit();
+    }
     query_submitted_ = true;
 }
 
 std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
+    if (is_empty_query()) {
+        query_submitted_ = false;
+        return buffers_;
+    }
+
     if (!query_submitted_) {
         throw TileDBSOMAError(fmt::format(
             "[ManagedQuery][{}] submit query before reading results", name_));

--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -115,10 +115,11 @@ void SOMAReader::submit() {
     // Submit the query
     mq_->submit();
     first_read_next_ = true;
+    submitted_ = true;
 }
 
 std::optional<std::shared_ptr<ArrayBuffers>> SOMAReader::read_next() {
-    if (mq_->status() == Query::Status::UNINITIALIZED) {
+    if (!submitted_) {
         throw TileDBSOMAError(
             "[SOMAReader] submit must be called before read_next");
     }

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -78,6 +78,24 @@ def test_soma_reader_dim_points():
     assert sr.results_complete()
     assert arrow_table.num_rows == len(obs_id_points)
 
+def test_soma_reader_empty_dim_points():
+    """Read scalar dimension slice from obs array into an arrow table."""
+
+    name = "obs"
+    uri = os.path.join(SOMA_URI, name)
+    sr = clib.SOMAReader(uri)
+
+    obs_id_points = []
+
+    sr.set_dim_points("soma_joinid", obs_id_points)
+
+    sr.submit()
+    arrow_table = sr.read_next()
+
+    # test that all results are present in the arrow table (no incomplete queries)
+    assert sr.results_complete()
+    assert arrow_table.num_rows == len(obs_id_points)
+
 
 def test_soma_reader_dim_points_arrow_array():
     """Read scalar dimension slice from obs array into an arrow table."""

--- a/libtiledbsoma/test/unit_column_buffer.cc
+++ b/libtiledbsoma/test/unit_column_buffer.cc
@@ -90,9 +90,6 @@ TEST_CASE("ColumnBuffer: Create from array") {
         REQUIRE(buffers->name() == "d1");
         REQUIRE(buffers->is_var() == true);
         REQUIRE(buffers->is_nullable() == false);
-        REQUIRE(buffers->data<char>().size() >= 9);
-        REQUIRE(buffers->offsets().size() >= 10);
-        REQUIRE_THROWS(buffers->validity().size() == 0);
     }
 
     {
@@ -100,8 +97,5 @@ TEST_CASE("ColumnBuffer: Create from array") {
         REQUIRE(buffers->name() == "a1");
         REQUIRE(buffers->is_var() == true);
         REQUIRE(buffers->is_nullable() == true);
-        REQUIRE(buffers->data<int32_t>().size() >= 21);
-        REQUIRE(buffers->offsets().size() >= 22);
-        REQUIRE(buffers->validity().size() >= 21);
     }
 }


### PR DESCRIPTION
This PR provides the empty range query support described in #593 (a query containing only empty ranges should return empty results).

While reviewing #593, I realized some C++ refactoring would make empty range queries easier to support.

**Note** - This PR does not contain the python API changes in #593, in case we want to keep those changes separate.