### PR TITLE
Remove `__eq__` method from base `TileDBObject` class.

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -68,12 +68,6 @@ class TileDBObject(somacore.SOMAObject, Generic[_HandleType]):
     def __repr__(self) -> str:
         return f'{self.soma_type}(uri="{self.uri}")'
 
-    # TODO: This is dangerous; two objects with the same URI may be different.
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, TileDBObject):
-            return False
-        return self.uri == other.uri
-
     @property
     def uri(self) -> str:
         """


### PR DESCRIPTION
Because SOMA objects have a lot of complex state, saying that they have the same URI isn't really enough for equality, and the existence of the `__eq__` method is more likely to cause confusion if the user has two separate handles open on the same backing object.