### PR TITLE
[python] Explicit casting of Numpy nulls to Arrow nulls

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -711,7 +711,7 @@ def _build_tiledb_schema(
     dom = tiledb.Domain(dims, ctx=context.tiledb_ctx)
 
     attrs = []
-    metadata = schema.metadata or dict()
+    metadata = schema.metadata or {}
     for attr_name in schema.names:
         if attr_name in index_column_names:
             continue

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -720,7 +720,7 @@ def _build_tiledb_schema(
             dtype=_arrow_types.tiledb_type_from_arrow_type(
                 schema.field(attr_name).type
             ),
-            nullable=metadata.get(bytes(attr_name, "utf-8")) == b"nullable",
+            nullable=metadata.get(attr_name.encode("utf-8")) == b"nullable",
             filters=tiledb_create_options.attr_filters(attr_name, ["ZstdFilter"]),
             ctx=context.tiledb_ctx,
         )

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -711,6 +711,7 @@ def _build_tiledb_schema(
     dom = tiledb.Domain(dims, ctx=context.tiledb_ctx)
 
     attrs = []
+    metadata = schema.metadata or dict()
     for attr_name in schema.names:
         if attr_name in index_column_names:
             continue
@@ -719,6 +720,7 @@ def _build_tiledb_schema(
             dtype=_arrow_types.tiledb_type_from_arrow_type(
                 schema.field(attr_name).type
             ),
+            nullable=metadata.get(bytes(attr_name, 'utf-8')) == b'nullable',
             filters=tiledb_create_options.attr_filters(attr_name, ["ZstdFilter"]),
             ctx=context.tiledb_ctx,
         )

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -720,7 +720,7 @@ def _build_tiledb_schema(
             dtype=_arrow_types.tiledb_type_from_arrow_type(
                 schema.field(attr_name).type
             ),
-            nullable=metadata.get(bytes(attr_name, 'utf-8')) == b'nullable',
+            nullable=metadata.get(bytes(attr_name, "utf-8")) == b"nullable",
             filters=tiledb_create_options.attr_filters(attr_name, ["ZstdFilter"]),
             ctx=context.tiledb_ctx,
         )

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -575,6 +575,8 @@ def _write_dataframe(
     for k in df:
         if df[k].dtype == "category":
             df[k] = df[k].astype(df[k].cat.categories.dtype)
+        elif df[k].isnull().all():
+            df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
     arrow_table = pa.Table.from_pandas(df)
 
     try:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -572,12 +572,20 @@ def _write_dataframe(
     df.set_index(SOMA_JOINID, inplace=True)
 
     # Categoricals are not yet well supported, so we must flatten
+    # Also replace Numpy/Pandas-style nulls with Arrow-style nulls
     null_fields = set()
     for k in df:
         if df[k].dtype == "category":
             df[k] = df[k].astype(df[k].cat.categories.dtype)
-        elif df[k].isnull().all():
-            df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
+        if df[k].isnull().any():
+            if df[k].isnull().all():
+                df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
+            else:
+                df[k].where(
+                    df[k].notnull(),
+                    pd.Series(pa.nulls(df[k].isnull().sum(), pa.infer_type(df[k]))),
+                    inplace=True
+                )
             null_fields.add(k)
     arrow_table = pa.Table.from_pandas(df)
     if null_fields:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -582,7 +582,7 @@ def _write_dataframe(
     arrow_table = pa.Table.from_pandas(df)
     if null_fields:
         md = arrow_table.schema.metadata
-        md.update(dict.fromkeys(null_fields, 'nullable'))
+        md.update(dict.fromkeys(null_fields, "nullable"))
         arrow_table = arrow_table.replace_schema_metadata(md)
 
     try:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -583,7 +583,7 @@ def _write_dataframe(
     if null_fields:
         md = arrow_table.schema.metadata
         md.update(dict.fromkeys(null_fields, 'nullable'))
-        arrow_table = pa.Table.from_pandas(df, schema=arrow_table.replace_schema_metadata(md).schema)
+        arrow_table = arrow_table.replace_schema_metadata(md)
 
     try:
         soma_df = _factory.open(df_uri, "w", soma_type=DataFrame, context=context)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -584,7 +584,7 @@ def _write_dataframe(
                 df[k].where(
                     df[k].notnull(),
                     pd.Series(pa.nulls(df[k].isnull().sum(), pa.infer_type(df[k]))),
-                    inplace=True
+                    inplace=True,
                 )
             null_fields.add(k)
     arrow_table = pa.Table.from_pandas(df)

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -429,11 +429,7 @@ def test_null_obs(adata, tmp_path: Path):
     )
     #   Create column of partially-null values
     rng = np.random.RandomState(seed)
-    adata.obs["empty_partial"] = rng.choice(
-        (np.NaN, 1.0),
-        adata.n_obs,
-        True
-    )
+    adata.obs["empty_partial"] = rng.choice((np.NaN, 1.0), adata.n_obs, True)
     uri = tiledbsoma.io.from_anndata(
         output_path, adata, "RNA", ingest_mode="write", X_kind=tiledbsoma.SparseNDArray
     )

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import anndata
 import numpy as np
+import pandas as pd
 import pytest
 import somacore
 import tiledb
@@ -11,9 +12,6 @@ import tiledb
 import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import _constants, _factory
-
-import numpy as np
-import pandas as pd
 
 HERE = Path(__file__).parent
 
@@ -426,15 +424,10 @@ def test_null_obs(adata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
     adata.obs["empty"] = pd.Categorical(
-        [np.NaN] * adata.n_obs,
-        dtype=pd.CategoricalDtype(categories=[], ordered=False)
+        [np.NaN] * adata.n_obs, dtype=pd.CategoricalDtype(categories=[], ordered=False)
     )
     uri = tiledbsoma.io.from_anndata(
-        output_path,
-        adata,
-        "RNA",
-        ingest_mode="write",
-        X_kind=tiledbsoma.SparseNDArray
+        output_path, adata, "RNA", ingest_mode="write", X_kind=tiledbsoma.SparseNDArray
     )
     exp = tiledbsoma.Experiment.open(uri)
     with tiledb.open(exp.obs.uri, "r") as obs:

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -420,9 +420,8 @@ def test_export_anndata(adata):
         assert readback.varp[key].shape == adata.varp[key].shape
 
 
-def test_null_obs(adata):
-    tempdir = tempfile.TemporaryDirectory()
-    output_path = tempdir.name
+def test_null_obs(adata, tmp_path: Path):
+    output_path = tmp_path.as_uri()
     adata.obs["empty"] = pd.Categorical(
         [np.NaN] * adata.n_obs, dtype=pd.CategoricalDtype(categories=[], ordered=False)
     )
@@ -434,5 +433,3 @@ def test_null_obs(adata):
         assert obs.attr("empty").isnullable
         for k in adata.obs:
             assert obs.attr(k).isnullable == adata.obs[k].isnull().all()
-
-    tempdir.cleanup()


### PR DESCRIPTION
Cast Numpy nulls (eg. NaN) to an arrow null when writing data frames. Necessary when obs/var in AnnData/h5ad contain nulled columns

Reprex:
```python
import os
import shutil
import tiledbsoma
import tiledbsoma.io
import tempfile
import pandas as pd
import scanpy as sc
import numpy as np

SOMA_PATH = os.path.join(tempfile.gettempdir(), "soma-exp")
tiledbsoma.logging.debug()

adata = sc.datasets.pbmc3k()

# Create a pandas series with datatype categorical containing all Nan values
adata.obs["empty"] = pd.Categorical(
    [np.NaN] * adata.n_obs, dtype=pd.CategoricalDtype(categories=[], ordered=False)
)

if os.path.exists(SOMA_PATH):
    print(f"Removing existing SOMA: {SOMA_PATH}")
    shutil.rmtree(SOMA_PATH)

tiledbsoma.io.from_anndata(
    experiment_uri=SOMA_PATH, anndata=adata, measurement_name="RNA"
)
```