### PR TITLE
[r] Limit pkgdown runs to releases and manual triggers

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,12 +1,12 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    # To publish docs from your branch: list the branch name here instead of main.
-    branches: [main]
-  pull_request:
-    # To publish docs from your branch: list the branch name here instead of main.
-    branches: [main]
+  #push:
+  #  # To publish docs from your branch: list the branch name here instead of main.
+  #  branches: [main]
+  #pull_request:
+  #  # To publish docs from your branch: list the branch name here instead of main.
+  #  branches: [main]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
**Issue and/or context:**

Every push or pull request currently triggers `pkgdown` rebuilds which is more than is needed.  

**Changes:**

Limits triggers to releases and manual calls (aka `workflow_dispatch` see [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch))

**Notes for Reviewer:**

[SC 26530](https://app.shortcut.com/tiledb-inc/story/26530/tiledbsoma-ci-burns-too-many-cycles-for-pkgdown)
