### PR TITLE
[r] Fix query performance [WIP / not ready for review / please do not review]

### DIFF
--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -94,7 +94,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @return An [`arrow::Table`].
     read_arrow_table = function(
       coords = NULL,
-      result_order = "ROW_MAJOR",
+      result_order = "auto",
       iterated = FALSE,
       log_level = "warn"
     ) {

--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -7,7 +7,7 @@ tiledb_zstd_filter <- function(level = 3L) {
 }
 
 match_query_layout <- function(layout) {
-  layouts <- c("ROW_MAJOR", "COL_MAJOR", "GLOBAL_ORDER", "UNORDERED")
+  layouts <- c("ROW_MAJOR", "COL_MAJOR", "GLOBAL_ORDER", "UNORDERED", "auto") # "auto" is used by libtiledbsoma
   match.arg(layout, choices = layouts, several.ok = FALSE)
 }
 


### PR DESCRIPTION
Some queries which specify both obs and var filters, even on small data, are found to be slower in tiledbsoma-r than tiledbsoma-py. Debugging through core reveals that the core strategy selector was choosing the legacy reader for X queries as initiated by tiledbsoma-r, vs choosing the sparse global-order reader as initiated by tiledbsoma-py. This in turn was caused by selection of row-major layout for the query; we should be using auto.