### PR TITLE
[python] Set up caching for packages downloaded with Pip

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,6 +44,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: ./apis/python/setup.py
 
     - name: Install testing prereqs
       run: python -m pip -v install -U pip pytest-cov typeguard


### PR DESCRIPTION
This uses the Python GitHub Action's built-in tool to cache the Pip downloaded package directory. This cache contains the wheels (or other package files) that were downloaded and thus avoids having to download them again. Only the downloaded package files themselves are cached; this does not enforce "stickiness" on what versions are installed (i.e. if a new version of a dependency is released, that new version will be downloaded and used; the cache will not "stick" to the old version indefinitely).