### PR TITLE
[python] Directly use backend TileDB dimension names for `DataFrame`

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -61,24 +61,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         handle = cls._create_internal(uri, tdb_schema, context)
         return cls(
             handle,
-            _index_column_names=tuple(index_column_names),
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
-
-    def __init__(
-        self,
-        handle: tiledb.Array,
-        *,
-        # Hints to pre-fill cache entries.
-        _index_column_names: Optional[Tuple[str, ...]] = None,
-        _dont_call_this_use_create_or_open_instead: str = "",
-    ):
-        super().__init__(
-            handle,
-            _dont_call_this_use_create_or_open_instead=_dont_call_this_use_create_or_open_instead,
-        )
-        self._index_column_names = _index_column_names
-        """Cache for the index column names."""
 
     def keys(self) -> Tuple[str, ...]:
         """
@@ -93,11 +77,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         """
         Return index (dimension) column names.
         """
-        # If we've cached the answer, skip the storage read. Especially if the storage is on the
-        # cloud, where we'll avoid an HTTP request.
-        if self._index_column_names is None:
-            self._index_column_names = self._tiledb_dim_names()
-        return self._index_column_names
+        return self._tiledb_dim_names()
 
     @property
     def count(self) -> int:

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -219,7 +219,7 @@ def _read_soma_type(hdl: ReadWriteHandle[TDBHandle]) -> str:
 
 def _to_array_class(name: str) -> Type["tiledb_array.TileDBArray"]:
     options: Dict[str, Type[tiledb_array.TileDBArray]] = {
-        cls.soma_type.lower(): cls  # type: ignore[attr-defined,misc]
+        cls.soma_type.lower(): cls
         for cls in (
             dataframe.DataFrame,
             dense_nd_array.DenseNDArray,


### PR DESCRIPTION
We were pre-caching the dimension names for the DataFrame because we were previously opening and closing the TileDB array handle (if it was not already open) when they were requested. However, since we now have a long-lived handle that we keep around, that is no longer needed.

---

Based on @bkmartinjr’s [a comment on an earlier review](https://github.com/single-cell-data/TileDB-SOMA/pull/824#discussion_r1089607732):

> I'm not sure caching the index column names makes any sense given the change to stateful handles. I believe that it was originally put in place to avoid repeated calls to open on the array (just to get the dimension names). With an open handle guaranteed, getting dim names is cheap, ergo caching is not worth the complexity.