### PR TITLE
[python] Fix legacy misuse of`urllib.parse.urljoin`

### DIFF
--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+import os
 
 import numpy as np
 import pyarrow as pa
@@ -89,23 +89,23 @@ def test_experiment_basic(tmp_path):
     experiment.create_legacy()
 
     experiment["obs"] = create_and_populate_obs(
-        soma.DataFrame(uri=urljoin(basedir, "obs"))
+        soma.DataFrame(uri=os.path.join(basedir, "obs"))
     )
-    experiment["ms"] = soma.Collection(uri=urljoin(basedir, "ms")).create_legacy()
+    experiment["ms"] = soma.Collection(uri=os.path.join(basedir, "ms")).create_legacy()
 
     measurement = soma.Measurement(uri=f"{experiment.ms.uri}/RNA")
     measurement.create_legacy()
     experiment.ms.set("RNA", measurement)
 
     measurement["var"] = create_and_populate_var(
-        soma.DataFrame(uri=urljoin(measurement.uri, "var"))
+        soma.DataFrame(uri=os.path.join(measurement.uri, "var"))
     )
     measurement["X"] = soma.Collection(
-        uri=urljoin(measurement.uri, "X")
+        uri=os.path.join(measurement.uri, "X")
     ).create_legacy()
 
     nda = create_and_populate_sparse_nd_array(
-        soma.SparseNDArray(uri=urljoin(measurement.X.uri, "data"))
+        soma.SparseNDArray(uri=os.path.join(measurement.X.uri, "data"))
     )
     measurement.X.set("data", nda)
 

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,4 +1,4 @@
-import os
+from urllib.parse import urljoin
 
 import numpy as np
 import pyarrow as pa
@@ -89,23 +89,23 @@ def test_experiment_basic(tmp_path):
     experiment.create_legacy()
 
     experiment["obs"] = create_and_populate_obs(
-        soma.DataFrame(uri=os.path.join(basedir, "obs"))
+        soma.DataFrame(uri=urljoin(basedir + "/", "obs"))
     )
-    experiment["ms"] = soma.Collection(uri=os.path.join(basedir, "ms")).create_legacy()
+    experiment["ms"] = soma.Collection(uri=urljoin(basedir + "/", "ms")).create_legacy()
 
     measurement = soma.Measurement(uri=f"{experiment.ms.uri}/RNA")
     measurement.create_legacy()
     experiment.ms.set("RNA", measurement)
 
     measurement["var"] = create_and_populate_var(
-        soma.DataFrame(uri=os.path.join(measurement.uri, "var"))
+        soma.DataFrame(uri=urljoin(measurement.uri + "/", "var"))
     )
     measurement["X"] = soma.Collection(
-        uri=os.path.join(measurement.uri, "X")
+        uri=urljoin(measurement.uri + "/", "X")
     ).create_legacy()
 
     nda = create_and_populate_sparse_nd_array(
-        soma.SparseNDArray(uri=os.path.join(measurement.X.uri, "data"))
+        soma.SparseNDArray(uri=urljoin(measurement.X.uri + "/", "data"))
     )
     measurement.X.set("data", nda)
 


### PR DESCRIPTION
## Issue and/or context:

Prep-work for #821

## Changes:

```
>>> from urllib.parse import urljoin
>>> urljoin("A", "B")
'B'

>>> urljoin("A"+"/", "B")
'A/B'

>>> import os
>>> os.path.join("A", "B")
'A/B'
```

`urljoin` is confusing and error-prone. (Its use for unit tests tracks back to #381.). We should not use it for unit tests.

`os.path.join` is correct and trustworthy. We should use it for unit tests.

Barring that, we should work around the idiosyncracies of `urljoin`.