### PR TITLE
[python] Cache pre-commit environments

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -48,6 +48,13 @@ jobs:
     - name: Install testing prereqs
       run: python -m pip -v install -U pip pytest-cov typeguard
 
+    - name: Restore pre-commit cache
+      if: matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9'
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/python-ci.yml') }}
+
     - name: Run pre-commit hooks on all files
       if: matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9'
       run: python -m pip -v install pre-commit && pre-commit run -a -v


### PR DESCRIPTION
Context: #693 

Pre-commit sets up its runtime environments in a cache directory. If that cache does not exist, it has to download and set up the environment anew with every run (cf. "This may take a few minutes..." in the pre-commit output). This accounts for the majority of the runtime of the step within GitHub actions. Caching the environments means that this no longer needs to happen.