### PR TITLE
[python] Allow all operations on a collection to share a timestamp

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -186,7 +186,7 @@ class CollectionBase(
                 create_uri,
                 platform_config=platform_config,
                 context=self.context,
-                tiledb_timestamp=self.tiledb_timestamp,
+                tiledb_timestamp=self.tiledb_timestamp_ms,
             ),
             uri,
         )
@@ -209,7 +209,7 @@ class CollectionBase(
             lambda create_uri: DataFrame.create(
                 create_uri,
                 context=self.context,
-                tiledb_timestamp=self.tiledb_timestamp,
+                tiledb_timestamp=self.tiledb_timestamp_ms,
                 **kwargs,
             ),
             uri,
@@ -226,7 +226,7 @@ class CollectionBase(
             lambda create_uri: cls.create(
                 create_uri,
                 context=self.context,
-                tiledb_timestamp=self.tiledb_timestamp,
+                tiledb_timestamp=self.tiledb_timestamp_ms,
                 **kwargs,
             ),
             uri,
@@ -310,7 +310,7 @@ class CollectionBase(
                 entry.entry.uri,
                 self.mode,
                 self.context,
-                self.tiledb_timestamp,
+                self.tiledb_timestamp_ms,
             )
             # Since we just opened this object, we own it and should close it.
             self._close_stack.enter_context(entry.soma)

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -32,6 +32,7 @@ from ._dense_nd_array import DenseNDArray
 from ._exception import SOMAError, is_does_not_exist_error
 from ._sparse_nd_array import SparseNDArray
 from ._tiledb_object import AnyTileDBObject, TileDBObject
+from ._types import OpenTimestamp
 from ._util import is_relative_uri, make_relative_path, uri_joinpath
 from .options import SOMATileDBContext
 
@@ -72,7 +73,7 @@ class CollectionBase(
         *,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[int] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
     ) -> Self:
         """Creates and opens a new SOMA collection in storage [lifecycle: experimental].
 

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -11,6 +11,7 @@ from typing_extensions import Self
 
 from . import _arrow_types, _util
 from ._tiledb_array import TileDBArray
+from ._types import OpenTimestamp
 from .options._soma_tiledb_context import SOMATileDBContext
 from .options._tiledb_create_options import TileDBCreateOptions
 
@@ -29,7 +30,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         shape: Sequence[Union[int, None]],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[int] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
     ) -> Self:
         """
         Create a SOMA ``NDArray`` at the given URI [lifecycle: experimental].

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -29,6 +29,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         shape: Sequence[Union[int, None]],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[int] = None,
     ) -> Self:
         """
         Create a SOMA ``NDArray`` at the given URI [lifecycle: experimental].
@@ -49,6 +50,10 @@ class NDArray(TileDBArray, somacore.NDArray):
 
         :param platform_config: Platform-specific options used to create this Array,
             provided via ``{"tiledb": {"create": ...}}`` nested keys.
+
+        :param tiledb_timestamp: If specified, overrides the default timestamp
+            used to open this object. If unset, uses the timestamp provided by
+            the context.
         """
         # Implementor note: we carefully say "maximum possible int64 size" rather than 2**63-1. The
         # reason that the latter, while temptingly simple, is actually untrue is that tiledb core
@@ -65,7 +70,7 @@ class NDArray(TileDBArray, somacore.NDArray):
             context,
             is_sparse=cls.is_sparse,
         )
-        handle = cls._create_internal(uri, schema, context)
+        handle = cls._create_internal(uri, schema, context, tiledb_timestamp)
         return cls(
             handle,
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -13,7 +13,7 @@ from ._constants import SOMA_JOINID
 from ._query_condition import QueryCondition
 from ._read_iters import TableReadIter
 from ._tiledb_array import TileDBArray
-from ._types import NPFloating, NPInteger, Slice, is_slice_of
+from ._types import NPFloating, NPInteger, OpenTimestamp, Slice, is_slice_of
 from .options import SOMATileDBContext
 from .options._tiledb_create_options import TileDBCreateOptions
 
@@ -80,7 +80,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         index_column_names: Sequence[str] = (SOMA_JOINID,),
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[int] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
     ) -> "DataFrame":
         """
         Creates the data structure on disk/S3/cloud.

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -80,6 +80,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         index_column_names: Sequence[str] = (SOMA_JOINID,),
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[int] = None,
     ) -> "DataFrame":
         """
         Creates the data structure on disk/S3/cloud.
@@ -98,6 +99,10 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         :param platform_config: Platform-specific options used to create this DataFrame,
             provided via ``{"tiledb": {"create": ...}}`` nested keys.
+
+        :param tiledb_timestamp: If specified, overrides the default timestamp
+            used to open this object. If unset, uses the timestamp provided by
+            the context.
         """
         context = context or SOMATileDBContext()
         schema = _canonicalize_schema(schema, index_column_names)
@@ -107,7 +112,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             TileDBCreateOptions.from_platform_config(platform_config),
             context,
         )
-        handle = cls._create_internal(uri, tdb_schema, context)
+        handle = cls._create_internal(uri, tdb_schema, context, tiledb_timestamp)
         return cls(
             handle,
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -25,6 +25,7 @@ from ._constants import (
 )
 from ._exception import SOMAError
 from ._funcs import typeguard_ignore
+from ._types import OpenTimestamp
 from .options import SOMATileDBContext
 
 _Obj = TypeVar("_Obj", bound="_tiledb_object.AnyTileDBObject")
@@ -38,7 +39,7 @@ def open(
     *,
     soma_type: Optional[str] = None,
     context: Optional[SOMATileDBContext] = None,
-    tiledb_timestamp: Optional[int] = None,
+    tiledb_timestamp: Optional[OpenTimestamp] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
     ...
 
@@ -50,7 +51,7 @@ def open(
     *,
     soma_type: Type[_Obj],
     context: Optional[SOMATileDBContext] = None,
-    tiledb_timestamp: Optional[int] = None,
+    tiledb_timestamp: Optional[OpenTimestamp] = None,
 ) -> _Obj:
     ...
 
@@ -62,7 +63,7 @@ def open(
     *,
     soma_type: Union[Type["_tiledb_object.AnyTileDBObject"], str, None] = None,
     context: Optional[SOMATileDBContext] = None,
-    tiledb_timestamp: Optional[int] = None,
+    tiledb_timestamp: Optional[OpenTimestamp] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
     """Opens a TileDB SOMA object [lifecycle: experimental].
 
@@ -99,12 +100,12 @@ def open(
 
 def _open_internal(
     opener: Callable[
-        [str, options.OpenMode, SOMATileDBContext, Optional[int]], _Wrapper
+        [str, options.OpenMode, SOMATileDBContext, Optional[OpenTimestamp]], _Wrapper
     ],
     uri: str,
     mode: options.OpenMode,
     context: SOMATileDBContext,
-    timestamp: Optional[int],
+    timestamp: Optional[OpenTimestamp],
 ) -> "_tiledb_object.TileDBObject[_Wrapper]":
     """Lower-level open function for internal use only."""
     handle = opener(uri, mode, context, timestamp)

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -38,6 +38,7 @@ def open(
     *,
     soma_type: Optional[str] = None,
     context: Optional[SOMATileDBContext] = None,
+    tiledb_timestamp: Optional[int] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
     ...
 
@@ -49,6 +50,7 @@ def open(
     *,
     soma_type: Type[_Obj],
     context: Optional[SOMATileDBContext] = None,
+    tiledb_timestamp: Optional[int] = None,
 ) -> _Obj:
     ...
 
@@ -60,6 +62,7 @@ def open(
     *,
     soma_type: Union[Type["_tiledb_object.AnyTileDBObject"], str, None] = None,
     context: Optional[SOMATileDBContext] = None,
+    tiledb_timestamp: Optional[int] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
     """Opens a TileDB SOMA object [lifecycle: experimental].
 
@@ -70,9 +73,12 @@ def open(
         If the stored SOMA object is not of the correct type, an error will be
         raised.
     :param context: If set, the ``SOMATileDBContext`` data to use.
+    :param tiledb_timestamp: If specified, overrides the default timestamp
+        used to open this object. If unset, uses the timestamp provided by
+        the context.
     """
     context = context or SOMATileDBContext()
-    obj = _open_internal(_tdb_handles.open, uri, mode, context)
+    obj = _open_internal(_tdb_handles.open, uri, mode, context, tiledb_timestamp)
     try:
         if soma_type:
             if isinstance(soma_type, str):
@@ -92,13 +98,16 @@ def open(
 
 
 def _open_internal(
-    opener: Callable[[str, options.OpenMode, SOMATileDBContext], _Wrapper],
+    opener: Callable[
+        [str, options.OpenMode, SOMATileDBContext, Optional[int]], _Wrapper
+    ],
     uri: str,
     mode: options.OpenMode,
     context: SOMATileDBContext,
+    timestamp: Optional[int],
 ) -> "_tiledb_object.TileDBObject[_Wrapper]":
     """Lower-level open function for internal use only."""
-    handle = opener(uri, mode, context)
+    handle = opener(uri, mode, context, timestamp)
     try:
         return _reify_handle(handle)
     except Exception:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -61,7 +61,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     uri: str
     mode: options.OpenMode
     context: SOMATileDBContext
-    timestamp: int
+    timestamp_ms: int
     _handle: _RawHdl_co
     closed: bool = attrs.field(default=False, init=False)
 
@@ -75,12 +75,12 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     ) -> Self:
         if mode not in ("r", "w"):
             raise ValueError(f"Invalid open mode {mode!r}")
-        real_timestamp = context._open_timestamp(timestamp)
+        timestamp_ms = context._open_timestamp(timestamp)
         try:
-            tdb = cls._opener(uri, mode, context, real_timestamp)
-            handle = cls(uri, mode, context, real_timestamp, tdb)
+            tdb = cls._opener(uri, mode, context, timestamp_ms)
+            handle = cls(uri, mode, context, timestamp_ms, tdb)
             if mode == "w":
-                with cls._opener(uri, "r", context, real_timestamp) as auxiliary_reader:
+                with cls._opener(uri, "r", context, timestamp_ms) as auxiliary_reader:
                     handle._do_initial_reads(auxiliary_reader)
             else:
                 handle._do_initial_reads(tdb)
@@ -143,7 +143,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         if self.mode == "w":
             self.metadata._write()
             self._handle.close()
-            self._handle = self._opener(self.uri, "w", self.context, self.timestamp)
+            self._handle = self._opener(self.uri, "w", self.context, self.timestamp_ms)
 
     def _check_open(self) -> None:
         if self.closed:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -25,6 +25,7 @@ from somacore import options
 from typing_extensions import Literal, Self
 
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
+from ._types import OpenTimestamp
 from .options._soma_tiledb_context import SOMATileDBContext
 
 RawHandle = Union[tiledb.Array, tiledb.Group]
@@ -36,7 +37,7 @@ def open(
     uri: str,
     mode: options.OpenMode,
     context: SOMATileDBContext,
-    timestamp: Optional[int],
+    timestamp: Optional[OpenTimestamp],
 ) -> "Wrapper[RawHandle]":
     """Determine whether the URI is an array or group, and open it."""
     obj_type = tiledb.object_type(uri, ctx=context.tiledb_ctx)
@@ -70,7 +71,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         uri: str,
         mode: options.OpenMode,
         context: SOMATileDBContext,
-        timestamp: Optional[int],
+        timestamp: Optional[OpenTimestamp],
     ) -> Self:
         if mode not in ("r", "w"):
             raise ValueError(f"Invalid open mode {mode!r}")

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -75,7 +75,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     ) -> Self:
         if mode not in ("r", "w"):
             raise ValueError(f"Invalid open mode {mode!r}")
-        timestamp_ms = context._open_timestamp(timestamp)
+        timestamp_ms = context._open_timestamp_ms(timestamp)
         try:
             tdb = cls._opener(uri, mode, context, timestamp_ms)
             handle = cls(uri, mode, context, timestamp_ms, tdb)

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -71,7 +71,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         kwargs = {
             "name": self.__class__.__name__,
             "platform_config": self._ctx.config().dict(),
-            "timestamp": self.context._timestamp_arg(),
+            "timestamp": (0, self.tiledb_timestamp),
         }
         # Leave empty arguments out of kwargs to allow C++ constructor defaults to apply, as
         # they're not all wrapped in std::optional<>.
@@ -138,7 +138,11 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
 
     @classmethod
     def _create_internal(
-        cls, uri: str, schema: tiledb.ArraySchema, context: SOMATileDBContext
+        cls,
+        uri: str,
+        schema: tiledb.ArraySchema,
+        context: SOMATileDBContext,
+        tiledb_timestamp: Optional[int],
     ) -> _tdb_handles.ArrayWrapper:
         """Creates the TileDB Array for this type and returns an opened handle.
 
@@ -147,6 +151,6 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         the newly-created array, open for writing.
         """
         tiledb.Array.create(uri, schema, ctx=context.tiledb_ctx)
-        handle = cls._wrapper_type.open(uri, "w", context)
+        handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
         cls._set_create_metadata(handle)
         return handle

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -9,7 +9,7 @@ from . import _tdb_handles, _util
 from . import libtiledbsoma as clib
 from ._arrow_types import tiledb_schema_to_arrow
 from ._tiledb_object import TileDBObject
-from ._types import is_nonstringy_sequence
+from ._types import OpenTimestamp, is_nonstringy_sequence
 from .options._soma_tiledb_context import SOMATileDBContext
 
 
@@ -142,7 +142,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         uri: str,
         schema: tiledb.ArraySchema,
         context: SOMATileDBContext,
-        tiledb_timestamp: Optional[int],
+        tiledb_timestamp: Optional[OpenTimestamp],
     ) -> _tdb_handles.ArrayWrapper:
         """Creates the TileDB Array for this type and returns an opened handle.
 

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -71,7 +71,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         kwargs = {
             "name": self.__class__.__name__,
             "platform_config": self._ctx.config().dict(),
-            "timestamp": (0, self.tiledb_timestamp),
+            "timestamp": (0, self.tiledb_timestamp_ms),
         }
         # Leave empty arguments out of kwargs to allow C++ constructor defaults to apply, as
         # they're not all wrapped in std::optional<>.

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -1,3 +1,4 @@
+import datetime
 from contextlib import ExitStack
 from typing import Any, Generic, MutableMapping, Optional, Type, TypeVar
 
@@ -9,6 +10,7 @@ from typing_extensions import Self
 from . import _constants, _tdb_handles
 from ._exception import SOMAError
 from ._types import OpenTimestamp
+from ._util import ms_to_datetime
 from .options import SOMATileDBContext
 
 _WrapperType_co = TypeVar(
@@ -141,9 +143,14 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         return self._handle.mode
 
     @property
-    def tiledb_timestamp(self) -> int:
+    def tiledb_timestamp(self) -> datetime.datetime:
+        """The time that this object was opened in UTC."""
+        return ms_to_datetime(self.tiledb_timestamp_ms)
+
+    @property
+    def tiledb_timestamp_ms(self) -> int:
         """The time this object was opened, as millis since the Unix epoch."""
-        return self._handle.timestamp
+        return self._handle.timestamp_ms
 
     @classmethod
     def exists(

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -8,6 +8,7 @@ from typing_extensions import Self
 
 from . import _constants, _tdb_handles
 from ._exception import SOMAError
+from ._types import OpenTimestamp
 from .options import SOMATileDBContext
 
 _WrapperType_co = TypeVar(
@@ -37,7 +38,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         uri: str,
         mode: options.OpenMode = "r",
         *,
-        tiledb_timestamp: Optional[int] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
         context: Optional[SOMATileDBContext] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
@@ -149,7 +150,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         cls,
         uri: str,
         context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[int] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
     ) -> bool:
         """Finds whether an object of this type exists at the given URI.
         [lifecycle: experimental].

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -1,3 +1,4 @@
+import datetime
 import pathlib
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union
 
@@ -30,6 +31,12 @@ NTuple = Tuple[int, ...]
 
 IngestMode = Literal["write", "schema_only", "resume"]  # for static-analysis checks
 INGEST_MODES = ("write", "schema_only", "resume")  # for run-time checks
+
+OpenTimestamp = Union[int, datetime.datetime]
+"""Types that can be used as a timestamp to open a TileDB object.
+
+Integers are treated as milliseconds since the Unix epoch.
+"""
 
 ArrowReadResult = Union[
     pa.Table,

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -252,7 +252,7 @@ def ms_to_datetime(millis: int) -> datetime.datetime:
     """Returns the millisecond timestamp as a timezone-aware UTC datetime.
 
     This may raise an exception, since millis may be outside the representable
-    range for
+    range for a Python datetime.
     """
     secs, millis = divmod(millis, 1000)
     dt = datetime.datetime.fromtimestamp(secs, tz=datetime.timezone.utc)

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -246,3 +246,14 @@ def to_timestamp_ms(input: OpenTimestamp) -> int:
     if not 0 <= timestamp_ms <= _ETERNITY_MS:
         raise ValueError("open timestamp must be between 0 (Unix epoch) and 2**64-1 ms")
     return timestamp_ms
+
+
+def ms_to_datetime(millis: int) -> datetime.datetime:
+    """Returns the millisecond timestamp as a timezone-aware UTC datetime.
+
+    This may raise an exception, since millis may be outside the representable
+    range for
+    """
+    secs, millis = divmod(millis, 1000)
+    dt = datetime.datetime.fromtimestamp(secs, tz=datetime.timezone.utc)
+    return dt.replace(microsecond=millis * 1000)

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -231,7 +231,7 @@ _ETERNITY_MS = 2**64 - 1
 
 
 def to_timestamp_ms(input: OpenTimestamp) -> int:
-    """Converts a timestamp input type to Unix millis."""
+    """Converts a timestamp input type to millis since the Unix epoch."""
     check_type("tiledb_timestamp", input, (int, datetime.datetime))
     if isinstance(input, int):
         timestamp_ms = input

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -48,6 +48,12 @@ class SOMATileDBContext:
     """
     Default timestamp for operations on SOMA objects, in millis since the Unix epoch.
 
+    WARNING: This should not be set unless you are *absolutely* sure you want to
+    use the same timestamp across multiple operations. If multiple writes to the
+    same object are performed at the same timestamp, they have no defined order.
+    In most cases, it is better to pass a timestamp to a single ``open`` call,
+    or to simply use the default behavior.
+
     This is used when a timestamp is not provided to an ``open`` operation.
 
     ``None``, the default, sets the timestamp on each root ``open`` operation.

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -41,7 +41,9 @@ class SOMATileDBContext:
 
     tiledb_ctx: tiledb.Ctx = _build_default_tiledb_ctx()
 
-    timestamp: Optional[int] = attrs.field(default=None, converter=_maybe_timestamp_ms)
+    timestamp_ms: Optional[int] = attrs.field(
+        default=None, converter=_maybe_timestamp_ms
+    )
     """
     Default timestamp for operations on SOMA objects, in Unix millis.
 
@@ -90,6 +92,6 @@ class SOMATileDBContext:
         """Returns the real timestamp that should be used to open an object."""
         if in_timestamp is not None:
             return to_timestamp_ms(in_timestamp)
-        if self.timestamp is not None:
-            return self.timestamp
+        if self.timestamp_ms is not None:
+            return self.timestamp_ms
         return int(time.time() * 1000)

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -449,7 +449,7 @@ def test_timestamped_ops(tmp_path):
 
     # open A via collection @ t=25 => A should reflect first write only
     with soma.Collection.open(
-        tmp_path.as_uri(), context=SOMATileDBContext(timestamp_ms=25)
+        tmp_path.as_uri(), context=SOMATileDBContext(timestamp=25)
     ) as sc:
         assert sc["A"].read((slice(None), slice(None))).to_numpy().tolist() == [
             [0, 0],
@@ -458,13 +458,13 @@ def test_timestamped_ops(tmp_path):
 
     # open collection @ t=15 => A should not even be there
     with soma.Collection.open(
-        tmp_path.as_uri(), context=SOMATileDBContext(timestamp_ms=15)
+        tmp_path.as_uri(), context=SOMATileDBContext(timestamp=15)
     ) as sc:
         assert "A" not in sc
 
     # confirm timestamp validation in SOMATileDBContext
     with pytest.raises(ValueError):
-        SOMATileDBContext(timestamp_ms=-1)
+        SOMATileDBContext(timestamp=-1)
 
 
 def test_issue919(tmp_path):
@@ -481,7 +481,7 @@ def test_issue919(tmp_path):
     for i in range(25):
         uri = str(tmp_path / str(i))
 
-        context = SOMATileDBContext(timestamp_ms=100)
+        context = SOMATileDBContext(timestamp=100)
         with soma.Collection.create(uri, context=context) as c:
             expt = c.add_new_collection("expt", soma.Experiment)
             expt.add_new_collection("causes_bug")
@@ -497,7 +497,7 @@ def test_issue919(tmp_path):
 
 def test_context_timestamp(tmp_path: pathlib.Path):
     """Verifies that timestamps are inherited by collections."""
-    fixed_time = SOMATileDBContext(timestamp_ms=123)
+    fixed_time = SOMATileDBContext(timestamp=123)
     with soma.Collection.create(tmp_path.as_uri(), context=fixed_time) as coll:
         assert coll.tiledb_timestamp_ms == 123
         sub = coll.add_new_collection("sub_1")

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -935,6 +935,8 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             "string": ["apple"],
         }
         sidf.write(pa.Table.from_pydict(data))
+        assert sidf.tiledb_timestamp_ms == 1615402800000
+        assert sidf.tiledb_timestamp.isoformat() == "2021-03-10T19:00:00+00:00"
 
     end = start + datetime.timedelta(minutes=3, seconds=25)
     with soma.DataFrame.open(uri=uri, mode="w", tiledb_timestamp=end) as sidf:
@@ -944,6 +946,8 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             "string": ["ball", "cat"],
         }
         sidf.write(pa.Table.from_pydict(data))
+        assert sidf.tiledb_timestamp_ms == 1615403005000
+        assert sidf.tiledb_timestamp.isoformat() == "2021-03-10T19:03:25+00:00"
 
     # Without consolidate:
     # * There are two fragments:
@@ -978,10 +982,12 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             assert list(x.as_py() for x in table["string"]) == ["ball", "cat"]
             assert sidf.count == 2
 
-    middle = 1615402883000
+    middle = 1615402887987
     # read at t=15 & see only the first write
     with soma.DataFrame.open(tmp_path.as_posix(), tiledb_timestamp=middle) as sidf:
         tab = sidf.read().concat()
         assert list(x.as_py() for x in tab["soma_joinid"]) == [0]
         assert list(x.as_py() for x in tab["float"]) == [100.1]
         assert list(x.as_py() for x in tab["string"]) == ["apple"]
+        assert sidf.tiledb_timestamp_ms == 1615402887987
+        assert sidf.tiledb_timestamp.isoformat() == "2021-03-10T19:01:27.987000+00:00"

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Dict, List
 
 import numpy as np
@@ -919,11 +920,13 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             ("string", pa.large_string()),
         ]
     )
+
+    start = datetime.datetime(2021, 3, 10, 19, 0, tzinfo=datetime.timezone.utc)
     with soma.DataFrame.create(
         uri,
         schema=schema,
         index_column_names=["soma_joinid"],
-        tiledb_timestamp=10,
+        tiledb_timestamp=start,
         platform_config=platform_config,
     ) as sidf:
         data = {
@@ -933,7 +936,8 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
         }
         sidf.write(pa.Table.from_pydict(data))
 
-    with soma.DataFrame.open(uri=uri, mode="w", tiledb_timestamp=20) as sidf:
+    end = start + datetime.timedelta(minutes=3, seconds=25)
+    with soma.DataFrame.open(uri=uri, mode="w", tiledb_timestamp=end) as sidf:
         data = {
             "soma_joinid": [0, 1],
             "float": [200.2, 300.3],
@@ -952,7 +956,7 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
         tiledb.consolidate(uri)
         tiledb.vacuum(uri)
 
-    # read without timestamp & see final image
+    # read without timestamp (i.e., after final write) & see final image
     with soma.DataFrame.open(uri) as sidf:
         table = sidf.read().concat()
         if allows_duplicates:
@@ -974,8 +978,9 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             assert list(x.as_py() for x in table["string"]) == ["ball", "cat"]
             assert sidf.count == 2
 
+    middle = 1615402883000
     # read at t=15 & see only the first write
-    with soma.DataFrame.open(tmp_path.as_posix(), tiledb_timestamp=15) as sidf:
+    with soma.DataFrame.open(tmp_path.as_posix(), tiledb_timestamp=middle) as sidf:
         tab = sidf.read().concat()
         assert list(x.as_py() for x in tab["soma_joinid"]) == [0]
         assert list(x.as_py() for x in tab["float"]) == [100.1]

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -8,7 +8,6 @@ import somacore
 import tiledb
 
 import tiledbsoma as soma
-from tiledbsoma.options import SOMATileDBContext
 
 
 @pytest.fixture
@@ -924,7 +923,7 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
         uri,
         schema=schema,
         index_column_names=["soma_joinid"],
-        context=SOMATileDBContext(timestamp=10),
+        tiledb_timestamp=10,
         platform_config=platform_config,
     ) as sidf:
         data = {
@@ -934,9 +933,7 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
         }
         sidf.write(pa.Table.from_pydict(data))
 
-    with soma.DataFrame.open(
-        uri=uri, mode="w", context=SOMATileDBContext(timestamp=20)
-    ) as sidf:
+    with soma.DataFrame.open(uri=uri, mode="w", tiledb_timestamp=20) as sidf:
         data = {
             "soma_joinid": [0, 1],
             "float": [200.2, 300.3],
@@ -978,9 +975,7 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             assert sidf.count == 2
 
     # read at t=15 & see only the first write
-    with soma.DataFrame.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
-    ) as sidf:
+    with soma.DataFrame.open(tmp_path.as_posix(), tiledb_timestamp=15) as sidf:
         tab = sidf.read().concat()
         assert list(x.as_py() for x in tab["soma_joinid"]) == [0]
         assert list(x.as_py() for x in tab["float"]) == [100.1]

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -352,7 +352,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         type=pa.uint8(),
         shape=(2, 2),
-        context=SOMATileDBContext(timestamp_ms=1),
+        context=SOMATileDBContext(timestamp=1),
     ) as a:
         a.write(
             (slice(0, 2), slice(0, 2)),
@@ -361,7 +361,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into top-left entry @ t=10
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp_ms=10)
+        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=10)
     ) as a:
         a.write(
             (slice(0, 1), slice(0, 1)),
@@ -370,7 +370,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into bottom-right entry @ t=20
     with soma.DenseNDArray.open(
-        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp_ms=20)
+        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
     ) as a:
         a.write(
             (slice(1, 2), slice(1, 2)),
@@ -386,7 +386,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the writes up til then
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(timestamp_ms=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
     ) as a:
         assert a.read((slice(0, 1), slice(0, 1))).to_numpy().tolist() == [
             [1, 0],
@@ -395,7 +395,7 @@ def test_timestamped_ops(tmp_path):
 
 
 def test_fixed_timestamp(tmp_path: pathlib.Path):
-    fixed_time = SOMATileDBContext(timestamp_ms=999)
+    fixed_time = SOMATileDBContext(timestamp=999)
     with soma.DenseNDArray.create(
         tmp_path.as_posix(),
         type=pa.uint8(),

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -352,7 +352,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         type=pa.uint8(),
         shape=(2, 2),
-        context=SOMATileDBContext(timestamp=1),
+        context=SOMATileDBContext(timestamp_ms=1),
     ) as a:
         a.write(
             (slice(0, 2), slice(0, 2)),
@@ -361,7 +361,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into top-left entry @ t=10
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=10)
+        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp_ms=10)
     ) as a:
         a.write(
             (slice(0, 1), slice(0, 1)),
@@ -370,7 +370,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into bottom-right entry @ t=20
     with soma.DenseNDArray.open(
-        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
+        uri=tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp_ms=20)
     ) as a:
         a.write(
             (slice(1, 2), slice(1, 2)),
@@ -386,7 +386,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the writes up til then
     with soma.DenseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp_ms=15)
     ) as a:
         assert a.read((slice(0, 1), slice(0, 1))).to_numpy().tolist() == [
             [1, 0],
@@ -395,24 +395,24 @@ def test_timestamped_ops(tmp_path):
 
 
 def test_fixed_timestamp(tmp_path: pathlib.Path):
-    fixed_time = SOMATileDBContext(timestamp=999)
+    fixed_time = SOMATileDBContext(timestamp_ms=999)
     with soma.DenseNDArray.create(
         tmp_path.as_posix(),
         type=pa.uint8(),
         shape=(2, 2),
         context=fixed_time,
     ) as ndarr:
-        assert ndarr.tiledb_timestamp == 999
+        assert ndarr.tiledb_timestamp_ms == 999
         ndarr.metadata["metadata"] = "created"
 
     with soma.open(tmp_path.as_posix(), context=fixed_time) as ndarr_read:
-        assert ndarr_read.tiledb_timestamp == 999
+        assert ndarr_read.tiledb_timestamp_ms == 999
         assert ndarr_read.metadata["metadata"] == "created"
 
     with soma.open(
         tmp_path.as_posix(), context=fixed_time, tiledb_timestamp=1000
     ) as read_1000:
-        assert read_1000.tiledb_timestamp == 1000
+        assert read_1000.tiledb_timestamp_ms == 1000
         assert read_1000.metadata["metadata"] == "created"
 
     with pytest.raises(soma.SOMAError):

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -104,15 +104,15 @@ def test_SOMATileDBContext_evolve():
     assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
 
     now = int(time.time() * 1000)
-    open_ts = context._open_timestamp(None)
+    open_ts = context._open_timestamp_ms(None)
     assert -100 < now - open_ts < 100
-    assert 999 == context._open_timestamp(999)
+    assert 999 == context._open_timestamp_ms(999)
 
-    context_ts_1 = context.replace(timestamp_ms=1)
+    context_ts_1 = context.replace(timestamp=1)
 
     assert context_ts_1.timestamp_ms == 1
-    assert context_ts_1._open_timestamp(None) == 1
-    assert context_ts_1._open_timestamp(2) == 2
+    assert context_ts_1._open_timestamp_ms(None) == 1
+    assert context_ts_1._open_timestamp_ms(2) == 2
 
     # verify tiledb_ctx
     new_tdb_context = context.replace(tiledb_config={"vfs.s3.region": "us-west-2"})

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 from pathlib import Path
 
 import anndata
@@ -100,21 +101,19 @@ def test_SOMATileDBContext_evolve():
 
     # verify defaults expected by subsequent tests
     assert context.timestamp is None
-    assert context.timestamp_start == 0
     assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
+
+    now = int(time.time() * 1000)
+    open_ts = context._open_timestamp(None)
+    assert -100 < now - open_ts < 100
+    assert 999 == context._open_timestamp(999)
 
     context_ts_1 = context.replace(timestamp=1)
 
-    # veirfy timestamp
     assert context_ts_1.timestamp == 1
-
-    # verify timestamp_start
-    assert context_ts_1.replace(timestamp_start=1).timestamp_start == 1
-
-    with pytest.raises(ValueError):
-        context_ts_1.replace(timestamp_start=2)
+    assert context_ts_1._open_timestamp(None) == 1
+    assert context_ts_1._open_timestamp(2) == 2
 
     # verify tiledb_ctx
-    context.replace(tiledb_config={"vfs.s3.region": "us-west-2"}).tiledb_ctx.config()[
-        "vfs.s3.region"
-    ] == "us-west-2"
+    new_tdb_context = context.replace(tiledb_config={"vfs.s3.region": "us-west-2"})
+    assert new_tdb_context.tiledb_ctx.config()["vfs.s3.region"] == "us-west-2"

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -100,7 +100,7 @@ def test_SOMATileDBContext_evolve():
     context = tiledbsoma.options.SOMATileDBContext()
 
     # verify defaults expected by subsequent tests
-    assert context.timestamp is None
+    assert context.timestamp_ms is None
     assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
 
     now = int(time.time() * 1000)
@@ -108,9 +108,9 @@ def test_SOMATileDBContext_evolve():
     assert -100 < now - open_ts < 100
     assert 999 == context._open_timestamp(999)
 
-    context_ts_1 = context.replace(timestamp=1)
+    context_ts_1 = context.replace(timestamp_ms=1)
 
-    assert context_ts_1.timestamp == 1
+    assert context_ts_1.timestamp_ms == 1
     assert context_ts_1._open_timestamp(None) == 1
     assert context_ts_1._open_timestamp(2) == 2
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1042,7 +1042,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the first write
     with soma.SparseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp_ms=15)
     ) as a:
         assert a.read().coos().concat().to_scipy().todense().tolist() == [
             [1, 0],

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1042,7 +1042,7 @@ def test_timestamped_ops(tmp_path):
 
     # read @ t=15 & see only the first write
     with soma.SparseNDArray.open(
-        tmp_path.as_posix(), context=SOMATileDBContext(timestamp_ms=15)
+        tmp_path.as_posix(), context=SOMATileDBContext(timestamp=15)
     ) as a:
         assert a.read().coos().concat().to_scipy().todense().tolist() == [
             [1, 0],

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1013,7 +1013,7 @@ def test_timestamped_ops(tmp_path):
         tmp_path.as_posix(),
         type=pa.uint16(),
         shape=(2, 2),
-        context=SOMATileDBContext(timestamp=10),
+        tiledb_timestamp=10,
     ) as a:
         # write 1 into top-left entry @ t=10
         a.write(
@@ -1024,7 +1024,7 @@ def test_timestamped_ops(tmp_path):
 
     # write 1 into bottom-right entry @ t=20
     with soma.SparseNDArray.open(
-        tmp_path.as_posix(), mode="w", context=SOMATileDBContext(timestamp=20)
+        tmp_path.as_posix(), mode="w", tiledb_timestamp=20
     ) as a:
         a.write(
             pa.SparseCOOTensor.from_scipy(
@@ -1047,16 +1047,5 @@ def test_timestamped_ops(tmp_path):
         assert a.read().coos().concat().to_scipy().todense().tolist() == [
             [1, 0],
             [0, 0],
-        ]
-        assert a.nnz == 1
-
-    # read with (timestamp_start, timestamp_end) = (15, 25) & see only the second write
-    with soma.SparseNDArray.open(
-        tmp_path.as_posix(),
-        context=SOMATileDBContext(timestamp_start=15, timestamp=25),
-    ) as a:
-        assert a.read().coos().concat().to_scipy().todense().tolist() == [
-            [0, 0],
-            [0, 1],
         ]
         assert a.nnz == 1


### PR DESCRIPTION
This change is intended as one cohesive unit, but its three parts can be separated from each other if not wanted:

1. Adding a `tiledb_timestamp` parameter to `open`s to allow us to open entire collections in a timestamp-coherent manner.
2. Allowing users to pass that `tiledb_timestamp` as a Python datetime.
3. Making the `tiledb_timestamp` member on TileDB objects into a Python datetime (while the raw msec value is still available at `tiledb_timestamp_ms`.

This also removes the `timestamp_start` parameter, which seems like an advanced feature on top of the already advanced feature that is timestamps.

The overall goal is to provide the “expected” behavior, where opening a collection of objects acts like opening one object, and when you don’t specify a timestamp, things just work and you don’t have to think about it.

This is a follow-up for issues discovered in #919.