### PR TITLE
[docs/python] Expand docstrings for `Experiment` and `Measurement`

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -25,7 +25,8 @@ class Experiment(
         AnyTileDBObject,
     ],
 ):
-    """A collection subtype representing an annotated 2D matrix of measurements.
+    """A collection subtype that combines observations and measurements
+    from an individual experiment.
 
     In single cell biology, this can represent multiple modes of measurement
     across a single collection of cells (i.e., a "multimodal dataset").

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -25,8 +25,12 @@ class Experiment(
         AnyTileDBObject,
     ],
 ):
-    """An :class:`Experiment` represents a single-cell experiment. It is
-    a container class that has observations and measurements.
+    """A collection subtype representing an annotated 2D matrix of measurements.
+
+    In single cell biology, this can represent multiple modes of measurement
+    across a single collection of cells (i.e., a "multimodal dataset").
+    Within an experiment, a set of measurements on a single set of variables
+    (i.e., features) is represented as a :class:`Measurement`.
 
     Attributes:
         obs (DataFrame):
@@ -36,6 +40,21 @@ class Experiment(
             defined in this dataframe.
         ms (Collection):
             A collection of named measurements.
+
+    Example:
+        >>> import tiledbsoma
+        >>> with tiledbsoma.open("/path/to/experiment") as exp:
+        ...     # While users can interact directly with an Experiment's fields:
+        ...     obs_df = exp.obs
+        ...
+        ...     # the primary use case is to run queries on the experiment data.
+        ...     q = exp.query(
+        ...         "mtdna",
+        ...         obs_query=tiledbsoma.AxisQuery(value_filter="tissue == 'lung'"),
+        ...         var_query=tiledbsoma.AxisQuery(coords=(slice(50, 100),)),
+        ...     )
+        ...     query_obs = q.obs().concat().to_pandas()
+        ...     query_var = q.var().concat().to_pandas()
 
     Lifecycle:
         Experimental.

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -29,8 +29,19 @@ class Measurement(
         AnyTileDBObject,
     ],
 ):
-    """A :class:`Measurement` is a sub-element of a :class:`Experiment`, and is otherwise
-    a specialized :class:`Collection` with pre-defined fields.
+    """A set of observations defined by a dataframe, with measurements.
+
+    This is a common set of annotated variables (defined by the ``var``
+    dataframe) for which values (e.g., measurements or calculations) are stored
+    in sparse and dense ND arrays.
+
+    The observables are inherited from the parent ``Experiment``'s
+    ``obs`` dataframe. The ``soma_joinid`` of these observables (``obsid``),
+    along with those of the measurement's ``var`` dataframe (``varid``),
+    are the indices for all the other matrices stored in the measurement.
+
+    In most cases, users interact with a measurement via querying the experiment
+    which contains it, rather than directly accessing its fields.
 
     Attributes:
         var (DataFrame):


### PR DESCRIPTION
Takes expanded copy from the `somacore` package and adds an example for `Experiment`.

Suggestions and adding other relevant reviewers welcome. Fixes #974.