### PR TITLE
[r] Adjust SparseNDArray test to renamed soma_data method

### DIFF
--- a/apis/r/tests/testthat/test_SOMASparseNdArray.R
+++ b/apis/r/tests/testthat/test_SOMASparseNdArray.R
@@ -1,5 +1,4 @@
 test_that("SOMASparseNDArray creation", {
-  skip_if(TRUE) # temporary
   uri <- withr::local_tempdir("sparse-ndarray")
   ndarray <- SOMASparseNDArray$new(uri)
   ndarray$create(arrow::int32(), shape = c(10, 10))
@@ -8,7 +7,7 @@ test_that("SOMASparseNDArray creation", {
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
 
   expect_equal(ndarray$attrnames(), "soma_data")
-  expect_equal(tiledb::datatype(ndarray$attributes()$data), "INT32")
+  expect_equal(tiledb::datatype(ndarray$attributes()$soma_data), "INT32")
 
   mat <- create_sparse_matrix_with_int_dims(10, 10)
   ndarray$write(mat)


### PR DESCRIPTION
This PR updates one test to refer to the now-renamed `soma_data` method (see #397 for original rationale).