### PR TITLE
[r] [python] support bytes metadata field + R SOMA_ENCODING_VERSION

### DIFF
--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -171,6 +171,10 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
         raise SOMAError(
             f"stored TileDB object does not have {SOMA_OBJECT_TYPE_METADATA_KEY!r}"
         )
+
+    if isinstance(obj_type, bytes):
+        obj_type = str(obj_type, "utf-8")
+
     if not isinstance(obj_type, str):
         raise SOMAError(
             f"stored TileDB object {SOMA_OBJECT_TYPE_METADATA_KEY!r}"
@@ -180,6 +184,10 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
         raise SOMAError(
             f"stored TileDB object does not have {SOMA_ENCODING_VERSION_METADATA_KEY}"
         )
+
+    if isinstance(encoding_version, bytes):
+        encoding_version = str(encoding_version, "utf-8")
+
     if encoding_version != SOMA_ENCODING_VERSION:
         raise ValueError(f"Unsupported SOMA object encoding version {encoding_version}")
 

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -47,7 +47,7 @@ read_only_error <- function(field_name) {
 
 SOMA_OBJECT_TYPE_METADATA_KEY <- "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY <- "soma_encoding_version"
-SOMA_ENCODING_VERSION <- "0"
+SOMA_ENCODING_VERSION <- "1"
 
 check_arrow_pointers <- function(arrlst) {
     stopifnot("First argument must be an external pointer to ArrowArray" = check_arrow_array_tag(arrlst[[1]]),


### PR DESCRIPTION
**Issue and/or context:**
The R-Python interop testing found two issues:
1. Metadata fields (`SOMA_OBJECT_TYPE_METADATA_KEY`, `SOMA_ENCODING_VERSION`) are written using bytes by the R API
2. The `SOMA_ENCODING_VERSION` does not match

**Changes:**
1. Decode the metadata fields to UTF-8 strings if they're bytes
2. Bump R's `SOMA_ENCODING_VERSION` to 1

**Notes for Reviewer:**
Note that R is not currently doing the same metadata checks that Python is doing w.r.t. metadata. Worth adding them ?

