### PR TITLE
[c++/python] Use `py::print` in libtiledbsoma11 to print, not `cout`

### DIFF
--- a/apis/python/tests/test_util_tiledb.py
+++ b/apis/python/tests/test_util_tiledb.py
@@ -4,7 +4,7 @@ import pytest
 import tiledbsoma as soma
 
 
-def test_stats(tmp_path, capfd: pytest.CaptureFixture[str]):
+def test_stats(tmp_path, capsys: pytest.CaptureFixture[str]):
     """Make sure these exist, don't throw, and write correctly."""
     soma.tiledbsoma_stats_enable()
     soma.tiledbsoma_stats_reset()
@@ -25,6 +25,6 @@ def test_stats(tmp_path, capfd: pytest.CaptureFixture[str]):
 
     soma.tiledbsoma_stats_dump()
     soma.tiledbsoma_stats_disable()
-    stdout, stderr = capfd.readouterr()
+    stdout, stderr = capsys.readouterr()
     assert stdout != ""
     assert stderr == ""

--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -135,9 +135,10 @@ PYBIND11_MODULE(libtiledbsoma, m) {
     m.def(
         "tiledbsoma_stats_dump",
         []() {
+            py::print(version());
             std::string stats;
             tiledb::Stats::dump(&stats);
-            std::cout << version() << "\n" << stats;
+            py::print(stats);
         },
         "Print TileDB internal statistics.");
 


### PR DESCRIPTION
Even after #887 was submitted, I would occasionally see stats output written to the console after tests completed (when running with `-s`, to disable output capture by default). I believe this is due to buffering within `std::cout` where the text may not actually hit the fd by the time the function returns and the test ends.

It could have also potentially introduced confusing output:

    print("before")
    tiledbsoma_stats_dump()
    print("after")

Depending upon how Python internally buffers `sys.stdout` and how that interacts with the system, the "before" could potentially appear after the `tiledbsoma_stats_dump` output (and it may be possible for "after" to appear *before* it? not sure about that).

Just letting Python handle it all with `py::print` is way easier.