### PR TITLE
[r] Seurat outgestors expect sparse arrays in `obsm` and `varm`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9017
+Version: 0.0.0.9018
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/utils-seurat.R
+++ b/apis/r/R/utils-seurat.R
@@ -41,6 +41,7 @@
       m <- regexpr(pattern = '[[:upper:]]+', text = x)
       x <- tolower(unlist(regmatches(x = x, m = m)))
       x[x == 'pc'] <- 'pca'
+      x[x == 'ic'] <- 'ica'
       x
     }
   ))


### PR DESCRIPTION
Following discussion about #1200, `query$to_seurat()` and `query$to_seurat_reduction()` now expect arrays in `obsm` and `varm` to be sparse. Warnings are thrown if arrays are dense, but will continue to read them.

See also #1245.