### PR TITLE
[python] Support indices of type `bytes`

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -186,10 +186,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 dim_name = arr.schema.domain.dim(i).name
                 if dim_coords is None:
                     pass  # No constraint; select all in this dimension
-                elif isinstance(dim_coords, int) or isinstance(dim_coords, str):
-                    # TO DO: Support index types other than int and string when we have support
-                    # in libtiledbsoma's SOMAReader. See also
-                    # https://github.com/single-cell-data/TileDB-SOMA/issues/419
+                elif isinstance(dim_coords, (int, str, bytes)):
                     sr.set_dim_points(dim_name, [dim_coords])
                 elif isinstance(dim_coords, np.ndarray):
                     if dim_coords.ndim != 1:
@@ -298,9 +295,6 @@ def _canonicalize_schema(
             raise ValueError(
                 f"All index names must be dataframe schema: '{index_column_name}' not in {schema_names_string}"
             )
-        # TODO: Pending
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/418
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/419
         if schema.field(index_column_name).type not in [
             pa.int8(),
             pa.uint8(),
@@ -312,10 +306,14 @@ def _canonicalize_schema(
             pa.uint64(),
             pa.float32(),
             pa.float64(),
+            pa.binary(),
+            pa.large_binary(),
             pa.string(),
             pa.large_string(),
         ]:
-            raise TypeError("Unsupported index type - pending fix #418 and #419")
+            raise TypeError(
+                f"Unsupported index type {schema.field(index_column_name).type}"
+            )
 
     return schema
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -342,12 +342,8 @@ def make_dataframe(request):
         pa.uint64(),
         pa.string(),
         pa.large_string(),
-        pytest.param(
-            pa.binary(), marks=pytest.mark.xfail
-        ),  # TODO: remove xfail when #419 is fixed
-        pytest.param(
-            pa.large_binary(), marks=pytest.mark.xfail
-        ),  # TODO: remove xfail when #419 is fixed
+        pa.binary(),
+        pa.large_binary(),
     ],
     indirect=True,
 )
@@ -365,9 +361,8 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
     """
     schema = pa.schema(
         [
-            # TO DO: Support other index types when we have support for more than int and string
-            # index types in libtiledbsoma's SOMAReader. See also
-            # https://github.com/single-cell-data/TileDB-SOMA/issues/419.
+            # TO DO: Support other index types when we have support for more than int and string/bytes
+            # index types in libtiledbsoma's SOMAReader.
             ("index1", pa.int64()),
             ("index2", pa.string()),
             ("index3", pa.int64()),
@@ -620,8 +615,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
             "throws": None,
         },
         # 2D: indexing slot is list
-        # TODO: at present SOMAReader only accepts int and string dims. See also:
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/419
+        # TODO: at present SOMAReader only accepts int and string/byte dims.
         {
             "index_column_names": ["index2", "index3"],
             "coords": [["aaa", "ccc"], None],


### PR DESCRIPTION
## Issue and/or context:

#419

## Changes:

All core-level support now exists. This is just a matter of un-xfailing the relevant unit-test cases.