### PR TITLE
Refactor factory._construct_member

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -163,11 +163,7 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
                 from .factory import _construct_member
 
                 tdb = self._cached_values[key].tdb
-                soma = _construct_member(
-                    tdb.uri,
-                    context=self.context,
-                    object_type=tdb.type.__name__.lower(),
-                )
+                soma = _construct_member(tdb.uri, self.context, tdb.type)
                 if soma is None:
                     # if we were unable to create an object, it wasn't actually a SOMA object
                     raise KeyError(err_str)

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -3,11 +3,11 @@ This module exists to avoid what would otherwise be cyclic-module-import issues 
 Collection.
 """
 
-from typing import Optional, Union
+from typing import Mapping, Optional, Type, Union
 
 import tiledb
 
-from .collection import Collection
+from .collection import Collection, CollectionBase
 from .dataframe import DataFrame
 from .dense_nd_array import DenseNDArray
 from .exception import SOMAError
@@ -15,28 +15,32 @@ from .experiment import Experiment
 from .measurement import Measurement
 from .options import SOMATileDBContext
 from .sparse_nd_array import SparseNDArray
+from .tiledb_array import TileDBArray
+from .tiledb_object import TileDBObject
 from .util import (
     SOMA_ENCODING_VERSION,
     SOMA_ENCODING_VERSION_METADATA_KEY,
     SOMA_OBJECT_TYPE_METADATA_KEY,
-    SPEC_NAMES_TO_CLASS_NAMES,
 )
 
-ObjectTypes = Union[
-    Experiment,
-    Measurement,
-    Collection,
-    DataFrame,
-    DenseNDArray,
-    SparseNDArray,
-]
+SPEC_NAME_TO_CLASS: Mapping[str, Type[TileDBObject]] = {
+    # Maps languge-independent-spec names to Python-implementation class
+    "SOMAExperiment": Experiment,
+    "SOMAMeasurement": Measurement,
+    "SOMACollection": Collection,
+    "SOMADataFrame": DataFrame,
+    "SOMADenseNDArray": DenseNDArray,
+    "SOMADenseNdArray": DenseNDArray,
+    "SOMASparseNDArray": SparseNDArray,
+    "SOMASparseNdArray": SparseNDArray,
+}
 
 
 def _construct_member(
     member_uri: str,
-    context: Optional[SOMATileDBContext] = None,
-    object_type: Optional[str] = None,
-) -> Optional[ObjectTypes]:
+    context: SOMATileDBContext,
+    object_type: Type[Union[tiledb.Array, tiledb.Group]],
+) -> Optional[TileDBObject]:
     """
     Given a name/uri from a Collection, create a SOMA object matching the type
     of the underlying object. In other words, if the name/uri points to an DataFrame,
@@ -45,32 +49,24 @@ def _construct_member(
     Returns None if the URI does not point at a TileDB object, or if the TileDB
     object is not recognized as a SOMA object.
 
-    Solely for the use of ``Collection``. In fact this would/should be a method of the ``Collection`` class,
-    but there are cyclic-module-import issues.  This allows us to examine storage metadata and invoke the appropriate
-    per-type constructor when reading SOMA groups/arrays from storage.  See also ``_set_object_type_metadata`` and
+    Solely for the use of ``Collection``. In fact this would/should be a method of the
+    ``Collection`` class, but there are cyclic-module-import issues.  This allows us to
+    examine storage metadata and invoke the appropriate per-type constructor when reading
+    SOMA groups/arrays from storage.  See also ``_set_object_type_metadata`` and
     ``_get_object_type_metadata`` within ``TileDBObject``.
     """
-
-    context = context or SOMATileDBContext()
-
-    # Get the class name from TileDB storage. At the TileDB level there are just "arrays" and
-    # "groups", with separate metadata-getters.
-    if object_type is None:
-        object_type = tiledb.object_type(member_uri, ctx=context.tiledb_ctx)
-
     # auto-detect class name from metadata
-    try:
-        if object_type == "array":
-            with tiledb.open(member_uri, ctx=context.tiledb_ctx) as A:
-                spec_name = A.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
-                encoding_version = A.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY)
-        elif object_type == "group":
-            with tiledb.Group(member_uri, mode="r", ctx=context.tiledb_ctx) as G:
-                spec_name = G.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
-                encoding_version = G.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY)
-        else:
-            return None
+    if object_type is tiledb.Array:
+        tdb_open = tiledb.open
+    elif object_type is tiledb.Group:
+        tdb_open = tiledb.Group
+    else:
+        return None
 
+    try:
+        with tdb_open(member_uri, ctx=context.tiledb_ctx) as o:
+            spec_name = o.meta.get(SOMA_OBJECT_TYPE_METADATA_KEY, None)
+            encoding_version = o.meta.get(SOMA_ENCODING_VERSION_METADATA_KEY)
     except tiledb.TileDBError:
         return None
 
@@ -80,38 +76,20 @@ def _construct_member(
         raise SOMAError("internal error: encoding_version not found")
     if encoding_version != SOMA_ENCODING_VERSION:
         raise ValueError("Unsupported SOMA object encoding version")
-    if spec_name not in SPEC_NAMES_TO_CLASS_NAMES:
-        raise SOMAError(f'name "{spec_name}" unrecognized')
-    class_name = SPEC_NAMES_TO_CLASS_NAMES[spec_name]
 
     # Now invoke the appropriate per-class constructor.
-    if class_name == "Experiment":
-        _check_object_type(object_type, "group")
-        return Experiment(uri=member_uri, context=context)
-    elif class_name == "Measurement":
-        _check_object_type(object_type, "group")
-        return Measurement(uri=member_uri, context=context)
-    elif class_name == "Collection":
-        _check_object_type(object_type, "group")
-        return Collection(uri=member_uri, context=context)
-    elif class_name == "DataFrame":
-        _check_object_type(object_type, "array")
-        return DataFrame(uri=member_uri, context=context)
-    elif class_name in ["DenseNDArray", "DenseNdArray"]:
-        _check_object_type(object_type, "array")
-        return DenseNDArray(uri=member_uri, context=context)
-    elif class_name in ["SparseNDArray", "SparseNdArray"]:
-        _check_object_type(object_type, "array")
-        return SparseNDArray(uri=member_uri, context=context)
-    else:
-        raise SOMAError(f'internal error: class name "{class_name}" unrecognized')
+    cls = SPEC_NAME_TO_CLASS.get(spec_name)
+    if cls is None:
+        raise SOMAError(f'name "{spec_name}" unrecognized')
 
-
-def _check_object_type(
-    actual_object_type: Union[None, str], expected_object_type: str
-) -> None:
-    """Helper function for `_construct_member`"""
-    if actual_object_type is not None and actual_object_type != expected_object_type:
+    if issubclass(cls, CollectionBase) and object_type is not tiledb.Group:
         raise SOMAError(
-            f'internal error: expected object_type None or "{expected_object_type}"; got "{actual_object_type}"'
+            f'internal error: expected "group" object_type; got "{object_type}"'
         )
+
+    if issubclass(cls, TileDBArray) and object_type is not tiledb.Array:
+        raise SOMAError(
+            f'internal error: expected "array" object_type; got "{object_type}"'
+        )
+
+    return cls(uri=member_uri, context=context)

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -10,28 +10,6 @@ SOMA_OBJECT_TYPE_METADATA_KEY = "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
 SOMA_ENCODING_VERSION = "1"
 
-SPEC_NAMES_TO_CLASS_NAMES = {
-    # Maps languge-independent-spec names to Python-implementation class names
-    "SOMAExperiment": "Experiment",
-    "SOMAMeasurement": "Measurement",
-    "SOMACollection": "Collection",
-    "SOMADataFrame": "DataFrame",
-    "SOMADenseNDArray": "DenseNDArray",
-    "SOMADenseNdArray": "DenseNDArray",
-    "SOMASparseNDArray": "SparseNDArray",
-    "SOMASparseNdArray": "SparseNDArray",
-}
-
-CLASS_NAMES_TO_SPEC_NAMES = {
-    # Maps Python-implementation class names to language-independent-spec names
-    "Experiment": "SOMAExperiment",
-    "Measurement": "SOMAMeasurement",
-    "Collection": "SOMACollection",
-    "DataFrame": "SOMADataFrame",
-    "DenseNDArray": "SOMADenseNDArray",
-    "SparseNDArray": "SOMASparseNDArray",
-}
-
 
 def get_start_stamp() -> float:
     """


### PR DESCRIPTION
- Replaced the `if/elif/elif/....` logic in `factory._construct_member` with a dict lookup. Classes are first-class (pun not intended) objects  in Python so they can be stored as values in a `SPEC_NAME_TO_CLASS` dict.
- Tightened `context` and `object_type` parameters to be non-optional. Also changed `object_type` to be an actual type instead of str.