### PR TITLE
[r] Put like with like in test-helpers

### DIFF
--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -1,3 +1,14 @@
+get_data <- function(x, package = NULL) {
+  stopifnot(
+    is_scalar_character(x),
+    is.null(package) || is_scalar_character(package)
+  )
+  e <- new.env()
+  on.exit(rm(e), add = TRUE)
+  data(list = x, package = package, envir = e)
+  return(e[[x]])
+}
+
 create_sparse_matrix_with_int_dims <- function(nrows = 10, ncols = 5, seed = 1, repr = "T") {
   set.seed(seed)
   Matrix::rsparsematrix(
@@ -34,50 +45,4 @@ create_arrow_schema <- function() {
     arrow::field("bar", arrow::float64(), nullable = FALSE),
     arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
   )
-}
-
-create_and_populate_soma_dataframe <- function(
-  uri,
-  nrows = 10L,
-  seed = 1,
-  index_column_names = "foo"
-) {
-  set.seed(seed)
-
-  arrow_schema <- create_arrow_schema()
-
-  tbl <- arrow::arrow_table(
-    foo = seq.int(nrows) + 1000L,
-    soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
-    bar = seq(nrows) + 0.1,
-    baz = as.character(seq.int(nrows) + 1000L),
-    schema = arrow_schema
-  )
-
-  sdf <- SOMADataFrame$new(uri, internal_use_only = "allowed_use")
-  sdf$create(arrow_schema, index_column_names = index_column_names)
-  sdf$write(tbl)
-  sdf
-}
-
-#' @param ... Arguments passed to create_sparse_matrix_with_int_dims
-create_and_populate_sparse_nd_array <- function(uri, ...) {
-
-  smat <- create_sparse_matrix_with_int_dims(...)
-
-  ndarray <- SOMASparseNDArray$new(uri, internal_use_only = "allowed_use")
-  ndarray$create(arrow::int32(), shape = dim(smat))
-  ndarray$write(smat)
-  ndarray
-}
-
-get_data <- function(x, package = NULL) {
-  stopifnot(
-    is_scalar_character(x),
-    is.null(package) || is_scalar_character(package)
-  )
-  e <- new.env()
-  on.exit(rm(e), add = TRUE)
-  data(list = x, package = package, envir = e)
-  return(e[[x]])
 }

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -1,3 +1,27 @@
+create_and_populate_soma_dataframe <- function(
+  uri,
+  nrows = 10L,
+  seed = 1,
+  index_column_names = "foo"
+) {
+  set.seed(seed)
+
+  arrow_schema <- create_arrow_schema()
+
+  tbl <- arrow::arrow_table(
+    foo = seq.int(nrows) + 1000L,
+    soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
+    bar = seq(nrows) + 0.1,
+    baz = as.character(seq.int(nrows) + 1000L),
+    schema = arrow_schema
+  )
+
+  sdf <- SOMADataFrame$new(uri, internal_use_only = "allowed_use")
+  sdf$create(arrow_schema, index_column_names = index_column_names)
+  sdf$write(tbl)
+  sdf
+}
+
 create_and_populate_obs <- function(uri, nrows = 10L, seed = 1) {
   create_and_populate_soma_dataframe(
     uri = uri,
@@ -24,6 +48,17 @@ create_and_populate_var <- function(uri, nrows = 10L, seed = 1) {
   sdf$create(tbl$schema, index_column_names = "soma_joinid")
   sdf$write(tbl)
   sdf
+}
+
+#' @param ... Arguments passed to create_sparse_matrix_with_int_dims
+create_and_populate_sparse_nd_array <- function(uri, ...) {
+
+  smat <- create_sparse_matrix_with_int_dims(...)
+
+  ndarray <- SOMASparseNDArray$new(uri, internal_use_only = "allowed_use")
+  ndarray$create(arrow::int32(), shape = dim(smat))
+  ndarray$write(smat)
+  ndarray
 }
 
 # Create a SOMAExperiment with a single measurement, "RNA"


### PR DESCRIPTION
This is a line-count-reducing PR which will help simplify #1325.

It puts the helpers which make SOMA data `helper-test-soma-objects.R` and leaves the ones that do not in `helper-test-data.R`.