### PR TITLE
[r] `SOMASparseNDArray$read_sparse_matrix`: set dims on the returned `sparseMatrix`

### DIFF
--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -168,10 +168,10 @@ SOMASparseNDArray <- R6::R6Class(
 
       if (isFALSE(iterated)) {
           tbl <- self$read_arrow_table(coords = coords, result_order = result_order, log_level = log_level)
-          m <- Matrix::sparseMatrix(i = 1 + as.numeric(tbl$GetColumnByName("soma_dim_0")),
-                                    j = 1 + as.numeric(tbl$GetColumnByName("soma_dim_1")),
-                                    x = as.numeric(tbl$GetColumnByName("soma_data")),
-                                    repr = repr)
+          Matrix::sparseMatrix(i = 1 + as.numeric(tbl$GetColumnByName("soma_dim_0")),
+                               j = 1 + as.numeric(tbl$GetColumnByName("soma_dim_1")),
+                               x = as.numeric(tbl$GetColumnByName("soma_data")),
+                               dims = as.integer(self$shape()), repr = repr)
       } else {
           ## should we error if this isn't null?
           if (!is.null(self$soma_reader_pointer)) {


### PR DESCRIPTION
#1099

Quick hit here to set the `sparseMatrix` dims for non-iterated reads only. I have WIP on iterated reads, but ran into a few complications, so I'd like to keep working on that in additional PR(s) to come.