### PR TITLE
[r] Update result_order docs and defaults

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9015
+Version: 0.0.0.9016
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -29,7 +29,7 @@
 #' }
 #' @export
 soma_array_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto", config = NULL) {
-    .Call(`_tiledbsoma_soma_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config)
+    .Call(`_tiledbsoma_soma_array_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config)
 }
 
 #' @noRd

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -160,7 +160,7 @@ SOMADataFrame <- R6::R6Class(
     read = function(coords = NULL,
                     column_names = NULL,
                     value_filter = NULL,
-                    result_order = "UNORDERED",
+                    result_order = "auto",
                     iterated = FALSE,
                     log_level = "warn") {
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -152,8 +152,7 @@ SOMADataFrame <- R6::R6Class(
     #' @param value_filter Optional string containing a logical expression that is used
     #' to filter the returned values. See [`tiledb::parse_query_condition`] for
     #' more information.
-    #' @param result_order Optional order of read results. This can be one of either
-    #' `"ROW_MAJOR, `"COL_MAJOR"`, `"GLOBAL_ORDER"`, or `"UNORDERED"`.
+    #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
     #' @param log_level Optional logging level with default value of `"warn"`.

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -95,7 +95,7 @@ SOMADenseNDArray <- R6::R6Class(
     #' @return An [`arrow::Table`].
     read_arrow_table = function(
       coords = NULL,
-      result_order = "ROW_MAJOR",
+      result_order = "auto",
       iterated = FALSE,
       log_level = "warn"
     ) {

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -88,8 +88,7 @@ SOMADenseNDArray <- R6::R6Class(
     #' @param coords Optional `list` of integer vectors, one for each dimension, with a
     #' length equal to the number of values to read. If `NULL`, all values are
     #' read. List elements can be named when specifying a subset of dimensions.
-    #' @param result_order Optional order of read results. This can be one of either
-    #' `"ROW_MAJOR, `"COL_MAJOR"`, `"GLOBAL_ORDER"`, or `"UNORDERED"`.
+    #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
     #' @param log_level Optional logging level with default value of `"warn"`.
@@ -147,8 +146,7 @@ SOMADenseNDArray <- R6::R6Class(
     #' @param coords Optional `list` of integer vectors, one for each dimension, with a
     #' length equal to the number of values to read. If `NULL`, all values are
     #' read. List elements can be named when specifying a subset of dimensions.
-    #' @param result_order Optional order of read results. This can be one of either
-    #' `"ROW_MAJOR, `"COL_MAJOR"`, `"GLOBAL_ORDER"`, or `"UNORDERED"`.
+    #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
     #' @param log_level Optional logging level with default value of `"warn"`.

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -86,8 +86,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param coords Optional `list` of integer vectors, one for each dimension, with a
     #' length equal to the number of values to read. If `NULL`, all values are
     #' read. List elements can be named when specifying a subset of dimensions.
-    #' @param result_order Optional order of read results. This can be one of either
-    #' `"ROW_MAJOR, `"COL_MAJOR"`, `"GLOBAL_ORDER"`, or `"UNORDERED"`.
+    #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
     #' @param log_level Optional logging level with default value of `"warn"`.
@@ -144,8 +143,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param coords Optional `list` of integer vectors, one for each dimension, with a
     #' length equal to the number of values to read. If `NULL`, all values are
     #' read. List elements can be named when specifying a subset of dimensions.
-    #' @param result_order Optional order of read results. This can be one of either
-    #' `"ROW_MAJOR, `"COL_MAJOR"`, `"GLOBAL_ORDER"`, or `"UNORDERED"`.
+    #' @template param-result-order
     #' @param repr Optional one-character code for sparse matrix representation type
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -151,7 +151,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @return A `matrix` object
     read_sparse_matrix = function(
       coords = NULL,
-      result_order = "ROW_MAJOR",
+      result_order = "auto",
       repr = c("C", "T", "R"),
       iterated = FALSE,
       log_level = "warn"

--- a/apis/r/man/ConfigList.Rd
+++ b/apis/r/man/ConfigList.Rd
@@ -10,7 +10,7 @@ Essentially, serves as a nested map where the inner map is a
 \code{\{<param>: \link[tiledbsoma:ScalarMap]{\{<key>: <value>\}}\}}
 }
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ConfigList}
+\code{tiledbsoma::MappingBase} -> \code{ConfigList}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/PlatformConfig.Rd
+++ b/apis/r/man/PlatformConfig.Rd
@@ -11,7 +11,7 @@ map is a \code{\link{ScalarMap}} contained within a \code{\link{ConfigList}}
 \code{\{platform: \{param: \{key: value\}\}\}}
 }
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{PlatformConfig}
+\code{tiledbsoma::MappingBase} -> \code{PlatformConfig}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -12,7 +12,7 @@ SOMA Array Base Class
 Adds SOMA-specific functionality to the \code{\link{TileDBArray}} class.  (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{SOMAArrayBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{SOMAArrayBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -10,7 +10,7 @@ and the values are any SOMA-defined foundational or composed type, including
 or \code{SOMAExperiment}.  (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMACollection}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMACollection}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -11,7 +11,7 @@ Base class for objects containing persistent collection of SOMA
 objects, mapping string keys to any SOMA object.  (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{SOMACollectionBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{SOMACollectionBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAContextBase.Rd
+++ b/apis/r/man/SOMAContextBase.Rd
@@ -10,7 +10,7 @@ context options
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{SOMAContextBase}
+\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{SOMAContextBase}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -10,7 +10,7 @@ row and is intended to act as a join key for other objects, such as
 \code{\link{SOMASparseNDArray}}.  (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMADataFrame}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMADataFrame}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -103,7 +103,7 @@ column, and optionally filtered.
   coords = NULL,
   column_names = NULL,
   value_filter = NULL,
-  result_order = "UNORDERED",
+  result_order = "auto",
   iterated = FALSE,
   log_level = "warn"
 )}\if{html}{\out{</div>}}
@@ -122,7 +122,7 @@ to filter the returned values. See \code{\link[tiledb:parse_query_condition]{til
 more information.}
 
 \item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -25,7 +25,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMADenseNDArray}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMADenseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -95,7 +95,7 @@ Read as an 'arrow::Table' (lifecycle: experimental)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMADenseNDArray$read_arrow_table(
   coords = NULL,
-  result_order = "ROW_MAJOR",
+  result_order = "auto",
   iterated = FALSE,
   log_level = "warn"
 )}\if{html}{\out{</div>}}
@@ -109,7 +109,10 @@ length equal to the number of values to read. If \code{NULL}, all values are
 read. List elements can be named when specifying a subset of dimensions.}
 
 \item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
+
+\item{\code{result_order}}{Optional order of read results. This can be one of either
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
@@ -144,7 +147,10 @@ length equal to the number of values to read. If \code{NULL}, all values are
 read. List elements can be named when specifying a subset of dimensions.}
 
 \item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
+
+\item{\code{result_order}}{Optional order of read results. This can be one of either
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -10,7 +10,7 @@ cells (aka a "multimodal dataset") with pre-defined fields: \code{obs} and \code
 (see \emph{Active Bindings} below for details). (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAExperiment}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAExperiment}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAMeasurement.Rd
+++ b/apis/r/man/SOMAMeasurement.Rd
@@ -10,7 +10,7 @@ and is otherwise a specialized \code{\link{SOMACollection}} with pre-defined fie
 details). (lifecycle: experimental)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAMeasurement}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAMeasurement}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -23,7 +23,7 @@ the object are overwritten and new index values are added. (lifecycle: experimen
 }
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMASparseNDArray}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMASparseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -93,7 +93,7 @@ Read as an 'arrow::Table' (lifecycle: experimental)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$read_arrow_table(
   coords = NULL,
-  result_order = "ROW_MAJOR",
+  result_order = "auto",
   iterated = FALSE,
   log_level = "warn"
 )}\if{html}{\out{</div>}}
@@ -107,7 +107,10 @@ length equal to the number of values to read. If \code{NULL}, all values are
 read. List elements can be named when specifying a subset of dimensions.}
 
 \item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
+
+\item{\code{result_order}}{Optional order of read results. This can be one of either
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
@@ -128,7 +131,7 @@ Read as a sparse matrix (lifecycle: experimental)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$read_sparse_matrix(
   coords = NULL,
-  result_order = "ROW_MAJOR",
+  result_order = "auto",
   repr = c("C", "T", "R"),
   iterated = FALSE,
   log_level = "warn"
@@ -143,7 +146,10 @@ length equal to the number of values to read. If \code{NULL}, all values are
 read. List elements can be named when specifying a subset of dimensions.}
 
 \item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, }"GLOBAL_ORDER"\verb{, or }"UNORDERED"`.}
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
+
+\item{\code{result_order}}{Optional order of read results. This can be one of either
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
 \item{\code{repr}}{Optional one-character code for sparse matrix representation type}
 

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -7,7 +7,7 @@
 Context map for TileDB-backed SOMA objects
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{\link[tiledbsoma:SOMAContextBase]{tiledbsoma::SOMAContextBase}} -> \code{SOMATileDBContext}
+\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{tiledbsoma::SOMAContextBase} -> \code{SOMATileDBContext}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/ScalarMap.Rd
+++ b/apis/r/man/ScalarMap.Rd
@@ -9,7 +9,7 @@ optionally be limited further to a specific atomic vector type
 (eg. \dQuote{\code{logical}})
 }
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ScalarMap}
+\code{tiledbsoma::MappingBase} -> \code{ScalarMap}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/TileDBArray.Rd
+++ b/apis/r/man/TileDBArray.Rd
@@ -8,7 +8,7 @@ Base class for representing an individual TileDB array.
 (lifecycle: experimental)
 }
 \section{Super class}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBArray}
+\code{tiledbsoma::TileDBObject} -> \code{TileDBArray}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TileDBGroup.Rd
+++ b/apis/r/man/TileDBGroup.Rd
@@ -10,7 +10,7 @@ A \code{TileDBArray} or \code{TileDBGroup}.
 Base class for interacting with TileDB groups (lifecycle: experimental)
 }
 \section{Super class}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBGroup}
+\code{tiledbsoma::TileDBObject} -> \code{TileDBGroup}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/roxygen/templates/param-result-order.R
+++ b/apis/r/man/roxygen/templates/param-result-order.R
@@ -1,0 +1,2 @@
+#' @param result_order Optional order of read results. This can be one of either
+#' `"ROW_MAJOR, `"COL_MAJOR"`, or `"auto"` (default).

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -13,7 +13,7 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 
 // soma_array_reader
 Rcpp::List soma_array_reader(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, const std::string& loglevel, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_soma_reader(SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP, SEXP configSEXP) {
+RcppExport SEXP _tiledbsoma_soma_array_reader(SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP, SEXP configSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -196,7 +196,7 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_tiledbsoma_soma_reader", (DL_FUNC) &_tiledbsoma_soma_reader, 9},
+    {"_tiledbsoma_soma_array_reader", (DL_FUNC) &_tiledbsoma_soma_array_reader, 9},
     {"_tiledbsoma_set_log_level", (DL_FUNC) &_tiledbsoma_set_log_level, 1},
     {"_tiledbsoma_get_column_types", (DL_FUNC) &_tiledbsoma_get_column_types, 2},
     {"_tiledbsoma_nnz", (DL_FUNC) &_tiledbsoma_nnz, 2},


### PR DESCRIPTION
**Issue and/or context:** #1195

**Changes:** A follow-up to #1195 that updates the documentation for `result_order` to remove invalid options: global_order and unordered. I've also set the result_order default to "auto" for all reader functions.

**Notes for Reviewer:** GitHub Actions is currently suffering an outage so no CI atm. However, I did validate this locally and confirmed it addresses the minor issue introduced in #1195.

