### PR TITLE
[r] Fix storage of int64 values by SOMADataFrame

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -107,6 +107,11 @@ SOMADataFrame <- R6::R6Class(
     #'
     write = function(values) {
       on.exit(private$close())
+
+      # Prevent downcasting of int64 to int32 when materializing a column
+      op <- options(arrow.int64_downcast = FALSE)
+      on.exit(options(op), add = TRUE, after = FALSE)
+
       schema_names <- c(self$dimnames(), self$attrnames())
 
       stopifnot(

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -78,12 +78,14 @@ test_that("int64 values are stored correctly", {
   sidf$create(asch, index_column_names = "foo")
   tbl0 <- arrow::arrow_table(foo = 1L:10L, bar = 1L:10L, schema = asch)
 
+  orig_downcast_value <- getOption("arrow.int64_downcast")
+
   sidf$write(tbl0)
   tbl1 <- sidf$read()
   expect_true(tbl1$Equals(tbl0))
 
   # verify int64_downcast option was restored
-  expect_true(is.null(getOption("arrow.int64_downcast")))
+  expect_equal(getOption("arrow.int64_downcast"), orig_downcast_value)
 })
 
 test_that("SOMADataFrame read", {

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -67,6 +67,25 @@ test_that("SOMADataFrame creation", {
   expect_true(tbl1$Equals(tbl0$Filter(tbl0$bar < 5)))
 })
 
+test_that("int64 values are stored correctly", {
+  uri <- withr::local_tempdir("soma-indexed-dataframe")
+  asch <- arrow::schema(
+    arrow::field("foo", arrow::int32(), nullable = FALSE),
+    arrow::field("bar", arrow::int64(), nullable = FALSE),
+  )
+
+  sidf <- SOMADataFrame$new(uri)
+  sidf$create(asch, index_column_names = "foo")
+  tbl0 <- arrow::arrow_table(foo = 1L:10L, bar = 1L:10L, schema = asch)
+
+  sidf$write(tbl0)
+  tbl1 <- sidf$read()
+  expect_true(tbl1$Equals(tbl0))
+
+  # verify int64_downcast option was restored
+  expect_true(is.null(getOption("arrow.int64_downcast")))
+})
+
 test_that("SOMADataFrame read", {
     tdir <- tempfile()
     tgzfile <- system.file("raw-data", "soco-pbmc3k_processed-obs.tar.gz", package="tiledbsoma")


### PR DESCRIPTION
This updates `SOMADataFrame`'s write method to temporarily disable arrow's `int64->int32` downcasting behavior. 

Thanks to @eddelbuettel for the help tracking down and solving this issue.