### PR TITLE
Fix and re-enable CI macOS builds

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          #- {os: macOS-latest}
+          - {os: macOS-latest}
           - {os: ubuntu-latest}
 
     runs-on: ${{ matrix.os }}

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     glue,
     urltools,
     Rcpp,
-    arch,
+    arch (>= 0.0.2),
     dplyr,
     data.table,
     spdl

--- a/apis/r/copy_source.sh
+++ b/apis/r/copy_source.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-test -d ../../libtiledbsoma && cp -a ../../libtiledbsoma/ src/
+test -d ../../libtiledbsoma && cp -a ../../libtiledbsoma src/


### PR DESCRIPTION
Fixes a minor issue with `copy_source.sh` resulting from the different behavior of `cp` on macOS and Linux. 

For posterity (and I because I will surely forget almost immediatley), the issue was that `cp -a` on macOS copies the contents of a directory rather than the directory itself if the source ends in a `/`.

Also bumps the minimum required version of _arch_ to 0.0.2 (thanks to @eddelbuettel).