### PR TITLE
[python] Explicitly remove support for slice steps.

### DIFF
--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -145,7 +145,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
           then `slice(None)` -- i.e. no constraint -- is assumed for the missing dimensions.
         * Per-dimension, explicitly specified coordinates can be one of: None, a value, a
           list/ndarray/paarray/etc of values, a slice, etc.
-        * Slices are doubly inclusive: slice(2,4) means [2,3,4] not [2,3]. Slice steps can only be +1.
+        * Slices are doubly inclusive: slice(2,4) means [2,3,4] not [2,3].
+          Slice steps are not supported.
           Slices can be `slice(None)`, meaning select all in that dimension, but may not be half-specified:
           `slice(2,None)` and `slice(None,4)` are both unsupported.
         * Negative indexing is unsupported.

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -97,9 +97,9 @@ def slice_to_range(
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """
-    if ids.step is not None and ids.step != 1:
-        raise ValueError("slice step must be 1 or None")
-    if ids.start is None and ids.stop is None:
+    if ids.step is not None:
+        raise ValueError("slice steps are not supported")
+    if ids == slice(None):
         return None
 
     start = ids.start


### PR DESCRIPTION
While we previously allowed the slice `step` value to be 1, this doesn't make sense when we slice in the context of floating-point dimensions (or string dimensions). For this reason, steps are disallowed entirely.

---

This is a proposal which I’m fine with seeing rejected, however this is the reasoning behind the language I put [disallowing slice steps](https://github.com/single-cell-data/SOMA/blob/2765ce5cf36ff6a374c8cca2c512dd0dc734fd22/python-spec/src/somacore/data.py#L113-L114) in the specification side (and make sure that it gets noticed too)