### PR TITLE
[c++] Support `nnz` when `allow_duplicates=True`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ update:
 # -------------------------------------------------------------------
 .PHONY: test
 test: data
-	ctest --test-dir build/libtiledbsoma -C Release --verbose
+	ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
 	pytest apis/python/tests libtiledbsoma/test
 
 .PHONY: data

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -990,5 +990,5 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
     ) as sidf:
         tab = sidf.read().concat()
         assert list(x.as_py() for x in tab["soma_joinid"]) == [0]
-        assert list(x.as_py() for x in tab["B"]) == [100.1]
-        assert list(x.as_py() for x in tab["C"]) == ["foo"]
+        assert list(x.as_py() for x in tab["float"]) == [100.1]
+        assert list(x.as_py() for x in tab["string"]) == ["apple"]

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -966,9 +966,17 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
     with soma.DataFrame.open(uri) as sidf:
         table = sidf.read().concat()
         if allows_duplicates:
-            assert list(x.as_py() for x in table["soma_joinid"]) == [0, 0, 1]
-            assert list(x.as_py() for x in table["float"]) == [100.1, 200.2, 300.3]
-            assert list(x.as_py() for x in table["string"]) == ["apple", "ball", "cat"]
+            assert sorted(list(x.as_py() for x in table["soma_joinid"])) == [0, 0, 1]
+            assert sorted(list(x.as_py() for x in table["float"])) == [
+                100.1,
+                200.2,
+                300.3,
+            ]
+            assert sorted(list(x.as_py() for x in table["string"])) == [
+                "apple",
+                "ball",
+                "cat",
+            ]
             assert sidf.count == 3
         else:
             assert list(x.as_py() for x in table["soma_joinid"]) == [0, 1]

--- a/libtiledbsoma/src/soma_reader.cc
+++ b/libtiledbsoma/src/soma_reader.cc
@@ -213,6 +213,9 @@ uint64_t SOMAReader::nnz() {
 
         // If any relevant fragment is a consolidated fragment, fall back to
         // counting cells, because the fragment may contain duplicates.
+        // If the application is allowing duplicates (in which case it's the
+        // application's job to otherwise ensure uniqueness), then
+        // sum-over-fragments is the right thing to do.
         if (!mq_->schema()->allows_dups() && frag_ts.first != frag_ts.second) {
             return nnz_slow();
         }

--- a/libtiledbsoma/test/unit_soma_reader.cc
+++ b/libtiledbsoma/test/unit_soma_reader.cc
@@ -172,11 +172,8 @@ TEST_CASE("SOMAReader: nnz") {
         // Get total cell num
         auto sr = SOMAReader::open(ctx, uri);
 
-        uint64_t nnz;
-        if (num_fragments > 1 && overlap && allow_duplicates) {
-          nnz = sr->nnz();
-          REQUIRE(nnz == expected_nnz);
-        }
+        uint64_t nnz = sr->nnz();
+        REQUIRE(nnz == expected_nnz);
     }
 }
 
@@ -221,14 +218,8 @@ TEST_CASE("SOMAReader: nnz with timestamp") {
         auto sr = SOMAReader::open(
             ctx, uri, "nnz", {}, "auto", "auto", timestamp);
 
-        uint64_t nnz;
-        if (num_fragments > 1 && overlap && allow_duplicates) {
-            REQUIRE_THROWS(nnz = sr->nnz());
-            LOG_DEBUG("Caught expected exception for nnz with duplicates");
-        } else {
-            nnz = sr->nnz();
-            REQUIRE(nnz == expected_nnz);
-        }
+        uint64_t nnz = sr->nnz();
+        REQUIRE(nnz == expected_nnz);
     }
 }
 
@@ -280,13 +271,7 @@ TEST_CASE("SOMAReader: nnz with consolidation") {
         // Get total cell num
         auto sr = SOMAReader::open(ctx, uri, "nnz", {}, "auto", "auto");
 
-        uint64_t nnz;
-        if (allow_duplicates) {
-            REQUIRE_THROWS(nnz = sr->nnz());
-            LOG_DEBUG("Caught expected exception for nnz with duplicates");
-        } else {
-            nnz = sr->nnz();
-            REQUIRE(nnz == expected_nnz);
-        }
+        uint64_t nnz = sr->nnz();
+        REQUIRE(nnz == expected_nnz);
     }
 }

--- a/libtiledbsoma/test/unit_soma_reader.cc
+++ b/libtiledbsoma/test/unit_soma_reader.cc
@@ -136,7 +136,7 @@ std::tuple<std::string, uint64_t> create_array(
     uint64_t nnz = num_fragments * num_cells_per_fragment;
 
     // Adjust nnz when overlap is enabled
-    if (overlap) {
+    if (overlap && !allow_duplicates) {
         nnz = (num_fragments + 1) / 2 * num_cells_per_fragment;
     }
 
@@ -174,11 +174,8 @@ TEST_CASE("SOMAReader: nnz") {
 
         uint64_t nnz;
         if (num_fragments > 1 && overlap && allow_duplicates) {
-            REQUIRE_THROWS(nnz = sr->nnz());
-            LOG_DEBUG("Caught expected exception for nnz with duplicates");
-        } else {
-            nnz = sr->nnz();
-            REQUIRE(nnz == expected_nnz);
+          nnz = sr->nnz();
+          REQUIRE(nnz == expected_nnz);
         }
     }
 }

--- a/libtiledbsoma/test/unit_soma_reader.cc
+++ b/libtiledbsoma/test/unit_soma_reader.cc
@@ -135,8 +135,12 @@ std::tuple<std::string, uint64_t> create_array(
 
     uint64_t nnz = num_fragments * num_cells_per_fragment;
 
+    if (allow_duplicates) {
+        return {uri, nnz};
+    }
+
     // Adjust nnz when overlap is enabled
-    if (overlap && !allow_duplicates) {
+    if (overlap) {
         nnz = (num_fragments + 1) / 2 * num_cells_per_fragment;
     }
 
@@ -272,6 +276,11 @@ TEST_CASE("SOMAReader: nnz with consolidation") {
         auto sr = SOMAReader::open(ctx, uri, "nnz", {}, "auto", "auto");
 
         uint64_t nnz = sr->nnz();
-        REQUIRE(nnz == expected_nnz);
+        if (allow_duplicates) {
+            // Since we wrote twice
+            REQUIRE(nnz == 2 * expected_nnz);
+        } else {
+            REQUIRE(nnz == expected_nnz);
+        }
     }
 }


### PR DESCRIPTION
**Issue and/or context:**

#988 

**Changes:**

We've established the pattern that:

* `allow_duplicates=False` is the default
* `allow_duplicates=True` is supported with user caveats that uniqueness is the application's responsibility

Here we honor that pattern.