### PR TITLE
[python] Remove unnecessary steps from lint job

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -38,31 +38,13 @@ jobs:
     steps:
     - name: Checkout TileDB-SOMA
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0  # ensure we get all tags to inform package version determination
 
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
-
-    - name: Install testing/linting prereqs
-      run: python -m pip -v install -U pip typeguard mypy types-setuptools
-
-    - name: Cache native libraries
-      uses: actions/cache@v3
-      with:
-        path: |
-          build
-          dist
-        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'apis/python/setup.py') }}
-
-    # needed for mypy type checking
-    - name: Install tiledbsoma
-      run: python -m pip -v install -e apis/python
-      env:
-        CC: ${{ inputs.cc }}
-        CXX: ${{ inputs.cxx }}
+        cache: pip
+        cache-dependency-path: ./.github/workflows/python-ci-single.yml
 
     - name: Restore pre-commit cache
       uses: actions/cache@v3


### PR DESCRIPTION
Because pre-commit–based `mypy` doesn’t depend upon the packages in the installed directory, the only thing we need to install is pre-commit.

Context: #693 