### PR TITLE
[python] Address leading-underscore issue for `uns` data

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1194,19 +1194,25 @@ def _ingest_uns_dict(
         _maybe_set(parent, parent_key, coll, use_relative_uri=use_relative_uri)
         coll.metadata["soma_tiledbsoma_type"] = "uns"
         for key, value in dct.items():
+            sanitized_key = key
+            # uns/_scvi cannot be uploaded to TileDB Cloud since
+            # "name must begin with an unaccented alphanumeric character" --
+            # so turn that into "u_scvi".
+            if key.startswith("_"):
+                sanitized_key = "u" + key
             if isinstance(value, np.generic):
                 # This is some kind of numpy scalar value. Metadata entries
                 # only accept native Python types, so unwrap it.
                 value = value.item()
             if isinstance(value, (int, float, str)):
                 # Primitives get set on the metadata.
-                coll.metadata[key] = value
+                coll.metadata[sanitized_key] = value
                 continue
             if isinstance(value, Mapping):
                 # Mappings are represented as sub-dictionaries.
                 _ingest_uns_dict(
                     coll,
-                    key,
+                    sanitized_key,
                     value,
                     platform_config,
                     context,
@@ -1216,21 +1222,23 @@ def _ingest_uns_dict(
                 continue
             if isinstance(value, pd.DataFrame):
                 with _write_dataframe(
-                    _util.uri_joinpath(coll.uri, key),
+                    _util.uri_joinpath(coll.uri, sanitized_key),
                     value,
                     None,
                     platform_config,
                     context=context,
                     ingest_mode=ingest_mode,
                 ) as df:
-                    _maybe_set(coll, key, df, use_relative_uri=use_relative_uri)
+                    _maybe_set(
+                        coll, sanitized_key, df, use_relative_uri=use_relative_uri
+                    )
                 continue
             if isinstance(value, list) or "numpy" in str(type(value)):
                 value = np.asarray(value)
             if isinstance(value, np.ndarray):
                 if value.dtype.names is not None:
                     msg = (
-                        f"Skipped {coll.uri}[{key!r}]"
+                        f"Skipped {coll.uri}[{sanitized_key!r}]"
                         " (uns): unsupported structured array"
                     )
                     # This is a structured array, which we do not support.
@@ -1239,7 +1247,7 @@ def _ingest_uns_dict(
 
                 _ingest_uns_ndarray(
                     coll,
-                    key,
+                    sanitized_key,
                     value,
                     platform_config,
                     context=context,
@@ -1247,7 +1255,7 @@ def _ingest_uns_dict(
                 )
             else:
                 msg = (
-                    f"Skipped {coll.uri}[{key!r}]"
+                    f"Skipped {coll.uri}[{sanitized_key!r}]"
                     f" (uns object): unrecognized type {type(value)}"
                 )
                 logging.log_io(msg, msg)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -10,7 +10,7 @@ other formats. Currently only ``.h5ad`` (`AnnData <https://anndata.readthedocs.i
 """
 
 import math
-import re
+import string
 import time
 from typing import (
     Any,
@@ -1199,7 +1199,7 @@ def _ingest_uns_dict(
             # Things like uns/_scvi cannot be uploaded to TileDB Cloud since
             # "name must begin with an unaccented alphanumeric character" --
             # so turn that into "u_scvi".
-            if not re.match("^[a-zA-Z].*$", key):
+            if key[0] not in string.ascii_letters + string.digits:
                 key = "u" + key
 
             if isinstance(value, np.generic):

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1199,7 +1199,7 @@ def _ingest_uns_dict(
             # Things like uns/_scvi cannot be uploaded to TileDB Cloud since
             # "name must begin with an unaccented alphanumeric character" --
             # so turn that into "u_scvi".
-            if not re.match('^[a-zA-Z].*$', key):
+            if not re.match("^[a-zA-Z].*$", key):
                 key = "u" + key
 
             if isinstance(value, np.generic):
@@ -1231,9 +1231,7 @@ def _ingest_uns_dict(
                     context=context,
                     ingest_mode=ingest_mode,
                 ) as df:
-                    _maybe_set(
-                        coll, key, df, use_relative_uri=use_relative_uri
-                    )
+                    _maybe_set(coll, key, df, use_relative_uri=use_relative_uri)
                 continue
             if isinstance(value, list) or "numpy" in str(type(value)):
                 value = np.asarray(value)

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -27,7 +27,7 @@ def h5ad_file(request):
 @pytest.fixture
 def h5ad_file_extended(request):
     # This has more component arrays in it
-    input_path = HERE.parent / "testdata/pbmc3k_processed.h5ad"
+    input_path = HERE.parent / "testdata/pbmc3k_processed_with_underscore_uns.h5ad"
     return input_path
 
 
@@ -318,6 +318,7 @@ def test_ingest_uns(tmp_path: pathlib.Path, h5ad_file_extended):
             "draw_graph",
             "louvain",
             "neighbors",
+            "u_neighbors",
             "pca",
             "rank_genes_groups",
         }


### PR DESCRIPTION
**Issue and/or context:**

Found during testing. Issue is that TileDB Cloud disallows leading underscores, but we sometimes have things like `uns/_scvi`. Failure:

```
error creating the group, please check your inputs and try again: name must begin with an unaccented alphanumeric character
```

**Changes:**

Prepend a leading `u`, e.g. `uns/u_scvi`.

**Notes for Reviewer:**

This is still in draft until I get some unit-test cases up that test the affected case. (Already verified ad-hoc on laptop.)