### PR TITLE
[r] Support iterated sparse and dense matrix reads

### DIFF
--- a/apis/r/tests/testthat/test_SOMAReader-Iterated.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Iterated.R
@@ -109,3 +109,51 @@ test_that("Iterated Interface from SOMA Classes", {
     }
 
 })
+
+test_that("Iterated Interface from SOMA Sparse Matrix", {
+    skip_if_not_installed("pbmc3k.tiledb")      # a Suggests: pre-package 3k PBMC data
+
+    tdir <- tempfile()
+    tgzfile <- system.file("raw-data", "soco-pbmc3k.tar.gz", package="pbmc3k.tiledb")
+    untar(tarfile = tgzfile, exdir = tdir)
+    uri <- file.path(tdir, "soco", "pbmc3k_processed", "ms", "RNA", "X", "data")
+
+    sdf <- SOMASparseNDArray$new(uri)
+    expect_true(inherits(sdf, "SOMAArrayBase"))
+
+    sdf$read_sparse_matrix(iterated = TRUE)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_equal(n, 6596)
+    expect_true(sdf$read_complete())
+
+    rm(sdf)
+
+})

--- a/apis/r/tests/testthat/test_SOMAReader-Iterated.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Iterated.R
@@ -157,3 +157,51 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
     rm(sdf)
 
 })
+
+test_that("Iterated Interface from SOMA Dense Matrix", {
+    skip_if_not_installed("pbmc3k.tiledb")      # a Suggests: pre-package 3k PBMC data
+
+    tdir <- tempfile()
+    tgzfile <- system.file("raw-data", "soco-pbmc3k.tar.gz", package="pbmc3k.tiledb")
+    untar(tarfile = tgzfile, exdir = tdir)
+    uri <- file.path(tdir, "soco", "pbmc3k_processed", "ms", "RNA", "X", "data")
+
+    sdf <- SOMADenseNDArray$new(uri)
+    expect_true(inherits(sdf, "SOMAArrayBase"))
+
+    sdf$read_dense_matrix(iterated = TRUE)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_false(sdf$read_complete())
+    dat <- sdf$read_next()
+    d <- dim(dat)
+    expect_equal(d[2], 1838)
+    n <- n + d[1]
+    expect_true(n > 0)
+
+    expect_equal(n, 2638)
+    expect_true(sdf$read_complete())
+
+    rm(sdf)
+
+})


### PR DESCRIPTION
#### Issue and/or context:

Additional read accessors in 'iterated' mode

#### Changes:

Support for iterated sparse matrices 

#### Notes for Reviewer:

Still flagged a draft for comment.  Test function may be best illustration.  Sparse matrix representation mode is cached locally. 

See https://app.shortcut.com/tiledb-inc/story/24951/support-iterated-sparse-matrix-reads