### PR TITLE
[python] Add `add_new_dataframe` and `_sparse`/`_dense_ndarray`

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -233,7 +233,10 @@ class CollectionBase(
         self._close_stack.enter_context(new_arr)
         return new_arr
 
-    # These are both correct but mypy doesn't get it.
+    # These user-facing functions forward all parameters directly to
+    # self._add_new_ndarray, with the specific class type substituted in the
+    # first parameter, but without having to duplicate the entire arg list.
+    # (mypy doesn't yet understand that these are of the correct type.)
     add_new_dense_ndarray = functools.partialmethod(  # type: ignore[assignment]
         _add_new_ndarray, DenseNDArray
     )

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -225,7 +225,7 @@ class CollectionBase(
             platform_config=platform_config,
             context=self.context,
         )
-        # A NDArray might not be the declared type of this collection,
+        # An NDArray might not be the declared type of this collection,
         # but we can't really handle that within the type system.
         self._set_element(
             key, new_arr, use_relative_uri=was_relative  # type: ignore[arg-type]

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -161,9 +161,9 @@ class CollectionBase(
     ) -> "AnyTileDBCollection":
         if key in self:
             raise KeyError(f"{key!r} already exists in {type(self)}")
-        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         child_cls = cls or Collection  # set the default
         self._check_allows_child(key, child_cls)
+        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         # mypy gets confused by the inferred union type of child_cls,
         # but this is valid.
         new_group: CollectionBase[Any] = child_cls.create(  # type: ignore[misc]
@@ -187,8 +187,8 @@ class CollectionBase(
     ) -> DataFrame:
         if key in self:
             raise KeyError(f"{key!r} already exists in {type(self)}")
-        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         self._check_allows_child(key, DataFrame)
+        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         new_df = DataFrame.create(
             absolute_uri,
             index_column_names=index_column_names,
@@ -216,8 +216,8 @@ class CollectionBase(
     ) -> _NDArr:
         if key in self:
             raise KeyError(f"{key!r} already exists in {type(self)}")
-        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         self._check_allows_child(key, cls)
+        absolute_uri, was_relative = self._new_absolute_uri(key=key, uri=uri)
         new_arr = cls.create(
             absolute_uri,
             type=type,

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -240,9 +240,19 @@ class CollectionBase(
     add_new_dense_ndarray = functools.partialmethod(  # type: ignore[assignment]
         _add_new_ndarray, DenseNDArray
     )
+    """Creates a new dense NDArray as a child of this collection.
+
+    Parameters are as in :meth:`DenseNDArray.create`.
+    See :meth:`add_new_collection` for details about child creation.
+    """
     add_new_sparse_ndarray = functools.partialmethod(  # type: ignore[assignment]
         _add_new_ndarray, SparseNDArray
     )
+    """Creates a new sparse NDArray as a child of this collection.
+
+    Parameters are as in :meth:`SparseNDArray.create`.
+    See :meth:`add_new_collection` for details about child creation.
+    """
 
     def __len__(self) -> int:
         """

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -220,8 +220,18 @@ def test_cascading_close(tmp_path: pathlib.Path):
         dog = outer.add_new_collection("dog")
         spitz = dog.add_new_collection("spitz")
         akita = spitz.add_new_collection("akita")
+        hachiko = akita.add_new_dense_ndarray(
+            "hachiko", type=pa.float64(), shape=(1, 2, 3)
+        )
         shiba = spitz.add_new_collection("shiba")
+        kabosu = shiba.add_new_sparse_ndarray("kabosu", type=pa.uint8(), shape=(10,))
         mutt = dog.add_new_collection("mutt")
+        louis = mutt.add_new_dataframe(
+            "louis",
+            schema=pa.schema(
+                (("soma_joinid", pa.int64()), ("stripes", pa.large_string()))
+            ),
+        )
 
         # A mix of collections we own and collections we don't own
         unowned_path = tmp_path / "unowned"
@@ -238,8 +248,11 @@ def test_cascading_close(tmp_path: pathlib.Path):
             dog,
             spitz,
             akita,
+            hachiko,
             shiba,
+            kabosu,
             mutt,
+            louis,
             bird,
             raptor,
             un_eagle,
@@ -249,7 +262,7 @@ def test_cascading_close(tmp_path: pathlib.Path):
             assert not elem.closed
 
     # Owned children should be closed
-    for elem in (dog, spitz, akita, shiba, mutt, bird, raptor):
+    for elem in (dog, spitz, akita, hachiko, shiba, kabosu, mutt, louis, bird, raptor):
         assert elem.closed
     # Unowned children should not be closed
     for elem in (un_eagle, un_eagle_golden, un_corvid):
@@ -276,7 +289,7 @@ def test_cascading_close(tmp_path: pathlib.Path):
         # Accessing all of these results in reifying a SOMA object.
         # All of these are owned.
         crawl(reopened)
-        assert len(all_elements) == 11
+        assert len(all_elements) == 14
         assert not any(elem.closed for elem in all_elements)
 
         # Closing part of the subtree is fine (though not typical).


### PR DESCRIPTION
This completes the `add_new_` methods to allow users to add not just collections but also data objects.  Just like `add_new_collection`, the newly-added members' lifecycle is owned by the collection itself.