### PR TITLE
[r] Upcast axis query coords to integer64

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -174,7 +174,7 @@ SOMADataFrame <- R6::R6Class(
               is.null(column_names) || all(column_names %in% c(self$dimnames(), self$attrnames()))
       )
 
-      coords <- validate_read_coords(coords, dimnames = self$dimnames())
+      coords <- validate_read_coords(coords, dimnames = self$dimnames(), int64cast = FALSE)
 
       if (!is.null(value_filter)) {
           value_filter <- validate_read_value_filter(value_filter)

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -168,6 +168,14 @@ SOMADataFrame <- R6::R6Class(
       uri <- self$uri
       arr <- self$object                 # need array (schema) to properly parse query condition
 
+      ## if unnamed set names
+      if (!is.null(coords)) {
+          if (!is.list(coords))
+              coords <- list(coords)
+          if (is.null(names(coords)))
+              names(coords) <- self$dimnames()
+      }
+
       stopifnot(
           ## check columns
           "'column_names' must only contain valid dimension or attribute columns" =

--- a/apis/r/R/SOMADenseNdArray.R
+++ b/apis/r/R/SOMADenseNdArray.R
@@ -124,12 +124,12 @@ SOMADenseNDArray <- R6::R6Class(
 
       if (isFALSE(iterated)) {
           rl <- soma_array_reader(uri = uri,
-                            dim_points = coords,        # NULL is dealt with by soma_array_reader()
-                            result_order = result_order,
-                            loglevel = log_level,       # idem
-                            config = as.character(tiledb::config(
-                              self$tiledbsoma_ctx$get_tiledb_context()
-                            )))
+                                  dim_points = coords,        # NULL is dealt with by soma_array_reader()
+                                  result_order = result_order,
+                                  loglevel = log_level,       # idem
+                                  config = as.character(tiledb::config(
+                                      self$tiledbsoma_ctx$get_tiledb_context()
+                                  )))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -66,7 +66,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     obs = function(column_names = NULL) {
       obs_query <- self$obs_query
       self$obs_df$read(
-        coords = obs_query$coords,
+        coords = recursively_make_integer64(obs_query$coords),
         value_filter = obs_query$value_filter,
         column_names = column_names
       )

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -77,7 +77,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     var = function(column_names = NULL) {
       var_query <- self$var_query
       self$var_df$read(
-        coords = var_query$coords,
+        coords = recursively_make_integer64(var_query$coords),
         value_filter = var_query$value_filter,
         column_names = column_names
       )

--- a/apis/r/R/SOMASparseNdArray.R
+++ b/apis/r/R/SOMASparseNdArray.R
@@ -120,12 +120,12 @@ SOMASparseNDArray <- R6::R6Class(
 
       if (isFALSE(iterated)) {
           rl <- soma_array_reader(uri = uri,
-                            dim_points = coords,        # NULL is dealt with by soma_array_reader()
-                            result_order = result_order,
-                            loglevel = log_level,       # idem
-                            config = as.character(tiledb::config(
-                              self$tiledbsoma_ctx$get_tiledb_context()
-                            )))
+                                  dim_points = coords,        # NULL is dealt with by soma_array_reader()
+                                  result_order = result_order,
+                                  loglevel = log_level,       # idem
+                                  config = as.character(tiledb::config(
+                                      self$tiledbsoma_ctx$get_tiledb_context()
+                                  )))
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?

--- a/apis/r/R/utils-assertions.R
+++ b/apis/r/R/utils-assertions.R
@@ -120,6 +120,9 @@ validate_read_coords <- function(coords, dimnames = NULL) {
         all(names(coords) %in% dimnames)
     )
   }
+
+  coords <- make_integer64_list(coords)
+
   coords
 }
 
@@ -131,4 +134,19 @@ validate_read_value_filter <- function(value_filter) {
       is.null(value_filter) || is_scalar_character(value_filter)
     )
   value_filter
+}
+
+#' Ensure vector is an integer64 vector
+#' @noRd
+make_integer64 <- function(x) {
+  if (!bit64::is.integer64(x))
+    bit64::as.integer64(x)
+  else
+    x
+}
+
+#' Ensure list is list of integer64 vectors
+#' @noRd
+make_integer64_list <- function(lst) {
+  lapply(lst, make_integer64)
 }

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -91,11 +91,11 @@ Rcpp::List soma_array_reader(const std::string& uri,
 
     // Read selected columns from the uri (return is unique_ptr<SOMAArrayReader>)
     auto sr = tdbs::SOMAArrayReader::open(uri,
-                                     "unnamed",                   // name parameter could be added
-                                     platform_config,             // to add, done in iterated reader
-                                     column_names,
-                                     batch_size,
-                                     result_order);
+                                          "unnamed",         // name parameter could be added
+                                          platform_config,   // to add, done in iterated reader
+                                          column_names,
+                                          batch_size,
+                                          result_order);
 
     std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = sr->schema();

--- a/apis/r/tests/testthat/test_SOMADataFrame.R
+++ b/apis/r/tests/testthat/test_SOMADataFrame.R
@@ -74,9 +74,12 @@ test_that("Basic mechanics", {
   rb1 <- arrow::as_record_batch(sdf$read())
   expect_equivalent(dplyr::collect(rb0), dplyr::collect(rb1))
 
-
   # Slicing by foo
   tbl1 <- sdf$read(coords = list(foo = 1L:2L))
+  expect_true(tbl1$Equals(tbl0$Slice(offset = 0, length = 2)))
+
+  # Slicing unnamed also work
+  tbl1 <- sdf$read(coords = 1L:2L)
   expect_true(tbl1$Equals(tbl0$Slice(offset = 0, length = 2)))
 
   # Subselecting columns
@@ -180,6 +183,7 @@ test_that("SOMADataFrame read", {
     sdf <- SOMADataFrame$new(uri, internal_use_only = "allowed_use")
     z <- sdf$read(coords = list(soma_joinid=coords))
     expect_equal(z$num_rows, 10L)
+
 })
 
 test_that("soma_ prefix is reserved", {


### PR DESCRIPTION
**Issue and/or context:**

In #1171 @mlin points out some usabilit shortcomings with an axis query.  This PR addresses one of the two concerns and lifts the requirement for explicit `as.integer64()` casts.  Changing the naming is a litte tricker as can be confronted with one or two dimension data sets and use a list with names if case fewer than all dimensions are constrained in the query.

**Changes:**

Integer vectors are now converted to `integer64` as needed.

**Notes for Reviewer:**

#1171
[SC 27100](https://app.shortcut.com/tiledb-inc/story/27100/r-improve-usability-of-somaaxisquery-coords)