### PR TITLE
[python] Update pyarrow dependency

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -109,7 +109,7 @@ setuptools.setup(
         "attrs>=22.1",
         "numpy",
         "pandas",
-        "pyarrow",
+        "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
         "tiledb>=0.19.0",


### PR DESCRIPTION
Context: #713 

Fixes the problem as described in that issue.

Works for all of Python 3.7 .. 3.10.