### PR TITLE
[c++] Adjust two more include paths

### DIFF
--- a/libtiledbsoma/src/external/include/thread_pool/producer_consumer_queue.h
+++ b/libtiledbsoma/src/external/include/thread_pool/producer_consumer_queue.h
@@ -42,7 +42,7 @@
 #include <deque>
 #include <queue>
 
-#include "tiledbsoma/logger_public.h"
+#include "soma/logger_public.h"
 
 namespace tiledbsoma {
 

--- a/libtiledbsoma/src/external/src/thread_pool/thread_pool.cc
+++ b/libtiledbsoma/src/external/src/thread_pool/thread_pool.cc
@@ -37,7 +37,7 @@
 #include <queue>
 #include <thread>
 
-#include "tiledbsoma/logger_public.h"
+#include "soma/logger_public.h"
 
 namespace tiledbsoma {
 


### PR DESCRIPTION
**Issue and/or context:**

The logger interface moved to soma/ and two more files need an adjustment,

**Changes:**

For two include paths:  `s/tiledbsoma/soma/`

**Notes for Reviewer:**

[SC 28590](https://app.shortcut.com/tiledb-inc/story/28590/leftover-path-adjustment)
