### PR TITLE
[python] No allow-duplicates for sparse N-d arrays

### DIFF
--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -122,11 +122,13 @@ def build_tiledb_schema(
 
     cell_order, tile_order = create_options.cell_tile_orders()
 
+    # TODO: accept more TileDB array-schema options from create_options
+    # https://github.com/single-cell-data/TileDB-SOMA/issues/876
     return tiledb.ArraySchema(
         domain=dom,
         attrs=attrs,
         sparse=is_sparse,
-        allows_duplicates=is_sparse,
+        allows_duplicates=False,
         offsets_filters=create_options.offsets_filters(),
         capacity=create_options.get("capacity", 100000),
         tile_order=tile_order,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -41,6 +41,10 @@ def test_dense_nd_array_create_ok(
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
 
+    # Validate TileDB array schema
+    with tiledb.open(tmp_path.as_posix()) as A:
+        assert not A.schema.sparse
+
 
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
@@ -72,6 +76,10 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
 
         t = b.read((slice(None),) * ndim, result_order="column-major")
         assert t.equals(pa.Tensor.from_numpy(data.transpose()))
+
+    # Validate TileDB array schema
+    with tiledb.open(tmp_path.as_posix()) as A:
+        assert not A.schema.sparse
 
     # write a single-value sub-array and recheck
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as c:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -258,6 +258,11 @@ def test_sparse_nd_array_read_write_sparse_tensor(
 
         assert t.shape == shape
 
+    # Validate TileDB array schema
+    with tiledb.open(tmp_path.as_posix()) as A:
+        assert A.schema.sparse
+        assert not A.schema.allows_duplicates
+
 
 @pytest.mark.parametrize("shape", [(10,), (23, 4), (5, 3, 1), (8, 4, 2, 30)])
 @pytest.mark.parametrize("test_enumeration", range(10))
@@ -277,6 +282,11 @@ def test_sparse_nd_array_read_write_table(
     t = next(b.read((slice(None),) * len(shape)).tables())
     assert isinstance(t, pa.Table)
     assert tables_are_same_value(data, t)
+
+    # Validate TileDB array schema
+    with tiledb.open(tmp_path.as_posix()) as A:
+        assert A.schema.sparse
+        assert not A.schema.allows_duplicates
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
@@ -302,6 +312,11 @@ def test_sparse_nd_array_read_as_pandas(
     assert df.sort_values(by=dim_names, ignore_index=True).equals(
         data.to_pandas().sort_values(by=dim_names, ignore_index=True)
     )
+
+    # Validate TileDB array schema
+    with tiledb.open(tmp_path.as_posix()) as A:
+        assert A.schema.sparse
+        assert not A.schema.allows_duplicates
 
 
 def test_empty_read(tmp_path):


### PR DESCRIPTION
## Issue and/or context:

Fixes #875

## Changes:

Undoes the inadvertent https://github.com/single-cell-data/TileDB-SOMA/pull/681/commits/fa08391e68cc1555275a92362c1971c189c9acab#diff-c57e3497da1ff73a9f6544da46c2129f132e4c4a73dbc4c96ee972d9fb3bdf39L112

## Notes for Reviewer:

Does not address #876, which will be handled on a separate PR.