### PR TITLE
Allow passing 0-length lists of coordinates to DataFrame.

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -140,7 +140,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         * None
         * A sequence of coordinates is accepted, one per dimension.
-        * Sequence length must be at least one and <= number of dimensions.
+        * Sequence length must be <= number of dimensions.
         * If the sequence contains missing coordinates (length less than number of dimensions),
           then `slice(None)` -- i.e. no constraint -- is assumed for the missing dimensions.
         * Per-dimension, explicitly specified coordinates can be one of: None, a value, a
@@ -166,12 +166,12 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             result_order=result_order.value,
         )
 
-        if coords is not None:
+        if coords:
             if not isinstance(coords, (list, tuple)):
                 raise TypeError(
                     f"coords type {type(coords)} unsupported; expected list or tuple"
                 )
-            if len(coords) < 1 or len(coords) > schema.domain.ndim:
+            if schema.domain.ndim < len(coords):
                 raise ValueError(
                     f"coords {coords} must have length between 1 and ndim ({schema.domain.ndim}); got {len(coords)}"
                 )

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -55,9 +55,9 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 raise TypeError(
                     f"coords type {type(coords)} unsupported; expected list or tuple"
                 )
-            if len(coords) < 1 or len(coords) > schema.domain.ndim:
+            if len(coords) > schema.domain.ndim:
                 raise ValueError(
-                    f"coords {coords} must have length between 1 and ndim ({schema.domain.ndim}); got {len(coords)}"
+                    f"coords {coords} must be shorter than ndim ({schema.domain.ndim}); got {len(coords)}"
                 )
 
             for i, coord in enumerate(coords):

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -66,7 +66,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         ------------------------
         * None
         * A sequence of coordinates is accepted, one per dimension.
-        * Sequence length must be at least one and <= number of dimensions.
+        * Sequence length must be <= number of dimensions.
         * If the sequence contains missing coordinates (length < number of dimensions),
           then ``slice(None)`` -- i.e. no constraint -- is assumed for the
           remaining dimensions.
@@ -93,9 +93,9 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             raise TypeError(
                 f"coords type {type(coords)} unsupported; expected list or tuple"
             )
-        if len(coords) < 1 or len(coords) > schema.domain.ndim:
+        if len(coords) > schema.domain.ndim:
             raise ValueError(
-                f"coords {coords} must have length between 1 and ndim ({schema.domain.ndim}); got {len(coords)}"
+                f"coords {coords} must be shorter than ndim ({schema.domain.ndim}); got {len(coords)}"
             )
 
         for i, coord in enumerate(coords):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -518,6 +518,12 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
         },
         {
             "index_column_names": ["index1"],
+            "coords": [],  # len(ids) != len(index_column_names)
+            "A": [10, 11, 12, 13, 14, 15],
+            "throws": None,
+        },
+        {
+            "index_column_names": ["index1"],
             "coords": [slice(1, 3)],  # Indexing slot is double-ended slice
             "A": [11, 12, 13],
             "throws": None,
@@ -560,13 +566,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
         },
         {
             "index_column_names": ["index1"],
-            "coords": [],  # len(ids) != len(index_column_names)
-            "A": None,
-            "throws": ValueError,
-        },
-        {
-            "index_column_names": ["index1"],
-            "coords": [(1,), (2,)],  # len(ids) != len(index_column_names)
+            "coords": [(1,), (2,)],  # len(ids) > len(index_column_names)
             "A": None,
             "throws": ValueError,
         },

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -130,12 +130,27 @@ def test_dense_nd_array_reshape(tmp_path):
             "output": np.array([[200, 201, 202, 203, 204, 205]]),
         },
         {
+            "coords": (2,),
+            "output": np.array([[200, 201, 202, 203, 204, 205]]),
+        },
+        {
             "coords": (slice(None, 2), slice(5, None)),
             "output": np.array([[5], [105], [205]]),
         },
         {
             "coords": (slice(0, 2), slice(5, 5)),
             "output": np.array([[5], [105], [205]]),
+        },
+        {
+            "coords": (),
+            "output": np.array(
+                [
+                    [0, 1, 2, 3, 4, 5],
+                    [100, 101, 102, 103, 104, 105],
+                    [200, 201, 202, 203, 204, 205],
+                    [300, 301, 302, 303, 304, 305],
+                ]
+            ),
         },
         {
             "coords": (slice(None), slice(None)),

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -483,6 +483,15 @@ def test_csr_csc_2d_read(tmp_path, shape):
             },
             "throws": None,
         },
+        # Coords is empty
+        {
+            "shape": (4,),
+            "coords": (),
+            "dims": {
+                "soma_dim_0": [0, 1, 2, 3],
+            },
+            "throws": None,
+        },
         # Coords has None in a slot
         {
             "shape": (4,),
@@ -644,6 +653,41 @@ def test_csr_csc_2d_read(tmp_path, shape):
         {
             "shape": (3, 4),
             "coords": (slice(None), slice(None)),
+            "dims": {
+                "soma_dim_0": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                    2,
+                ],
+                "soma_dim_1": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    0,
+                    1,
+                    2,
+                    3,
+                    0,
+                    1,
+                    2,
+                    3,
+                ],
+            },
+            "throws": None,
+        },
+        {
+            "shape": (3, 4),
+            "coords": [],
             "dims": {
                 "soma_dim_0": [
                     0,
@@ -844,9 +888,7 @@ def test_sparse_nd_array_error_corners(tmp_path):
         ((slice(-10, 2),)),  # negative start
         ((slice(-10, -2),)),  # negative start & stop
         ((slice(10, -2),)),  # negative stop
-        (()),  # empty, wrong ndim
-        ([]),  # empty, wrong ndim
-        ((slice(None), slice(None))),  # wrong ndim
+        ((slice(None), slice(None))),  # too many dims
     ],
 )
 def test_bad_coords(tmp_path, bad_coords):


### PR DESCRIPTION
This is an oddity I noticed when working on documentation for the `DataFrame.read` method in somacore. It's not a bug per se but is a special case that I found unexpected. I dug through back to #538 where this was introduced and didn't find the reasoning behind this particular behavior. It's fine to keep as-is but I figured I would see if we do want to keep this behavior.

---

Currently, DataFrame allows passing a sequence of coordinates shorter than the number of indexed dimensions:

    # df has 4 dimensions

    df.read(coords=[1, 2, 3, 4])
    # -> [1, 2, 3, 4]
    df.read(coords=[1, 2])
    # -> [1, 2, unrestricted, unrestricted]
    df.read(coords=[1])
    # -> [1, unrestricted, unrestricted, unrestricted]

However, this pattern does not continue down to 0 dimensions:

    df.read(coords=[])
    # -> Not allowed

despite the fact that not passing coordinates at all is allowed:

    df.read(coords=None)
    # -> [unrestricted, unrestricted, unrestricted, unrestricted]

This change treats the zero-length array equivalent to an array of any other length:

    df.read(coords=[])
    # -> [unrestricted, unrestricted, unrestricted, unrestricted]