### PR TITLE
Allow slicing with any type and with negative values.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs"
-        - "somacore==0.0.0a14"
+        - "somacore==0.0.0a15"
         - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -183,7 +183,7 @@ setuptools.setup(
         "pyarrow >= 9.0.0",
         "scanpy",
         "scipy",
-        "somacore==0.0.0a14",
+        "somacore==0.0.0a15",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/sparse_nd_array.py
@@ -147,9 +147,9 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         )
 
     def _set_reader_coord(
-        self, sr: clib.SOMAReader, dim: tiledb.Dim, coord: object
+        self, sr: clib.SOMAReader, dim_idx: int, dim: tiledb.Dim, coord: object
     ) -> bool:
-        if super()._set_reader_coord(sr, dim, coord):
+        if super()._set_reader_coord(sr, dim_idx, dim, coord):
             return True
         if isinstance(coord, (Sequence, pa.Array, pa.ChunkedArray, np.ndarray)):
             if isinstance(coord, np.ndarray) and coord.ndim != 1:

--- a/apis/python/src/tiledbsoma/types.py
+++ b/apis/python/src/tiledbsoma/types.py
@@ -41,6 +41,6 @@ ArrowReadResult = Union[
 ]
 
 # Re-exporting things from the somacore types namespace here.
-Comparable = types.Comparable
 Slice = types.Slice
 is_nonstringy_sequence = types.is_nonstringy_sequence
+is_slice_of = types.is_slice_of

--- a/apis/python/src/tiledbsoma/util.py
+++ b/apis/python/src/tiledbsoma/util.py
@@ -1,10 +1,13 @@
 import pathlib
 import time
 import urllib.parse
-from typing import Any, List, Optional, Tuple, Type
+from itertools import zip_longest
+from typing import Any, Optional, Tuple, Type, TypeVar
 
 import somacore
 from somacore import options
+
+from .types import Slice, is_slice_of
 
 
 def get_start_stamp() -> float:
@@ -91,29 +94,55 @@ def uri_joinpath(base: str, path: str) -> str:
     return urllib.parse.urlunparse(parts)
 
 
-def slice_to_range(ids: slice, domain: Tuple[int, int]) -> Optional[Tuple[int, int]]:
-    """
-    For the interface between ``DataFrame::read`` et al. (Python) and ``SOMAReader`` (C++).
-    """
-    if ids.step is not None:
+def validate_slice(slc: Slice[Any]) -> None:
+    """Checks that a slice has no step and is not inverted."""
+    if slc.step is not None:
         raise ValueError("slice steps are not supported")
-    if ids == slice(None):
+    if slc.start is None or slc.stop is None:
+        # All half-specified slices are valid.
+        return
+    if slc.stop < slc.start:
+        raise ValueError(
+            f"slice start ({slc.start!r}) must be <= slice stop ({slc.stop!r})"
+        )
+
+
+_T = TypeVar("_T")
+
+
+class NonNumericDimensionError(TypeError):
+    """Raised when trying to get a numeric range for a non-numeric dimension."""
+
+
+def slice_to_numeric_range(
+    slc: Slice[Any], domain: Tuple[_T, _T]
+) -> Optional[Tuple[_T, _T]]:
+    """Constrains the given slice to the ``domain`` for numeric dimensions.
+
+    We assume the slice has already been validated by validate_slice.
+    """
+    if slc == slice(None):
         return None
 
     domain_start, domain_stop = domain
-
+    if isinstance(domain_stop, (str, bytes)):
+        # Strings don't have a real "domain" so we can't handle them
+        # the same way that we handle numeric types.
+        raise NonNumericDimensionError("only numeric dimensions supported")
     # TODO: with future C++ improvements, move half-slice logic to SOMAReader
-    start = domain_start if ids.start is None else ids.start
-    stop = domain_stop if ids.stop is None else ids.stop
+    start = domain_start if slc.start is None else max(slc.start, domain_start)
+    stop = domain_stop if slc.stop is None else min(slc.stop, domain_stop)
 
-    # Indexing beyond end of array should "trim" to end of array
-    # TODO: Allow negative indexing:
-    # start = max(start, domain_start)
-    stop = min(stop, domain_stop)
+    if stop < start:
+        # With the above, we have guaranteed that at least one bound will
+        # include the domain.  If we get here, that means that the other bound
+        # never included it (e.g. stop == slc.stop < domain_start == start).
+        raise ValueError(
+            f"slice [{slc.start!r}:{slc.stop!r}] does not overlap"
+            f" [{domain_start!r}:{domain_stop!r}]"
+        )
 
-    if start > stop:
-        raise ValueError("slice start must be <= slice stop")
-    return (start, stop)
+    return start, stop
 
 
 def dense_indices_to_shape(
@@ -133,16 +162,12 @@ def dense_indices_to_shape(
             f" array dimension count ({len(array_shape)})"
         )
 
-    shape: List[int] = []
-    for i, extent in enumerate(array_shape):
-        if i < len(coords):
-            shape.append(dense_index_to_shape(coords[i], extent))
-        else:
-            shape.append(extent)
-
+    shape = tuple(
+        dense_index_to_shape(coord, extent)
+        for coord, extent in zip_longest(coords, array_shape)
+    )
     if result_order is somacore.ResultOrder.ROW_MAJOR:
-        return tuple(shape)
-
+        return shape
     return tuple(reversed(shape))
 
 
@@ -157,19 +182,18 @@ def dense_index_to_shape(coord: options.DenseCoord, array_length: int) -> int:
     """
     if coord is None:
         return array_length
-
-    if type(coord) is int:
+    if isinstance(coord, int):
         return 1
+    if is_slice_of(coord, int):
+        # We verify that `step` is None elsewhere, so we can always assume
+        # that we're asked for a continuous slice.
+        if coord.stop is None:
+            stop = array_length
+        else:
+            stop = min(coord.stop + 1, array_length)
+        return stop - (coord.start or 0)
 
-    if type(coord) is slice:
-        start, stop, step = coord.indices(array_length)
-        if step != 1:
-            raise ValueError("stepped slice ranges are not supported")
-        # This is correct for doubly-inclusive slices which SOMA uses.
-        stop = min(stop, array_length - 1)
-        return stop - start + 1
-
-    raise TypeError("coordinates must be tuple of int or slice")
+    raise TypeError(f"coordinate {coord} must be integer or integer slice")
 
 
 def check_type(

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -378,6 +378,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
             ("strings_aaa", pa.string()),
             ("zero_one", pa.int64()),
             ("thousands", pa.int64()),
+            ("both_signs", pa.int64()),
             ("soma_joinid", pa.int64()),
             ("A", pa.int64()),
         ]
@@ -392,6 +393,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
         "strings_aaa": ["aaa", "aaa", "bbb", "bbb", "ccc", "ccc"],
         "zero_one": [0, 1, 0, 1, 0, 1],
         "thousands": [1000, 2000, 1000, 1000, 1000, 1000],
+        "both_signs": [-1, -2, -3, 1, 2, 3],
         "soma_joinid": [10, 11, 12, 13, 14, 15],
         "A": [10, 11, 12, 13, 14, 15],
     }
@@ -534,6 +536,13 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
             "index_column_names": ["0_thru_5"],
             "coords": [slice(2, None)],  # Half-slice
             "A": [12, 13, 14, 15],
+            "throws": None,
+        },
+        {
+            "name": "1D indexing with negatives",
+            "index_column_names": ["both_signs"],
+            "coords": [slice(-2, 1)],
+            "A": [11, 10, 13],
             "throws": None,
         },
         {

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -537,6 +537,27 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
             "throws": None,
         },
         {
+            "name": "1D indexing by ['bbb':'c']",
+            "index_column_names": ["strings_aaa", "zero_one"],
+            "coords": [slice("bbb", "c")],
+            "A": [12, 13],
+            "throws": None,
+        },
+        {
+            "name": "1D indexing by ['ccc':]",
+            "index_column_names": ["strings_aaa", "zero_one"],
+            "coords": [slice("ccc", None)],
+            "A": [14, 15],
+            "throws": None,
+        },
+        {
+            "name": "1D indexing by [:'bbd']",
+            "index_column_names": ["strings_aaa", "zero_one"],
+            "coords": [slice("bbd")],
+            "A": [10, 11, 12, 13],
+            "throws": None,
+        },
+        {
             "name": "1D indexing with one partition",
             "index_column_names": ["0_thru_5"],
             "coords": [slice(2, None)],
@@ -561,7 +582,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
         },
         {
             "name": "slice must overlap domain (negative)",
-            "index_column_names": ["0_thru_5"],
+            "index_column_names": ["soma_joinid"],
             "coords": [slice(-2, -1)],
             "A": None,
             "throws": ValueError,

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -493,6 +493,15 @@ def test_csr_csc_2d_read(tmp_path, shape):
             "throws": None,
         },
         {
+            "name": "coords=[[-100:100]]",
+            "shape": (4,),
+            "coords": (slice(-100, 100),),
+            "dims": {
+                "soma_dim_0": [0, 1, 2, 3],
+            },
+            "throws": None,
+        },
+        {
             "name": "coords=[4]",
             "shape": (4,),
             "coords": (1,),
@@ -536,6 +545,16 @@ def test_csr_csc_2d_read(tmp_path, shape):
             "name": "coords=([:2],[2:])",
             "shape": (3, 4),
             "coords": (slice(None, 2), slice(2, None)),
+            "dims": {
+                "soma_dim_0": [0, 0, 1, 1, 2, 2],
+                "soma_dim_1": [2, 3, 2, 3, 2, 3],
+            },
+            "throws": None,
+        },
+        {
+            "name": "coords=([-10:2],[2:500])",
+            "shape": (3, 4),
+            "coords": (slice(-10, 2), slice(2, 500)),
             "dims": {
                 "soma_dim_0": [0, 0, 1, 1, 2, 2],
                 "soma_dim_1": [2, 3, 2, 3, 2, 3],
@@ -881,13 +900,14 @@ def test_sparse_nd_array_error_corners(tmp_path):
 @pytest.mark.parametrize(
     "bad_coords",
     [
-        ((slice(1, 10, 2),)),  # step != 1
-        ((slice(32, 1),)),  # start > stop
-        ((slice(-32),)),  # negagive start
-        ((slice(-10, 2),)),  # negative start
-        ((slice(-10, -2),)),  # negative start & stop
-        ((slice(10, -2),)),  # negative stop
-        ((slice(None), slice(None))),  # too many dims
+        (slice(1, 10, 1),),  # explicit step
+        (slice(32, 1),),  # stop < start
+        (slice(-10, -2),),  # negative start & stop
+        (slice(-32),),  # stop < entire domain
+        (slice(10, -2),),  # stop < start
+        (slice(100, None),),  # entire domain < start
+        (slice(150, 200),),  # entire domain < start
+        (slice(None), slice(None)),  # too many dims
     ],
 )
 def test_bad_coords(tmp_path, bad_coords):


### PR DESCRIPTION
- Removes the "slice indices must be positive" requirement,  per discussion on https://github.com/single-cell-data/SOMA/pull/119.
- Enables slicing for string dimensions.

This change also follows up on the previous change to allow"over-indexing" off the low end of a domain to work just as it does when indexing off the high end of a domain: the low end is clipped to the bottom of the domain. So for a dimension with domain [−3, 8]:

    slice(-100, 100) -> -3, 8
    slice(-5, 0) -> -3, 0
    slice(5, 10) -> 5, 8
    slice(-100, -50) -> error (too low)
    slice(50, 100) -> error (too high)

Since this uses the New And Improved `is_slice_of` function, this also pulls in the new somacore (where that is the only change present).

Fixes #933.