### PR TITLE
[r] Handle empty matrices when creating SOMA from Seurat

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.22.9001
+Version: 0.1.22.9002
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,5 +1,9 @@
 # tiledbsoma (development version)
 
+## Changes
+
+- The `SOMA`'s `from_seurat_assay()` method now checks for and skips empty matrices following Seurat's definition of an empty matrix (#990)
+
 ## Features
 
 - The `SOMACollection`'s `to_seurat()` method gains a `somas` argument that makes it possible to select a subset of `SOMA`s and `X` layers to be retrieved (#571).

--- a/apis/r/R/utils-seurat.R
+++ b/apis/r/R/utils-seurat.R
@@ -4,5 +4,6 @@ is_seurat_assay <- function(x) {
 
 seurat_assay_has_scale_data <- function(x) {
   stopifnot(is_seurat_assay(x))
-  length(SeuratObject::GetAssayData(x, "scale.data")) > 0
+  !SeuratObject::IsMatrixEmpty(SeuratObject::GetAssayData(x, 'scale.data'))
+  # length(SeuratObject::GetAssayData(x, "scale.data")) > 0
 }

--- a/apis/r/tests/testthat/test_SOMA_Seurat.R
+++ b/apis/r/tests/testthat/test_SOMA_Seurat.R
@@ -318,3 +318,71 @@ test_that("individual layers can be added or updated", {
   expect_identical(soma$X$members$counts$fragment_count(), 1)
   expect_identical(soma$X$members$data$fragment_count(), 2)
 })
+
+test_that("assays with missing layers are handled: new('matrix')", {
+  try(tiledb::tiledb_vfs_remove_dir(tdb_uri), silent = TRUE)
+  assay <- pbmc_small[["RNA"]]
+  assay <- SeuratObject::SetAssayData(assay, "counts", new("matrix"))
+  soma <- SOMA$new(uri = tdb_uri)
+  soma$from_seurat_assay(assay)
+
+  expect_equal(names(soma$members$X$members), c("data", "scale.data"))
+  expect_s4_class(assay1 <- soma$to_seurat_assay(), "Assay")
+  expect_true(
+    inherits(mat <- SeuratObject::GetAssayData(assay1, "counts"), "matrix")
+  )
+  expect_true(all(dim(mat) == 0L))
+  expect_true(SeuratObject::IsMatrixEmpty(mat))
+})
+
+test_that("assays with missing layers are handled: new('dgCMatrix')", {
+  assay <- pbmc_small[["RNA"]]
+  assay <- SeuratObject::SetAssayData(assay, "counts", new("dgCMatrix"))
+  soma <- SOMA$new(uri = tdb_uri)
+  soma$from_seurat_assay(assay)
+
+  expect_equal(names(soma$members$X$members), c("data", "scale.data"))
+  expect_s4_class(assay1 <- soma$to_seurat_assay(), "Assay")
+  expect_true(
+    inherits(mat <- SeuratObject::GetAssayData(assay1, "counts"), "matrix")
+  )
+  expect_true(all(dim(mat) == 0L))
+  expect_true(SeuratObject::IsMatrixEmpty(mat))
+})
+
+test_that("assays with missing layers are handled: matrix()", {
+  assay <- pbmc_small[["RNA"]]
+  assay <- SeuratObject::SetAssayData(assay, "counts", matrix())
+  soma <- SOMA$new(uri = tdb_uri)
+  soma$from_seurat_assay(assay)
+
+  expect_equal(names(soma$members$X$members), c("data", "scale.data"))
+  expect_s4_class(assay1 <- soma$to_seurat_assay(), "Assay")
+  expect_true(
+    inherits(mat <- SeuratObject::GetAssayData(assay1, "counts"), "matrix")
+  )
+  expect_true(all(dim(mat) == 0L))
+  expect_true(SeuratObject::IsMatrixEmpty(mat))
+})
+
+test_that("assays with missing layers are handled: dgCMatrix()", {
+  assay <- pbmc_small[["RNA"]]
+  expect_s4_class(
+    m <- as(
+      as(Matrix::Matrix(NA_real_, sparse = TRUE), "generalMatrix"),
+      "CsparseMatrix"
+    ),
+    "dgCMatrix"
+  )
+  assay <- SeuratObject::SetAssayData(assay, "counts", new("matrix"))
+  soma <- SOMA$new(uri = tdb_uri)
+  soma$from_seurat_assay(assay)
+
+  expect_equal(names(soma$members$X$members), c("data", "scale.data"))
+  expect_s4_class(assay1 <- soma$to_seurat_assay(), "Assay")
+  expect_true(
+    inherits(mat <- SeuratObject::GetAssayData(assay1, "counts"), "matrix")
+  )
+  expect_true(all(dim(mat) == 0L))
+  expect_true(SeuratObject::IsMatrixEmpty(mat))
+})

--- a/apis/r/tests/testthat/test_SOMA_Seurat.R
+++ b/apis/r/tests/testthat/test_SOMA_Seurat.R
@@ -336,6 +336,7 @@ test_that("assays with missing layers are handled: new('matrix')", {
 })
 
 test_that("assays with missing layers are handled: new('dgCMatrix')", {
+  try(tiledb::tiledb_vfs_remove_dir(tdb_uri), silent = TRUE)
   assay <- pbmc_small[["RNA"]]
   assay <- SeuratObject::SetAssayData(assay, "counts", new("dgCMatrix"))
   soma <- SOMA$new(uri = tdb_uri)
@@ -351,6 +352,7 @@ test_that("assays with missing layers are handled: new('dgCMatrix')", {
 })
 
 test_that("assays with missing layers are handled: matrix()", {
+  try(tiledb::tiledb_vfs_remove_dir(tdb_uri), silent = TRUE)
   assay <- pbmc_small[["RNA"]]
   assay <- SeuratObject::SetAssayData(assay, "counts", matrix())
   soma <- SOMA$new(uri = tdb_uri)
@@ -366,6 +368,7 @@ test_that("assays with missing layers are handled: matrix()", {
 })
 
 test_that("assays with missing layers are handled: dgCMatrix()", {
+  try(tiledb::tiledb_vfs_remove_dir(tdb_uri), silent = TRUE)
   assay <- pbmc_small[["RNA"]]
   expect_s4_class(
     m <- as(


### PR DESCRIPTION
Seurat allows empty matrices for `counts` and `scale.data`
Empty matrices are defined as 0x0 or 1x1 with a value of `NA` 
Use `SeuratObject::IsMatrixEmpty` to determine empty matrices 
Skip writing empty matrices

fixes Tiledb-Inc/tiledbsc#92