### PR TITLE
Make the pull-request template a little less shouty

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
-## Issue and/or context:
+**Issue and/or context:**
 
-## Changes:
+**Changes:**
 
-## Notes for Reviewer:
+**Notes for Reviewer:**
 


### PR DESCRIPTION
No tracking issue -- just aesthetics.

Having used this template for a while I find the `##` a bit much, and unnecessary. Also, it's error-prone as if one does at first

```
## Issue: foo
```

one needs to immediately re-edit to

```
## Issue:

foo
```

which is error-prone and (micro-)time-consuming.