### PR TITLE
[python] Fix `use_relative_uri` for tiledbsoma.io [pre-824]

### DIFF
--- a/apis/python/devtools/ingestor
+++ b/apis/python/devtools/ingestor
@@ -102,19 +102,19 @@ select `relative=True`. (This is the default.)
         tiledbsoma.logging.info()
 
     if args.relative is None:
-        rel_member_uris = None
+        use_relative_uri = None
     else:
         relative = args.relative[0]
         if relative == "true":
-            rel_member_uris = True
+            use_relative_uri = True
         elif relative == "false":
-            rel_member_uris = False
+            use_relative_uri = False
         elif relative == "auto":
-            rel_member_uris = None
+            use_relative_uri = None
         else:
             raise tiledbsoma.exception.SOMAError(f"Internal coding error in {__file__}")
 
-    context = SOMATileDBContext(member_uris_are_relative=rel_member_uris)
+    context = SOMATileDBContext()
     soco_dir = args.o.rstrip("/")
 
     if args.n:
@@ -131,6 +131,7 @@ select `relative=True`. (This is the default.)
                 output_path=output_path,
                 ingest_mode=args.ingest_mode[0],
                 context=context,
+                use_relative_uri=use_relative_uri,
                 write_soco=write_soco,
                 soco_dir=soco_dir,
                 measurement_name=args.measurement_name,
@@ -144,6 +145,7 @@ select `relative=True`. (This is the default.)
                 output_path=output_path,
                 ingest_mode=args.ingest_mode[0],
                 context=context,
+                use_relative_uri=use_relative_uri,
                 write_soco=write_soco,
                 soco_dir=soco_dir,
                 measurement_name=args.measurement_name,
@@ -159,6 +161,7 @@ select `relative=True`. (This is the default.)
                 output_path=output_path,
                 ingest_mode=args.ingest_mode[0],
                 context=context,
+                use_relative_uri=use_relative_uri,
                 write_soco=write_soco,
                 soco_dir=soco_dir,
                 measurement_name=args.measurement_name,
@@ -171,6 +174,7 @@ select `relative=True`. (This is the default.)
                 output_path=output_path,
                 ingest_mode=args.ingest_mode[0],
                 context=context,
+                use_relative_uri=use_relative_uri,
                 write_soco=write_soco,
                 soco_dir=soco_dir,
                 measurement_name=args.measurement_name,
@@ -187,6 +191,7 @@ def ingest_one(
     output_path: str,
     ingest_mode: str,
     context: SOMATileDBContext,
+    use_relative_uri: bool,
     write_soco: bool,
     soco_dir: str,
     measurement_name: str,
@@ -220,7 +225,13 @@ def ingest_one(
     exp = tiledbsoma.Experiment(uri=output_path, context=context)
     exp_name = os.path.splitext(os.path.basename(output_path))[0]
 
-    tiledbsoma.io.from_h5ad(exp, input_path, measurement_name, ingest_mode=ingest_mode)
+    tiledbsoma.io.from_h5ad(
+        exp,
+        input_path,
+        measurement_name,
+        ingest_mode=ingest_mode,
+        use_relative_uri=use_relative_uri,
+    )
 
     if write_soco:
         soco = tiledbsoma.Collection(soco_dir, context=context)
@@ -228,7 +239,7 @@ def ingest_one(
             soco.create_legacy()
         if not soco.exists():
             raise tiledbsoma.exception.SOMAError(f"Could not create SOCO at {soco.uri}")
-        soco.set(exp_name, exp)
+        soco.set(exp_name, exp, use_relative_uri=use_relative_uri)
 
         tiledbsoma.logging.logger.info("")
         tiledbsoma.logging.logger.info(

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -191,7 +191,7 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
 
         [lifecycle: experimental]
         """
-        self._set_element(key, value, relative=use_relative_uri)
+        self._set_element(key, value, use_relative_uri=use_relative_uri)
 
     def __setitem__(self, key: str, value: CollectionElementType) -> None:
         """
@@ -311,20 +311,23 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
         if self._cached_values is None:
             raise SOMAError("internal error: _cached_values is None")
 
-    def _determine_default_relative(self, uri: str) -> Optional[bool]:
-        """Defaulting for the relative parameter."""
-        if self.context.member_uris_are_relative is not None:
-            return self.context.member_uris_are_relative
-        if uri.startswith("tiledb://"):
-            # TileDB-Cloud does not use relative URIs, ever.
-            return False
-        return None
-
     def _set_element(
-        self, key: str, value: CollectionElementType, relative: Optional[bool] = None
+        self,
+        key: str,
+        value: CollectionElementType,
+        use_relative_uri: Optional[bool] = False,
     ) -> None:
-        if relative is None:
-            relative = self._determine_default_relative(value.uri)
+
+        # The SOMA API supports use_relative_uri in [True, False, None].
+        # The TileDB-Py API supports use_relative_uri in [True, False].
+        # Map from the former to the latter -- and also honor our contract
+        # for None -- using the following rule.
+        if use_relative_uri is None:
+            if value.uri.startswith("tiledb://"):
+                # TileDB-Cloud does not use relative URIs, ever.
+                use_relative_uri = False
+            else:
+                use_relative_uri = True
 
         if key in self._subclass_constrained_soma_types:
             # Implement the sub-class protocol constraining the value type of certain item keys
@@ -344,13 +347,13 @@ class CollectionBase(TileDBObject, somacore.Collection[CollectionElementType]):
 
         uri = (
             make_relative_path(value.uri, relative_to=self.uri)
-            if relative
+            if use_relative_uri
             else value.uri
         )
         for retry in [True, False]:
             try:
                 with self._ensure_open("w"):
-                    self._tiledb_obj.add(uri=uri, relative=relative, name=key)
+                    self._tiledb_obj.add(uri=uri, relative=use_relative_uri, name=key)
                 break
             except tiledb.TileDBError as e:
                 if is_does_not_exist_error(e):

--- a/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/soma_tiledb_context.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import attrs
 import tiledb
@@ -29,8 +29,3 @@ class SOMATileDBContext:
     """
 
     tiledb_ctx: tiledb.Ctx = _build_default_tiledb_ctx()
-
-    member_uris_are_relative: Optional[bool] = None
-    """Allows "relocatability" for local disk / S3, and correct behavior for TileDB Cloud."""
-
-    # read_timestamp, e.g.


### PR DESCRIPTION
## Issue and/or context:

#821 

## Changes:

In addition to the problem described in #821, namely, S3 and local-disk SOMA data is being written with absolute, not relative, URIs: having an option-flag within the `context` struct is a hold-over from the `main-old` days when we had multiple things propagated from parent to child -- including the (now long-gone) `indent` strings for `__repr__`. It's now redundant with `use_relative_uri`; we don't need both.

## Notes to the reviewer:

This is the same as 833 but this is _not_ is atop the branch create-create from PR https://github.com/single-cell-data/TileDB-SOMA/pull/824