### PR TITLE
[python] Switching to pandas2 in `setup.py`

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -264,7 +264,7 @@ setuptools.setup(
         # longer need to support the old pip solver (default on ubuntu 20.04).
         "numba==0.56.4",
         "numpy>=1.18,<1.24",
-        "pandas",
+        "pandas==2.0.0",
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",
         "scipy",


### PR DESCRIPTION
For #1124 

Note that this change by itself may not be sufficient as most of our usecases is in the form of arrow table.concact.to_pandas() I tried to use `pd.set_option("mode.dtype_backend", "pyarrow")` but was not able to get the same effect and als to_pandas(...) does not have the dtype argument like some of the pandas methods.

**Issue and/or context:1124

**Changes:Updating pandas version

**Notes for Reviewer:**

