### PR TITLE
Update to mypy 1.0.0 and FINALLY use `Self`!

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     - id: ruff
       args: ["--force-exclude", "--config=apis/python/pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.0
     hooks:
     - id: mypy
       additional_dependencies:

--- a/apis/python/src/tiledbsoma/collection.py
+++ b/apis/python/src/tiledbsoma/collection.py
@@ -25,6 +25,7 @@ import somacore
 import somacore.collection
 import tiledb
 from somacore import options
+from typing_extensions import Self
 
 from . import tdb_handles
 from .common_nd_array import NDArray
@@ -41,7 +42,6 @@ from .util import is_relative_uri, make_relative_path, uri_joinpath
 CollectionElementType = TypeVar("CollectionElementType", bound=AnyTileDBObject)
 _TDBO = TypeVar("_TDBO", bound=AnyTileDBObject)
 _Coll = TypeVar("_Coll", bound="CollectionBase[AnyTileDBObject]")
-_Self = TypeVar("_Self", bound="CollectionBase[AnyTileDBObject]")
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 
 
@@ -70,12 +70,12 @@ class CollectionBase(
     # TODO: Implement additional creation of members on collection subclasses.
     @classmethod
     def create(
-        cls: Type[_Self],
+        cls,
         uri: str,
         *,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
-    ) -> _Self:
+    ) -> Self:
         context = context or SOMATileDBContext()
         tiledb.group_create(uri=uri, ctx=context.tiledb_ctx)
         handle = cls._wrapper_type.open(uri, "w", context)

--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -1,19 +1,18 @@
 """Common code shared by both NDArray implementations."""
 
-from typing import Optional, Sequence, Tuple, Type, TypeVar, cast
+from typing import Optional, Sequence, Tuple, cast
 
 import numpy as np
 import pyarrow as pa
 import somacore
 import tiledb
 from somacore import options
+from typing_extensions import Self
 
 from . import arrow_types, util
 from .options.soma_tiledb_context import SOMATileDBContext
 from .options.tiledb_create_options import TileDBCreateOptions
 from .tiledb_array import TileDBArray
-
-_Self = TypeVar("_Self", bound="NDArray")
 
 
 class NDArray(TileDBArray, somacore.NDArray):
@@ -23,14 +22,14 @@ class NDArray(TileDBArray, somacore.NDArray):
 
     @classmethod
     def create(
-        cls: Type[_Self],
+        cls,
         uri: str,
         *,
         type: pa.DataType,
         shape: Sequence[int],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
-    ) -> _Self:
+    ) -> Self:
         """
         Create a SOMA ``NDArray`` named with the URI.
 

--- a/apis/python/src/tiledbsoma/tdb_handles.py
+++ b/apis/python/src/tiledbsoma/tdb_handles.py
@@ -19,6 +19,7 @@ from typing import (
 import attrs
 import tiledb
 from somacore import options
+from typing_extensions import Self
 
 from .exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from .options import SOMATileDBContext
@@ -26,7 +27,6 @@ from .options import SOMATileDBContext
 RawHandle = Union[tiledb.Array, tiledb.Group]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 """A raw TileDB object. Covariant because Handles are immutable enough."""
-_Self = TypeVar("_Self", bound="AnyWrapper")
 
 
 def open(
@@ -58,9 +58,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     closed: bool = attrs.field(default=False, init=False)
 
     @classmethod
-    def open(
-        cls: Type[_Self], uri: str, mode: options.OpenMode, context: SOMATileDBContext
-    ) -> _Self:
+    def open(cls, uri: str, mode: options.OpenMode, context: SOMATileDBContext) -> Self:
         if mode not in ("r", "w"):
             raise ValueError(f"Invalid open mode {mode!r}")
         try:
@@ -142,7 +140,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     def __repr__(self) -> str:
         return f"<{type(self).__name__} {self.mode} on {self.uri!r}>"
 
-    def __enter__(self: _Self) -> _Self:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_: Any) -> None:

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, MutableMapping, Optional, Type, TypeVar
 import somacore
 import tiledb
 from somacore import options
+from typing_extensions import Self
 
 from . import constants, tdb_handles
 from .exception import SOMAError
@@ -16,7 +17,6 @@ _WrapperType_co = TypeVar(
 
 Covariant because ``_handle`` is read-only.
 """
-_Self = TypeVar("_Self", bound="AnyTileDBObject")
 
 
 class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
@@ -32,13 +32,13 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @classmethod
     def open(
-        cls: Type[_Self],
+        cls,
         uri: str,
         mode: options.OpenMode = "r",
         *,
         context: Optional[SOMATileDBContext] = None,
         platform_config: Optional[options.PlatformConfig] = None,
-    ) -> _Self:
+    ) -> Self:
         """Opens this specific type of SOMA object."""
         del platform_config  # unused
         context = context or SOMATileDBContext()


### PR DESCRIPTION
I discovered this when I was trying to figure out why there were inconsistencies between the errors reported by mypy running in pre-commit and the mypy I had installed in my development venv, which were driving me thoroughly insane while I was trying to do completely innocuous things. This seems to have fixed it, and finally, I can eliminate all those `TypeVar("_Self")`s!