### PR TITLE
[python] Get `readthedocs` going

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -38,6 +38,8 @@ build:
 
     - python -m pip install -v apis/python
 
+    - python scripts/show-versions.py
+
     - sphinx-build --version
 
     # This works but custom CSS styling is going missing somehow:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -42,8 +42,4 @@ build:
 
     - sphinx-build --version
 
-    # This works but custom CSS styling is going missing somehow:
-    #- sphinx-build -E -T -b html -d _readthedocs/doctrees -D language=en doc/source _readthedocs/html
-    # Experiment copied from tiledb-py:
-    #- python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
-    - python -m sphinx -T -E -b html -d _readthedocs/doctrees -D language=en doc/source _readthedocs/html
+    - sphinx-build -T -E -b html -d _readthedocs/doctrees -D language=en doc/source _readthedocs/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,8 +32,8 @@ build:
   commands:
     # Sandbox alert: `pip install -e .` will _not_ let python find the tiledbsoma package
     # within sphinx build
-    #- apt-get install python3-sphinx
     - python -m pip install --upgrade pip
+
     - python -m pip install -r doc/requirements_doc.txt
 
     - python -m pip install -v apis/python

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -37,16 +37,17 @@ Classes and functions are annotated with API maturity tags, for example:
 
 These tags indicate the maturity of each interface, and are patterned after
 the RStudio lifecycle stage model. Tags are:
-  - ``experimental``: Under active development and may undergo significant and
-    breaking changes.
-  - ``maturing``: Under active development but the interface and behavior have
-    stabilized and are unlikely to change significantly but breaking changes
-    are still possible.
-  - ``stable``: The interface is considered stable and breaking changes will be
-    avoided where possible. Breaking changes that cannot be avoided will be
-    accompanied by a major version bump.
-  - ``deprecated``: The API is no longer recommended for use and may be removed
-    in a future release.
+
+- ``experimental``: Under active development and may undergo significant and
+  breaking changes.
+- ``maturing``: Under active development but the interface and behavior have
+  stabilized and are unlikely to change significantly but breaking changes
+  are still possible.
+- ``stable``: The interface is considered stable and breaking changes will be
+  avoided where possible. Breaking changes that cannot be avoided will be
+  accompanied by a major version bump.
+- ``deprecated``: The API is no longer recommended for use and may be removed
+  in a future release.
 
 If no tag is present, the state is ``experimental``.
 
@@ -54,19 +55,20 @@ Data types:
 ------------
 
 The principal persistent types provided by SOMA are:
-  - ``Collection`` -- a string-keyed container of SOMA objects.
-  - ``DataFrame`` -- a multi-column table with a user-defined schema,
-    defining the number of columns and their respective column name
-    and value type.
-  - ``SparseNDArray`` -- a sparse multi-dimensional array, storing
-    Arrow primitive data types, i.e., int, float, etc.
-  - ``DenseNDArray`` -- a dnese multi-dimensional array, storing
-    Arrow primitive data types, i.e., int, float, etc.
-  - ``Experiment`` -- a specialized ``Collection``, representing an
-    annotated 2-D matrix of measurements.
-  - ``Measurement`` -- a specialized ``Collection``, for use within
-    the ``Experiment`` class, representing a set of measurements on
-    a single set of variables (features, e.g., genes)
+
+- ``Collection`` -- a string-keyed container of SOMA objects.
+- ``DataFrame`` -- a multi-column table with a user-defined schema,
+  defining the number of columns and their respective column name
+  and value type.
+- ``SparseNDArray`` -- a sparse multi-dimensional array, storing
+  Arrow primitive data types, i.e., int, float, etc.
+- ``DenseNDArray`` -- a dnese multi-dimensional array, storing
+  Arrow primitive data types, i.e., int, float, etc.
+- ``Experiment`` -- a specialized ``Collection``, representing an
+  annotated 2-D matrix of measurements.
+- ``Measurement`` -- a specialized ``Collection``, for use within
+  the ``Experiment`` class, representing a set of measurements on
+  a single set of variables (features, e.g., genes)
 
 SOMA ``Experiment`` and ``Measurement`` are inspired by use cases from
 single-cell biology.
@@ -79,10 +81,12 @@ example, the schema of a ``tiledbsoma.DataFrame`` is expressed as an
 Error handling
 ---------------
 Most errors will be signaled with a raised Exception. Of note:
-  - ``NotImplementedError`` will be raised when the requested function or method
-    is unsupported.
-  - ``SOMAError`` is a base class for all SOMA-specific errors.
-  - ``TileDBError`` will be raised for many TileDB-specific errors.
+
+- ``NotImplementedError`` will be raised when the requested function or method
+  is unsupported.
+- ``SOMAError`` is a base class for all SOMA-specific errors.
+- ``TileDBError`` will be raised for many TileDB-specific errors.
+
 Most errors will raise an appropriate Python error, e.g., ``TypeError`` or
 ``ValueError``.
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -25,6 +25,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     """``DenseNDArray`` is a dense, N-dimensional array, with offset (zero-based)
     integer indexing on each dimension. ``DenseNDArray`` has a user-defined
     schema, which includes:
+
     * The element type, expressed as an Arrow type, indicating the type of data
       contained within the array.
     * The shape of the array, i.e., the number of dimensions and the length of

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -3,7 +3,8 @@
 #
 # Licensed under the MIT License.
 
-"""Implementation of SOMA DenseNDArray.
+"""
+Implementation of SOMA DenseNDArray.
 """
 
 from typing import Optional, Tuple

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -35,6 +35,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     """``SparseNDArray`` is a sparse, N-dimensional array, with offset
     (zero-based) integer indexing on each dimension.
     ``SparseNDArray`` has a user-defined schema, which includes:
+
     * The element type, expressed as an Arrow type, indicating the type of data
       contained within the array.
     * The shape of the array, i.e., the number of dimensions and the length of

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -3,7 +3,8 @@
 #
 # Licensed under the MIT License.
 
-"""Implementation of SOMA SparseNDArray.
+"""
+Implementation of SOMA SparseNDArray.
 """
 from typing import Optional, Sequence, Tuple, Union, cast
 

--- a/apis/python/version.py
+++ b/apis/python/version.py
@@ -93,15 +93,11 @@ def readGitVersion():
         )
         data, stderr = proc.communicate()
         if proc.returncode:
-            print("-- RGV NONE", proc.returncode, stderr)
             return None
         ver = data.decode().splitlines()[0].strip()
-    except Exception as e:
-        print("-- RGV EXC")
-        print(e)
+    except Exception:
         return None
 
-    print("-- RGV DATA", data)
     if not ver:
         return None
     m = re.search(_GIT_DESCRIPTION_RE, ver)
@@ -120,13 +116,9 @@ def readGitVersion():
 
 def readReleaseVersion():
     try:
-        print("-- RRV PWD", os.getcwd())
-        print("-- RRV DENTS", os.listdir())
-        print("-- RRV RVF", RELEASE_VERSION_FILE)
         fd = open(RELEASE_VERSION_FILE)
         try:
             ver = fd.readline().strip()
-            print("-- RRV VER", ver)
         finally:
             fd.close()
         if not re.search(_PEP386_VERSION_RE, ver):
@@ -134,11 +126,8 @@ def readReleaseVersion():
                 "version: release version (%s) is invalid, "
                 "will use it anyway\n" % ver
             )
-        print("-- RRV VER2", ver)
         return ver
-    except Exception as e:
-        print("-- RRV EXC")
-        print(e)
+    except Exception:
         return None
 
 
@@ -149,13 +138,6 @@ def writeReleaseVersion(version):
 
 
 def getVersion():
-    print()
-    print()
-    print("GET VERSION ENTER")
-    print("-- RELEASE VERSION", readReleaseVersion())
-    print("-- GIT     VERSION", readGitVersion())
-    print()
-    print()
     release_version = readReleaseVersion()
     version = readGitVersion() or release_version
     if not version:

--- a/doc/source/gensidebar.py
+++ b/doc/source/gensidebar.py
@@ -73,7 +73,7 @@ def generate_sidebar(conf, conf_api):
 
     toctree("API Reference")
     write_api("tiledbsoma-py", "Python", "python-api")
-    write_api_url("R", "https://tiledb-inc.github.io/TileDB-SOMA/reference/index.html")
+    write_api_url("R", "https://single-cell-data.github.io/TileDB-SOMA")
     endl()
 
     write_if_changed("_sidebar.rst.inc", "\n".join(lines))

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -19,7 +19,7 @@ Features:
 * Enables distributed computation over datasets
 
 The tiledbsoma module
-------------------------
+---------------------
 .. automodule:: tiledbsoma
    :members:
 
@@ -29,6 +29,6 @@ The tiledbsoma.io module
    :members:
 
 The tiledbsoma.logging module
-------------------------
+-----------------------------
 .. automodule:: tiledbsoma.logging
    :members:


### PR DESCRIPTION
**Issue and/or context:** #1041 

**Changes:**

Gets Python API docs into `readthedocs`. 

**Notes for Reviewer:**

Current preview link (not on main): https://tiledbsoma.readthedocs.io/en/kerl-readthedocs-initial/python-api.html

There's more work to do but this gets the bulk of the docs available on the web for users to see. In particular `readthdocs` still  needs a button poked manually; I don't have commit-triggers set up. Also some info about this (and R's `pkgdown`) needs to be written in this repo's developer wiki.