### PR TITLE
[r] Address remaining two R CMD check nags

### DIFF
--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,4 +1,4 @@
-# tiledbsoma development version
+# tiledbsoma 0.0.0.*
 
 ## Changes
 

--- a/apis/r/inst/include/tiledbsoma_types.h
+++ b/apis/r/inst/include/tiledbsoma_types.h
@@ -9,6 +9,12 @@
 #include <Rinterface.h>
 #include <R_ext/Print.h>
 
+// we currently get deprecation warnings by default which are noisy
+// this turns them off for RcppExports.cpp
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
 #include <nanoarrow.h>          			// for C interface to Arrow
 #include <tiledb/tiledb>					// for QueryCondition etc
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -3,9 +3,6 @@ CXX_STD = CXX17
 ## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 10.14 for macOS
 PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx17_macos@ -Iinclude
 
-## When this becomes a CRAN package we may have to remove this. For now it keeps the noise down
-PKG_CXXFLAGS = -Wno-deprecated-declarations
-
 ## We also need the TileDB library
 PKG_LIBS = @cxx17_macos@ @tiledb_libs@ @tiledb_rpath@
 

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -1,6 +1,11 @@
 #include <Rcpp.h>               // for R interface to C++
 #include <nanoarrow.h>          // for C interface to Arrow
 
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
 // We get these via nanoarrow and must cannot include carrow.h again
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
 #include <tiledbsoma/tiledbsoma>

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -1,4 +1,7 @@
-// Work in progress
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
 
 #include <Rcpp.h>               // for R interface to C++
 #include <nanoarrow.h>          // for C interface to Arrow

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -1,4 +1,9 @@
 
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
 #include <Rcpp.h>               // for R interface to C++
 #include <nanoarrow.h>          // for C interface to Arrow
 

--- a/apis/r/src/stats.cpp
+++ b/apis/r/src/stats.cpp
@@ -1,3 +1,8 @@
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
 #include <Rcpp.h>
 #include <tiledbsoma/tiledbsoma>
 

--- a/apis/r/src/version.cpp
+++ b/apis/r/src/version.cpp
@@ -1,4 +1,9 @@
 
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
 #include <Rcpp.h>
 #include <tiledbsoma/tiledbsoma>
 


### PR DESCRIPTION
**Issue and/or context:**

With the different PRs adding polish and suppressing warnings we were down to two:  one concern the fact that we used a (so-called) non-portable flag to suppress deprecations warning -- so I took this inside the source files instead. The other concerned the (incomplete) NEWS file which was lacking a version to match a checking regexp, so I added that.

**Changes:**

See above.  No code or test changes.  But now beautiful 'Status: OK' without any nags.

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/770b22f7-676d-4291-b070-c2235ae6277d)

**Notes for Reviewer:**

[SC 29034](https://app.shortcut.com/tiledb-inc/story/29034/avoid-remaining-nags-from-r-cmd-check)