### PR TITLE
[r] `SOMASparseNDArray$read_sparse_matrix`: set dims on iterated `sparseMatrix` parts

### DIFF
--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -235,7 +235,7 @@ SOMASparseNDArray <- R6::R6Class(
           Matrix::sparseMatrix(i = 1 + as.numeric(tbl$GetColumnByName("soma_dim_0")),
                                j = 1 + as.numeric(tbl$GetColumnByName("soma_dim_1")),
                                x = as.numeric(tbl$GetColumnByName("soma_data")),
-                               repr = private$sparse_repr)
+                               dims = as.integer(self$shape()), repr = private$sparse_repr)
       }
     },
 

--- a/apis/r/tests/testthat/test_SOMAReader-Iterated.R
+++ b/apis/r/tests/testthat/test_SOMAReader-Iterated.R
@@ -143,6 +143,8 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
         expect_gt(nnz, 0)
         nnzTotal <- nnzTotal + nnz
         rowsTotal <- rowsTotal + nnzRows(dat)
+        # the shard dims always match the shape of the whole sparse matrix
+        expect_equal(dim(dat), as.integer(sdf$shape()))
     }
     expect_true(sdf$read_complete())
 

--- a/apis/r/tests/testthat/test_SOMASparseNdArray.R
+++ b/apis/r/tests/testthat/test_SOMASparseNdArray.R
@@ -77,6 +77,15 @@ test_that("SOMASparseNDArray read_sparse_matrix", {
   ## not sure why all.equal(mat, mat2) does not pass
   expect_true(all.equal(as.numeric(mat), as.numeric(mat2[1:9,1:9])))
   expect_equal(sum(mat), sum(mat2))
+
+  # repeat with iterated reader
+  ndarray$read_sparse_matrix(repr="T", iterated=TRUE)
+  mat2 <- ndarray$read_next()
+  expect_s4_class(mat2, "sparseMatrix")
+  expect_equal(nrow(mat2), 10)
+  expect_equal(ncol(mat2), 10)
+  expect_true(all.equal(as.numeric(mat), as.numeric(mat2[1:9,1:9])))
+  expect_equal(sum(mat), sum(mat2))
 })
 
 test_that("SOMASparseNDArray creation with duplicates", {


### PR DESCRIPTION
For iterated reads, I think the dims of each shard have to match the whole array shape, because in principle we could be returning entries from anywhere in the array.

It would be nice to have some other slot that would make it easy for the user to figure out the 'bounding box' of the returned shard, without having to do something cute like `nnzRows <- function(m) { sum(Matrix::rowSums(m != 0) > 0) }` (which is partly due to ChatGPT btw =). Not sure where to hang that though, any suggestions?

Should complete #1099