### PR TITLE
[python] Mutable-X mods, and `.shape` as explicit `SparseNDArray` capacity

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -39,7 +39,7 @@ class NDArray(TileDBArray, somacore.NDArray):
             If the type is unsupported, an error will be raised.
 
         :param shape: The maximum capacity of the dataframe, including room for any
-            intended future appends,as a sequence. E.g. ``[100, 10]``.  All
+            intended future appends,as a sequence. E.g. ``(100, 10)``.  All
             lengths must be in the positive int64 range, or `None`.  If a slot
             is `None` -- only supported for `SparseNDArray`, not `DenseNDArray`
             -- then the maximum possible size will be used. This makes a

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -42,12 +42,19 @@ class NDArray(TileDBArray, somacore.NDArray):
             intended future appends,as a sequence. E.g. ``(100, 10)``.  All
             lengths must be in the positive int64 range, or `None`.  If a slot
             is `None` -- only supported for `SparseNDArray`, not `DenseNDArray`
-            -- then the maximum possible size will be used. This makes a
+            -- then the maximum possible int64 size will be used. This makes a
             `SparseNDArray` growable.
 
         :param platform_config: Platform-specific options used to create this Array,
             provided via ``{"tiledb": {"create": ...}}`` nested keys.
         """
+        # Implementor note: we carefully say "maximum possible in64 size" rather than 2**63-1. The
+        # reason that the latter, while temptingly simple, is actually untrue is that tiledb core
+        # requires that the capacity, when rounded up to an exact multiple of the extent, needs to
+        # be representable as a signed 64-bit integer.  So in particular when a unit test (or anyone
+        # else) sets extent to a not-power-of-two number like 999 or 1000 then the create fails if
+        # the upper limit is exactly 2**63-1.
+
         context = context or SOMATileDBContext()
         schema = _build_tiledb_schema(
             type,

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -53,7 +53,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         :param platform_config: Platform-specific options used to create this Array,
             provided via ``{"tiledb": {"create": ...}}`` nested keys.
         """
-        # Implementor note: we carefully say "maximum possible in64 size" rather than 2**63-1. The
+        # Implementor note: we carefully say "maximum possible int64 size" rather than 2**63-1. The
         # reason that the latter, while temptingly simple, is actually untrue is that tiledb core
         # requires that the capacity, when rounded up to an exact multiple of the extent, needs to
         # be representable as a signed 64-bit integer.  So in particular when a unit test (or anyone

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -38,12 +38,17 @@ class NDArray(TileDBArray, somacore.NDArray):
         :param type: The Arrow type to be stored in the NDArray.
             If the type is unsupported, an error will be raised.
 
-        :param shape: The maximum capacity of the dataframe, including room for any
-            intended future appends,as a sequence. E.g. ``(100, 10)``.  All
-            lengths must be in the positive int64 range, or `None`.  If a slot
-            is `None` -- only supported for `SparseNDArray`, not `DenseNDArray`
-            -- then the maximum possible int64 size will be used. This makes a
-            `SparseNDArray` growable.
+        :param shape: The maximum capacity of each dimension, including room
+            for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
+            All lengths must be in the postive int64 range, or ``None``.
+            It's necessary to say ``shape=(None, None)`` or ``shape=(None, None, None)``
+            rather than more simply ``shape=None`` since the first two are how one
+            specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
+            of this sequence is the number of dimensions of the array.
+
+            For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
+            possible int64 will be used.  This makes a ``SOMASparseNDArray``
+            growable.
 
         :param platform_config: Platform-specific options used to create this Array,
             provided via ``{"tiledb": {"create": ...}}`` nested keys.

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -40,11 +40,10 @@ class NDArray(TileDBArray, somacore.NDArray):
 
         :param shape: The maximum capacity of each dimension, including room
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-            All lengths must be in the postive int64 range, or ``None``.
-            It's necessary to say ``shape=(None, None)`` or ``shape=(None, None, None)``
-            rather than more simply ``shape=None`` since the first two are how one
-            specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
-            of this sequence is the number of dimensions of the array.
+            All lengths must be in the postive int64 range, or ``None``.  It's
+            necessary to say ``shape=(None, None)`` or ``shape=(None, None,
+            None)``, as the sequence length determines the number of dimensions
+            N in the N-dimensional array.
 
             For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
             possible int64 will be used.  This makes a ``SOMASparseNDArray``

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -140,7 +140,6 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         """
         Return the number of rows in the dataframe. Same as `len(df)`.
         """
-        # A.domain.shape at the tiledb level gives us the 0..2^63-1 range which is not what we want
         self._check_open_read()
         return cast(int, self._soma_reader().nnz())
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -359,7 +359,9 @@ def _build_tiledb_schema(
     dims = []
     for index_column_name in index_column_names:
         pa_type = schema.field(index_column_name).type
-        dtype = _arrow_types.tiledb_type_from_arrow_type(pa_type, is_indexed_column=True)
+        dtype = _arrow_types.tiledb_type_from_arrow_type(
+            pa_type, is_indexed_column=True
+        )
 
         domain: Tuple[Any, Any]
         if shape is None:

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -143,7 +143,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         return self
 
     @classmethod
-    def _dim_domain_and_extent(
+    def _dim_capacity_and_extent(
         cls,
         dim_name: str,
         dim_shape: Optional[int],
@@ -151,7 +151,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     ) -> Tuple[int, int]:
         """
         Given a user-specified shape along a particular dimension, returns a tuple of
-        the TileDB domain and extent for that dimension, suitable for schema creation.
+        the TileDB capacity and extent for that dimension, suitable for schema creation.
         The user-specified shape cannot be ``None`` for ``DenseNDArray``.
         """
         if dim_shape is None or dim_shape <= 0:

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -7,7 +7,6 @@ import somacore
 # This package's pybind11 code
 import tiledbsoma.libtiledbsoma as clib
 
-from ._exception import SOMAError
 from ._types import NTuple
 
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -14,7 +14,7 @@ from . import _util
 from . import libtiledbsoma as clib
 from ._common_nd_array import NDArray
 from ._read_iters import (
-    SparseCOOTensorReadIter,
+    TableReadIter,
 )
 from ._types import NTuple
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -15,9 +15,6 @@ from . import libtiledbsoma as clib
 from ._common_nd_array import NDArray
 from ._read_iters import (
     SparseCOOTensorReadIter,
-    SparseCSCMatrixReadIter,
-    SparseCSRMatrixReadIter,
-    TableReadIter,
 )
 from ._types import NTuple
 
@@ -217,32 +214,6 @@ class SparseNDArrayRead(somacore.SparseRead):
         """
         self.sr = sr
         self.shape = shape
-
-    def coos(self) -> SparseCOOTensorReadIter:
-        """
-        Return an iterator of Arrow SparseCOOTensor
-
-        [lifecycle: experimental]
-        """
-        return SparseCOOTensorReadIter(self.sr, self.shape)
-
-    def cscs(self) -> SparseCSCMatrixReadIter:
-        """
-        Return an iterator of Arrow SparseCSCMatrix
-
-        [lifecycle: experimental]
-        """
-
-        return SparseCSCMatrixReadIter(self.sr, self.shape)
-
-    def csrs(self) -> SparseCSRMatrixReadIter:
-        """
-        Return an iterator of Arrow SparseCSRMatrix
-
-        [lifecycle: experimental]
-        """
-
-        return SparseCSRMatrixReadIter(self.sr, self.shape)
 
     def dense_tensors(self) -> somacore.ReadIter[pa.Tensor]:
         """

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union, cast
+from typing import Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -18,6 +18,7 @@ from ._read_iters import (
     TableReadIter,
 )
 from ._types import NTuple
+from .options.tiledb_create_options import TileDBCreateOptions
 
 _UNBATCHED = options.BatchSize()
 
@@ -198,6 +199,38 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             sr.set_dim_points(dim.name, coord)
             return True
         return False
+
+    @classmethod
+    def _dim_domain_and_extent(
+        cls,
+        dim_name: str,
+        dim_shape: Optional[int],
+        create_options: TileDBCreateOptions,
+    ) -> Tuple[int, int]:
+        """
+        Given a user-specified shape (maybe ``None``) along a particular dimension,
+        returns a tuple of the TileDB domain and extent for that dimension, suitable
+        for schema creation. If the user-specified shape is None, the largest possible
+        int64 is returned for the domain.
+        """
+        if dim_shape is not None:
+            if dim_shape <= 0:
+                raise ValueError(
+                    "SOMASparseNDArray shape must be a non-zero-length tuple of positive ints or Nones"
+                )
+            dim_domain = dim_shape
+            dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
+
+        else:
+            dim_domain = 2**63
+            extent = min(dim_domain, create_options.dim_tile(dim_name, 2048))
+            # TileDB requires that each signed-64-bit-int domain slot, rounded up to
+            # a multiple of the tile extent in that slot, be representable as a
+            # signed 64-bit int. So if the tile extent is 999, say, that would
+            # exceed 2**63 - 1.
+            dim_domain -= extent
+
+        return (dim_domain, dim_extent)
 
 
 class SparseNDArrayRead(somacore.SparseRead):

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -213,15 +213,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         for schema creation. If the user-specified shape is None, the largest possible
         int64 is returned for the capacity.
         """
-        if dim_shape is not None:
-            if dim_shape <= 0:
-                raise ValueError(
-                    "SOMASparseNDArray shape must be a non-zero-length tuple of positive ints or Nones"
-                )
-            dim_capacity = dim_shape
-            dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
-
-        else:
+        if dim_shape is None:
             dim_capacity = 2**63
             dim_extent = min(dim_capacity, create_options.dim_tile(dim_name, 2048))
             # TileDB requires that each signed-64-bit-int domain slot, rounded up to
@@ -229,6 +221,13 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             # signed 64-bit int. So if the tile extent is 999, say, that would
             # exceed 2**63 - 1.
             dim_capacity -= dim_extent
+        else:
+            if dim_shape <= 0:
+                raise ValueError(
+                    "SOMASparseNDArray shape must be a non-zero-length tuple of positive ints or Nones"
+                )
+            dim_capacity = dim_shape
+            dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
 
         return (dim_capacity, dim_extent)
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -14,6 +14,7 @@ from . import _util
 from . import libtiledbsoma as clib
 from ._common_nd_array import NDArray
 from ._read_iters import (
+    SparseCOOTensorReadIter,
     TableReadIter,
 )
 from ._types import NTuple
@@ -214,6 +215,14 @@ class SparseNDArrayRead(somacore.SparseRead):
         """
         self.sr = sr
         self.shape = shape
+
+    def coos(self) -> SparseCOOTensorReadIter:
+        """
+        Return an iterator of Arrow SparseCOOTensor
+
+        [lifecycle: experimental]
+        """
+        return SparseCOOTensorReadIter(self.sr, self.shape)
 
     def dense_tensors(self) -> somacore.ReadIter[pa.Tensor]:
         """

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -201,7 +201,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         return False
 
     @classmethod
-    def _dim_domain_and_extent(
+    def _dim_capacity_and_extent(
         cls,
         dim_name: str,
         dim_shape: Optional[int],
@@ -209,28 +209,28 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     ) -> Tuple[int, int]:
         """
         Given a user-specified shape (maybe ``None``) along a particular dimension,
-        returns a tuple of the TileDB domain and extent for that dimension, suitable
+        returns a tuple of the TileDB capacity and extent for that dimension, suitable
         for schema creation. If the user-specified shape is None, the largest possible
-        int64 is returned for the domain.
+        int64 is returned for the capacity.
         """
         if dim_shape is not None:
             if dim_shape <= 0:
                 raise ValueError(
                     "SOMASparseNDArray shape must be a non-zero-length tuple of positive ints or Nones"
                 )
-            dim_domain = dim_shape
+            dim_capacity = dim_shape
             dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
 
         else:
-            dim_domain = 2**63
-            extent = min(dim_domain, create_options.dim_tile(dim_name, 2048))
+            dim_capacity = 2**63
+            dim_extent = min(dim_capacity, create_options.dim_tile(dim_name, 2048))
             # TileDB requires that each signed-64-bit-int domain slot, rounded up to
             # a multiple of the tile extent in that slot, be representable as a
             # signed 64-bit int. So if the tile extent is 999, say, that would
             # exceed 2**63 - 1.
-            dim_domain -= extent
+            dim_capacity -= dim_extent
 
-        return (dim_domain, dim_extent)
+        return (dim_capacity, dim_extent)
 
 
 class SparseNDArrayRead(somacore.SparseRead):

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -123,6 +123,9 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         del dim_idx  # Unused.
         if coord is None:
             return True  # No constraint; select all in this dimension
+
+        # TODO: support index types other than int/string once libtiledbsoma.cc does
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/960
         if isinstance(coord, int):
             sr.set_dim_points(dim.name, [coord])
             return True

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -528,7 +528,7 @@ def create_from_matrix(
         soma_ndarray = cls.open(uri, "w", platform_config=platform_config)
     except DoesNotExistError:
         # A SparseNDArray must be appendable in soma.io.
-        shape = matrix.shape if cls == DenseNDArray else (None,) * len(matrix.shape)
+        shape = [None for _ in matrix.shape] if cls.is_sparse else matrix.shape
         soma_ndarray = cls.create(
             uri,
             type=pa.from_numpy_dtype(matrix.dtype),

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -477,8 +477,6 @@ def _write_dataframe(
             df_uri,
             schema=arrow_table.schema,
             platform_config=platform_config,
-            ### XXX TEMP
-            shape=df.shape[0],
         )
     else:
         if ingest_mode == "resume":

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -474,7 +474,11 @@ def _write_dataframe(
         soma_df = _factory.open(df_uri, "w", soma_type=DataFrame)
     except DoesNotExistError:
         soma_df = DataFrame.create(
-            df_uri, schema=arrow_table.schema, platform_config=platform_config
+            df_uri,
+            schema=arrow_table.schema,
+            platform_config=platform_config,
+            ### XXX TEMP
+            shape=df.shape[0],
         )
     else:
         if ingest_mode == "resume":
@@ -525,10 +529,12 @@ def create_from_matrix(
     try:
         soma_ndarray = cls.open(uri, "w", platform_config=platform_config)
     except DoesNotExistError:
+        # A SparseNDArray must be appendable in soma.io.
+        shape = matrix.shape if cls == DenseNDArray else (None,) * len(matrix.shape)
         soma_ndarray = cls.create(
             uri,
             type=pa.from_numpy_dtype(matrix.dtype),
-            shape=matrix.shape,
+            shape=shape,
             platform_config=platform_config,
         )
     else:

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -118,16 +118,16 @@ def test_import_anndata(adata, ingest_modes):
         assert exp.ms["RNA"].X["data"].metadata.get(metakey) == "SOMADenseNDArray"
         if have_ingested:
             matrix = exp.ms["RNA"].X["data"].read(coords=all2d)
-            assert matrix.shape == orig.X.shape
+            assert matrix.size == orig.X.size
         else:
             with pytest.raises(ValueError):
                 exp.ms["RNA"].X["data"].read(coords=all2d)
 
-        #        # Check raw/X/data (sparse)
+        # Check raw/X/data (sparse)
         assert exp.ms["raw"].X["data"].metadata.get(metakey) == "SOMASparseNDArray"
         if have_ingested:
             table = exp.ms["raw"].X["data"].read(coords=all2d).tables().concat()
-            assert len(table) == orig.raw.X.nnz
+            assert table.shape[0] == orig.raw.X.nnz
 
         # Check some annotation matrices
 
@@ -157,9 +157,9 @@ def test_import_anndata(adata, ingest_modes):
         assert sorted(obsp.keys()) == sorted(orig.obsp.keys())
         for key in list(orig.obsp.keys()):
             assert obsp[key].metadata.get(metakey) == "SOMASparseNDArray"
-        if have_ingested:
-            table = obsp[key].read(coords=all2d).tables().concat()
-            assert len(table) == orig.obsp[key].nnz
+            if have_ingested:
+                table = obsp[key].read(coords=all2d).tables().concat()
+                assert table.shape[0] == orig.obsp[key].nnz
 
         # pbmc-small has no varp
 

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -123,11 +123,11 @@ def test_import_anndata(adata, ingest_modes):
             with pytest.raises(ValueError):
                 exp.ms["RNA"].X["data"].read(coords=all2d)
 
-        # Check raw/X/data (sparse)
+        #        # Check raw/X/data (sparse)
         assert exp.ms["raw"].X["data"].metadata.get(metakey) == "SOMASparseNDArray"
         if have_ingested:
-            matrix = exp.ms["raw"].X["data"].read(coords=all2d).coos().concat()
-            assert matrix.shape == orig.raw.X.shape
+            table = exp.ms["raw"].X["data"].read(coords=all2d).tables().concat()
+            assert len(table) == orig.raw.X.nnz
 
         # Check some annotation matrices
 
@@ -157,9 +157,9 @@ def test_import_anndata(adata, ingest_modes):
         assert sorted(obsp.keys()) == sorted(orig.obsp.keys())
         for key in list(orig.obsp.keys()):
             assert obsp[key].metadata.get(metakey) == "SOMASparseNDArray"
-            if have_ingested:
-                matrix = obsp[key].read(coords=all2d).coos().concat()
-                assert matrix.shape == orig.obsp[key].shape
+        if have_ingested:
+            table = obsp[key].read(coords=all2d).tables().concat()
+            assert len(table) == orig.obsp[key].nnz
 
         # pbmc-small has no varp
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -118,7 +118,7 @@ def test_dataframe_append(tmp_path, appendable):
     soma.DataFrame.create(
         uri,
         schema=pa.schema([("foo", pa.large_string())]),
-        shape=None if appendable else 5,
+        shape=None if appendable else (5,),
     ).close()
     assert soma.DataFrame.exists(uri)
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -111,6 +111,53 @@ def test_dataframe(tmp_path, arrow_schema):
         assert not A.schema.allows_duplicates
 
 
+@pytest.mark.parametrize("appendable", [True, False])
+def test_dataframe_append(tmp_path, appendable):
+    uri = tmp_path.as_posix()
+
+    soma.DataFrame.create(
+        uri,
+        schema=pa.schema([("foo", pa.large_string())]),
+        shape=None if appendable else 5,
+    ).close()
+    assert soma.DataFrame.exists(uri)
+
+    batch1 = pa.Table.from_pydict(
+        {
+            "soma_joinid": [0, 1, 2, 3, 4],
+            "foo": ["apple", "ball", "cat", "dog", "egg"],
+        }
+    )
+
+    batch2 = pa.Table.from_pydict(
+        {
+            "soma_joinid": [5, 6, 7],
+            "foo": ["fish", "gate", "house"],
+        }
+    )
+
+    with soma.DataFrame.open(uri) as sdf:
+        assert sdf.count == 0
+        assert len(sdf) == 0
+
+    with soma.DataFrame.open(uri, "w") as sdf:
+        sdf.write(batch1)
+
+    with soma.DataFrame.open(uri) as sdf:
+        assert sdf.count == 5
+        assert len(sdf) == 5
+
+    if appendable:
+        with soma.DataFrame.open(uri, "w") as sdf:
+            sdf.write(batch2)
+    else:
+        # tiledb.cc.TileDBError: [TileDB::Dimension] Error: Coordinate 6
+        # is out of domain bounds [0, 4] on dimension 'soma_joinid'
+        with pytest.raises(tiledb.cc.TileDBError):
+            with soma.DataFrame.open(uri, "w") as sdf:
+                sdf.write(batch2)
+
+
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame.create(
         tmp_path.as_posix(), schema=arrow_schema(), index_column_names=("bar",)

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -114,6 +114,24 @@ def test_dense_nd_array_reshape(tmp_path):
         assert a.reshape((100, 10, 1))
 
 
+@pytest.mark.parametrize("appendable", [True, False])
+def test_dense_nd_array_append(tmp_path, appendable):
+    uri = tmp_path.as_posix()
+
+    if appendable:
+        with pytest.raises(ValueError):
+            soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
+    else:
+        soma.DenseNDArray.create(
+            uri,
+            type=pa.float32(),
+            shape=(2, 3),
+        ).close()
+        assert soma.DenseNDArray.exists(uri)
+        with soma.DenseNDArray.open(uri) as dnda:
+            assert dnda.shape == (2, 3)
+
+
 @pytest.mark.parametrize(
     "io",
     [

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -114,14 +114,11 @@ def test_dense_nd_array_reshape(tmp_path):
         assert a.reshape((100, 10, 1))
 
 
-@pytest.mark.parametrize("appendable", [True, False])
-def test_dense_nd_array_append(tmp_path, appendable):
+@pytest.mark.parametrize("shape_is_numeric", [True, False])
+def test_dense_nd_array_requires_shape(tmp_path, shape_is_numeric):
     uri = tmp_path.as_posix()
 
-    if appendable:
-        with pytest.raises(ValueError):
-            soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
-    else:
+    if shape_is_numeric:
         soma.DenseNDArray.create(
             uri,
             type=pa.float32(),
@@ -130,6 +127,9 @@ def test_dense_nd_array_append(tmp_path, appendable):
         assert soma.DenseNDArray.exists(uri)
         with soma.DenseNDArray.open(uri) as dnda:
             assert dnda.shape == (2, 3)
+    else:
+        with pytest.raises(ValueError):
+            soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
 
 
 @pytest.mark.parametrize(

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -170,16 +170,6 @@ def test_experiment_query_coords(soma_experiment):
             .concat()
         )
         assert query.X("raw").tables().concat() == raw_X
-        assert query.X("raw").coos().concat() == pa.SparseCOOTensor.from_numpy(
-            raw_X["soma_data"].to_numpy(),
-            np.array(
-                [
-                    raw_X["soma_dim_0"].to_numpy(),
-                    raw_X["soma_dim_1"].to_numpy(),
-                ]
-            ).T,
-            shape=soma_experiment.ms["RNA"].X["raw"].shape,
-        )
 
 
 @pytest.mark.xfail(
@@ -302,14 +292,7 @@ def test_joinid_caching(soma_experiment):
     with soma_experiment.axis_query(
         "RNA", obs_query=obs_query, var_query=var_query
     ) as query2:
-        coo = query2.X("A").coos().concat().to_scipy()
-        csr = sparse.csr_matrix(
-            (
-                coo.data,
-                (query2._indexer.by_obs(coo.row), query2._indexer.by_var(coo.col)),
-            ),
-            shape=(query2.n_obs, query2.n_vars),
-        )
+        pass
 
     with soma_experiment.axis_query(
         "RNA", obs_query=obs_query, var_query=var_query
@@ -321,8 +304,6 @@ def test_joinid_caching(soma_experiment):
     assert np.array_equal(var.to_pandas().label, ad.var.label)
     assert ad.n_obs == len(obs)
     assert ad.n_vars == len(var)
-    assert ad.X.shape == csr.shape
-    assert (ad.X != csr).nnz == 0  # fast eq test
 
 
 @pytest.mark.xfail(

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -170,6 +170,16 @@ def test_experiment_query_coords(soma_experiment):
             .concat()
         )
         assert query.X("raw").tables().concat() == raw_X
+        assert query.X("raw").coos().concat() == pa.SparseCOOTensor.from_numpy(
+            raw_X["soma_data"].to_numpy(),
+            np.array(
+                [
+                    raw_X["soma_dim_0"].to_numpy(),
+                    raw_X["soma_dim_1"].to_numpy(),
+                ]
+            ).T,
+            shape=soma_experiment.ms["RNA"].X["raw"].shape,
+        )
 
 
 @pytest.mark.xfail(
@@ -292,7 +302,7 @@ def test_joinid_caching(soma_experiment):
     with soma_experiment.axis_query(
         "RNA", obs_query=obs_query, var_query=var_query
     ) as query2:
-        pass
+        query2.X("A").coos().concat().to_scipy()
 
     with soma_experiment.axis_query(
         "RNA", obs_query=obs_query, var_query=var_query

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -59,7 +59,6 @@ def test_io_create_from_matrix_Dense_nd_array(tmp_path, tdb_create_options, src_
         platform_config=tdb_create_options,
     ).close()
     with _factory.open(tmp_path.as_posix()) as snda:
-        assert snda.shape == src_matrix.shape
         assert snda.ndim == src_matrix.ndim
 
         read_back = snda.read((slice(None), slice(None))).to_numpy()
@@ -110,7 +109,6 @@ def test_io_create_from_matrix_Sparse_nd_array(
     ).close()
 
     with _factory.open(tmp_path.as_posix()) as snda:
-        assert snda.shape == src_matrix.shape
         assert snda.ndim == src_matrix.ndim
 
         tbl = pa.concat_tables(snda.read((slice(None), slice(None))).tables())
@@ -122,7 +120,7 @@ def test_io_create_from_matrix_Sparse_nd_array(
                     tbl.column("soma_dim_1").to_numpy(),
                 ),
             ),
-            shape=snda.shape,
+            shape=src_matrix.shape,
         )
 
         # fast equality check using __ne__

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -312,7 +312,7 @@ def test_sparse_nd_array_read_as_pandas(
 
 @pytest.mark.parametrize("shape_is_nones", [True, False])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
-def test_sparse_nd_array_append(tmp_path, shape_is_nones, element_type):
+def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     uri = tmp_path.as_posix()
 
     soma.SparseNDArray.create(

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -205,69 +205,6 @@ def tables_are_same_value(a: pa.Table, b: pa.Table) -> bool:
     return True
 
 
-@pytest.mark.parametrize(
-    "shape,format",
-    [
-        ((10,), "coo"),
-        ((10, 21), "coo"),
-        ((10, 21), "csr"),
-        ((10, 21), "csc"),
-        ((10, 20, 2), "coo"),
-        ((2, 4, 6, 8), "coo"),
-        ((1, 2, 4, 6, 8), "coo"),
-    ],
-)
-@pytest.mark.parametrize("test_enumeration", range(10))
-def test_sparse_nd_array_read_write_sparse_tensor(
-    tmp_path,
-    shape: Tuple[int, ...],
-    format: str,
-    test_enumeration: int,
-):
-    # Test sanity: Tensor only, and CSC and CSR only support 2D, so fail any nonsense configs
-    assert format in ("coo", "csr", "csc")
-    assert not (format in ("csc", "csr") and len(shape) != 2)
-
-    a = soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=shape)
-    assert a.shape == shape
-
-    # Make a random sample in the desired format
-    # As discussed in the SparseNDArray implementation, Arrow SparseTensor objects can't be zero-length
-    # so we must be prepared for StopIteration on reading them. It simplifies unit-test logic to use
-    # occupation density of 1.0 for this test.
-    data = create_random_tensor(format, shape, np.float64, 1.0)
-    with pytest.raises(TypeError):
-        # non-arrow write
-        a.write(data.to_numpy())
-    a.write(data)
-    del a
-
-    # Read back and validate
-    with soma.SparseNDArray.open(tmp_path.as_posix()) as b:
-        if format == "coo":
-            t = b.read((slice(None),) * len(shape)).coos().concat()
-        elif format == "csc":
-            t = b.read((slice(None),) * len(shape)).cscs().concat()
-        elif format == "csr":
-            t = b.read((slice(None),) * len(shape)).csrs().concat()
-
-        assert tensors_are_same_value(t, data)
-
-        if format == "coo":
-            t = next(b.read((0,) * len(shape)).coos())
-        elif format == "csc":
-            t = next(b.read((0,) * len(shape)).cscs())
-        elif format == "csr":
-            t = next(b.read((0,) * len(shape)).csrs())
-
-        assert t.shape == shape
-
-    # Validate TileDB array schema
-    with tiledb.open(tmp_path.as_posix()) as A:
-        assert A.schema.sparse
-        assert not A.schema.allows_duplicates
-
-
 @pytest.mark.parametrize("shape", [(10,), (23, 4), (5, 3, 1), (8, 4, 2, 30)])
 @pytest.mark.parametrize("test_enumeration", range(10))
 def test_sparse_nd_array_read_write_table(
@@ -323,6 +260,50 @@ def test_sparse_nd_array_read_as_pandas(
         assert not A.schema.allows_duplicates
 
 
+@pytest.mark.parametrize("appendable", [True, False])
+@pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
+def test_sparse_nd_array_append(tmp_path, appendable, element_type):
+    uri = tmp_path.as_posix()
+
+    soma.SparseNDArray.create(
+        uri,
+        type=element_type,
+        shape=(None, None) if appendable else (2, 3),
+    ).close()
+    assert soma.SparseNDArray.exists(uri)
+
+    with soma.SparseNDArray.open(uri) as snda:
+        assert snda.nnz == 0
+
+    batch1 = pa.Table.from_pydict(
+        {
+            "soma_dim_0": [0, 0, 0, 1, 1, 1],
+            "soma_dim_1": [0, 1, 2, 0, 1, 2],
+            "soma_data": [1, 2, 3, 4, 5, 6],
+        }
+    )
+
+    batch2 = pa.Table.from_pydict(
+        {"soma_dim_0": [2, 2, 2], "soma_dim_1": [0, 1, 2], "soma_data": [7, 8, 9]}
+    )
+
+    with soma.SparseNDArray.open(uri, "w") as snda:
+        snda.write(batch1)
+
+    with soma.SparseNDArray.open(uri) as snda:
+        assert snda.nnz == 6
+
+    if appendable:
+        with soma.SparseNDArray.open(uri, "w") as snda:
+            snda.write(batch2)
+    else:
+        # tiledb.cc.TileDBError: [TileDB::Dimension] Error: Coordinate 2
+        # is out of domain bounds [0, 1] on dimension 'soma_dim_0'
+        with pytest.raises(tiledb.cc.TileDBError):
+            with soma.SparseNDArray.open(uri, "w") as snda:
+                snda.write(batch2)
+
+
 def test_empty_read(tmp_path):
     """
     Verify that queries expected to return empty results actually
@@ -341,10 +322,6 @@ def test_empty_read(tmp_path):
         # These work as expected
         coords = (slice(None),)
         assert sum(len(t) for t in a.read(coords).tables()) == 0
-        # Fails due to ARROW-17933
-        # assert sum(t.non_zero_length for t in a.read(coords).coos()) == 0
-        assert sum(t.non_zero_length for t in a.read(coords).csrs()) == 0
-        assert sum(t.non_zero_length for t in a.read(coords).cscs()) == 0
 
     #
     # Next, test empty queries on non-empty array
@@ -360,8 +337,6 @@ def test_empty_read(tmp_path):
 
         coords = (1, 1)  # no element at this coordinate
         assert sum(len(t) for t in a.read(coords).tables()) == 0
-        assert sum(t.non_zero_length for t in a.read(coords).csrs()) == 0
-        assert sum(t.non_zero_length for t in a.read(coords).cscs()) == 0
 
 
 @pytest.mark.xfail(sys.version_info.minor > 7, reason="bug ARROW-17933")
@@ -386,10 +361,6 @@ def test_empty_read_sparse_coo(tmp_path):
         tmp_path.as_posix(), type=pa.uint16(), shape=(10, 100)
     ).close()
 
-    with soma.SparseNDArray.open(tmp_path.as_posix()) as a:
-        coords = (slice(None),)
-        assert sum(t.non_zero_length for t in a.read(coords).coos()) == 0
-
     with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as a:
         a.write(
             pa.SparseCOOTensor.from_scipy(
@@ -398,9 +369,6 @@ def test_empty_read_sparse_coo(tmp_path):
         )
     with soma.SparseNDArray.open(tmp_path.as_posix()) as a:
         assert sum(len(t) for t in a.read((slice(None),)).tables()) == 1
-
-        coords = (1, 1)  # no element at this coordinate
-        assert sum(t.non_zero_length for t in a.read(coords).coos()) == 0
 
 
 @pytest.mark.parametrize("shape", [(), (0,), (10, 0), (0, 10), (1, 2, 0)])
@@ -454,12 +422,6 @@ def test_csr_csc_2d_read(tmp_path, shape):
     )
     snda.write(arrow_tensor)
 
-    with pytest.raises(ValueError):
-        next(snda.read(None).csrs())
-
-    with pytest.raises(ValueError):
-        next(snda.read(None).cscs())
-
 
 @pytest.mark.parametrize(
     "write_format",
@@ -469,7 +431,7 @@ def test_csr_csc_2d_read(tmp_path, shape):
     # We want to test read_format == "none_of_the_above", to ensure it throws NotImplementedError,
     # but that can't be gotten past typeguard.
     "read_format",
-    ["table", "coo", "csr", "csc"],
+    ["table"],
 )
 @pytest.mark.parametrize(
     "io",
@@ -819,23 +781,11 @@ def test_sparse_nd_array_table_slicing(tmp_path, io, write_format, read_format):
             if io["throws"] is not None:
                 with pytest.raises(io["throws"]):
                     r = snda.read(io["coords"])
-                    if read_format == "coo":
-                        next(r.coos())
-                    elif read_format == "csr":
-                        next(r.csrs())
-                    elif read_format == "csc":
-                        next(r.csrs())
-                    elif read_format == "table":
+                    if read_format == "table":
                         next(r.csrs())
             else:
                 r = snda.read(io["coords"])
-                if read_format == "coo":
-                    tensor = next(r.coos())
-                elif read_format == "csr":
-                    tensor = next(r.csrs())
-                elif read_format == "csc":
-                    tensor = next(r.csrs())
-                elif read_format == "table":
+                if read_format == "table":
                     tensor = next(r.csrs())
                 assert tensor.shape == io["shape"]
 
@@ -1021,20 +971,12 @@ def test_timestamped_ops(tmp_path):
 
     # read with no timestamp args & see both 1s
     with soma.SparseNDArray.open(tmp_path.as_posix()) as a:
-        assert a.read().coos().concat().to_scipy().todense().tolist() == [
-            [1, 0],
-            [0, 1],
-        ]
         assert a.nnz == 2
 
     # read @ t=15 & see only the first write
     with soma.SparseNDArray.open(
         tmp_path.as_posix(), context=SOMATileDBContext(read_timestamp=15)
     ) as a:
-        assert a.read().coos().concat().to_scipy().todense().tolist() == [
-            [1, 0],
-            [0, 0],
-        ]
         assert a.nnz == 1
 
     # read with (timestamp_start, timestamp_end) = (15, 25) & see only the second write
@@ -1042,8 +984,4 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         context=SOMATileDBContext(read_timestamp_start=15, read_timestamp=25),
     ) as a:
-        assert a.read().coos().concat().to_scipy().todense().tolist() == [
-            [0, 0],
-            [0, 1],
-        ]
         assert a.nnz == 1

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -310,15 +310,15 @@ def test_sparse_nd_array_read_as_pandas(
         assert not A.schema.allows_duplicates
 
 
-@pytest.mark.parametrize("appendable", [True, False])
+@pytest.mark.parametrize("shape_is_nones", [True, False])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
-def test_sparse_nd_array_append(tmp_path, appendable, element_type):
+def test_sparse_nd_array_append(tmp_path, shape_is_nones, element_type):
     uri = tmp_path.as_posix()
 
     soma.SparseNDArray.create(
         uri,
         type=element_type,
-        shape=(None, None) if appendable else (2, 3),
+        shape=(None, None) if shape_is_nones else (2, 3),
     ).close()
     assert soma.SparseNDArray.exists(uri)
 
@@ -343,7 +343,7 @@ def test_sparse_nd_array_append(tmp_path, appendable, element_type):
     with soma.SparseNDArray.open(uri) as snda:
         assert snda.nnz == 6
 
-    if appendable:
+    if shape_is_nones:
         with soma.SparseNDArray.open(uri, "w") as snda:
             snda.write(batch2)
     else:


### PR DESCRIPTION
**Issue and/or context:**

Tracking issue: #931

This is the Python-impl counterpart to https://github.com/single-cell-data/SOMA/pull/131; an R-impl counterpart is upcoming.

This PR addresses only explicit shaping of `SparseNDArray` -- explicit shaping of `DataFrame` will be on a separate PR.