### PR TITLE
[c++] Fix build on MacOS 13.3

### DIFF
--- a/libtiledbsoma/cmake/Modules/FindCatch_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindCatch_EP.cmake
@@ -1,3 +1,9 @@
+# catch2 has a set-but-unused-variable warning as of MacOS 13.3.
+# So we need to not use -Werror, as that's third-party code out of our control.
+#
+# See also:
+# https://discourse.cmake.org/t/how-to-turn-off-warning-flags-for-project-added-by-fetchcontent-declare/2461
+
 Include(FetchContent)
 
 FetchContent_Declare(
@@ -6,4 +12,23 @@ FetchContent_Declare(
   GIT_TAG        v3.0.1
 )
 
+get_property(
+    compile_options
+    DIRECTORY
+    PROPERTY COMPILE_OPTIONS
+)
+
+set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY COMPILE_OPTIONS -Wno-error=unused-but-set-variable
+)
+
 FetchContent_MakeAvailable(Catch2)
+
+set_property(
+    DIRECTORY
+    PROPERTY COMPILE_OPTIONS ${compile_options}
+)
+
+unset(compile_options)


### PR DESCRIPTION
**Issue and/or context:**

The third-party `catch2` package has

```
/Users/johnkerl/git/single-cell-data/TileDB-SOMA/build/libtiledbsoma/_deps/catch2-src/src/catch2/catch_session.cpp:64:25: warning: variable 'reporterIdx' set but not used [-Wunused-but-set-variable]
            std::size_t reporterIdx = 0;
```

which is not new,  but, newly this errors out in MacOS 13.3 (which yours truly installed just today).

**Changes:**

Since we don't control this third-party library but we do control how we compile it, apply the correct flags.

