### PR TITLE
Add lifecycle maturity tags to public API docstrings (Python)

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -12,7 +12,6 @@ from .general_utilities import (
     get_storage_engine,
 )
 from .measurement import Measurement
-from .metadata_mapping import MetadataMapping
 from .sparse_nd_array import SparseNDArray
 from .tiledb_array import TileDBArray
 from .tiledb_object import TileDBObject
@@ -35,6 +34,5 @@ __all__ = [
     "SOMAError",
     "DataFrame",
     "Measurement",
-    "MetadataMapping",  # TODO: should this be exported?
     "SparseNDArray",
 ]

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -35,6 +35,6 @@ __all__ = [
     "SOMAError",
     "DataFrame",
     "Measurement",
-    "MetadataMapping",
+    "MetadataMapping",  # TODO: should this be exported?
     "SparseNDArray",
 ]

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -89,6 +89,8 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
     ):
         """
         Also see the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
         super().__init__(uri=uri, parent=parent, context=context)
         self._cached_values = None
@@ -96,6 +98,8 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
     def create(self) -> "CollectionBase[CollectionElementType]":
         """
         Creates the data structure on disk/S3/cloud.
+
+        [lifecycle: experimental]
         """
         return self._create(self.soma_type)
 
@@ -163,6 +167,8 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         """
         Adds an element to the collection.  This interface allows explicit control over
         `relative` URI, and uses the member's default name.
+
+        [lifecycle: experimental]
         """
         self._set_element(key, value, relative=relative)
 
@@ -366,6 +372,8 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
 class Collection(CollectionBase[TileDBObject]):
     """
     A persistent collection of SOMA objects, mapping string keys to any SOMA object.
+
+    [lifecycle: experimental]
     """
 
     pass

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -10,7 +10,8 @@ from somacore import options
 from . import util, util_arrow
 from .collection import CollectionBase
 from .constants import SOMA_JOINID
-from .options import SOMATileDBContext, TileDBCreateOptions
+from .options import SOMATileDBContext
+from .options.tiledb_create_options import TileDBCreateOptions
 from .query_condition import QueryCondition
 from .tiledb_array import TileDBArray
 from .types import NPFloating, NPInteger, PlatformConfig

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -25,6 +25,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     Represents ``obs``, ``var``, and others.
 
     All ``DataFrame`` must contain a column called ``soma_joinid``, of type ``int64``. The ``soma_joinid`` column contains a unique value for each row in the ``DataFrame``, and intended to act as a joint key for other objects, such as ``SparseNDArray``.
+
+    [lifecycle: experimental]
     """
 
     _index_column_names: Union[Tuple[()], Tuple[str, ...]]
@@ -40,6 +42,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     ):
         """
         See also the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
         super().__init__(uri=uri, parent=parent, context=context)
         self._index_column_names = ()
@@ -55,6 +59,10 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         platform_config: Optional[somacore.options.PlatformConfig] = None,
     ) -> "DataFrame":
         """
+        Creates the data structure on disk/S3/cloud.
+
+        [lifecycle: experimental]
+
         :param schema: Arrow Schema defining the per-column schema. This schema must define all columns, including columns to be named as index columns. If the schema includes types unsupported by the SOMA implementation, an error will be raised.
 
         :param index_column_names: A list of column names to use as user-defined index columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must exist in the schema, and at least one index column name is required.
@@ -160,6 +168,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     def keys(self) -> Sequence[str]:
         """
         Returns the names of the columns when read back as a dataframe.
+
+        [lifecycle: experimental]
         """
         return self._tiledb_array_keys()
 
@@ -202,6 +212,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     ) -> TableReadIter:
         """
         Read a user-defined subset of data, addressed by the dataframe indexing columns, optionally filtered, and return results as one or more Arrow.Table.
+
+        [lifecycle: experimental]
 
         :param coords: for each index dimension, which rows to read. Defaults to ``None``, meaning no constraint -- all IDs.
 
@@ -309,6 +321,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     ) -> None:
         """
         Write an Arrow.Table to the persistent object. As duplicate index values are not allowed, index values already present in the object are overwritten and new index values are added.
+
+        [lifecycle: experimental]
 
         :param values: An Arrow.Table containing all columns, including the index columns. The schema for the values must match the schema for the ``DataFrame``.
         """

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -22,6 +22,8 @@ _UNBATCHED = options.BatchSize()
 class DenseNDArray(TileDBArray, somacore.DenseNDArray):
     """
     Represents ``X`` and others.
+
+    [lifecycle: experimental]
     """
 
     def __init__(
@@ -47,6 +49,8 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
     ) -> "DenseNDArray":
         """
         Create a ``DenseNDArray`` named with the URI.
+
+        [lifecycle: experimental]
 
         :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
 
@@ -130,7 +134,9 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
 
     def reshape(self, shape: NTuple) -> None:
         """
-        Unsupported operation for this object type [lifecycle: experimental].
+        Unsupported operation for this object type.
+
+        [lifecycle: experimental]
         """
         raise NotImplementedError("reshape operation not implemented.")
 
@@ -156,6 +162,8 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
         is 10 by 20, then some acceptable values of ``coords`` include ``(3, 4)``,
         ``(slice(5, 10),)``, and ``(slice(5, 10), slice(6, 12))``. Slice indices are
         doubly inclusive.
+
+        [lifecycle: experimental]
         """
         del batch_size, partitions, platform_config  # Currently unused.
         result_order = somacore.ResultOrder(result_order)
@@ -236,6 +244,8 @@ class DenseNDArray(TileDBArray, somacore.DenseNDArray):
         """
         Write subarray, defined by ``coords`` and ``values``. Will overwrite existing
         values in the array.
+
+        [lifecycle: experimental]
 
         Parameters
         ----------

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -12,7 +12,8 @@ from tiledbsoma.util import dense_indices_to_shape
 
 from .collection import CollectionBase
 from .exception import SOMAError
-from .options import SOMATileDBContext, TileDBCreateOptions
+from .options import SOMATileDBContext
+from .options.tiledb_create_options import TileDBCreateOptions
 from .tiledb_array import TileDBArray
 from .types import NTuple, PlatformConfig
 

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -20,6 +20,8 @@ class Experiment(CollectionBase[TileDBObject]):
              defined in this dataframe.
 
     ``ms``: A collection of named measurements.
+
+    [lifecycle: experimental]
     """
 
     _subclass_constrained_soma_types: Dict[str, Tuple[str, ...]] = {
@@ -38,6 +40,8 @@ class Experiment(CollectionBase[TileDBObject]):
     ):
         """
         Also see the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
         super().__init__(uri=uri, parent=parent, context=context)
 
@@ -47,6 +51,8 @@ class Experiment(CollectionBase[TileDBObject]):
     def create(self) -> "Experiment":
         """
         Creates the data structure on disk/S3/cloud.
+
+        [lifecycle: experimental]
         """
         self._create(self.soma_type)
         return self
@@ -78,6 +84,8 @@ class Experiment(CollectionBase[TileDBObject]):
         """
         Create a query on this Experiment. See ``ExperimentAxisQuery`` for more
         information on parameters and usage.
+
+        [lifecycle: experimental]
         """
         if not self.exists():
             raise ValueError(f"Experiment {self.uri} does not exist.")

--- a/apis/python/src/tiledbsoma/general_utilities.py
+++ b/apis/python/src/tiledbsoma/general_utilities.py
@@ -4,6 +4,8 @@ from pkg_resources import DistributionNotFound, get_distribution
 def get_SOMA_version() -> str:
     """
     Return semver-compatible version of the supported SOMA API.
+
+    [lifecycle: experimental]
     """
     return "0.2.0-dev"
 
@@ -11,6 +13,8 @@ def get_SOMA_version() -> str:
 def get_implementation() -> str:
     """
     Return the implementation name, e.g., "python-tiledb".
+
+    [lifecycle: experimental]
     """
     return "python-tiledb"
 
@@ -18,6 +22,8 @@ def get_implementation() -> str:
 def get_implementation_version() -> str:
     """
     Return the package implementation version as a semver
+
+    [lifecycle: experimental]
     """
     try:
         return get_distribution("tiledbsoma").version
@@ -28,5 +34,7 @@ def get_implementation_version() -> str:
 def get_storage_engine() -> str:
     """
     Return underlying storage engine name, e.g., "tiledb".
+
+    [lifecycle: experimental]
     """
     return "tiledb"

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -55,6 +55,8 @@ def from_h5ad(
 
     The "schema_only" ingest_mode creates groups and array schema, without writing array data.
     This is useful as a prep-step for parallel append-ingest of multiple H5ADs to a single soma.
+
+    [lifecycle: experimental]
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(
@@ -107,6 +109,8 @@ def from_anndata(
 
     The "schema_only" ingest_mode creates groups and array schema, without writing array data.
     This is useful as a prep-step for parallel append-ingest of multiple H5ADs to a single soma.
+
+    [lifecycle: experimental]
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(
@@ -486,6 +490,8 @@ def add_X_layer(
     This is useful for adding X data, for example from scanpy.pp.normalize_total, scanpy.pp.log1p, etc.
 
     Use `ingest_mode="resume"` to not error out if the schema already exists.
+
+    [lifecycle: experimental]
     """
     uri = f"{exp.ms[measurement_name].X.uri}/{X_layer_name}"
     sparse_nd_array = SparseNDArray(uri)
@@ -821,6 +827,8 @@ def to_h5ad(
 ) -> None:
     """
     Converts the experiment group to anndata format and writes it to the specified .h5ad file.
+
+    [lifecycle: experimental]
     """
     s = util.get_start_stamp()
     logging.log_io(None, f"START  Experiment.to_h5ad -> {h5ad_path}")
@@ -852,6 +860,8 @@ def to_anndata(
     * obs,var as ``pandas.dataframe``
     * obsm,varm arrays as ``numpy.ndarray``
     * obsp,varp arrays as ``scipy.sparse.csr_matrix``
+
+    [lifecycle: experimental]
     """
 
     s = util.get_start_stamp()

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -28,7 +28,8 @@ from tiledbsoma import (
 from tiledbsoma.exception import SOMAError
 
 from .constants import SOMA_JOINID
-from .options import SOMATileDBContext, TileDBCreateOptions
+from .options import SOMATileDBContext
+from .options.tiledb_create_options import TileDBCreateOptions
 from .types import INGEST_MODES, IngestMode, NPNDArray, Path
 
 SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]

--- a/apis/python/src/tiledbsoma/logging.py
+++ b/apis/python/src/tiledbsoma/logging.py
@@ -7,6 +7,8 @@ logger = logging.getLogger("tiledbsoma")
 def warning() -> None:
     """
     Sets ``tiledbsoma.logging`` to a WARNING level. Use ``tiledbsoma.logging.info()`` in notebooks to suppress progress indicators for data ingestion.
+
+    [lifecycle: experimental]
     """
     _set_level(logging.WARNING)
 
@@ -14,6 +16,8 @@ def warning() -> None:
 def info() -> None:
     """
     Sets ``tiledbsoma.logging`` to an INFO level. Use ``tiledbsoma.logging.info()`` in notebooks to see progress indicators for data ingestion.
+
+    [lifecycle: experimental]
     """
     _set_level(logging.INFO)
 
@@ -21,6 +25,8 @@ def info() -> None:
 def debug() -> None:
     """
     Sets ``tiledbsoma.logging`` to an DEBUG level. Use ``tiledbsoma.logging.debug()`` in notebooks to see more detailed progress indicators for data ingestion.
+
+    [lifecycle: experimental]
     """
     _set_level(logging.DEBUG)
 
@@ -37,6 +43,8 @@ def _set_level(level: int) -> None:
 def log_io(info_message: Optional[str], debug_message: str) -> None:
     """
     Data-ingestion timeframes range widely.  Some folks won't want details for smaller uploads; some will want details for larger ones.  For I/O and for I/O only, it's helpful to print a short message at INFO level, or a different, longer message at/beyond DEBUG level.
+
+    [lifecycle: experimental]
     """
     if logger.level == logging.INFO:
         if info_message is not None:

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -37,6 +37,8 @@ class Measurement(CollectionBase[TileDBObject]):
     ``varp``: ``Collection`` of ``SparseNDArray``
 
     A collection of sparse matrices containing pairwise annotations of each ``var`` row. Indexed with ``[varid_1, varid_2]``
+
+    [lifecycle: experimental]
     """
 
     _subclass_constrained_soma_types: Dict[str, Tuple[str, ...]] = {
@@ -59,6 +61,8 @@ class Measurement(CollectionBase[TileDBObject]):
     ):
         """
         Also see the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
         super().__init__(uri=uri, parent=parent, context=context)
 
@@ -68,6 +72,8 @@ class Measurement(CollectionBase[TileDBObject]):
     def create(self) -> "Measurement":
         """
         Creates the data structure on disk/S3/cloud.
+
+        [lifecycle: experimental]
         """
         self._create(self.soma_type)
         return self

--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -1,5 +1,4 @@
 from .soma_tiledb_context import SOMATileDBContext
-from .tiledb_create_options import TileDBCreateOptions
 
 __all__ = [
     "SOMATileDBContext",

--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -2,6 +2,5 @@ from .soma_tiledb_context import SOMATileDBContext
 from .tiledb_create_options import TileDBCreateOptions
 
 __all__ = [
-    "TileDBCreateOptions",
     "SOMATileDBContext",
 ]

--- a/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
@@ -24,6 +24,8 @@ class SOMATileDBContext:
     """
     Maintains TileDB-specific context for TileDbObjects. This context can be shared across multiple SOMA objects,
     including having a child object inherit it from its parent.
+
+    [lifecycle: experimental]
     """
 
     tiledb_ctx: tiledb.Ctx = _build_default_tiledb_ctx()

--- a/apis/python/src/tiledbsoma/options/tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/tiledb_create_options.py
@@ -40,6 +40,12 @@ StrOrMap = Union[str, Mapping[str, Any]]
 
 @attrs.define(frozen=True)
 class TileDBCreateOptions(Mapping[str, Any]):
+    """
+    Provides strongly-typed access and default values for `platform_config` options stored under the "tiledb"->"create"
+    Mapping keys.
+
+    Intended for internal use only.
+    """
 
     _config: Mapping[str, Any] = field(factory=dict)
 

--- a/apis/python/src/tiledbsoma/options/tiledb_platform_config.py
+++ b/apis/python/src/tiledbsoma/options/tiledb_platform_config.py
@@ -1,7 +1,0 @@
-from typing import TypedDict
-
-from tiledbsoma.options import TileDBCreateOptions
-
-
-class TileDBPlatformConfig(TypedDict):
-    create: TileDBCreateOptions

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -5,15 +5,15 @@ import numpy as np
 import pyarrow as pa
 import somacore
 import tiledb
-from somacore import options
 from somacore.options import PlatformConfig
 
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
 
-from . import util, util_arrow
+from . import options, util, util_arrow
 from .collection import CollectionBase
-from .options import SOMATileDBContext, TileDBCreateOptions
+from .options import SOMATileDBContext
+from .options.tiledb_create_options import TileDBCreateOptions
 from .tiledb_array import TileDBArray
 from .types import NTuple
 from .util_iter import (

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -29,6 +29,8 @@ _UNBATCHED = options.BatchSize()
 class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     """
     Represents ``X`` and others.
+
+    [lifecycle: experimental]
     """
 
     def __init__(
@@ -40,6 +42,8 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     ):
         """
         Also see the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
 
         super().__init__(uri=uri, parent=parent, context=context)
@@ -55,6 +59,8 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     ) -> "SparseNDArray":
         """
         Create a ``SparseNDArray`` named with the URI.
+
+        [lifecycle: experimental]
 
         :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
 
@@ -141,6 +147,8 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     def reshape(self, shape: NTuple) -> None:
         """
         Unsupported operation for this object type.
+
+        [lifecycle: experimental]
         """
         raise NotImplementedError("reshape operation not implemented.")
 
@@ -166,6 +174,8 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
     ) -> "SparseNDArrayRead":
         """
         Read a user-defined slice of the SparseNDArray.
+
+        [lifecycle: experimental]
 
         Parameters
         ----------
@@ -263,6 +273,8 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
         """
         Write an Arrow object to the SparseNDArray.
 
+        [lifecycle: experimental]
+
         Arrow sparse tensor: the coordinates in the Arrow SparseTensor will be interpreted
         as the coordinates to write to. Supports the _experimental_ SparseCOOTensor,
         SparseCSRMatrix and SparseCSCMatrix. There is currently no support for Arrow
@@ -304,26 +316,60 @@ class SparseNDArray(TileDBArray, somacore.SparseNDArray):
 
 
 class SparseNDArrayRead(somacore.SparseRead):
+    """
+    Intermediate type to choose result format when reading a sparse array.
+
+    See docs for somacore.data.SparseRead
+
+    [lifecycle: experimental]
+    """
+
     def __init__(self, sr: clib.SOMAReader, shape: NTuple):
+        """
+        [lifecycle: experimental]
+        """
         self.sr = sr
         self.shape = shape
 
     def coos(self) -> SparseCOOTensorReadIter:
-        """Return an iterator of Arrow SparseCOOTensor"""
+        """
+        Return an iterator of Arrow SparseCOOTensor
+
+        [lifecycle: experimental]
+        """
         return SparseCOOTensorReadIter(self.sr, self.shape)
 
     def cscs(self) -> SparseCSCMatrixReadIter:
-        """Return an iterator of Arrow SparseCSCMatrix"""
+        """
+        Return an iterator of Arrow SparseCSCMatrix
+
+        [lifecycle: experimental]
+        """
+
         return SparseCSCMatrixReadIter(self.sr, self.shape)
 
     def csrs(self) -> SparseCSRMatrixReadIter:
-        """Return an iterator of Arrow SparseCSRMatrix"""
+        """
+        Return an iterator of Arrow SparseCSRMatrix
+
+        [lifecycle: experimental]
+        """
+
         return SparseCSRMatrixReadIter(self.sr, self.shape)
 
     def dense_tensors(self) -> somacore.ReadIter[pa.Tensor]:
-        """Return an iterator of Arrow Tensor"""
+        """
+        Return an iterator of Arrow Tensor
+
+        [lifecycle: experimental]
+        """
+
         raise NotImplementedError()
 
     def tables(self) -> TableReadIter:
-        """Return an iterator of Arrow Table"""
+        """
+        Return an iterator of Arrow Table
+
+        [lifecycle: experimental]
+        """
         return TableReadIter(self.sr)

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -5,12 +5,13 @@ import numpy as np
 import pyarrow as pa
 import somacore
 import tiledb
+from somacore import options
 from somacore.options import PlatformConfig
 
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
 
-from . import options, util, util_arrow
+from . import util, util_arrow
 from .collection import CollectionBase
 from .options import SOMATileDBContext
 from .options.tiledb_create_options import TileDBCreateOptions

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -14,6 +14,8 @@ from .util_arrow import get_arrow_schema_from_tiledb_uri
 class TileDBArray(TileDBObject):
     """
     Wraps arrays from TileDB-Py by retaining a URI, options, etc.  Also serves as an abstraction layer to hide TileDB-specific details from the API, unless requested.
+
+    [lifecycle: experimental]
     """
 
     def __init__(
@@ -26,6 +28,8 @@ class TileDBArray(TileDBObject):
     ):
         """
         See the ``TileDBObject`` constructor.
+
+        [lifecycle: experimental]
         """
         super().__init__(uri, parent=parent, context=context)
 

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -14,6 +14,8 @@ class TileDBObject(ABC, somacore.SOMAObject):
     Base class for ``TileDBArray`` and ``Collection``.
 
     Accepts a SOMATileDBContext, to enable session state to be shared across SOMA objects.
+
+    [lifecycle: experimental]
     """
 
     _uri: str
@@ -34,6 +36,8 @@ class TileDBObject(ABC, somacore.SOMAObject):
         Initialization-handling shared between ``TileDBArray`` and ``Collection``.  Specify ``context`` for
         the top-level object; omit it and specify parent for non-top-level objects. Note that the parent reference
         is solely for propagating the context
+
+        [lifecycle: experimental]
         """
 
         self._uri = uri
@@ -70,8 +74,10 @@ class TileDBObject(ABC, somacore.SOMAObject):
         """
         Delete the storage specified with the URI.
 
-        TODO: should this raise an error if the object does not exist?
+        [lifecycle: experimental]
         """
+
+        # TODO: should this raise an error if the object does not exist?
         try:
             tiledb.remove(self._uri)
         except tiledb.TileDBError:
@@ -106,6 +112,8 @@ class TileDBObject(ABC, somacore.SOMAObject):
         This might be in case an object has not yet been populated, or, if a containing object has been populated but doesn't have a particular member (e.g. not all ``Measurement`` objects have a ``varp``).
 
         For ``tiledb://`` URIs this is a REST-server request which we'd like to cache.  However, remove-and-replace use-cases are possible and common in notebooks and it turns out caching the existence-check isn't a robust approach.
+
+        [lifecycle: experimental]
         """
 
         # Pre-checking if the group exists by calling tiledb.object_type is simple, however, for

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -5,7 +5,9 @@ from scipy import sparse as sp
 
 import tiledbsoma as soma
 import tiledbsoma.io as somaio
-from tiledbsoma.options import SOMATileDBContext, TileDBCreateOptions
+from tiledbsoma.options import SOMATileDBContext
+
+from .options.tiledb_create_options import TileDBCreateOptions
 
 
 @pytest.fixture

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -6,8 +6,7 @@ from scipy import sparse as sp
 import tiledbsoma as soma
 import tiledbsoma.io as somaio
 from tiledbsoma.options import SOMATileDBContext
-
-from .options.tiledb_create_options import TileDBCreateOptions
+from tiledbsoma.options.tiledb_create_options import TileDBCreateOptions
 
 
 @pytest.fixture

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -7,7 +7,7 @@ import tiledb
 
 import tiledbsoma
 import tiledbsoma.io
-from tiledbsoma.options import TileDBCreateOptions
+from tiledbsoma.options.tiledb_create_options import TileDBCreateOptions
 
 HERE = Path(__file__).parent
 


### PR DESCRIPTION
## Issue and/or context:
#708 

## Changes:
- Added to all publicly exported classes and their methods, including constructor
- Added to top-level functions in io, logging, general_utilties modules
- Not added to @property methods
- Not added to exceptions
- All are "experimental" maturity for now

Unrelated:
- Removed dead code: `TileDBPlatformConfig` class
- No longer export `TileDBCreateOptions` or `MetadataMapping` (they're for internal use only)

## Notes for Reviewer:
If this is approved, will tackle R changes in a separate PR.

