### PR TITLE
[python] Set log level depending on in-notebook or not, and use `stdout`

### DIFF
--- a/apis/python/src/tiledbsoma/logging.py
+++ b/apis/python/src/tiledbsoma/logging.py
@@ -4,9 +4,8 @@
 # Licensed under the MIT License.
 
 import logging
+import sys
 from typing import Optional
-
-logger = logging.getLogger("tiledbsoma")
 
 
 def warning() -> None:
@@ -48,7 +47,7 @@ def _set_level(level: int) -> None:
     # ``tiledbsoma.logging.info()`` then ``tiledbsoma.logging.debug()``, etc., then log messages will appear
     # twice.
     if not logger.hasHandlers():
-        logger.addHandler(logging.StreamHandler())
+        logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 
 def log_io(info_message: Optional[str], debug_message: str) -> None:
@@ -66,3 +65,29 @@ def log_io(info_message: Optional[str], debug_message: str) -> None:
     elif logger.level <= logging.DEBUG:
         if debug_message is not None:
             logger.debug(debug_message)
+
+
+def _in_notebook() -> bool:
+    try:
+        from IPython import get_ipython
+
+        if "IPKernelApp" not in get_ipython().config:  # pragma: no cover
+            return False
+    except ImportError:
+        return False
+    except AttributeError:
+        return False
+    return True
+
+
+logger = logging.getLogger("tiledbsoma")
+# For interactive notebook use it's _crucial_ that data ingests (which can take several minutes)
+# must make a progress indicator to show something is happening -- by default and with zero user
+# intervention.
+#
+# Additional note: without this first _set_level, default logging will go to stderr. We want it to
+# stdout.
+if _in_notebook():
+    _set_level(logging.INFO)
+else:
+    _set_level(logging.WARN)


### PR DESCRIPTION
**Issue and/or context:**

User feedback after https://github.com/single-cell-data/TileDB-SOMA/releases/tag/1.0.0

Also involves #390.

**Changes:**

* Log to stdout rather than stderr. This makes notebook cells not be pink.
* Log by default at a higher verbosity level for notebook environments.

**Notes for Reviewer:**

