### PR TITLE
[python] Prep for ExperimentAxisQuery perf work in `somacore`

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -1,3 +1,5 @@
+from somacore import AxisQuery, ExperimentAxisQuery
+
 from .collection import Collection
 from .dataframe import DataFrame
 from .dense_nd_array import DenseNDArray
@@ -27,6 +29,8 @@ __all__ = [
     "TileDBPlatformConfig",
     "TileDBObject",
     "TileDBArray",
+    "AxisQuery",
+    "ExperimentAxisQuery",
     "Collection",
     "DenseNDArray",
     "DoesNotExistError",


### PR DESCRIPTION
## Issue and/or context:

This PR is in preparation for landing PR single-cell-data/SOMA#61.  See also, related PR single-cell-data/SOMA#83

## Changes:
* Added two somacore name exports for better API UX:  `AxisQuery` and `ExperimentAxisQuery`
*  Reworked the `ExperimentAxisQuery` tests to use the public interface (the private interfaces are changing).  Tests do the same thing, but now use the supported API.

## Notes for Reviewer:

None.