### PR TITLE
Add pandas-stubs for mypy and fix uncovered typing issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
     rev: v0.991
     hooks:
     - id: mypy
-      additional_dependencies: ["types-setuptools", "somacore==0.0.0a5"]
+      additional_dependencies: ["types-setuptools", "pandas-stubs", "somacore==0.0.0a5"]
       args: ["--config-file=apis/python/setup.cfg", "apis/python/src", "apis/python/tools"]
       pass_filenames: false

--- a/apis/python/src/tiledbsoma/experiment_query.py
+++ b/apis/python/src/tiledbsoma/experiment_query.py
@@ -1,8 +1,12 @@
+from typing import cast
+
 import pandas as pd
 import pyarrow as pa
 
+from .types import NDArray, PDSeries
 
-def X_as_series(tbl: pa.Table) -> pd.Series:
+
+def X_as_series(tbl: pa.Table) -> PDSeries:
     """
     Convert the COO 2D matrix data returned from ``SparseNDArray.read_table()``
     into a Pandas Series, with coordindates as a Pandas MultiIndex [lifecycle: experimental].
@@ -35,7 +39,7 @@ def X_as_series(tbl: pa.Table) -> pd.Series:
     dim_0 = tbl["soma_dim_0"].to_numpy()
     dim_1 = tbl["soma_dim_1"].to_numpy()
     return pd.Series(
-        data,
+        cast(NDArray, data),
         pd.MultiIndex.from_arrays((dim_0, dim_1), names=("soma_dim_0", "soma_dim_1")),
         dtype=pd.SparseDtype(data.dtype, fill_value=0),
         name="soma_data",

--- a/apis/python/src/tiledbsoma/experiment_query.py
+++ b/apis/python/src/tiledbsoma/experiment_query.py
@@ -3,7 +3,7 @@ from typing import cast
 import pandas as pd
 import pyarrow as pa
 
-from .types import NDArray, PDSeries
+from .types import NPNDArray, PDSeries
 
 
 def X_as_series(tbl: pa.Table) -> PDSeries:
@@ -39,7 +39,7 @@ def X_as_series(tbl: pa.Table) -> PDSeries:
     dim_0 = tbl["soma_dim_0"].to_numpy()
     dim_1 = tbl["soma_dim_1"].to_numpy()
     return pd.Series(
-        cast(NDArray, data),
+        cast(NPNDArray, data),
         pd.MultiIndex.from_arrays((dim_0, dim_1), names=("soma_dim_0", "soma_dim_1")),
         dtype=pd.SparseDtype(data.dtype, fill_value=0),
         name="soma_data",

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -29,10 +29,10 @@ from tiledbsoma.exception import SOMAError
 
 from .constants import SOMA_JOINID
 from .options import SOMATileDBContext, TileDBCreateOptions
-from .types import INGEST_MODES, IngestMode, NDArray, Path
+from .types import INGEST_MODES, IngestMode, NPNDArray, Path
 
 SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
-Matrix = Union[NDArray, SparseMatrix]
+Matrix = Union[NPNDArray, SparseMatrix]
 
 
 # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -380,8 +380,7 @@ def _write_dataframe(
             # This lets us check for already-ingested dataframes, when in resume-ingest mode.
             with soma_df._tiledb_open() as A:
                 storage_ned = A.nonempty_domain()
-            sorted_dim_values = sorted(list(df.index))
-            dim_range = ((sorted_dim_values[0], sorted_dim_values[-1]),)
+            dim_range = ((int(df.index.min()), int(df.index.max())),)
             if _chunk_is_contained_in(dim_range, storage_ned):
                 logging.log_io(
                     f"Skipped {soma_df.uri}",

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -10,12 +10,12 @@ from typing_extensions import Literal
 if TYPE_CHECKING:
     NPInteger = np.integer[npt.NBitBase]
     NPFloating = np.floating[npt.NBitBase]
-    NDArray = npt.NDArray[np.number[npt.NBitBase]]
+    NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
     PDSeries = pd.Series[Any]
 else:
     NPInteger = np.integer
     NPFloating = np.floating
-    NDArray = np.ndarray
+    NPNDArray = np.ndarray
     PDSeries = pd.Series
 
 

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -11,10 +11,12 @@ if TYPE_CHECKING:
     NPInteger = np.integer[npt.NBitBase]
     NPFloating = np.floating[npt.NBitBase]
     NDArray = npt.NDArray[np.number[npt.NBitBase]]
+    PDSeries = pd.Series[Any]
 else:
     NPInteger = np.integer
     NPFloating = np.floating
     NDArray = np.ndarray
+    PDSeries = pd.Series
 
 
 Path = Union[str, pathlib.Path]

--- a/apis/python/src/tiledbsoma/util_ann.py
+++ b/apis/python/src/tiledbsoma/util_ann.py
@@ -208,17 +208,11 @@ def _describe_ann_file_show_uns_types(
         display_name = os.path.sep.join(current_path_components)
         if isinstance(value, Mapping):
             _describe_ann_file_show_uns_types(value, current_path_components)
-        elif isinstance(value, np.ndarray):
-            print(
-                "%-*s" % (namewidth, display_name),
-                value.shape,
-                type(value),
-                value.dtype,
-            )
-        elif isinstance(value, (sp.csr_matrix, pd.DataFrame)):
-            print("%-*s" % (namewidth, display_name), value.shape, type(value))
         else:
-            print("%-*s" % (namewidth, display_name), type(value))
+            info = ["%-*s" % (namewidth, display_name), type(value)]
+            if isinstance(value, (np.ndarray, sp.csr_matrix, pd.DataFrame)):
+                info.extend((value.shape, value.dtype))
+            print(*info)
 
 
 # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -9,7 +9,7 @@ import scipy.sparse as sp
 import somacore
 import tiledb
 
-from .types import NDArray, PDSeries
+from .types import NPNDArray, PDSeries
 
 SOMA_OBJECT_TYPE_METADATA_KEY = "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
@@ -113,7 +113,7 @@ def _to_supported_series(x: PDSeries) -> PDSeries:
     return x.astype("O")
 
 
-_MT = TypeVar("_MT", NDArray, sp.spmatrix, PDSeries)
+_MT = TypeVar("_MT", NPNDArray, sp.spmatrix, PDSeries)
 
 
 def _to_supported_base(x: _MT) -> _MT:


### PR DESCRIPTION
Add public type stubs for `pandas` via [pandas-stubs](https://pypi.org/project/pandas-stubs/) and fix the 9 resulting mypy errors.