### PR TITLE
More unit tests, plus partial fix for #801

### DIFF
--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -64,11 +64,11 @@ def _construct_member(
         if object_type == "array":
             with tiledb.open(member_uri, ctx=context.tiledb_ctx) as A:
                 spec_name = A.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
-                encoding_version = A.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY, None)
+                encoding_version = A.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY)
         elif object_type == "group":
             with tiledb.Group(member_uri, mode="r", ctx=context.tiledb_ctx) as G:
                 spec_name = G.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
-                encoding_version = G.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY, None)
+                encoding_version = G.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY)
         else:
             return None
 
@@ -80,7 +80,7 @@ def _construct_member(
     if encoding_version is None:
         raise SOMAError("internal error: encoding_version not found")
     if encoding_version != SOMA_ENCODING_VERSION:
-        raise SOMAError("Unsupported SOMA object encoding version")
+        raise ValueError("Unsupported SOMA object encoding version")
     if spec_name not in SPEC_NAMES_TO_CLASS_NAMES:
         raise SOMAError(f'name "{spec_name}" unrecognized')
     class_name = SPEC_NAMES_TO_CLASS_NAMES[spec_name]

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -15,7 +15,12 @@ from .experiment import Experiment
 from .measurement import Measurement
 from .options import SOMATileDBContext
 from .sparse_nd_array import SparseNDArray
-from .util import SOMA_OBJECT_TYPE_METADATA_KEY, SPEC_NAMES_TO_CLASS_NAMES
+from .util import (
+    SOMA_ENCODING_VERSION,
+    SOMA_ENCODING_VERSION_METADATA_KEY,
+    SPEC_NAMES_TO_CLASS_NAMES,
+    SOMA_OBJECT_TYPE_METADATA_KEY,
+)
 
 ObjectTypes = Union[
     Experiment,
@@ -58,10 +63,12 @@ def _construct_member(
     try:
         if object_type == "array":
             with tiledb.open(member_uri, ctx=context.tiledb_ctx) as A:
-                spec_name = A.meta[SOMA_OBJECT_TYPE_METADATA_KEY]
+                spec_name = A.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
+                encoding_version = A.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY, None)
         elif object_type == "group":
             with tiledb.Group(member_uri, mode="r", ctx=context.tiledb_ctx) as G:
-                spec_name = G.meta[SOMA_OBJECT_TYPE_METADATA_KEY]
+                spec_name = G.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
+                encoding_version = G.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY, None)
         else:
             return None
 
@@ -70,6 +77,10 @@ def _construct_member(
 
     if spec_name is None:
         raise SOMAError("internal error: spec_name was not found")
+    if encoding_version is None:
+        raise SOMAError("internal error: encoding_version not found")
+    if encoding_version != SOMA_ENCODING_VERSION:
+        raise SOMAError("Unsupported SOMA object encoding version")
     if spec_name not in SPEC_NAMES_TO_CLASS_NAMES:
         raise SOMAError(f'name "{spec_name}" unrecognized')
     class_name = SPEC_NAMES_TO_CLASS_NAMES[spec_name]

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -18,8 +18,8 @@ from .sparse_nd_array import SparseNDArray
 from .util import (
     SOMA_ENCODING_VERSION,
     SOMA_ENCODING_VERSION_METADATA_KEY,
-    SPEC_NAMES_TO_CLASS_NAMES,
     SOMA_OBJECT_TYPE_METADATA_KEY,
+    SPEC_NAMES_TO_CLASS_NAMES,
 )
 
 ObjectTypes = Union[

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -232,10 +232,6 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
                             raise ValueError(
                                 f"slice start and stop may not be negative; got ({lo}, {hi})"
                             )
-                        if lo > hi:
-                            raise ValueError(
-                                f"slice start must be <= slice stop; got ({lo}, {hi})"
-                            )
                         sr.set_dim_ranges(dim_name, [lo_hi])
                     # Else, no constraint in this slot. This is `slice(None)` which is like
                     # Python indexing syntax `[:]`.

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -1,0 +1,157 @@
+from typing import Type
+
+import numpy as np
+import pytest
+import tiledb
+
+import tiledbsoma as soma
+import tiledbsoma.factory as factory
+
+
+UNKNOWN_ENCODING_VERSION = "3141596"
+
+
+@pytest.fixture
+def soma_collection(tmp_path):
+    uri = tmp_path.as_posix()
+    tiledb.group_create(uri)
+    with tiledb.Group(uri, mode="w") as G:
+        _setmetadata(G, "SOMACollection", soma.util.SOMA_ENCODING_VERSION)
+    collection = soma.Collection(uri)
+    return collection
+
+
+@pytest.fixture
+def tiledb_factory(soma_collection, object_type, metadata_key, encoding_version):
+    """Create a parent group and an object with specified metadata"""
+    parent_collection = soma_collection
+    object_uri = f"{parent_collection.uri}/object"
+
+    # create object
+    if object_type == "array":
+        schema = tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(name="rows", domain=(0, 100), dtype=np.int64)
+            ),
+            attrs=[
+                tiledb.Attr(name="a", dtype=np.int32),
+                tiledb.Attr(name="b", dtype=np.float32),
+            ],
+        )
+        tiledb.Array.create(object_uri, schema)
+        with tiledb.open(object_uri, mode="w") as A:
+            _setmetadata(A, metadata_key, encoding_version)
+    else:
+        tiledb.group_create(object_uri)
+        with tiledb.Group(object_uri, mode="w") as G:
+            _setmetadata(G, metadata_key, encoding_version)
+
+    return object_uri, parent_collection
+
+
+@pytest.mark.parametrize(
+    "object_type,metadata_key,encoding_version,expected_soma_type",
+    [
+        ("group", "SOMAExperiment", soma.util.SOMA_ENCODING_VERSION, soma.Experiment),
+        ("group", "SOMAMeasurement", soma.util.SOMA_ENCODING_VERSION, soma.Measurement),
+        ("group", "SOMACollection", soma.util.SOMA_ENCODING_VERSION, soma.Collection),
+        ("array", "SOMADataFrame", soma.util.SOMA_ENCODING_VERSION, soma.DataFrame),
+        (
+            "array",
+            "SOMADenseNDArray",
+            soma.util.SOMA_ENCODING_VERSION,
+            soma.DenseNDArray,
+        ),
+        pytest.param(
+            "array",
+            "SOMADenseNdArray",
+            soma.util.SOMA_ENCODING_VERSION,
+            soma.DenseNDArray,
+            marks=pytest.mark.xfail(reason="TileDB-SOMA bug #800"),
+        ),
+        ("array", "SOMASparseNDArray", "1", soma.SparseNDArray),
+        pytest.param(
+            "array",
+            "SOMASparseNdArray",
+            soma.util.SOMA_ENCODING_VERSION,
+            soma.SparseNDArray,
+            marks=pytest.mark.xfail(reason="TileDB-SOMA bug #800"),
+        ),
+    ],
+)
+def test_factory(tiledb_factory, expected_soma_type: Type):
+    """Happy path tests"""
+    object_uri, parent_collection = tiledb_factory
+    soma_obj = soma.factory._construct_member(object_uri, parent_collection, None, None)
+    assert isinstance(soma_obj, expected_soma_type)
+    assert soma_obj.exists()
+
+
+@pytest.mark.parametrize(
+    "object_type,metadata_key,encoding_version",
+    [
+        ("group", "SOMAExperiment", UNKNOWN_ENCODING_VERSION),
+        ("group", "SOMAMeasurement", UNKNOWN_ENCODING_VERSION),
+        ("group", "SOMACollection", UNKNOWN_ENCODING_VERSION),
+        ("array", "SOMADataFrame", UNKNOWN_ENCODING_VERSION),
+        ("array", "SOMADenseNDArray", UNKNOWN_ENCODING_VERSION),
+        ("array", "SOMASparseNDArray", UNKNOWN_ENCODING_VERSION),
+    ],
+)
+def test_factory_unsupported_version(tiledb_factory):
+    """All of these should raise, as they are encoding formats from the future"""
+    with pytest.raises(soma.SOMAError):
+        object_uri, parent_collection = tiledb_factory
+        soma.factory._construct_member(object_uri, parent_collection, None, None)
+
+
+@pytest.mark.parametrize(
+    "object_type,metadata_key,encoding_version",
+    [
+        ("array", "AnUnknownTypeName", soma.util.SOMA_ENCODING_VERSION),
+        ("group", "AnUnknownTypeName", soma.util.SOMA_ENCODING_VERSION),
+        ("array", "AnUnknownTypeName", None),
+        ("group", "AnUnknownTypeName", None),
+        ("array", None, soma.util.SOMA_ENCODING_VERSION),
+        ("group", None, soma.util.SOMA_ENCODING_VERSION),
+        ("array", None, None),
+        ("group", None, None),
+        (
+            "array",
+            "SOMACollection",
+            soma.util.SOMA_ENCODING_VERSION,
+        ),  # Collections can't be arrays
+        (
+            "group",
+            "SOMADataFrame",
+            soma.util.SOMA_ENCODING_VERSION,
+        ),  # DataFrame can't be a group
+    ],
+)
+def test_factory_unsupported_types(tiledb_factory):
+    """Illegal or non-existant metadata"""
+    with pytest.raises(soma.SOMAError):
+        object_uri, parent_collection = tiledb_factory
+        soma.factory._construct_member(object_uri, parent_collection, None, None)
+
+
+def test_factory_unknown_files(soma_collection):
+    """Test with non-TileDB files or other wierdness"""
+
+    assert (
+        soma.factory._construct_member(
+            "/tmp/no/such/file/exists/", soma_collection, None, None
+        )
+        is None
+    )
+
+
+def _setmetadata(open_tdb_object, metadata_key, encoding_version):
+    """set only those values which are not None"""
+    changes = {}
+    if metadata_key is not None:
+        changes[soma.util.SOMA_OBJECT_TYPE_METADATA_KEY] = metadata_key
+    if encoding_version is not None:
+        changes[soma.util.SOMA_ENCODING_VERSION_METADATA_KEY] = encoding_version
+    if changes:
+        open_tdb_object.meta.update(changes)

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -5,6 +5,7 @@ import pytest
 import tiledb
 
 import tiledbsoma as soma
+import tiledbsoma.factory as factory
 
 UNKNOWN_ENCODING_VERSION = "3141596"
 
@@ -80,7 +81,7 @@ def tiledb_factory(soma_collection, object_type, metadata_key, encoding_version)
 def test_factory(tiledb_factory, expected_soma_type: Type):
     """Happy path tests"""
     object_uri, parent_collection = tiledb_factory
-    soma_obj = soma.factory._construct_member(object_uri, parent_collection, None, None)
+    soma_obj = factory._construct_member(object_uri, parent_collection, None, None)
     assert isinstance(soma_obj, expected_soma_type)
     assert soma_obj.exists()
 
@@ -98,9 +99,9 @@ def test_factory(tiledb_factory, expected_soma_type: Type):
 )
 def test_factory_unsupported_version(tiledb_factory):
     """All of these should raise, as they are encoding formats from the future"""
-    with pytest.raises(soma.SOMAError):
+    with pytest.raises(ValueError):
         object_uri, parent_collection = tiledb_factory
-        soma.factory._construct_member(object_uri, parent_collection, None, None)
+        factory._construct_member(object_uri, parent_collection, None, None)
 
 
 @pytest.mark.parametrize(
@@ -130,14 +131,14 @@ def test_factory_unsupported_types(tiledb_factory):
     """Illegal or non-existant metadata"""
     with pytest.raises(soma.SOMAError):
         object_uri, parent_collection = tiledb_factory
-        soma.factory._construct_member(object_uri, parent_collection, None, None)
+        factory._construct_member(object_uri, parent_collection, None, None)
 
 
 def test_factory_unknown_files(soma_collection):
     """Test with non-TileDB files or other wierdness"""
 
     assert (
-        soma.factory._construct_member(
+        factory._construct_member(
             "/tmp/no/such/file/exists/", soma_collection, None, None
         )
         is None

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -5,8 +5,6 @@ import pytest
 import tiledb
 
 import tiledbsoma as soma
-import tiledbsoma.factory as factory
-
 
 UNKNOWN_ENCODING_VERSION = "3141596"
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -816,14 +816,3 @@ def test_sparse_nd_array_error_corners(tmp_path):
         next(a.read(coords=[]).tables())
     with pytest.raises(ValueError):
         next(a.read(coords=((slice(None), slice(None)))).tables())
-
-
-"""
-
-204, 232, 236, 
-283, 
-303, 
-325
-
-
-"""

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -341,6 +341,8 @@ def test_empty_read(tmp_path):
     # These work as expected
     coords = (slice(None),)
     assert sum(len(t) for t in a.read(coords).tables()) == 0
+    # Fails due to ARROW-17933
+    # assert sum(t.non_zero_length for t in a.read(coords).coos()) == 0
     assert sum(t.non_zero_length for t in a.read(coords).csrs()) == 0
     assert sum(t.non_zero_length for t in a.read(coords).cscs()) == 0
 
@@ -754,3 +756,74 @@ def test_sparse_nd_array_table_slicing(tmp_path, io, write_format, read_format):
             elif read_format == "table":
                 tensor = next(r.csrs())
             assert tensor.shape == io["shape"]
+
+
+def test_sparse_nd_array_not_implemented(tmp_path):
+    """Poke all of the expected not implemented API"""
+    a = soma.SparseNDArray(uri=tmp_path.as_posix())
+    a.create(pa.uint32(), (99,))
+
+    with pytest.raises(NotImplementedError):
+        next(a.read().dense_tensors())
+
+
+def test_sparse_nd_array_error_corners(tmp_path):
+    """Poke edge error handling"""
+    a = soma.SparseNDArray(uri=tmp_path.as_posix())
+    a.create(pa.uint32(), (99,))
+    a.write(
+        create_random_tensor(format="coo", shape=(99,), dtype=np.uint32, density=0.1)
+    )
+
+    # Write should reject unknown types
+    with pytest.raises(TypeError):
+        a.write(pa.array(np.zeros((99,), dtype=np.uint32)))
+    with pytest.raises(TypeError):
+        a.write(pa.chunked_array([np.zeros((99,), dtype=np.uint32)]))
+
+    # Write should reject wrong dimensionality
+    with pytest.raises(ValueError):
+        a.write(
+            pa.SparseCSRMatrix.from_scipy(
+                sparse.random(10, 10, format="csr", dtype=np.uint32)
+            )
+        )
+    with pytest.raises(ValueError):
+        a.write(
+            pa.SparseCSCMatrix.from_scipy(
+                sparse.random(10, 10, format="csc", dtype=np.uint32)
+            )
+        )
+
+    # certain coords are illegal
+    with pytest.raises(ValueError):
+        next(a.read((slice(1, 10, 2),)).tables())
+    with pytest.raises(ValueError):
+        next(a.read((slice(32, 1),)).tables())
+    with pytest.raises(ValueError):
+        next(a.read((slice(-32),)).tables())
+    with pytest.raises(ValueError):
+        next(a.read((slice(-10, 2),)).tables())
+    with pytest.raises(ValueError):
+        next(a.read((slice(-10, -2),)).tables())
+    with pytest.raises(ValueError):
+        next(a.read((slice(10, -2),)).tables())
+    with pytest.raises(TypeError):
+        next(a.read("hi").tables())
+    with pytest.raises(ValueError):
+        next(a.read(coords=()).tables())
+    with pytest.raises(ValueError):
+        next(a.read(coords=[]).tables())
+    with pytest.raises(ValueError):
+        next(a.read(coords=((slice(None), slice(None)))).tables())
+
+
+"""
+
+204, 232, 236, 
+283, 
+303, 
+325
+
+
+"""


### PR DESCRIPTION
## Issue and/or context:

We need to increase unit tests

## Changes:
* Improved unit tests for SparseNDArray
* New unit tests for factory.py 
* Fixed a couple of minor bugs related to error handling:
    * Partial fix for #801 - check encoding version in reification. We still need to check it for other code paths
    * Correctly handle the case of missing object metadata (use `meta.get(key, None)` rather than `meta[key]`)

## Notes for Reviewer:
None
