### PR TITLE
Unify coordinate-parsing logic and use entire dimension for slicing.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs"
-        - "somacore==0.0.0a13"
+        - "somacore==0.0.0a14"
         - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -183,7 +183,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a13",
+        "somacore==0.0.0a14",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/dataframe.py
+++ b/apis/python/src/tiledbsoma/dataframe.py
@@ -1,5 +1,4 @@
-import collections.abc
-from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, Mapping, Optional, Sequence, Tuple, cast
 
 import numpy as np
 import pyarrow as pa
@@ -9,6 +8,7 @@ from somacore import options
 from typing_extensions import Self
 
 from . import arrow_types, util
+from . import libtiledbsoma as clib
 from .constants import SOMA_JOINID
 from .options import SOMATileDBContext
 from .options.tiledb_create_options import TileDBCreateOptions
@@ -17,7 +17,6 @@ from .read_iters import TableReadIter
 from .tiledb_array import TileDBArray
 from .types import NPFloating, NPInteger
 
-Slice = TypeVar("Slice", bound=Sequence[int])
 _UNBATCHED = options.BatchSize()
 
 
@@ -169,52 +168,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             result_order=result_order.value,
         )
 
-        if not isinstance(coords, (list, tuple)):
-            raise TypeError(
-                f"coords type {type(coords)} unsupported; expected list or tuple"
-            )
-        if schema.domain.ndim < len(coords):
-            raise ValueError(
-                f"coords {coords} must have length between 1 and ndim ({schema.domain.ndim}); got {len(coords)}"
-            )
-
-        for i, dim_coords in enumerate(coords):
-            # Example: coords = [None, 3, slice(4,5)]
-            # dim_coords takes on values None, 3, and slice(4,5) in this loop body.
-            dim = schema.domain.dim(i)
-            if dim_coords is None:
-                pass  # No constraint; select all in this dimension
-            elif isinstance(dim_coords, (int, str, bytes)):
-                sr.set_dim_points(dim.name, [dim_coords])
-            elif isinstance(dim_coords, np.ndarray):
-                if dim_coords.ndim != 1:
-                    raise ValueError(
-                        f"only 1D numpy arrays may be used to index; got {dim_coords.ndim}"
-                    )
-                sr.set_dim_points(dim.name, dim_coords)
-            elif isinstance(dim_coords, slice):
-                # TODO: Allow negative indices.
-                lo_hi = util.slice_to_range(dim_coords, (0, dim.domain[1]))
-                if lo_hi is not None:
-                    lo, hi = lo_hi
-                    if lo < 0 or hi < 0:
-                        raise ValueError(
-                            f"slice start and stop may not be negative; got ({lo}, {hi})"
-                        )
-                    if lo > hi:
-                        raise ValueError(
-                            f"coordinate at slot {i} must have lo <= hi; got {lo} > {hi}"
-                        )
-                    sr.set_dim_ranges(dim.name, [lo_hi])
-                # Else, no constraint in this slot. This is `slice(None)` which is like
-                # Python indexing syntax `[:]`.
-            elif isinstance(
-                dim_coords,
-                (collections.abc.Sequence, pa.Array, pa.ChunkedArray),
-            ):
-                sr.set_dim_points(dim.name, dim_coords)
-            else:
-                raise TypeError(f"coords[{i}] type {type(dim_coords)} is unsupported")
+        self._set_reader_coords(sr, coords)
 
         # TODO: platform_config
         # TODO: batch_size
@@ -257,6 +211,24 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self._handle.writer[dim_cols_tuple] = attr_cols_map
 
         return self
+
+    def _set_reader_coord(
+        self, sr: clib.SOMAReader, dim: tiledb.Dim, coord: object
+    ) -> bool:
+        if super()._set_reader_coord(sr, dim, coord):
+            return True
+
+        if isinstance(coord, (str, bytes)):
+            sr.set_dim_points(dim.name, [coord])
+            return True
+        if isinstance(coord, (Sequence, pa.Array, pa.ChunkedArray, np.ndarray)):
+            if isinstance(coord, np.ndarray) and coord.ndim != 1:
+                raise ValueError(
+                    f"only 1D numpy arrays may be used to index; got {coord.ndim}"
+                )
+            sr.set_dim_points(dim.name, coord)
+            return True
+        return False
 
 
 def _canonicalize_schema(

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -48,39 +48,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
         sr = self._soma_reader(result_order=result_order.value)
 
-        if not isinstance(coords, (list, tuple)):
-            raise TypeError(
-                f"coords type {type(coords)} unsupported; expected list or tuple"
-            )
-        if len(coords) > schema.domain.ndim:
-            raise ValueError(
-                f"coords {coords} must be shorter than ndim ({schema.domain.ndim}); got {len(coords)}"
-            )
-
-        for i, coord in enumerate(coords):
-            dim = schema.domain.dim(i)
-
-            if coord is None:
-                pass  # No constraint; select all in this dimension
-            elif isinstance(coord, int):
-                sr.set_dim_points(dim.name, [coord])
-            elif isinstance(coord, slice):
-                lo_hi = util.slice_to_range(coord, dim.domain)
-                if lo_hi is not None:
-                    lo, hi = lo_hi
-                    if lo < 0 or hi < 0:
-                        raise ValueError(
-                            f"slice start and stop may not be negative; got ({lo}, {hi})"
-                        )
-                    if lo > hi:
-                        raise ValueError(
-                            f"slice start must be <= slice stop; got ({lo}, {hi})"
-                        )
-                    sr.set_dim_ranges(dim.name, [lo_hi])
-                # Else, no constraint in this slot. This is `slice(None)` which is like
-                # Python indexing syntax `[:]`.
-            else:
-                raise TypeError(f"coord type {type(coord)} at slot {i} unsupported")
+        self._set_reader_coords(sr, coords)
 
         sr.submit()
 

--- a/apis/python/src/tiledbsoma/dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/dense_nd_array.py
@@ -58,15 +58,14 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             )
 
         for i, coord in enumerate(coords):
-            dim_name = schema.domain.dim(i).name
+            dim = schema.domain.dim(i)
+
             if coord is None:
                 pass  # No constraint; select all in this dimension
             elif isinstance(coord, int):
-                sr.set_dim_points(dim_name, [coord])
+                sr.set_dim_points(dim.name, [coord])
             elif isinstance(coord, slice):
-                ned = self._handle.reader.nonempty_domain()
-                # ned is None iff the array has no data
-                lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
+                lo_hi = util.slice_to_range(coord, dim.domain)
                 if lo_hi is not None:
                     lo, hi = lo_hi
                     if lo < 0 or hi < 0:
@@ -77,7 +76,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                         raise ValueError(
                             f"slice start must be <= slice stop; got ({lo}, {hi})"
                         )
-                    sr.set_dim_ranges(dim_name, [lo_hi])
+                    sr.set_dim_ranges(dim.name, [lo_hi])
                 # Else, no constraint in this slot. This is `slice(None)` which is like
                 # Python indexing syntax `[:]`.
             else:

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -99,34 +99,32 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         for i, coord in enumerate(coords):
             #                # Example: coords = [None, 3, slice(4,5)]
             #                # coord takes on values None, 3, and slice(4,5) in this loop body.
-            dim_name = schema.domain.dim(i).name
+            dim = schema.domain.dim(i)
             if coord is None:
                 pass  # No constraint; select all in this dimension
             elif isinstance(coord, int):
-                sr.set_dim_points(dim_name, [coord])
+                sr.set_dim_points(dim.name, [coord])
             elif isinstance(coord, np.ndarray):
                 if coord.ndim != 1:
                     raise ValueError(
                         f"only 1D numpy arrays may be used to index; got {coord.ndim}"
                     )
-                sr.set_dim_points(dim_name, coord)
+                sr.set_dim_points(dim.name, coord)
             elif isinstance(coord, slice):
-                ned = self._handle.reader.nonempty_domain()
-                # ned is None iff the array has no data
-                lo_hi = util.slice_to_range(coord, ned[i]) if ned else None
+                lo_hi = util.slice_to_range(coord, dim.domain)
                 if lo_hi is not None:
                     lo, hi = lo_hi
                     if lo < 0 or hi < 0:
                         raise ValueError(
                             f"slice start and stop may not be negative; got ({lo}, {hi})"
                         )
-                    sr.set_dim_ranges(dim_name, [lo_hi])
+                    sr.set_dim_ranges(dim.name, [lo_hi])
                 # Else, no constraint in this slot. This is `slice(None)` which is like
                 # Python indexing syntax `[:]`.
             elif isinstance(
                 coord, (collections.abc.Sequence, pa.Array, pa.ChunkedArray)
             ):
-                sr.set_dim_points(dim_name, coord)
+                sr.set_dim_points(dim.name, coord)
             else:
                 raise TypeError(f"coord type {type(coord)} at slot {i} unsupported")
 

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
+from somacore import types
 from typing_extensions import Literal
 
 if TYPE_CHECKING:
@@ -38,3 +39,8 @@ ArrowReadResult = Union[
     pa.SparseCSRMatrix,
     pa.SparseCSCMatrix,
 ]
+
+# Re-exporting things from the somacore types namespace here.
+Comparable = types.Comparable
+Slice = types.Slice
+is_nonstringy_sequence = types.is_nonstringy_sequence

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -91,9 +91,7 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(
-    ids: slice, nonempty_domain: Tuple[int, int]
-) -> Optional[Tuple[int, int]]:
+def slice_to_range(ids: slice, domain: Tuple[int, int]) -> Optional[Tuple[int, int]]:
     """
     For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
     """
@@ -102,18 +100,16 @@ def slice_to_range(
     if ids == slice(None):
         return None
 
-    start = ids.start
-    stop = ids.stop
+    domain_start, domain_stop = domain
 
     # TODO: with future C++ improvements, move half-slice logic to SOMAReader
-    if start is None:
-        start = nonempty_domain[0]
-    if stop is None:
-        stop = nonempty_domain[1]
+    start = domain_start if ids.start is None else ids.start
+    stop = domain_stop if ids.stop is None else ids.stop
 
     # Indexing beyond end of array should "trim" to end of array
-    if stop > nonempty_domain[1]:
-        stop = nonempty_domain[1]
+    # TODO: Allow negative indexing:
+    # start = max(start, domain_start)
+    stop = min(stop, domain_stop)
 
     if start > stop:
         raise ValueError("slice start must be <= slice stop")

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -1,7 +1,7 @@
 import pathlib
 import time
 import urllib.parse
-from typing import Any, List, Optional, Tuple, Type, Union
+from typing import Any, List, Optional, Tuple, Type
 
 import somacore
 from somacore import options
@@ -146,10 +146,7 @@ def dense_indices_to_shape(
     return tuple(reversed(shape))
 
 
-def dense_index_to_shape(
-    coord: Union[int, slice],
-    array_length: int,
-) -> int:
+def dense_index_to_shape(coord: options.DenseCoord, array_length: int) -> int:
     """
     Given a subarray per-dimension index specified as a slice or scalar (e.g, ``[:], 1, [1:2]``),
     and the shape of the array in that dimension, return the shape of the subarray in
@@ -158,6 +155,9 @@ def dense_index_to_shape(
     Note that Python slice semantics are right-endpoint-exclusive whereas SOMA slice semantics are
     doubly inclusive.
     """
+    if coord is None:
+        return array_length
+
     if type(coord) is int:
         return 1
 


### PR DESCRIPTION
Part of work on #933.

This first step deduplicates much of the coordinate-parsing code so that further changes only need to be made in one place rather than many. This also changes half-specified reads to use the entire half-domain of the array, rather than querying for the non-empty domain and then using that.

The behavior of negative and string indices is unchanged; this just reorganizes.