### PR TITLE
[r] Return lists of Arrow 'Table' objects in `read(iterated=TRUE)`

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -192,23 +192,28 @@ SOMADataFrame <- R6::R6Class(
       }
 
       if (isFALSE(iterated)) {
+          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
           rl <- soma_array_reader(uri = uri,
-                            colnames = column_names,   # NULL is dealt with by soma_array_reader()
-                            qc = value_filter,         # idem
-                            dim_points = coords,       # idem
-                            loglevel = log_level,      # idem
-                            config = as.character(tiledb::config(
-                              self$tiledbsoma_ctx$context()
-                            )))
+                                  colnames = column_names,   # NULL dealt with by soma_array_reader()
+                                  qc = value_filter,         # idem
+                                  dim_points = coords,       # idem
+                                  loglevel = log_level,      # idem
+                                  config = cfg)
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?
-          if (!is.null(self$soma_reader_pointer)) {
-              warning("pointer not null, skipping")
+          if (!is.null(private$soma_reader_pointer)) {
+              warning("Reader pointer not null, skipping")
+              rl <- NULL
           } else {
               private$soma_reader_setup()
+              rl <- list()
+              while (!self$read_complete()) {
+                  ## soma_reader_transform() applied inside read_next()
+                  rl <- c(rl, self$read_next())
+              }
           }
-          invisible(NULL)
+          invisible(rl)
       }
     }
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -192,7 +192,7 @@ SOMADataFrame <- R6::R6Class(
       }
 
       if (isFALSE(iterated)) {
-          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
+          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
           rl <- soma_array_reader(uri = uri,
                                   colnames = column_names,   # NULL dealt with by soma_array_reader()
                                   qc = value_filter,         # idem

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -123,22 +123,27 @@ SOMADenseNDArray <- R6::R6Class(
       private$dense_matrix <- FALSE
 
       if (isFALSE(iterated)) {
+          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
           rl <- soma_array_reader(uri = uri,
-                                  dim_points = coords,        # NULL is dealt with by soma_array_reader()
+                                  dim_points = coords,        # NULL dealt with by soma_array_reader()
                                   result_order = result_order,
                                   loglevel = log_level,       # idem
-                                  config = as.character(tiledb::config(
-                                      self$tiledbsoma_ctx$context()
-                                  )))
+                                  config = cfg)
           private$soma_reader_transform(rl)
       } else {
           ## should we error if this isn't null?
           if (!is.null(self$soma_reader_pointer)) {
               warning("pointer not null, skipping")
+              rl <- NULL
           } else {
               private$soma_reader_setup()
+              rl <- list()
+              while (!self$read_complete()) {
+                  ## soma_reader_transform() applied inside read_next()
+                  rl <- c(rl, self$read_next())
+              }
           }
-          invisible(NULL)
+          invisible(rl)
       }
     },
 

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -123,7 +123,7 @@ SOMADenseNDArray <- R6::R6Class(
       private$dense_matrix <- FALSE
 
       if (isFALSE(iterated)) {
-          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
+          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
           rl <- soma_array_reader(uri = uri,
                                   dim_points = coords,        # NULL dealt with by soma_array_reader()
                                   result_order = result_order,

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -119,7 +119,7 @@ SOMASparseNDArray <- R6::R6Class(
       }
 
       if (isFALSE(iterated)) {
-          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$get_tiledb_context()))
+          cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
           rl <- soma_array_reader(uri = uri,
                                   dim_points = coords,        # NULL dealt with by soma_array_reader()
                                   result_order = result_order,

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -87,33 +87,19 @@ test_that("Iterated Interface from SOMA Classes", {
                       dense = SOMADenseNDArray$new(uri, internal_use_only = "allowed_use"))
         expect_true(inherits(sdf, "SOMAArrayBase"))
 
-        switch(tc,
-               data.frame = sdf$read(iterated = TRUE),
-               sparse = sdf$read_arrow_table(iterated = TRUE),
-               dense = sdf$read_arrow_table(iterated = TRUE))
-
-        expect_false(sdf$read_complete())
-        dat <- sdf$read_next()
-        n <- dat$num_rows
-        expect_true(n > 0)
-
-        expect_false(sdf$read_complete())
-        dat <- sdf$read_next()
-        n <- n + dat$num_rows
-        expect_true(n > 0)
-
-        expect_false(sdf$read_complete())
-        dat <- sdf$read_next()
-        n <- n + dat$num_rows
-        expect_true(n > 0)
-
-        expect_false(sdf$read_complete())
-        dat <- sdf$read_next()
-        n <- n + dat$num_rows
-        expect_true(n > 0)
-
-        expect_equal(n, 4848644)
+        rl <- switch(tc,
+                     data.frame = sdf$read(iterated = TRUE),
+                     sparse = sdf$read_arrow_table(iterated = TRUE),
+                     dense = sdf$read_arrow_table(iterated = TRUE))
+        expect_true(is.list(rl))
         expect_true(sdf$read_complete())
+        n <- length(rl)
+        expect_true(n > 0)
+
+        dat <- do.call(rbind, rl)
+        expect_true(inherits(dat, "Table"))
+        expect_equal(dat$num_columns, 3)
+        expect_equal(dat$num_rows, 4848644)
 
         rm(sdf)
     }


### PR DESCRIPTION
**Issue and/or context:**

The common `read()` accessor for data frames and (dense and sparse) arrays has a boolean toggle `iterated`. When true, one-shot reads are attempted (subject to the memory budget constraints).  

When false, we had previously pushed the responsibility of iterating to the user.  This PR suggests to change that and to return a list of Arrow Table objects to the user.

A list is _the_ fundamental 'large' data structure in R. It is common and well understood; users can then proceed to iterated over the chunks as needed.

**Changes:**

A rather small code change for each of the three accessors along with a simplification in the unit tests as the test no longer needs to loop.

**Notes for Reviewer:**

[SC 27280](https://app.shortcut.com/tiledb-inc/story/27280/r-provide-iterated-reads-returning-list-of-arrow-tables)
