### PR TITLE
[r] Allow default `index_column_names=c("soma_joinid")`

### DIFF
--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -7,11 +7,11 @@
 #' @param platform_config Optional platform configuration
 #' @param tiledbsoma_ctx Optional SOMATileDBContext
 #' @export
-SOMADataFrameCreate <- function(uri, schema, index_column_names,
+SOMADataFrameCreate <- function(uri, schema, index_column_names = c("soma_joinid"),
                                 platform_config = NULL, tiledbsoma_ctx = NULL) {
     sdf <- SOMADataFrame$new(uri, platform_config, tiledbsoma_ctx,
                              mode="WRITE", internal_use_only = "allowed_use")
-    sdf$create(schema, index_column_names, platform_config=platform_config)
+    sdf$create(schema, index_column_names=index_column_names, platform_config=platform_config)
     sdf
 }
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -20,7 +20,7 @@ SOMADataFrame <- R6::R6Class(
     #' @param index_column_names A vector of column names to use as user-defined
     #' index columns.  All named columns must exist in the schema, and at least
     #' one index column name is required.
-    create = function(schema, index_column_names, platform_config=NULL) {
+    create = function(schema, index_column_names=c("soma_joinid"), platform_config=NULL) {
       schema <- private$validate_schema(schema, index_column_names)
 
       attr_column_names <- setdiff(schema$names, index_column_names)

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -38,11 +38,20 @@ create_dense_matrix_with_int_dims <- function(nrows = 10, ncols = 5, seed = 1) {
   )
 }
 
-create_arrow_schema <- function() {
-  arrow::schema(
-    arrow::field("foo", arrow::int32(), nullable = FALSE),
-    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
-    arrow::field("bar", arrow::float64(), nullable = FALSE),
-    arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
-  )
+create_arrow_schema <- function(foo_first=TRUE) {
+  if (foo_first) {
+    arrow::schema(
+      arrow::field("foo", arrow::int32(), nullable = FALSE),
+      arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+      arrow::field("bar", arrow::float64(), nullable = FALSE),
+      arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
+    )
+  } else {
+    arrow::schema(
+      arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+      arrow::field("foo", arrow::int32(), nullable = FALSE),
+      arrow::field("bar", arrow::float64(), nullable = FALSE),
+      arrow::field("baz", arrow::large_utf8(), nullable = FALSE)
+    )
+  }
 }

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -1,20 +1,35 @@
 test_that("DataFrame Factory", {
     uri <- tempfile()
 
-    # check that straight use of new() errors, but 'with handshake' passes
+    # Check that straight use of new() errors, but 'with handshake' passes
     expect_error(SOMADataFrame$new(uri))
     expect_silent(d1 <- SOMADataFrame$new(uri, internal_use_only = "allowed_use"))
 
-    # check creation of a DF
+    # Check creation of a DF
+    asch <- create_arrow_schema(foo_first=FALSE)
+    expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch))
+    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, foo = 1L:10L, bar = sqrt(1:10),
+                              baz = letters[1:10], schema = asch)
+    d2$write(tbl)
+
+    # Check opening to read
+    expect_silent(d3 <- SOMADataFrameOpen(uri))
+    expect_silent(chk <- d3$read())
+    expect_equal(tbl, chk)
+})
+
+test_that("DataFrame Factory with specified index_column_names", {
+    uri <- tempfile()
+
+    # Check creation of a DF
     asch <- create_arrow_schema()
-    expect_error(d2 <- SOMADataFrameCreate(uri, asch)) # misses ind col name
-    expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "foo")) # misses scheme
+    expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "foo")) # misses schema
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "foo"))
     tbl <- arrow::arrow_table(foo = 1L:10L, soma_joinid = 1L:10L, bar = sqrt(1:10),
                               baz = letters[1:10], schema = asch)
     d2$write(tbl)
 
-    # check opening to read
+    # Check opening to read
     expect_silent(d3 <- SOMADataFrameOpen(uri))
     expect_silent(chk <- d3$read())
     expect_equal(tbl, chk)


### PR DESCRIPTION
Found on PR #1325 for issue #1346.

This is a simple Python/R parity issue.