### PR TITLE
[c++] Omit no-longer-needed libtiledbsoma commit-hash info from `show_package_versions`

### DIFF
--- a/libtiledbsoma/src/version.cc
+++ b/libtiledbsoma/src/version.cc
@@ -34,19 +34,12 @@
 #include <tiledb/tiledb>
 #include "tiledbsoma/logger_public.h"
 
-#ifdef BUILD_COMMIT_HASH
-#define VERSION BUILD_COMMIT_HASH
-#else
-#define VERSION "dev"
-#endif
-
 namespace tiledbsoma::version {
 
 std::string as_string() {
     int major, minor, patch;
     tiledb_version(&major, &minor, &patch);
-    return fmt::format(
-        "libtiledbsoma={};libtiledb={}.{}.{}", VERSION, major, minor, patch);
+    return fmt::format("libtiledb={}.{}.{}", major, minor, patch);
 }
 
 std::tuple<int, int, int> embedded_version_triple() {


### PR DESCRIPTION
As in #1193. The commit-hash information is (a) not always available; (b) never useful to the end user; (c) completely superseded now that we are (as we have been for some months now) doing tagged releases on `main`.