### PR TITLE
[python] Cache builds of libtiledbsoma in Python CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -47,6 +47,14 @@ jobs:
         cache: pip
         cache-dependency-path: ./apis/python/setup.py
 
+    - name: Cache native libraries
+      uses: actions/cache@v3
+      with:
+        path: |
+          build
+          dist
+        key: libtiledbsoma-build-dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('libtiledbsoma', 'apis/python/setup.py') }}
+
     - name: Install testing prereqs
       run: python -m pip -v install -U pip pytest-cov typeguard
 


### PR DESCRIPTION
Context: #693

This caches the `build` and `dist` directories [was: `dist/lib`], which is the output from the libtiledbsoma build process. It uses the hash of all files in the `libtiledbsoma` directory (as well as `setup.py`) to ensure that when any file is changed, the cache is invalidated and the build is done anew.

---

I'm not sure how I would set this up on the R side but something analogous would be good there, too.