### PR TITLE
[python] build wheels only for CPython (not PyPy) to save CI time

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -39,10 +39,10 @@ jobs:
       matrix:
         include:
         - os: ubuntu-20.04
-          cibw_build: '*-manylinux_x86_64'
+          cibw_build: 'cp3*-manylinux_x86_64'
           platform: manylinux2014
         - os: macos-11
-          cibw_build: '*-macosx_x86_64'
+          cibw_build: 'cp3*-macosx_x86_64'
           platform: macosx
     steps:
     - name: Download sdist artifact


### PR DESCRIPTION
h/t @gsakkis 

https://github.com/single-cell-data/TileDB-SOMA/actions/runs/3901051185

18min wall time, I want to say that's halved?
looks like a nice easy win (assuming we're not interested in PyPy in the foreseeable)