### PR TITLE
[python] Fix pip-install instructions

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -12,7 +12,11 @@ This code is hosted at [PyPI](https://pypi.org/project/tiledbsoma/), so you can 
 
 ```shell
 $ python -m pip install tiledbsoma
+# or
+$ python -m pip install --pre tiledbsoma
 ```
+
+Without `--pre` you will get version 0.1.* (the `main-old` branch); with `--pre`, you will get 0.5.0a* (the `main` branch).
 
 To install a specific version:
 


### PR DESCRIPTION
## Issue and/or context:

This `README.md` is propagated to https://pypi.org/project/tiledbsoma and is currently given erroneous instruction on how to pip-install for folks using `main` (the current pre-release development version).

