### PR TITLE
[docs] Add notebooks as tutorials to the docsite

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -40,7 +40,7 @@ release = "1.0.0rc5"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.doctest", "sphinx.ext.intersphinx", 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.doctest", "sphinx.ext.intersphinx", 'sphinx.ext.napoleon', "nbsphinx"]
 
 # Mapping for linking between RTD subprojects.
 if readthedocs:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,3 +4,10 @@ TileDB-SOMA Python Project
 This project encompasses the Python language bindings for the TileDB-SOMA library.
 
 .. include:: _sidebar.rst.inc
+
+Tutorials
+--------
+.. toctree::
+   :maxdepth: 1
+    
+   tutorials

--- a/doc/source/notebooks/tutorial_exp_query.ipynb
+++ b/doc/source/notebooks/tutorial_exp_query.ipynb
@@ -1,0 +1,1 @@
+../../../apis/python/notebooks/tutorial_exp_query.ipynb

--- a/doc/source/notebooks/tutorial_soma_objects.ipynb
+++ b/doc/source/notebooks/tutorial_soma_objects.ipynb
@@ -1,0 +1,1 @@
+../../../apis/python/notebooks/tutorial_soma_objects.ipynb

--- a/doc/source/notebooks/tutorial_soma_reading.ipynb
+++ b/doc/source/notebooks/tutorial_soma_reading.ipynb
@@ -1,0 +1,1 @@
+../../../apis/python/notebooks/tutorial_soma_reading.ipynb


### PR DESCRIPTION
**Issue and/or context:**
https://github.com/single-cell-data/TileDB-SOMA/issues/1017

**Changes:**
Add notebooks as tutorials

**Notes for Reviewer:**

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/7020189/226043069-f67902d8-f65f-4848-921e-4218db88267e.png">
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/7020189/226043214-076b6700-ee35-4887-9b3c-2d53e84d9c28.png">
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/7020189/226043335-a08a5b38-041f-48f5-9859-428638a7ec14.png">


