### PR TITLE
[python] Update `platform_config` usage advice

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -96,9 +96,8 @@ class CollectionBase(
             uri:
                 The location to create this SOMA collection at.
             platform_config:
-                Platform-specific options used to create this array,
-                provided via ``{"tiledb": {"create": ...}}`` nested keys,
-                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
+                Platform-specific options used to create this collection, provided in the form
+                ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}``.
             context:
                 If provided, the :class:`SOMATileDBContext` to use when creating and
                 opening this collection.

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -59,9 +59,8 @@ class NDArray(TileDBArray, somacore.NDArray):
                 possible int64 will be used.  This makes a :class:`SparseNDArray`
                 growable.
             platform_config:
-                Platform-specific options used to create this array,
-                provided via ``{"tiledb": {"create": ...}}`` nested keys,
-                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
+                Platform-specific options used to create this array, provided in the form
+                ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}``.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -160,9 +160,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 possible values for the column's datatype.  This makes a
                 :class:`DataFrame` growable.
             platform_config:
-                Platform-specific options used to create this array,
-                provided via ``{"tiledb": {"create": ...}}`` nested keys,
-                where the ``...`` is of type ``tiledbsoma.options._tiledb_create_options.TileDBCreateOptions``.
+                Platform-specific options used to create this array, provided in the form
+                ``{"tiledb": {"create": {"dataframe_dim_zstd_level": 7}}}``.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -97,8 +97,8 @@ def from_h5ad(
 
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
 
-        platform_config: Optional dict including data of the form ``{"tiledb": {"create": create_options}}``
-        where ``create_options`` is a :class:`TileDBCreateOptions`.
+        platform_config: Platform-specific options used to create this array, provided in the form
+        ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}`` nested keys.
 
         ingest_mode: The ingestion type to perform:
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
@@ -184,8 +184,9 @@ def from_anndata(
 
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
 
-        platform_config: Optional dict including data of the form ``{"tiledb": {"create": create_options}}``
-        where ``create_options`` is a :class:`TileDBCreateOptions`.
+        platform_config:
+            Platform-specific options used to create this array, provided in the form
+            ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}``.
 
         ingest_mode: The ingestion type to perform:
             - ``write``: Writes all data, creating new layers if the SOMA already exists.


### PR DESCRIPTION
**Issue and/or context:** Follow-on to #1370, with improved usage advice -- tracking issue #1394

**Changes:** Use the intended syntax.

**Notes for Reviewer:** Where is a good reference link we can point users to that has a list of available keys? The only list I'm aware of is in [TileDBCreateOptions](https://github.com/single-cell-data/TileDB-SOMA/blob/1.2.3/apis/python/src/tiledbsoma/options/_tiledb_create_options.py) method names, but this is not exported API.