### PR TITLE
[python] Add optional shape parameter to `SparseNDArrayRead .coos()`

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -292,14 +292,18 @@ class SparseNDArrayRead(somacore.SparseRead):
         self.sr = sr
         self.shape = shape
 
-    def coos(self) -> SparseCOOTensorReadIter:
+    def coos(self, shape: Optional[NTuple] = None) -> SparseCOOTensorReadIter:
         """
         Returns an iterator of Arrow SparseCOOTensor.
+
+        Args:
+            shape:
+                Optionally, a NTuple that overrides the default capacity.
 
         Lifecycle:
             Experimental.
         """
-        return SparseCOOTensorReadIter(self.sr, self.shape)
+        return SparseCOOTensorReadIter(self.sr, shape or self.shape)
 
     def dense_tensors(self) -> somacore.ReadIter[pa.Tensor]:
         """

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -303,6 +303,8 @@ class SparseNDArrayRead(somacore.SparseRead):
         Lifecycle:
             Experimental.
         """
+        if shape is not None and (len(shape) != len(self.shape)):
+            raise ValueError(f"shape must be a tuple of size {len(self.shape)}")
         return SparseCOOTensorReadIter(self.sr, shape or self.shape)
 
     def dense_tensors(self) -> somacore.ReadIter[pa.Tensor]:

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -298,7 +298,7 @@ class SparseNDArrayRead(somacore.SparseRead):
 
         Args:
             shape:
-                Optionally, a NTuple that overrides the default capacity.
+                Optionally, a tuple that overrides the default capacity.
 
         Lifecycle:
             Experimental.

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -430,6 +430,17 @@ def test_empty_read_sparse_coo(tmp_path):
         assert sum(t.non_zero_length for t in a.read(coords).coos()) == 0
 
 
+def test_coo_custom_shape(tmp_path):
+    soma.SparseNDArray.create(
+        tmp_path.as_posix(), type=pa.uint16(), shape=(1000, 1000)
+    ).close()
+
+    with soma.SparseNDArray.open(tmp_path.as_posix()) as a:
+        coords = (slice(None),)
+        assert a.read(coords).coos().shape == (1000, 1000)
+        assert a.read(coords).coos(shape=(500, 500)).shape == (500, 500)
+
+
 @pytest.mark.parametrize("shape", [(), (0,), (10, 0), (0, 10), (1, 2, 0)])
 def test_zero_length_fail(tmp_path, shape):
     """Zero length dimensions are expected to fail"""

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -439,6 +439,8 @@ def test_coo_custom_shape(tmp_path):
         coords = (slice(None),)
         assert a.read(coords).coos().shape == (1000, 1000)
         assert a.read(coords).coos(shape=(500, 500)).shape == (500, 500)
+        with pytest.raises(ValueError):
+            assert a.read(coords).coos(shape=(500, 500, 500))
 
 
 @pytest.mark.parametrize("shape", [(), (0,), (10, 0), (0, 10), (1, 2, 0)])


### PR DESCRIPTION
**Issue and/or context:**
A `SparseNDArray` can be created with a capacity that is too high for slices to be handled when reading a slice of the array. For instance, this is what gets created by default on my machine when converting a very small h5ad:

```
>>> X.shape
(9223372036854773760, 9223372036854773760)
>>> X.read((slice(0),)).coos().concat().to_scipy().todense()
ValueError: array is too big; `arr.size * arr.dtype.itemsize` is larger than the maximum possible size.
```

This issue makes working with the slices very difficult since scipy will refuse to densify the array (a similar behavior occurs when converting to a `csr_matrix`)

**Changes:**
This adds an optional parameter to `.coos()` that allows specifying a custom shape. This will be particularly useful when the exact shape of the matrix is known beforehand (for instance, when working on a single dataset, where it can be inferred by the size of `var` and `obs`).

**Notes for Reviewer:**
- Do we want to add a constraint where the custom shape must be less than (or equal) the original capacity?

