### PR TITLE
[python] Propagate context rather than parent.context

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -83,9 +83,6 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         self,
         uri: str,
         *,
-        # Non-top-level objects can have a parent to propagate context, depth, etc.
-        parent: Optional[CollectionBase[Any]] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -91,7 +91,7 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         """
         Also see the ``TileDBObject`` constructor.
         """
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
         self._cached_values = None
 
     def create(self) -> "CollectionBase[CollectionElementType]":

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -159,7 +159,6 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
                 tdb = self._cached_values[key].tdb
                 soma = _construct_member(
                     tdb.uri,
-                    self,
                     context=self.context,
                     object_type=tdb.type.__name__.lower(),
                 )

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -8,7 +8,6 @@ import tiledb
 from somacore import options
 
 from . import util, util_arrow
-from .collection import CollectionBase
 from .constants import SOMA_JOINID
 from .options import SOMATileDBContext, TileDBCreateOptions
 from .query_condition import QueryCondition
@@ -34,8 +33,6 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self,
         uri: str,
         *,
-        parent: Optional[CollectionBase[Any]] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -41,7 +41,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         """
         See also the ``TileDBObject`` constructor.
         """
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
         self._index_column_names = ()
         self._is_sparse = None
 

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -34,7 +34,7 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
         """
         Also see the ``TileDBObject`` constructor.
         """
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
     # soma_type: Final = "SOMADenseNDArray"

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -10,7 +10,6 @@ import tiledbsoma.util as util
 import tiledbsoma.util_arrow as util_arrow
 from tiledbsoma.util import dense_indices_to_shape
 
-from .collection import CollectionBase
 from .exception import SOMAError
 from .options import SOMATileDBContext, TileDBCreateOptions
 from .tiledb_array import TileDBArray
@@ -28,7 +27,6 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
         self,
         uri: str,
         *,
-        parent: Optional[CollectionBase[Any]] = None,
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Dict, Optional, Tuple, cast
 
 import somacore
 from typing_extensions import Final
@@ -31,9 +31,6 @@ class Experiment(CollectionBase[TileDBObject]):
         self,
         uri: str,
         *,
-        # Non-top-level objects can have a parent to propagate context, depth, etc.
-        parent: Optional[CollectionBase[Any]] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -39,7 +39,7 @@ class Experiment(CollectionBase[TileDBObject]):
         """
         Also see the ``TileDBObject`` constructor.
         """
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
     soma_type: Final = "SOMAExperiment"

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -3,11 +3,11 @@ This module exists to avoid what would otherwise be cyclic-module-import issues 
 Collection.
 """
 
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import tiledb
 
-from .collection import Collection, CollectionBase
+from .collection import Collection
 from .dataframe import DataFrame
 from .dense_nd_array import DenseNDArray
 from .exception import SOMAError
@@ -34,7 +34,6 @@ ObjectTypes = Union[
 
 def _construct_member(
     member_uri: str,
-    parent: CollectionBase[Any],
     context: Optional[SOMATileDBContext] = None,
     object_type: Optional[str] = None,
 ) -> Optional[ObjectTypes]:
@@ -88,22 +87,22 @@ def _construct_member(
     # Now invoke the appropriate per-class constructor.
     if class_name == "Experiment":
         _check_object_type(object_type, "group")
-        return Experiment(uri=member_uri, parent=parent)
+        return Experiment(uri=member_uri, context=context)
     elif class_name == "Measurement":
         _check_object_type(object_type, "group")
-        return Measurement(uri=member_uri, parent=parent)
+        return Measurement(uri=member_uri, context=context)
     elif class_name == "Collection":
         _check_object_type(object_type, "group")
-        return Collection(uri=member_uri, parent=parent)
+        return Collection(uri=member_uri, context=context)
     elif class_name == "DataFrame":
         _check_object_type(object_type, "array")
-        return DataFrame(uri=member_uri, parent=parent)
+        return DataFrame(uri=member_uri, context=context)
     elif class_name in ["DenseNDArray", "DenseNdArray"]:
         _check_object_type(object_type, "array")
-        return DenseNDArray(uri=member_uri, parent=parent)
+        return DenseNDArray(uri=member_uri, context=context)
     elif class_name in ["SparseNDArray", "SparseNdArray"]:
         _check_object_type(object_type, "array")
-        return SparseNDArray(uri=member_uri, parent=parent)
+        return SparseNDArray(uri=member_uri, context=context)
     else:
         raise SOMAError(f'internal error: class name "{class_name}" unrecognized')
 

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -60,7 +60,7 @@ class Measurement(CollectionBase[TileDBObject]):
         """
         Also see the ``TileDBObject`` constructor.
         """
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
     soma_type: Final = "SOMAMeasurement"

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Dict, Optional, Tuple, Union, cast
 
 from typing_extensions import Final
 
@@ -52,9 +52,6 @@ class Measurement(CollectionBase[TileDBObject]):
         self,
         uri: str,
         *,
-        # Non-top-level objects can have a parent to propagate context, depth, etc.
-        parent: Optional[CollectionBase[Any]] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -42,7 +42,7 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
         Also see the ``TileDBObject`` constructor.
         """
 
-        super().__init__(uri=uri, parent=parent, context=context)
+        super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
     # soma_type: Final = "SOMASparseNDArray"

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Any, List, Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -12,7 +12,6 @@ from somacore.options import PlatformConfig
 import tiledbsoma.libtiledbsoma as clib
 
 from . import util, util_arrow
-from .collection import CollectionBase
 from .options import SOMATileDBContext, TileDBCreateOptions
 from .tiledb_array import TileDBArray
 from .types import NTuple
@@ -35,7 +34,6 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
         self,
         uri: str,
         *,
-        parent: Optional[CollectionBase[Any]] = None,
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -20,8 +20,6 @@ class TileDBArray(TileDBObject):
         self,
         uri: str,
         *,
-        parent: Optional["TileDBObject"] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -27,7 +27,7 @@ class TileDBArray(TileDBObject):
         """
         See the ``TileDBObject`` constructor.
         """
-        super().__init__(uri, parent=parent, context=context)
+        super().__init__(uri, context=context)
 
     @property
     def schema(self) -> pa.Schema:

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -39,9 +39,6 @@ class TileDBObject(ABC, somacore.SOMAObject):
         # All objects:
         uri: str,
         *,
-        # Non-top-level objects can have a parent to propagate context, depth, etc.
-        parent: Optional["TileDBObject"] = None,
-        # Top-level objects should specify this:
         context: Optional[SOMATileDBContext] = None,
     ):
         """
@@ -51,17 +48,7 @@ class TileDBObject(ABC, somacore.SOMAObject):
         """
 
         self._uri = uri
-
-        if parent is not None:
-            if context is not None:
-                raise TypeError(
-                    "Only one of `context` and `parent` params can be passed as an arg"
-                )
-            # inherit from parent
-            self._context = parent._context
-        else:
-            self._context = context or SOMATileDBContext()
-
+        self._context = context or SOMATileDBContext()
         self._metadata = MetadataMapping(self)
         self._close_stack = ExitStack()
 

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -61,12 +61,10 @@ def test_collection_basic(tmp_path):
     assert collection.uri == basedir
     assert "foobar" not in collection
 
-    dataframe = soma.DataFrame(os.path.join(basedir, "sdf"), parent=collection)
+    dataframe = soma.DataFrame(os.path.join(basedir, "sdf"))
     create_and_populate_dataframe(dataframe)
 
-    sparse_nd_array = soma.SparseNDArray(
-        os.path.join(basedir, "snda"), parent=collection
-    )
+    sparse_nd_array = soma.SparseNDArray(os.path.join(basedir, "snda"))
     create_and_populate_sparse_nd_array(sparse_nd_array)
 
     collection.set("sdf", dataframe)

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -81,7 +81,7 @@ def tiledb_factory(soma_collection, object_type, metadata_key, encoding_version)
 def test_factory(tiledb_factory, expected_soma_type: Type):
     """Happy path tests"""
     object_uri, parent_collection = tiledb_factory
-    soma_obj = factory._construct_member(object_uri, parent_collection, None, None)
+    soma_obj = factory._construct_member(object_uri, parent_collection._context)
     assert isinstance(soma_obj, expected_soma_type)
     assert soma_obj.exists()
 
@@ -101,7 +101,7 @@ def test_factory_unsupported_version(tiledb_factory):
     """All of these should raise, as they are encoding formats from the future"""
     with pytest.raises(ValueError):
         object_uri, parent_collection = tiledb_factory
-        factory._construct_member(object_uri, parent_collection, None, None)
+        factory._construct_member(object_uri, parent_collection._context)
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_factory_unsupported_types(tiledb_factory):
     """Illegal or non-existant metadata"""
     with pytest.raises(soma.SOMAError):
         object_uri, parent_collection = tiledb_factory
-        factory._construct_member(object_uri, parent_collection, None, None)
+        factory._construct_member(object_uri, parent_collection._context)
 
 
 def test_factory_unknown_files(soma_collection):
@@ -139,7 +139,8 @@ def test_factory_unknown_files(soma_collection):
 
     assert (
         factory._construct_member(
-            "/tmp/no/such/file/exists/", soma_collection, None, None
+            "/tmp/no/such/file/exists/",
+            soma_collection._context,
         )
         is None
     )

--- a/apis/python/tests/test_tiledb_object.py
+++ b/apis/python/tests/test_tiledb_object.py
@@ -1,10 +1,8 @@
 from typing import Union
 
-import pytest
 import tiledb
 
 from tiledbsoma import TileDBObject
-from tiledbsoma.options import SOMATileDBContext
 
 
 class FakeTileDBObject(TileDBObject):
@@ -29,24 +27,6 @@ def test_tiledb_object_default_context_added():
     assert o.context.tiledb_ctx is not None
     assert o._ctx is not None
     assert o._ctx == o.context.tiledb_ctx
-
-
-def test_child_inherits_parent_context():
-    context = SOMATileDBContext()
-    p = FakeTileDBObject("parent", context=context)
-
-    c = FakeTileDBObject("parent/child", parent=p)
-
-    assert c.context is not None
-    assert c.context == p.context
-
-
-def test_mutually_exclusive_create_args():
-    context = SOMATileDBContext()
-    p = FakeTileDBObject("parent", context=context)
-
-    with pytest.raises(TypeError):
-        FakeTileDBObject("child", parent=p, context=context)
 
 
 def test_open_close():


### PR DESCRIPTION
## Issue and/or context:

#638 

## Changes:

This is one step on #638. One of the things that needs doing is making `create` a class method. There, there won't be a `parent` naturally passed in.

Meanwhile, ever since the Misty Days of Yore -- mid-2022 -- we have been propagating both `parent` and `context` through the constructor call chain. The `parent` used to do many things, but in this current SOMA epoch, all but one use of `parent` has been refactored away, leaving solely `parent.context` being put to use. Instead of passing `parent` and `context` both down the call chain, only to take `context` or `parent.context` at the bottom, now we can simply -- with zero loss of _any functionality_ -- pass `context` at the top of the call chain.
