### PR TITLE
[python] Check to ensure we're not doing partitioned reads

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -150,7 +150,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
           `slice(2,None)` and `slice(None,4)` are both unsupported.
         * Negative indexing is unsupported.
         """
-        del batch_size, partitions, platform_config  # Currently unused.
+        del batch_size, platform_config  # Currently unused.
+        util.check_unpartitioned(partitions)
         self._check_open_read()
         result_order = options.ResultOrder(result_order)
 

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -80,8 +80,9 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
         :return: A SparseNDArrayRead to access result iterators in various formats.
         """
-        del result_order, batch_size, partitions, platform_config  # Currently unused.
+        del result_order, batch_size, platform_config  # Currently unused.
         self._check_open_read()
+        util.check_unpartitioned(partitions)
 
         if coords is None:
             coords = (slice(None),)

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -192,3 +192,15 @@ def check_type(
         raise TypeError(
             f"expected {name} argument to be one of {expected_types!r}; got {type(actual_value)}"
         )
+
+
+def check_unpartitioned(partitions: Optional[options.ReadPartitions]) -> None:
+    """Ensures that we're not being asked for a partitioned read.
+
+    Because we currently don't support partitioned reads, we should reject all
+    reads that request partitions to avoid giving the user duplicate data across
+    sharded tasks.
+    """
+    if not partitions or partitions == options.IOfN(0, 1):
+        return
+    raise ValueError("Paritioned reads are not currently supported")


### PR DESCRIPTION
Since we don't yet support partitioning, we shouldn't return results which aren't partitioned to callers who expect it.