### PR TITLE
Honor AWS_DEFAULT_REGION if no overriding ctx is specified

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -61,13 +61,8 @@ class TileDBObject(ABC):
 
         cfg = {}
 
-        # Crucial for reducing number of HTTP requests for tiledb-cloud URIs.
-        # With default (small) value, it can take many HTTP-request round trips to satisfy
-        # a single query.
-        cfg["py.init_buffer_bytes"] = 4 * 1024**3
-
         # This is necessary for smaller tile capacities when querying with a smaller memory budget.
-        cfg["sm.mem.reader.sparse_global_order.ratio_array_data"] = 0.3  # type: ignore
+        cfg["sm.mem.reader.sparse_global_order.ratio_array_data"] = 0.3
 
         # Temp workaround pending https://app.shortcut.com/tiledb-inc/story/23827
         region = os.getenv("AWS_DEFAULT_REGION")

--- a/apis/python/tools/peek-exp.py
+++ b/apis/python/tools/peek-exp.py
@@ -37,11 +37,7 @@ else:
     print(f"{sys.argv[0]}: need just one Experiment path.", file=sys.stderr)
     sys.exit(1)
 
-cfg = tiledb.Config()
-cfg["py.init_buffer_bytes"] = 4 * 1024**3
-ctx = tiledb.Ctx(cfg)
-
-exp = tiledbsoma.Experiment(input_path, ctx=ctx)
+exp = tiledbsoma.Experiment(input_path)
 if not exp.exists():
     print("Does not exist yet:", input_path)
 


### PR DESCRIPTION
Addresses issue #391

This is temporary pending TileDB-internal Shortcut task 23827

Validation/use-case:

```
$ export AWS_DEFAULT_REGION=us-west-2
$ python
>>> import tiledbsoma as soma
>>> exp = soma.Experiment("s3://bucket-which-is-in-us-west-2/path/to/soma/experiment")
>>> print(exp)
```

This is crucial for good out-of-the-box UX and uptake/exploration.

(Of course, if a config region is supplied,it is honored -- this mod applies solely for users who don't have a `ctx`/`cfg` and perhaps haven't even learned what those are yet.)