### PR TITLE
[python] Add and improve documentation for many public-facing methods

### DIFF
--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -76,6 +76,17 @@ class CollectionBase(
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
+        """Creates and opens a new SOMA collection in storage.
+
+        This creates a new SOMA collection of the current type in storage and
+        returns it opened for writing.
+
+        :param uri: The location to create this SOMA collection at.
+        :param platform_config: Optional call-specific options to use when
+            creating this collection. (Currently unused.)
+        :param context: If provided, the Context to use when creating and
+            opening this collection.
+        """
         context = context or SOMATileDBContext()
         tiledb.group_create(uri=uri, ctx=context.tiledb_ctx)
         handle = cls._wrapper_type.open(uri, "w", context)
@@ -88,17 +99,19 @@ class CollectionBase(
     # Subclass protocol to constrain which SOMA objects types  may be set on a
     # particular collection key. Used by Experiment and Measurement.
     _subclass_constrained_soma_types: ClassVar[Dict[str, Tuple[str, ...]]] = {}
+    """A map limiting what types may be set to certain keys.
+
+    Map keys are the key of the collection to constrain; values are the SOMA
+    type names of the types that may be set to the key.  See ``Experiment`` and
+    ``Measurement`` for details.
+    """
 
     def __init__(
         self,
         handle: tdb_handles.GroupWrapper,
-        *,
-        _dont_call_this_use_create_or_open_instead: str = "",
+        **kwargs: Any,
     ):
-        super().__init__(
-            handle,
-            _dont_call_this_use_create_or_open_instead=_dont_call_this_use_create_or_open_instead,
-        )
+        super().__init__(handle, **kwargs)
         self._contents = {
             key: _CachedElement(entry) for key, entry in handle.initial_contents.items()
         }
@@ -146,6 +159,22 @@ class CollectionBase(
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "AnyTileDBCollection":
+        """Adds a new sub-collection to this collection.
+
+        :param key: The key to add.
+        :param cls: Optionally, the specific type of sub-collection to create.
+            For instance, passing ``tiledbsoma.Experiment`` here will create a
+            ``SOMAExperiment`` as the sub-entry. By default, a basic
+            ``Collection`` will be created.
+        :param uri: If provided, the sub-collection will be created at this URI.
+            This can be absolute, in which case the sub-collection will be
+            linked to by absolute URI in the stored collection, or relative,
+            in which case the sub-collection will be linked to by relative URI.
+            The default is to use a relative URI generated based on the key.
+        :param platform_config: Platform configuration options to use when
+            creating this sub-collection. This is passed directly to
+            ``[CurrentCollectionType].create()``.
+        """
         child_cls: Type[AnyTileDBCollection] = (
             cls or Collection  # type: ignore[assignment]
         )
@@ -167,6 +196,12 @@ class CollectionBase(
         index_column_names: Sequence[str] = (SOMA_JOINID,),
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> DataFrame:
+        """Adds a new DataFrame to this collection.
+
+        For details about the behavior of ``key`` and ``uri``, see
+        :meth:`add_new_collection`. The remaining parameters are passed to
+        :meth:`DataFrame.create` unchanged.
+        """
         return self._add_new_element(
             key,
             DataFrame,
@@ -190,6 +225,13 @@ class CollectionBase(
         shape: Sequence[int],
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> _NDArr:
+        """Adds a new NDArray to this Collection.
+
+        For details about the behavior of ``key`` and ``uri``, see
+        :meth:`add_new_collection`. The remaining parameters are passed to
+        the NDArray type's ``create`` method unchanged.
+        """
+        # cls is normally provided by the partial functions below.
         return self._add_new_element(
             key,
             cls,
@@ -294,11 +336,14 @@ class CollectionBase(
         *,
         use_relative_uri: Optional[bool] = None,
     ) -> None:
-        """
-        Adds an element to the collection.  This interface allows explicit control over
-        `relative` URI, and uses the member's default name.
+        """Adds an element to the collection. [lifecycle: experimental]
 
-        [lifecycle: experimental]
+        :param key: The key of the element to be added.
+        :param value: The value to be added to this collection.
+        :param use_relative_uri: By default (None), the collection will
+            determine whether the element should be stored by relative URI.
+            If True, the collection will store the child by absolute URI.
+            If False, the collection will store the child by relative URI.
         """
         uri_to_add = value.uri
         # The SOMA API supports use_relative_uri in [True, False, None].

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -84,7 +84,7 @@ class CollectionBase(
         :param uri: The location to create this SOMA collection at.
         :param platform_config: Optional call-specific options to use when
             creating this collection. (Currently unused.)
-        :param context: If provided, the Context to use when creating and
+        :param context: If provided, the ``SOMATileDBContext`` to use when creating and
             opening this collection.
         """
         context = context or SOMATileDBContext()
@@ -225,7 +225,7 @@ class CollectionBase(
         shape: Sequence[int],
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> _NDArr:
-        """Adds a new NDArray to this Collection.
+        """Adds a new ND Array to this Collection.
 
         For details about the behavior of ``key`` and ``uri``, see
         :meth:`add_new_collection`. The remaining parameters are passed to

--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -31,18 +31,21 @@ class NDArray(TileDBArray, somacore.NDArray):
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
         """
-        Create a SOMA ``NDArray`` named with the URI.
+        Create a SOMA ``NDArray`` at the given URI.
 
         [lifecycle: experimental]
 
-        :param type: an Arrow type defining the type of each element in the array. If the type is unsupported, an error will be raised.
+        :param type: The Arrow type to be stored in the NDArray.
+            If the type is unsupported, an error will be raised.
 
-        :param shape: the length of each domain as a list, e.g., [100, 10]. All lengths must be in the positive int64 range.
+        :param shape: the length of each dimension as a sequence, e.g., ``[100, 10]``.
+            All lengths must be in the positive int64 range.
 
-        :param platform_config: Platform-specific options used to create this Array, provided via "tiledb"->"create" nested keys
+        :param platform_config: Platform-specific options used to create this Array,
+            provided via ``{"tiledb": {"create": ...}}`` nested keys.
         """
         context = context or SOMATileDBContext()
-        schema = build_tiledb_schema(
+        schema = _build_tiledb_schema(
             type,
             shape,
             TileDBCreateOptions.from_platform_config(platform_config),
@@ -71,7 +74,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         raise NotImplementedError("reshape operation not implemented.")
 
 
-def build_tiledb_schema(
+def _build_tiledb_schema(
     type: pa.DataType,
     shape: Sequence[int],
     create_options: TileDBCreateOptions,

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -24,7 +24,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     """
     Represents ``obs``, ``var``, and others.
 
-    All ``DataFrame`` must contain a column called ``soma_joinid``, of type ``int64``. The ``soma_joinid`` column contains a unique value for each row in the ``DataFrame``, and intended to act as a joint key for other objects, such as ``SparseNDArray``.
+    All ``DataFrame`` must contain a column called ``soma_joinid``, of type ``int64``.
+    The ``soma_joinid`` column contains a unique value for each row in the dataframe,
+    and acts as a joint key for other objects, such as ``SparseNDArray``.
 
     [lifecycle: experimental]
     """
@@ -46,11 +48,18 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         [lifecycle: experimental]
 
-        :param schema: Arrow Schema defining the per-column schema. This schema must define all columns, including columns to be named as index columns. If the schema includes types unsupported by the SOMA implementation, an error will be raised.
+        :param schema: Arrow Schema defining the per-column schema. This schema
+            must define all columns, including columns to be named as index columns.
+            If the schema includes types unsupported by the SOMA implementation,
+            an error will be raised.
 
-        :param index_column_names: A list of column names to use as user-defined index columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must exist in the schema, and at least one index column name is required.
+        :param index_column_names: A list of column names to use as user-defined
+            index columns (e.g., ``['cell_type', 'tissue_type']``).
+            All named columns must exist in the schema, and at least one
+            index column name is required.
 
-        :param platform_config: Platform-specific options used to create this DataFrame, provided via "tiledb"->"create" nested keys
+        :param platform_config: Platform-specific options used to create this DataFrame,
+            provided via ``{"tiledb": {"create": ...}}`` nested keys.
         """
         context = context or SOMATileDBContext()
         schema = _canonicalize_schema(schema, index_column_names)
@@ -108,19 +117,21 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> TableReadIter:
         """
-        Read a user-defined subset of data, addressed by the dataframe indexing columns, optionally filtered, and return results as one or more Arrow.Table.
+        Read a user-defined subset of data, addressed by the dataframe indexing columns,
+        optionally filtered, and return results as one or more Arrow.Table.
 
         [lifecycle: experimental]
 
-        :param coords: for each index dimension, which rows to read. Defaults to ``None``, meaning no constraint -- all IDs.
-
-        :param column_names: the named columns to read and return. Defaults to ``None``, meaning no constraint -- all column names.
-
-        :param partitions: an optional ``ReadPartitions`` hint to indicate how results should be organized.
-
-        :param result_order: order of read results. This can be one of 'row-major', 'col-major', or 'auto'.
-
-        :param value_filter: an optional [value filter] to apply to the results. Defaults to no filter.
+        :param coords: for each index dimension, which rows to read.
+            Defaults to ``None``, meaning no constraint -- all IDs.
+        :param column_names: the named columns to read and return.
+            Defaults to ``None``, meaning no constraint -- all column names.
+        :param partitions: an optional ``ReadPartitions`` hint to indicate
+            how results should be organized.
+        :param result_order: order of read results.
+            This can be one of 'row-major', 'col-major', or 'auto'.
+        :param value_filter: an optional [value filter] to apply to the results.
+            Defaults to no filter.
 
         **Indexing**: the ``coords`` parameter will support, per dimension: a list of values of the type of the indexed column.
 
@@ -215,11 +226,15 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self, values: pa.Table, platform_config: Optional[Mapping[str, Any]] = None
     ) -> None:
         """
-        Write an Arrow.Table to the persistent object. As duplicate index values are not allowed, index values already present in the object are overwritten and new index values are added.
+        Write an Arrow.Table to the persistent object. As duplicate index values
+        are not allowed, index values already present in the object are overwritten
+        and new index values are added.
 
         [lifecycle: experimental]
 
-        :param values: An Arrow.Table containing all columns, including the index columns. The schema for the values must match the schema for the ``DataFrame``.
+        :param values: An Arrow.Table containing all columns, including
+            the index columns. The schema for the values must match
+            the schema for the ``DataFrame``.
         """
         util.check_type("values", values, (pa.Table,))
 
@@ -245,10 +260,10 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 def _canonicalize_schema(
     schema: pa.Schema, index_column_names: Sequence[str]
 ) -> pa.Schema:
-    """
-    Handle default column additions (e.g., soma_joinid) and error checking on required columns.
+    """Turn a pyarrow Schema into the canonical version and check for errors.
 
-    Returns a schema, which may be modified by the addition of required columns.
+    Returns a schema, which may be modified by the addition of required columns
+    (e.g. ``soma_joinid``).
     """
     util.check_type("schema", schema, (pa.Schema,))
     if not index_column_names:
@@ -309,6 +324,7 @@ def _build_tiledb_schema(
     tiledb_create_options: TileDBCreateOptions,
     context: SOMATileDBContext,
 ) -> tiledb.ArraySchema:
+    """Converts a pyarrow.Schema into a TileDB ArraySchema for creation."""
     dims = []
     for index_column_name in index_column_names:
         pa_type = schema.field(index_column_name).type

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -24,7 +24,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     """
     Represents ``obs``, ``var``, and others.
 
-    All ``DataFrame`` must contain a column called ``soma_joinid``, of type ``int64``.
+    Every ``DataFrame`` must contain a column called ``soma_joinid``, of type ``int64``.
     The ``soma_joinid`` column contains a unique value for each row in the dataframe,
     and acts as a joint key for other objects, such as ``SparseNDArray``.
 
@@ -48,7 +48,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         [lifecycle: experimental]
 
-        :param schema: Arrow Schema defining the per-column schema. This schema
+        :param schema: Arrow schema defining the per-column schema. This schema
             must define all columns, including columns to be named as index columns.
             If the schema includes types unsupported by the SOMA implementation,
             an error will be raised.
@@ -118,7 +118,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     ) -> TableReadIter:
         """
         Read a user-defined subset of data, addressed by the dataframe indexing columns,
-        optionally filtered, and return results as one or more Arrow.Table.
+        optionally filtered, and return results as one or more Arrow tables.
 
         [lifecycle: experimental]
 
@@ -226,13 +226,13 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self, values: pa.Table, platform_config: Optional[Mapping[str, Any]] = None
     ) -> None:
         """
-        Write an Arrow.Table to the persistent object. As duplicate index values
+        Write an Arrow table to the persistent object. As duplicate index values
         are not allowed, index values already present in the object are overwritten
         and new index values are added.
 
         [lifecycle: experimental]
 
-        :param values: An Arrow.Table containing all columns, including
+        :param values: An Arrow table containing all columns, including
             the index columns. The schema for the values must match
             the schema for the ``DataFrame``.
         """
@@ -260,7 +260,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 def _canonicalize_schema(
     schema: pa.Schema, index_column_names: Sequence[str]
 ) -> pa.Schema:
-    """Turn a pyarrow Schema into the canonical version and check for errors.
+    """Turn a Arrow schema into the canonical version and check for errors.
 
     Returns a schema, which may be modified by the addition of required columns
     (e.g. ``soma_joinid``).
@@ -324,7 +324,7 @@ def _build_tiledb_schema(
     tiledb_create_options: TileDBCreateOptions,
     context: SOMATileDBContext,
 ) -> tiledb.ArraySchema:
-    """Converts a pyarrow.Schema into a TileDB ArraySchema for creation."""
+    """Converts an Arrow schema into a TileDB ArraySchema for creation."""
     dims = []
     for index_column_name in index_column_names:
         pa_type = schema.field(index_column_name).type

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -32,11 +32,12 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     ) -> pa.Tensor:
         """
         Read a user-defined dense slice of the array and return as an Arrow ``Tensor``.
+
         Coordinates must specify a contiguous subarray, and the number of coordinates
-        must be less than or equal to the number of dimensions. For example, if the array
-        is 10 by 20, then some acceptable values of ``coords`` include ``(3, 4)``,
-        ``(slice(5, 10),)``, and ``(slice(5, 10), slice(6, 12))``. Slice indices are
-        doubly inclusive.
+        must be less than or equal to the number of dimensions. For example,
+        if the array is 10 by 20, then some acceptable values of ``coords`` include
+        ``(3, 4)``, ``(slice(5, 10),)``, and ``(slice(5, 10), slice(6, 12))``.
+        Slice indices are doubly inclusive.
 
         [lifecycle: experimental]
         """
@@ -123,14 +124,12 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
         [lifecycle: experimental]
 
-        Parameters
-        ----------
-        coords - per-dimension tuple of scalar or slice
-            Define the bounds of the subarray to be written.
-
-        values - pyarrow.Tensor
-            Define the values to be written to the subarray.  Must have same shape
-            as defind by ``coords``, and the type must match the DenseNDArray.
+        :param coords: A per-dimension tuple of scalars or slices
+            defining the bounds of the subarray to be written.
+        :param values: The values to be written to the subarray.  Must have
+        the same shape as ``coords``, and the type must match the DenseNDArray.
+        :param platform_config: Optional platform-specific options to use
+            in this write operation (currently unused).
         """
         util.check_type("values", values, (pa.Tensor,))
 

--- a/apis/python/src/tiledbsoma/exception.py
+++ b/apis/python/src/tiledbsoma/exception.py
@@ -2,10 +2,14 @@ import tiledb
 
 
 class SOMAError(Exception):
+    """Base error type for SOMA-specific exceptions."""
+
     pass
 
 
 class DoesNotExistError(SOMAError):
+    """Raised when attempting to open a non-existent SOMA object."""
+
     pass
 
 

--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -69,7 +69,7 @@ def open(
         This can be provided as a SOMA type name
         If the stored SOMA object is not of the correct type, an error will be
         raised.
-    :param context: If set, the context data to use.
+    :param context: If set, the ``SOMATileDBContext`` data to use.
     """
     context = context or SOMATileDBContext()
     obj = _open_internal(tdb_handles.open, uri, mode, context)

--- a/apis/python/src/tiledbsoma/measurement.py
+++ b/apis/python/src/tiledbsoma/measurement.py
@@ -19,31 +19,40 @@ class Measurement(
     ],
 ):
     """
-    A ``Measurement`` is a sub-element of a ``Experiment``, and is otherwise a specialized ``Collection`` with pre-defined fields:
+    A ``Measurement`` is a sub-element of a ``Experiment``, and is otherwise
+    a specialized ``Collection`` with pre-defined fields:
 
     ``var``: ``DataFrame``
 
-    Primary annotations on the variable axis, for variables in this measurement (i.e., annotates columns of ``X``). The contents of the ``soma_joinid`` column define the variable index domain, AKA var_id. All variables for this measurement must be defined in this dataframe.
+    Primary annotations on the variable axis, for variables in this measurement
+    (i.e., annotates columns of ``X``). The contents of the ``soma_joinid`` column
+    define the variable index domain, AKA var_id. All variables for this measurement
+    must be defined in this dataframe.
 
     ``X``: ``Collection`` of ``SparseNDArray``
 
-    A collection of sparse matrices, each containing measured feature values. Each matrix is indexed by ``[obsid, varid]``.
+    A collection of sparse matrices, each containing measured feature values.
+    Each matrix is indexed by ``[obsid, varid]``.
 
     ``obsm``: ``Collection`` of ``DenseNDArray``
 
-    A collection of dense matrices containing annotations of each ``obs`` row. Has the same shape as ``obs``, and is indexed with ``obsid``.
+    A collection of dense matrices containing annotations of each ``obs`` row.
+    Has the same shape as ``obs``, and is indexed with ``obsid``.
 
     ``obsp``: ``Collection`` of ``SparseNDArray``
 
-    A collection of sparse matrices containing pairwise annotations of each ``obs`` row. Indexed with ``[obsid_1, obsid_2]``.
+    A collection of sparse matrices containing pairwise annotations of each ``obs`` row.
+    Indexed with ``[obsid_1, obsid_2]``.
 
     ``varm``: ``Collection`` of ``DenseNDArray``
 
-    A collection of dense matrices containing annotations of each ``var`` row. Has the same shape as ``var``, and is indexed with ``varid``.
+    A collection of dense matrices containing annotations of each ``var`` row.
+    Has the same shape as ``var``, and is indexed with ``varid``.
 
     ``varp``: ``Collection`` of ``SparseNDArray``
 
-    A collection of sparse matrices containing pairwise annotations of each ``var`` row. Indexed with ``[varid_1, varid_2]``
+    A collection of sparse matrices containing pairwise annotations of each ``var`` row.
+    Indexed with ``[varid_1, varid_2]``
 
     [lifecycle: experimental]
     """

--- a/apis/python/src/tiledbsoma/query_condition.py
+++ b/apis/python/src/tiledbsoma/query_condition.py
@@ -93,18 +93,19 @@ class QueryCondition:
 
     Example::
 
-        with tiledb.open(uri, mode="r") as A:
+        with tiledbsoma.open(df_uri) as dataframe:
             # Select cells where the attribute values for `foo` are less than 5
             # and `bar` equal to string "asdf".
             # Note precedence is equivalent to:
-            # tiledbsoma.QueryCondition("foo > 5 or ('asdf' == attr('b a r') and baz <= val(1.0))")
-            A.query(cond="foo > 5 or 'asdf' == attr('b a r') and baz <= val(1.0)")
+            # "foo > 5 or ('asdf' == attr('b a r') and baz <= val(1.0))"
+            foo_bar_baz = dataframe.read(
+                value_filter="foo > 5 or 'asdf' == attr('b a r') and baz <= val(1.0)")
 
             # Select cells where the attribute values for `foo` are equal to
             # 1, 2, or 3.
             # Note this is equivalent to:
-            # tiledbsoma.QueryCondition("foo == 1 or foo == 2 or foo == 3")
-            A.query(cond="foo in [1, 2, 3]")
+            # "foo == 1 or foo == 2 or foo == 3"
+            foo_123 = dataframe.read(value_filter="foo in [1, 2, 3]")
     """
 
     expression: str

--- a/apis/python/src/tiledbsoma/query_condition.py
+++ b/apis/python/src/tiledbsoma/query_condition.py
@@ -91,20 +91,20 @@ class QueryCondition:
 
         ``val ::= <num> | <str> | val(val)``
 
-    **Example:**
+    Example::
 
-    >>> with tiledb.open(uri, mode="r") as A:
-    >>>     # Select cells where the attribute values for `foo` are less than 5
-    >>>     # and `bar` equal to string "asdf".
-    >>>     # Note precedence is equivalent to:
-    >>>     # tiledbsoma.QueryCondition("foo > 5 or ('asdf' == attr('b a r') and baz <= val(1.0))")
-    >>>     A.query(cond="foo > 5 or 'asdf' == attr('b a r') and baz <= val(1.0)")
-    >>>
-    >>>     # Select cells where the attribute values for `foo` are equal to
-    >>>     # 1, 2, or 3.
-    >>>     # Note this is equivalent to:
-    >>>     # tiledbsoma.QueryCondition("foo == 1 or foo == 2 or foo == 3")
-    >>>     A.query(cond="foo in [1, 2, 3]")
+        with tiledb.open(uri, mode="r") as A:
+            # Select cells where the attribute values for `foo` are less than 5
+            # and `bar` equal to string "asdf".
+            # Note precedence is equivalent to:
+            # tiledbsoma.QueryCondition("foo > 5 or ('asdf' == attr('b a r') and baz <= val(1.0))")
+            A.query(cond="foo > 5 or 'asdf' == attr('b a r') and baz <= val(1.0)")
+
+            # Select cells where the attribute values for `foo` are equal to
+            # 1, 2, or 3.
+            # Note this is equivalent to:
+            # tiledbsoma.QueryCondition("foo == 1 or foo == 2 or foo == 3")
+            A.query(cond="foo in [1, 2, 3]")
     """
 
     expression: str

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -39,7 +39,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     @property
     def nnz(self) -> int:
         """
-        Return the number of stored values in the array, including explicitly stored zeros.
+        The number of stored values in the array, including explicitly stored zeros.
         """
         self._check_open_read()
         return cast(int, self._soma_reader().nnz())
@@ -58,29 +58,27 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
         [lifecycle: experimental]
 
-        Parameters
-        ----------
-        coords : Tuple[Union[int, slice, Tuple[int, ...], List[int], pa.IntegerArray], ...]
-            Per-dimension tuple of scalar, slice, sequence of scalar or Arrow IntegerArray
-            Arrow arrays currently unimplemented.
+        :param coords: A per-dimension tuple of scalar, slice, sequence of scalar
+            or Arrow IntegerArray defining the region to read.
+            (Arrow arrays currently unimplemented.)
 
         Acceptable ways to index
         ------------------------
         * None
         * A sequence of coordinates is accepted, one per dimension.
         * Sequence length must be at least one and <= number of dimensions.
-        * If the sequence contains missing coordinates (length less than number of dimensions),
-          then `slice(None)` -- i.e. no constraint -- is assumed for the missing dimensions.
-        * Per-dimension, explicitly specified coordinates can be one of: None, a value, a
-          list/ndarray/paarray/etc of values, a slice, etc.
-        * Slices are doubly inclusive: slice(2,4) means [2,3,4] not [2,3]. Slice steps can only be +1.
-          Slices can be `slice(None)`, meaning select all in that dimension, but may not be half-specified:
+        * If the sequence contains missing coordinates (length < number of dimensions),
+          then ``slice(None)`` -- i.e. no constraint -- is assumed for the
+          remaining dimensions.
+        * Per-dimension, explicitly specified coordinates can be one of:
+          None, a value, a list/ndarray/paarray/etc of values, a slice, etc.
+        * Slices are doubly inclusive: slice(2,4) means [2,3,4] not [2,3].
+          Slice steps can only be +1. Slices can be `slice(None)`, meaning
+          select all in that dimension, but may not be half-specified:
           `slice(2,None)` and `slice(None,4)` are both unsupported.
         * Negative indexing is unsupported.
 
-        Returns
-        -------
-        SparseNDArrayRead - which can be used to access an iterator of results in various formats.
+        :return: A SparseNDArrayRead to access result iterators in various formats.
         """
         del result_order, batch_size, partitions, platform_config  # Currently unused.
         self._check_open_read()
@@ -153,7 +151,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
         [lifecycle: experimental]
 
-        Arrow sparse tensor: the coordinates in the Arrow SparseTensor will be interpreted
+        Arrow sparse tensor: the coordinates in the Arrow SparseTensor are interpreted
         as the coordinates to write to. Supports the _experimental_ SparseCOOTensor,
         SparseCSRMatrix and SparseCSCMatrix. There is currently no support for Arrow
         SparseCSFTensor or dense Tensor.

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -21,9 +21,10 @@ Covariant because ``_handle`` is read-only.
 
 class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     """
-    Base class for ``TileDBArray`` and ``Collection``.
+    Base class for all TileDB SOMA objects.
 
-    Accepts a SOMATileDBContext, to enable session state to be shared across SOMA objects.
+    Accepts a SOMATileDBContext, to enable session state to be shared
+    across SOMA objects.
 
     [lifecycle: experimental]
     """
@@ -39,7 +40,13 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         context: Optional[SOMATileDBContext] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
-        """Opens this specific type of SOMA object."""
+        """Opens this specific type of SOMA object.
+
+        :param uri: The URI to open.
+        :param mode: The mode to open the object in.
+            ``r``: Open for reading only (cannot write).
+            ``w``: Open for writing only (cannot read).
+        """
         del platform_config  # unused
         context = context or SOMATileDBContext()
         handle = cls._wrapper_type.open(uri, mode, context)
@@ -109,8 +116,8 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     def close(self) -> None:
         """
-        Release any resources held while the object is open. Closing an already-closed object is a
-        no-op.
+        Release any resources held while the object is open.
+        Closing an already-closed object is a no-op.
         """
         self._close_stack.close()
         self._closed = True
@@ -122,13 +129,12 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @property
     def mode(self) -> options.OpenMode:
-        """
-        Current open mode: read (r), write (w), or closed (None).
-        """
+        """The mode this object was opened in, either ``r`` or ``w``."""
         return self._handle.mode
 
     @classmethod
     def exists(cls, uri: str, context: Optional[SOMATileDBContext] = None) -> bool:
+        """Finds whether an object of this type exists at the given URI."""
         context = context or SOMATileDBContext()
         try:
             with cls._wrapper_type.open(uri, "r", context) as hdl:


### PR DESCRIPTION
- Adds many missing docstrings
- Reformats unwrapped docstrings to wrap around 80–88 lines for easier onscreen reading
- Converts some docstrings to be (closer to?) Sphinx format.

Part of #858 and #602.