### PR TITLE
[r] Adjust (vendored) r-ci.sh script

### DIFF
--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -196,6 +196,7 @@ BootstrapLinuxOptions() {
     if [[ "${USE_BSPM}" != "FALSE" ]]; then
         sudo Rscript --vanilla -e 'install.packages("bspm", repos="https://cran.r-project.org")'
         echo "suppressMessages(bspm::enable())" | sudo tee --append /etc/R/Rprofile.site >/dev/null
+        echo "options(bspm.version.check=FALSE)" | sudo tee --append /etc/R/Rprofile.site >/dev/null
         echo "options(bspm.sudo=TRUE)" | sudo tee --append /etc/R/Rprofile.site >/dev/null
     fi
 }


### PR DESCRIPTION
**Issue and/or context:**

The `bspm` package driving binary installations of CRAN packages under Ubuntu has a breaking changes.  Our script is vendored and cannot take advantage of corresponding changes made 'upstream' for r-ci.sh so we have to push a hot fix.

**Changes:**

A new R run-time option is set to govern version comparison when best-available options are compared.  The same fix was just applied to the tiledb-r branch currently running CI and stopped a CI issue there.

**Notes for Reviewer:**

[SC 25605](https://app.shortcut.com/tiledb-inc/story/25605/r-cis-h-adjustment)
