### PR TITLE
tiledbsoma 0.1.22

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyarrow
     scanpy
     scipy
-    tiledb>=0.19.1
+    tiledb>=0.19.0
 python_requires = >3.7
 
 [options.extras_require]

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
             "pyarrow",
             "scanpy",
             "scipy",
-            "tiledb>=0.19.1",
+            "tiledb>=0.19.0",
         ],
         python_requires=">=3.7",
     )

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.21
+Version: 0.1.22
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",


### PR DESCRIPTION
## Issue and/or context:

Update for TileDB Cloud. The rule `tiledb >= 0.19.0` suffices (and is already used in `main`).

## Changes:

`tiledb >= 0.19.0` rather than `tiledb >= 0.19.1`

## Notes for Reviewer:

