### PR TITLE
Pull in `somacore==0.0.0a12` and associated improvements.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs"
-        - "somacore==0.0.0a10"
+        - "somacore==0.0.0a12"
         - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -182,7 +182,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a10",
+        "somacore==0.0.0a12",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -1,7 +1,4 @@
-# TODO: once we've merged somacore 0.0.0a12, change this to
-# from somacore import AxisColumnNames, AxisQuery, ExperimentAxisQuery
-from somacore import AxisQuery, ExperimentAxisQuery
-from somacore.query.query import AxisColumnNames
+from somacore import AxisColumnNames, AxisQuery, ExperimentAxisQuery
 
 from .collection import Collection
 from .dataframe import DataFrame

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     ClassVar,
     Dict,
-    Generic,
     Iterator,
     List,
     Optional,
@@ -22,6 +21,7 @@ from typing import (
 import attrs
 import pyarrow as pa
 import somacore
+import somacore.collection
 import tiledb
 from somacore import options
 
@@ -54,8 +54,7 @@ class _CachedElement:
 
 class CollectionBase(
     TileDBObject[tdb_handles.GroupWrapper],
-    somacore.Collection[CollectionElementType],
-    Generic[CollectionElementType],
+    somacore.collection.BaseCollection[CollectionElementType],
 ):
     """
     Contains a key-value mapping where the keys are string names and the values
@@ -437,7 +436,9 @@ class CollectionBase(
 AnyTileDBCollection = CollectionBase[AnyTileDBObject]
 
 
-class Collection(CollectionBase[CollectionElementType], Generic[CollectionElementType]):
+class Collection(
+    CollectionBase[CollectionElementType], somacore.Collection[CollectionElementType]
+):
     """
     A persistent collection of SOMA objects, mapping string keys to any SOMA object.
 

--- a/apis/python/src/tiledbsoma/experiment.py
+++ b/apis/python/src/tiledbsoma/experiment.py
@@ -1,12 +1,18 @@
 from somacore import experiment
 
-from . import collection
+from .collection import Collection, CollectionBase
+from .dataframe import DataFrame
+from .measurement import Measurement
 from .tiledb_object import AnyTileDBObject
 
 
-class Experiment(  # type: ignore[misc]
-    experiment.Experiment[AnyTileDBObject],
-    collection.AnyTileDBCollection,
+class Experiment(
+    CollectionBase[AnyTileDBObject],
+    experiment.Experiment[  # type: ignore[type-var]
+        DataFrame,
+        Collection[Measurement],
+        AnyTileDBObject,
+    ],
 ):
     """
     ``obs``: Primary annotations on the observation axis. The contents of the

--- a/apis/python/src/tiledbsoma/io.py
+++ b/apis/python/src/tiledbsoma/io.py
@@ -580,7 +580,7 @@ def add_matrix_to_collection(
 
     Use `ingest_mode="resume"` to not error out if the schema already exists.
     """
-    with cast(Measurement, exp.ms[measurement_name]) as meas:
+    with exp.ms[measurement_name] as meas:
         if collection_name in meas:
             coll = cast(Collection[RawHandle], meas[collection_name])
         else:
@@ -983,7 +983,7 @@ def to_anndata(
     s = util.get_start_stamp()
     logging.log_io(None, "START  Experiment.to_anndata")
 
-    measurement = cast(Measurement, experiment.ms[measurement_name])
+    measurement = experiment.ms[measurement_name]
 
     obs_df = experiment.obs.read().concat().to_pandas()
     obs_df.drop([SOMA_JOINID], axis=1, inplace=True)

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -1,12 +1,22 @@
 from somacore import measurement
 
-from .collection import CollectionBase
+from .collection import Collection, CollectionBase
+from .common_nd_array import NDArray
+from .dataframe import DataFrame
+from .dense_nd_array import DenseNDArray
+from .sparse_nd_array import SparseNDArray
 from .tiledb_object import AnyTileDBObject
 
 
-class Measurement(  # type: ignore[misc]
-    measurement.Measurement[AnyTileDBObject],
+class Measurement(
     CollectionBase[AnyTileDBObject],
+    measurement.Measurement[  # type: ignore[type-var]
+        DataFrame,
+        Collection[NDArray],
+        Collection[DenseNDArray],
+        Collection[SparseNDArray],
+        AnyTileDBObject,
+    ],
 ):
     """
     A ``Measurement`` is a sub-element of a ``Experiment``, and is otherwise a specialized ``Collection`` with pre-defined fields:


### PR DESCRIPTION
- Enforces use of object-identity–based equality for SOMA collections.
- Adds support for `bytes` and `str` in experiment axis queries.
- Improves type annotations for better static analysis.