### PR TITLE
Document newly-created `platform_config` options.

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -69,7 +69,11 @@ interface TDBConfig {
 interface TDBCreateOptions {
   dims?: { [dim: string]: TDBDimension };
   attrs?: { [attr: string]: TDBAttr };
+  allows_duplicates?: bool;
+
   offsets_filters?: TDBFilter[];
+  validity_filters?: TDBFilter[];
+
   capacity?: number;
   cell_order?: string;
   tile_order?: string;


### PR DESCRIPTION
Adds `allows_duplicates` and `validity_filters` to the documentation for `TDBCreateOptions` in the README file.

(See also: #888, #876)