### PR TITLE
[python] Undo AWS_DEFAULT_REGION workaround

### DIFF
--- a/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Optional, Union
 
 import attrs
@@ -16,13 +15,6 @@ def _build_default_tiledb_ctx() -> tiledb.Ctx:
     cfg: Dict[str, Union[str, float]] = {
         "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3
     }
-
-    # This is necessary for smaller tile capacities when querying with a smaller memory budget.
-
-    # Temp workaround pending https://app.shortcut.com/tiledb-inc/story/23827
-    region = os.getenv("AWS_DEFAULT_REGION")
-    if region is not None:
-        cfg["vfs.s3.region"] = region
 
     return tiledb.Ctx(cfg)
 


### PR DESCRIPTION
## Issue and/or context:

#391 , now possible since core 2.14 at #770 is merged