### PR TITLE
[python] Additional experiment-query unit tests

### DIFF
--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -416,7 +416,7 @@ def test_error_corners(soma_experiment: soma.Experiment):
     """Verify a couple of error conditions / corner cases."""
     assert soma_experiment.exists()
 
-    # Unkonwn Measurement name
+    # Unknown Measurement name
     with pytest.raises(ValueError):
         soma_experiment.axis_query("no-such-measurement")
 


### PR DESCRIPTION
## Issue and/or context:

#778  - need to increase unit tests

## Changes:

Added additional unit tests for `somacore.ExperimentAxisQuery` and related.

## Notes for Reviewer:

Note: routines in `_fast_csr` compiled by numba are tested, but codecov will not report them as such