### PR TITLE
[python] [WIP] Explicit casting of Numpy nulls to Arrow nulls

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -575,6 +575,8 @@ def _write_dataframe(
     for k in df:
         if df[k].dtype == "category":
             df[k] = df[k].astype(df[k].cat.categories.dtype)
+        elif df[k].isnull().all():
+            df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
     arrow_table = pa.Table.from_pandas(df)
 
     try:


### PR DESCRIPTION
Cast Numpy nulls (eg. NaN) to an arrow null when writing data frames. Necessary when obs/var in AnnData/h5ad contain nulled columns

Reprex:
```python
import os
import shutil
import tiledbsoma
import tiledbsoma.io
import tempfile
import pandas as pd
import scanpy as sc
import numpy as np

SOMA_PATH = os.path.join(tempfile.gettempdir(), "soma-exp")
tiledbsoma.logging.debug()

adata = sc.datasets.pbmc3k()

# Create a pandas series with datatype categorical containing all Nan values
adata.obs["empty"] = pd.Categorical(
    [np.NaN] * adata.n_obs, dtype=pd.CategoricalDtype(categories=[], ordered=False)
)

if os.path.exists(SOMA_PATH):
    print(f"Removing existing SOMA: {SOMA_PATH}")
    shutil.rmtree(SOMA_PATH)

tiledbsoma.io.from_anndata(
    experiment_uri=SOMA_PATH, anndata=adata, measurement_name="RNA"
)
```