### PR TITLE
[r] Provide `context()` accessor

### DIFF
--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -67,7 +67,7 @@ SOMAArrayBase <- R6::R6Class(
     soma_reader_setup = function() {
       private$soma_reader_pointer <- sr_setup(
         self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       )
     },
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -198,7 +198,7 @@ SOMADataFrame <- R6::R6Class(
                             dim_points = coords,       # idem
                             loglevel = log_level,      # idem
                             config = as.character(tiledb::config(
-                              self$tiledbsoma_ctx$get_tiledb_context()
+                              self$tiledbsoma_ctx$context()
                             )))
           private$soma_reader_transform(rl)
       } else {

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -128,7 +128,7 @@ SOMADenseNDArray <- R6::R6Class(
                                   result_order = result_order,
                                   loglevel = log_level,       # idem
                                   config = as.character(tiledb::config(
-                                      self$tiledbsoma_ctx$get_tiledb_context()
+                                      self$tiledbsoma_ctx$context()
                                   )))
           private$soma_reader_transform(rl)
       } else {

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -124,7 +124,7 @@ SOMASparseNDArray <- R6::R6Class(
                                   result_order = result_order,
                                   loglevel = log_level,       # idem
                                   config = as.character(tiledb::config(
-                                      self$tiledbsoma_ctx$get_tiledb_context()
+                                      self$tiledbsoma_ctx$context()
                                   )))
           private$soma_reader_transform(rl)
       } else {

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -206,7 +206,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @description Retrieve number of non-zero elements (lifecycle: experimental)
     #' @return A scalar with the number of non-zero elements
     nnz = function() {
-      nnz(self$uri, config=as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context())))
+      nnz(self$uri, config=as.character(tiledb::config(self$tiledbsoma_ctx$context())))
     }
 
   ),

--- a/apis/r/R/SOMATileDBContext.R
+++ b/apis/r/R/SOMATileDBContext.R
@@ -110,7 +110,7 @@ SOMATileDBContext <- R6::R6Class(
     },
     #' @return A \code{\link[tiledb:tiledb_ctx]{tiledb_ctx}} object, which is
     #' a stored (and long-lived) result from \code{to_tiledb_context}.
-    get_tiledb_context = function() {
+    context = function() {
       return(private$.tiledb_ctx)
     }
   ),

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -26,7 +26,7 @@ TileDBArray <- R6::R6Class(
       args$uri <- self$uri
       args$query_type <- "READ"
       args$query_layout <- "UNORDERED"
-      args$ctx <- self$tiledbsoma_ctx$get_tiledb_context()
+      args$ctx <- self$tiledbsoma_ctx$context()
       do.call(tiledb::tiledb_array, args)
     },
 
@@ -94,7 +94,7 @@ TileDBArray <- R6::R6Class(
     shape = function() {
       as.integer64(shape(
         self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       ))
     },
 
@@ -250,7 +250,7 @@ TileDBArray <- R6::R6Class(
     initialize_object = function() {
       private$tiledb_object <- tiledb::tiledb_array(
         uri = self$uri,
-        ctx = self$tiledbsoma_ctx$get_tiledb_context(),
+        ctx = self$tiledbsoma_ctx$context(),
         query_layout = "UNORDERED"
       )
       self$close()

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -21,7 +21,7 @@ TileDBGroup <- R6::R6Class(
       spdl::info("Creating new {} at '{}'", self$class(), self$uri)
       tiledb::tiledb_group_create(
         uri = self$uri,
-        ctx = self$get_tiledb_config('create')$get_tiledb_context()
+        ctx = self$get_tiledb_config('create')$context()
       )
       self
     },
@@ -194,7 +194,7 @@ TileDBGroup <- R6::R6Class(
     initialize_object = function() {
       private$tiledb_object <- tiledb::tiledb_group(
         self$uri,
-        ctx = self$tiledbsoma_ctx$get_tiledb_context()
+        ctx = self$tiledbsoma_ctx$context()
       )
       self$close()
     },

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -71,7 +71,7 @@ TileDBObject <- R6::R6Class(
       } else {
         stop("Unknown object type", call. = FALSE)
       }
-      tiledb::tiledb_object_type(self$uri, ctx = self$tiledbsoma_ctx$get_tiledb_context()) %in% expected_type
+      tiledb::tiledb_object_type(self$uri, ctx = self$tiledbsoma_ctx$context()) %in% expected_type
     },
     #' @param param Parameter name from \code{self$platform_config} to fetch
     #' @return SOMATileDBContext

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -19,7 +19,7 @@ Context map for TileDB-backed SOMA objects
 \item \href{#method-SOMATileDBContext-get}{\code{SOMATileDBContext$get()}}
 \item \href{#method-SOMATileDBContext-set}{\code{SOMATileDBContext$set()}}
 \item \href{#method-SOMATileDBContext-to_tiledb_context}{\code{SOMATileDBContext$to_tiledb_context()}}
-\item \href{#method-SOMATileDBContext-get_tiledb_context}{\code{SOMATileDBContext$get_tiledb_context()}}
+\item \href{#method-SOMATileDBContext-context}{\code{SOMATileDBContext$context()}}
 \item \href{#method-SOMATileDBContext-clone}{\code{SOMATileDBContext$clone()}}
 }
 }
@@ -152,11 +152,11 @@ constructed. Most useful for the constructor of this class.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-SOMATileDBContext-get_tiledb_context"></a>}}
-\if{latex}{\out{\hypertarget{method-SOMATileDBContext-get_tiledb_context}{}}}
-\subsection{Method \code{get_tiledb_context()}}{
+\if{html}{\out{<a id="method-SOMATileDBContext-context"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMATileDBContext-context}{}}}
+\subsection{Method \code{context()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMATileDBContext$get_tiledb_context()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMATileDBContext$context()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{


### PR DESCRIPTION
**Issue and/or context:**

Per #1011 and the spec, an accessor named `context()` is desired.

**Changes:**

The _existing_ one is renamed in the R code and the generated Rd documentation.  Tests are not affected.

**Notes for Reviewer:**

closes #1011
[SC 27095](https://app.shortcut.com/tiledb-inc/story/27095/r-add-a-context-accessor)
