### PR TITLE
Don't do R CI jobs on pre-commit changes.

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - "apis/python/**"
+      - ".pre-commit-config.yaml"
   push:
     branches: [main]
 


### PR DESCRIPTION
I was puzzled as to why, whenever we updated dependencies, the R build workflow would run despite R code not being changed. Turns out it was because the pre-commit configuration (which lives outside of the ignored Python directory) was triggering it to run.

Since R currently does not use pre-commit, we can safely ignore it, meaning that Python dependency changes will no longer trigger mysterious R workflows.