### PR TITLE
tiledbsoma 0.1.21 [main-old]

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.20
+Version: 0.1.21
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",


### PR DESCRIPTION
https://github.com/single-cell-data/TileDB-SOMA/releases/tag/0.1.20 was fine but lacked a PyPI wheel.

This release will fix that.

See also https://github.com/single-cell-data/TileDB-SOMA/wiki#branches-and-releases which I recently updated with an info tip to help avoid the very mistake I just made this morning -- specifically this part:

> If you've created a GitHub branch (not tag, branch) like 0.1.20, do not tag that branch -- instead, merge that PR back to main-old and then make the tag on main-old -- else PyPI-publish CI won't run