### PR TITLE
[r] Avoid "Error: Can't convert input object to pointer"

### DIFF
--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -33,11 +33,11 @@ SOMAArrayBase <- R6::R6Class(
       if (is.null(private$soma_reader_pointer)) {
           NULL
       } else {
-          rl <- sr_next(private$soma_reader_pointer)
-          if (is.null(rl[[1]])) {
-            rl
+          if (sr_complete(private$soma_reader_pointer)) {
+              invisible(NULL)
           } else {
-            private$soma_reader_transform(rl)
+              rl <- sr_next(private$soma_reader_pointer)
+              private$soma_reader_transform(rl)
           }
       }
     }

--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -34,7 +34,11 @@ SOMAArrayBase <- R6::R6Class(
           NULL
       } else {
           rl <- sr_next(private$soma_reader_pointer)
-          private$soma_reader_transform(rl)
+          if (is.null(rl[[1]])) {
+            rl
+          } else {
+            private$soma_reader_transform(rl)
+          }
       }
     }
 


### PR DESCRIPTION
Noticed while working with @mlin on dataset traversal in R.

Here is a repro script:

```
#!/usr/bin/env Rscript

library(tiledbsoma)
library(tiledb)

cat("Loading experiment:\n")
exp <- SOMAExperiment$new('path/to/data')

cat("\nGetting var:\n")
sdf <- exp$ms$get("RNA")$var

cat("\nDefining iterated read:\n")
sdf$read(iterated=TRUE)

cat("\nread_next 1:\n")
print(sdf$read_next())

cat("\nread_next 2:\n")
print(sdf$read_next())
```

Before this change, we see:

```
Loading experiment:

Getting var:

Defining iterated read:

read_next 1:
Table
60664 rows x 4 columns
$soma_joinid <int64 not null>
$feature_id <large_string not null>
$feature_name <large_string not null>
$feature_length <int64 not null>

read_next 2:
Error: Can't convert input object to pointer
```

With this change, we see:

```
Loading experiment:

Getting var:

Defining iterated read:

read_next 1:
Table
60664 rows x 4 columns
$soma_joinid <int64 not null>
$feature_id <large_string not null>
$feature_name <large_string not null>
$feature_length <int64 not null>

read_next 2:
[[1]]
NULL

[[2]]
NULL
```