### PR TITLE
[python] Fix wheel builds given recent Conda-related changes

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -23,9 +23,7 @@ jobs:
       with:
         fetch-depth: 0  # ensure we get all tags to inform package version determination
     - name: Build sdist
-      run: |
-        python -m pip install pybind11
-        python setup.py sdist
+      run: python setup.py sdist
       working-directory: ./apis/python
     - name: Upload sdist artifact
       uses: actions/upload-artifact@v3
@@ -111,7 +109,7 @@ jobs:
         pip install $WHL
         echo "WHL=$WHL" >> $GITHUB_ENV
     - name: Smoke test ${{ matrix.os }}
-      run: python -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__); tiledbsoma.show_package_versions()'
+      run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
       # TODO: more thorough local smoke test
     - name: Smoke test in docker
       # Repeat test in stock ubuntu 20.04 docker image. This uses an older pip
@@ -121,7 +119,7 @@ jobs:
         docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
           apt-get -qq update && apt-get install -y python3-pip python3-wheel
           pip3 install /mnt/$WHL
-          python3 -c 'import tiledbsoma; print(tiledbsoma.libtiledbsoma.__file__); tiledbsoma.show_package_versions()'
+          python3 -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         "
 
   # TODO: publlish to TestPyPI

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   # Normally the smoke test only runs on merge to main.  To run it on a PR CI, uncomment `pull_request:`
   # pull_request:
-  # branches: [main]
+  #   branches: [main]
   # paths-ignore:
   #   - 'apis/r/**'
   release:
@@ -23,7 +23,9 @@ jobs:
       with:
         fetch-depth: 0  # ensure we get all tags to inform package version determination
     - name: Build sdist
-      run: python setup.py sdist
+      run: |
+        python -m pip install pybind11
+        python setup.py sdist
       working-directory: ./apis/python
     - name: Upload sdist artifact
       uses: actions/upload-artifact@v3
@@ -85,9 +87,13 @@ jobs:
         - os: ubuntu-20.04
           platform: manylinux2014
           arch: x86_64
+          cc: gcc-11
+          cxx: g++-11
         - os: macos-11
           platform: macosx
           arch: x86_64
+          cc: clang
+          cxx: clang++
     steps:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/apis/python/MANIFEST.in
+++ b/apis/python/MANIFEST.in
@@ -1,3 +1,4 @@
 include RELEASE-VERSION version.py
+include src/tiledbsoma/*.cc
 graft dist_links
 prune dist_links/libtiledbsoma/test/__pycache__

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -165,13 +165,21 @@ INC_DIRS = [
     "../../libtiledbsoma/include",
     "../../libtiledbsoma/external/include",
     "../../build/externals/install/include",
+    str(libtiledbsoma_dir / "include"),
+    str(
+        "./src/tiledbsoma"
+    ),  # since pytiledbsoma.cc does #include of query_condition.cc
+    str(libtiledbsoma_dir.parent / "build/externals/install/include"),
 ]
+
 LIB_DIRS = [
     str(libtiledbsoma_dir / "lib"),
 ]
 CXX_FLAGS = [
     f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib")}',
 ]
+if sys.platform == "darwin":
+    CXX_FLAGS.append("-mmacosx-version-min=10.14")
 
 if os.name == "posix" and sys.platform != "darwin":
     LIB_DIRS.append(str(libtiledbsoma_dir / "lib" / "x86_64-linux-gnu"))
@@ -223,7 +231,7 @@ setuptools.setup(
             library_dirs=LIB_DIRS,
             libraries=["tiledbsoma"],
             extra_link_args=CXX_FLAGS,
-            extra_compile_args=["-std=c++17"],
+            extra_compile_args=["-std=c++17"] + CXX_FLAGS,
             language="c++",
         )
     ],

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -22,10 +22,17 @@ import subprocess
 import sys
 
 import setuptools
-
-# import setuptools.command.build_ext
+import setuptools.command.build_ext
 import wheel.bdist_wheel
-from pybind11.setup_helpers import Pybind11Extension
+
+try:
+    from pybind11.setup_helpers import Pybind11Extension
+except ImportError:
+    # Explanation:
+    # https://pybind11.readthedocs.io/en/stable/compiling.html#classic-setup-requires
+    # This works around a catch-22 where pybind11 is a requirement to load setup.py, yet pip cannot
+    # read&install our requirements without loading setup.py.
+    from setuptools import Extension as Pybind11Extension
 
 this_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.insert(0, str(this_dir))
@@ -162,8 +169,8 @@ class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
 
 
 INC_DIRS = [
-    "../../libtiledbsoma/include",
-    "../../libtiledbsoma/external/include",
+    "dist_links/libtiledbsoma/include",
+    "dist_links/libtiledbsoma/external/include",
     "../../build/externals/install/include",
     str(libtiledbsoma_dir / "include"),
     str(
@@ -236,6 +243,7 @@ setuptools.setup(
         )
     ],
     zip_safe=False,
+    setup_requires=["pybind11"],
     install_requires=[
         "anndata",
         "attrs>=22.2",

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -56,7 +56,7 @@ def show_package_versions() -> None:
     Lifecycle: Experimental.
     """
     print("tiledbsoma.__version__       ", get_implementation_version())
-    print("TileDB-Py tiledb.__version__ ", tiledb.__version__)
+    print("TileDB-Py tiledb.version()   ", tiledb.version())
     print(
         "TileDB core version          ",
         ".".join(str(ijk) for ijk in list(tiledb.libtiledb.version())),

--- a/scripts/show-versions.py
+++ b/scripts/show-versions.py
@@ -13,7 +13,7 @@ import tiledb
 import tiledbsoma
 
 print("tiledbsoma.__version__   ", tiledbsoma.__version__)
-print("tiledb.__version__       ", ".".join(str(e) for e in tiledb.version()))
+print("tiledb.version()         ", ".".join(str(e) for e in tiledb.version()))
 print("core version             ", ".".join(map(str, tiledb.libtiledb.version())))
 print("anndata.__version__  (ad)", ad.__version__)
 print("numpy.__version__    (np)", np.__version__)


### PR DESCRIPTION
Recent changes resulted in wheel-build failures. This PR takes input from @nguyenv, @mlin, and myself to solve this problem.

Note this is a neaten of the exploratory PR #1113. We do not run wheel builds on every PR, pre-merge or post-merge -- only on releases, and in a nightly cron. #1113 contains the fixes here, and it also has a dev-only tweak to run wheel builds pre-merge. That is how this current PR was validated.