### PR TITLE
[r] Update mode semantics for implicit open

### DIFF
--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -71,8 +71,8 @@ SOMACollectionBase <- R6::R6Class(
     #' @description Retrieve a SOMA object by name. (lifecycle: experimental)
     #' @param name The name of the object to retrieve.
     #' @returns SOMA object.
-    get = function(name, mode = "READ") {
-      super$get(name, mode = mode)
+    get = function(name) {
+      super$get(name)
     },
 
     #' @description Add a new SOMA collection to this collection. (lifecycle: experimental)
@@ -201,7 +201,6 @@ SOMACollectionBase <- R6::R6Class(
         platform_config = self$platform_config,
         internal_use_only = "allowed_use"
       )
-      obj$open(mode = "READ", internal_use_only = "allowed_use")
       obj
     },
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -133,10 +133,10 @@ TileDBGroup <- R6::R6Class(
    },
 
     #' @description Retrieve a group member by name. If the member isn't already
-    #' open, it is opened for read. (lifecycle: experimental)
+    #' open, it is opened in the same mode as the parent is open for. (lifecycle: experimental)
     #' @param name The name of the member.
     #' @returns A `TileDBArray` or `TileDBGroup`.
-    get = function(name, mode = "READ") {
+    get = function(name) {
       stopifnot(is_scalar_character(name))
       private$check_open_for_read_or_write()
 
@@ -157,21 +157,17 @@ TileDBGroup <- R6::R6Class(
       # may override construct_member.
       if (is.null(member$object)) {
         obj <- private$construct_member(member$uri, member$type)
-      } else {
-        obj <- member$object
-      }
 
-      # TODO: this seems a bit ad-hoc but is passing tests ...
-      # issue is doing foo$bar$get("baz", "WRITE") if foo$bar$get("baz")
-      # has already been implicitly opened.
-      if (obj$is_open()) {
-        if (mode == "WRITE" && obj$mode() != "WRITE") {
-          obj$close()
-          obj$open(mode, internal_use_only = "allowed_use")
+        if (self$is_open()) {
+          obj$open(mode = self$mode(), internal_use_only = "allowed_use")
         }
       } else {
-        obj$open(mode, internal_use_only = "allowed_use")
+        obj <- member$object
+        if (!obj$is_open()) {
+          obj$open(mode = self$mode(), internal_use_only = "allowed_use")
+        }
       }
+
       obj
     },
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -157,10 +157,7 @@ TileDBGroup <- R6::R6Class(
       # may override construct_member.
       if (is.null(member$object)) {
         obj <- private$construct_member(member$uri, member$type)
-
-        if (self$is_open()) {
-          obj$open(mode = self$mode(), internal_use_only = "allowed_use")
-        }
+        obj$open(mode = self$mode(), internal_use_only = "allowed_use")
       } else {
         obj <- member$object
         if (!obj$is_open()) {

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -133,7 +133,7 @@ TileDBGroup <- R6::R6Class(
    },
 
     #' @description Retrieve a group member by name. If the member isn't already
-    #' open, it is opened in the same mode as the parent is open for. (lifecycle: experimental)
+    #' open, it is opened in the same mode as the parent. (lifecycle: experimental)
     #' @param name The name of the member.
     #' @returns A `TileDBArray` or `TileDBGroup`.
     get = function(name) {

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -2,7 +2,7 @@
 #'
 NULL
 
-#' Convert a \pkg{Seurat} Sub-Object to a SOMA Object
+#' Convert a \pkg{Seurat} Sub-Object to a SOMA Object, returned opened for write
 #'
 #' Various helpers to write \pkg{Seurat} sub-objects to SOMA objects.
 #'
@@ -23,7 +23,7 @@ NULL
 NULL
 
 #' @return \code{Assay} method: a \code{\link{SOMAMeasurement}} with the
-#' data from \code{x}
+#' data from \code{x}, returned opened for write
 #'
 #' @rdname write_soma_seurat_sub
 #'
@@ -178,7 +178,7 @@ write_soma.Assay <- function(
 #' (eg. \code{nrow(assay)})
 #'
 #' @return \code{DimReduc} and \code{Graph} methods: invisibly returns
-#' \code{soma_parent} with the values of \code{x} added to it
+#' \code{soma_parent}, opened for write, with the values of \code{x} added to it
 #'
 #' @rdname write_soma_seurat_sub
 #'
@@ -380,7 +380,7 @@ write_soma.Graph <- function(
   return(invisible(soma_parent))
 }
 
-#' Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA
+#' Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA, returned opened for write
 #'
 #' @inheritParams write_soma
 #' @param x A \code{\link[SeuratObject]{Seurat}} object

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -12,7 +12,7 @@
 #' @param tiledbsoma_ctx Optional \code{\link{SOMATileDBContext}}
 #'
 #' @return The URI to the resulting \code{\link{SOMAExperiment}} generated from
-#' the data contained in \code{x}
+#' the data contained in \code{x}, returned opened for write
 #'
 #' @section Known methods:
 #' \itemize{
@@ -39,7 +39,7 @@ write_soma <- function(x, uri, ..., platform_config = NULL, tiledbsoma_ctx = NUL
 #' relative or aboslute
 #'
 #' @return The resulting SOMA \link[tiledbsoma:SOMASparseNDArray]{array} or
-#' \link[tiledbsoma:SOMADataFrame]{data frame}
+#' \link[tiledbsoma:SOMADataFrame]{data frame}, returned opened for write
 #'
 #' @name write_soma_objects
 #' @rdname write_soma_objects

--- a/apis/r/tests/testthat/test-SeuratOutgest-graph.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-graph.R
@@ -8,11 +8,11 @@ test_that("Load graph from ExperimentQuery mechanics", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
 
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add graph
@@ -29,6 +29,11 @@ test_that("Load graph from ExperimentQuery mechanics", {
   exp_ms_rna$add_new_collection(obsp, 'obsp')
 
   exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   query <- SOMAExperimentAxisQuery$new(
@@ -88,10 +93,10 @@ test_that("Load graph from sliced ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add graph
@@ -107,6 +112,11 @@ test_that("Load graph from sliced ExperimentQuery", {
   ))
   exp_ms_rna$add_new_collection(obsp, 'obsp')
   exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_slice <- bit64::as.integer64(seq(3, 72))
@@ -152,10 +162,10 @@ test_that("Load graph from indexed ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add graph
@@ -171,6 +181,11 @@ test_that("Load graph from indexed ExperimentQuery", {
   ))
   exp_ms_rna$add_new_collection(obsp, 'obsp')
   exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_value_filter <- paste0(

--- a/apis/r/tests/testthat/test-SeuratOutgest-object.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-object.R
@@ -8,10 +8,10 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add embeddings
@@ -65,7 +65,11 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   ))
   exp_ms_rna$add_new_collection(obsp, 'obsp')
 
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   query <- SOMAExperimentAxisQuery$new(
@@ -237,10 +241,10 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add embeddings
@@ -294,7 +298,11 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
   ))
   exp_ms_rna$add_new_collection(obsp, 'obsp')
 
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_slice <- bit64::as.integer64(seq(3, 72))
@@ -350,10 +358,10 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add embeddings
@@ -407,7 +415,11 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
   ))
   exp_ms_rna$add_new_collection(obsp, 'obsp')
   
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_value_filter <- paste0(

--- a/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
@@ -8,7 +8,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
 
@@ -81,7 +81,11 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   varm$close()
   exp_ms_rna$add_new_collection(varm, 'varm')
 
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   experiment <- SOMAExperimentOpen(experiment$uri)
@@ -272,11 +276,11 @@ test_that("Load reduction from sliced ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
 
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add embeddings
@@ -347,7 +351,11 @@ test_that("Load reduction from sliced ExperimentQuery", {
 
   exp_ms_rna$add_new_collection(varm, 'varm')
 
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_slice <- bit64::as.integer64(seq(3, 72))
@@ -468,11 +476,11 @@ test_that("Load reduction from indexed ExperimentQuery", {
     n_obs = n_obs,
     n_var = n_var,
     X_layer_names = c("counts", "logcounts"),
-    mode = "READ"
+    mode = "WRITE"
   )
   on.exit(experiment$close())
 
-  exp_ms_rna <- experiment$ms$get('RNA', 'WRITE')
+  exp_ms_rna <- experiment$ms$get('RNA')
   expect_equal(exp_ms_rna$mode(), 'WRITE')
 
   # Add embeddings
@@ -540,7 +548,11 @@ test_that("Load reduction from indexed ExperimentQuery", {
   ))
   exp_ms_rna$add_new_collection(varm, 'varm')
 
-  exp_ms_rna$close()
+  experiment$close()
+
+  # Re-open for read.
+  # Leverage the still-pending on.exit(experiment$close()).
+  experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
   obs_value_filter <- paste0(

--- a/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
@@ -51,7 +51,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   ))
   obsm$close()
 
-  exp_ms_rna <- SOMACollectionOpen(experiment$ms$get("RNA")$uri, "WRITE")
+  exp_ms_rna <- experiment$ms$get("RNA")
   exp_ms_rna$add_new_collection(obsm, 'obsm')
 
   # Add loadings
@@ -88,7 +88,6 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   experiment <- SOMAExperimentOpen(experiment$uri)
 
   # Create the query
-  experiment <- SOMAExperimentOpen(experiment$uri)
   query <- SOMAExperimentAxisQuery$new(
     experiment = experiment,
     measurement_name = "RNA"


### PR DESCRIPTION
Addresses #1378:

* Remove `mode` optarg on `collection$get`
* Have opened children inherit parent's mode