### PR TITLE
[python] Pin typeguard to < 3.0

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -89,7 +89,7 @@ jobs:
         key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov typeguard types-setuptools
+      run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools
 
     - name: Install tiledbsoma
       run: python -m pip -v install -e apis/python

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -1,4 +1,4 @@
 cmake >= 3.21
 pybind11-global >= 2.10.0
-typeguard 
+typeguard < 3.0
 pytest

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -253,7 +253,7 @@ setuptools.setup(
             "black",
             "ruff",
             "pytest",
-            "typeguard",
+            "typeguard<3.0",
         ]
     },
     python_requires=">=3.7",


### PR DESCRIPTION
**Issue and/or context:**

https://pypi.org/project/typeguard/3.0.0/ just dropped yesterday. As a result all new CI is failing with

```
    from typeguard.importhook import install_import_hook
E   ModuleNotFoundError: No module named 'typeguard.importhook'

```

**Changes:**

Don't use typeguard 3.