### PR TITLE
[python] Add run-time type checks to `PlatformConfig` on ingest/create

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -40,7 +40,12 @@ from ._exception import SOMAError, is_does_not_exist_error
 from ._sparse_nd_array import SparseNDArray
 from ._tiledb_object import AnyTileDBObject, TileDBObject
 from ._types import OpenTimestamp
-from ._util import is_relative_uri, make_relative_path, uri_joinpath
+from ._util import (
+    is_relative_uri,
+    make_relative_path,
+    uri_joinpath,
+    validate_platform_config,
+)
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
@@ -91,8 +96,9 @@ class CollectionBase(
             uri:
                 The location to create this SOMA collection at.
             platform_config:
-                Optional call-specific options to use when
-                creating this collection. (Currently unused.)
+                Platform-specific options used to create this array,
+                provided via ``{"tiledb": {"create": ...}}`` nested keys,
+                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
             context:
                 If provided, the :class:`SOMATileDBContext` to use when creating and
                 opening this collection.
@@ -109,6 +115,7 @@ class CollectionBase(
             Experimental.
         """
         context = _validate_soma_tiledb_context(context)
+        validate_platform_config(platform_config)
         tiledb.group_create(uri=uri, ctx=context.tiledb_ctx)
         handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
         cls._set_create_metadata(handle)

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -59,8 +59,9 @@ class NDArray(TileDBArray, somacore.NDArray):
                 possible int64 will be used.  This makes a :class:`SparseNDArray`
                 growable.
             platform_config:
-                Platform-specific options used to create this Array,
-                provided via ``{"tiledb": {"create": ...}}`` nested keys.
+                Platform-specific options used to create this array,
+                provided via ``{"tiledb": {"create": ...}}`` nested keys,
+                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by
@@ -88,6 +89,7 @@ class NDArray(TileDBArray, somacore.NDArray):
         # the upper limit is exactly 2**63-1.
 
         context = _validate_soma_tiledb_context(context)
+        _util.validate_platform_config(platform_config)
         schema = cls._build_tiledb_schema(
             type,
             shape,

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -160,8 +160,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 possible values for the column's datatype.  This makes a
                 :class:`DataFrame` growable.
             platform_config:
-                Platform-specific options used to create this
-                DataFrame, provided via ``{"tiledb": {"create": ...}}`` nested keys.
+                Platform-specific options used to create this array,
+                provided via ``{"tiledb": {"create": ...}}`` nested keys,
+                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by
@@ -201,6 +202,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             Experimental.
         """
         context = _validate_soma_tiledb_context(context)
+        _util.validate_platform_config(platform_config)
         schema = _canonicalize_schema(schema, index_column_names)
         tdb_schema = _build_tiledb_schema(
             schema,

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -14,6 +14,7 @@ import somacore
 from somacore import options
 
 from ._types import OpenTimestamp, Slice, is_slice_of
+from .options._tiledb_create_options import TileDBCreateOptions
 
 
 def get_start_stamp() -> float:
@@ -260,3 +261,12 @@ def ms_to_datetime(millis: int) -> datetime.datetime:
     secs, millis = divmod(millis, 1000)
     dt = datetime.datetime.fromtimestamp(secs, tz=datetime.timezone.utc)
     return dt.replace(microsecond=millis * 1000)
+
+
+def validate_platform_config(platform_config: Any) -> None:
+    """Offers a run-time type check on this ingestion/creation argument, which is easy to miskey."""
+    if platform_config is not None:
+        if isinstance(platform_config, TileDBCreateOptions):
+            raise TypeError(
+                """platform_config argument is of type TileDBCreateOptions -- please wrap it in `{"tiledb": {"create": argument}}`."""
+            )

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -196,8 +196,6 @@ def from_anndata(
               writing any data to the array. Useful to prepare for appending
               multiple H5AD files to a single SOMA.
 
-        XXX use_relative_uri
-
         X_kind: Which type of matrix is used to store dense X data from the
             H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -95,6 +95,11 @@ def from_h5ad(
 
         measurement_name: The name of the measurement to store data in.
 
+        context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
+
+        platform_config: Optional dict including data of the form ``{"tiledb": {"create": create_options}}``
+        where ``create_options`` is a :class:`TileDBCreateOptions`.
+
         ingest_mode: The ingestion type to perform:
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
             - ``resume``: Adds data to an existing SOMA, skipping writing data
@@ -177,6 +182,11 @@ def from_anndata(
 
         measurement_name: The name of the measurement to store data in.
 
+        context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
+
+        platform_config: Optional dict including data of the form ``{"tiledb": {"create": create_options}}``
+        where ``create_options`` is a :class:`TileDBCreateOptions`.
+
         ingest_mode: The ingestion type to perform:
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
             - ``resume``: Adds data to an existing SOMA, skipping writing data
@@ -185,6 +195,8 @@ def from_anndata(
             - ``schema_only``: Creates groups and the array schema, without
               writing any data to the array. Useful to prepare for appending
               multiple H5AD files to a single SOMA.
+
+        XXX use_relative_uri
 
         X_kind: Which type of matrix is used to store dense X data from the
             H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
@@ -204,6 +216,8 @@ def from_anndata(
         raise TypeError(
             "Second argument is not an AnnData object -- did you want from_h5ad?"
         )
+
+    _util.validate_platform_config(platform_config)
 
     context = _validate_soma_tiledb_context(context)
 
@@ -650,6 +664,8 @@ def create_from_matrix(
     Lifecycle:
         Experimental.
     """
+    _util.validate_platform_config(platform_config)
+
     # SparseDataset has no ndim but it has a shape
     if len(matrix.shape) != 2:
         raise ValueError(f"expected matrix.shape == 2; got {matrix.shape}")

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -56,7 +56,7 @@ def test_io_create_from_matrix_Dense_nd_array(tmp_path, tdb_create_options, src_
         soma.DenseNDArray,
         tmp_path.as_posix(),
         src_matrix,
-        platform_config=tdb_create_options,
+        platform_config={"tiledb": {"create": tdb_create_options}},
     ).close()
     with _factory.open(tmp_path.as_posix()) as snda:
         assert snda.ndim == src_matrix.ndim
@@ -107,7 +107,7 @@ def test_io_create_from_matrix_Sparse_nd_array(
         soma.SparseNDArray,
         tmp_path.as_posix(),
         src_matrix,
-        platform_config=tdb_create_options,
+        platform_config={"tiledb": {"create": tdb_create_options}},
     ).close()
 
     with _factory.open(tmp_path.as_posix()) as snda:


### PR DESCRIPTION
**Issue and/or context:**

Resolves a UX issue encountered yesterday.

Note that Python doesn't do run-time type-checking.

We do have types enabled, and we do have CI for `ruff` and `mypy`, and we do have `typeguard` enabled in our CI which _does_ enforce run-time type checking at CI time -- for all code within this package.

However, `typeguard` is not used at runtime outside of CI, so we must add manual checks at the user interface where arguments are coming from out-of-package. This PR is one in a series of several PRs wherein we manually add a type-check to a crucial argument.
