### PR TITLE
[r] Also show osVersion when displaying package versions

### DIFF
--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -26,11 +26,13 @@ map_query_layout <- function(layout) {
 #' @export
 #' @importFrom utils packageVersion
 show_package_versions <- function() {
-    cat("tiledbsoma:    ", toString(utils::packageVersion("tiledbsoma")), "\n")
-    cat("tiledb-r:      ", toString(utils::packageVersion("tiledb")), "\n")
-    cat("tiledb core:   ", as.character(tiledb::tiledb_version(compact=TRUE)), "\n")
-    cat("libtiledbsoma: ", libtiledbsoma_version(), "\n")
-    cat("R:             ", R.version.string, "\n")
+    cat("tiledbsoma:    ", toString(utils::packageVersion("tiledbsoma")), "\n",
+        "tiledb-r:      ", toString(utils::packageVersion("tiledb")), "\n",
+        "tiledb core:   ", as.character(tiledb::tiledb_version(compact=TRUE)), "\n",
+        "libtiledbsoma: ", libtiledbsoma_version(), "\n",
+        "R:             ", R.version.string, "\n",
+        "OS:            ", utils::osVersion, "\n",
+        sep="")
 }
 
 #' @rdname tiledbsoma_stats_enable


### PR DESCRIPTION
**Issue and/or context:**

Small 'quality of life' improvement also showing OS version

**Changes:**

Adds a line to the helper function:

```r
> tiledbsoma::show_package_versions()
tiledbsoma:    0.0.0.9014
tiledb-r:      0.19.0.1
tiledb core:   2.16.0
libtiledbsoma: libtiledbsoma=d5492c54-modified;libtiledb=2.16.0
R:             R version 4.2.3 (2023-03-15)
OS:            Ubuntu 22.10
> 
```

**Notes for Reviewer:**

closes #1148
[SC 26873](https://app.shortcut.com/tiledb-inc/story/26873/also-show-utils-osversion-when-showing)
