### PR TITLE
[python] A few minor readthedocs-related neatens

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -65,7 +65,7 @@ def from_h5ad(
     use_relative_uri: Optional[bool] = None,
 ) -> Experiment:
     """
-    Reads an .h5ad file and writes to a TileDB group structure.
+    Reads an ``.h5ad`` file and writes to a TileDB group structure.
 
     Returns an experiment opened for writing.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,7 @@ author = "TileDB, Inc."
 # The short X.Y version
 version = "0.1"
 # The full version, including alpha/beta/rc tags
-release = "0.1.12"
+release = "1.0rc0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -1,7 +1,7 @@
 TileDB-SOMA Python API Reference
 ================================
 
-**SOMA --- for stack of matrices, annotated --- is a unified data model and API for single-cell data.**
+**SOMA is a unified data model and API for single-cell data.**
 
 If you know about ``obs``, ``var``, and ``X``, you'll recognize what you're seeing.
 
@@ -37,49 +37,38 @@ There is also a submodule ``io`` which contains logic for importing data from ``
 Composed Types
 --------------
 
-SOMACollection
+Collection
 ^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMACollection
+.. autoclass:: tiledbsoma.Collection
    :members:
 
-SOMAExperiment
+Experiment
 ^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMAExperiment
+.. autoclass:: tiledbsoma.Experiment
    :members:
 
-SOMAMeasurement
+Measurement
 ^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMAMeasurement
+.. autoclass:: tiledbsoma.Measurement
    :members:
 
 Foundational Types
 ------------------
 
-SOMADataFrame
+DataFrame
 ^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMADataFrame
+.. autoclass:: tiledbsoma.DataFrame
    :members:
 
-SOMAIndexedDataFrame
-^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMAIndexedDataFrame
-   :members:
-
-SOMASparseNdArray
+SparseNDArray
 ^^^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMASparseNdArray
+.. autoclass:: tiledbsoma.SparseNDArray
    :members:
 
-SOMADenseNdArray
+DenseNDArray
 ^^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMADenseNdArray
+.. autoclass:: tiledbsoma.DenseNDArray
    :members:
-
-SOMAMetadataMapping
-^^^^^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.SOMAMetadataMapping
-   :members:
-
 
 I/O functions
 -------------
@@ -103,36 +92,12 @@ to_anndata
 Options
 -------
 
-TileDBPlatformConfig
+PlatformConfig
 ^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: tiledbsoma.TileDBPlatformConfig
+.. autoclass:: tiledbsoma.PlatformConfig
    :members:
 
 logging
 ^^^^^^^
 .. automodule:: tiledbsoma.logging
-   :members:
-
-Implementation-level classes
-----------------------------
-
-.. autoclass:: tiledbsoma.TileDBArray
-   :members:
-.. autoclass:: tiledbsoma.TileDBObject
-   :members:
-.. automodule:: tiledbsoma.factory
-   :members:
-.. automodule:: tiledbsoma.general_utilities
-   :members:
-.. automodule:: tiledbsoma.util
-   :members:
-.. automodule:: tiledbsoma.util_ann
-   :members:
-.. automodule:: tiledbsoma.util_arrow
-   :members:
-.. automodule:: tiledbsoma.util_pandas
-   :members:
-.. automodule:: tiledbsoma.util_scipy
-   :members:
-.. automodule:: tiledbsoma.util_tiledb
    :members:


### PR DESCRIPTION
**Issue and/or context:**

Just a few neatenings related to `readthedocs` format.

See `doc/README.md` in the base of this repo for how to render locally. Some example screenshots are here:

<img width="1059" alt="Screenshot 2023-02-21 at 3 16 03 PM" src="https://user-images.githubusercontent.com/2008794/220449107-a989368c-a9b5-4ad1-bbb4-f9ddd9bfb6bc.png">

<img width="1101" alt="Screenshot 2023-02-21 at 3 16 22 PM" src="https://user-images.githubusercontent.com/2008794/220449112-72d71882-14b9-49e1-8c5d-8bf02bc800ec.png">

More work remains to do here for certain; nonetheless the updates on this PR are worth making.