### PR TITLE
[python] Correctly default ingest mode for  updates to obsm et al.

### DIFF
--- a/apis/python/src/tiledbsoma/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_matrix_group.py
@@ -126,7 +126,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         dim_values: Labels,
         matrix_name: str,
         *,
-        ingest_mode: str,
+        ingest_mode: str = "write",
     ) -> None:
         """
         Populates a component of the ``obsm`` or ``varm`` subgroup for a SOMA object.

--- a/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsoma/annotation_pairwise_matrix_group.py
@@ -173,7 +173,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         dim_values: Labels,
         matrix_name: str,
         *,
-        ingest_mode: str,
+        ingest_mode: str = "write",
     ) -> None:
         """
         Populates a component of the ``obsp`` or ``varp`` subgroup for a SOMA object.

--- a/apis/python/tests/test_add_layer.py
+++ b/apis/python/tests/test_add_layer.py
@@ -49,7 +49,6 @@ def test_add_layer(adata):
         soma.obs.ids(),
         soma.var.ids(),
         "data2",
-        ingest_mode="write",
     )
 
     csr2 = soma.X.data2.csr()
@@ -66,7 +65,6 @@ def test_add_layer(adata):
         soma.obsm.X_tsne.df(),
         soma.obs_keys(),
         "voila",
-        ingest_mode="write",
     )
     assert sorted(soma.obsm.keys()) == ["X_pca", "X_tsne", "voila"]
     assert soma.obsm.voila.shape() == soma.obsm.X_tsne.shape()
@@ -76,7 +74,6 @@ def test_add_layer(adata):
         soma.obsp.distances.csr(),
         soma.obs_keys(),
         "voici",
-        ingest_mode="write",
     )
     assert sorted(soma.obsp.keys()) == ["distances", "voici"]
     assert soma.obsp.voici.shape() == soma.obsp.distances.shape()


### PR DESCRIPTION
## Issue and/or context:

On last month's #628 , `ingest_mode` was made optional and defaulting to `"write"` in _almost_ all callsites -- I missed two, as @ckrilow noticed.