### PR TITLE
[r] Don't doubly specify in a unit-test case

### DIFF
--- a/apis/r/tests/testthat/test_SOMAReader-Iterated.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Iterated.R
@@ -15,7 +15,7 @@ test_that("Iterated Interface from SOMAReader", {
     expect_true(dir.exists(uri))
 
     ctx <- tiledb_ctx()
-    sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)))
+    sr <- sr_setup(uri, config=as.character(config(ctx)))
     expect_true(inherits(sr, "externalptr"))
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -29,7 +29,7 @@ test_that("Iterated Interface from SOMAReader", {
     expect_equal(nrow(rl), 4848644)
     expect_equal(ncol(rl), 3)
 
-    sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), dim_points=list(soma_dim_0=as.integer64(1)))
+    sr <- sr_setup(uri, config=as.character(config(ctx)), dim_points=list(soma_dim_0=as.integer64(1)))
     expect_true(inherits(sr, "externalptr"))
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -43,7 +43,7 @@ test_that("Iterated Interface from SOMAReader", {
     expect_equal(nrow(rl), 1838)
     expect_equal(ncol(rl), 3)
 
-    sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), dim_range=list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
+    sr <- sr_setup(uri, config=as.character(config(ctx)), dim_range=list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
     expect_true(inherits(sr, "externalptr"))
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -62,7 +62,7 @@ test_that("Iterated Interface from SOMAReader", {
     tgzfile <- system.file("raw-data", "soco-pbmc3k_processed-obs.tar.gz", package="tiledbsoma")
     untar(tarfile = tgzfile, exdir = tdir)
     uri <- file.path(tdir, "obs")
-    sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)))
+    sr <- sr_setup(uri, config=as.character(config(ctx)))
 
     expect_false(tiledbsoma:::sr_complete(sr))
     dat <- dat <- sr_next(sr)


### PR DESCRIPTION
Follow on from #1082 -- thanks to @eddelbuettel 