### PR TITLE
Add pre-commit hook for mypy and remove explicit mypy step from python-ci

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,12 +45,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install testing/linting prereqs
-      run: python -m pip -v install -U pip pytest-cov typeguard pre-commit mypy types-setuptools
+    - name: Install testing prereqs
+      run: python -m pip -v install -U pip pytest-cov typeguard
 
     - name: Run pre-commit hooks on all files
       if: matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9'
-      run: pre-commit run -a -v
+      run: python -m pip -v install pre-commit && pre-commit run -a -v
 
     - name: Check C++ Format
       if: matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9'
@@ -67,11 +67,6 @@ jobs:
 
     - name: Show XCode version
       run: clang --version
-
-    - name: Check type annotations with mypy
-      if: matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9'
-      working-directory: apis/python
-      run: python -m mypy .
 
     - name: Generate test data
       shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
     - id: flake8
       additional_dependencies: ["flake8-bugbear==22.12.6"]
       args: ["--config", "apis/python/setup.cfg"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    - id: mypy
+      additional_dependencies: ["types-setuptools", "somacore==0.0.0a3"]
+      args: ["--config-file=apis/python/setup.cfg", "apis/python/src", "apis/python/tools"]
+      pass_filenames: false

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -10,7 +10,6 @@ select = B,C,E,F,W,T4,B9
 extend-exclude = dist_links,query_condition.py
 
 [mypy]
-exclude = tests|dist_links|version.py|setup.py
 show_error_codes = True
 ignore_missing_imports = True
 warn_unreachable = True


### PR DESCRIPTION
Run `mypy` via `pre-commit` so that typing errors are caught before being committed.

One small downside is the need to specify explicitly the dependencies to be installed in the mypy virtualenv (e.g. `somacore`), instead of having all the `tiledbsoma` dependencies already installed as on https://github.com/single-cell-data/TileDB-SOMA/pull/726. That's because AFAICT the `additional_dependencies` option can install only PyPI packages, not local dependencies (e.g. `apis/python/`).