### PR TITLE
Add quote marks around a few strings in C++ errors.

### DIFF
--- a/libtiledbsoma/src/column_buffer.cc
+++ b/libtiledbsoma/src/column_buffer.cc
@@ -115,7 +115,7 @@ ColumnBuffer::ColumnBuffer(
     , is_var_(is_var)
     , is_nullable_(is_nullable) {
     LOG_DEBUG(fmt::format(
-        "[ColumnBuffer] {} {} bytes is_var={} is_nullable={}",
+        "[ColumnBuffer] '{}' {} bytes is_var={} is_nullable={}",
         name,
         num_bytes,
         is_var_,
@@ -201,7 +201,7 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
             num_bytes = std::stoull(value_str);
         } catch (const std::exception& e) {
             throw TileDBSOMAError(fmt::format(
-                "[ColumnBuffer] Error parsing {}: {} ({})",
+                "[ColumnBuffer] Error parsing {}: '{}' ({})",
                 CONFIG_KEY_INIT_BYTES,
                 value_str,
                 e.what()));

--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -89,7 +89,7 @@ SOMAReader::SOMAReader(
         LOG_DEBUG(fmt::format("timestamp = {}", array->open_timestamp_end()));
     } catch (const std::exception& e) {
         throw TileDBSOMAError(
-            fmt::format("Error opening array: {}\n  {}", uri_, e.what()));
+            fmt::format("Error opening array: '{}'\n  {}", uri_, e.what()));
     }
 
     reset(column_names, batch_size, result_order);
@@ -116,7 +116,7 @@ void SOMAReader::reset(
             layout = TILEDB_COL_MAJOR;
         } else {
             throw TileDBSOMAError(
-                fmt::format("Unknown result_order {}", result_order));
+                fmt::format("Unknown result_order '{}'", result_order));
         }
         mq_->set_layout(layout);
     }


### PR DESCRIPTION
A few strings in error messages were unquoted, which meant it was sometimes ambiguous as to what was going on or what the invalid value might be.