### PR TITLE
[r] Use dimension information when applying coords

### DIFF
--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -179,7 +179,7 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
 
     auto ptr = new tdbs::SOMAReader(uri, name, ctxptr, column_names, batch_size, result_order);
 
-    std::unordered_map<std::string, tiledb_datatype_t> name2type;
+    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = ptr->schema();
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
@@ -187,7 +187,7 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
         spdl::info("[soma_reader] Dimension {} type {} domain {} extent {}",
                    dim.name(), tiledb::impl::to_str(dim.type()),
                    dim.domain_to_str(), dim.tile_extent_to_str());
-        name2type.emplace(std::make_pair(dim.name(), dim.type()));
+        name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
     // If we have a query condition, apply it
@@ -202,13 +202,13 @@ Rcpp::XPtr<tdbs::SOMAReader> sr_setup(Rcpp::XPtr<tiledb::Context> ctx,
     // The List element is a simple vector of points and each point is applied to the named dimension
     if (!dim_points.isNull()) {
         Rcpp::List lst(dim_points);
-        apply_dim_points(ptr, name2type, lst);
+        apply_dim_points(ptr, name2dim, lst);
     }
 
     // If we have a dimension points, apply them
     if (!dim_ranges.isNull()) {
         Rcpp::List lst(dim_ranges);
-        apply_dim_ranges(ptr, name2type, lst);
+        apply_dim_ranges(ptr, name2dim, lst);
     }
 
     ptr->submit();

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -7,45 +7,61 @@
 namespace tdbs = tiledbsoma;
 
 void apply_dim_points(tdbs::SOMAReader *sr,
-                      std::unordered_map<std::string, tiledb_datatype_t>& name2type,
+                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
                       Rcpp::List lst) {
     std::vector<std::string> colnames = lst.attr("names");
     for (auto& nm: colnames) {
-        auto tp = name2type[nm];
+        auto dm = name2dim[nm];
+        auto tp = dm->type();
         if (tp == TILEDB_UINT64) {
             Rcpp::NumericVector payload = lst[nm];
             std::vector<int64_t> iv = getInt64Vector(payload);
             std::vector<uint64_t> uv(iv.size());
+            const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
             for (size_t i=0; i<iv.size(); i++) {
                 uv[i] = static_cast<uint64_t>(iv[i]);
-                sr->set_dim_point<uint64_t>(nm, uv[i]);  // bonked when use with vector
-                spdl::info("[export_arrow_array] Applying dim point {} on {}", uv[i], nm);
+                if (uv[i] >= pr.first && uv[i] <= pr.second) {
+                    sr->set_dim_point<uint64_t>(nm, uv[i]);  // bonked when use with vector
+                    spdl::info("[apply_dim_points] Applying dim point {} on {}", uv[i], nm);
+                }
             }
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericVector payload = lst[nm];
             std::vector<int64_t> iv = getInt64Vector(payload);
+            const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
             for (size_t i=0; i<iv.size(); i++) {
-                sr->set_dim_point<int64_t>(nm, iv[i]);
-                spdl::info("[export_arrow_array] Applying dim point {} on {}", iv[i], nm) ;
+                if (iv[i] >= pr.first && iv[i] <= pr.second) {
+                    sr->set_dim_point<int64_t>(nm, iv[i]);
+                    spdl::info("[apply_dim_points] Applying dim point {} on {}", iv[i], nm);
+                }
             }
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericVector payload = lst[nm];
+            const std::pair<float,float> pr = dm->domain<float>();
             for (R_xlen_t i=0; i<payload.size(); i++) {
-                float v = static_cast<uint64_t>(payload[i]);
-                sr->set_dim_point<float>(nm, v);
-                spdl::info("[export_arrow_array] Applying dim point {} on {}", v, nm) ;
+                float v = static_cast<float>(payload[i]);
+                if (v >= pr.first && v <= pr.second) {
+                    sr->set_dim_point<float>(nm, v);
+                    spdl::info("[apply_dim_points] Applying dim point {} on {}", v, nm);
+                }
             }
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericVector payload = lst[nm];
+            const std::pair<double,double> pr = dm->domain<double>();
             for (R_xlen_t i=0; i<payload.size(); i++) {
-                sr->set_dim_point<double>(nm,payload[i]);
-                spdl::info("[export_arrow_array] Applying dim point {} on {}", payload[i], nm) ;
+                if (payload[i] >= pr.first && payload[i] <= pr.second) {
+                    sr->set_dim_point<double>(nm,payload[i]);
+                    spdl::info("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                }
             }
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerVector payload = lst[nm];
+            const std::pair<int32_t,int32_t> pr = dm->domain<int32_t>();
             for (R_xlen_t i=0; i<payload.size(); i++) {
-                sr->set_dim_point<int32_t>(nm,payload[i]);
-                spdl::info("[export_arrow_array] Applying dim point {} on {}", payload[i], nm) ;
+                if (payload[i] >= pr.first && payload[i] <= pr.second) {
+                    sr->set_dim_point<int32_t>(nm,payload[i]);
+                    spdl::info("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                }
             }
         } else {
             Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));
@@ -54,62 +70,71 @@ void apply_dim_points(tdbs::SOMAReader *sr,
 }
 
 void apply_dim_ranges(tdbs::SOMAReader* sr,
-                      std::unordered_map<std::string, tiledb_datatype_t>& name2type,
+                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
                       Rcpp::List lst) {
     std::vector<std::string> colnames = lst.attr("names");
     for (auto& nm: colnames) {
-        auto tp = name2type[nm];
+        auto dm = name2dim[nm];
+        auto tp = dm->type();
         if (tp == TILEDB_UINT64) {
             Rcpp::NumericMatrix mm = lst[nm];
             Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
             Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            std::vector<std::pair<uint64_t, uint64_t>> vp(mm.nrow());
+            const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
             for (int i=0; i<mm.nrow(); i++) {
                 uint64_t l = static_cast<uint64_t>(makeScalarInteger64(lo[i]));
                 uint64_t h = static_cast<uint64_t>(makeScalarInteger64(hi[i]));
-                std::vector<std::pair<uint64_t, uint64_t>> vp{std::make_pair(l,h)};
-                sr->set_dim_ranges<uint64_t>(nm, vp);
-                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
+                vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
+                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
             }
+            sr->set_dim_ranges<uint64_t>(nm, vp);
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericMatrix mm = lst[nm];
             std::vector<int64_t> lo = getInt64Vector(mm.column(0));
             std::vector<int64_t> hi = getInt64Vector(mm.column(1));
+            std::vector<std::pair<int64_t, int64_t>> vp(mm.nrow());
+            const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
             for (int i=0; i<mm.nrow(); i++) {
-                std::vector<std::pair<int64_t, int64_t>> vp{std::make_pair(lo[i], hi[i])};
-                sr->set_dim_ranges<int64_t>(nm, vp);
-                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
+                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
+                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
             }
+            sr->set_dim_ranges<int64_t>(nm, vp);
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericMatrix mm = lst[nm];
             Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
             Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            std::vector<std::pair<float, float>> vp(mm.nrow());
+            const std::pair<float,float> pr = dm->domain<float>();
             for (int i=0; i<mm.nrow(); i++) {
-                float l = static_cast<float_t>(lo[i]);
-                float h = static_cast<float_t>(hi[i]);
-                std::vector<std::pair<float, float>> vp{std::make_pair(l,h)};
-                sr->set_dim_ranges<float>(nm, vp);
-                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
+                float l = static_cast<float>(lo[i]);
+                float h = static_cast<float>(hi[i]);
+                vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
+                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
             }
+            sr->set_dim_ranges<float>(nm, vp);
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericMatrix mm = lst[nm];
             Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
             Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            std::vector<std::pair<double, double>> vp(mm.nrow());
+            const std::pair<double,double> pr = dm->domain<double>();
             for (int i=0; i<mm.nrow(); i++) {
-                std::vector<std::pair<double, double>> vp{std::make_pair(lo[i],hi[i])};
-                sr->set_dim_ranges<double>(nm, vp);
-                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
+                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
+                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
             }
+            sr->set_dim_ranges<double>(nm, vp);
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerMatrix mm = lst[nm];
             Rcpp::IntegerMatrix::Column lo = mm.column(0); // works as proxy for int and float types
             Rcpp::IntegerMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            std::vector<std::pair<int32_t, int32_t>> vp(mm.nrow());
+            const std::pair<int32_t,int32_t> pr = dm->domain<int32_t>();
             for (int i=0; i<mm.nrow(); i++) {
-                int32_t l = static_cast<int32_t>(lo[i]);
-                int32_t h = static_cast<int32_t>(hi[i]);
-                std::vector<std::pair<int32_t, int32_t>> vp{std::make_pair(l,h)};
-                sr->set_dim_ranges<int32_t>(nm, vp);
-                spdl::info("[export_arrow_array] Applying dim point {} on {} with {} - {}", i, nm[i], l, h) ;
+                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
+                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm[i], lo[i], hi[i]) ;
             }
+            sr->set_dim_ranges<int32_t>(nm, vp);
         } else {
             Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));
         }

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -33,10 +33,10 @@ inline std::vector<int64_t> getInt64Vector(Rcpp::NumericVector vec) {
 
 // Applies (named list of) vectors of points to the named dimensions
 void apply_dim_points(tdbs::SOMAReader* sr,
-                      std::unordered_map<std::string, tiledb_datatype_t>& name2type,
+                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
                       Rcpp::List lst);
 
 // Applies (named list of) matrices of points to the named dimensions
 void apply_dim_ranges(tdbs::SOMAReader* sr,
-                      std::unordered_map<std::string, tiledb_datatype_t>& name2type,
+                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
                       Rcpp::List lst);

--- a/apis/r/tests/testthat/test_SOMAReader-Arrow.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Arrow.R
@@ -47,7 +47,7 @@ test_that("Arrow Interface from SOMAReader", {
     soma_reader(uri = uri,
                 colnames = c("obs_id", "percent_mito", "n_counts", "louvain"),
                 dim_ranges=list(soma_joinid=rbind(bit64::as.integer64(c(1000, 1004)),
-                                                 bit64::as.integer64(c(2000, 2004)))),
+                                                  bit64::as.integer64(c(2000, 2004)))),
                 dim_points=list(soma_joinid=bit64::as.integer64(seq(0, 100, by=20)))) |>
         arch::from_arch_array(arrow::RecordBatch) |>
         arrow::as_arrow_table() |>


### PR DESCRIPTION
#### Context

Issue #900 showed that selecting dimension points (or ranges) outside the non-empty domain lead to errors.  This PR reflect is domain of a dimension and only applies forming point (or range) selections.

#### Changes:

The Dimension object is passed down to the helper functions setting points or ranges

#### Notes for Reviewer:

See #900 and [SC #25314](https://app.shortcut.com/tiledb-inc/story/25314/soma-reader-attempts-to-set-dim-points-beyond-array-dimension) and [SC #25319](https://app.shortcut.com/tiledb-inc/story/25319/soma-r-package-check-ranges-and-dim-points-agains-non-empty-domain)

#### Demo

<details>  

With logging at the info level, we now see that the previously 'bad' ceases to select beyond index position nine.

```r
> library(tiledbsoma)
> uri <- "/tmp/tiledb/foosnda"
> ndarray <- SOMASparseNDArray$new(uri)
> tbl_bad <- ndarray$read_arrow_table(coords = list(soma_dim_0=0, soma_dim_1=0:12), log_level="info")
[2023-02-11 16:56:51.933] [default] [Process: 1570260] [info] [soma_reader] Reading from /tmp/tiledb/foosnda
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [soma_reader] Dimension soma_dim_0 type INT64 domain [0,9] extent 10
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [soma_reader] Dimension soma_dim_1 type INT64 domain [0,9] extent 10
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 0 on soma_dim_0
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 0 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 1 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 2 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 3 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 4 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 5 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 6 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 7 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 8 on soma_dim_1
[2023-02-11 16:56:51.936] [default] [Process: 1570260] [info] [apply_dim_points] Applying dim point 9 on soma_dim_1
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Read complete with 5 rows and 3 cols
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Accessing soma_dim_0 at 0
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Incoming name soma_dim_0
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Accessing soma_dim_1 at 1
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Incoming name soma_dim_1
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Accessing soma_data at 2
[2023-02-11 16:56:51.939] [default] [Process: 1570260] [info] [soma_reader] Incoming name soma_data
> print(dplyr::collect(tbl_bad))
# A tibble: 5 × 3
  soma_dim_0 soma_dim_1 soma_data
       <int>      <int>     <int>
1          0          0        25
2          0          1        26
3          0          2        41
4          0          5        79
5          0          9        48
> 
```

</details>
