### PR TITLE
[python] Auto-consolidate fragment metadata and commits

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -402,6 +402,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         dim_cols_list = [dim_cols_map[name] for name in self.index_column_names]
         dim_cols_tuple = tuple(dim_cols_list)
         self._handle.writer[dim_cols_tuple] = attr_cols_map
+        self._consolidate_and_vacuum_fragment_metadata()
 
         return self
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -174,6 +174,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
         del platform_config  # Currently unused.
         self._handle.writer[coords] = values.to_numpy()
+        self._consolidate_and_vacuum_fragment_metadata()
         return self
 
     @classmethod

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -189,6 +189,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         if isinstance(values, pa.SparseCOOTensor):
             data, coords = values.to_numpy()
             arr[tuple(c for c in coords.T)] = data
+            self._consolidate_and_vacuum_fragment_metadata()
             return self
 
         if isinstance(values, (pa.SparseCSCMatrix, pa.SparseCSRMatrix)):
@@ -199,6 +200,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             # TODO: the ``to_scipy`` function is not zero copy. Need to explore zero-copy options.
             sp = values.to_scipy().tocoo()
             arr[sp.row, sp.col] = sp.data
+            self._consolidate_and_vacuum_fragment_metadata()
             return self
 
         if isinstance(values, pa.Table):
@@ -209,6 +211,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 for n in range(coord_tbl.num_columns)
             )
             arr[coords] = data
+            self._consolidate_and_vacuum_fragment_metadata()
             return self
 
         raise TypeError(


### PR DESCRIPTION
**Issue and/or context:**

Note that fragment metadata and commits are easy to consolidate and we should always do it immediately post-write. This is not to be confused with consolidating array data, which is opt-in.

Tracked in SC-25195.

**Changes:** Leverages TileDB Cloud 2.15.

