### PR TITLE
[r] Refine group member caching behavior

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9020
+Version: 0.0.0.9021
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -104,13 +104,16 @@ TileDBGroup <- R6::R6Class(
       stopifnot(is_scalar_character(name))
 
       private$open("WRITE")
+      on.exit(self$close())
       tiledb::tiledb_group_remove_member(
         grp = self$object,
         uri = name
       )
-      self$close()
-      # TODO: Avoid closing/re-opening the group to update the cache
-      private$update_member_cache()
+
+      # Drop member if cache has been initialized
+      if (is.list(private$member_cache)) {
+        private$member_cache[[name]] <- NULL
+      }
     },
 
     #' @description Length in the number of members. (lifecycle: experimental)


### PR DESCRIPTION
**Changes:** This refines member cache handling in the `TileDBGroup` class.

**Notes for Reviewer:** When adding a new member, the original URI is now preserved in the member cache. 

