### PR TITLE
[python] Improve spec/impl consistency on `cls`/`type`/`kind` parameters

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -138,7 +138,7 @@ class CollectionBase(
     def add_new_collection(
         self,
         key: str,
-        cls: None = None,
+        kind: None = None,
         *,
         uri: Optional[str] = ...,
         platform_config: Optional[options.PlatformConfig] = ...,
@@ -149,7 +149,7 @@ class CollectionBase(
     def add_new_collection(
         self,
         key: str,
-        cls: Type[_Coll],
+        kind: Type[_Coll],
         *,
         uri: Optional[str] = ...,
         platform_config: Optional[options.PlatformConfig] = ...,
@@ -159,7 +159,7 @@ class CollectionBase(
     def add_new_collection(
         self,
         key: str,
-        cls: Optional[Type[AnyTileDBCollection]] = None,
+        kind: Optional[Type[AnyTileDBCollection]] = None,
         *,
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
@@ -167,7 +167,7 @@ class CollectionBase(
         """Adds a new sub-collection to this collection [lifecycle: experimental].
 
         :param key: The key to add.
-        :param cls: Optionally, the specific type of sub-collection to create.
+        :param kind: Optionally, the specific type of sub-collection to create.
             For instance, passing ``tiledbsoma.Experiment`` here will create a
             ``SOMAExperiment`` as the sub-entry. By default, a basic
             ``Collection`` will be created.
@@ -180,7 +180,7 @@ class CollectionBase(
             creating this sub-collection. This is passed directly to
             ``[CurrentCollectionType].create()``.
         """
-        child_cls: Type[AnyTileDBCollection] = cls or Collection
+        child_cls: Type[AnyTileDBCollection] = kind or Collection
         return self._add_new_element(
             key,
             child_cls,
@@ -234,7 +234,7 @@ class CollectionBase(
             uri,
         )
 
-    @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("cls",))
+    @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("kind",))
     def add_new_dense_ndarray(self, key: str, **kwargs: Any) -> DenseNDArray:
         """Adds a new DenseNDArray to this Collection [lifecycle: experimental].
 
@@ -244,7 +244,7 @@ class CollectionBase(
         """
         return self._add_new_ndarray(DenseNDArray, key, **kwargs)
 
-    @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("cls",))
+    @_funcs.forwards_kwargs_to(_add_new_ndarray, exclude=("kind",))
     def add_new_sparse_ndarray(self, key: str, **kwargs: Any) -> SparseNDArray:
         """Adds a new SparseNDArray to this Collection [lifecycle: experimental].
 
@@ -257,14 +257,14 @@ class CollectionBase(
     def _add_new_element(
         self,
         key: str,
-        cls: Type[_TDBO],
+        kind: Type[_TDBO],
         factory: Callable[[str], _TDBO],
         user_uri: Optional[str],
     ) -> _TDBO:
         """Handles the common parts of adding new elements.
 
         :param key: The key to be added.
-        :param cls: The type of the element to be added.
+        :param kind: The type of the element to be added.
         :param factory: A callable that, given the full URI to be added,
             will create the backing storage at that URI and return
             the reified SOMA object.
@@ -273,7 +273,7 @@ class CollectionBase(
         """
         if key in self:
             raise KeyError(f"{key!r} already exists in {type(self)}")
-        self._check_allows_child(key, cls)
+        self._check_allows_child(key, kind)
         child_uri = self._new_child_uri(key=key, user_uri=user_uri)
         child = factory(child_uri.full_uri)
         # The resulting element may not be the right type for this collection,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -174,7 +174,7 @@ def test_collection_repr(tmp_path: pathlib.Path, relative: bool) -> None:
     b_path = a_path / "B"
     b_uri = b_path.as_uri()
     b_uri_to_add = "B" if relative else b_uri
-    b = a.add_new_collection("Another_Name", cls=soma.Experiment, uri=b_uri_to_add)
+    b = a.add_new_collection("Another_Name", kind=soma.Experiment, uri=b_uri_to_add)
 
     assert b.uri == b_uri
 


### PR DESCRIPTION

**Issue and/or context:**
#834, https://github.com/single-cell-data/TileDB-SOMA/issues/834#issuecomment-1452797584

**Changes:**
Use `kind` for collection type param in `CollectionBase.add_new_collection()`

**Notes for Reviewer:**

