### PR TITLE
[r] Caveat for TileDB-R dependency

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -33,6 +33,9 @@ Imports:
     Matrix,
     stats,
     bit64,
+    # We can't pin on 0.17.*, 0.18.*, etc since CRAN forbids it.  This means that whenever tiledb-r
+    # bumps, we can have CI fails in the time window between that release and our bumping
+    # libtilesoma's core-dependency version.
     tiledb (>= 0.17.0),
     arrow,
     utils,


### PR DESCRIPTION
## Issue and/or context:

Found via group debug regarding today's CI failures -- core 2.14 is out, and `tiledb-r` 0.18.0 is out (at CRAN), but `tiledb-py` 0.20 is not yet and we haven't bumped `libtiledbsoma`'s core dependency from 2.13 to 2.14 yet. So R CI fails with `tiledb-r` writing a 2.14 array that `libtiledbsoma` can't read because it's a too-new version.

See also #752 