### PR TITLE
[r] Limit builds to unix operating systems

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -59,3 +59,4 @@ Suggests:
     pbmc3k.tiledb
 VignetteBuilder: knitr
 Config/testthat/edition: 2
+OS_type: unix


### PR DESCRIPTION
#### Issue and/or context:

Building on Windows will likely require changes to the `cmake` setup.

#### Changes:

Set the OS_type: field in `DESCRPTION`

#### Notes for Reviewer:

See https://app.shortcut.com/tiledb-inc/story/24923/r-limit-builds-to-unix-operating-systems