### PR TITLE
Pull the common parts of NDArrays into the base NDArray class.

### DIFF
--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -1,9 +1,6 @@
-"""Common code shared by both NDArray implementations.
+"""Common code shared by both NDArray implementations."""
 
-TODO: Extract more stuff.
-"""
-
-from typing import Optional, Sequence, Type, TypeVar
+from typing import Optional, Sequence, Tuple, Type, TypeVar, cast
 
 import numpy as np
 import pyarrow as pa
@@ -20,6 +17,8 @@ _Self = TypeVar("_Self", bound="NDArray")
 
 
 class NDArray(TileDBArray, somacore.NDArray):
+    """Abstract base for the common behaviors of both kinds of NDArray."""
+
     @classmethod
     def create(
         cls: Type[_Self],
@@ -51,6 +50,21 @@ class NDArray(TileDBArray, somacore.NDArray):
         )
         handle = cls._create_internal(uri, schema, context)
         return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Return length of each dimension, always a list of length ``ndim``
+        """
+        return cast(Tuple[int, ...], self._handle.reader.schema.domain.shape)
+
+    def reshape(self, shape: Tuple[int, ...]) -> None:
+        """
+        Unsupported operation for this object type.
+
+        [lifecycle: experimental]
+        """
+        raise NotImplementedError("reshape operation not implemented.")
 
 
 def build_tiledb_schema(

--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -3,15 +3,54 @@
 TODO: Extract more stuff.
 """
 
-from typing import Sequence
+from typing import Optional, Sequence, Type, TypeVar
 
 import numpy as np
 import pyarrow as pa
+import somacore
 import tiledb
+from somacore import options
 
 from . import util, util_arrow
 from .options.soma_tiledb_context import SOMATileDBContext
 from .options.tiledb_create_options import TileDBCreateOptions
+from .tiledb_array import TileDBArray
+
+_Self = TypeVar("_Self", bound="NDArray")
+
+
+class NDArray(TileDBArray, somacore.NDArray):
+    @classmethod
+    def create(
+        cls: Type[_Self],
+        uri: str,
+        *,
+        type: pa.DataType,
+        shape: Sequence[int],
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[SOMATileDBContext] = None,
+    ) -> _Self:
+        """
+        Create a SOMA ``NDArray`` named with the URI.
+
+        [lifecycle: experimental]
+
+        :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
+
+        :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the positive int64 range.
+
+        :param platform_config: Platform-specific options used to create this Array, provided via "tiledb"->"create" nested keys
+        """
+        context = context or SOMATileDBContext()
+        schema = build_tiledb_schema(
+            type,
+            shape,
+            TileDBCreateOptions.from_platform_config(platform_config),
+            context,
+            is_sparse=cls.is_sparse,
+        )
+        handle = cls._create_internal(uri, schema, context)
+        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
 
 
 def build_tiledb_schema(

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -1,59 +1,24 @@
-from typing import Optional, Sequence, cast
+from typing import Optional, cast
 
 import pyarrow as pa
 import somacore
 from somacore import options
 
 from . import util
-from .common_nd_array import build_tiledb_schema
+from .common_nd_array import NDArray
 from .exception import SOMAError
-from .options import SOMATileDBContext
-from .options.tiledb_create_options import TileDBCreateOptions
-from .tiledb_array import TileDBArray
 from .types import NTuple
 from .util import dense_indices_to_shape
 
 _UNBATCHED = options.BatchSize()
 
 
-class DenseNDArray(TileDBArray, somacore.DenseNDArray):
+class DenseNDArray(NDArray, somacore.DenseNDArray):
     """
     Represents ``X`` and others.
 
     [lifecycle: experimental]
     """
-
-    @classmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        type: pa.DataType,
-        shape: Sequence[int],
-        platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[SOMATileDBContext] = None,
-    ) -> "DenseNDArray":
-        """
-        Create a ``DenseNDArray`` named with the URI.
-
-        [lifecycle: experimental]
-
-        :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
-
-        :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the positive int64 range.
-
-        :param platform_config: Platform-specific options used to create this Array, provided via "tiledb"->"create" nested keys
-        """
-        context = context or SOMATileDBContext()
-        schema = build_tiledb_schema(
-            type,
-            shape,
-            TileDBCreateOptions.from_platform_config(platform_config),
-            context,
-            is_sparse=False,
-        )
-        handle = cls._create_internal(uri, schema, context)
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
 
     @property
     def shape(self) -> NTuple:

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -11,10 +11,9 @@ from somacore.options import PlatformConfig
 import tiledbsoma.libtiledbsoma as clib
 
 from . import util
-from .common_nd_array import build_tiledb_schema
+from .common_nd_array import NDArray, build_tiledb_schema
 from .options import SOMATileDBContext
 from .options.tiledb_create_options import TileDBCreateOptions
-from .tiledb_array import TileDBArray
 from .types import NTuple
 from .util_iter import (
     SparseCOOTensorReadIter,
@@ -26,7 +25,7 @@ from .util_iter import (
 _UNBATCHED = options.BatchSize()
 
 
-class SparseNDArray(TileDBArray, somacore.SparseNDArray):
+class SparseNDArray(NDArray, somacore.SparseNDArray):
     """
     Represents ``X`` and others.
 

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Optional, Sequence, Union, cast
+from typing import Optional, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -11,9 +11,7 @@ from somacore.options import PlatformConfig
 import tiledbsoma.libtiledbsoma as clib
 
 from . import util
-from .common_nd_array import NDArray, build_tiledb_schema
-from .options import SOMATileDBContext
-from .options.tiledb_create_options import TileDBCreateOptions
+from .common_nd_array import NDArray
 from .types import NTuple
 from .util_iter import (
     SparseCOOTensorReadIter,
@@ -31,53 +29,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
     [lifecycle: experimental]
     """
-
-    @classmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        type: pa.DataType,
-        shape: Sequence[int],
-        platform_config: Optional[PlatformConfig] = None,
-        context: Optional[SOMATileDBContext] = None,
-    ) -> "SparseNDArray":
-        """
-        Create a ``SparseNDArray`` named with the URI.
-
-        [lifecycle: experimental]
-
-        :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
-
-        :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the positive int64 range.
-
-        :param platform_config: Platform-specific options used to create this Array, provided via "tiledb"->"create" nested keys
-        """
-        context = context or SOMATileDBContext()
-        schema = build_tiledb_schema(
-            type,
-            shape,
-            TileDBCreateOptions.from_platform_config(platform_config),
-            context,
-            is_sparse=True,
-        )
-        handle = cls._create_internal(uri, schema, context)
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
-
-    @property
-    def shape(self) -> NTuple:
-        """
-        Return length of each dimension, always a list of length ``ndim``
-        """
-        return cast(NTuple, self._handle.reader.schema.domain.shape)
-
-    def reshape(self, shape: NTuple) -> None:
-        """
-        Unsupported operation for this object type.
-
-        [lifecycle: experimental]
-        """
-        raise NotImplementedError("reshape operation not implemented.")
 
     # Inherited from somacore
     # * ndim accessor


### PR DESCRIPTION
Eliminates some duplicate code and some redundant type-assertions/casts.