### PR TITLE
[python] More memory-reduction for ingest [main]

### DIFF
--- a/apis/python/src/tiledbsoma/util_scipy.py
+++ b/apis/python/src/tiledbsoma/util_scipy.py
@@ -1,5 +1,3 @@
-from typing import List, Union
-
 import pandas as pd
 import scipy.sparse as sp
 
@@ -12,31 +10,3 @@ def csr_from_tiledb_df(df: pd.DataFrame, num_rows: int, num_cols: int) -> sp.csr
         (df["soma_data"], (df["soma_dim_0"], df["soma_dim_1"])),
         shape=(num_rows, num_cols),
     )
-
-
-def find_sparse_chunk_size(
-    mat: Union[sp.csr_matrix, sp.csc_matrix],
-    start_index: int,
-    axis: int,
-    goal_chunk_nnz: int,
-) -> int:
-    """
-    Given a sparse matrix and a start index, return a step size, on the stride axis,
-    which will achieve the cummulative nnz desired.
-
-    :param mat: The input scipy.sparse matrix.
-    :param start_index: the index at which to start a chunk.
-    :param axis: the stride axis, across which to find a chunk.
-    :param goal_chunk_nnz: Desired number of non-zero array entries for the chunk.
-    """
-    chunk_size = 1
-    sum_nnz = 0
-    coords: List[Union[slice, int]] = [slice(None), slice(None)]
-    for index in range(start_index, mat.shape[axis]):
-        coords[axis] = index
-        sum_nnz += mat[tuple(coords)].nnz
-        if sum_nnz > goal_chunk_nnz:
-            break
-        chunk_size += 1
-
-    return chunk_size

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -209,22 +209,20 @@ def test_export_anndata(adata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
-    orig = adata
-
     exp = tiledbsoma.Experiment(output_path)
-    tiledbsoma.io.from_anndata(exp, orig, measurement_name="RNA")
+    tiledbsoma.io.from_anndata(exp, adata, measurement_name="RNA")
 
     readback = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
 
-    assert readback.obs.shape == orig.obs.shape
-    assert readback.var.shape == orig.var.shape
-    assert readback.X.shape == orig.X.shape
+    assert readback.obs.shape == adata.obs.shape
+    assert readback.var.shape == adata.var.shape
+    assert readback.X.shape == adata.X.shape
 
-    for key in orig.obsm.keys():
-        assert readback.obsm[key].shape == orig.obsm[key].shape
-    for key in orig.varm.keys():
-        assert readback.varm[key].shape == orig.varm[key].shape
-    for key in orig.obsp.keys():
-        assert readback.obsp[key].shape == orig.obsp[key].shape
-    for key in orig.varp.keys():
-        assert readback.varp[key].shape == orig.varp[key].shape
+    for key in adata.obsm.keys():
+        assert readback.obsm[key].shape == adata.obsm[key].shape
+    for key in adata.varm.keys():
+        assert readback.varm[key].shape == adata.varm[key].shape
+    for key in adata.obsp.keys():
+        assert readback.obsp[key].shape == adata.obsp[key].shape
+    for key in adata.varp.keys():
+        assert readback.varp[key].shape == adata.varp[key].shape


### PR DESCRIPTION
This is crucial good UX for uptake of the SOMA product.

Here we leverage two things:

* `adata = anndata.read_h5ad(path_to_h5ad, "r")` with the `"r"` already in place (not new)
* Replace `adata.X[:]` with `adata.X` (new) -- this is a paginable object we can use to read CSR/CSC into memory a chunk at a time without needing to read the entire CSR/CSV into memory

Sandbox experiments using `htop` and a 58GB `.h5ad` file have shown peak memory on ingest drops from over 30GB without this PR, to about 15GB with this PR.

Note: currently stacked atop `kerl/resume-mode-main-2` which is also awaiting code review.