### PR TITLE
[python] Depend on somacore 0.0.0a5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
     rev: v0.991
     hooks:
     - id: mypy
-      additional_dependencies: ["types-setuptools", "somacore==0.0.0a4"]
+      additional_dependencies: ["types-setuptools", "somacore==0.0.0a5"]
       args: ["--config-file=apis/python/setup.cfg", "apis/python/src", "apis/python/tools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -110,7 +110,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a4",
+        "somacore==0.0.0a5",
         "tiledb>=0.19.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],


### PR DESCRIPTION
## Issue and/or context:

Unbreaks Python CI for https://github.com/single-cell-data/TileDB-SOMA/pull/763 which needs the one PR between `somacore` 0.0.0a4 and 0.0.0a5 namely https://github.com/single-cell-data/SOMA/pull/89

See also issues #755 and chanzuckerberg/cell-census#56
