### PR TITLE
[python] Bump versions of precommit hooks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,29 +8,17 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apis/python
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
 
-      - name: Check Python Black Format
+      - name: Run pre-commit hooks on all files
         run: |
-          python -m pip install black
-          python -m black --check --diff . tools/[a-z]*
-
-      - name: Check for unsorted / unformatted Python imports with isort
-        run: |
-          python -m pip install isort
-          python -m isort --check --diff .
-
-      - name: Check Python style guide enforcement with flake8
-        run: |
-          python -m pip install flake8-bugbear
-          python -m flake8 . tools/[a-z]*
+          python -m pip install pre-commit
+          pre-commit run -a -v
 
       - name: Check type annotations with mypy
+        working-directory: apis/python
         run: |
           # mypy 0.990 has false positives on `import anndata as ad` and `Module has no attribute
           # "read_h5ad"` etc :(
@@ -40,6 +28,5 @@ jobs:
 
       - name: Check C++ Format
         run: |
-          cd ../..
           ./scripts/run-clang-format.sh . clang-format 0 \
-            $(find libtiledbsoma -name "*.cc" -or -name "*.h")
+          $(find libtiledbsoma -name "*.cc" -or -name "*.h")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,17 @@
 files: ^apis/python/
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
     - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
     - id: isort
       args: ["--profile", "black"]
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
+      additional_dependencies: ["flake8-bugbear==22.12.6"]
       args: ["--config", "apis/python/setup.cfg"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+files: ^apis/python/
 repos:
   - repo: https://github.com/ambv/black
     rev: 22.3.0


### PR DESCRIPTION
- Bump versions of precommit hooks & add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear)
- Update linter Github action to trigger pre-commit hooks instead of running manually black/isort/flake8/...