### PR TITLE
[r] Correct handling of soma_joinid and soma_rowid

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -189,7 +189,9 @@ SOMADataFrame <- R6::R6Class(
           is_arrow_schema(schema),
         is.character(index_column_names) && length(index_column_names) > 0,
         "All 'index_column_names' must be defined in the 'schema'" =
-          assert_subset(index_column_names, schema$names, type = "field")
+          assert_subset(index_column_names, schema$names, type = "field"),
+        "Column names must not start with reserved prefix 'soma_'" =
+          all(!startsWith(setdiff(schema$names, "soma_joinid"), "soma_"))
       )
 
       # Add soma_joinid column if not present

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' `SOMADataFrame` is a multi-column table that must contain a column
-#' called `soma_joinid` of type `uint64`, which contains a unique value for each
+#' called `soma_joinid` of type `int64`, which contains a unique value for each
 #' row and is intended to act as a join key for other objects, such as
 #' [`SOMASparseNDArray`].
 

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -42,7 +42,7 @@ create_and_populate_soma_dataframe <- function(uri) {
 
   tbl <- arrow::arrow_table(
     foo = 1L:10L,
-    soma_joinid = 1L:10L,
+    soma_joinid = 11L:20L,
     bar = 1.1:10.1,
     baz = letters[1:10],
     schema = arrow_schema

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -30,6 +30,7 @@ create_dense_matrix_with_int_dims <- function(nrows = 10, ncols = 5, seed = 1) {
 create_arrow_schema <- function() {
   arrow::schema(
     arrow::field("foo", arrow::int32(), nullable = FALSE),
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
     arrow::field("bar", arrow::float64(), nullable = FALSE),
     arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
   )
@@ -41,6 +42,7 @@ create_and_populate_soma_dataframe <- function(uri) {
 
   tbl <- arrow::arrow_table(
     foo = 1L:10L,
+    soma_joinid = 1L:10L,
     bar = 1.1:10.1,
     baz = letters[1:10],
     schema = arrow_schema

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -27,13 +27,17 @@ create_dense_matrix_with_int_dims <- function(nrows = 10, ncols = 5, seed = 1) {
   )
 }
 
-create_and_populate_soma_dataframe <- function(uri) {
-
-  arrow_schema <- arrow::schema(
+create_arrow_schema <- function() {
+  arrow::schema(
     arrow::field("foo", arrow::int32(), nullable = FALSE),
     arrow::field("bar", arrow::float64(), nullable = FALSE),
     arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
   )
+}
+
+create_and_populate_soma_dataframe <- function(uri) {
+
+  arrow_schema <- create_arrow_schema()
 
   tbl <- arrow::arrow_table(
     foo = 1L:10L,

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -1,10 +1,6 @@
 test_that("SOMADataFrame creation", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
-  asch <- arrow::schema(
-    arrow::field("foo", arrow::int32(), nullable = FALSE),
-    arrow::field("bar", arrow::float64(), nullable = FALSE),
-    arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
-  )
+  asch <- create_arrow_schema()
   sidf <- SOMADataFrame$new(uri)
   expect_error(
     sidf$create(asch),

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -1,6 +1,13 @@
-test_that("SOMADataFrame creation", {
+test_that("Basic mechanics", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- create_arrow_schema()
+
+  # Add a soma_joinid column to the schema
+  asch <- asch$AddField(
+    i = 1,
+    field = arrow::field("soma_joinid", arrow::int64(), nullable = FALSE)
+  )
+
   sidf <- SOMADataFrame$new(uri)
   expect_error(
     sidf$create(asch),
@@ -28,9 +35,10 @@ test_that("SOMADataFrame creation", {
   )
 
   tbl0 <- arrow::arrow_table(foo = 1L:10L,
+                             soma_joinid = 1L:10L,
                              bar = 1.1:10.1,
                              baz = letters[1:10],
-                             schema=asch)
+                             schema = asch)
 
   sidf$write(tbl0)
 
@@ -56,7 +64,7 @@ test_that("SOMADataFrame creation", {
   )
 
   tbl1 <- sidf$read(column_names = "bar")
-  expect_true(tbl1$Equals(tbl0$SelectColumns(1L)))
+  expect_true(tbl1$Equals(tbl0$SelectColumns(2L)))
 
   # Attribute filters
   tbl1 <- sidf$read(value_filter = "bar < 5")

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -119,3 +119,16 @@ test_that("SOMADataFrame read", {
     z <- sdf$read(ids = list(soma_joinid=ids))
     expect_equal(z$num_rows, 10L)
 })
+
+test_that("soma_joinid is added on creation", {
+  uri <- withr::local_tempdir("soma-indexed-dataframe")
+  asch <- create_arrow_schema()
+
+  sidf <- SOMADataFrame$new(uri)
+  sidf$create(asch, index_column_names = "foo")
+
+  expect_true("soma_joinid" %in% sidf$attrnames())
+  expect_equal(tiledb::datatype(sidf$attributes()$soma_joinid), "INT64")
+})
+
+

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -131,4 +131,19 @@ test_that("soma_joinid is added on creation", {
   expect_equal(tiledb::datatype(sidf$attributes()$soma_joinid), "INT64")
 })
 
+test_that("soma_joinid validations", {
+  uri <- withr::local_tempdir("soma-indexed-dataframe")
+  asch <- create_arrow_schema()
 
+  # Add a soma_joinid column with the wrong type
+  asch <- asch$AddField(
+    i = 1,
+    field = arrow::field("soma_joinid", arrow::int32(), nullable = FALSE)
+  )
+
+  sidf <- SOMADataFrame$new(uri)
+  expect_error(
+    sidf$create(asch, index_column_names = "foo"),
+    "soma_joinid field must be of type Arrow int64"
+  )
+})

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -46,8 +46,8 @@ test_that("SOMADataFrame creation", {
   expect_true(tbl1$Equals(tbl0))
 
   # Slicing by foo
-  tbl1 <- sidf$read(ids = list(foo=1L:2L))
-  expect_true(tbl1$Equals(tbl1$Slice(offset = 0, length = 2)))
+  tbl1 <- sidf$read(ids = list(foo = 1L:2L))
+  expect_true(tbl1$Equals(tbl0$Slice(offset = 0, length = 2)))
 
   # Subselecting columns
   expect_error(

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -2,12 +2,6 @@ test_that("Basic mechanics", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- create_arrow_schema()
 
-  # Add a soma_joinid column to the schema
-  asch <- asch$AddField(
-    i = 1,
-    field = arrow::field("soma_joinid", arrow::int64(), nullable = FALSE)
-  )
-
   sidf <- SOMADataFrame$new(uri)
   expect_error(
     sidf$create(asch),
@@ -75,12 +69,12 @@ test_that("int64 values are stored correctly", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- arrow::schema(
     arrow::field("foo", arrow::int32(), nullable = FALSE),
-    arrow::field("bar", arrow::int64(), nullable = FALSE),
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
   )
 
   sidf <- SOMADataFrame$new(uri)
   sidf$create(asch, index_column_names = "foo")
-  tbl0 <- arrow::arrow_table(foo = 1L:10L, bar = 1L:10L, schema = asch)
+  tbl0 <- arrow::arrow_table(foo = 1L:10L, soma_joinid = 1L:10L, schema = asch)
 
   orig_downcast_value <- getOption("arrow.int64_downcast")
 
@@ -140,6 +134,7 @@ test_that("soma_ prefix is reserved", {
 test_that("soma_joinid is added on creation", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- create_arrow_schema()
+  asch <- asch$RemoveField(match("soma_joinid", asch$names) - 1)
 
   sidf <- SOMADataFrame$new(uri)
   sidf$create(asch, index_column_names = "foo")
@@ -153,6 +148,7 @@ test_that("soma_joinid validations", {
   asch <- create_arrow_schema()
 
   # Add a soma_joinid column with the wrong type
+  asch <- asch$RemoveField(match("soma_joinid", asch$names) - 1)
   asch <- asch$AddField(
     i = 1,
     field = arrow::field("soma_joinid", arrow::int32(), nullable = FALSE)

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -120,6 +120,23 @@ test_that("SOMADataFrame read", {
     expect_equal(z$num_rows, 10L)
 })
 
+test_that("soma_ prefix is reserved", {
+  uri <- withr::local_tempdir("soma-indexed-dataframe")
+  asch <- create_arrow_schema()
+
+  # Add a soma_joinid column with the wrong type
+  asch <- asch$AddField(
+    i = 1,
+    field = arrow::field("soma_foo", arrow::int32(), nullable = FALSE)
+  )
+
+  sidf <- SOMADataFrame$new(uri)
+  expect_error(
+    sidf$create(asch, index_column_names = "foo"),
+    "Column names must not start with reserved prefix 'soma_'"
+  )
+})
+
 test_that("soma_joinid is added on creation", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- create_arrow_schema()


### PR DESCRIPTION
Addresses #386 for the R package.

Updates `SOMADataFrame`'s `create` method to: 

- automatically add `soma_joinid` if it's missing from the schema.
- prevents the creation of `SOMADataFrames` with `soma_` prefixed columns
- assert `soma_joinid` is of type `int64`
