### PR TITLE
[R] Fix reading very sparse assays

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9013
+Version: 0.0.0.9014
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -779,6 +779,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           i = self$indexer$by_obs(obs)$as_vector() + 1L,
           j = self$indexer$by_var(var)$as_vector() + 1L,
           x = self$X(lyr)$GetColumnByName('soma_data')$as_vector(),
+          dims = c(self$n_obs, self$n_vars),
           repr = switch(EXPR = repr, D = 'T', repr)
         )
         mat <- Matrix::t(mat)


### PR DESCRIPTION
`matrix::sparseMatrix` drops unused rows/columns at the end of the matrix. This causes issues when reading in an `X` layer to a Seurat assay 

As a fix, explicitly set the matrix shape to `c(query$n_obs, query$n_vars)` when reading