### PR TITLE
[python] Put `capacity` on the same footing as other `PlatformConfig` parameters

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -180,7 +180,7 @@ class NDArray(TileDBArray, somacore.NDArray):
             allows_duplicates=create_options.get("allows_duplicates", False),
             offsets_filters=create_options.offsets_filters(),
             validity_filters=create_options.validity_filters(),
-            capacity=create_options.get("capacity", 100000),
+            capacity=create_options.capacity(),
             tile_order=tile_order,
             cell_order=cell_order,
             ctx=context.tiledb_ctx,

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -29,6 +29,7 @@ DEFAULT_OFFSET_FILTERS = (
 )
 DEFAULT_VALIDITY_FILTERS = None
 DEFAULT_TILE_EXTENT = 2048
+DEFAULT_CAPACITY = 100000
 # TODO: pending further work on
 #  https://github.com/single-cell-data/TileDB-SOMA/issues/27
 # DEFAULT_OBS_EXTENT = 256
@@ -71,6 +72,9 @@ class TileDBCreateOptions(Mapping[str, Any]):
 
     def goal_chunk_nnz(self) -> int:
         return self.get("goal_chunk_nnz", DEFAULT_GOAL_CHUNK_NNZ)
+
+    def capacity(self) -> int:
+        return self.get("capacity", DEFAULT_CAPACITY)
 
     def offsets_filters(
         self,


### PR DESCRIPTION
Found while working on #1223, #1224, and some performance analysis.