### PR TITLE
[r] Revert back to CI use of tiledb-r from CRAN

### DIFF
--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -48,9 +48,5 @@ jobs:
       - name: Install dependencies
         run: ./tools/ci/install-r-dependencies.sh
 
-      # need current GH version
-      - name: Update TileDB-R
-        run: Rscript -e 'install.packages("remotes"); remotes::install_github("TileDB-Inc/TileDB-R")'
-        
       - name: Build and check R package
         run: ./tools/ci/build-and-check-r-package.sh


### PR DESCRIPTION
**Issue and/or context:**

In the `main-old` branch,  PR #1100 accomodated setting 'legacy validity' and needed to (temporarily) install tiledb-r from GitHub to have access to a new enough version 0.18.0.3.  As 0.19.0 is now on CRAN we can revert this.

**Changes:**

Revert one add block in the CI yaml

**Notes for Reviewer:**

[SC 26661](https://app.shortcut.com/tiledb-inc/story/26661/revert-use-of-github-tiledb-in-main-old-ci)