### PR TITLE
[python] Use the same timestamp across read and write operations

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -166,7 +166,7 @@ class ArrayWrapper(Wrapper[tiledb.Array]):
         return tiledb.open(
             uri,
             mode,
-            timestamp=(context.timestamp_start, context.timestamp),
+            timestamp=context._timestamp_arg(),
             ctx=context.tiledb_ctx,
         )
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -24,7 +24,7 @@ from somacore import options
 from typing_extensions import Literal, Self
 
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
-from .options import SOMATileDBContext
+from .options._soma_tiledb_context import SOMATileDBContext
 
 RawHandle = Union[tiledb.Array, tiledb.Group]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
@@ -67,12 +67,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
             tdb = cls._opener(uri, mode, context)
             handle = cls(uri, mode, context, tdb)
             if mode == "w":
-                # Briefly open a read-mode handle to populate metadata/schema/group contents/etc.,
-                # ignoring any read_timestamp set in the context to get an up-to-date view in
-                # preparation for writing.
-                with cls._opener(
-                    uri, "r", context, use_latest_read_timestamp=True
-                ) as auxiliary_reader:
+                with cls._opener(uri, "r", context) as auxiliary_reader:
                     handle._do_initial_reads(auxiliary_reader)
             else:
                 handle._do_initial_reads(tdb)
@@ -89,7 +84,6 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         uri: str,
         mode: options.OpenMode,
         context: SOMATileDBContext,
-        use_latest_read_timestamp: bool = False,
     ) -> _RawHdl_co:
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
@@ -168,19 +162,13 @@ class ArrayWrapper(Wrapper[tiledb.Array]):
         uri: str,
         mode: options.OpenMode,
         context: SOMATileDBContext,
-        use_latest_read_timestamp: bool = False,
     ) -> tiledb.Array:
-        if not use_latest_read_timestamp:
-            timestamp_arg = (
-                context.write_timestamp
-                if mode == "w"
-                else (context.read_timestamp_start, context.read_timestamp)
-            )
-        else:
-            # array opened in write mode should initialize with latest metadata
-            assert mode == "r"
-            timestamp_arg = None
-        return tiledb.open(uri, mode, timestamp=timestamp_arg, ctx=context.tiledb_ctx)
+        return tiledb.open(
+            uri,
+            mode,
+            timestamp=(context.timestamp_start, context.timestamp),
+            ctx=context.tiledb_ctx,
+        )
 
     @property
     def schema(self) -> tiledb.ArraySchema:
@@ -210,21 +198,8 @@ class GroupWrapper(Wrapper[tiledb.Group]):
         uri: str,
         mode: options.OpenMode,
         context: SOMATileDBContext,
-        use_latest_read_timestamp: bool = False,
     ) -> tiledb.Group:
-        if not use_latest_read_timestamp:
-            # As of Feb 2023, tiledb.Group() has no timestamp arg; instead its timestamps must be
-            # set in the tiledb.Ctx config. SOMATileDBContext prepares the suitable tiledb.Ctx.
-            ctx_arg = (
-                context._group_write_tiledb_ctx
-                if mode == "w"
-                else context._group_read_tiledb_ctx
-            )
-        else:
-            # Group opened in write mode should initialize with latest contents & metadata
-            assert mode == "r"
-            ctx_arg = context.tiledb_ctx
-        return tiledb.Group(uri, mode, ctx=ctx_arg)
+        return tiledb.Group(uri, mode, ctx=context._group_tiledb_ctx)
 
     def _do_initial_reads(self, reader: tiledb.Group) -> None:
         super()._do_initial_reads(reader)

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -72,8 +72,8 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
             "name": self.__class__.__name__,
             "platform_config": self._ctx.config().dict(),
             "timestamp": (
-                self.context.read_timestamp_start,
-                self.context.read_timestamp,
+                self.context.timestamp_start,
+                self.context.timestamp,
             ),
         }
         # Leave empty arguments out of kwargs to allow C++ constructor defaults to apply, as

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -420,13 +420,13 @@ def test_timestamped_ops(tmp_path):
 
     # create collection @ t=10
     with soma.Collection.create(
-        tmp_path.as_uri(), context=SOMATileDBContext(write_timestamp=10)
+        tmp_path.as_uri(), context=SOMATileDBContext(timestamp=10)
     ):
         pass
 
     # add array A to it @ t=20
     with soma.Collection.open(
-        tmp_path.as_uri(), mode="w", context=SOMATileDBContext(write_timestamp=20)
+        tmp_path.as_uri(), mode="w", context=SOMATileDBContext(timestamp=20)
     ) as sc:
         sc.add_new_dense_ndarray("A", type=pa.uint8(), shape=(2, 2)).write(
             (slice(0, 2), slice(0, 2)),
@@ -435,7 +435,7 @@ def test_timestamped_ops(tmp_path):
 
     # access A via collection @ t=30 and write something into it
     with soma.Collection.open(
-        tmp_path.as_uri(), mode="w", context=SOMATileDBContext(write_timestamp=30)
+        tmp_path.as_uri(), mode="w", context=SOMATileDBContext(timestamp=30)
     ) as sc:
         sc["A"].write(
             (slice(0, 1), slice(0, 1)),
@@ -451,7 +451,7 @@ def test_timestamped_ops(tmp_path):
 
     # open A via collection @ t=25 => A should reflect first write only
     with soma.Collection.open(
-        tmp_path.as_uri(), context=SOMATileDBContext(read_timestamp=25)
+        tmp_path.as_uri(), context=SOMATileDBContext(timestamp=25)
     ) as sc:
         assert sc["A"].read((slice(None), slice(None))).to_numpy().tolist() == [
             [0, 0],
@@ -460,17 +460,17 @@ def test_timestamped_ops(tmp_path):
 
     # open collection @ t=15 => A should not even be there
     with soma.Collection.open(
-        tmp_path.as_uri(), context=SOMATileDBContext(read_timestamp=15)
+        tmp_path.as_uri(), context=SOMATileDBContext(timestamp=15)
     ) as sc:
         assert "A" not in sc
 
     # confirm timestamp validation in SOMATileDBContext
     with pytest.raises(ValueError):
-        SOMATileDBContext(read_timestamp=-1)
+        SOMATileDBContext(timestamp=-1)
     with pytest.raises(ValueError):
-        SOMATileDBContext(read_timestamp_start=2, read_timestamp=1)
+        SOMATileDBContext(timestamp_start=2, timestamp=1)
     with pytest.raises(ValueError):
-        SOMATileDBContext(write_timestamp=-1)
+        SOMATileDBContext(timestamp=-1)
 
 
 def test_issue919(tmp_path):
@@ -487,7 +487,7 @@ def test_issue919(tmp_path):
     for i in range(25):
         uri = str(tmp_path / str(i))
 
-        context = SOMATileDBContext(write_timestamp=100)
+        context = SOMATileDBContext(timestamp=100)
         with soma.Collection.create(uri, context=context) as c:
             expt = c.add_new_collection("expt", soma.Experiment)
             expt.add_new_collection("causes_bug")

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -925,7 +925,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         schema=schema,
         index_column_names=["soma_joinid"],
-        context=SOMATileDBContext(write_timestamp=10),
+        context=SOMATileDBContext(timestamp=10),
     ) as sidf:
         data = {
             "soma_joinid": [0],
@@ -935,7 +935,7 @@ def test_timestamped_ops(tmp_path):
         sidf.write(pa.Table.from_pydict(data))
 
     with soma.DataFrame.open(
-        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(write_timestamp=20)
+        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
     ) as sidf:
         data = {
             "soma_joinid": [0, 1],
@@ -953,7 +953,7 @@ def test_timestamped_ops(tmp_path):
 
     # read at t=15 & see only the first write
     with soma.DataFrame.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(read_timestamp=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
     ) as sidf:
         tab = sidf.read().concat()
         assert list(x.as_py() for x in tab["soma_joinid"]) == [0]

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -351,7 +351,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         type=pa.uint8(),
         shape=(2, 2),
-        context=SOMATileDBContext(write_timestamp=1),
+        context=SOMATileDBContext(timestamp=1),
     ) as a:
         a.write(
             (slice(0, 2), slice(0, 2)),
@@ -360,7 +360,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into top-left entry @ t=10
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(write_timestamp=10)
+        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=10)
     ) as a:
         a.write(
             (slice(0, 1), slice(0, 1)),
@@ -369,7 +369,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into bottom-right entry @ t=20
     with soma.DenseNDArray.open(
-        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(write_timestamp=20)
+        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
     ) as a:
         a.write(
             (slice(1, 2), slice(1, 2)),
@@ -385,7 +385,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the writes up til then
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(read_timestamp=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
     ) as a:
         assert a.read((slice(0, 1), slice(0, 1))).to_numpy().tolist() == [
             [1, 0],
@@ -395,7 +395,7 @@ def test_timestamped_ops(tmp_path):
     # read with (timestamp_start, timestamp_end) = (15, 25) & see only the t=20 write
     with soma.DenseNDArray.open(
         tmp_path.as_posix(),
-        context=SOMATileDBContext(read_timestamp_start=15, read_timestamp=25),
+        context=SOMATileDBContext(timestamp_start=15, timestamp=25),
     ) as a:
         F = 255  # fill value
         assert a.read((slice(0, 1), slice(0, 1))).to_numpy().tolist() == [

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -99,14 +99,14 @@ def test_SOMATileDBContext_evolve():
     context = tiledbsoma.options.SOMATileDBContext()
 
     # verify defaults expected by subsequent tests
-    assert context.read_timestamp_start == 0
+    assert context.timestamp_start == 0
     assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
 
-    # verify read_timestamp_start
-    assert context.replace(read_timestamp_start=1).read_timestamp_start == 1
+    # verify timestamp_start
+    assert context.replace(timestamp_start=1).timestamp_start == 1
 
-    # veirfy write_timestamp
-    assert context.replace(write_timestamp=1).write_timestamp == 1
+    # veirfy timestamp
+    assert context.replace(timestamp=1).timestamp == 1
 
     # verify tiledb_ctx
     context.replace(tiledb_config={"vfs.s3.region": "us-west-2"}).tiledb_ctx.config()[

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1013,7 +1013,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         type=pa.uint16(),
         shape=(2, 2),
-        context=SOMATileDBContext(write_timestamp=10),
+        context=SOMATileDBContext(timestamp=10),
     ) as a:
         # write 1 into top-left entry @ t=10
         a.write(
@@ -1024,7 +1024,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into bottom-right entry @ t=20
     with soma.SparseNDArray.open(
-        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(write_timestamp=20)
+        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
     ) as a:
         a.write(
             pa.SparseCOOTensor.from_scipy(
@@ -1042,7 +1042,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the first write
     with soma.SparseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(read_timestamp=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
     ) as a:
         assert a.read().coos().concat().to_scipy().todense().tolist() == [
             [1, 0],
@@ -1053,7 +1053,7 @@ def test_timestamped_ops(tmp_path):
     # read with (timestamp_start, timestamp_end) = (15, 25) & see only the second write
     with soma.SparseNDArray.open(
         tmp_path.as_posix(),
-        context=SOMATileDBContext(read_timestamp_start=15, read_timestamp=25),
+        context=SOMATileDBContext(timestamp_start=15, timestamp=25),
     ) as a:
         assert a.read().coos().concat().to_scipy().todense().tolist() == [
             [0, 0],


### PR DESCRIPTION
This eliminates the distinction between the timestamps used to read and write TileDB data. This ensures that:

- All data is written with the same timestamp.
- When one context is used to write and then read the same data, the same timestamp is used for both operations.
- A consistent view of a TileDB object is used for metadata when opening a handle for writing.

---

Given that all our tests pass, and this eliminates the "auxiliary read at time now" hack, I think this might be the right thing to do for this case.