### PR TITLE
Publish to TestPyPI on nightly or manual run

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -122,6 +122,21 @@ jobs:
           python3 -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         "
 
+  publish-to-test-pypi:
+    name: Publish package to TestPyPI
+    needs: smoke-test
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    steps:
+    - name: Publish packages to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      continue-on-error: true
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        packages_dir: dist-wheel
+        verbose: true
+
   publish-to-pypi:
     name: Publish package to PyPI
     needs: smoke-test


### PR DESCRIPTION
**Issue and/or context:**

* Yesterday's https://github.com/single-cell-data/TileDB-SOMA/releases/tag/1.2.2 failed autotwine at https://github.com/single-cell-data/TileDB-SOMA/actions/runs/4803354502/jobs/8548134200
* I was able to handtwine following https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-WIP
* Nonetheless we need to find release-only CI errors _before_ the release, not after

**Changes:**

Run TestPyPI

**Notes for Reviewer:**

