### PR TITLE
[r][python] DenseNDArray R-Python roundtrip testing

### DIFF
--- a/apis/system/tests/test_densendarray_write_python_read_r.py
+++ b/apis/system/tests/test_densendarray_write_python_read_r.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+import tiledbsoma as soma
+
+from .common import TestWritePythonReadR
+
+
+class TestDenseNDArrayWritePythonReadR(TestWritePythonReadR):
+    """
+    Tests that a SOMADenseNDArray can be written by Python and read by R.
+    """
+
+    @pytest.fixture(scope="class")
+    def dense_nd_array(self):
+        arr = soma.DenseNDArray.create(self.uri, type=pa.int32(), shape=(2, 3, 4))
+        ndarray = np.random.default_rng().integers(0, 10, 24).reshape(2, 3, 4)
+        data = pa.Tensor.from_numpy(ndarray)
+        arr.write((slice(None),), data)
+        return ndarray
+
+    def base_R_script(self):
+        return f"""
+        library("tiledbsoma")
+        soma_ndarray <- SOMADenseNDArrayOpen("{self.uri}")
+        table = soma_ndarray$read_arrow_table()
+        df = as.data.frame(table)
+        """
+
+    def test_ndarray_shape_matches(self, dense_nd_array):
+        """
+        The source ndarray is a 2x3x4 tensor, so the resulting soma_ndarray should have 3 dimensions.
+        """
+        self.r_assert("stopifnot(length(soma_ndarray$dimensions()) == 3)")
+
+    def test_ndarray_type_matches(self, dense_nd_array):
+        """
+        The DenseNDArray should have a type of int32.
+        """
+        self.r_assert('stopifnot(table$soma_data$type$ToString() == "int32")')
+
+    def test_ndarray_content_matches(self, dense_nd_array):
+        """
+        The DenseNDArray content should match. To test this, we convert the DenseNDArray into an arrow.Table and
+        to a data.frame, and we use the coordinates to match the values.
+        """
+        multi_assert = ""
+        for x, y, z in np.ndindex((2, 3, 4)):
+            val = dense_nd_array[x, y, z]
+            multi_assert += f"stopifnot(df[which(df$soma_dim_0 == {x} & df$soma_dim_1 == {y} & df$soma_dim_2 == {z}),]$soma_data == {val})"
+            multi_assert += "\n"
+        self.r_assert(multi_assert)

--- a/apis/system/tests/test_densendarray_write_r_read_python.py
+++ b/apis/system/tests/test_densendarray_write_r_read_python.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+import tiledbsoma as soma
+
+from .common import TestReadPythonWriteR
+
+
+class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
+    @pytest.fixture(scope="class")
+    def R_ndarray(self):
+        base_script = f"""
+        library("tiledbsoma")
+        library("arrow")
+
+        sndarray <- SOMADenseNDArrayCreate("{self.uri}", int32(), c(2,3))
+        mat <- matrix(c(1,2,3,4,5,6), nrow=3, ncol=2)
+        sndarray$write(mat)
+        """
+        self.execute_R_script(base_script)
+
+    def test_ndarray_shape_matches(self, R_ndarray):
+        """
+        The source ndarray is a 3x2 matrix, so the resulting soma_ndarray should have 2 dimensions.
+        """
+        with soma.open(self.uri) as sdf:
+            ndarr = sdf.read()
+            assert ndarr.shape == (3, 2)
+
+    def test_ndarray_type_matches(self, R_ndarray):
+        """
+        The DenseNDArray should have a type of int32.
+        """
+        with soma.open(self.uri) as sdf:
+            ndarr = sdf.read()
+            assert ndarr.type == "int32"
+
+    def test_ndarray_content_matches(self, R_ndarray):
+        """
+        The DenseNDArray content should match.
+        """
+        with soma.open(self.uri) as sdf:
+            arr = sdf.read().concat().to_numpy()
+            np.array_equal(arr[0], np.asarray([1, 2, 3]))
+            np.array_equal(arr[1], np.asarray([4, 5, 6]))

--- a/apis/system/tests/test_densendarray_write_r_read_python.py
+++ b/apis/system/tests/test_densendarray_write_r_read_python.py
@@ -7,6 +7,10 @@ from .common import TestReadPythonWriteR
 
 
 class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
+    """
+    Tests that a SOMADenseNDArray can be written by R and read by Python.
+    """
+
     @pytest.fixture(scope="class")
     def R_ndarray(self):
         base_script = f"""

--- a/apis/system/tests/test_densendarray_write_r_read_python.py
+++ b/apis/system/tests/test_densendarray_write_r_read_python.py
@@ -13,7 +13,7 @@ class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
         library("tiledbsoma")
         library("arrow")
 
-        sndarray <- SOMADenseNDArrayCreate("{self.uri}", int32(), c(2,3))
+        sndarray <- SOMADenseNDArrayCreate("{self.uri}", int32(), c(3, 2))
         mat <- matrix(c(1,2,3,4,5,6), nrow=3, ncol=2)
         sndarray$write(mat)
         """
@@ -25,7 +25,7 @@ class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
         """
         with soma.open(self.uri) as sdf:
             ndarr = sdf.read()
-            assert ndarr.shape == (2, 3)
+            assert ndarr.shape == (3, 2)
 
     def test_ndarray_type_matches(self, R_ndarray):
         """
@@ -41,5 +41,6 @@ class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
         """
         with soma.open(self.uri) as sdf:
             arr = sdf.read().concat().to_numpy()
-            np.array_equal(arr[0], np.asarray([1, 2, 3]))
-            np.array_equal(arr[1], np.asarray([4, 5, 6]))
+            np.array_equal(arr[0], np.asarray([1, 2]))
+            np.array_equal(arr[1], np.asarray([3, 4]))
+            np.array_equal(arr[2], np.asarray([5, 6]))

--- a/apis/system/tests/test_densendarray_write_r_read_python.py
+++ b/apis/system/tests/test_densendarray_write_r_read_python.py
@@ -25,7 +25,7 @@ class TestDenseNDArrayWriteRReadPython(TestReadPythonWriteR):
         """
         with soma.open(self.uri) as sdf:
             ndarr = sdf.read()
-            assert ndarr.shape == (3, 2)
+            assert ndarr.shape == (2, 3)
 
     def test_ndarray_type_matches(self, R_ndarray):
         """


### PR DESCRIPTION
**Issue and/or context:**
https://github.com/single-cell-data/TileDB-SOMA/issues/435

**Changes:**
- Add a pair of tests for DenseNDArray

**Notes for Reviewer:**
- The Python->R testing creates a 3-dimensional array (for generality)
- The R->Python testing creates a 2-dimensional array (right now, it looks like that's the only way you can create a DenseNDArray in R)

