### PR TITLE
python: Include key–value pairs in metadata `repr`.

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -142,7 +142,8 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
             raise SOMAError(f"{self!r} is closed")
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__} {self.mode} on {self.uri!r}>"
+        closed_str = " (closed)" if self.closed else ""
+        return f"<{type(self).__name__} {self.mode} on {self.uri!r}{closed_str}>"
 
     def __enter__(self) -> Self:
         return self
@@ -343,7 +344,10 @@ class MetadataWrapper(MutableMapping[str, Any]):
         self._mods.clear()
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.owner})"
+        prefix = f"{type(self).__name__}({self.owner})"
+        if self.owner.closed:
+            return f"<{prefix}>"
+        return f"<{prefix} {self.cache}>"
 
 
 def _check_metadata_type(key: str, obj: object) -> None:

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -98,6 +98,15 @@ def test_metadata(soma_object):
 
     with _factory.open(uri, "r") as second_read:
         assert non_soma_metadata(second_read) == {"foobar": True, "my": "enemies"}
+        # We don't want to test the exact metadata format,
+        # just that it includes the key–value pairs.
+        meta_repr = repr(second_read.metadata)
+        # 'True' might get turned into '1', so only check the key.
+        assert "'foobar': " in meta_repr
+        assert "'my': 'enemies'" in meta_repr
+    # ...but closed metadata does not.
+    meta_repr_closed = repr(second_read.metadata)
+    assert "foobar" not in meta_repr_closed
 
 
 def test_add_delete_metadata(soma_object):


### PR DESCRIPTION
Fixes #935.