### PR TITLE
[c++] Add `cstring` Header to `util.cc`

### DIFF
--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -31,6 +31,7 @@
  */
 
 #include "utils/util.h"
+#include <cstring>
 
 namespace tiledbsoma::util {
 

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -33,7 +33,6 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-#include <cstring>
 #include <regex>
 #include <span/span.hpp>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -33,6 +33,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <cstring>
 #include <regex>
 #include <span/span.hpp>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'


### PR DESCRIPTION
**Issue and/or context:**

When running _TileDB-SOMA Python CI (Full)_, we fail when building with error `no member named 'memcpy' in namespace 'std'`. This was not caught when running the minimal CI tests.

**Changes:**

Include `cstring` header in `utils/util.h`.

**Notes for Reviewer:**

Full CI run working [here](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/4832925550).
