### PR TITLE
[python] Put `allows_duplicates` on the same footing as other `PlatformConfig` parameters

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -177,7 +177,7 @@ class NDArray(TileDBArray, somacore.NDArray):
             domain=dom,
             attrs=attrs,
             sparse=is_sparse,
-            allows_duplicates=create_options.get("allows_duplicates", False),
+            allows_duplicates=create_options.allows_duplicates(),
             offsets_filters=create_options.offsets_filters(),
             validity_filters=create_options.validity_filters(),
             capacity=create_options.capacity(),

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -730,10 +730,10 @@ def _build_tiledb_schema(
         domain=dom,
         attrs=attrs,
         sparse=True,
-        allows_duplicates=tiledb_create_options.get("allows_duplicates", False),
+        allows_duplicates=tiledb_create_options.allows_duplicates(),
         offsets_filters=tiledb_create_options.offsets_filters(),
         validity_filters=tiledb_create_options.validity_filters(),
-        capacity=tiledb_create_options.get("capacity", 100000),
+        capacity=tiledb_create_options.capacity(),
         cell_order=cell_order,
         # As of TileDB core 2.8.2, we cannot consolidate string-indexed sparse arrays with
         # col-major tile order: so we write ``X`` with row-major tile order.

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -30,6 +30,8 @@ DEFAULT_OFFSET_FILTERS = (
 DEFAULT_VALIDITY_FILTERS = None
 DEFAULT_TILE_EXTENT = 2048
 DEFAULT_CAPACITY = 100000
+DEFAULT_ALLOWS_DUPLICATES = False
+
 # TODO: pending further work on
 #  https://github.com/single-cell-data/TileDB-SOMA/issues/27
 # DEFAULT_OBS_EXTENT = 256
@@ -75,6 +77,9 @@ class TileDBCreateOptions(Mapping[str, Any]):
 
     def capacity(self) -> int:
         return self.get("capacity", DEFAULT_CAPACITY)
+
+    def allows_duplicates(self) -> bool:
+        return self.get("allows_duplicates", DEFAULT_ALLOWS_DUPLICATES)
 
     def offsets_filters(
         self,


### PR DESCRIPTION
More of #1229. Found at https://github.com/single-cell-data/TileDB-SOMA/pull/1216#discussion_r1161724856.