### PR TITLE
[python] Write TileDB Cloud–specific metadata to Experiments

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -6,11 +6,14 @@
 """Implementation of a SOMA Experiment.
 """
 
+from typing import Any
+
 from somacore import experiment
 
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._measurement import Measurement
+from ._tdb_handles import Wrapper
 from ._tiledb_object import AnyTileDBObject
 
 
@@ -44,3 +47,11 @@ class Experiment(
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
     }
+
+    @classmethod
+    def _set_create_metadata(cls, handle: Wrapper[Any]) -> None:
+        # Root SOMA objects include a `dataset_type` entry to allow the
+        # TileDB Cloud UI to detect that they are SOMA datasets.
+        if handle.uri.startswith("tiledb://"):
+            handle.metadata["dataset_type"] = "soma"
+        return super()._set_create_metadata(handle)

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -265,7 +265,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     @classmethod
     def _set_create_metadata(cls, handle: _tdb_handles.AnyWrapper) -> None:
         """Sets the necessary metadata on a newly-created TileDB object."""
-        handle.writer.meta.update(
+        handle.metadata.update(
             {
                 _constants.SOMA_OBJECT_TYPE_METADATA_KEY: cls.soma_type,
                 _constants.SOMA_ENCODING_VERSION_METADATA_KEY: _constants.SOMA_ENCODING_VERSION,


### PR DESCRIPTION
TileDB Cloud uses the `dataset_type` key to provide richer information about datasets. They need to be set on the root Experiment.