### PR TITLE
Minor cleanup to deduplicate some code.

### DIFF
--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -45,10 +45,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         self._check_open_read()
         result_order = somacore.ResultOrder(result_order)
 
-        arr = self._handle.reader
-        target_shape = dense_indices_to_shape(coords, arr.shape, result_order)
-        schema = arr.schema
-        ned = arr.nonempty_domain()
+        schema = self._handle.schema
+        target_shape = dense_indices_to_shape(coords, schema.shape, result_order)
 
         sr = self._soma_reader(result_order=result_order.value)
 
@@ -69,6 +67,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 elif isinstance(coord, int):
                     sr.set_dim_points(dim_name, [coord])
                 elif isinstance(coord, slice):
+                    ned = self._handle.reader.nonempty_domain()
+                    # ned is None iff the array has no data
                     lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
                     if lo_hi is not None:
                         lo, hi = lo_hi

--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -29,7 +29,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     [lifecycle: experimental]
     """
 
-    __slots__ = ("_close_stack", "_handle", "_closed")
+    __slots__ = ("_close_stack", "_handle")
 
     @classmethod
     def open(
@@ -87,7 +87,6 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             )
         self._handle = handle
         self._close_stack.enter_context(self._handle)
-        self._closed = False
 
     _wrapper_type: Type[_WrapperType_co]
     """Class variable of the Wrapper class used to open this object type."""
@@ -120,12 +119,11 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Closing an already-closed object is a no-op.
         """
         self._close_stack.close()
-        self._closed = True
 
     @property
     def closed(self) -> bool:
         """True if the object has been closed. False if it is still open."""
-        return self._closed
+        return self._handle.closed
 
     @property
     def mode(self) -> options.OpenMode:


### PR DESCRIPTION
- Makes `_handle.closed` the canonical place that `close` comes from.
- Uses `_handle.schema` to get array schemas rather than going through the `writer`.