### PR TITLE
Tighten TileDB pypi dependency to be a 0.21.x version.

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -289,7 +289,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         "somacore==1.0.2",
-        "tiledb>=0.21.2",
+        "tiledb~=0.21.2",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={


### PR DESCRIPTION
It was brought up to me that using `tiledb>=0.21.2` could result in v0.22.0 matching, which is not what we want (this would cause a core version mismatch, which is Bad™). Instead, we should pin to `~=0.21.2`, which means "any v0.21.x version where x >= 2".