### PR TITLE
Switch to somacore 0.0.0a10.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs"
-        - "somacore==0.0.0a8"
+        - "somacore==0.0.0a10"
         - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -110,7 +110,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a8",
+        "somacore==0.0.0a10",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -43,7 +43,7 @@ class Experiment(CollectionBase[TileDBObject]):
         super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
-    soma_type: Final = "SOMAExperiment"
+    soma_type: Final = "SOMAExperiment"  # type: ignore[misc]
 
     def create_legacy(self) -> "Experiment":
         """

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -64,7 +64,7 @@ class Measurement(CollectionBase[TileDBObject]):
         super().__init__(uri=uri, context=context)
 
     # Inherited from somacore
-    soma_type: Final = "SOMAMeasurement"
+    soma_type: Final = "SOMAMeasurement"  # type: ignore[misc]
 
     def create_legacy(self) -> "Measurement":
         """


### PR DESCRIPTION
This does not include any behavior changes relative to current code but will make for smoother sailing for changes that depend upon it by ensuring that the native libraries are cached for the new `setup.py`.