### PR TITLE
Add `--tiledb` Argument For `setup.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build ?= Release
 .PHONY: install
 install: clean
 	@./scripts/bld --prefix=${prefix} --tiledb=${tiledb} --build=${build}
-	@pip install -v -e apis/python
+	@cd apis/python && python setup.py install --tiledb=${tiledb}
 
 .PHONY: r-build
 r-build: clean

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -48,6 +48,9 @@ for arg in args:
     if (start, eq) == ("--libtiledbsoma", "="):
         libtiledbsoma_dir = pathlib.Path(last)
         sys.argv.remove(arg)
+    if arg.find("--tiledb") == 0:
+        tiledb_dir = pathlib.Path(arg.split("=")[1])
+        sys.argv.remove(arg)
 
 if libtiledbsoma_dir is None:
     scripts_dir = this_dir / "dist_links" / "scripts"
@@ -179,13 +182,16 @@ INC_DIRS = [
         "./src/tiledbsoma"
     ),  # since pytiledbsoma.cc does #include of query_condition.cc
     str(libtiledbsoma_dir.parent / "build/externals/install/include"),
+    str(tiledb_dir / "include"),
 ]
 
 LIB_DIRS = [
     str(libtiledbsoma_dir / "lib"),
+    str(tiledb_dir / "lib"),
 ]
 CXX_FLAGS = [
     f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib")}',
+    f'-Wl,-rpath,{str(tiledb_dir / "lib")}',
 ]
 if sys.platform == "darwin":
     CXX_FLAGS.append("-mmacosx-version-min=10.14")
@@ -193,10 +199,16 @@ if sys.platform == "darwin":
 if os.name == "posix" and sys.platform != "darwin":
     LIB_DIRS.append(str(libtiledbsoma_dir / "lib" / "x86_64-linux-gnu"))
     LIB_DIRS.append(str(libtiledbsoma_dir / "lib64"))
+    LIB_DIRS.append(str(tiledb_dir / "lib" / "x86_64-linux-gnu"))
+    LIB_DIRS.append(str(tiledb_dir / "lib64"))
     CXX_FLAGS.append(
         f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib" / "x86_64-linux-gnu")}'
     )
     CXX_FLAGS.append(f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib64")}')
+    CXX_FLAGS.append(
+        f'-Wl,-rpath,{str(tiledb_dir / "lib" / "x86_64-linux-gnu")}'
+    )
+    CXX_FLAGS.append(f'-Wl,-rpath,{str(tiledb_dir / "lib64")}')
 
 # ----------------------------------------------------------------
 # Don't use `if __name__ == "__main__":` as the `python_requires` must

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -41,6 +41,7 @@ sys.path.insert(0, str(this_dir))
 import version  # noqa E402
 
 libtiledbsoma_dir: Optional[pathlib.Path] = None
+tiledb_dir: Optional[pathlib.Path] = None
 
 args = sys.argv[:]
 for arg in args:
@@ -62,6 +63,8 @@ if libtiledbsoma_dir is None:
         # in extracted sdist, with libtiledbsoma copied into dist_links/
         libtiledbsoma_dir = this_dir / "dist_links" / "dist"
 
+if tiledb_dir is None:
+    tiledb_dir = this_dir
 
 def get_libtiledbsoma_library_name():
     """

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -66,6 +66,7 @@ if libtiledbsoma_dir is None:
 if tiledb_dir is None:
     tiledb_dir = this_dir
 
+
 def get_libtiledbsoma_library_name():
     """
     :return: List of TileDB shared library names.
@@ -208,9 +209,7 @@ if os.name == "posix" and sys.platform != "darwin":
         f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib" / "x86_64-linux-gnu")}'
     )
     CXX_FLAGS.append(f'-Wl,-rpath,{str(libtiledbsoma_dir / "lib64")}')
-    CXX_FLAGS.append(
-        f'-Wl,-rpath,{str(tiledb_dir / "lib" / "x86_64-linux-gnu")}'
-    )
+    CXX_FLAGS.append(f'-Wl,-rpath,{str(tiledb_dir / "lib" / "x86_64-linux-gnu")}')
     CXX_FLAGS.append(f'-Wl,-rpath,{str(tiledb_dir / "lib64")}')
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
**Issue and/or context:**

`setup.py` could not find TileDB headers and libraries if installed in custom location.

**Changes:**

Add `--tiledb` argument to `setup.py`, so it can be added to include and lib paths when building Pybind11 bindings.

