### PR TITLE
[python] Constrain numba & numpy versions for compatibility with old pip solver

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -104,6 +104,7 @@ jobs:
         echo "WHL=$WHL" >> $GITHUB_ENV
     - name: Smoke test ${{ matrix.os }}
       run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
+      # TODO: more thorough local smoke test
     - name: Smoke test in docker
       # Repeat test in stock ubuntu 20.04 docker image. This uses an older pip
       # version with the old dependency solver. see issue #1051

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -103,7 +103,15 @@ jobs:
         pip install $whl
     - name: Smoke test ${{ matrix.os }}
       run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
-      # TODO: more thorough local smoke test
+    - name: Smoke test in docker
+      # on Linux, repeat in a stock ubuntu 20.04 docker image, which will use
+      # a version of pip with the older dependency solver. see issue #1051
+      if: ${{ matrix.platform == 'manylinux2014' }}
+      run: |
+        docker run --rm -it -v $(pwd):/mnt ubuntu:20.04 bash -ec "
+          apt-get -qq update && apt-get install -y python3-pip python3-wheel
+          pip3 install /mnt/$whl
+          python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'"
 
   # TODO: publlish to TestPyPI
     #- name: Publish package to TestPyPI

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -97,10 +97,11 @@ jobs:
       run: |
         set -x
         ls -lR
-        whl=$(find . -name 'tiledbsoma-*-cp38-cp38-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
-        unzip -l $whl
+        WHL=$(find . -name 'tiledbsoma-*-cp38-cp38-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+        unzip -l $WHL
         pip install wheel
-        pip install $whl
+        pip install $WHL
+        echo "WHL=$WHL" >> $GITHUB_ENV
     - name: Smoke test ${{ matrix.os }}
       run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
     - name: Smoke test in docker
@@ -110,7 +111,7 @@ jobs:
       run: |
         docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
           apt-get -qq update && apt-get install -y python3-pip python3-wheel
-          pip3 install /mnt/$whl
+          pip3 install /mnt/$WHL
           python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'"
 
   # TODO: publlish to TestPyPI

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -105,14 +105,19 @@ jobs:
     - name: Smoke test ${{ matrix.os }}
       run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
     - name: Smoke test in docker
-      # on Linux, repeat in a stock ubuntu 20.04 docker image, which will use
-      # a version of pip with the older dependency solver. see issue #1051
+      # Repeat the test in stock ubuntu docker images. In particular, this
+      # exercises 20.04's stock pip, which uses the old dependency solver. see
+      # issue #1051
       if: ${{ matrix.platform == 'manylinux2014' }}
       run: |
-        docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
+        TEST_SCRIPT="
           apt-get -qq update && apt-get install -y python3-pip python3-wheel
           pip3 install /mnt/$WHL
-          python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'"
+          python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
+        "
+        for image in ubuntu:20.04 ubuntu:22.04 ; do
+          docker run -v $(pwd):/mnt "$image" bash -ec "$TEST_SCRIPT"
+        done
 
   # TODO: publlish to TestPyPI
     #- name: Publish package to TestPyPI

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -105,19 +105,15 @@ jobs:
     - name: Smoke test ${{ matrix.os }}
       run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
     - name: Smoke test in docker
-      # Repeat the test in stock ubuntu docker images. In particular, this
-      # exercises 20.04's stock pip, which uses the old dependency solver. see
-      # issue #1051
+      # Repeat test in stock ubuntu 20.04 docker image. This uses an older pip
+      # version with the old dependency solver. see issue #1051
       if: ${{ matrix.platform == 'manylinux2014' }}
       run: |
-        TEST_SCRIPT="
+        docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
           apt-get -qq update && apt-get install -y python3-pip python3-wheel
           pip3 install /mnt/$WHL
           python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'
         "
-        for image in ubuntu:20.04 ubuntu:22.04 ; do
-          docker run -v $(pwd):/mnt "$image" bash -ec "$TEST_SCRIPT"
-        done
 
   # TODO: publlish to TestPyPI
     #- name: Publish package to TestPyPI

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -108,7 +108,7 @@ jobs:
       # a version of pip with the older dependency solver. see issue #1051
       if: ${{ matrix.platform == 'manylinux2014' }}
       run: |
-        docker run --rm -it -v $(pwd):/mnt ubuntu:20.04 bash -ec "
+        docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
           apt-get -qq update && apt-get install -y python3-pip python3-wheel
           pip3 install /mnt/$whl
           python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__)'"

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -196,8 +196,8 @@ setuptools.setup(
     ext_modules=[setuptools.Extension("tiledbsoma.libtiledbsoma", sources=[])],
     zip_safe=False,
     install_requires=[
-    # CAUTION: the old pip solver (<=2020) is sensitive to the order of this
-    # requirements list. See TileDB-SOMA issue #1051 for example.
+        # CAUTION: the old pip solver (<=2020) is sensitive to the order of
+        # this requirements list. See TileDB-SOMA issue #1051 for example.
         "scanpy>=1.9.2",
         "anndata",
         "somacore==1.0.0rc4",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -196,15 +196,17 @@ setuptools.setup(
     ext_modules=[setuptools.Extension("tiledbsoma.libtiledbsoma", sources=[])],
     zip_safe=False,
     install_requires=[
+    # CAUTION: the old pip solver (<=2020) is sensitive to the order of this
+    # requirements list. See TileDB-SOMA issue #1051 for example.
+        "scanpy>=1.9.2",
         "anndata",
+        "somacore==1.0.0rc4",
+        "tiledb==0.20.*",
+        "pyarrow>=9.0.0",
         "attrs>=22.2",
         "numpy",
         "pandas",
-        "pyarrow>=9.0.0",
-        "scanpy>=1.9.2",
         "scipy",
-        "somacore==1.0.0rc4",
-        "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -196,17 +196,20 @@ setuptools.setup(
     ext_modules=[setuptools.Extension("tiledbsoma.libtiledbsoma", sources=[])],
     zip_safe=False,
     install_requires=[
-        # NOTE: we bring in numpy through the transitive requirements,
-        #          scanpy > numba > numpy
-        # numba 0.56.4 (current as of this writing) requires numpy<1.24. If we
-        # require our own bare "numpy", then the old pip solver (<=2020) isn't
-        # smart enough to obey the nested requirement, instead installing a
-        # newer numpy>=1.24 which breaks numba 0.56.4. issue #1051
-        "scanpy>=1.9.2",
         "anndata",
         "attrs>=22.2",
+        # Pinning numba & its particular numpy constraints:
+        # The old pip solver (<=2020) doesn't deal with the transitive
+        # requirements (scanpy -> numba -> numpy) properly resulting in broken
+        # installation of incompatible numpy>=1.24. Issue #1051
+        # These pins can be removed either when there's a new numba release
+        # with less-particular numpy version constraints, or if we decide we no
+        # longer need to support the old pip solver (default on ubuntu 20.04).
+        "numba==0.56.4",
+        "numpy>=1.18,<1.24",
         "pandas",
         "pyarrow>=9.0.0",
+        "scanpy>=1.9.2",
         "scipy",
         "somacore==1.0.0rc4",
         "tiledb==0.20.*",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -196,17 +196,20 @@ setuptools.setup(
     ext_modules=[setuptools.Extension("tiledbsoma.libtiledbsoma", sources=[])],
     zip_safe=False,
     install_requires=[
-        # CAUTION: the old pip solver (<=2020) is sensitive to the order of
-        # this requirements list. See TileDB-SOMA issue #1051 for example.
+        # NOTE: we bring in numpy through the transitive requirements,
+        #          scanpy > numba > numpy
+        # numba 0.56.4 (current as of this writing) requires numpy<1.24. If we
+        # require our own bare "numpy", then the old pip solver (<=2020) isn't
+        # smart enough to obey the nested requirement, instead installing a
+        # newer numpy>=1.24 which breaks numba 0.56.4. issue #1051
         "scanpy>=1.9.2",
         "anndata",
+        "attrs>=22.2",
+        "pandas",
+        "pyarrow>=9.0.0",
+        "scipy",
         "somacore==1.0.0rc4",
         "tiledb==0.20.*",
-        "pyarrow>=9.0.0",
-        "attrs>=22.2",
-        "numpy",
-        "pandas",
-        "scipy",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={


### PR DESCRIPTION
**Issue and/or context:** #1051. The old pip solver (default on ubuntu 20.04) doesn't handle the numba's particular numpy version constraints when numba itself is only our transitive dependency (via scanpy).

**Changes:** After trying a bunch of things (see commit history) it seems that pinning the exact current numba version and also lifting up its numpy constraints is the least-bad solution. Also left a comment on when the pins can/should be relaxed, and tests the ubuntu 20.04 case in in the python-packaging workflow.