### PR TITLE
[python] Depend on somacore 1.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs==1.5.3.230214"
-        - "somacore==1.0.0"
+        - "somacore==1.0.1"
         - "types-setuptools==67.4.0.3"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -262,7 +262,7 @@ setuptools.setup(
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",
         "scipy",
-        "somacore==1.0.0",
+        "somacore==1.0.1",
         "tiledb==0.21.*",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],


### PR DESCRIPTION
**Issue and/or context:** #1089

**Changes:** The sole change on `somacore` 1.0.1 is more lifecycle-experimental tags for things imported into `tiledbsoma`.