### PR TITLE
[r] Release 0.1.19

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           working-directory: "apis/r"
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
           working-directory: "apis/r"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install libgeos on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -31,7 +31,7 @@ jobs:
       _R_CHECK_FORCE_SUGGESTS_: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install libgeos on Linux
         if: runner.os == 'Linux'

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.16.9001
+Version: 0.1.19
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,15 +1,22 @@
 # tiledbsoma 0.1.19
 
+## Changes
+
+- Updated `setup-r` GitHub Action to v2
+
+# tiledbsoma 0.1.18
+
 ## Features
 
 - The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods.
 
 ## Changes
 
-- Updated `setup-r` GitHub Action to v2
+- Increased capacity of `AssayMatrix` arrays from 1,000 to 100,000 to improve remote-read performance ($543)
 
 ## Fixes
-* Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire)
+
+- Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire)
 
 # tiledbsoma 0.1.12
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,7 +12,7 @@
 
 ## Changes
 
-- Increased capacity of `AssayMatrix` arrays from 1,000 to 100,000 to improve remote-read performance (#543)
+- Decreased capacity of `AssayMatrix` arrays from 100,000 to 1,000 to improve remote-read performance (#543)
 
 ## Fixes
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,4 +1,4 @@
-# tiledbsoma (development version)
+# tiledbsoma 0.1.19
 
 ## Features
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,7 +12,7 @@
 
 ## Changes
 
-- Increased capacity of `AssayMatrix` arrays from 1,000 to 100,000 to improve remote-read performance ($543)
+- Increased capacity of `AssayMatrix` arrays from 1,000 to 100,000 to improve remote-read performance (#543)
 
 ## Fixes
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -4,6 +4,10 @@
 
 - The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods.
 
+## Changes
+
+- Updated `setup-r` GitHub Action to v2
+
 ## Fixes
 * Don't use default assay name when recreating a `Seurat` object (thanks @dan11mcguire)
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Changes
 
-- Updated `setup-r` GitHub Action to v2
+- Updated `setup-r` GitHub Action to v2 and `checkout` to v3
 
 # tiledbsoma 0.1.18
 


### PR DESCRIPTION
Updates package version number to 0.1.19 in preparation for release. 

Other changes:

- Updated `setup-r` GitHub Action to v2

Note: CI test failures are due to a core issue that will be fixed in 2.13.1.