### PR TITLE
[python] Make add-X-layer logic friendlier

### DIFF
--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -473,6 +473,26 @@ def create_from_matrix(
     )
 
 
+def add_X_layer(
+    exp: Experiment,
+    measurement_name: str,
+    X_layer_name: str,
+    X_layer_data: Union[
+        Matrix, h5py.Dataset
+    ],  # e.g. a scipy.csr_matrix from scanpy analysis
+    ingest_mode: IngestMode = "write",
+) -> None:
+    """
+    This is useful for adding X data, for example from scanpy.pp.normalize_total, scanpy.pp.log1p, etc.
+
+    Use `ingest_mode="resume"` to not error out if the schema already exists.
+    """
+    uri = f"{exp.ms[measurement_name].X.uri}/{X_layer_name}"
+    sparse_nd_array = SparseNDArray(uri)
+    create_from_matrix(sparse_nd_array, X_layer_data, ingest_mode=ingest_mode)
+    exp.ms[measurement_name].X.set(X_layer_name, sparse_nd_array)
+
+
 def _write_matrix_to_denseNDArray(
     soma_ndarray: DenseNDArray,
     matrix: Union[Matrix, h5py.Dataset],

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -220,6 +220,18 @@ def test_resume_mode(adata, resume_mode_h5ad_file):
     tempdir2.cleanup()
 
 
+def test_add_X_layer(adata):
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+
+    exp = tiledbsoma.Experiment(output_path)
+    tiledbsoma.io.from_anndata(exp, adata, measurement_name="RNA")
+    assert list(exp.ms["RNA"].X.keys()) == ["data"]
+
+    tiledbsoma.io.add_X_layer(exp, "RNA", "data2", adata.X)
+    assert sorted(list(exp.ms["RNA"].X.keys())) == ["data", "data2"]
+
+
 def test_export_anndata(adata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name


### PR DESCRIPTION
## Issue and/or context:

#643

## Changes:

This is a key piece of UX present within `main-old` but currently lacking in `main`, on discussion with @ckrilow on feature-parity gap analysis between `main-old` and `main`. Namely, a key workflow is like this:

```
import tiledbsoma, tiledbsoma.io
import scanpy

adata = ... AnnData object obtained somehow

exp = soma.Experiment(uri)

soma.io.from_anndata(exp, adata, "RNA")

scanpy.pp.normalize_total(adata, inplace=True)
scanpy.pp.log1p(adata, copy=False)

... need to make a new exp.ms["RNA"].X["normalized"] from adata.X
```

The problem with the existing `write` methods is they all assume Arrow format. This leaves the user with many lines of plumbing to invent. We need to do this for them so they don't have to.

This is a crucial bit of feature parity with `main-old`.