### PR TITLE
Put more info in the `__repr__` of SOMA objects.

### DIFF
--- a/apis/python/src/tiledbsoma/tiledb_object.py
+++ b/apis/python/src/tiledbsoma/tiledb_object.py
@@ -104,7 +104,12 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         return self._handle.metadata
 
     def __repr__(self) -> str:
-        return f'{self.soma_type}(uri="{self.uri}")'
+        return f"<{self._my_repr()}>"
+
+    def _my_repr(self) -> str:
+        """``__repr__``, but without the ``<>``."""
+        open_str = "CLOSED" if self.closed else "open"
+        return f"{type(self).__name__} {self.uri!r} ({open_str} for {self.mode!r})"
 
     @property
     def uri(self) -> str:


### PR DESCRIPTION
This adds more information to the general `__repr__` of SOMA objects, including their open mode and status, and slightly reformats the representation of collections.

It also ensures that `repr` will work on objects and collections that have been closed, and that `repr` will only recurse into sub-elements of a collection that have already been opened (so it doesn't eagerly open up an entire collection tree).

---

Yet another entry from the List Of Things I Notice While Doing Other Things.