### PR TITLE
[python] Correct incorrect object-type metadata on storage

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -103,8 +103,15 @@ class CollectionBase(TileDBObject, MutableMapping[str, CollectionElementType]):
         """
         Creates the data structure on disk/S3/cloud.
         """
+        return self._create(self.soma_type)
+
+    def _create(self, soma_type: str) -> "CollectionBase[CollectionElementType]":
+        """
+        Helper for `create`. Ensures that the type name of a child class, not
+        its parent class, is written to object-type metadata in storage.
+        """
         tiledb.group_create(uri=self._uri, ctx=self._ctx)
-        self._common_create()  # object-type metadata etc
+        self._common_create(soma_type)  # object-type metadata etc
         self._cached_values = {}
         return self
 

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -63,7 +63,7 @@ class DataFrame(TileDBArray):
         self._create_empty(schema, index_column_names, config_wrapper.create_options())
         self._index_column_names = tuple(index_column_names)
 
-        self._common_create()  # object-type metadata etc
+        self._common_create(self.soma_type)  # object-type metadata etc
         return self
 
     def _create_empty(

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -112,7 +112,7 @@ class DenseNDArray(TileDBArray):
 
         tiledb.Array.create(self._uri, sch, ctx=self._ctx)
 
-        self._common_create()  # object-type metadata etc
+        self._common_create(self.soma_type)  # object-type metadata etc
 
         return self
 

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -52,7 +52,7 @@ class Experiment(CollectionBase[TileDBObject]):
         """
         Creates the data structure on disk/S3/cloud.
         """
-        super().create()
+        self._create(self.soma_type)
         return self
 
     @property

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -75,7 +75,7 @@ class Measurement(CollectionBase[TileDBObject]):
         """
         Creates the data structure on disk/S3/cloud.
         """
-        super().create()
+        self._create(self.soma_type)
         return self
 
     @property

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -119,7 +119,7 @@ class SparseNDArray(TileDBArray):
 
         tiledb.Array.create(self._uri, sch, ctx=self._ctx)
 
-        self._common_create()  # object-type metadata etc
+        self._common_create(self.soma_type)  # object-type metadata etc
 
         return self
 

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -138,21 +138,21 @@ class TileDBObject(ABC):
         """Open the underlying TileDB array or Group"""
         ...
 
-    def _common_create(self) -> None:
+    def _common_create(self, soma_type: str) -> None:
         """
         Utility method for various constructors.
         """
-        self._set_object_type_metadata()
+        self._set_object_type_metadata(soma_type)
 
-    def _set_object_type_metadata(self) -> None:
+    def _set_object_type_metadata(self, soma_type: str) -> None:
         """
         This helps nested-structure traversals (especially those that start at the Collection level) confidently navigate with a minimum of introspection on group contents.
         """
-        # TODO: make a multi-set in MetadataMapping that would above a double-open there.
+        # TODO: make a multi-set in MetadataMapping that would avoid a double-open there.
         with self._tiledb_open("w") as obj:
             obj.meta.update(
                 {
-                    util.SOMA_OBJECT_TYPE_METADATA_KEY: self.soma_type,
+                    util.SOMA_OBJECT_TYPE_METADATA_KEY: soma_type,
                     util.SOMA_ENCODING_VERSION_METADATA_KEY: util.SOMA_ENCODING_VERSION,
                 }
             )
@@ -161,6 +161,4 @@ class TileDBObject(ABC):
         """
         Returns the class name associated with the group/array.
         """
-        # mypy says:
-        # error: Returning Any from function declared to return "str"  [no-any-return]
-        return self._metadata.get(util.SOMA_OBJECT_TYPE_METADATA_KEY)  # type: ignore
+        return cast(str, self._metadata.get(util.SOMA_OBJECT_TYPE_METADATA_KEY))

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -73,6 +73,10 @@ def test_import_anndata(adata, ingest_modes):
             list(orig.obs.keys()) + ["soma_joinid", "obs_id"]
         )
 
+        # Check ms
+        assert exp.ms.metadata.get(metakey) == "SOMACollection"
+        assert exp.ms["RNA"].metadata.get(metakey) == "SOMAMeasurement"
+
         # Check var
         var = exp.ms["RNA"].var.read().concat().to_pandas()
         assert sorted(var.columns.to_list()) == sorted(
@@ -87,6 +91,9 @@ def test_import_anndata(adata, ingest_modes):
         assert sorted(exp.ms["RNA"].var.keys()) == sorted(
             list(orig.var.keys()) + ["soma_joinid", "var_id"]
         )
+
+        # Check Xs
+        assert exp.ms["RNA"].X.metadata.get(metakey) == "SOMACollection"
 
         # Check X/data (dense)
         assert exp.ms["RNA"].X["data"].metadata.get(metakey) == "SOMADenseNDArray"


### PR DESCRIPTION
I discovered this bug while working on #685, but the bug precedes #685. For `Measurement` and `Experiment` objects, we have been writing soma type `SOMACollection` rather than `SOMAMeasurement` and `SOMAExperiment`, respectively. This bug wasn't caught sooner because it wasn't tested sooner. This PR fixes both problems.