### PR TITLE
[python Make the default timestamp in `SOMATileDBContext` be `None`

### DIFF
--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -71,10 +71,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         kwargs = {
             "name": self.__class__.__name__,
             "platform_config": self._ctx.config().dict(),
-            "timestamp": (
-                self.context.timestamp_start,
-                self.context.timestamp,
-            ),
+            "timestamp": self.context._timestamp_arg(),
         }
         # Leave empty arguments out of kwargs to allow C++ constructor defaults to apply, as
         # they're not all wrapped in std::optional<>.

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any, Dict, Optional, Tuple, Union
 
 import attrs
@@ -32,15 +31,18 @@ class SOMATileDBContext:
 
     tiledb_ctx: tiledb.Ctx = _build_default_tiledb_ctx()
 
-    timestamp: Optional[int] = attrs.field(factory=lambda: int(time.time() * 1000))
+    timestamp: Optional[int] = attrs.field(default=None)
     """
     Timestamp for operations on SOMA objects, in milliseconds since Unix epoch.
-    Defaults to the time of context initialization.
 
-    Set to ``None`` to use the current wall time and opt out of timestamp
-    consistency. **Reads** will see data as of the time that the individual
-    TileDB object is opened. **Writes** will be recorded as of when the TileDB
-    object is closed.
+    ``None``, the default, does not provide cross-object timestamp consistency:
+
+    - **Reads** will see data as of the time that the individual TileDB object
+      is opened.
+    - **Writes** will be recorded as of when the TileDB object is closed.
+
+    If a value is passed, that timestamp (representing milliseconds since
+    the Unix epoch) is used as the timestamp to record all operations.
 
     Set to 0xFFFFFFFFFFFFFFFF (UINT64_MAX) to get the absolute latest revision
     (i.e., including changes that occur "after" the current wall time) as of

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -99,14 +99,20 @@ def test_SOMATileDBContext_evolve():
     context = tiledbsoma.options.SOMATileDBContext()
 
     # verify defaults expected by subsequent tests
+    assert context.timestamp is None
     assert context.timestamp_start == 0
     assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
 
-    # verify timestamp_start
-    assert context.replace(timestamp_start=1).timestamp_start == 1
+    context_ts_1 = context.replace(timestamp=1)
 
     # veirfy timestamp
-    assert context.replace(timestamp=1).timestamp == 1
+    assert context_ts_1.timestamp == 1
+
+    # verify timestamp_start
+    assert context_ts_1.replace(timestamp_start=1).timestamp_start == 1
+
+    with pytest.raises(ValueError):
+        context_ts_1.replace(timestamp_start=2)
 
     # verify tiledb_ctx
     context.replace(tiledb_config={"vfs.s3.region": "us-west-2"}).tiledb_ctx.config()[


### PR DESCRIPTION
Storing timestamps in the Context is problematic since it is likely that users will want to share many parts of the Context across multiple open calls.  This would result in every object opened on that shared context having the same timestamp, and not just the child tree of a single open call from user code.  This is already an issue with Cell Census, which uses a single shared context for the entire duration of the program.

Because of this, it's better to have the timestamp be unset rather than having it set to context creation.