### PR TITLE
[python/r] Always write TileDB Cloud–specific metadata to Experiments

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -52,6 +52,5 @@ class Experiment(
     def _set_create_metadata(cls, handle: Wrapper[Any]) -> None:
         # Root SOMA objects include a `dataset_type` entry to allow the
         # TileDB Cloud UI to detect that they are SOMA datasets.
-        if handle.uri.startswith("tiledb://"):
-            handle.metadata["dataset_type"] = "soma"
+        handle.metadata["dataset_type"] = "soma"
         return super()._set_create_metadata(handle)

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -27,7 +27,7 @@ SOMACollectionBase <- R6::R6Class(
 
       # Root SOMA objects include a `dataset_type` entry to allow the
       # TileDB Cloud UI to detect that they are SOMA datasets.
-      if (self$class() == "SOMAExperiment" && startsWith(self$uri, "tiledb://")) {
+      if (self$class() == "SOMAExperiment")) {
         metadata <- list(dataset_type = "soma")
       } else {
         metadata <- list()

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -27,7 +27,7 @@ SOMACollectionBase <- R6::R6Class(
 
       # Root SOMA objects include a `dataset_type` entry to allow the
       # TileDB Cloud UI to detect that they are SOMA datasets.
-      if (self$class() == "SOMAExperiment")) {
+      if (self$class() == "SOMAExperiment") {
         metadata <- list(dataset_type = "soma")
       } else {
         metadata <- list()


### PR DESCRIPTION
This follows on #1260 to always set the `dataset_type` key on SOMA Experiments.

