### PR TITLE
Fix `__del__` error when improperly constructing a TileDB object.

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -85,7 +85,10 @@ class CollectionBase(
         tiledb.group_create(uri=uri, ctx=context.tiledb_ctx)
         handle = ReadWriteHandle.open_group(uri, "w", context)
         cls._set_create_metadata(handle)
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
+        return cls(
+            handle,
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+        )
 
     @classmethod
     def open(
@@ -101,7 +104,10 @@ class CollectionBase(
         context = context or SOMATileDBContext()
         handle = ReadWriteHandle.open_group(uri, mode, context)
         # TODO: Verify that we have the right type using metadata.
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
+        return cls(
+            handle,
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+        )
 
     # Subclass protocol to constrain which SOMA objects types  may be set on a
     # particular collection key. Used by Experiment and Measurement.
@@ -111,9 +117,12 @@ class CollectionBase(
         self,
         handle: ReadWriteHandle[tiledb.Group],
         *,
-        _this_is_internal_only: str = "",
+        _dont_call_this_use_create_or_open_instead: str = "",
     ):
-        super().__init__(handle, _this_is_internal_only=_this_is_internal_only)
+        super().__init__(
+            handle,
+            _dont_call_this_use_create_or_open_instead=_dont_call_this_use_create_or_open_instead,
+        )
         self._cached_group_contents: Optional[Dict[str, _CachedElement]] = None
         """The contents of the persisted TileDB Group, cached for performance.
 

--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -49,7 +49,10 @@ class NDArray(TileDBArray, somacore.NDArray):
             is_sparse=cls.is_sparse,
         )
         handle = cls._create_internal(uri, schema, context)
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
+        return cls(
+            handle,
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+        )
 
     @property
     def shape(self) -> Tuple[int, ...]:

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -62,7 +62,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         return cls(
             handle,
             _index_column_names=tuple(index_column_names),
-            _this_is_internal_only="tiledbsoma-internal-code",
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 
     def __init__(
@@ -71,9 +71,12 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         *,
         # Hints to pre-fill cache entries.
         _index_column_names: Optional[Tuple[str, ...]] = None,
-        _this_is_internal_only: str = "",
+        _dont_call_this_use_create_or_open_instead: str = "",
     ):
-        super().__init__(handle, _this_is_internal_only=_this_is_internal_only)
+        super().__init__(
+            handle,
+            _dont_call_this_use_create_or_open_instead=_dont_call_this_use_create_or_open_instead,
+        )
         self._index_column_names = _index_column_names
         """Cache for the index column names."""
 

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -149,7 +149,10 @@ def _open_array(
             raise TypeError(f"stored data is {cls}; expected {want_type}")
         return cast(
             _Arr,
-            cls(handle, _this_is_internal_only="tiledbsoma-internal-code"),
+            cls(
+                handle,
+                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+            ),
         )
     except Exception:
         handle.close()
@@ -172,7 +175,10 @@ def _open_group(
             raise TypeError(f"stored data is {cls}; expected {want_type}")
         return cast(
             _Coll,
-            cls(handle, _this_is_internal_only="tiledbsoma-internal-code"),
+            cls(
+                handle,
+                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+            ),
         )
     except Exception:
         handle.close()

--- a/apis/python/src/tiledbsoma/tiledb_array.py
+++ b/apis/python/src/tiledbsoma/tiledb_array.py
@@ -37,7 +37,10 @@ class TileDBArray(TileDBObject[tiledb.Array]):
         context = context or SOMATileDBContext()
         handle = ReadWriteHandle.open_array(uri, mode, context)
 
-        return cls(handle, _this_is_internal_only="tiledbsoma-internal-code")
+        return cls(
+            handle,
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+        )
 
     _STORAGE_TYPE = "array"
 


### PR DESCRIPTION
Context: #860.

If a user called

    something = tiledbsoma.Experiment(whatever)

after they got the expected exception saying "use the factory method instead", they would also get an unexpected error from the `__del__` method of the SOMA object.

This change:
- Eliminates the `__del__` error
- Improves the error message you get from improper construction
- Makes the secret key parameter name even more descriptive.