### PR TITLE
[r] Allow use pbmc3k data package in test

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     rmarkdown,
     knitr,
     withr,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    pbmc3k.tiledb
 VignetteBuilder: knitr
 Config/testthat/edition: 2


### PR DESCRIPTION
#### Issue and/or context:

The iterated reader is only truly testable on a large dataset as we do not (currently) set the chunk size of reads. A local data package, containing a compressed tarball of the standard dataset in the repo (in hdf5 form) has been useful for local tests.  Before (or inconjunction to) moving the data set to cloud storage we can also _very cheaply_ take advantage of infrastructure we already have in the `Additional_repositories:` field used to provide the Arrow helper `arch` while we await to Arrow team's release of `nanoarrow`.

#### Changes:

A one word addition to `DESCRIPTION`, plus an injection of the data package into the [ghrr drat repo via this commit](https://github.com/ghrr/drat/commit/a91e5118e57863ebe0da85712ecccdc6c45735a8)

This permits the [unit test file we long had](https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/r/tests/testthat/test_SOMAReader-Iterated.R) to also run at CI rather than to skip itself.

#### Notes for Reviewer:

See https://app.shortcut.com/tiledb-inc/story/24864/take-advantage-of-additional-repositories-to-add-the-data-package