### PR TITLE
[python] Pin stub versions used in type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-        - "pandas-stubs"
+        - "pandas-stubs==1.5.3.230214"
         - "somacore==1.0.0rc3"
-        - "types-setuptools"
+        - "types-setuptools==67.4.0.3"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false


### PR DESCRIPTION
`pandas-stubs` released a new version on 2023-02-27, which caused builds to break despite no changes.  We should fix the new issues, but in the short term, just pin the stubs to the then-current version.

(See the build breakage from the last rev of #1001.)