### PR TITLE
[R] Fix `to_seurat()` cell-level meta data

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9014
+Version: 0.0.0.9015
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -254,9 +254,9 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       )
       if (!(isFALSE(obs_column_names) || rlang::is_na(obs_column_names))) {
         obs <- as.data.frame(
-          x = self$obs(obs_column_names)$to_data_frame(),
-          row.names = cells
+          x = self$obs(obs_column_names)$to_data_frame()
         )
+        row.names(obs) <- cells
         object[[names(obs)]] <- obs
       }
       # Load in reductions


### PR DESCRIPTION
Set cell names in cell-level meta data with `row.names<-` instead of `as.data.frame()`; addresses issue where returned cell-level meta data had `NAs` instead of actual values
```R
> expt <- tiledbsoma::SOMAExperimentOpen(
    "s3://cellxgene-data-public/cell-census/2023-03-16/soma/census_data/mus_musculus",
    tiledbsoma_ctx = tiledbsoma::SOMATileDBContext$new(c("vfs.s3.region" = "us-west-2"))
  )
> obs_query <- tiledbsoma::SOMAAxisQuery$new(
    value_filter = "tissue_general == 'vasculature'"
  )
> var_query <- tiledbsoma::SOMAAxisQuery$new(
    value_filter = "feature_name %in% c('Gm53058', '0610010K14Rik')"
  )
> expt_query <- tiledbsoma::SOMAExperimentAxisQuery$new(
    expt, "RNA",
    obs_query = obs_query,
    var_query = var_query
  )
> seurat <- expt_query$to_seurat(
    c(counts = "raw"),
    obs_column_names = c("soma_joinid", "cell_type", "tissue", "tissue_general", "assay"),
    var_column_names = c("soma_joinid", "feature_id", "feature_name", "feature_length")
  )
> head(seurat)
               orig.ident nCount_RNA nFeature_RNA
cell2373686 SeuratProject        266            1
cell2373687 SeuratProject          0            0
cell2373688 SeuratProject          0            0
cell2373689 SeuratProject        200            1
cell2373690 SeuratProject         88            1
cell2373691 SeuratProject          0            0
cell2373692 SeuratProject          0            0
cell2373693 SeuratProject        122            1
cell2373694 SeuratProject          0            0
cell2373695 SeuratProject          0            0
            soma_joinid
cell2373686     2373686
cell2373687     2373687
cell2373688     2373688
cell2373689     2373689
cell2373690     2373690
cell2373691     2373691
cell2373692     2373692
cell2373693     2373693
cell2373694     2373694
cell2373695     2373695
                                       cell_type
cell2373686         fibroblast of cardiac tissue
cell2373687              aortic endothelial cell
cell2373688              aortic endothelial cell
cell2373689              aortic endothelial cell
cell2373690         fibroblast of cardiac tissue
cell2373691              aortic endothelial cell
cell2373692         fibroblast of cardiac tissue
cell2373693         fibroblast of cardiac tissue
cell2373694         fibroblast of cardiac tissue
cell2373695 professional antigen presenting cell
            tissue tissue_general      assay
cell2373686  aorta    vasculature Smart-seq2
cell2373687  aorta    vasculature Smart-seq2
cell2373688  aorta    vasculature Smart-seq2
cell2373689  aorta    vasculature Smart-seq2
cell2373690  aorta    vasculature Smart-seq2
cell2373691  aorta    vasculature Smart-seq2
cell2373692  aorta    vasculature Smart-seq2
cell2373693  aorta    vasculature Smart-seq2
cell2373694  aorta    vasculature Smart-seq2
cell2373695  aorta    vasculature Smart-seq2
```
fixes #1170