### PR TITLE
[docs/python] Add `tutorials.rst`

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -1,0 +1,8 @@
+Tutorials
+==========
+
+.. toctree::
+   :glob:
+   :maxdepth: 2
+    
+   notebooks/*


### PR DESCRIPTION
**Issue and/or context:**
This file was missing and prevented the tutorials from being added to the docsite

**Changes:**

**Notes for Reviewer:**

