### PR TITLE
[r] Handle config in non-iterated readers

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -19,8 +19,7 @@
 #' @param result_order Character value with the desired result order, defaults to \sQuote{auto}
 #' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
 #' which lets prior setting prevail, any other value is set as new logging level.
-#' @param arrlst A list containing the pointers to an Arrow data structure
-#' @param xp An external pointer to an ArrowSchema or ArrowData
+#' @param config Optional character vector containing TileDB config.
 #' @return A List object with two pointers to Arrow array data and schema is returned
 #' @examples
 #' \dontrun{
@@ -29,8 +28,8 @@
 #' tb <- as_arrow_table(z)
 #' }
 #' @export
-soma_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto") {
-    .Call(`_tiledbsoma_soma_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel)
+soma_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto", config = NULL) {
+    .Call(`_tiledbsoma_soma_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config)
 }
 
 #' @noRd

--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -65,7 +65,7 @@ SOMAArrayBase <- R6::R6Class(
 
     # Instantiate soma_reader_pointer with a soma_reader object
     soma_reader_setup = function() {
-      private$soma_reader_pointer <- sr_setup(self$uri, config=as.character(tiledb::config(tiledb::tiledb_ctx())))
+      private$soma_reader_pointer <- sr_setup(self$uri, config=as.character(tiledb::config(self$ctx)))
     },
 
     ## to be refined in derived classes

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -189,7 +189,8 @@ SOMADataFrame <- R6::R6Class(
                             colnames = column_names,   # NULL is dealt with by soma_reader()
                             qc = value_filter,         # idem
                             dim_points = coords,       # idem
-                            loglevel = log_level)      # idem
+                            loglevel = log_level,      # idem
+                            config=as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -190,7 +190,7 @@ SOMADataFrame <- R6::R6Class(
                             qc = value_filter,         # idem
                             dim_points = coords,       # idem
                             loglevel = log_level,      # idem
-                            config=as.character(tiledb::config(self$ctx)))
+                            config = as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -124,7 +124,8 @@ SOMADenseNDArray <- R6::R6Class(
           rl <- soma_reader(uri = uri,
                             dim_points = coords,        # NULL is dealt with by soma_reader()
                             result_order = result_order,
-                            loglevel = log_level)       # idem
+                            loglevel = log_level,       # idem
+                            config=as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -125,7 +125,7 @@ SOMADenseNDArray <- R6::R6Class(
                             dim_points = coords,        # NULL is dealt with by soma_reader()
                             result_order = result_order,
                             loglevel = log_level,       # idem
-                            config=as.character(tiledb::config(self$ctx)))
+                            config = as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -124,7 +124,7 @@ SOMASparseNDArray <- R6::R6Class(
                             dim_points = coords,        # NULL is dealt with by soma_reader()
                             result_order = result_order,
                             loglevel = log_level,       # idem
-                            config=as.character(tiledb::config(self$ctx)))
+                            config = as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -123,7 +123,8 @@ SOMASparseNDArray <- R6::R6Class(
           rl <- soma_reader(uri = uri,
                             dim_points = coords,        # NULL is dealt with by soma_reader()
                             result_order = result_order,
-                            loglevel = log_level)       # idem
+                            loglevel = log_level,       # idem
+                            config=as.character(tiledb::config(self$ctx)))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/man/soma_reader.Rd
+++ b/apis/r/man/soma_reader.Rd
@@ -17,7 +17,8 @@ soma_reader(
   dim_ranges = NULL,
   batch_size = "auto",
   result_order = "auto",
-  loglevel = "auto"
+  loglevel = "auto",
+  config = NULL
 )
 
 nnz(uri)
@@ -51,9 +52,7 @@ for the given dimension. Each dimension can be one entry in the list.}
 \item{loglevel}{Character value with the desired logging level, defaults to \sQuote{auto}
 which lets prior setting prevail, any other value is set as new logging level.}
 
-\item{xp}{An external pointer to an ArrowSchema or ArrowData}
-
-\item{arrlst}{A list containing the pointers to an Arrow data structure}
+\item{config}{Optional character vector containing TileDB config.}
 }
 \value{
 A List object with two pointers to Arrow array data and schema is returned

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -12,8 +12,8 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // soma_reader
-Rcpp::List soma_reader(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, const std::string& loglevel);
-RcppExport SEXP _tiledbsoma_soma_reader(SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP) {
+Rcpp::List soma_reader(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, const std::string& loglevel, Rcpp::Nullable<Rcpp::CharacterVector> config);
+RcppExport SEXP _tiledbsoma_soma_reader(SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP, SEXP configSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -25,7 +25,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type batch_size(batch_sizeSEXP);
     Rcpp::traits::input_parameter< std::string >::type result_order(result_orderSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type loglevel(loglevelSEXP);
-    rcpp_result_gen = Rcpp::wrap(soma_reader(uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
+    rcpp_result_gen = Rcpp::wrap(soma_reader(uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -172,7 +173,7 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_tiledbsoma_soma_reader", (DL_FUNC) &_tiledbsoma_soma_reader, 8},
+    {"_tiledbsoma_soma_reader", (DL_FUNC) &_tiledbsoma_soma_reader, 9},
     {"_tiledbsoma_set_log_level", (DL_FUNC) &_tiledbsoma_set_log_level, 1},
     {"_tiledbsoma_get_column_types", (DL_FUNC) &_tiledbsoma_get_column_types, 2},
     {"_tiledbsoma_nnz", (DL_FUNC) &_tiledbsoma_nnz, 1},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -54,8 +54,7 @@ namespace tdbs = tiledbsoma;
 //' @param result_order Character value with the desired result order, defaults to \sQuote{auto}
 //' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
 //' which lets prior setting prevail, any other value is set as new logging level.
-//' @param arrlst A list containing the pointers to an Arrow data structure
-//' @param xp An external pointer to an ArrowSchema or ArrowData
+//' @param config Optional character vector containing TileDB config.
 //' @return A List object with two pointers to Arrow array data and schema is returned
 //' @examples
 //' \dontrun{
@@ -72,7 +71,8 @@ Rcpp::List soma_reader(const std::string& uri,
                        Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
                        std::string batch_size = "auto",
                        std::string result_order = "auto",
-                       const std::string& loglevel = "auto") {
+                       const std::string& loglevel = "auto",
+                       Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
 
     if (loglevel != "auto") {
         spdl::set_level(loglevel);
@@ -82,6 +82,18 @@ Rcpp::List soma_reader(const std::string& uri,
     spdl::info("[soma_reader] Reading from {}", uri);
 
     std::map<std::string, std::string> platform_config = {}; // to add, see riterator.cpp
+
+    if (!config.isNull()) {
+        Rcpp::CharacterVector confvec(config.get());
+        Rcpp::CharacterVector namesvec = confvec.attr("names"); // extract names from named R vector
+        size_t n = confvec.length();
+        for (size_t i = 0; i<n; i++) {
+            platform_config.emplace(std::make_pair(std::string(namesvec[i]), std::string(confvec[i])));
+            spdl::debug("[sr_setup] config map adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i]));
+        }
+        tiledb::Config cfg(platform_config);
+        spdl::debug("[sr_setup] creating ctx object with supplied config");
+    }
 
     std::vector<std::string> column_names = {};
     if (!colnames.isNull()) {    // If we have column names, select them


### PR DESCRIPTION
As reported by @mlin . Similar scenario as #1078 but with non-iterated readers.

Repro script:

```
#!/usr/bin/env Rscript

library(tiledbsoma)
library(tiledb)

uri <- 's3://.....'

config <- tiledb_config()
config["vfs.s3.region"] <- "us-west-2"
ctx <- tiledb_ctx(config)

cat("Loading experiment:\n")
exp <- SOMAExperiment$new(uri, ctx=ctx)

cat("\nGetting var:\n")
sdf <- exp$ms$get("RNA")$var

cat("\nDoing read:\n")
print(sdf$read())
```

This was failing to get the AWS region correct:

```
Error in soma_reader(uri = uri, colnames = column_names, qc = value_filter,  :
  Error opening array: 's3://cellxgene-data-public/cell-census/2023-03-06/soma/census_data/homo_sapiens/ms/RNA/var'
  [TileDB::Array] Error: Error while listing with prefix 's3://cellxgene-data-public/cell-census/2023-03-06/soma/census_data/homo_sapiens/ms/RNA/var/' and delimiter '/'
Exception:  PermanentRedirect
Error message:  Unable to parse ExceptionName: PermanentRedirect Message: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```

With this PR it works correctly:

```
Table
60664 rows x 4 columns
$soma_joinid <int64 not null>
$feature_id <large_string not null>
$feature_name <large_string not null>
$feature_length <int64 not null>
```

I don't know a great way to unit-test this but I do know this change is the right thing to do. (It's a re-use of an existing, known-good pattern from `apis/r/src/riterator.cpp` to `apis/r/src/rinterface.cpp`.)