### PR TITLE
[python] Fix ingest to cloud URIs (part 1 of 2)

### DIFF
--- a/apis/python/src/tiledbsoma/util_tiledb.py
+++ b/apis/python/src/tiledbsoma/util_tiledb.py
@@ -84,7 +84,12 @@ def is_does_not_exist_error(e: tiledb.TileDBError) -> bool:
     stre = str(e)
     # Local-disk/S3 does-not-exist exceptions say 'Group does not exist'; TileDB Cloud
     # does-not-exist exceptions are worded less clearly.
-    if "does not exist" in stre or "HTTP code 401" in stre:
+    if (
+        "does not exist" in stre
+        or "Unrecognized array" in stre
+        or "HTTP code 401" in stre
+        or "HTTP code 404" in stre
+    ):
         return True
 
     return False


### PR DESCRIPTION
## Issue and/or context:

In conjunction with #863, this allows ingest to tiledb-cloud URIs to again succeed.

```
uri = 'tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch/test-cloud-20230201'
soma = tiledbsoma.SOMA(uri)
tiledbsoma.io.from_h5ad(soma, '/tmp/test.h5ad')
```

Note this test scenario does not pass until and unless #863 is also included. I'm putting this up as a PR on `main` instead of atop #863 at the explicit request of @thetorpedodog .

## Note

Since this is an open-source package we do not have unit tests taking the `tiledb.cloud` dependency.