### PR TITLE
[r] [RFC] Add `SOMASparseNDArray$read_spam_matrix()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -63,7 +63,9 @@ Suggests:
     testthat (>= 3.0.0),
     pbmc3k.tiledb,
     SeuratObject (>= 4.1.0),
-    datasets
+    datasets,
+    spam,
+    spam64
 VignetteBuilder: knitr
 Config/testthat/edition: 2
 OS_type: unix

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -272,6 +272,7 @@ test_that("platform_config defaults", {
 test_that("SOMASparseNDArray read_spam_matrix", {
   skip_if_not_installed('spam')
   library(spam)
+  library(Matrix)
   uri <- withr::local_tempdir("sparse-ndarray-spam")
   ndarray <- SOMASparseNDArray$new(uri, internal_use_only = "allowed_use")
   ndarray$create(arrow::int32(), shape = c(10, 20))

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -271,8 +271,7 @@ test_that("platform_config defaults", {
 
 test_that("SOMASparseNDArray read_spam_matrix", {
   skip_if_not_installed('spam')
-  library(spam)
-  library(Matrix)
+  withr::local_package("spam")
   uri <- withr::local_tempdir("sparse-ndarray-spam")
   ndarray <- SOMASparseNDArray$new(uri, internal_use_only = "allowed_use")
   ndarray$create(arrow::int32(), shape = c(10, 20))
@@ -289,11 +288,12 @@ test_that("SOMASparseNDArray read_spam_matrix", {
   # Test transposed
   expect_no_condition(spt <- ndarray$read_spam_matrix(transpose = TRUE))
   expect_s4_class(spt, 'spam')
-  expect_identical(dim(spt), dim(t(mat)))
-  expect_identical(as.matrix(spt), as.matrix(t(mat)))
+  mat_t <- Matrix::t(mat)
+  expect_identical(dim(spt), dim(mat_t))
+  expect_identical(as.matrix(spt), as.matrix(mat_t))
 
   # Test with coords
-  coords <- list(soma_dim_0=0, soma_dim_1=0:2)
+  coords <- list(soma_dim_0 = 0, soma_dim_1 = 0:2)
   expect_no_condition(spc <- ndarray$read_spam_matrix(coords))
   expect_identical(
     dim(spc),

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -271,6 +271,7 @@ test_that("platform_config defaults", {
 
 test_that("SOMASparseNDArray read_spam_matrix", {
   skip_if_not_installed('spam')
+  library(spam)
   uri <- withr::local_tempdir("sparse-ndarray-spam")
   ndarray <- SOMASparseNDArray$new(uri, internal_use_only = "allowed_use")
   ndarray$create(arrow::int32(), shape = c(10, 20))


### PR DESCRIPTION
Add support for reading spam matrices from sparse arrays. This allows users to read in data exceding the capacity of Matrix-based sparse matrices (`nnz > .Machine$integer.max || dim(mat) > .Machine$integer.max`)

Implemented SOMA methods:

- `SOMASparseNDArray$read_spam_matrix()`: allows reading in an array as a spam matrix (both 32- and 64-bit)

Future work:

- determine if this is desired functionality
- we may want to combine all sparse-matrix readers into one `read_sparse_matrix()` or `read_matrix()` method with options to determine how to realize the matrix

Note for reviewers:

I don't know if this is functionality we want to support. I'm more than happy to say that we don't want to support spam, in which case we can close and move on

partially addresses #1348