### PR TITLE
[python] Typo-fix in `NDArray` `create` error message

### DIFF
--- a/apis/python/src/tiledbsoma/common_nd_array.py
+++ b/apis/python/src/tiledbsoma/common_nd_array.py
@@ -86,7 +86,7 @@ def _build_tiledb_schema(
 
     # check on shape
     if len(shape) == 0 or any(e <= 0 for e in shape):
-        raise ValueError("DenseNDArray shape must be non-zero length tuple of ints > 0")
+        raise ValueError("SOMA NDArray shape must be non-zero length tuple of ints > 0")
 
     if not pa.types.is_primitive(type):
         raise TypeError(


### PR DESCRIPTION
Just a typofix. It looks like the code modified here was once only for `DenseNDArray`, but is now being leveraged for duplicate sparse/dense use.