### PR TITLE
[python] Ingest `uns` values from AnnData files

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -78,12 +78,13 @@ def from_h5ad(
     use_relative_uri: Optional[bool] = None,
     X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
 ) -> str:
-    """Reads an ``.h5ad`` file and writes it to a tiledbsoma Experiment.
+    """Reads an ``.h5ad`` file and writes it to an :class:`Experiment`.
 
-    Measurement data is stored in a Measurement in the experiment's ``ms`` field,
-    with the key provided by ``measurement_name``. Data elements are available
-    at the standard fields (``var``, ``X``, etc.). ``uns`` unstructured data is
-    partially supported, and is available at the measurement's ``uns`` key
+    Measurement data is stored in a :class:`Measurement` in the experiment's
+    ``ms`` field, with the key provided by ``measurement_name``. Data elements
+    are available at the standard fields (``var``, ``X``, etc.). Unstructured
+    data from ``uns`` is partially supported (structured arrays and non-numeric
+    NDArrays are skipped), and is available at the measurement's ``uns`` key
     (i.e., at ``your_experiment.ms[measurement_name]["uns"]``).
 
     Args:
@@ -158,12 +159,13 @@ def from_anndata(
     use_relative_uri: Optional[bool] = None,
     X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
 ) -> str:
-    """Writes an anndata object to a tiledbsoma Experiment.
+    """Writes an anndata object to a :class:`Experiment`.
 
-    Measurement data is stored in a Measurement in the experiment's ``ms`` field,
-    with the key provided by ``measurement_name``. Data elements are available
-    at the standard fields (``var``, ``X``, etc.). ``uns`` unstructured data is
-    partially supported, and is available at the measurement's ``uns`` key
+    Measurement data is stored in a :class:`Measurement` in the experiment's
+    ``ms`` field, with the key provided by ``measurement_name``. Data elements
+    are available at the standard fields (``var``, ``X``, etc.). Unstructured
+    data from ``uns`` is partially supported (structured arrays and non-numeric
+    NDArrays are skipped), and is available at the measurement's ``uns`` key
     (i.e., at ``your_experiment.ms[measurement_name]["uns"]``).
 
     Args:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -78,20 +78,36 @@ def from_h5ad(
     use_relative_uri: Optional[bool] = None,
     X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
 ) -> str:
-    """Reads an ``.h5ad`` file and writes to a TileDB group structure.
+    """Reads an ``.h5ad`` file and writes it to a tiledbsoma Experiment.
 
-    Returns a URI for the created experiment.
+    Measurement data is stored in a Measurement in the experiment's ``ms`` field,
+    with the key provided by ``measurement_name``. Data elements are available
+    at the standard fields (``var``, ``X``, etc.). ``uns`` unstructured data is
+    partially supported, and is available at the measurement's ``uns`` key
+    (i.e., at ``your_experiment.ms[measurement_name]["uns"]``).
 
-    The "write" ingest_mode (which is the default) writes all data, creating new layers if the soma already exists.
+    Args:
+        experiment_uri: The experiment to create or update.
 
-    The "resume" ingest_mode skips data writes if data are within dimension ranges of the existing soma.
-    This is useful for continuing after a partial/interrupted previous upload.
+        input_path: A path to an input H5AD file.
 
-    The "schema_only" ingest_mode creates groups and array schema, without writing array data.
-    This is useful as a prep-step for parallel append-ingest of multiple H5ADs to a single soma.
+        measurement_name: The name of the measurement to store data in.
 
-    The ``X_kind`` parameter allows you to specify how dense X matrices from the H5AD are stored
-    within the SOMA experiment -- whether as dense or as sparse.
+        ingest_mode: The ingestion type to perform:
+            - ``write``: Writes all data, creating new layers
+              if the SOMA already exists.
+            - ``resume``: Adds data to an existing SOMA, skipping writing data
+              that was previously written. Useful for continuing after a partial
+              or interrupted ingestion operation.
+            - ``schema_only``: Creates groups and the array schema, without
+              writing any data to the array. Useful to prepare for appending
+              multiple H5AD files to a single SOMA.
+
+        X_kind: Which type of matrix is used to store dense X data from the
+            H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
+
+    Returns:
+        The URI of the newly created experiment.
 
     Lifecycle:
         Experimental.
@@ -142,20 +158,36 @@ def from_anndata(
     use_relative_uri: Optional[bool] = None,
     X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
 ) -> str:
-    """Top-level writer method for creating a TileDB group for an :class:`Experiment` object.
+    """Writes an anndata object to a tiledbsoma Experiment.
 
-    Returns a URI for the created experiment.
+    Measurement data is stored in a Measurement in the experiment's ``ms`` field,
+    with the key provided by ``measurement_name``. Data elements are available
+    at the standard fields (``var``, ``X``, etc.). ``uns`` unstructured data is
+    partially supported, and is available at the measurement's ``uns`` key
+    (i.e., at ``your_experiment.ms[measurement_name]["uns"]``).
 
-    The "write" ingest_mode (which is the default) writes all data, creating new layers if the soma already exists.
+    Args:
+        experiment_uri: The experiment to create or update.
 
-    The "resume" ingest_mode skips data writes if data are within dimension ranges of the existing soma.
-    This is useful for continuing after a partial/interrupted previous upload.
+        input_path: A path to an input H5AD file.
 
-    The "schema_only" ingest_mode creates groups and array schema, without writing array data.
-    This is useful as a prep-step for parallel append-ingest of multiple H5ADs to a single soma.
+        measurement_name: The name of the measurement to store data in.
 
-    The ``X_kind`` parameter allows you to specify how dense X matrices from the H5AD are stored
-    within the SOMA experiment -- whether as dense or as sparse.
+        ingest_mode: The ingestion type to perform:
+            - ``write``: Writes all data, creating new layers
+              if the SOMA already exists.
+            - ``resume``: Adds data to an existing SOMA, skipping writing data
+              that was previously written. Useful for continuing after a partial
+              or interrupted ingestion operation.
+            - ``schema_only``: Creates groups and the array schema, without
+              writing any data to the array. Useful to prepare for appending
+              multiple H5AD files to a single SOMA.
+
+        X_kind: Which type of matrix is used to store dense X data from the
+            H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
+
+    Returns:
+        The URI of the newly created experiment.
 
     Lifecycle:
         Experimental.

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -307,8 +307,21 @@ def test_ingest_uns(tmp_path: pathlib.Path, h5ad_file_extended):
     with tiledbsoma.Experiment.open(uri) as exp:
         uns = exp.ms["hello"]["uns"]
         assert isinstance(uns, tiledbsoma.Collection)
-        assert uns.metadata["soma_tiledbsoma:type"] == "uns"
-        assert set(uns) == {"draw_graph", "louvain", "neighbors", "pca"}
+        assert uns.metadata["soma_tiledbsoma_type"] == "uns"
+        assert set(uns) == {
+            "draw_graph",
+            "louvain",
+            "neighbors",
+            "pca",
+            "rank_genes_groups",
+        }
+        rgg = uns["rank_genes_groups"]
+        assert set(rgg) == {"params"}, "structured arrays not imported"
+        assert rgg["params"].metadata.items() >= {
+            ("groupby", "louvain"),
+            ("method", "t-test_overestim_var"),
+            ("reference", "rest"),
+        }
         dg_params = uns["draw_graph"]["params"]
         assert isinstance(dg_params, tiledbsoma.Collection)
         assert dg_params.metadata["layout"] == "fr"

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1,7 +1,9 @@
+import pathlib
 import tempfile
 from pathlib import Path
 
 import anndata
+import numpy as np
 import pytest
 import tiledb
 
@@ -52,7 +54,6 @@ def adata(h5ad_file):
     [tiledbsoma.SparseNDArray, tiledbsoma.DenseNDArray],
 )
 def test_import_anndata(adata, ingest_modes, X_kind):
-
     have_ingested = False
 
     tempdir = tempfile.TemporaryDirectory()
@@ -62,7 +63,6 @@ def test_import_anndata(adata, ingest_modes, X_kind):
     all2d = (slice(None), slice(None))  # keystroke-saver
 
     for ingest_mode in ingest_modes:
-
         uri = tiledbsoma.io.from_anndata(
             output_path,
             orig,
@@ -252,7 +252,6 @@ def test_resume_mode(adata, resume_mode_h5ad_file):
 
 @pytest.mark.parametrize("use_relative_uri", [False, True, None])
 def test_ingest_relative(h5ad_file_extended, use_relative_uri):
-
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
@@ -298,6 +297,26 @@ def test_ingest_relative(h5ad_file_extended, use_relative_uri):
         assert G.is_relative("data") == expected_relative
 
     exp.close()
+
+
+def test_ingest_uns(tmp_path: pathlib.Path, h5ad_file_extended):
+    tmp_uri = tmp_path.as_uri()
+    original = anndata.read(h5ad_file_extended)
+    uri = tiledbsoma.io.from_anndata(tmp_uri, original, measurement_name="hello")
+
+    with tiledbsoma.Experiment.open(uri) as exp:
+        uns = exp.ms["hello"]["uns"]
+        assert isinstance(uns, tiledbsoma.Collection)
+        assert uns.metadata["soma_tiledbsoma:type"] == "uns"
+        assert set(uns) == {"draw_graph", "louvain", "neighbors", "pca"}
+        dg_params = uns["draw_graph"]["params"]
+        assert isinstance(dg_params, tiledbsoma.Collection)
+        assert dg_params.metadata["layout"] == "fr"
+        random_state = dg_params["random_state"]
+        assert isinstance(random_state, tiledbsoma.DenseNDArray)
+        assert np.array_equal(random_state.read().to_numpy(), np.array([0]))
+        got_pca_variance = uns["pca"]["variance"].read().to_numpy()
+        assert np.array_equal(got_pca_variance, original.uns["pca"]["variance"])
 
 
 def test_add_matrix_to_collection(adata):


### PR DESCRIPTION
This ingests `uns` data into a similar structure to what v0.1.x does: a nested collection of groups, TileDB objects, and metadata.

- Scalar values are ingested as metadata entries.
- Pandas dataframes are ingested as SOMA dataframes, using the same logic as non-uns dataframes.
- Numpy ndarrays are ingested as SOMA dense ndarrays.