### PR TITLE
[python] Use the contents of `bld`, not `setup.py`, for binary cache

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -10,7 +10,7 @@ on:
       python_version:
         required: true
         type: string
-      os: 
+      os:
         required: true
         type: string
       cc:
@@ -22,7 +22,7 @@ on:
       report_codecov:
         required: true
         type: boolean
-      is_mac: 
+      is_mac:
         required: false
         type: boolean
         default: false
@@ -30,7 +30,7 @@ on:
         required: false
         type: boolean
         default: false
-      
+
 jobs:
   lint:
     if: ${{ inputs.run_lint }}
@@ -86,7 +86,7 @@ jobs:
         path: |
           build
           dist
-        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'apis/python/setup.py') }}
+        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
       run: python -m pip -v install -U pip pytest-cov typeguard types-setuptools

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -40,7 +40,12 @@ def find_or_build_package_data(setuptools_cmd):
     # Call the build script if the install library directory does not exist
     lib_dir = libtiledbsoma_dir / "dist" / "lib"
     if not lib_dir.exists():
-        subprocess.run("bash bld", cwd=scripts_dir, shell=True)
+        # Note: The GitHub build process uses the contents of `bld` as a key
+        # to cache the native binaries. Using non-default options here will
+        # cause that cache to fall out of sync.
+        #
+        # See `.github/workflows/python-ci-single.yml` for configuration.
+        subprocess.run(["./bld"], cwd=scripts_dir)
 
     # Copy native libs into the package dir so they can be found by package_data
     package_data = []


### PR DESCRIPTION
We were (I was) using the contents of `setup.py` for the cache key when building the tiledbsoma C++ library. This was not ideal since it meant the cache would be busted when unrelated changes happened. We should instead use the `bld` script, which does the actual blding, as the key.