### PR TITLE
Add pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,4 @@
+Tracking issue and/or context:
+
+Description of proposed changes:
+

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-Tracking issue and/or context:
+## Issue and/or context:
 
 Description of proposed changes:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,5 +2,5 @@
 
 ## Changes:
 
-## Notes for Reviewer
+## Notes for Reviewer:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,6 @@
 ## Issue and/or context:
 
-Description of proposed changes:
+## Changes:
+
+## Notes for Reviewer
 


### PR DESCRIPTION
Empty PR descriptions are unhelpful. While we can't add a rule to require non-empty PR descriptions, what we can do is at least make a template.