### PR TITLE
[c++] Install cmake Target and Config for libtiledbsoma

### DIFF
--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -37,6 +37,8 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
+set(TILEDBSOMA_CMAKE_INPUTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/inputs")
+
 # TileDB-SOMA Options
 option(TILEDBSOMA_BUILD_PYTHON "Build Python API bindings" ON)
 option(TILEDBSOMA_BUILD_CLI "Build tiledbsoma CLI tool" ON)
@@ -243,12 +245,3 @@ if(TILEDBSOMA_ENABLE_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()
-
-# PKG Config file
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/inputs/tiledbsoma.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/tiledbsoma.pc
-  @ONLY
-)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tiledbsoma.pc
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/libtiledbsoma/cmake/inputs/Config.cmake.in
+++ b/libtiledbsoma/cmake/inputs/Config.cmake.in
@@ -1,0 +1,27 @@
+#
+# This file attempts to locate the TileDBSoma library. If found, the following
+# imported targets are created:
+#   - TileDBSOMA::tiledbsoma
+#   - TileDBSOMA::tiledbsoma_static
+# And the following variables are defined:
+#   - TILEDBSOMA_FOUND
+#   - TileDBSOMA_FOUND
+#
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")
+
+# Targets required for linking against tiledbsoma_static:
+@TILEDBSOMA_STATIC_DEP_STRING@
+# -- End required targets for static
+
+# Define a convenience all-caps variable
+if (NOT DEFINED TILEDBSOMA_FOUND)
+  if (TARGET TileDBSOMA::tiledbsoma)
+    set(TILEDBSOMA_FOUND TRUE)
+  else()
+    set(TILEDBSOMA_FOUND FALSE)
+  endif()
+endif()

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -234,20 +234,55 @@ if(TILEDBSOMA_BUILD_CLI)
     ${TILEDB_SOMA_EXPORT_HEADER_DIR}
     ${pybind11_INCLUDE_DIRS}
   )
-
-  set_target_properties(tiledbsoma-cli PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 endif()
 
 # ###########################################################
 # Installation
 # ###########################################################
+# Get library directory for multiarch linux distros
 include(GNUInstallDirs)
+
+# Include module with function 'configure_package_config_file'
+include(CMakePackageConfigHelpers)
 
 # Set directory where TileDBConfig.cmake will be installed
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/tiledbsoma")
 
 # Set name for export target file (will be installed to CONFIG_INSTALL_DIR)
 set(TARGETS_EXPORT_NAME "TileDBSomaTargets")
+
+# Path to generated cmake file
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/TileDBSomaConfig.cmake")
+
+# Generate 'TileDBConfig.cmake'
+# This process requires these variables to be defined at this point:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+#   * TILEDB_STATIC_DEP_STRING
+configure_package_config_file(
+  "${TILEDBSOMA_CMAKE_INPUTS_DIR}/Config.cmake.in"
+  "${PROJECT_CONFIG}"
+  INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+# Install config file to <prefix>/lib/cmake/tiledbsoma/TileDBSomaConfig.cmake
+install(
+  FILES "${PROJECT_CONFIG}"
+  DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+
+# Set rpath so the TileDB-SOMA dynamic dependencies can be located.
+if (NOT WIN32 AND NOT TILEDBSOMA_BUILD_STATIC)
+  set_target_properties(tiledbsoma
+    PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+  )
+endif()
+
+if(TILEDBSOMA_BUILD_CLI)
+  set_target_properties(tiledbsoma-cli PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+endif()
 
 install(
   TARGETS ${TILEDBSOMA_INSTALL_TARGETS}
@@ -258,3 +293,19 @@ install(
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tiledbsoma
 )
+
+# Install targets file to <prefix>/lib/cmake/tiledbsoma/TileDBSOMATargets.cmake
+install(
+  EXPORT "${TARGETS_EXPORT_NAME}"
+  NAMESPACE "${PROJECT_NAME}::"
+  DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+# PKG Config file
+configure_file(
+  "${TILEDBSOMA_CMAKE_INPUTS_DIR}/tiledbsoma.pc.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/tiledbsoma.pc
+  @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tiledbsoma.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
This setups installation of the cmake targets and config for libtiledbsoma. This allows other cmake packages to correctly detect and inhert the build targets for libtiledbsoma.