### PR TITLE
[ci] Fix publish_to_pypi.yml parse error

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -125,7 +125,8 @@ jobs:
   publish-to-pypi:
     name: Publish package to PyPI
     needs: smoke-test
-    if: matrix.os == 'ubuntu-20.04' && github.event_name == 'release'
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release'
     steps:
     - name: Publish packages to PyPI
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
cf. https://github.com/single-cell-data/TileDB-SOMA/issues/1226#issuecomment-1501009554

This at least stops GitHub from choking on the YAML. I doubt the PyPI publishing will actually work yet, but we can come back to that a bit later since we can fall back on manual publishing.