### PR TITLE
Remove matplotlib pin since scanpy is fixed.

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -177,11 +177,10 @@ setuptools.setup(
     install_requires=[
         "anndata",
         "attrs>=22.1",
-        "matplotlib<3.7",  # https://github.com/scverse/scanpy/issues/2411
         "numpy",
         "pandas",
-        "pyarrow >= 9.0.0",
-        "scanpy",
+        "pyarrow>=9.0.0",
+        "scanpy>=1.9.2",
         "scipy",
         "somacore==0.0.0a15",
         "tiledb==0.20.*",


### PR DESCRIPTION
Ensures installation of scanpy 1.9.2, which includes the matplotlib fix: https://github.com/scverse/scanpy/releases/tag/1.9.2