### PR TITLE
[python] Require TileDB-Py >= 0.21.1

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -289,7 +289,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         "somacore==1.0.2",
-        "tiledb==0.21.*",
+        "tiledb>=0.21.2",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={


### PR DESCRIPTION
**Issue and/or context:** Normally in our `setup.py` we pin like `tiledb==0.21.*`. However, I found the following today:

* I have an EC2 instance I normally leave powered off. It had a recent `tiledbsoma` version, and therewith, `tiledb-py 0.21.1` 
* Today I did `pip install tiledbsoma`
* This upgraded `tiledbsoma` to 1.2.2 (recent) but it left `tiledb-py` as-is, at 0.21.1.
* However we _truly require features_ from 0.21.2 -- in particular the new `config` argument to `Group`
* I had to manually `pip install -U tiledb`. Our users shouldn't have to.

(Side note: our `tiledbsoma`-to-core dependency is fine: https://github.com/single-cell-data/TileDB-SOMA/blob/main/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake)