### PR TITLE
Separate pip installation of prereqs and tiledbsoma itself.

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python packages
-      run: python -m pip -v install pytest pytest-cov typeguard typing_extensions apis/python
+      run: |
+        # Python package install commands
+        # 1. Testing prereqs.
+        python -m pip -v install --upgrade pip wheel pytest pytest-cov typeguard
+        # 2. The package itself.
+        python -m pip -v install apis/python
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}


### PR DESCRIPTION
- Separates the `pip install` steps for the build-/test-only deps (pytype, typeguard, etc.) from the package itself.
- Installs the `wheel` package so that we use wheels to install where possible (editor's note: why is this not included by default???).