### PR TITLE
[python] Add test case for issue 768 -- existence of `ExperimentAxisQuery.get_indexer()`

### DIFF
--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -304,7 +304,11 @@ def test_experiment_query_indexer(soma_experiment):
         obs_query=AxisQuery(coords=(slice(1, 10),)),
         var_query=AxisQuery(coords=(slice(1, 10),)),
     ) as query:
-        indexer = query._indexer
+        # TODO: remove this work-around once a new `somacore` is released.
+        # workaround:
+        indexer = getattr(query, 'indexer', query._indexer)
+        # future version:
+        # indexer = query.indexer
 
         # coords outside of our query should return -1
         assert np.array_equal(

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -306,7 +306,7 @@ def test_experiment_query_indexer(soma_experiment):
     ) as query:
         # TODO: remove this work-around once a new `somacore` is released.
         # workaround:
-        indexer = getattr(query, 'indexer', query._indexer)
+        indexer = getattr(query, "indexer", query._indexer)
         # future version:
         # indexer = query.indexer
 


### PR DESCRIPTION
## Issue and/or context:

Public API for ExperimentAxisQuery indexer was accidentally removed in the `somacore` refactoring.  See #768 

single-cell-data/SOMA#90 resolves the underlying issue.

This PR adds a unit test.

## Changes:

Add unit test of public API.

## Notes for Reviewer:

The test change will fall back on the old (private) API, as a temporary work-around until such time as `tiledbsoma` is updated to use a `somacore` release that contains this fix.