### PR TITLE
[python] Depend on somacore 1.0.0rc5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs==1.5.3.230214"
-        - "somacore==1.0.0rc4"
+        - "somacore==1.0.0rc5"
         - "types-setuptools==67.4.0.3"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -211,7 +211,7 @@ setuptools.setup(
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",
         "scipy",
-        "somacore==1.0.0rc4",
+        "somacore==1.0.0rc5",
         "tiledb==0.20.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],


### PR DESCRIPTION
The upcoming `tiledbsoma` 1.0.0rc5 gets #1053 and #1061 into notebook author's hands. This PR brings in recent `somacore` docstring work (althoug there will be more such this week of course).