### PR TITLE
[r] Clarify status of DenseNDArray writes and matrices

### DIFF
--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -15,7 +15,10 @@
 #' more dimensions.
 #'
 #' The default "fill" value for `SOMADenseNDArray` is the zero or null value of
-#' the array type (e.g., Arrow.float32 defaults to 0.0).  (lifecycle: experimental)
+#' the array type (e.g., Arrow.float32 defaults to 0.0).
+#'
+#' The `write` method is currently limited to writing from 2-d matrices.
+#' (lifecycle: experimental)
 #' @export
 
 SOMADenseNDArray <- R6::R6Class(
@@ -183,6 +186,8 @@ SOMADenseNDArray <- R6::R6Class(
     },
 
     #' @description Write matrix data to the array. (lifecycle: experimental)
+    #'
+    #' More general write methods for higher-dimensional array could be added.
     #'
     #' @param values A `matrix`. Character dimension names are ignored because
     #' `SOMANDArray`'s use integer indexing.

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -19,7 +19,10 @@ All dimensions must have a positive, non-zero length, and there must be 1 or
 more dimensions.
 
 The default "fill" value for \code{SOMADenseNDArray} is the zero or null value of
-the array type (e.g., Arrow.float32 defaults to 0.0).  (lifecycle: experimental)
+the array type (e.g., Arrow.float32 defaults to 0.0).
+
+The \code{write} method is currently limited to writing from 2-d matrices.
+(lifecycle: experimental)
 }
 \section{Super classes}{
 \code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMADenseNDArray}
@@ -159,6 +162,8 @@ A \code{matrix} object
 \if{latex}{\out{\hypertarget{method-SOMADenseNDArray-write}{}}}
 \subsection{Method \code{write()}}{
 Write matrix data to the array. (lifecycle: experimental)
+
+More general write methods for higher-dimensional array could be added.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMADenseNDArray$write(values, coords = NULL)}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
**Issue and/or context:**

The `write` member class is currently limited to matrices; reads can take more dimensions.  This can be extended as needed.

**Changes:**

Documentation has been updated in the R file, and the generated Rd file.

**Notes for Reviewer:**

Mostly following earlier Slack discussion
[SC 26798](https://app.shortcut.com/tiledb-inc/story/26798/clarify-densendarray-writes-limited-to-matrices)
