### PR TITLE
[r] Set #define so that spdlog uses REprintf

### DIFF
--- a/apis/r/inst/include/tiledbsoma_types.h
+++ b/apis/r/inst/include/tiledbsoma_types.h
@@ -1,8 +1,16 @@
 
 // this file can make headers available for the generated file RcppExports.cpp
 
-#include <nanoarrow.h>          // for C interface to Arrow
-#include <tiledb/tiledb>	// for QueryCondition etc
+// defining this prevents spdlog to use stderr -- see bottom of spdlog/logger-inl.h
+#define USING_R
+#define R_R_H
+// it also needs these R headers to define REprintf and ::R_FlushConsole
+#include <R.h>
+#include <Rinterface.h>
+#include <R_ext/Print.h>
+
+#include <nanoarrow.h>          			// for C interface to Arrow
+#include <tiledb/tiledb>					// for QueryCondition etc
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
 #include <tiledbsoma/tiledbsoma>
 


### PR DESCRIPTION
**Issue and/or context:**

When checking the package with `R CMD check`, a NOTE is issued because output is directed to `stderr` which R and CRAN dislike.  Per _Writing R Extensions_ all output should go via R's own io buffers to be nicely synchronised.

This actually comes from `spdlog` and it is something I noticed a few years ago, and convinced upstream to accomodate with a very simple (double) switch (from [here](https://github.com/gabime/spdlog/blob/57a9fd0841f00e92b478a07fef62636d7be612a8/include/spdlog/logger-inl.h#L250-L254) in current sources, in our version in another file but 

```c++
#if defined(USING_R) && defined(R_R_H) // if in R environment
        REprintf(null, err_counter, date_buf, name().c_str(), msg.c_str());
#else
        std::fprintf(stderr, null, err_counter, date_buf, name().c_str(), msg.c_str());
#endif
```

**Changes:**

Before the inclusion of the `spdlog` header (via the `libtiledbsoma` headers) we define the two `#define` needed to make the switch, and include the R header files to make `REprintf()` (== printing via R's error buffer) and also console flusher (used from another file with the same `#define` switches) visible.  

No other changes

**Notes for Reviewer:**

This is not urgent as we are not planning to submit to CRAN 'this week' but it is something we talked about, and reducing line noise from package checks is general a positve.

[SC 29024](https://app.shortcut.com/tiledb-inc/story/29024/r-avoid-a-nag-from-r-cmd-check)

