### PR TITLE
[python] Use `**kwargs` and a function decorator to forward arguments

### DIFF
--- a/apis/python/src/tiledbsoma/factory.py
+++ b/apis/python/src/tiledbsoma/factory.py
@@ -24,8 +24,8 @@ from .constants import (
     SOMA_OBJECT_TYPE_METADATA_KEY,
 )
 from .exception import SOMAError
+from .funcs import typeguard_ignore
 from .options import SOMATileDBContext
-from .util import typeguard_ignore
 
 _Obj = TypeVar("_Obj", bound="tiledb_object.AnyTileDBObject")
 _Wrapper = TypeVar("_Wrapper", bound=tdb_handles.AnyWrapper)

--- a/apis/python/src/tiledbsoma/funcs.py
+++ b/apis/python/src/tiledbsoma/funcs.py
@@ -1,0 +1,116 @@
+"""Utilities and decorators around modifying functions."""
+
+import inspect
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    List,
+    TypeVar,
+)
+
+from typing_extensions import ParamSpec
+
+_Params = ParamSpec("_Params")
+_T = TypeVar("_T")
+_CT = TypeVar("_CT", bound=Callable[..., Any])
+
+
+# Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
+# decorator without having to depend upon typeguard at runtime.
+def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
+    """No-op. Returns the argument unchanged."""
+    return f
+
+
+try:
+    import typeguard
+
+    typeguard_ignore = typeguard.typeguard_ignore  # noqa: F811
+except ImportError:
+    pass
+
+
+def forwards_kwargs_to(
+    dst: Callable[..., Any], *, exclude: Collection[str] = ()
+) -> Callable[[_CT], _CT]:
+    """Decorator function to update the signature with ``dst``'s kwargs.
+
+    Example::
+
+        def _internal(__it, a, b, c=3, *d, e=6, **f) -> None:
+            ...
+
+        @forwards_kwargs_to(_internal, exclude=("b",))
+        def external(a, param1, param2, **kwargs) -> None:
+            _internal(a="x", b=1, **kwargs)
+            # Do other stuff
+
+        # inspect.signature(external) is now:
+        #     (a, param1, param2, *, c=3, e=6, **f) -> None
+
+    This gives online help (like ``help()`` and autocompletion in ipython)
+    information about the entire expected signature of the function without
+    having to repeat the entire thing. However, it cannot (currently) provide
+    information useful for static typing.
+    """
+    dst_params = tuple(inspect.Signature.from_callable(dst).parameters.values())
+
+    def wrap(me: _CT) -> _CT:
+        my_sig = inspect.Signature.from_callable(me)
+        merged: List[inspect.Parameter] = []
+        claimed_names = set(exclude)
+        for param in my_sig.parameters.values():
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                # This is our **kwargs parameter, so substitute in
+                # the destination function's arguments.
+                for dst_param in dst_params:
+                    if dst_param.kind == inspect.Parameter.VAR_KEYWORD:
+                        # This is dst's **kwargs parameter. Pass it directly.
+                        merged.append(dst_param)
+                    elif _can_be_kwarg(dst_param):
+                        # In this case:
+                        #     def internal(a, b): ...
+                        #     @forwards_kwargs_to(internal)
+                        #     def public(b, **kwargs): ...
+                        # `b` cannot be forwarded to `internal`, so we skip it.
+                        if dst_param.name not in claimed_names:
+                            # ...however, `a` can.
+                            merged.append(
+                                dst_param.replace(kind=inspect.Parameter.KEYWORD_ONLY)
+                            )
+                            claimed_names.add(dst_param.name)
+                    # else: this param is positional-only.
+            else:
+                # This is one of our other params; add it to the signature.
+                if _can_be_kwarg(param):
+                    # This is one of our kwargs, so claim its name.
+                    claimed_names.add(param.name)
+                merged.append(param)
+
+        # Lastly, make sure that we don't have any duplicate names.
+        # The name of positional-only, *args, and **kwargs arguments
+        # don't matter, so we can change them to make the signature unique.
+        for idx, param in enumerate(merged):
+            if _can_be_kwarg(param):
+                continue  # Is already a named arg; can't be changed.
+
+            # Ensure this isn't a dupe by adding `_`s until it's not.
+            while param.name in claimed_names:
+                param = param.replace(name=param.name + "_")
+            claimed_names.add(param.name)
+            merged[idx] = param
+
+        me.__signature__ = my_sig.replace(  # type: ignore[attr-defined]
+            parameters=merged
+        )
+        return me
+
+    return wrap
+
+
+def _can_be_kwarg(param: inspect.Parameter) -> bool:
+    return not param.name.startswith("__") and param.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -6,8 +6,8 @@ import pandas._typing as pdt
 import scipy.sparse as sp
 from pandas.api.types import infer_dtype, is_categorical_dtype
 
+from ..funcs import typeguard_ignore
 from ..types import NPNDArray, PDSeries
-from ..util import typeguard_ignore
 
 _DT = TypeVar("_DT", bound=pdt.Dtype)
 _MT = TypeVar("_MT", NPNDArray, sp.spmatrix, PDSeries)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -37,6 +37,7 @@ from .. import (
 from ..common_nd_array import NDArray
 from ..constants import SOMA_JOINID
 from ..exception import DoesNotExistError, SOMAError
+from ..funcs import typeguard_ignore
 from ..options import SOMATileDBContext
 from ..options.tiledb_create_options import TileDBCreateOptions
 from ..tdb_handles import RawHandle
@@ -395,7 +396,7 @@ def _create_or_open_coll(
     ...
 
 
-@util.typeguard_ignore
+@typeguard_ignore
 def _create_or_open_coll(cls: Type[Any], uri: str, ingest_mode: str) -> Any:
     try:
         thing = cls.open(uri, "w")
@@ -465,7 +466,7 @@ def _write_dataframe(
     return soma_df
 
 
-@util.typeguard_ignore
+@typeguard_ignore
 def create_from_matrix(
     cls: Type[_NDArr],
     uri: str,

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -1,27 +1,10 @@
 import pathlib
 import time
 import urllib.parse
-from typing import Any, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import somacore
 from somacore import options
-
-# Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
-# decorator without having to depend upon typeguard at runtime.
-_F = TypeVar("_F")
-
-
-def typeguard_ignore(f: _F) -> _F:
-    """No-op. Returns the argument unchanged."""
-    return f
-
-
-try:
-    import typeguard
-
-    typeguard_ignore = typeguard.typeguard_ignore  # noqa: F811
-except ImportError:
-    pass
 
 
 def get_start_stamp() -> float:

--- a/apis/python/tests/test_funcs.py
+++ b/apis/python/tests/test_funcs.py
@@ -1,0 +1,62 @@
+import inspect
+import sys
+import textwrap
+
+import pytest
+
+from tiledbsoma import funcs
+
+
+@pytest.mark.parametrize(
+    ("dst_sig", "outer_sig", "want"),
+    [
+        ("(a: int) -> float", "(no_kwargs: int) -> int", "(no_kwargs: int) -> int"),
+        (
+            "(*, two: int = 2, three: float, **more)",
+            "(one = 1, **kwargs) -> str",
+            "(one=1, *, two: int = 2, three: float, **more) -> str",
+        ),
+        (
+            "(__pos_only_dst, *args, hello)",
+            "(__pos_only_outer, __args, *rest, kw1, **kwargs)",
+            "(__pos_only_outer, __args, *rest, kw1, hello)",
+        ),
+        (
+            "(dont_shadow: int, *ignore, do_rename_: str, **do_rename: frozenset)",
+            "(__pos_only, *dont_shadow, do_rename: bytes = b'', **kwargs) -> complex",
+            "(__pos_only, *dont_shadow_, do_rename: bytes = b'', dont_shadow: int, do_rename_: str, **do_rename__: frozenset) -> complex",
+        ),
+        pytest.param(
+            "(pos_only, some_name, /, dst_both_arg, *args, dst_kwarg=1, **dup_dict: complex)",
+            "(dst_both_arg, dst_kwarg: int = 10, /, dup_dict: dict = (), **kwargs) -> None",
+            "(dst_both_arg_, dst_kwarg_: int = 10, /, dup_dict: dict = (), *, dst_both_arg, dst_kwarg=1, **dup_dict_: complex) -> None",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 8), reason="/ is new in 3.8"
+            ),
+        ),
+    ],
+)
+def test_forwards_kwargs(dst_sig: str, outer_sig: str, want: str):
+    code = textwrap.dedent(
+        f"""
+        def dst{dst_sig}: ...
+        @forwards_kwargs_to(dst)
+        def outer{outer_sig}: ...
+        """
+    )
+    variables = dict(forwards_kwargs_to=funcs.forwards_kwargs_to)
+    exec(code, variables)
+    got_sig = inspect.signature(variables["outer"])
+    assert str(got_sig) == want
+
+
+def test_forwards_kwargs_exclude():
+    def dst(one, two, three):
+        ...
+
+    @funcs.forwards_kwargs_to(dst, exclude=("one", "three"))
+    def wrapped(one, four, five, **kwargs) -> None:
+        ...
+
+    got_sig = inspect.signature(wrapped)
+    assert str(got_sig) == "(one, four, five, *, two) -> None"


### PR DESCRIPTION
In #848 the main reason I used `functools.partialmethod` was to avoid having to repeat the same parameter list multiple times (and specify the same defaults multiple times, etc. etc.). However, `partialmethod` doesn't pick up the function's `__doc__` and related attributes, which meant that doing `help(coll.add_new_sparse_ndarray)` just gave you the documentation for `partialmethod`, which is completely useless.

This is one potential solution, which IMO has a lot of advantages:

- less repetition, and useful in more places than anticipated.
- no way for arg lists/defaults to go out of sync.
- pretty much the intended use case for `**kwargs`.

However, it does have some disadvantages:

- less static analysis support.
- somewhat complex internals (though they are well-tested and hidden behind a simple abstraction).

I'm not deeply attached to this idea (though I think it is pretty neat) and would be willing to go with the simpler solution (just repeat everything three+ times).

Fixes #858.

See the narrative below for way more detail:

---

For methods which primarily consist of forwarding arguments from themselves to another backing function, this change replaces the repeated argument list with the use of `**kwargs` to reduce repetition and the possibility of drifting defaults. Additionally, it creates a new `@forwards_kwargs_to` decorator to update the `__signature__` of the wrapper function to ensure that online help still provides useful information.

Background:

One of the primary reasons to avoid using `**kwargs` to pass arguments directly through functions is that doing so means users no longer receive useful help information when using a function in an interactive environment like ipython. Instead of seeing the parameters the function expects (and type annotations and defaults), the help text (and parameter hints, etc.) will only show the `**kwargs`.

Conversely, using `**kwargs` is often useful and beneficial for a library implementor (like us). Directly using `**kwargs` means that arguments can be passed through untouched, and there is no need to repeat argument lists and default parameters, all of which can get out of sync from caller to callee.

These two goals are somewhat at odds. However, the standard library provides a semi-documented workaround: a callable can provide a `__signature__` member which is used *instead of* the actual function signature of the called object in online help (e.g. `help(some_fn)`) and is also used to provide parameter information in interactive shells.

How it works:

The new `@forwards_kwargs_to` decorator inspects the argument list of both the wrapped function and the destination function and generates a Signature which accurately reflects the combined parameters, default values, and ordering of a function that uses `**kwargs` to directly forward arguments to a backing function. It sets the `__signature__` member on the wrapped function. This value is then used at runtime.

Example (from an actual ipython session with this code)

    $ ipython
    In [1]: import tiledbsoma

    In [2]: coll = tiledbsoma.open("some-collection")

    In [3]: coll.add_new_dense_ndarray?
    Signature:
    coll.add_new_dense_ndarray(
        key: 'str',
        *,
        uri: 'Optional[str]' = None,
        type: pyarrow.lib.DataType,
        shape: Sequence[int],
        platform_config: Optional[Mapping[str, Any]] = None,
    ) -> 'DenseNDArray'
    Docstring:
    Adds a new DenseNDArray to this Collection.

    For details about the behavior of ``key`` and ``uri``, see
    :meth:`add_new_collection`. The remaining parameters are passed to
    the :meth:`DenseNDArray.create` method unchanged.

    In [4]: coll.add_new_dense_ndarray('something', <TAB>
    platform_config= ...
    shape=           ...
    type=            ...
    uri=             ...

Cons:

The `__signature__` value is generated at runtime and cannot be used at static analysis time. This means that tools like `mypy` and other static analysis–based development tools (e.g. Pylance's intellisense) aren't able to provide detailed type checking.