### PR TITLE
[python] Capture stdout/stderr from `stats_dump` output

### DIFF
--- a/apis/python/tests/test_util_tiledb.py
+++ b/apis/python/tests/test_util_tiledb.py
@@ -1,13 +1,29 @@
+import pyarrow as pa
 import pytest
 
 import tiledbsoma
 
 
-def test_stats(capfd: pytest.CaptureFixture[str]):
+def test_stats(tmp_path, capfd: pytest.CaptureFixture[str]):
     """Make sure these exist, don't throw, and write correctly."""
     tiledbsoma.stats_enable()
-    tiledbsoma.stats_dump()
     tiledbsoma.stats_reset()
+
+    schema = pa.schema([("soma_joinid", pa.int64())])
+    with tiledbsoma.DataFrame.create(
+        tmp_path.as_posix(),
+        schema=schema,
+        index_column_names=["soma_joinid"],
+    ) as sidf:
+        data = {
+            "soma_joinid": [0],
+        }
+        sidf.write(pa.Table.from_pydict(data))
+
+    with tiledbsoma.DataFrame.open(tmp_path.as_posix()) as sidf:
+        sidf.read().concat()
+
+    tiledbsoma.stats_dump()
     tiledbsoma.stats_disable()
     stdout, stderr = capfd.readouterr()
     assert stdout != ""

--- a/apis/python/tests/test_util_tiledb.py
+++ b/apis/python/tests/test_util_tiledb.py
@@ -1,9 +1,14 @@
+import pytest
+
 import tiledbsoma
 
 
-def test_stats():
-    """Make sure these exist and don't throw"""
+def test_stats(capfd: pytest.CaptureFixture[str]):
+    """Make sure these exist, don't throw, and write correctly."""
     tiledbsoma.stats_enable()
     tiledbsoma.stats_dump()
     tiledbsoma.stats_reset()
     tiledbsoma.stats_disable()
+    stdout, stderr = capfd.readouterr()
+    assert stdout != ""
+    assert stderr == ""

--- a/libtiledbsoma/test/test_soma_reader.py
+++ b/libtiledbsoma/test/test_soma_reader.py
@@ -174,8 +174,6 @@ def test_soma_reader_dim_mixed():
 def test_soma_reader_obs_slice_x():
     """Read X/data sliced by obs."""
 
-    clib.stats_enable()
-
     # read obs
     # ---------------------------------------------------------------1
     name = "obs"
@@ -199,9 +197,6 @@ def test_soma_reader_obs_slice_x():
     assert sr.results_complete()
     assert obs.num_rows == 60
 
-    # clib.stats_dump()
-    clib.stats_reset()
-
     # read X/data
     # ---------------------------------------------------------------1
     name = "X/data"
@@ -224,9 +219,6 @@ def test_soma_reader_obs_slice_x():
         total_num_rows += x_data.num_rows
 
     assert total_num_rows == 110280
-
-    # clib.stats_dump()
-    clib.stats_disable()
 
 
 def test_soma_reader_column_names():


### PR DESCRIPTION
Because of missing `stats_reset` calls in previous code, there would be huge volumes (megabytes) of stats output if you did `pytest -vs ./tests` with no options. This captures the output from `stats_dump` in a fixture and verifies its presence, and removes debugging stats management calls.