### PR TITLE
[c++] Add Array metadata methods

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -181,6 +181,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     py::gil_scoped_release release;
 
                     auto reader = SOMAArray::open(
+                        TILEDB_READ,
                         uri,
                         name,
                         platform_config,

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -90,7 +90,8 @@ Rcpp::List soma_array_reader(const std::string& uri,
     }
 
     // Read selected columns from the uri (return is unique_ptr<SOMAArray>)
-    auto sr = tdbs::SOMAArray::open(uri,
+    auto sr = tdbs::SOMAArray::open(TILEDB_READ,
+                                          uri,
                                           "unnamed",         // name parameter could be added
                                           platform_config,   // to add, done in iterated reader
                                           column_names,
@@ -196,7 +197,7 @@ void set_log_level(const std::string& level) {
 Rcpp::CharacterVector get_column_types(const std::string& uri,
                                        const std::vector<std::string>& colnames) {
 
-    auto sr = tdbs::SOMAArray::open(uri);
+    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri);
     sr->submit();
     auto sr_data = sr->read_next();
     size_t n = colnames.size();
@@ -213,7 +214,7 @@ Rcpp::CharacterVector get_column_types(const std::string& uri,
 //' @export
 // [[Rcpp::export]]
 double nnz(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
-    auto sr = tdbs::SOMAArray::open(uri, "unnamed", config_vector_to_map(config));
+    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri, "unnamed", config_vector_to_map(config));
     return static_cast<double>(sr->nnz());
 }
 
@@ -236,6 +237,6 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 // [[Rcpp::export]]
 Rcpp::NumericVector shape(const std::string& uri,
                           Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
-    auto sr = tdbs::SOMAArray::open(uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
     return makeInteger64(sr->shape());
 }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -94,7 +94,7 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
     }
 
-    auto ptr = new tdbs::SOMAArray(uri, name, ctxptr, column_names, batch_size, result_order);
+    auto ptr = new tdbs::SOMAArray(TILEDB_READ, uri, name, ctxptr, column_names, batch_size, result_order);
 
     std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = ptr->schema();

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -45,12 +45,12 @@ void test_sdf(const std::string& uri) {
     // config["sm.mem.total_budget"] = "1118388608";
 
     // Read all values from the obs array
-    auto obs = SOMAArray::open(uri + "/obs", "obs");
+    auto obs = SOMAArray::open(TILEDB_READ, uri + "/obs", "obs");
     obs->submit();
     auto obs_data = obs->read_next();
 
     // Read all values from the var array
-    auto var = SOMAArray::open(uri + "/ms/RNA/var", "var");
+    auto var = SOMAArray::open(TILEDB_READ, uri + "/ms/RNA/var", "var");
     var->submit();
     auto var_data = var->read_next();
 
@@ -60,7 +60,8 @@ void test_sdf(const std::string& uri) {
     }
 
     // Read all values from the X/data array
-    auto x_data = SOMAArray::open(uri + "/ms/RNA/X/data", "X/data", config);
+    auto x_data = SOMAArray::open(
+        TILEDB_READ, uri + "/ms/RNA/X/data", "X/data", config);
     x_data->submit();
 
     int batches = 0;
@@ -79,7 +80,7 @@ void test_sdf(const std::string& uri) {
 namespace tdbs = tiledbsoma;
 void test_arrow(const std::string& uri) {
     const std::vector<std::string>& colnames{"n_counts", "n_genes", "louvain"};
-    auto obs = tdbs::SOMAArray::open(uri, "", {}, colnames);
+    auto obs = tdbs::SOMAArray::open(TILEDB_READ, uri, "", {}, colnames);
     obs->submit();
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto obs_data = obs->read_next();

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -266,6 +266,15 @@ class ManagedQuery {
     std::shared_ptr<ArrayBuffers> results();
 
     /**
+     * @brief Get the array.
+     *
+     * @return std::shared_ptr<Array> Array
+     */
+    std::shared_ptr<Array> array() {
+        return array_;
+    }
+
+    /**
      * @brief Get the schema of the array.
      *
      * @return std::shared_ptr<ArraySchema> Schema

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -266,15 +266,6 @@ class ManagedQuery {
     std::shared_ptr<ArrayBuffers> results();
 
     /**
-     * @brief Get the array.
-     *
-     * @return std::shared_ptr<Array> Array
-     */
-    std::shared_ptr<Array> array() {
-        return array_;
-    }
-
-    /**
      * @brief Get the schema of the array.
      *
      * @return std::shared_ptr<ArraySchema> Schema

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -54,6 +54,7 @@ class SOMAArray {
      * @brief Open an array at the specified URI and return SOMAArray
      * object.
      *
+     * @param mode TILEDB_READ or TILEDB_WRITE
      * @param uri URI of the array
      * @param name Name of the array
      * @param platform_config Config parameter dictionary
@@ -62,8 +63,8 @@ class SOMAArray {
      * @param result_order Read result order
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
-    __attribute__((visibility("default"))) static std::unique_ptr<SOMAArray>
-    open(
+    static std::unique_ptr<SOMAArray> open(
+        tiledb_query_type_t mode,
         std::string_view uri,
         std::string_view name = "unnamed",
         std::map<std::string, std::string> platform_config = {},
@@ -76,6 +77,7 @@ class SOMAArray {
      * @brief Open an array at the specified URI and return SOMAArray
      * object.
      *
+     * @param mode TILEDB_READ or TILEDB_WRITE
      * @param ctx TileDB context
      * @param uri URI of the array
      * @param name Name of the array
@@ -85,6 +87,7 @@ class SOMAArray {
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(
+        tiledb_query_type_t mode,
         std::shared_ptr<Context> ctx,
         std::string_view uri,
         std::string_view name = "unnamed",
@@ -99,11 +102,17 @@ class SOMAArray {
     /**
      * @brief Construct a new SOMAArray object
      *
+     * @param mode TILEDB_READ or TILEDB_WRITE
      * @param uri URI of the array
      * @param name name of the array
      * @param ctx TileDB context
+     * @param column_names Columns to read
+     * @param batch_size Batch size
+     * @param result_order Result order
+     * @param timestamp Timestamp
      */
     SOMAArray(
+        tiledb_query_type_t mode,
         std::string_view uri,
         std::string_view name,
         std::shared_ptr<Context> ctx,
@@ -118,6 +127,16 @@ class SOMAArray {
     ~SOMAArray() = default;
 
     /**
+     * Open the SOMAArray object.
+     */
+    void open(tiledb_query_type_t query_type);
+
+    /**
+     * Closes the SOMAArray object.
+     */
+    void close();
+
+    /**
      * @brief Reset the state of this SOMAArray object to prepare for a
      * new query, while holding the array open.
      *
@@ -125,7 +144,7 @@ class SOMAArray {
      * @param batch_size
      * @param result_order
      */
-    __attribute__((visibility("default"))) void reset(
+    void reset(
         std::vector<std::string> column_names = {},
         std::string_view batch_size = "auto",
         std::string_view result_order = "auto");
@@ -256,7 +275,7 @@ class SOMAArray {
      * @brief Submit the query
      *
      */
-    __attribute__((visibility("default"))) void submit();
+    void submit();
 
     /**
      * @brief Read the next chunk of results from the query. If all results have
@@ -272,9 +291,7 @@ class SOMAArray {
      *
      * @return std::optional<std::shared_ptr<ArrayBuffers>>
      */
-    __attribute__((visibility("default")))
-    std::optional<std::shared_ptr<ArrayBuffers>>
-    read_next();
+    std::optional<std::shared_ptr<ArrayBuffers>> read_next();
 
     /**
      * @brief Check if the query is complete.
@@ -319,7 +336,7 @@ class SOMAArray {
      *
      * @return uint64_t Total number of unique cells
      */
-    __attribute__((visibility("default"))) uint64_t nnz();
+    uint64_t nnz();
 
     /**
      * @brief Get the schema of the array.
@@ -336,7 +353,101 @@ class SOMAArray {
      * @return A vector with length equal to the number of dimensions; each
      * value in the vector is the capcity of each dimension.
      */
-    __attribute__((visibility("default"))) std::vector<int64_t> shape();
+    std::vector<int64_t> shape();
+
+    /**
+     * Set metadata key-value items to an open array. The array must
+     * opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value);
+
+    /**
+     * Deletes a metadata key-value item from an open array. The array must
+     * be opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the array.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key);
+
+    /**
+     * @brief Given the key, get the metadata value, value's type, and number
+     * of values.
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata. Keys with empty values are indicated
+     *     by value_num == 1 and value == NULL.
+     * @param value The metadata value in binary form.
+     *
+     * @note If the key does not exist, then `value` will be NULL.
+     */
+    void get_metadata(
+        const std::string& key,
+        tiledb_datatype_t* value_type,
+        uint32_t* value_num,
+        const void** value);
+
+    /**
+     * Given an index, get the metadata key, value, value's type, and number of
+     * values. The array must be opened in READ mode, otherwise the function
+     * will error out.
+     *
+     * @param index The index used to get the metadata.
+     * @param key The metadata key.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata. Keys with empty values are indicated
+     *     by value_num == 1 and value == NULL.
+     * @param value The metadata value in binary form.
+     */
+    void get_metadata_from_index(
+        uint64_t index,
+        std::string* key,
+        tiledb_datatype_t* value_type,
+        uint32_t* value_num,
+        const void** value);
+
+    /**
+     * Checks if key exists in metadata from an open array. The array must
+     * be opened in READ mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value associated with the key (if
+     * any).
+     * @return true if the key exists, else false.
+     * @note If the key does not exist, then `value_type` will not be modified.
+     */
+    bool has_metadata(const std::string& key, tiledb_datatype_t* value_type);
+
+    /**
+     * Returns then number of metadata items in an open array. The array must
+     * be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const;
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -133,7 +133,9 @@ class SOMAArray {
     /**
      * Open the SOMAArray object.
      */
-    void open(tiledb_query_type_t query_type);
+    void open(
+        tiledb_query_type_t mode,
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * Closes the SOMAArray object.

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -296,12 +296,20 @@ TEST_CASE("SOMAArray: metadata") {
     std::string base_uri = "mem://unit-test-array";
     const auto& [uri, expected_nnz] = create_array(base_uri, *ctx);
 
-    auto sr = SOMAArray::open(TILEDB_WRITE, ctx, uri);
+    auto sr = SOMAArray::open(
+        TILEDB_WRITE,
+        ctx,
+        uri,
+        "metadata_test",
+        {},
+        "auto",
+        "auto",
+        std::pair<uint64_t, uint64_t>(1, 1));
     int32_t val = 100;
     sr->set_metadata("md", TILEDB_INT32, 1, &val);
     sr->close();
 
-    sr->open(TILEDB_READ);
+    sr->open(TILEDB_READ, std::pair<uint64_t, uint64_t>(1, 1));
     REQUIRE(sr->has_metadata("md") == true);
     REQUIRE(sr->metadata_num() == 1);
 
@@ -318,11 +326,11 @@ TEST_CASE("SOMAArray: metadata") {
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
     sr->close();
 
-    sr->open(TILEDB_WRITE);
+    sr->open(TILEDB_WRITE, std::pair<uint64_t, uint64_t>(2, 2));
     sr->delete_metadata("md");
     sr->close();
 
-    sr->open(TILEDB_READ);
+    sr->open(TILEDB_READ, std::pair<uint64_t, uint64_t>(3, 3));
     REQUIRE(sr->has_metadata("md") == false);
     REQUIRE(sr->metadata_num() == 0);
     sr->close();

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -302,25 +302,20 @@ TEST_CASE("SOMAArray: metadata") {
     sr->close();
 
     sr->open(TILEDB_READ);
-    std::string key;
-    tiledb_datatype_t v_type;
-    uint32_t v_num;
-    const void* v;
-
-    REQUIRE(sr->has_metadata("md", &v_type));
+    REQUIRE(sr->has_metadata("md") == true);
     REQUIRE(sr->metadata_num() == 1);
-    REQUIRE(v_type == TILEDB_INT32);
 
-    sr->get_metadata_from_index(0, &key, &v_type, &v_num, &v);
-    REQUIRE(key == "md");
-    REQUIRE(v_type == TILEDB_INT32);
-    REQUIRE(v_num == 1);
-    REQUIRE(*((const int32_t*)v) == 100);
+    auto mdval = sr->get_metadata(0);
+    REQUIRE(std::get<MetadataInfo::key>(mdval) == "md");
+    REQUIRE(std::get<MetadataInfo::dtype>(mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
 
-    sr->get_metadata("md", &v_type, &v_num, &v);
-    REQUIRE(v_type == TILEDB_INT32);
-    REQUIRE(v_num == 1);
-    REQUIRE(*((const int32_t*)v) == 100);
+    mdval = sr->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::key>(mdval) == "md");
+    REQUIRE(std::get<MetadataInfo::dtype>(mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
     sr->close();
 
     sr->open(TILEDB_WRITE);
@@ -328,7 +323,7 @@ TEST_CASE("SOMAArray: metadata") {
     sr->close();
 
     sr->open(TILEDB_READ);
-    REQUIRE(sr->has_metadata("md", &v_type) == false);
+    REQUIRE(sr->has_metadata("md") == false);
     REQUIRE(sr->metadata_num() == 0);
     sr->close();
 }


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/926

**Changes:**

- Add `SOMAArray` metadata methods and test
- `SOMAArray::open` now also takes in mode as required argument
