### PR TITLE
lifecycle maturity tags

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -46,7 +46,7 @@ the RStudio lifecycle stage model. Tags are:
   - deprecated: The API is no longer recommended for use and may be removed
     in a future release.
 
-If no tag is present, the assumed state is ``experimental``.
+If no tag is present, the state is ``experimental``.
 
 Data types:
 -----------

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -73,7 +73,7 @@ class CollectionBase(
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
-        """Creates and opens a new SOMA collection in storage.
+        """Creates and opens a new SOMA collection in storage [lifecycle: experimental].
 
         This creates a new SOMA collection of the current type in storage and
         returns it opened for writing.
@@ -157,7 +157,7 @@ class CollectionBase(
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "AnyTileDBCollection":
-        """Adds a new sub-collection to this collection.
+        """Adds a new sub-collection to this collection [lifecycle: experimental].
 
         :param key: The key to add.
         :param cls: Optionally, the specific type of sub-collection to create.
@@ -187,7 +187,7 @@ class CollectionBase(
     def add_new_dataframe(
         self, key: str, *, uri: Optional[str] = None, **kwargs: Any
     ) -> DataFrame:
-        """Adds a new DataFrame to this collection.
+        """Adds a new DataFrame to this collection [lifecycle: experimental].
 
         For details about the behavior of ``key`` and ``uri``, see
         :meth:`add_new_collection`. The remaining parameters are passed to
@@ -222,7 +222,7 @@ class CollectionBase(
 
     @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("cls",))
     def add_new_dense_ndarray(self, key: str, **kwargs: Any) -> DenseNDArray:
-        """Adds a new DenseNDArray to this Collection.
+        """Adds a new DenseNDArray to this Collection [lifecycle: experimental].
 
         For details about the behavior of ``key`` and ``uri``, see
         :meth:`add_new_collection`. The remaining parameters are passed to
@@ -232,7 +232,7 @@ class CollectionBase(
 
     @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("cls",))
     def add_new_sparse_ndarray(self, key: str, **kwargs: Any) -> SparseNDArray:
-        """Adds a new SparseNDArray to this Collection.
+        """Adds a new SparseNDArray to this Collection [lifecycle: experimental].
 
         For details about the behavior of ``key`` and ``uri``, see
         :meth:`add_new_collection`. The remaining parameters are passed to

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -31,9 +31,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
         """
-        Create a SOMA ``NDArray`` at the given URI.
-
-        [lifecycle: experimental]
+        Create a SOMA ``NDArray`` at the given URI [lifecycle: experimental].
 
         :param type: The Arrow type to be stored in the NDArray.
             If the type is unsupported, an error will be raised.
@@ -77,14 +75,13 @@ class NDArray(TileDBArray, somacore.NDArray):
     def shape(self) -> Tuple[int, ...]:
         """
         Return capacity of each dimension, always a list of length ``ndim``
+        [lifecycle: experimental].
         """
         return cast(Tuple[int, ...], self._handle.schema.domain.shape)
 
     def reshape(self, shape: Tuple[int, ...]) -> None:
         """
-        Unsupported operation for this object type.
-
-        [lifecycle: experimental]
+        Unsupported operation for this object type [lifecycle: experimental].
         """
         raise NotImplementedError("reshape operation not implemented.")
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -124,14 +124,14 @@ class DataFrame(TileDBArray, somacore.DataFrame):
     @property
     def index_column_names(self) -> Tuple[str, ...]:
         """
-        Return index (dimension) column names.
+        Return index (dimension) column names [lifecycle: experimental].
         """
         return self._tiledb_dim_names()
 
     @property
     def count(self) -> int:
         """
-        Return the number of rows in the dataframe. Same as `len(df)`.
+        Return the number of rows in the dataframe. Same as `len(df)` [lifecycle: experimental].
         """
         self._check_open_read()
         return cast(int, self._soma_reader().nnz())

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -2,20 +2,23 @@ import tiledb
 
 
 class SOMAError(Exception):
-    """Base error type for SOMA-specific exceptions."""
+    """Base error type for SOMA-specific exceptions [lifecycle: experimental]."""
 
     pass
 
 
 class DoesNotExistError(SOMAError):
-    """Raised when attempting to open a non-existent SOMA object."""
+    """
+    Raised when attempting to open a non-existent SOMA object [lifecycle: experimental].
+    """
 
     pass
 
 
 def is_does_not_exist_error(e: tiledb.TileDBError) -> bool:
     """ "
-    Given a TileDBError, return true if it indicates the object does not exist.
+    Given a TileDBError, return true if it indicates the object does not exist
+    [lifecycle: experimental].
 
     Example
     -------
@@ -46,6 +49,8 @@ def is_duplicate_group_key_error(e: tiledb.TileDBError) -> bool:
     """
     Given a TileDBError, return try if it indicates a duplicate member
     add request in a tiledb.Group.
+
+    [lifecycle: experimental]
     """
     stre = str(e)
     if "member already exists in group" in stre:

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -61,7 +61,7 @@ def open(
     soma_type: Union[Type["_tiledb_object.AnyTileDBObject"], str, None] = None,
     context: Optional[SOMATileDBContext] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
-    """Opens a TileDB SOMA object.
+    """Opens a TileDB SOMA object [lifecycle: experimental].
 
     :param uri: The URI to open.
     :param mode: The mode to open in: ``r`` to read (default), ``w`` to write.

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -45,7 +45,8 @@ def get_storage_engine() -> str:
 
 def show_package_versions() -> None:
     """
-    Nominal use is for bug reports, so issue filers and issue fixers can be on the same page.
+    Nominal use is for bug reports, so issue filers and issue fixers can be on
+    the same page [lifecycle: experimental].
     """
     print("tiledbsoma.__version__   ", get_implementation_version())
     print("tiledb.__version__       ", tiledb.__version__)

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -79,7 +79,8 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     @property
     def nnz(self) -> int:
         """
-        The number of stored values in the array, including explicitly stored zeros.
+        The number of stored values in the array, including explicitly stored zeros
+        [lifecycle: experimental].
         """
         self._check_open_read()
         return cast(int, self._soma_reader().nnz())

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -27,7 +27,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
     @property
     def schema(self) -> pa.Schema:
         """
-        Return data schema, in the form of an Arrow Schema.
+        Return data schema, in the form of an Arrow Schema [lifecycle: experimental].
         """
         return tiledb_schema_to_arrow(self._tiledb_array_schema())
 

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -40,7 +40,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         context: Optional[SOMATileDBContext] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
-        """Opens this specific type of SOMA object.
+        """Opens this specific type of SOMA object [lifecycle: experimental].
 
         :param uri: The URI to open.
         :param mode: The mode to open the object in.
@@ -114,30 +114,30 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     @property
     def uri(self) -> str:
         """
-        Accessor for the object's storage URI
+        Accessor for the object's storage URI [lifecycle: experimental].
         """
         return self._handle.uri
 
     def close(self) -> None:
         """
-        Release any resources held while the object is open.
+        Release any resources held while the object is open [lifecycle: experimental].
         Closing an already-closed object is a no-op.
         """
         self._close_stack.close()
 
     @property
     def closed(self) -> bool:
-        """True if the object has been closed. False if it is still open."""
+        """True if the object has been closed. False if it is still open [lifecycle: experimental]."""
         return self._handle.closed
 
     @property
     def mode(self) -> options.OpenMode:
-        """The mode this object was opened in, either ``r`` or ``w``."""
+        """The mode this object was opened in, either ``r`` or ``w`` [lifecycle: experimental]."""
         return self._handle.mode
 
     @classmethod
     def exists(cls, uri: str, context: Optional[SOMATileDBContext] = None) -> bool:
-        """Finds whether an object of this type exists at the given URI."""
+        """Finds whether an object of this type exists at the given URI [lifecycle: experimental]."""
         context = context or SOMATileDBContext()
         try:
             with cls._wrapper_type.open(uri, "r", context) as hdl:

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -102,7 +102,7 @@ class SOMATileDBContext:
         self, *, tiledb_config: Optional[Dict[str, Any]] = None, **changes: Any
     ) -> Self:
         """
-        Create a copy of the context, merging changes.
+        Create a copy of the context, merging changes [lifecycle: experimental].
 
         Parameters
         ----------
@@ -128,7 +128,7 @@ class SOMATileDBContext:
 def group_timestamp_ctx(
     ctx: tiledb.Ctx, *, timestamp_start: int, timestamp: int
 ) -> tiledb.Ctx:
-    """Builds a TileDB context to open groups at the given timestamp."""
+    """Builds a TileDB context to open groups at the given timestamp [lifecycle: experimental]."""
     group_cfg = ctx.config().dict()
     group_cfg["sm.group.timestamp_start"] = timestamp_start
     group_cfg["sm.group.timestamp_end"] = timestamp

--- a/libtiledbsoma/src/pyapi/libtiledbsoma.cc
+++ b/libtiledbsoma/src/pyapi/libtiledbsoma.cc
@@ -123,15 +123,15 @@ PYBIND11_MODULE(libtiledbsoma, m) {
     m.def(
         "tiledbsoma_stats_enable",
         []() { tiledb::Stats::enable(); },
-        "Enable TileDB internal statistics.");
+        "Enable TileDB internal statistics [lifecycle: experimental].");
     m.def(
         "tiledbsoma_stats_disable",
         []() { tiledb::Stats::disable(); },
-        "Disable TileDB internal statistics.");
+        "Disable TileDB internal statistics [lifecycle: experimental].");
     m.def(
         "tiledbsoma_stats_reset",
         []() { tiledb::Stats::reset(); },
-        "Reset all TileDB internal statistics to 0.");
+        "Reset all TileDB internal statistics to 0 [lifecycle: experimental].");
     m.def(
         "tiledbsoma_stats_dump",
         []() {
@@ -140,7 +140,7 @@ PYBIND11_MODULE(libtiledbsoma, m) {
             tiledb::Stats::dump(&stats);
             py::print(stats);
         },
-        "Print TileDB internal statistics.");
+        "Print TileDB internal statistics [lifecycle: experimental].");
 
     py::class_<SOMAReader>(m, "SOMAReader")
         .def(


### PR DESCRIPTION
Fixes #976 

Specifically, added tags to any class or function that is visible via pydocs, and validated with `python -m pydoc tiledbsoma`

This means that some superclass methods remain unannotated, but that seems fine at this point in time.

See also: https://github.com/single-cell-data/SOMA/pull/144
