### PR TITLE
[python] Don't use `distro` in `show_package_versions`

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -249,7 +249,6 @@ setuptools.setup(
     install_requires=[
         "anndata",
         "attrs>=22.2",
-        "distro",
         # Pinning numba & its particular numpy constraints:
         # The old pip solver (<=2020) doesn't deal with the transitive
         # requirements (scanpy -> numba -> numpy) properly resulting in broken

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -6,9 +6,9 @@
 """General utility functions.
 """
 
+import os
 import sys
 
-import distro
 import tiledb
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -64,4 +64,5 @@ def show_package_versions() -> None:
     )
     print("libtiledbsoma version()      ", libtiledbsoma_version())
     print("python version               ", ".".join(str(v) for v in sys.version_info))
-    print("OS version                   ", distro.name(), distro.version())
+    u = os.uname()
+    print("OS version                   ", u.sysname, u.release)


### PR DESCRIPTION
Conda issue: https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/9#issuecomment-1486852905

Reverts https://github.com/single-cell-data/TileDB-SOMA/pull/1177/commits/70cce388ae5dd81d5d371b265e5c5f4573569c45