### PR TITLE
[r] Unit-test failure on Mac M1

### DIFF
--- a/apis/r/tests/testthat/test-EphemeralCollection.R
+++ b/apis/r/tests/testthat/test-EphemeralCollection.R
@@ -2,7 +2,7 @@ test_that("Ephemeral Colelction mechanics", {
   uri <- withr::local_tempdir('ephemeral-collection')
   expect_warning(EphemeralCollection$new(uri = uri))
   expect_no_condition(collection <- EphemeralCollection$new())
-  expect_true(grepl('^ephemeral-collection:0x[[:digit:]a-f]{12}$', collection$uri))
+  expect_true(grepl('^ephemeral-collection:0x[[:digit:]a-f]{6,32}$', collection$uri))
   expect_false(collection$exists())
   expect_s3_class(collection$create(), collection$class())
   expect_true(collection$soma_type == "SOMACollection")

--- a/apis/r/tests/testthat/test-EphemeralMeasurement.R
+++ b/apis/r/tests/testthat/test-EphemeralMeasurement.R
@@ -4,7 +4,7 @@ test_that("Ephemeral Measurement mechanics", {
   # dir.create(uri)
   expect_warning(EphemeralMeasurement$new(uri))
   expect_no_condition(measurement <- EphemeralMeasurement$new())
-  expect_true(grepl('^ephemeral-collection:0x[[:digit:]a-f]{12}$', measurement$uri))
+  expect_true(grepl('^ephemeral-collection:0x[[:digit:]a-f]{6,32}$', measurement$uri))
   expect_false(measurement$exists())
   expect_error(measurement$var)
   expect_s3_class(measurement$create(), measurement$class())


### PR DESCRIPTION
On my x86-64 Mac:

```
> data.table::address("asdf")
[1] "0x7fe67e3c73e0"
```

On my arm64 Mac:

```
> data.table::address("asdf")
[1] "0x12e8f2620"
```