### PR TITLE
Add `result_order` support to sparse NDArray reads.

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -271,7 +271,6 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         del batch_size, platform_config  # Currently unused.
         _util.check_unpartitioned(partitions)
         self._check_open_read()
-        result_order = options.ResultOrder(result_order)
 
         schema = self._handle.schema
         query_condition = None
@@ -282,7 +281,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             schema=schema,  # query_condition needs this
             column_names=column_names,
             query_condition=query_condition,
-            result_order=result_order.value,
+            result_order=result_order,
         )
 
         self._set_reader_coords(sr, coords)

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -89,7 +89,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         schema = self._handle.schema
         target_shape = dense_indices_to_shape(coords, schema.shape, result_order)
 
-        sr = self._soma_reader(result_order=result_order.value)
+        sr = self._soma_reader(result_order=result_order)
 
         self._set_reader_coords(sr, coords)
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -122,12 +122,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
         :return: A SparseNDArrayRead to access result iterators in various formats.
         """
-        del result_order, batch_size, platform_config  # Currently unused.
+        del batch_size, platform_config  # Currently unused.
         self._check_open_read()
         _util.check_unpartitioned(partitions)
 
         schema = self._handle.schema
-        sr = self._soma_reader(schema=schema)
+        sr = self._soma_reader(schema=schema, result_order=result_order)
         self._set_reader_coords(sr, coords)
         sr.submit()
         return SparseNDArrayRead(sr, schema.shape)


### PR DESCRIPTION
Fixes #710.