### PR TITLE
[ci] Use fewer CI resources for PR-pushes, more for merge [pending more research, please do not review]

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,6 +24,10 @@ jobs:
         # Free/Pro/Team/Enterprise, respectively, are 5/5/5/50 -- not say 5/10/25/50.  In practice
         # we find that the number of concurrent MacOS runners is the number one throttle on our CI.
         # Running MacOS CI immediately post-merge is an acceptable tradeoff.
+        # See also
+        # * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+        isPR:
+          - ${{ github.event_name == "pull_request" }}
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11
@@ -31,9 +35,11 @@ jobs:
           - runs-on: macos-12
             cc: gcc-11
             cxx: g++-11
-          - if: github.event_name == "pull_request" or github.event_name == "push"
-            os: [ubuntu-22.04]
-            python-version: ['3.7', '3.10']
+        exclude:
+          - isPR: true
+            os: macos-12
+          - isPR: true
+            python-version: ['3.8', '3.9']
 
     steps:
     - name: Select XCode version

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -28,7 +28,7 @@ jobs:
         # See also
         # * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
         isPR:
-            - ${{ github.event_name == 'pull_reauest' }}
+            - ${{ github.event_name == 'pull_request' }}
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     paths-ignore:
       - 'apis/r/**'
+    isPR: true
   push:
     branches: [main]
+    isPR: false
   release:
     types: [published]
+    isPR: false
 
 jobs:
   build:
@@ -27,8 +30,6 @@ jobs:
         # Running MacOS CI immediately post-merge is an acceptable tradeoff.
         # See also
         # * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
-        isPR:
-            - ${{ github.event_name == 'pull_reauest' }}
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,31 +15,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        if: github.event_name != "pull_request"
-          # Note: the `pull_request` and `push` events are the same unless one uses a fork-repo model
-          # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
-          os: [ubuntu-22.04, macos-12]
-          # os: [ubuntu-22.04, macos-12, windows-2019]
-          python-version: ['3.7', '3.8', '3.9', '3.10']
-          include:
-            - runs-on: ubuntu-22.04
-              cc: gcc-11
-              cxx: g++-11
-            - runs-on: macos-12
-              cc: gcc-11
-              cxx: g++-11
-        if: github.event_name == "pull_request"
-          # GHA MacOS caps for tiers Free/Pro/Team/Enterprise are 5/5/5/50 :(
-          # -- not 5/10/25/50 or anything reasonable :(.
-          # Since most of our CI activity is people pushing multiple iterations
-          # of PRs, let's ration some resources for that use-case, and save
-          # the full coverage for PR merges and releases.
-          os: [ubuntu-22.04]
-          python-version: ['3.7', '3.10']
-          include:
-            - runs-on: ubuntu-22.04
-              cc: gcc-11
-              cxx: g++-11
+        # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
+        os: [ubuntu-22.04, macos-12]
+        # os: [ubuntu-22.04, macos-12, windows-2019]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        # Note: the `pull_request` and `push` events are the same unless one uses a fork-repo model.
+        # We intentionally ration use of MacOS since the concurrency caps for tiers
+        # Free/Pro/Team/Enterprise, respectively, are 5/5/5/50 -- not say 5/10/25/50.  In practice
+        # we find that the number of concurrent MacOS runners is the number one throttle on our CI.
+        # Running MacOS CI immediately post-merge is an acceptable tradeoff.
+        include:
+          - runs-on: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+          - runs-on: macos-12
+            cc: gcc-11
+            cxx: g++-11
+          - if: github.event_name == "pull_request" or github.event_name == "push"
+            os: [ubuntu-22.04]
+            python-version: ['3.7', '3.10']
 
     steps:
     - name: Select XCode version

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,17 +15,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
-        os: [ubuntu-22.04, macos-12]
-        # os: [ubuntu-22.04, macos-12, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-          - runs-on: ubuntu-22.04
-            cc: gcc-11
-            cxx: g++-11
-          - runs-on: macos-12
-            cc: gcc-11
-            cxx: g++-11
+        if: github.event_name != "pull_request"
+          # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
+          os: [ubuntu-22.04, macos-12]
+          # os: [ubuntu-22.04, macos-12, windows-2019]
+          python-version: ['3.7', '3.8', '3.9', '3.10']
+          include:
+            - runs-on: ubuntu-22.04
+              cc: gcc-11
+              cxx: g++-11
+            - runs-on: macos-12
+              cc: gcc-11
+              cxx: g++-11
+        if: github.event_name == "pull_request"
+          # GHA MacOS caps for tiers Free/Pro/Team/Enterprise are 5/5/5/50 :(
+          # -- not 5/10/25/50 or anything reasonable :(.
+          # Since most of our CI activity is people pushing multiple iterations
+          # of PRs, let's ration some resources for that use-case, and save
+          # the full coverage for PR merges and releases.
+          os: [ubuntu-22.04]
+          python-version: ['3.7', '3.10']
+          include:
+            - runs-on: ubuntu-22.04
+              cc: gcc-11
+              cxx: g++-11
 
     steps:
     - name: Select XCode version

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,14 +20,15 @@ jobs:
         # os: [ubuntu-22.04, macos-12, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         # Note: the `pull_request` and `push` events are the same unless one uses a fork-repo model.
-        # We intentionally ration use of MacOS since the concurrency caps for tiers
+        #
+        # Not: we intentionally ration use of MacOS since the concurrency caps for tiers
         # Free/Pro/Team/Enterprise, respectively, are 5/5/5/50 -- not say 5/10/25/50.  In practice
         # we find that the number of concurrent MacOS runners is the number one throttle on our CI.
         # Running MacOS CI immediately post-merge is an acceptable tradeoff.
         # See also
         # * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
         isPR:
-          - ${{ github.event_name == "pull_request" }}
+            - ${{ github.event_name == 'pull_reauest' }}
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11
@@ -37,7 +38,7 @@ jobs:
             cxx: g++-11
         exclude:
           - isPR: true
-            os: macos-12
+            os: [macos-12]
           - isPR: true
             python-version: ['3.8', '3.9']
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -37,9 +37,9 @@ jobs:
             cc: gcc-11
             cxx: g++-11
         exclude:
-          - isPR: true
+          - if: isPR
             os: [macos-12]
-          - isPR: true
+          - if: isPR
             python-version: ['3.8', '3.9']
 
     steps:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         if: github.event_name != "pull_request"
+          # Note: the `pull_request` and `push` events are the same unless one uses a fork-repo model
           # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
           os: [ubuntu-22.04, macos-12]
           # os: [ubuntu-22.04, macos-12, windows-2019]

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -4,13 +4,10 @@ on:
   pull_request:
     paths-ignore:
       - 'apis/r/**'
-    isPR: true
   push:
     branches: [main]
-    isPR: false
   release:
     types: [published]
-    isPR: false
 
 jobs:
   build:
@@ -30,6 +27,8 @@ jobs:
         # Running MacOS CI immediately post-merge is an acceptable tradeoff.
         # See also
         # * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+        isPR:
+            - ${{ github.event_name == 'pull_reauest' }}
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11


### PR DESCRIPTION
## Issue and/or context:

#693

## Changes:

Narrative is in the comments

## Notes for Reviewer: 

Non-admins of this repo may lack access to this status page but it's routinely pegged at 5 running MacOS jobs:
https://github.com/organizations/single-cell-data/settings/actions/hosted-runners