### PR TITLE
[python] Depend on somacore 1.0.0rc3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs"
-        - "somacore==1.0.0rc2"
+        - "somacore==1.0.0rc3"
         - "types-setuptools"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -203,7 +203,7 @@ setuptools.setup(
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",
         "scipy",
-        "somacore==1.0.0rc2",
+        "somacore==1.0.0rc3",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -63,7 +63,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
     def read(
         self,
-        coords: options.DenseNDCoords = (),
+        coords: options.DenseNDCoords = (),  # type: ignore[type-arg]
         *,
         result_order: options.ResultOrderStr = somacore.ResultOrder.ROW_MAJOR,
         partitions: Optional[options.ReadPartitions] = None,
@@ -118,7 +118,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
     def write(
         self,
-        coords: options.DenseNDCoords,
+        coords: options.DenseNDCoords,  # type: ignore[type-arg]
         values: pa.Tensor,
         *,
         platform_config: Optional[options.PlatformConfig] = None,

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -146,7 +146,7 @@ def slice_to_numeric_range(
 
 
 def dense_indices_to_shape(
-    coords: options.DenseNDCoords,
+    coords: options.DenseNDCoords,  # type: ignore[type-arg]
     array_shape: Tuple[int, ...],
     result_order: somacore.ResultOrder,
 ) -> Tuple[int, ...]:


### PR DESCRIPTION
**Issue and/or context:**

Upcoming `tiledbsoma` 1.0.0rc2 will get bugfix PR #1003 into a release. Along the way (secondarily), keeps latest-as-of-now `somacore` and `tiledbsoma` in sync.
