### PR TITLE
[r] Static library is configured to install to `lib`

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -36,6 +36,13 @@ else
         rm -rf build
         cd ..
         echo "** static library made"
+
+        ## handle different distro library install paths
+        if test -d src/lib64; then
+            mv src/lib64 src/lib
+        elif test -d src/lib/x86_64-linux-gnu; then
+            mv src/libx86_64-linux-gnu src/lib
+        fi
     fi
 fi
 


### PR DESCRIPTION
**Issue and/or context:**
https://github.com/single-cell-data/TileDB-SOMA/issues/1220

Different Linux distros install libraries to different directories. On Debian-based systems libraries may be installed into `lib` or `lib/x86_64-linux-gnu`. On Fedora-based, they are installed into `lib64`.

**Changes:**

`Makevars` includes a link to `lib/libtilesoma.a`. To account for the fact that not all distros install to `lib`, we now copy `libtiledbsoma.a` into `lib` in `configure` as suggested by @eddelbuettel.
