### PR TITLE
[ci/python] Auto-create a GH issue on nightly CI fail

### DIFF
--- a/.github/workflows/daily-test-build-issue-template.md
+++ b/.github/workflows/daily-test-build-issue-template.md
@@ -1,0 +1,8 @@
+---
+title: Daily GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
+assignees: nguyenv, mlin, johnkerl
+labels: bug
+---
+
+See run for more details:
+https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -134,3 +134,17 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
         packages_dir: sdist, dist-wheel
         verbose: true
+
+  create_issue_on_fail:
+    runs-on: ubuntu-latest
+    needs: publish-to-pypi
+    if: failure() || cancelled()
+    steps:
+      - name: Checkout TileDB-SOMA `main`
+        uses: actions/checkout@v2
+      - name: Create Issue if Build Fails
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/workflows/daily-test-build-issue-template.md


### PR DESCRIPTION
**Issue and/or context:**

This will help to more quickly surface failures like the one fixed by #1226.

**Changes:**

Cloned shamelessly from https://github.com/TileDB-Inc/TileDB-Py.

**Notes for Reviewer:**

