### PR TITLE
[r] Fix creation of SOMADataFrames with non-int32 dimensions

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -50,7 +50,8 @@ SOMADataFrame <- R6::R6Class(
 
         tdb_dims[[field_name]] <- tiledb::tiledb_dim(
           name = field_name,
-          domain = arrow_type_range(field$type),
+          # Numeric index types must be positive values for indexing
+          domain = arrow_type_unsigned_range(field$type),
           tile = tile_extent,
           type = tiledb_type_from_arrow_type(field$type),
           filter_list = tiledb::tiledb_filter_list(c(

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -48,6 +48,11 @@ SOMADataFrame <- R6::R6Class(
           tile_extent
         )
 
+        # Default 2048 mods to 0 for 8-bit types and 0 is an invalid extent
+        if (field$type$bit_width %||% 0L == 8L) {
+          tile_extent <- 64L
+        }
+
         tdb_dims[[field_name]] <- tiledb::tiledb_dim(
           name = field_name,
           # Numeric index types must be positive values for indexing

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -38,11 +38,20 @@ SOMADataFrame <- R6::R6Class(
       for (field_name in index_column_names) {
         field <- schema$GetFieldByName(field_name)
 
+        # TODO: Parameterize
+        tile_extent <- 2048L
+
+        tile_extent <- switch(field$type$ToString(),
+          "int64" = bit64::as.integer64(tile_extent),
+          "double" = as.double(tile_extent),
+          "string" = NULL,
+          tile_extent
+        )
+
         tdb_dims[[field_name]] <- tiledb::tiledb_dim(
           name = field_name,
           domain = arrow_type_range(field$type),
-          # TODO: Parameterize
-          tile = 2048L,
+          tile = tile_extent,
           type = tiledb_type_from_arrow_type(field$type),
           filter_list = tiledb::tiledb_filter_list(c(
             tiledb_zstd_filter()

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -112,16 +112,17 @@ arrow_type_range <- function(x) {
     uint32 = bit64::as.integer64(c(0, 4294967295)),
     # We can't specify the full range of uint64 in R so we use the max of int64
     uint64 = c(bit64::as.integer64(0), bit64::lim.integer64()[2]),
-    float32 = c(-3.4028235e+38, 3.4028235e+38),
+    # float32/float
     float = c(-3.4028235e+38, 3.4028235e+38),
-    float64 = c(-1.7976931348623157e+308, 1.7976931348623157e+308),
+    # float64/double
     double =  c(-1.7976931348623157e+308, 1.7976931348623157e+308),
-    boolean = NULL,
+    # boolean/bool
     bool = NULL,
+    # string/utf8
     utf8 = NULL,
-    string = NULL,
     stop("Unsupported data type", call. = FALSE)
   )
+
 }
 
 #' Create an Arrow field from a TileDB dimension

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -99,7 +99,7 @@ arrow_type_from_tiledb_type <- function(x) {
 #' Retrieve limits for Arrow types
 #' @importFrom bit64 lim.integer64
 #' @noRd
-arrow_type_range <- function(x) {
+arrow_type_range <- function(x, signed = TRUE) {
   stopifnot(is_arrow_data_type(x))
 
   switch(x$name,
@@ -122,7 +122,23 @@ arrow_type_range <- function(x) {
     utf8 = NULL,
     stop("Unsupported data type", call. = FALSE)
   )
+}
 
+#' Retrieve unsigned limits for Arrow types
+#' This restricts the lower bound of signed numeric types to 0
+#' @noRd
+arrow_type_unsigned_range <- function(x) {
+  range <- arrow_type_range(x)
+  range[1] <- switch(x$name,
+    int8 = 0L,
+    int16 = 0L,
+    int32 = 0L,
+    int64 = bit64::as.integer64(0),
+    float = 0,
+    double = 0,
+    range[1]
+  )
+  range
 }
 
 #' Create an Arrow field from a TileDB dimension

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -99,7 +99,7 @@ arrow_type_from_tiledb_type <- function(x) {
 #' Retrieve limits for Arrow types
 #' @importFrom bit64 lim.integer64
 #' @noRd
-arrow_type_range <- function(x, signed = TRUE) {
+arrow_type_range <- function(x) {
   stopifnot(is_arrow_data_type(x))
 
   switch(x$name,

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -115,7 +115,7 @@ arrow_type_range <- function(x) {
     # float32/float
     float = c(-3.4028235e+38, 3.4028235e+38),
     # float64/double
-    double =  c(-1.7976931348623157e+308, 1.7976931348623157e+308),
+    double =  c(.Machine$double.xmin, .Machine$double.xmax),
     # boolean/bool
     bool = NULL,
     # string/utf8

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -66,11 +66,24 @@ test_that("Basic mechanics", {
 })
 
 test_that("creation with all supported dimension data types", {
+
+  sch <- arrow::schema(
+    arrow::field("int8", arrow::int8(), nullable = FALSE),
+    arrow::field("int16", arrow::int16(), nullable = FALSE),
+    arrow::field("double", arrow::float64(), nullable = FALSE),
+    arrow::field("int", arrow::int32(), nullable = FALSE),
+    arrow::field("int64", arrow::int64(), nullable = FALSE),
+    arrow::field("string", arrow::utf8(), nullable = FALSE)
+  )
+
   tbl0 <- arrow::arrow_table(
+    int8 = 1L:10L,
+    int16 = 1:10L,
     double = 1.1:10.1,
     int = 1L:10L,
     int64 = bit64::as.integer64(1L:10L),
-    string = letters[1:10]
+    string = letters[1:10],
+    schema = sch
   )
 
   for (dtype in tbl0$ColumnNames()) {

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -65,6 +65,24 @@ test_that("Basic mechanics", {
   expect_true(tbl1$Equals(tbl0$Filter(tbl0$bar < 5)))
 })
 
+test_that("creation with all supported dimension data types", {
+  tbl0 <- arrow::arrow_table(
+    double = 1.1:10.1,
+    int = 1L:10L,
+    int64 = bit64::as.integer64(1L:10L),
+    string = letters[1:10]
+  )
+
+  for (dtype in tbl0$ColumnNames()) {
+    uri <- withr::local_tempdir(paste0("soma-dataframe-", dtype))
+    sidf <- SOMADataFrame$new(uri)
+    expect_silent(
+      sidf$create(tbl0$schema, index_column_names = dtype)
+    )
+    expect_true(sidf$exists())
+  }
+})
+
 test_that("int64 values are stored correctly", {
   uri <- withr::local_tempdir("soma-indexed-dataframe")
   asch <- arrow::schema(


### PR DESCRIPTION
Minor tweaks to `SOMADataFrame` to support creation of dimensions with int64, float/double, and string data types. As per the spec, we limit the domain of numeric dimensions to non-negative values.