### PR TITLE
[r] Refactor build by as-needed rebuilding libtiledbsoma

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -37,12 +37,12 @@ jobs:
       - name: MkVars
         run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
-      - name: Build and install libtiledbsoma
-        run: sudo scripts/bld --prefix=/usr/local 
+      #- name: Build and install libtiledbsoma
+      #  run: sudo scripts/bld --prefix=/usr/local 
 
-      - name: Call ldconfig
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo ldconfig
+      #- name: Call ldconfig
+      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  run: sudo ldconfig
         
       - name: Test
         run: cd apis/r && tools/r-ci.sh run_tests

--- a/apis/r/.Rbuildignore
+++ b/apis/r/.Rbuildignore
@@ -19,6 +19,8 @@
 src/include
 src/libtiledbsoma
 tiledbsoma/libtiledbsoma.tar.gz.current
+tiledb.tar.gz
+tiledbsoma.tar.gz
 
 # vscode
 ^\.vscode$

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9022
+Version: 0.0.0.9023
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",
@@ -67,3 +67,4 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 2
 OS_type: unix
+SystemRequirements: cmake, git

--- a/apis/r/cleanup
+++ b/apis/r/cleanup
@@ -4,8 +4,11 @@ rm -r -f \
    src/*.o src/*.so src/*.dylib */*~ *~ \
    src/Makevars \
    tiledb.tar.gz \
+   tiledbsoma.tar.gz \
    tiledb/ \
+   tiledbsoma/ \
    inst/tiledb/ \
+   inst/tiledbsoma/ \
    src/include/ \
    src/lib \
    src/cmake_log.txt \

--- a/apis/r/configure
+++ b/apis/r/configure
@@ -2,20 +2,18 @@
 
 ## This allow for standard CRAN override preference for both a settable R_HOME
 ## with fallback to query R in $PATH for the value it has so it works both
-## explicitly or implicitly from the running R instance
+## explicitly, implicitly from the running R instance or by pointing at alternate
+## build when multiple R versions are installed (as CRAN does and some users do)
 : ${R_HOME=`R RHOME`}
 if test -z "${R_HOME}"; then
     echo Could not determine R_HOME.
     exit 1
 fi
 
-## look for tiledb core library and either use system library or download build
-have_tiledb="false"
-
-## check for pkg-config and use it to inquire about tiledb build options
+## Check for pkg-config and use it to inquire about tiledb and tiledbsoma build options
 pkg-config --version >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    pkg-config --exists tiledb
+    pkg-config --exists tiledb tiledbsoma
     if [ $? -eq 0 ]; then
         pkgcflags=`pkg-config --cflags tiledb tiledbsoma`
         pkglibs=`pkg-config --libs tiledb tiledbsoma`
@@ -27,11 +25,12 @@ if [ $? -eq 0 ]; then
             -e "s|@cxx17_macos@||" \
             src/Makevars.in > src/Makevars
 
-        have_tiledb="true"
         echo "** updated src/Makevars for system library via pkg-config"
+        exit 0
     fi
 fi
 
-if [ x"${have_tiledb}" = x"false" ]; then
-    ${R_HOME}/bin/Rscript tools/get_tarball.R
-fi
+## If we are still here `pkg-config` alone did not work.
+## So download tiledb (pre-made) and tiledbsoma (source, for now; then build)
+## This
+${R_HOME}/bin/Rscript tools/get_tarballs.R

--- a/apis/r/copy_source.sh
+++ b/apis/r/copy_source.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-## part one: if we are inside the git repo, simply copy over
-test -d ../../libtiledbsoma && cp -a ../../libtiledbsoma src/ && cp -a ../../scripts/bld src/libtiledbsoma && rm -rf src/libtiledbsoma/build src/libtiledbsoma/test/__pycache__
-
-## part two: also create a tar.gz 'for keeps' as we may need to install from partial source tree
-#test -d ../../libtiledbsoma && cd ../.. && tar -cz -f apis/r/libtiledbsoma.tar.gz libtiledbsoma

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -3,24 +3,21 @@ CXX_STD = CXX17
 ## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 10.14 for macOS
 PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx17_macos@ -Iinclude
 
+## When this becomes a CRAN package we may have to remove this. For now it keeps the noise down
+PKG_CXX17FLAGS = -Wno-deprecated-declarations
+
 ## We also need the TileDB library
-PKG_LIBS = @cxx17_macos@ -ltiledbsoma @tiledb_libs@ @tiledb_rpath@
+PKG_LIBS = @cxx17_macos@ @tiledb_libs@ @tiledb_rpath@
 
 all: $(SHLIB)
         # If we are:
         #  - on macOS aka Darwin which needs this
         #  - the library is present (implying non-system library use)
         # then let us call install_name_tool
-        #
-        # Pro-tip: here you can run things like `otool -L tiledbsoma.so`, `ls ../inst`, etc. but
-        # any attempted debug output will only be visible at the terminal if the R build fails.
-        #
-        # Note: we hard-code /usr/local/lib location for libtiledbsoma.so/dylib since this
-        # is likewise hard-coded in our CI build.
-        #
-	@if [ `uname -s` = 'Darwin' ] && [ -f tiledbsoma.so ]; then \
+	if [ `uname -s` = 'Darwin' ] && [ -f tiledbsoma.so ]; then \
 	    if [ -f ../inst/tiledb/lib/libtiledb.dylib ] ; then \
 	        install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; \
+		install_name_tool -add_rpath @loader_path/../tiledb/lib tiledbsoma.so; \
+	    	install_name_tool -add_rpath @loader_path/../tiledbsoma/lib tiledbsoma.so; \
 	    fi; \
-	    install_name_tool -add_rpath /usr/local/lib tiledbsoma.so; \
 	fi

--- a/apis/r/tools/build_libtiledbsoma.sh
+++ b/apis/r/tools/build_libtiledbsoma.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+## This script is invoked from the tarball-getting script `get_tarballs.R` which
+## itself is called from `configure`.
+
+cwd=`pwd`
+
+## This helps a little
+mv inst/tiledbsoma/TileDB-SOMA-* inst/tiledbsoma/TileDB-SOMA
+
+## Now make build/ and call cmake; make; make install
+mkdir inst/tiledbsoma/TileDB-SOMA/libtiledbsoma/build && \
+    cd inst/tiledbsoma/TileDB-SOMA/libtiledbsoma/build && \
+    cmake -DDOWNLOAD_TILEDB_PREBUILT=ON \
+          -DTILEDBSOMA_BUILD_CLI=OFF \
+          -DTILEDBSOMA_ENABLE_TESTING=OFF \
+          -DOVERRIDE_INSTALL_PREFIX=OFF \
+          -DCMAKE_INSTALL_PREFIX=${cwd}/inst/tiledbsoma .. && \
+    make && \
+    make install-libtiledbsoma && \
+    cd -
+
+rm -rf inst/tiledbsoma/TileDB-SOMA


### PR DESCRIPTION
**Issue and/or context:**

Since the switch to using an external libtiledbsoma and its single unconditional compilation, we no longer build in environments that build like an R installation with only the R package file tree (for us: from `apis/r` downwards). 

This includes for example the somewhat-visible and useful [r-universe](https://tiledb-inc.r-universe.dev/builds) providing binaries too but can also be seen in bug reports such as #1342 (which, while titled for macOS M2 is really generic) and carries over to `remotes::install_github()` installations somewhat common with R users.  The move to using an external library is the right move and should not be reverted.  However, as we _currently_ still do not have artifacts, this PR suggests to modify the build as a stop-gap measure.

**Changes:**

The build now takes two approach.  _Either_ system libraries (plural) for both TileDB Core and TiileDB-SOMA are found (via `pkg-config`) are found, and if so, used.  _Or_ the (most-recent and pinned) release sources for TileDB-SOMA are downloaded (that is large file, this can and should switch to just a libtiledbsoma source artifact to be built) and built as a shared library, along with artifact download of TileDB core.  

**Notes for Reviewer:**

[SC 28701](https://app.shortcut.com/tiledb-inc/story/28701/refactor-package-build-to-fetch-library-source-and-build-if-no-library-is-found)
