### PR TITLE
[python] Stop using the flush hack when writing metadata or group contents

### DIFF
--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -159,7 +159,9 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         )
         # Semi-hack: flush the metadata immediately upon creation so that the
         # backing storage isn't half-created (i.e., there is a tiledb object
-        # on disk, but its type is not stored). This is immutable, so it's fine.
+        # on disk, but its type is not stored).
+        # TODO: We should probably write this metadata at time 0.
+        # Doing so would eliminate this last _flush_hack call.
         handle._flush_hack()
 
     def _check_open_read(self) -> None:

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -242,12 +242,12 @@ def test_ingest_relative(h5ad_file_extended, use_relative_uri):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
-    exp = tiledbsoma.io.from_h5ad(
+    tiledbsoma.io.from_h5ad(
         output_path,
         h5ad_file_extended,
         measurement_name="RNA",
         use_relative_uri=use_relative_uri,
-    )
+    ).close()
 
     # * If they ask for relative=True, they should get that.
     # * If they ask for relative=False, they should get that.
@@ -257,6 +257,7 @@ def test_ingest_relative(h5ad_file_extended, use_relative_uri):
     if use_relative_uri is None:
         expected_relative = True  # since local disk
 
+    exp = tiledbsoma.open(output_path)
     with tiledb.Group(exp.uri) as G:
         assert G.is_relative("obs") == expected_relative
         assert G.is_relative("ms") == expected_relative

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -142,9 +142,21 @@ def test_collection_mapping(soma_object, tmp_path):
     assert len(c) == 1
     assert [k for k in c] == ["mumble"]
 
+    pytest.xfail(reason="currently supports one entry modification at a time")
     del c["mumble"]
     assert "mumble" not in c
     assert not c.get("mumble", False)
+
+
+def test_delete_add(soma_object, tmp_path: pathlib.Path):
+    tmp_uri = tmp_path.as_uri()
+    with soma.Collection.create(tmp_uri) as create:
+        create["porkchop sandwiches"] = soma_object
+
+    with soma.open(tmp_uri, "w", soma_type=soma.Collection) as update:
+        del update["porkchop sandwiches"]
+        pytest.xfail(reason="currently does not support removal/re-addition")
+        update["porkchop sandwiches"] = soma_object
 
 
 @pytest.mark.parametrize("relative", [False, True])
@@ -262,6 +274,7 @@ def test_collection_update_on_set(tmp_path):
     assert set(sc.keys()) == set(["A"])
     assert sc["A"] == A
 
+    pytest.xfail(reason="replacing entries is not supported")
     sc["A"] = B
     assert set(sc.keys()) == set(["A"])
     assert sc["A"] == B

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -184,11 +184,6 @@ def test_experiment_obs_type_constraint(tmp_path):
     se["obs"] = soma.DataFrame.create(
         (tmp_path / "E").as_uri(), schema=pa.schema([("A", pa.int32())])
     )
-    se["obs"] = soma.DataFrame.create(
-        (tmp_path / "F").as_uri(),
-        schema=pa.schema([("A", pa.int32())]),
-        index_column_names=["A"],
-    )
 
 
 def test_experiment_ms_type_constraint(tmp_path):


### PR DESCRIPTION
For metadata: Keep track of the operations we need to do and perform them only when we close.

For group contents: Forbid the forbidden operations.

Detailed explanations available in the commit messages.

Fixes #919.