### PR TITLE
Exclude matplotlib 3.7 due to incompatible scanpy.

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -177,6 +177,7 @@ setuptools.setup(
     install_requires=[
         "anndata",
         "attrs>=22.1",
+        "matplotlib<3.7",  # https://github.com/scverse/scanpy/issues/2411
         "numpy",
         "pandas",
         "pyarrow >= 9.0.0",


### PR DESCRIPTION
matplotlib just released v3.7, and unfortunately it introduced an incompatibility with scanpy:

https://github.com/scverse/scanpy/issues/2411

Excluding v3.7 works around this issue. This workaround can be removed once scanpy itself excludes v3.7, or if scanpy fixes the root cause.

---

In trying to figure out why https://github.com/single-cell-data/TileDB-SOMA/pull/928 failed despite not changing anything that would cause that type of failure, I figured that there must have been a dependency change.

So I looked at the output from the `pip install -e apis/python` step from [the failing job](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/4168929983/jobs/7216289034) to see if there were any new libraries. A new library would not be in the pip cache, so it would have to have been downloaded. The only entry that had a download bar was:

```
Collecting matplotlib>=3.4
  Downloading matplotlib-3.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.6/11.6 MB 29.3 MB/s eta 0:00:00
```

Looking at PyPI, [a new version of matplotlib](https://pypi.org/project/matplotlib/3.7.0/) was just released today, so I tried reverting to the previous version and everything built and ran correctly.