### PR TITLE
[python] Replace flake8 & isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies: ["types-setuptools", "pandas-stubs", "somacore==0.0.0a5"]
-      args: ["--config-file=apis/python/setup.cfg", "apis/python/src", "apis/python/devtools"]
+      args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     rev: 22.12.0
     hooks:
     - id: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
-    hooks:
-    - id: isort
-      args: ["--profile", "black"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.226
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,11 @@ repos:
     hooks:
     - id: isort
       args: ["--profile", "black"]
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.226
     hooks:
-    - id: flake8
-      additional_dependencies: ["flake8-bugbear==22.12.6"]
-      args: ["--config", "apis/python/setup.cfg"]
+    - id: ruff
+      args: ["--force-exclude", "--config=apis/python/pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -9,4 +9,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 ignore = ["E501"]
+extend-select = ["I001"]
 extend-exclude = ["query_condition.py"]
+fix = true
+
+[tool.ruff.isort]
+known-first-party = ["tiledbsoma"]
+known-third-party = ["anndata"]

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -6,3 +6,7 @@ requires = [
     "cmake>=3.21",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+ignore = ["E501"]
+extend-exclude = ["query_condition.py"]

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -7,6 +7,16 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.mypy]
+show_error_codes = true
+ignore_missing_imports = true
+warn_unreachable = true
+strict = true
+
+[[tool.mypy.overrides]]
+module = "tiledbsoma.query_condition"
+ignore_errors = true
+
 [tool.ruff]
 ignore = ["E501"]
 extend-select = ["I001"]

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -1,9 +1,0 @@
-[mypy]
-show_error_codes = True
-ignore_missing_imports = True
-warn_unreachable = True
-strict = True
-namespace_packages = False
-
-[mypy-tiledbsoma.query_condition]
-ignore_errors = True

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -1,8 +1,3 @@
-[isort]
-profile = black
-known_third_party = anndata
-skip = dist_links
-
 [mypy]
 show_error_codes = True
 ignore_missing_imports = True

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -3,12 +3,6 @@ profile = black
 known_third_party = anndata
 skip = dist_links
 
-[flake8]
-statistics = true
-ignore = E203,E501,W503,B950
-select = B,C,E,F,W,T4,B9
-extend-exclude = dist_links,query_condition.py
-
 [mypy]
 show_error_codes = True
 ignore_missing_imports = True

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -117,7 +117,7 @@ setuptools.setup(
     extras_require={
         "dev": [
             "black",
-            "flake8-bugbear",
+            "ruff",
             "isort",
             "pytest",
             "typeguard",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -118,7 +118,6 @@ setuptools.setup(
         "dev": [
             "black",
             "ruff",
-            "isort",
             "pytest",
             "typeguard",
         ]

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -370,7 +370,7 @@ def _validate_schema(schema: pa.Schema, index_column_names: Sequence[str]) -> pa
         # TODO: Pending
         # https://github.com/single-cell-data/TileDB-SOMA/issues/418
         # https://github.com/single-cell-data/TileDB-SOMA/issues/419
-        if not schema.field(index_column_name).type in [
+        if schema.field(index_column_name).type not in [
             pa.int8(),
             pa.uint8(),
             pa.int16(),


### PR DESCRIPTION
Replace flake8 & isort with [ruff](https://github.com/charliermarsh/ruff), a blazing fast Python linter.