### PR TITLE
[r] Correct typo and minor edit to configure

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -34,15 +34,16 @@ else
         cmake --build build -j 2 >> cmake_log.txt
         cmake --build build --target install-libtiledbsoma >> cmake_log.txt
         rm -rf build
+        ## handle different distro library install paths
+        ## TODO: figure out how to tell cmake to use lib/ in all cases
+        if test -d lib64; then
+            mv lib64 lib
+        elif test -d lib/x86_64-linux-gnu; then
+            mv lib/x86_64-linux-gnu lib
+        fi
         cd ..
         echo "** static library made"
 
-        ## handle different distro library install paths
-        if test -d src/lib64; then
-            mv src/lib64 src/lib
-        elif test -d src/lib/x86_64-linux-gnu; then
-            mv src/libx86_64-linux-gnu src/lib
-        fi
     fi
 fi
 


### PR DESCRIPTION
**Issue and/or context:**

PR #1221 had a one-char typo in its 'else' branch:  `lib` and `x86_64-linux-gnu` were not separated.

**Changes:**

The typo is corrected and the statement is moved before the subsequent `cd ..` making it a little shorter and more succinct.

No new code.

**Notes for Reviewer:**

Attempts to test this at the R-Hub builder service failed, as it did at the 'mac-builder' provided by CRAN.  Dependencies of this package are somewhat extensive and attempts to install all of these from source failed :-/  In at least one case simply because `cmake` was not around.  Such is life.  

We also made two different attempts to address this via `cmake`, neither one was successful.  Doing it from `cmake` has the added risk of being dependent on a particular version of the tool.  So this shell-based approach may be preferable.

[SC 27412](https://app.shortcut.com/tiledb-inc/story/27412/one-char-typo-correction)


