### PR TITLE
[ci] Ensure macOS builds use clang instead of gcc

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -20,8 +20,6 @@ jobs:
             cc: gcc-11
             cxx: g++-11
           - runs-on: macos-12
-            cc: gcc-11
-            cxx: g++-11
     uses: ./.github/workflows/python-ci-single.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -1,10 +1,17 @@
 name: TileDB-SOMA Python CI (Full)
 
+# This workflow calls ./python-ci-single.yml on the full {os} x {python version}
+# matrix. Since that's CI-resource-intensive, it runs only for main branch and
+# releases.
 on:
   push:
     branches: [main]
   release:
     types: [published]
+  # You can also invoke this workflow manually from
+  #   https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml
+  # to test a working branch on the full matrix.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
-        os: [ubuntu-22.04, macos-12]
+        os: [macos-12, ubuntu-22.04]
         # os: [ubuntu-22.04, macos-12, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         include:

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -12,14 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: restore Windows build once we have C++/libtiledbsoma integration supported there
-        os: [macos-12, ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
         # os: [ubuntu-22.04, macos-12, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
-          - runs-on: macos-12
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
+          - runs-on: macos-12
+            cc: clang
+            cxx: clang++
     uses: ./.github/workflows/python-ci-single.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -16,10 +16,10 @@ jobs:
         # os: [ubuntu-22.04, macos-12, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
+          - runs-on: macos-12
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
-          - runs-on: macos-12
     uses: ./.github/workflows/python-ci-single.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -10,13 +10,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-12, ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
         python-version: ['3.10', '3.7']
         include:
-          - runs-on: macos-12
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
+          - runs-on: macos-12
+            cc: clang
+            cxx: clang++
     # TODO: remove version before merge to main
     uses: ./.github/workflows/python-ci-single.yml
     with:

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04]
+        os: [macos-12, ubuntu-22.04]
         python-version: ['3.10', '3.7']
         include:
           - runs-on: macos-12

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -1,5 +1,12 @@
 name: TileDB-SOMA Python CI (Minimal)
 
+# This workflow calls ./python-ci-single.yml on a limited subset of the
+# {os} x {python version} matrix. It runs for all branches, in contrast to
+# ./python-ci-full.yml, which exhausts the matrix but only for main & releases,
+# since that's CI-resource-intensive.
+#
+# To test the full matrix on a working branch, invoke ./python-ci-full.yml from
+#   https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml
 on:
   push:
     paths-ignore:
@@ -10,16 +17,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04]
         python-version: ['3.10', '3.7']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
-          - runs-on: macos-12
-            cc: clang
-            cxx: clang++
-    # TODO: remove version before merge to main
     uses: ./.github/workflows/python-ci-single.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -13,6 +13,7 @@ jobs:
         os: [ubuntu-22.04]
         python-version: ['3.10', '3.7']
         include:
+          - runs-on: macos-12
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11


### PR DESCRIPTION
Appears to fix current main CI...unclear if setting gcc was intentional, and we do NOT do that for the wheel builds.