### PR TITLE
Add `add_new_collection` implementation.

### DIFF
--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -1,5 +1,3 @@
-from typing import Dict, Tuple
-
 from somacore import experiment
 
 from . import collection
@@ -21,7 +19,7 @@ class Experiment(  # type: ignore[misc]
     [lifecycle: experimental]
     """
 
-    _subclass_constrained_soma_types: Dict[str, Tuple[str, ...]] = {
+    _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
     }

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -1,5 +1,3 @@
-from typing import Dict, Tuple
-
 from somacore import measurement
 
 from .collection import CollectionBase
@@ -40,8 +38,8 @@ class Measurement(  # type: ignore[misc]
     [lifecycle: experimental]
     """
 
-    _subclass_constrained_soma_types: Dict[str, Tuple[str, ...]] = {
-        "var": ("SOMADataFrame", "SOMADataFrame"),
+    _subclass_constrained_soma_types = {
+        "var": ("SOMADataFrame",),
         "X": ("SOMACollection",),
         "obsm": ("SOMACollection",),
         "obsp": ("SOMACollection",),

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -63,6 +63,11 @@ def make_relative_path(uri: str, relative_to: str) -> str:
     return relpath
 
 
+def is_relative_uri(uri: str) -> bool:
+    """Detects whether a provided URI is a child relative URI to the parent."""
+    return "://" not in uri and not uri.startswith("/")
+
+
 def uri_joinpath(base: str, path: str) -> str:
     """
     Join a path to a URI.

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -144,14 +144,15 @@ def test_collection_mapping(soma_object, tmp_path):
 
 
 @pytest.mark.parametrize("relative", [False, True])
-def test_collection_repr(tmp_path, relative):
+def test_collection_repr(tmp_path, relative) -> None:
     a = soma.Collection.create((tmp_path / "A").as_uri())
     assert a.uri == (tmp_path / "A").as_uri()
 
-    b = soma.Collection.create((tmp_path / "A" / "B").as_uri())
+    b_uri = "B" if relative else (tmp_path / "A" / "B").as_uri()
+    b = a.add_new_collection("Another_Name", uri=b_uri)
+
     assert b.uri == (tmp_path / "A" / "B").as_uri()
 
-    a.set("Another_Name", b, use_relative_uri=relative)
     assert list(a.keys()) == ["Another_Name"]
     assert (
         a.__repr__()

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -89,17 +89,15 @@ def test_experiment_basic(tmp_path):
     experiment = soma.Experiment.create(basedir)
 
     experiment["obs"] = create_and_populate_obs(urljoin(basedir, "obs"))
-    experiment["ms"] = soma.Collection.create(urljoin(basedir, "ms"))
-
-    measurement = soma.Measurement.create(f"{experiment.ms.uri}/RNA")
-    experiment.ms.set("RNA", measurement)
+    ms = experiment.add_new_collection("ms", soma.Collection)
+    measurement = ms.add_new_collection("RNA", soma.Measurement)
 
     measurement["var"] = create_and_populate_var(urljoin(measurement.uri, "var"))
 
-    measurement["X"] = soma.Collection.create(urljoin(measurement.uri, "X"))
+    x = measurement.add_new_collection("X")
 
-    nda = create_and_populate_sparse_nd_array(urljoin(measurement.X.uri, "data"))
-    measurement.X.set("data", nda, use_relative_uri=False)
+    nda = create_and_populate_sparse_nd_array(urljoin(x.uri, "data"))
+    x.set("data", nda, use_relative_uri=False)
 
     # ----------------------------------------------------------------
     assert len(experiment) == 2

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -747,13 +747,10 @@ def make_experiment(
 
     with soma.Experiment.create((root / "exp").as_posix()) as exp:
         exp.obs = obs
-        with soma.Collection.create((root / "ms").as_posix()) as ms:
-            exp.ms = ms
-            with soma.Measurement.create(f"{ms.uri}/RNA") as rna:
-                ms["RNA"] = rna
+        with exp.add_new_collection("ms") as ms:
+            with ms.add_new_collection("RNA", soma.Measurement) as rna:
                 rna.var = var
-                with soma.Collection.create(f"{rna.uri}/X") as rna_x:
-                    rna.X = rna_x
+                with rna.add_new_collection("X", soma.Collection) as rna_x:
                     for X_layer_name in X_layer_names:
                         path = root / "X" / X_layer_name
                         path.mkdir(parents=True)
@@ -761,26 +758,16 @@ def make_experiment(
                             rna_x[X_layer_name] = arr
 
                 if obsp_layer_names:
-                    (root / "obsp").mkdir()
-                    with soma.Collection.create(f"{rna.uri}/obsp") as obsp:
-                        rna.obsp = obsp
+                    with rna.add_new_collection("obsp") as obsp:
                         for obsp_layer_name in obsp_layer_names:
-                            path = root / "obsp" / obsp_layer_name
-                            path.mkdir()
-                            with make_sparse_array(
-                                path.as_posix(), (n_obs, n_obs)
-                            ) as arr:
+                            obsp_path = f"{obsp.uri}/{obsp_layer_name}"
+                            with make_sparse_array(obsp_path, (n_obs, n_obs)) as arr:
                                 obsp[obsp_layer_name] = arr
 
                 if varp_layer_names:
-                    (root / "varp").mkdir()
-                    with soma.Collection.create(f"{rna.uri}/varp") as varp:
-                        rna.varp = varp
+                    with rna.add_new_collection("varp") as varp:
                         for varp_layer_name in varp_layer_names:
-                            path = root / "varp" / varp_layer_name
-                            path.mkdir()
-                            with make_sparse_array(
-                                path.as_posix(), (n_vars, n_vars)
-                            ) as arr:
+                            varp_path = f"{varp.uri}/{varp_layer_name}"
+                            with make_sparse_array(varp_path, (n_vars, n_vars)) as arr:
                                 varp[varp_layer_name] = arr
     return factory.open((root / "exp").as_posix())


### PR DESCRIPTION
This adds, in three steps, the `add_new_collection` implementation to Collection. The use of a relative vs. absolute URI is derived from the URI passed into the function (if it's relative, it's relative, if it's absolute, it's absolute). This does not currently support adding to a collection stored on TileDB Cloud without a URI specified.

As I understand it, because the `io.from_whatever` functions all generated their own URIs of the form `parent_uri/child_name`, this was never going to work with groups/arrays stored on TileDB Cloud, because it would try to generate a URI that looked like `tiledb://some_ns/some_group/child_name`, which is not allowed. This meant the `use_relative_uri` function was moot inside those functions anyway, since you can’t actually do the thing you want to use absolute URIs for. Is this understanding correct?