### PR TITLE
[python] Track ownership of accessed and added collection members.

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -164,6 +164,8 @@ class CollectionBase(
         self._set_element(
             key, cast(CollectionElementType, new_group), use_relative_uri=was_relative
         )
+        # Since we own this object, set it to be closed when we are closed.
+        self._close_stack.enter_context(new_group)
         return new_group
 
     def _not_implemented(self, *args: Any, **kwargs: Any) -> NoReturn:
@@ -209,6 +211,8 @@ class CollectionBase(
                 tiledb_type=storage_type,
                 soma_type=None,
             )
+            # Since we just opened this object, we own it and should close it.
+            self._close_stack.enter_context(entry.soma)
         return cast(CollectionElementType, entry.soma)
 
     def set(

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -45,7 +45,14 @@ class TileDBObject(somacore.SOMAObject, Generic[_HandleType]):
         self._handle = handle
         self._metadata = MetadataMapping(self._handle)
         self._close_stack = ExitStack()
+        """An exit stack to manage closing handles owned by this object.
+
+        This is used to manage both our direct handle (in the case of simple
+        TileDB objects) and the lifecycle of owned children (in the case of
+        Collections).
+        """
         self._close_stack.enter_context(self._handle)
+        self._closed = False
 
     _STORAGE_TYPE: StorageType
     _tiledb_type: ClassVar[Type[TDBHandle]]
@@ -81,6 +88,12 @@ class TileDBObject(somacore.SOMAObject, Generic[_HandleType]):
         no-op.
         """
         self._close_stack.close()
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        """True if the object has been closed. False if it is still open."""
+        return self._closed
 
     @property
     def mode(self) -> options.OpenMode:

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -747,27 +747,27 @@ def make_experiment(
 
     with soma.Experiment.create((root / "exp").as_posix()) as exp:
         exp.obs = obs
-        with exp.add_new_collection("ms") as ms:
-            with ms.add_new_collection("RNA", soma.Measurement) as rna:
-                rna.var = var
-                with rna.add_new_collection("X", soma.Collection) as rna_x:
-                    for X_layer_name in X_layer_names:
-                        path = root / "X" / X_layer_name
-                        path.mkdir(parents=True)
-                        with make_sparse_array(path.as_posix(), (n_obs, n_vars)) as arr:
-                            rna_x[X_layer_name] = arr
+        ms = exp.add_new_collection("ms")
+        rna = ms.add_new_collection("RNA", soma.Measurement)
+        rna.var = var
+        rna_x = rna.add_new_collection("X", soma.Collection)
+        for X_layer_name in X_layer_names:
+            path = root / "X" / X_layer_name
+            path.mkdir(parents=True)
+            with make_sparse_array(path.as_posix(), (n_obs, n_vars)) as arr:
+                rna_x[X_layer_name] = arr
 
-                if obsp_layer_names:
-                    with rna.add_new_collection("obsp") as obsp:
-                        for obsp_layer_name in obsp_layer_names:
-                            obsp_path = f"{obsp.uri}/{obsp_layer_name}"
-                            with make_sparse_array(obsp_path, (n_obs, n_obs)) as arr:
-                                obsp[obsp_layer_name] = arr
+        if obsp_layer_names:
+            obsp = rna.add_new_collection("obsp")
+            for obsp_layer_name in obsp_layer_names:
+                obsp_path = f"{obsp.uri}/{obsp_layer_name}"
+                with make_sparse_array(obsp_path, (n_obs, n_obs)) as arr:
+                    obsp[obsp_layer_name] = arr
 
-                if varp_layer_names:
-                    with rna.add_new_collection("varp") as varp:
-                        for varp_layer_name in varp_layer_names:
-                            varp_path = f"{varp.uri}/{varp_layer_name}"
-                            with make_sparse_array(varp_path, (n_vars, n_vars)) as arr:
-                                varp[varp_layer_name] = arr
+        if varp_layer_names:
+            varp = rna.add_new_collection("varp")
+            for varp_layer_name in varp_layer_names:
+                varp_path = f"{varp.uri}/{varp_layer_name}"
+                with make_sparse_array(varp_path, (n_vars, n_vars)) as arr:
+                    varp[varp_layer_name] = arr
     return factory.open((root / "exp").as_posix())


### PR DESCRIPTION
Collections are now responsible for the lifecycle of elements created using `collection.add_new_whatever` and items accessed through `collection["something"]`. This allows close operations to cascade from parent to child and allows a coherent API structure where the user opens a collection, has access to everything inside, and closes everything when they close the collection.

Part of #843.

Huge shout-out to @mlin for introducing `ExitStack`, which I had not heard of before, and which made this work almost trivial.