### PR TITLE
[r/python/c++] Expand tabs that are immediately following spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ data:
 .PHONY: check-format
 check-format:
 	 @./scripts/run-clang-format.sh . clang-format 0 \
-	 	`find libtiledbsoma -name "*.cc" -or -name "*.h"`
+		`find libtiledbsoma -name "*.cc" -or -name "*.h"`
 
 .PHONY: format
 format:
 	 @./scripts/run-clang-format.sh . clang-format 1 \
-	 	`find libtiledbsoma -name "*.cc" -or -name "*.h"`
+		`find libtiledbsoma -name "*.cc" -or -name "*.h"`
 
 # clean
 # -------------------------------------------------------------------

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -115,9 +115,9 @@ SOMADenseNDArray <- R6::R6Class(
       }
 
       rl <- soma_reader(uri = uri,
-                        dim_points = coords,       	# NULL is dealt with by soma_reader()
+                        dim_points = coords,        # NULL is dealt with by soma_reader()
                         result_order = result_order,
-                        loglevel = log_level)      	# idem
+                        loglevel = log_level)       # idem
       arrow::as_arrow_table(arch::from_arch_array(rl, arrow::RecordBatch))
     },
 

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -116,9 +116,9 @@ SOMASparseNDArray <- R6::R6Class(
       }
 
       rl <- soma_reader(uri = uri,
-                        dim_points = coords,       	# NULL is dealt with by soma_reader()
+                        dim_points = coords,        # NULL is dealt with by soma_reader()
                         result_order = result_order,
-                        loglevel = log_level)      	# idem
+                        loglevel = log_level)       # idem
       arrow::as_arrow_table(arch::from_arch_array(rl, arrow::RecordBatch))
     },
 

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -59,7 +59,7 @@ Rcpp::List soma_reader(const std::string& uri,
 
     // Read selected columns from the uri (return is unique_ptr<SOMAReader>)
     auto sr = tdbs::SOMAReader::open(uri,
-                                     "unnamed", 		  // name parameter could be added
+                                     "unnamed",                   // name parameter could be added
                                      platform_config,             // to add, done in iterated reader
                                      column_names,
                                      batch_size,
@@ -135,16 +135,16 @@ Rcpp::List soma_reader(const std::string& uri,
 
     struct ArrowArray* array_data_tmp = (struct ArrowArray*) R_ExternalPtrAddr(arrlst[0]);
     int rows = static_cast<int>(array_data_tmp->length);
-    SEXP sxp = arch_c_schema_xptr_new(Rcpp::wrap("+s"), 	// format
-                                      Rcpp::wrap(""),   	// name
-                                      Rcpp::List(),       	// metadata
-                                      Rcpp::wrap(2),      	// flags, 2 == unordered, nullable, no sorted map keys
-                                      schlst, 	        	// children
-                                      R_NilValue);        	// dictionary
+    SEXP sxp = arch_c_schema_xptr_new(Rcpp::wrap("+s"),     // format
+                                      Rcpp::wrap(""),       // name
+                                      Rcpp::List(),         // metadata
+                                      Rcpp::wrap(2),        // flags, 2 == unordered, nullable, no sorted map keys
+                                      schlst,               // children
+                                      R_NilValue);          // dictionary
     SEXP axp = arch_c_array_from_sexp(Rcpp::List::create(Rcpp::Named("")=R_NilValue), // buffers
-                                      Rcpp::wrap(rows), 	// length
-                                      Rcpp::wrap(-1), 	    // null count, -1 means not determined
-                                      Rcpp::wrap(0),    	// offset (in bytes)
+                                      Rcpp::wrap(rows),     // length
+                                      Rcpp::wrap(-1),       // null count, -1 means not determined
+                                      Rcpp::wrap(0),        // offset (in bytes)
                                       arrlst,               // children
                                       R_NilValue);          // dictionary
     Rcpp::List as = Rcpp::List::create(Rcpp::Named("schema") = sxp,

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -31,7 +31,7 @@ const tiledb_xptr_object tiledb_xptr_object_group                { 120 };
 const tiledb_xptr_object tiledb_xptr_object_query                { 130 };
 const tiledb_xptr_object tiledb_xptr_object_querycondition       { 140 };
 const tiledb_xptr_object tiledb_xptr_object_vfs                  { 150 };
-const tiledb_xptr_object tiledb_xptr_vfs_fh_t              		 { 160 };
+const tiledb_xptr_object tiledb_xptr_vfs_fh_t                    { 160 };
 const tiledb_xptr_object tiledb_xptr_vlc_buf_t                   { 170 };
 const tiledb_xptr_object tiledb_xptr_vlv_buf_t                   { 180 };
 const tiledb_xptr_object tiledb_xptr_query_buf_t                 { 190 };
@@ -69,7 +69,7 @@ template <typename T> Rcpp::XPtr<T> make_xptr(T* p) {
 }
 
 template <typename T> Rcpp::XPtr<T> make_xptr(SEXP p) {
-    return Rcpp::XPtr<T>(p); 	// the default XPtr ctor with deleter on and tag and prot nil
+    return Rcpp::XPtr<T>(p);    // the default XPtr ctor with deleter on and tag and prot nil
 }
 
 template<typename T> void check_xptr_tag(Rcpp::XPtr<T> ptr) {
@@ -263,18 +263,18 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAReader> sr) {
 
    struct ArrowArray* array_data_tmp = (struct ArrowArray*) R_ExternalPtrAddr(arrlst[0]);
    int rows = static_cast<int>(array_data_tmp->length);
-   SEXP sxp = arch_c_schema_xptr_new(Rcpp::wrap("+s"), 	// format
-                                     Rcpp::wrap(""),   	// name
-                                     Rcpp::List(),       	// metadata
-                                     Rcpp::wrap(2),      	// flags, 2 == unordered, nullable, no sorted map keys
-                                     schlst, 	        	// children
-                                     R_NilValue);        	// dictionary
+   SEXP sxp = arch_c_schema_xptr_new(Rcpp::wrap("+s"),  // format
+                                     Rcpp::wrap(""),    // name
+                                     Rcpp::List(),      // metadata
+                                     Rcpp::wrap(2),     // flags, 2 == unordered, nullable, no sorted map keys
+                                     schlst,            // children
+                                     R_NilValue);       // dictionary
    SEXP axp = arch_c_array_from_sexp(Rcpp::List::create(Rcpp::Named("")=R_NilValue), // buffers
-                                     Rcpp::wrap(rows), 	// length
-                                     Rcpp::wrap(-1), 	    // null count, -1 means not determined
-                                     Rcpp::wrap(0),    	// offset (in bytes)
-                                     arrlst,               // children
-                                     R_NilValue);          // dictionary
+                                     Rcpp::wrap(rows),  // length
+                                     Rcpp::wrap(-1),    // null count, -1 means not determined
+                                     Rcpp::wrap(0),     // offset (in bytes)
+                                     arrlst,            // children
+                                     R_NilValue);       // dictionary
    Rcpp::List as = Rcpp::List::create(Rcpp::Named("schema") = sxp,
                                       Rcpp::Named("array_data") = axp);
    as.attr("class") = "arch_array";


### PR DESCRIPTION
## Issue and/or context:

#707 -- general pre-release neatening

## Changes:

Whenever there is one or more spaces followed by one or more tabs, simply expand the tabs.

This way comments will align respecting the author's intent even when the code reader uses a different tab-width than the code author.

## Notes for Reviewer:

Nothing but whitespace; no functional changes.