### PR TITLE
[docs/python] Fix hyperlinks in Sphinx docs

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -4,7 +4,7 @@ SOMA -- stack of matrices, annotated -- is a flexible, extensible, and
 open-source API enabling access to data in a variety of formats, and is
 motivated by use cases from single-cell biology. The ``tiledbsoma``
 Python package is an implementation of SOMA using the
-[TileDB Embedded](https://github.com/TileDB-Inc/TileDB) engine.
+`TileDB Embedded <https://github.com/TileDB-Inc/TileDB>`_ engine.
 
 Provides:
 ----------
@@ -14,7 +14,7 @@ Provides:
      multi-dimensional arrays.
   3. An extended data model with support for single-cell biology data.
 
-See the [SOMA GitHub repo](https://github.com/single-cell-data/SOMA) for more
+See the `SOMA GitHub repo <https://github.com/single-cell-data/SOMA>`_ for more
 information on the SOMA project.
 
 Using the documentation:
@@ -73,10 +73,10 @@ The principal persistent types provided by SOMA are:
 SOMA ``Experiment`` and ``Measurement`` are inspired by use cases from
 single-cell biology.
 
-SOMA uses the [Arrow](https://arrow.apache.org/docs/python/index.html) type
+SOMA uses the `Arrow <https://arrow.apache.org/docs/python/index.html>`_ type
 system and memory model for its in-memory type system and schema. For
 example, the schema of a ``tiledbsoma.DataFrame`` is expressed as an
-[Arrow Schema](https://arrow.apache.org/docs/python/data.html#schemas).
+`Arrow Schema <https://arrow.apache.org/docs/python/data.html#schemas>`_.
 
 Error handling
 ---------------

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -43,7 +43,7 @@ def to_tiledb_supported_array_type(x: _MT) -> _MT:
     """Converts datatypes unrepresentable by TileDB into datatypes it can represent.
     E.g., categorical strings -> string.
 
-    See also [https://docs.scipy.org/doc/numpy-1.10.1/reference/arrays.dtypes.html](https://docs.scipy.org/doc/numpy-1.10.1/reference/arrays.dtypes.html).
+    See also `https://docs.scipy.org/doc/numpy-1.10.1/reference/arrays.dtypes.html ,https://docs.scipy.org/doc/numpy-1.10.1/reference/arrays.dtypes.html>`_.
 
     Preferentially converts to the underlying primitive type, as TileDB does not support
     most complex types. NOTE: this does not support ``datetime64`` conversion.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,7 +6,7 @@ This project encompasses the Python language bindings for the TileDB-SOMA librar
 .. include:: _sidebar.rst.inc
 
 Tutorials
---------
+---------
 .. toctree::
    :maxdepth: 1
     


### PR DESCRIPTION
**Issue and/or context:**

Two things for #1089:

* Things not having links that should
* Things having links which misrender

This PR is about the latter.

**Changes:**

While we're using Sphinx for Python docs, use Sphinx syntax for hyperlinks.

When we moved to Quarto (#1055) for Python docs, we can switch to using Quarto syntax for hyperlinks.

**Notes for Reviewer:**

