### PR TITLE
[r] Fix testing logic for iterated reads from `SOMASparseNDArray`

### DIFF
--- a/apis/r/tests/testthat/test_SOMAReader-Iterated.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Iterated.R
@@ -133,36 +133,26 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
 
     sdf$read_sparse_matrix(iterated = TRUE)
 
-    expect_false(sdf$read_complete())
-    dat <- sdf$read_next()
-    d <- dim(dat)
-    expect_equal(d[2], 1838)
-    n <- d[1]
-    expect_true(n > 0)
-
-    expect_false(sdf$read_complete())
-    dat <- sdf$read_next()
-    d <- dim(dat)
-    expect_equal(d[2], 1838)
-    n <- n + d[1]
-    expect_true(n > 0)
-
-    expect_false(sdf$read_complete())
-    dat <- sdf$read_next()
-    d <- dim(dat)
-    expect_equal(d[2], 1838)
-    n <- n + d[1]
-    expect_true(n > 0)
-
-    expect_false(sdf$read_complete())
-    dat <- sdf$read_next()
-    d <- dim(dat)
-    expect_equal(d[2], 1838)
-    n <- n + d[1]
-    expect_true(n > 0)
-
-    expect_equal(n, 6596)
+    nnzRows <- function(m) { sum(Matrix::rowSums(m != 0) > 0) }
+    nnzTotal <- 0
+    rowsTotal <- 0
+    for (i in 1:4) {
+        expect_false(sdf$read_complete())
+        dat <- sdf$read_next()
+        nnz <- Matrix::nnzero(dat)
+        expect_gt(nnz, 0)
+        nnzTotal <- nnzTotal + nnz
+        rowsTotal <- rowsTotal + nnzRows(dat)
+    }
     expect_true(sdf$read_complete())
+
+    # FIXME: TileDB-SOMA issue #1111
+    # expect_equal(rowsTotal, nnzRows(sdf$read_sparse_matrix()))
+    # expect_equal(nnzTotal, Matrix::nnzero(sdf$read_sparse_matrix()))
+    # in fact however, the test array is dense 2638x1838 with all nonzero entries.
+    expect_equal(rowsTotal, 2638)
+    expect_equal(nnzTotal, 4848644)
+    expect_equal(nnzTotal, prod(as.integer(sdf$shape())))
 
     rm(sdf)
 


### PR DESCRIPTION
RELATED: #1099, #1110

The existing tests "Iterated Interface from SOMA Sparse Matrix" were passing, but they were checking weird quantities in a way I doubt was intentional (but do correct me otherwise :). It checked that the sum of `dim(dat)[1]` over each returned `sparseMatrix` shard `dat` was 6596. This is a weird assertion because the whole test matrix has only 2638 rows. As we aren't yet expressly setting the dims of each `sparseMatrix` shard, `dim(dat)` defaults to (max row number with a nonzero entry, max column number with a nonzero entry) of each shard -- see `?Matrix::sparseMatrix`. As we progress in row-major order, the max row number keeps increasing to 2638 on the last iteration; thus the running total is much greater than nrow=2638.

This diff changes the test to verify more-natural quantities, the total number of nonzero rows and the total number of nonzero entries (though our actual test array is all-nonzero).

This also invites discussion of what `dim(dat)` *should* be. I think the only possible answers are the current default or the shape of the whole sparse array (even though we're only returning a shard of it). I suggest the latter since the former is more confusing and unpredictable as seen here. discussion?