### PR TITLE
[python,r] Added two badges (and ensure consistent two break before sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![TileDB-SOMA CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/ci.yml)
 [![TileDB-SOMA R CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml)
+[![PyPI version](https://badge.fury.io/py/tiledbsoma.svg)](https://badge.fury.io/py/tiledbsoma)
+[![tiledbsoma status badge](https://tiledb-inc.r-universe.dev/badges/tiledbsoma)](https://tiledb-inc.r-universe.dev)
 [![codecov](https://codecov.io/github/single-cell-data/TileDB-SOMA/branch/main/graph/badge.svg)](https://codecov.io/github/single-cell-data/TileDB-SOMA)
 
 
@@ -18,6 +20,7 @@ Get started on using TileDB-SOMA:
 * [Quick start](#quick-start).
 * Python [documentation](https://tiledbsoma.readthedocs.io/en/latest/python-api.html). 
 * R [documentation](https://single-cell-data.github.io/TileDB-SOMA/).
+
 
 ## What can TileDB-SOMA do?
 
@@ -83,14 +86,17 @@ If you are interested in listing any projects here please contact us at [soma@ch
 * Any/all questions, comments, and concerns are welcome at the [GitHub new-issue page](https://github.com/single-cell-data/TileDB-SOMA/issues/new/choose) -- or, you can also browse [existing issues](https://github.com/single-cell-data/TileDB-SOMA/issues).
 * If you believe you have found a security issue, in lieu of filing an issue please responsibly disclose it by contacting [security@tiledb.com](mailto:security@tiledb.com).
 
+
 ## Branches
 
 This branch, `main`, implements the [updated specfication](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md).  Please also see the `main-old` branch which implements the [original specification](https://github.com/single-cell-data/TileDB-SOMA/blob/main-old/spec/specification.md).
+
 
 ## Developer information
 
 * [TileDB-SOMA wiki](https://github.com/single-cell-data/TileDB-SOMA/wiki).
 * [Build instructions for developers](libtiledbsoma/README.md).
+
 
 ## Code of Conduct
 


### PR DESCRIPTION
closes #1374 

**Issue and/or context:**

As discussed in #1374 we can add two badges to link to packages

**Changes:**

Adds two lines of markdown (and, while at it, ensures each new section ('two hashes') has two empty lines in front of it which reads more clearly

**Notes for Reviewer:**

#1374
[SC 28916](https://app.shortcut.com/tiledb-inc/story/28916/extend-readme-with-two-package-to-pypi-and-r-universe)