### PR TITLE
Import somacore v0.0.0a7, without making any functional changes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,9 @@ repos:
     rev: v0.991
     hooks:
     - id: mypy
-      additional_dependencies: ["types-setuptools", "pandas-stubs", "somacore==0.0.0a5"]
+      additional_dependencies:
+        - "pandas-stubs"
+        - "somacore==0.0.0a7"
+        - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/devtools/ingestor
+++ b/apis/python/devtools/ingestor
@@ -225,7 +225,7 @@ def ingest_one(
     if write_soco:
         soco = tiledbsoma.Collection(soco_dir, context=context)
         if not soco.exists():
-            soco.create()
+            soco.create_legacy()
         if not soco.exists():
             raise tiledbsoma.exception.SOMAError(f"Could not create SOCO at {soco.uri}")
         soco.set(exp_name, exp)

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -110,7 +110,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a5",
+        "somacore==0.0.0a7",
         "tiledb>=0.20.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -18,6 +18,7 @@ from typing import (
 
 import somacore
 import tiledb
+from typing_extensions import NoReturn
 
 from .exception import DoesNotExistError, SOMAError
 from .options import SOMATileDBContext
@@ -91,7 +92,15 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         super().__init__(uri=uri, context=context)
         self._cached_values = None
 
-    def create(self) -> "CollectionBase[CollectionElementType]":
+    def _not_implemented(self, *args: Any, **kwargs: Any) -> NoReturn:
+        raise NotImplementedError()
+
+    add_new_collection = _not_implemented
+    add_new_dataframe = _not_implemented
+    add_new_dense_ndarray = _not_implemented
+    add_new_sparse_ndarray = _not_implemented
+
+    def create_legacy(self) -> "CollectionBase[CollectionElementType]":
         """
         Creates the data structure on disk/S3/cloud.
         """
@@ -174,13 +183,13 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         key: str,
         value: CollectionElementType,
         *,
-        relative: Optional[bool] = None,
+        use_relative_uri: Optional[bool] = None,
     ) -> None:
         """
         Adds an element to the collection.  This interface allows explicit control over
         `relative` URI, and uses the member's default name.
         """
-        self._set_element(key, value, relative=relative)
+        self._set_element(key, value, relative=use_relative_uri)
 
     def __setitem__(self, key: str, value: CollectionElementType) -> None:
         """

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -45,7 +45,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     # Inherited from somacore
     # soma_type: Final = "SOMADataFrame"
 
-    def create(
+    def create_legacy(
         self,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (SOMA_JOINID,),
@@ -193,7 +193,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         coords: Optional[options.SparseDFCoords] = None,
         column_names: Optional[Sequence[str]] = None,
         *,
-        result_order: options.StrOr[somacore.ResultOrder] = "auto",
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
         value_filter: Optional[str] = None,
         batch_size: options.BatchSize = _UNBATCHED,
         partitions: Optional[options.ReadPartitions] = None,

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -37,7 +37,7 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
     # Inherited from somacore
     # soma_type: Final = "SOMADenseNDArray"
 
-    def create(
+    def create_legacy(
         self,
         type: pa.DataType,
         shape: Union[NTuple, List[int]],
@@ -141,9 +141,7 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
         self,
         coords: options.DenseNDCoords,
         *,
-        result_order: options.StrOr[
-            somacore.ResultOrder
-        ] = somacore.ResultOrder.ROW_MAJOR,
+        result_order: options.ResultOrderStr = somacore.ResultOrder.ROW_MAJOR,
         batch_size: options.BatchSize = _UNBATCHED,
         partitions: Optional[options.ReadPartitions] = None,
         platform_config: Optional[PlatformConfig] = None,

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -41,7 +41,7 @@ class Experiment(CollectionBase[TileDBObject]):
     # Inherited from somacore
     soma_type: Final = "SOMAExperiment"
 
-    def create(self) -> "Experiment":
+    def create_legacy(self) -> "Experiment":
         """
         Creates the data structure on disk/S3/cloud.
         """
@@ -71,17 +71,15 @@ class Experiment(CollectionBase[TileDBObject]):
         *,
         obs_query: somacore.AxisQuery = _EMPTY_QUERY,
         var_query: somacore.AxisQuery = _EMPTY_QUERY,
-    ) -> somacore.ExperimentAxisQuery:
+    ) -> somacore.ExperimentAxisQuery["Experiment"]:  # type: ignore[type-var]
         """
         Create a query on this Experiment. See ``ExperimentAxisQuery`` for more
         information on parameters and usage.
         """
         if not self.exists():
             raise ValueError(f"Experiment {self.uri} does not exist.")
-        return somacore.ExperimentAxisQuery(
-            # While not technically a somacore.Experiment yet, we implement
-            # all the parts that `ExperimentAxisQuery` needs.
-            self,  # type: ignore[arg-type]
+        return somacore.ExperimentAxisQuery(  # type: ignore[type-var]
+            self,
             measurement_name,
             obs_query=obs_query,
             var_query=var_query,

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -313,13 +313,13 @@ def _check_create(
 ) -> Union[Experiment, Measurement, Collection]:
     if ingest_mode == "resume":
         if not thing.exists():
-            thing.create()
+            thing.create_legacy()
         # else fine
     else:
         if thing.exists():
             raise SOMAError(f"{thing.uri} already exists")
         else:
-            thing.create()
+            thing.create_legacy()
     return thing
 
 
@@ -390,7 +390,7 @@ def _write_dataframe(
         else:
             raise SOMAError(f"{soma_df.uri} already exists")
     else:
-        soma_df.create(arrow_table.schema, platform_config=platform_config)
+        soma_df.create_legacy(arrow_table.schema, platform_config=platform_config)
 
     if ingest_mode == "schema_only":
         logging.log_io(
@@ -430,7 +430,7 @@ def create_from_matrix(
     if ingest_mode != "resume" or not soma_ndarray.exists():
         if soma_ndarray.exists():
             raise SOMAError(f"{soma_ndarray.uri} already exists")
-        soma_ndarray.create(
+        soma_ndarray.create_legacy(
             type=pa.from_numpy_dtype(matrix.dtype),
             shape=matrix.shape,
             platform_config=platform_config,
@@ -508,7 +508,7 @@ def _write_matrix_to_denseNDArray(
     # * By checking chunkwise we can catch the case where a matrix was already *partly*
     #   ingested.
     # * Of course, this also helps us catch already-completed writes in the non-chunked case.
-    with soma_ndarray.open(
+    with soma_ndarray.open_legacy(
         "r"
     ):  # TODO: make sure we're not using an old timestamp for this
         storage_ned = None
@@ -528,7 +528,7 @@ def _write_matrix_to_denseNDArray(
                 )
                 return
 
-    with soma_ndarray.open("w"):
+    with soma_ndarray.open_legacy("w"):
         # Write all at once?
         if not tiledb_create_options.write_X_chunked():
             if not isinstance(matrix, np.ndarray):
@@ -668,7 +668,7 @@ def _write_matrix_to_sparseNDArray(
     # * By checking chunkwise we can catch the case where a matrix was already *partly*
     #   ingested.
     # * Of course, this also helps us catch already-completed writes in the non-chunked case.
-    with soma_ndarray.open(
+    with soma_ndarray.open_legacy(
         "r"
     ):  # TODO: make sure we're not using an old timestamp for this
         storage_ned = None
@@ -688,7 +688,7 @@ def _write_matrix_to_sparseNDArray(
                 )
                 return
 
-    with soma_ndarray.open("w"):
+    with soma_ndarray.open_legacy("w"):
         # Write all at once?
         if not tiledb_create_options.write_X_chunked():
             soma_ndarray.write(_coo_to_table(sp.coo_matrix(matrix)))

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -62,7 +62,7 @@ class Measurement(CollectionBase[TileDBObject]):
     # Inherited from somacore
     soma_type: Final = "SOMAMeasurement"
 
-    def create(self) -> "Measurement":
+    def create_legacy(self) -> "Measurement":
         """
         Creates the data structure on disk/S3/cloud.
         """

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -45,7 +45,7 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     # Inherited from somacore
     # soma_type: Final = "SOMASparseNDArray"
 
-    def create(
+    def create_legacy(
         self,
         type: pa.DataType,
         shape: Union[NTuple, List[int]],
@@ -159,7 +159,7 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
         self,
         coords: Optional[options.SparseNDCoords] = None,
         *,
-        result_order: options.StrOr[options.ResultOrder] = options.ResultOrder.AUTO,
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
         batch_size: options.BatchSize = _UNBATCHED,
         partitions: Optional[options.ReadPartitions] = None,
         platform_config: Optional[PlatformConfig] = None,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -19,7 +19,7 @@ def create_and_populate_dataframe(dataframe: soma.DataFrame) -> None:
         ]
     )
 
-    dataframe.create(schema=arrow_schema)
+    dataframe.create_legacy(schema=arrow_schema)
 
     pydict = {}
     pydict["soma_joinid"] = [0, 1, 2, 3, 4]
@@ -36,7 +36,7 @@ def create_and_populate_sparse_nd_array(
 ) -> None:
     nr = 10
     nc = 20
-    sparse_nd_array.create(pa.int64(), [nr, nc])
+    sparse_nd_array.create_legacy(pa.int64(), [nr, nc])
 
     tensor = pa.SparseCOOTensor.from_numpy(
         data=np.asarray([7, 8, 9]),
@@ -56,7 +56,7 @@ def test_collection_basic(tmp_path):
     with pytest.raises(soma.DoesNotExistError):
         assert "foobar" not in collection
 
-    collection.create()
+    collection.create_legacy()
     assert collection.exists()
     assert collection.uri == basedir
     assert "foobar" not in collection
@@ -74,10 +74,10 @@ def test_collection_basic(tmp_path):
     readback_collection = soma.Collection(collection.uri)
     assert len(readback_collection) == 2
 
-    with readback_collection.get("sdf").open() as sdf:
+    with readback_collection.get("sdf").open_legacy() as sdf:
         assert len(sdf._tiledb_obj.df[:]) == 5
 
-    with readback_collection.get("snda").open() as snda:
+    with readback_collection.get("snda").open_legacy() as snda:
         assert len(snda._tiledb_obj.df[:]) == 3
 
 
@@ -99,22 +99,22 @@ def soma_object(request, tmp_path):
 
     if class_name == "Collection":
         so = soma.Collection(uri=uri)
-        so.create()
+        so.create_legacy()
 
     elif class_name == "DataFrame":
         so = soma.DataFrame(uri=uri)
-        so.create(
+        so.create_legacy(
             schema=pa.schema([("C", pa.float32()), ("D", pa.uint32())]),
             index_column_names=["D"],
         )
 
     elif class_name == "DenseNDArray":
         so = soma.DenseNDArray(uri=uri)
-        so.create(type=pa.float64(), shape=(100, 10, 1))
+        so.create_legacy(type=pa.float64(), shape=(100, 10, 1))
 
     elif class_name == "SparseNDArray":
         so = soma.SparseNDArray(uri=uri)
-        so.create(type=pa.int8(), shape=(11,))
+        so.create_legacy(type=pa.int8(), shape=(11,))
 
     assert so is not None, f"Unknown class name: {class_name}"
     yield so
@@ -127,7 +127,7 @@ def test_collection_mapping(soma_object, tmp_path):
     with pytest.raises(soma.DoesNotExistError):
         assert "foobar" not in c
 
-    c.create()
+    c.create_legacy()
     assert c.exists()
     assert "foobar" not in c
 
@@ -155,16 +155,16 @@ def test_collection_mapping(soma_object, tmp_path):
 @pytest.mark.parametrize("relative", [False, True])
 def test_collection_repr(tmp_path, relative):
     a = soma.Collection(uri=(tmp_path / "A").as_uri())
-    a.create()
+    a.create_legacy()
     assert a.exists()
     assert a.uri == (tmp_path / "A").as_uri()
 
     b = soma.Collection(uri=(tmp_path / "A" / "B").as_uri())
-    b.create()
+    b.create_legacy()
     assert b.exists()
     assert b.uri == (tmp_path / "A" / "B").as_uri()
 
-    a.set("Another_Name", b, relative=relative)
+    a.set("Another_Name", b, use_relative_uri=relative)
     assert list(a.keys()) == ["Another_Name"]
     assert (
         a.__repr__()
@@ -206,11 +206,11 @@ def test_collection_update_on_set(tmp_path):
     tiledb.Group only has add/del. Verify.
     """
 
-    sc = soma.Collection(tmp_path.as_uri()).create()
-    A = soma.DenseNDArray(uri=(tmp_path / "A").as_uri()).create(
+    sc = soma.Collection(tmp_path.as_uri()).create_legacy()
+    A = soma.DenseNDArray(uri=(tmp_path / "A").as_uri()).create_legacy(
         type=pa.float64(), shape=(100, 10, 1)
     )
-    B = soma.DenseNDArray(uri=(tmp_path / "B").as_uri()).create(
+    B = soma.DenseNDArray(uri=(tmp_path / "B").as_uri()).create_legacy(
         type=pa.float64(), shape=(100, 10, 1)
     )
     assert sc.exists()
@@ -232,7 +232,7 @@ def test_exceptions_on_not_created(tmp_path):
     """
     sc = soma.Collection(tmp_path.as_uri())
 
-    A = soma.DenseNDArray(uri=(tmp_path / "A").as_uri()).create(
+    A = soma.DenseNDArray(uri=(tmp_path / "A").as_uri()).create_legacy(
         type=pa.float64(), shape=(100, 10, 1)
     )
     with pytest.raises(DoesNotExistError):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -40,14 +40,14 @@ def test_dataframe(tmp_path, arrow_schema):
     asch = arrow_schema()
     with pytest.raises(ValueError):
         # requires one or more index columns
-        sdf.create(schema=asch, index_column_names=[])
+        sdf.create_legacy(schema=asch, index_column_names=[])
     with pytest.raises(TypeError):
         # invalid schema type
-        sdf.create(schema=asch.to_string(), index_column_names=[])
+        sdf.create_legacy(schema=asch.to_string(), index_column_names=[])
     with pytest.raises(ValueError):
         # nonexistent indexed column
-        sdf.create(schema=asch, index_column_names=["bogus"])
-    sdf.create(schema=asch, index_column_names=["foo"])
+        sdf.create_legacy(schema=asch, index_column_names=["bogus"])
+    sdf.create_legacy(schema=asch, index_column_names=["foo"])
 
     assert sdf.count == 0
     assert len(sdf) == 0
@@ -100,7 +100,7 @@ def test_dataframe(tmp_path, arrow_schema):
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame(uri=tmp_path.as_posix())
     asch = arrow_schema()
-    sdf.create(schema=asch, index_column_names=("bar",))
+    sdf.create_legacy(schema=asch, index_column_names=("bar",))
     assert sdf.index_column_names == ("bar",)
 
 
@@ -120,7 +120,7 @@ def simple_data_frame(tmp_path):
     )
     index_column_names = ["index"]
     sdf = soma.DataFrame(uri=tmp_path.as_posix())
-    sdf.create(schema=schema, index_column_names=index_column_names)
+    sdf.create_legacy(schema=schema, index_column_names=index_column_names)
 
     data = {
         "index": [0, 1, 2, 3],
@@ -221,7 +221,7 @@ def test_DataFrame_read_column_names(simple_data_frame, ids, col_names):
 
 def test_empty_dataframe(tmp_path):
     a = soma.DataFrame((tmp_path / "A").as_posix())
-    a.create(pa.schema([("a", pa.int32())]), index_column_names=["a"])
+    a.create_legacy(pa.schema([("a", pa.int32())]), index_column_names=["a"])
     # Must not throw
     assert len(next(a.read())) == 0
     assert len(a.read().concat()) == 0
@@ -231,7 +231,7 @@ def test_empty_dataframe(tmp_path):
 
     with pytest.raises(ValueError):
         # illegal column name
-        soma.DataFrame((tmp_path / "B").as_posix()).create(
+        soma.DataFrame((tmp_path / "B").as_posix()).create_legacy(
             pa.schema([("a", pa.int32()), ("soma_bogus", pa.int32())]),
             index_column_names=["a"],
         )
@@ -246,20 +246,20 @@ def test_columns(tmp_path):
     """
 
     A = soma.DataFrame((tmp_path / "A").as_posix())
-    A.create(pa.schema([("a", pa.int32())]), index_column_names=["a"])
+    A.create_legacy(pa.schema([("a", pa.int32())]), index_column_names=["a"])
     assert sorted(A.keys()) == sorted(["a", "soma_joinid"])
     assert A.schema.field("soma_joinid").type == pa.int64()
     A.delete()
 
     B = soma.DataFrame((tmp_path / "B").as_posix())
     with pytest.raises(ValueError):
-        B.create(
+        B.create_legacy(
             pa.schema([("a", pa.int32()), ("soma_joinid", pa.float32())]),
             index_column_names=["a"],
         )
 
     D = soma.DataFrame((tmp_path / "D").as_posix())
-    D.create(
+    D.create_legacy(
         pa.schema([("a", pa.int32()), ("soma_joinid", pa.int64())]),
         index_column_names=["a"],
     )
@@ -269,7 +269,7 @@ def test_columns(tmp_path):
 
     E = soma.DataFrame((tmp_path / "E").as_posix())
     with pytest.raises(ValueError):
-        E.create(
+        E.create_legacy(
             pa.schema([("a", pa.int32()), ("soma_is_a_reserved_prefix", pa.bool_())]),
             index_column_names=["a"],
         )
@@ -342,7 +342,7 @@ def make_dataframe(request):
 def test_index_types(tmp_path, make_dataframe):
     """Verify that the index columns can be of various types"""
     sdf = soma.DataFrame(tmp_path.as_posix())
-    sdf.create(make_dataframe.schema, index_column_names=["index"])
+    sdf.create_legacy(make_dataframe.schema, index_column_names=["index"])
     sdf.write(make_dataframe)
 
 
@@ -365,7 +365,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
     )
 
     sdf = soma.DataFrame(uri=tmp_path.as_posix())
-    sdf.create(schema=schema, index_column_names=index_column_names)
+    sdf.create_legacy(schema=schema, index_column_names=index_column_names)
 
     data: Dict[str, list] = {
         "index1": [0, 1, 2, 3, 4, 5],
@@ -650,7 +650,7 @@ def test_read_indexing(tmp_path, io):
     schema, sdf, n_data = make_multiply_indexed_dataframe(
         tmp_path, io["index_column_names"]
     )
-    with soma.DataFrame(uri=sdf.uri).open() as sdf:
+    with soma.DataFrame(uri=sdf.uri).open_legacy() as sdf:
         assert sdf.exists()
         assert list(sdf.index_column_names) == io["index_column_names"]
 
@@ -725,11 +725,11 @@ def test_create_categorical_types(tmp_path, schema):
 
     # Test exception as normal column
     with pytest.raises(TypeError):
-        sdf.create(schema, index_column_names=["soma_joinid"])
+        sdf.create_legacy(schema, index_column_names=["soma_joinid"])
 
     # test as index column
     with pytest.raises(TypeError):
-        sdf.create(schema, index_column_names=["A"])
+        sdf.create_legacy(schema, index_column_names=["A"])
 
 
 def test_write_categorical_types(tmp_path):
@@ -738,7 +738,7 @@ def test_write_categorical_types(tmp_path):
     """
     sdf = soma.DataFrame(tmp_path.as_posix())
     schema = pa.schema([("soma_joinid", pa.int64()), ("A", pa.large_string())])
-    sdf.create(schema, index_column_names=["soma_joinid"])
+    sdf.create_legacy(schema, index_column_names=["soma_joinid"])
 
     df = pd.DataFrame(
         data={
@@ -748,7 +748,7 @@ def test_write_categorical_types(tmp_path):
             ),
         }
     )
-    with sdf.open("w"):
+    with sdf.open_legacy("w"):
         sdf.write(pa.Table.from_pandas(df))
 
     assert (df == sdf.read().concat().to_pandas()).all().all()
@@ -764,7 +764,7 @@ def test_result_order(tmp_path):
         ]
     )
     sdf = soma.DataFrame(uri=tmp_path.as_posix())
-    sdf.create(schema=schema, index_column_names=["row", "col"])
+    sdf.create_legacy(schema=schema, index_column_names=["row", "col"])
     data = {
         "row": [0] * 4 + [1] * 4 + [2] * 4 + [3] * 4,
         "col": [0, 1, 2, 3] * 4,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -32,8 +32,8 @@ def test_dense_nd_array_create_ok(
 
     a = soma.DenseNDArray(uri=tmp_path.as_posix())
     with pytest.raises(TypeError):
-        a.create(element_type.to_pandas_dtype(), shape)  # XXX
-    a.create(element_type, shape)
+        a.create_legacy(element_type.to_pandas_dtype(), shape)  # XXX
+    a.create_legacy(element_type, shape)
     assert a.soma_type == "SOMADenseNDArray"
     assert a.uri == tmp_path.as_posix()
     assert a.ndim == len(shape)
@@ -56,13 +56,13 @@ def test_dense_nd_array_create_fail(
 ):
     a = soma.DenseNDArray(uri=tmp_path.as_posix())
     with pytest.raises(TypeError):
-        a.create(element_type, shape)
+        a.create_legacy(element_type, shape)
     assert not a.exists()
 
 
 def test_dense_nd_array_delete(tmp_path):
     a = soma.DenseNDArray(uri=tmp_path.as_posix())
-    a.create(pa.int8(), (100, 100))
+    a.create_legacy(pa.int8(), (100, 100))
     assert a.exists()
 
     a.delete()
@@ -76,7 +76,7 @@ def test_dense_nd_array_delete(tmp_path):
 @pytest.mark.parametrize("shape", [(10,), (10, 20), (10, 20, 2), (2, 4, 6, 8)])
 def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
     a = soma.DenseNDArray(tmp_path.as_posix())
-    a.create(pa.float64(), shape)
+    a.create_legacy(pa.float64(), shape)
     ndim = len(shape)
 
     # random sample - written to entire array
@@ -88,7 +88,7 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
     del a
 
     # check multiple read paths
-    with soma.DenseNDArray(tmp_path.as_posix()).open() as b:
+    with soma.DenseNDArray(tmp_path.as_posix()).open_legacy() as b:
 
         t = b.read((slice(None),) * ndim, result_order="row-major")
         assert t.equals(pa.Tensor.from_numpy(data))
@@ -111,7 +111,7 @@ def test_zero_length_fail(tmp_path, shape):
     """Zero length dimensions are expected to fail"""
     a = soma.DenseNDArray(tmp_path.as_posix())
     with pytest.raises(ValueError):
-        a.create(type=pa.float32(), shape=shape)
+        a.create_legacy(type=pa.float32(), shape=shape)
 
 
 def test_dense_nd_array_reshape(tmp_path):
@@ -119,7 +119,7 @@ def test_dense_nd_array_reshape(tmp_path):
     Reshape currently unimplemented.
     """
     a = soma.DenseNDArray(tmp_path.as_posix())
-    a.create(type=pa.int32(), shape=(10, 10, 10))
+    a.create_legacy(type=pa.int32(), shape=(10, 10, 10))
     with pytest.raises(NotImplementedError):
         assert a.reshape((100, 10, 1))
 
@@ -179,7 +179,7 @@ def test_dense_nd_array_slicing(tmp_path, io):
     nr = 4
     nc = 6
 
-    a.create(pa.int64(), [nr, nc])
+    a.create_legacy(pa.int64(), [nr, nc])
     npa = np.zeros((nr, nc))
     for i in range(nr):
         for j in range(nc):
@@ -263,7 +263,7 @@ def test_dense_nd_array_indexing_errors(tmp_path, io):
     read_coords = io["coords"]
 
     a = soma.DenseNDArray(tmp_path.as_posix())
-    a.create(pa.int64(), shape)
+    a.create_legacy(pa.int64(), shape)
 
     npa = np.random.default_rng().standard_normal(np.prod(shape)).reshape(shape)
 

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -19,7 +19,7 @@ def create_and_populate_obs(obs: soma.DataFrame) -> soma.DataFrame:
     )
 
     # TODO: indexing option ...
-    obs.create(schema=obs_arrow_schema)
+    obs.create_legacy(schema=obs_arrow_schema)
 
     pydict = {}
     pydict["soma_joinid"] = [0, 1, 2, 3, 4]
@@ -42,7 +42,7 @@ def create_and_populate_var(var: soma.DataFrame) -> soma.DataFrame:
         ]
     )
 
-    var.create(schema=var_arrow_schema)
+    var.create_legacy(schema=var_arrow_schema)
 
     pydict = {}
     pydict["soma_joinid"] = [0, 1, 2, 3]
@@ -68,7 +68,7 @@ def create_and_populate_sparse_nd_array(
     # 3 . 8 .
     # 4 . . 9
 
-    sparse_nd_array.create(pa.int64(), [nr, nc])
+    sparse_nd_array.create_legacy(pa.int64(), [nr, nc])
 
     tensor = pa.SparseCOOTensor.from_numpy(
         data=np.asarray([7, 8, 9]),
@@ -86,21 +86,23 @@ def test_experiment_basic(tmp_path):
 
     # ----------------------------------------------------------------
     experiment = soma.Experiment(basedir)
-    experiment.create()
+    experiment.create_legacy()
 
     experiment["obs"] = create_and_populate_obs(
         soma.DataFrame(uri=urljoin(basedir, "obs"))
     )
-    experiment["ms"] = soma.Collection(uri=urljoin(basedir, "ms")).create()
+    experiment["ms"] = soma.Collection(uri=urljoin(basedir, "ms")).create_legacy()
 
     measurement = soma.Measurement(uri=f"{experiment.ms.uri}/RNA")
-    measurement.create()
+    measurement.create_legacy()
     experiment.ms.set("RNA", measurement)
 
     measurement["var"] = create_and_populate_var(
         soma.DataFrame(uri=urljoin(measurement.uri, "var"))
     )
-    measurement["X"] = soma.Collection(uri=urljoin(measurement.uri, "X")).create()
+    measurement["X"] = soma.Collection(
+        uri=urljoin(measurement.uri, "X")
+    ).create_legacy()
 
     nda = create_and_populate_sparse_nd_array(
         soma.SparseNDArray(uri=urljoin(measurement.X.uri, "data"))
@@ -168,47 +170,47 @@ def test_experiment_obs_type_constraint(tmp_path):
     only allow a constrained set of types to be set in their slots.
     """
 
-    se = soma.Experiment(uri=tmp_path.as_uri()).create()
+    se = soma.Experiment(uri=tmp_path.as_uri()).create_legacy()
 
     with pytest.raises(TypeError):
-        se["obs"] = soma.Collection(uri=(tmp_path / "A").as_uri()).create()
+        se["obs"] = soma.Collection(uri=(tmp_path / "A").as_uri()).create_legacy()
     with pytest.raises(TypeError):
-        se["obs"] = soma.SparseNDArray(uri=(tmp_path / "B").as_uri()).create(
+        se["obs"] = soma.SparseNDArray(uri=(tmp_path / "B").as_uri()).create_legacy(
             type=pa.float32(), shape=(10,)
         )
     with pytest.raises(TypeError):
-        se["obs"] = soma.DenseNDArray(uri=(tmp_path / "C").as_uri()).create(
+        se["obs"] = soma.DenseNDArray(uri=(tmp_path / "C").as_uri()).create_legacy(
             type=pa.float32(), shape=(10,)
         )
     with pytest.raises(TypeError):
-        se["obs"] = soma.Measurement(uri=(tmp_path / "D").as_uri()).create()
-    se["obs"] = soma.DataFrame(uri=(tmp_path / "E").as_uri()).create(
+        se["obs"] = soma.Measurement(uri=(tmp_path / "D").as_uri()).create_legacy()
+    se["obs"] = soma.DataFrame(uri=(tmp_path / "E").as_uri()).create_legacy(
         schema=pa.schema([("A", pa.int32())])
     )
-    se["obs"] = soma.DataFrame(uri=(tmp_path / "F").as_uri()).create(
+    se["obs"] = soma.DataFrame(uri=(tmp_path / "F").as_uri()).create_legacy(
         schema=pa.schema([("A", pa.int32())]), index_column_names=["A"]
     )
 
 
 def test_experiment_ms_type_constraint(tmp_path):
-    se = soma.Experiment(uri=tmp_path.as_uri()).create()
+    se = soma.Experiment(uri=tmp_path.as_uri()).create_legacy()
 
-    se["ms"] = soma.Collection(uri=(tmp_path / "A").as_uri()).create()
+    se["ms"] = soma.Collection(uri=(tmp_path / "A").as_uri()).create_legacy()
     with pytest.raises(TypeError):
-        se["ms"] = soma.SparseNDArray(uri=(tmp_path / "B").as_uri()).create(
+        se["ms"] = soma.SparseNDArray(uri=(tmp_path / "B").as_uri()).create_legacy(
             type=pa.float32(), shape=(10,)
         )
     with pytest.raises(TypeError):
-        se["ms"] = soma.DenseNDArray(uri=(tmp_path / "C").as_uri()).create(
+        se["ms"] = soma.DenseNDArray(uri=(tmp_path / "C").as_uri()).create_legacy(
             type=pa.float32(), shape=(10,)
         )
     with pytest.raises(TypeError):
-        se["ms"] = soma.Measurement(uri=(tmp_path / "D").as_uri()).create()
+        se["ms"] = soma.Measurement(uri=(tmp_path / "D").as_uri()).create_legacy()
     with pytest.raises(TypeError):
-        se["ms"] = soma.DataFrame(uri=(tmp_path / "E").as_uri()).create(
+        se["ms"] = soma.DataFrame(uri=(tmp_path / "E").as_uri()).create_legacy(
             schema=pa.schema([("A", pa.int32())])
         )
     with pytest.raises(TypeError):
-        se["ms"] = soma.DataFrame(uri=(tmp_path / "F").as_uri()).create(
+        se["ms"] = soma.DataFrame(uri=(tmp_path / "F").as_uri()).create_legacy(
             schema=pa.schema([("A", pa.int32())]), index_column_names=["A"]
         )

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -705,7 +705,7 @@ Fixture support & utility functions below.
 
 def make_dataframe(path: str, sz: int) -> soma.DataFrame:
     df = soma.DataFrame(uri=path)
-    df.create(
+    df.create_legacy(
         schema=pa.schema(
             [
                 ("soma_joinid", pa.int64()),
@@ -726,7 +726,7 @@ def make_dataframe(path: str, sz: int) -> soma.DataFrame:
 
 
 def make_sparse_array(path: str, shape: Tuple[int, int]) -> soma.SparseNDArray:
-    a = soma.SparseNDArray(path).create(pa.float32(), shape)
+    a = soma.SparseNDArray(path).create_legacy(pa.float32(), shape)
     tensor = pa.SparseCOOTensor.from_scipy(
         sparse.random(
             shape[0],
@@ -757,14 +757,16 @@ def make_experiment(
     assert len(obs) == n_obs
     assert len(var) == n_vars
 
-    experiment = soma.Experiment((root / "exp").as_posix()).create()
-    experiment["ms"] = soma.Collection((root / "ms").as_posix()).create()
-    experiment.ms["RNA"] = soma.Measurement(uri=f"{experiment.ms.uri}/RNA").create()
+    experiment = soma.Experiment((root / "exp").as_posix()).create_legacy()
+    experiment["ms"] = soma.Collection((root / "ms").as_posix()).create_legacy()
+    experiment.ms["RNA"] = soma.Measurement(
+        uri=f"{experiment.ms.uri}/RNA"
+    ).create_legacy()
     experiment["obs"] = obs
 
     measurement = experiment.ms["RNA"]
     measurement["var"] = var
-    measurement["X"] = soma.Collection(uri=f"{measurement.uri}/X").create()
+    measurement["X"] = soma.Collection(uri=f"{measurement.uri}/X").create_legacy()
 
     (root / "X").mkdir()
     for X_layer_name in X_layer_names:
@@ -776,7 +778,9 @@ def make_experiment(
 
     if obsp_layer_names:
         (root / "obsp").mkdir()
-        measurement["obsp"] = soma.Collection(uri=f"{measurement.uri}/obsp").create()
+        measurement["obsp"] = soma.Collection(
+            uri=f"{measurement.uri}/obsp"
+        ).create_legacy()
         for obsp_layer_name in obsp_layer_names:
             path = root / "obsp" / obsp_layer_name
             path.mkdir()
@@ -786,7 +790,9 @@ def make_experiment(
 
     if varp_layer_names:
         (root / "varp").mkdir()
-        measurement["varp"] = soma.Collection(uri=f"{measurement.uri}/varp").create()
+        measurement["varp"] = soma.Collection(
+            uri=f"{measurement.uri}/varp"
+        ).create_legacy()
         for varp_layer_name in varp_layer_names:
             path = root / "varp" / varp_layer_name
             path.mkdir()

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -28,22 +28,22 @@ def soma_object(request, tmp_path):
 
     if class_name == "Collection":
         so = soma.Collection(uri=uri)
-        so.create()
+        so.create_legacy()
 
     elif class_name == "DataFrame":
         so = soma.DataFrame(uri=uri)
-        so.create(
+        so.create_legacy(
             schema=pa.schema([("C", pa.float32()), ("D", pa.uint32())]),
             index_column_names=["D"],
         )
 
     elif class_name == "DenseNDArray":
         so = soma.DenseNDArray(uri=uri)
-        so.create(type=pa.float64(), shape=(100, 10, 1))
+        so.create_legacy(type=pa.float64(), shape=(100, 10, 1))
 
     elif class_name == "SparseNDArray":
         so = soma.SparseNDArray(uri=uri)
-        so.create(type=pa.int8(), shape=(11,))
+        so.create_legacy(type=pa.int8(), shape=(11,))
 
     assert so is not None, f"Unknown class name: {class_name}"
     yield so

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -52,7 +52,7 @@ def test_platform_config(adata):
             },
         )
 
-        with exp.ms["RNA"].X["data"].open() as data:
+        with exp.ms["RNA"].X["data"].open_legacy() as data:
             arr = data._tiledb_obj
             sch = arr.schema
             assert sch.capacity == 8888

--- a/apis/python/tests/test_tiledb_object.py
+++ b/apis/python/tests/test_tiledb_object.py
@@ -33,19 +33,19 @@ def test_open_close():
     o = FakeTileDBObject("parent")
 
     assert not o.mode
-    o.open("r")
+    o.open_legacy("r")
     assert o.mode == "r"
     o.close()
     assert not o.mode
     o.close()  # no-op
     assert not o.mode
 
-    with o.open("w"):
+    with o.open_legacy("w"):
         assert o.mode == "w"
     assert not o.mode
 
     try:
-        with o.open("w"):
+        with o.open_legacy("w"):
             assert o.mode == "w"
             raise RuntimeError("test")
     except Exception:
@@ -66,7 +66,7 @@ def test_open_close():
     with o._ensure_open():
         assert o.mode == "r"
     assert not o.mode
-    with o.open():
+    with o.open_legacy():
         with o._ensure_open():
             assert o.mode == "r"
         assert o.mode == "r"
@@ -74,7 +74,7 @@ def test_open_close():
     bad = False
     try:
         # reject attempt to write when already open read-only
-        with o.open("r"):
+        with o.open_legacy("r"):
             with o._ensure_open("w"):
                 bad = True
             bad = True
@@ -82,7 +82,7 @@ def test_open_close():
         pass
     assert not bad
     assert not o.mode
-    with o.open("w"):
+    with o.open_legacy("w"):
         # allow attempt to read when already open for write (manly for metadata; underlying TileDB
         # objects may reject other attempts)
         with o._ensure_open("r"):
@@ -94,7 +94,7 @@ def test_open_close():
     bad = False
     o.mock_open_error = True
     try:
-        with o.open("r"):
+        with o.open_legacy("r"):
             bad = True
         bad = True
     except Exception:

--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -64,7 +64,7 @@ def test_arrow_types_supported(tmp_path, arrow_type_info):
     arrow_type, expected_arrow_type = arrow_type_info
 
     sdf = soma.DataFrame(tmp_path.as_posix())
-    assert sdf == sdf.create(pa.schema([(str(arrow_type), arrow_type)]))
+    assert sdf == sdf.create_legacy(pa.schema([(str(arrow_type), arrow_type)]))
     schema = sdf.schema
     assert schema is not None
     assert sorted(schema.names) == sorted(["soma_joinid", str(arrow_type)])
@@ -78,7 +78,7 @@ def test_arrow_types_unsupported(tmp_path, arrow_type):
     sdf = soma.DataFrame(tmp_path.as_posix())
 
     with pytest.raises(TypeError, match=r"unsupported type|Unsupported Arrow type"):
-        assert sdf == sdf.create(pa.schema([(str(arrow_type), arrow_type)]))
+        assert sdf == sdf.create_legacy(pa.schema([(str(arrow_type), arrow_type)]))
 
 
 # ================================================================
@@ -134,7 +134,7 @@ def test_bool_arrays(tmp_path, bool_array):
     )
     index_column_names = ["soma_joinid"]
     sdf = soma.DataFrame(uri=tmp_path.as_posix())
-    sdf.create(schema=schema, index_column_names=index_column_names)
+    sdf.create_legacy(schema=schema, index_column_names=index_column_names)
     n_data = len(bool_array)
 
     data = {

--- a/apis/python/tests/test_unicode.py
+++ b/apis/python/tests/test_unicode.py
@@ -43,7 +43,7 @@ def sample_arrow_table():
 @pytest.fixture
 def sample_soma_dataframe(tmp_path, sample_arrow_table):
     sdf = soma.DataFrame(tmp_path.as_posix())
-    sdf.create(sample_arrow_table.schema, index_column_names=["soma_joinid"])
+    sdf.create_legacy(sample_arrow_table.schema, index_column_names=["soma_joinid"])
     sdf.write(sample_arrow_table)
     assert sdf.exists()
     return sdf
@@ -52,7 +52,7 @@ def sample_soma_dataframe(tmp_path, sample_arrow_table):
 def test_dataframe_unicode_columns(tmp_path, sample_arrow_table):
     """Verify round-trip of unicode in DataFrame value columns"""
     sdf = soma.DataFrame(tmp_path.as_posix())
-    sdf.create(sample_arrow_table.schema, index_column_names=["soma_joinid"])
+    sdf.create_legacy(sample_arrow_table.schema, index_column_names=["soma_joinid"])
     sdf.write(sample_arrow_table)
 
     assert sample_arrow_table.schema == sdf.schema
@@ -111,6 +111,6 @@ def test_dataframe_unicode_value_filter(sample_soma_dataframe):
 def test_dataframe_unicode_index(tmp_path, sample_arrow_table):
     """Verify round-trip of unicode in DataFrame index columns"""
     sdf = soma.DataFrame(tmp_path.as_posix())
-    sdf.create(sample_arrow_table.schema, index_column_names=["unicode"])
+    sdf.create_legacy(sample_arrow_table.schema, index_column_names=["unicode"])
     sdf.write(sample_arrow_table)
     assert sdf.read().concat().equals(sample_arrow_table)


### PR DESCRIPTION
This change imports the new version of somacore, but does not actually implement any of the new APIs specified by it.

- Because `create` and `open` are now class methods with different semantics, the existing methods are renamed `create_legacy` and `open_legacy`.
- Duplicate methods (reimplementing the context manager protocol) have been removed and are delegated to somacore.
