### PR TITLE
[r] Update Seurat ingestor to skip the data slot when it's identical to counts

### DIFF
--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -93,11 +93,18 @@ write_soma.Assay <- function(
   )
 
   # Write `X` matrices
-  for (slot in c('counts', 'data', 'scale.data')) {
-    mat <- SeuratObject::GetAssayData(object = x, slot = slot)
-    if (SeuratObject::IsMatrixEmpty(mat)) {
-      next
+  for (slot in c("counts", "data", "scale.data")) {
+    mat <- SeuratObject::GetAssayData(x, slot = slot)
+    if (SeuratObject::IsMatrixEmpty(mat)) next
+
+    # Skip 'data' slot if it's identical to 'counts'
+    if (slot == "data") {
+      if (identical(mat, SeuratObject::GetAssayData(x, slot = "counts"))) {
+        spdl::info("Skipping 'data' slot because it's identical to 'counts'")
+        next
+      }
     }
+
     if (!identical(x = dim(mat), y = dim(x))) {
       spdl::info("Padding layer {} to match dimensions of assay", sQuote(slot))
       mat <- pad_matrix(

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -116,6 +116,21 @@ test_that("Write Assay mechanics", {
     rna,
     soma_parent = SOMADataFrameCreate(uri = file.path(uri, 'data-frame'))
   ))
+
+  # Verify data slot isn't ingested when it's identical to counts
+  rna6 <- SeuratObject::CreateAssayObject(
+    counts = SeuratObject::GetAssayData(rna, "counts")
+  )
+  expect_identical(
+    SeuratObject::GetAssayData(rna6, "counts"),
+    SeuratObject::GetAssayData(rna6, "data")
+  )
+  expect_no_condition(ms6 <- write_soma(
+    rna6,
+    uri = "rna-identical-counts-data",
+    soma_parent = collection
+  ))
+  expect_equal(ms6$X$names(), "counts")
 })
 
 test_that("Write DimReduc mechanics", {


### PR DESCRIPTION
**Issue and/or context:** When a Seurat object is created with a single matrix it populates the `Assay`'s `counts` _and_ `data` slots with the same data.

```r
library(SeuratObject)
data("pbmc_small")

counts_mat <- GetAssayData(pbmc_small[["RNA"]], "counts")

seurat_obj <- CreateSeuratObject(counts = counts_mat)
seurat_obj

## An object of class Seurat 
## 230 features across 80 samples within 1 assay 
## Active assay: RNA (230 features, 0 variable features)
```

Retrieve the `counts` slot:

```r
GetAssayData(seurat_obj, "counts")[1:10, 1:5]

## 10 x 5 sparse Matrix of class "dgCMatrix"
##           ATGCCAGAACGACT CATGGCCTGTGCAT GAACCTGATGAACC TGACTGGATTCTCA
## MS4A1                  .              .              .              .
## CD79B                  1              .              .              .
## CD79A                  .              .              .              .
## HLA-DRA                .              1              .              .
## TCL1A                  .              .              .              .
## HLA-DQB1               1              .              .              .
## HVCN1                  .              .              .              .
## HLA-DMB                .              .              .              .
## LTB                    3              7             11             13
## LINC00926              .              .              .              .
##           AGTCAGACTGCACA
## MS4A1                  .
## CD79B                  .
## CD79A                  .
## HLA-DRA                1
## TCL1A                  .
## HLA-DQB1               .
## HVCN1                  .
## HLA-DMB                .
## LTB                    3
## LINC00926              .
```

Retrieve the `data` slot:

```r
GetAssayData(seurat_obj, "data")[1:10, 1:5]

## 10 x 5 sparse Matrix of class "dgCMatrix"
##           ATGCCAGAACGACT CATGGCCTGTGCAT GAACCTGATGAACC TGACTGGATTCTCA
## MS4A1                  .              .              .              .
## CD79B                  1              .              .              .
## CD79A                  .              .              .              .
## HLA-DRA                .              1              .              .
## TCL1A                  .              .              .              .
## HLA-DQB1               1              .              .              .
## HVCN1                  .              .              .              .
## HLA-DMB                .              .              .              .
## LTB                    3              7             11             13
## LINC00926              .              .              .              .
##           AGTCAGACTGCACA
## MS4A1                  .
## CD79B                  .
## CD79A                  .
## HLA-DRA                1
## TCL1A                  .
## HLA-DQB1               .
## HVCN1                  .
## HLA-DMB                .
## LTB                    3
## LINC00926              .
```

Verify they're identical:


```r
identical(GetAssayData(seurat_obj, "counts"), GetAssayData(seurat_obj, "data"))

## [1] TRUE
```

Currently, `write_soma()` would ingest both the `counts` and `data` slots, creating redundant data in the SOMA experiment.

**Changes:** This PR adds a check to `write_soma()` to ensure that the `counts` and `data` slots are not identical. If they are, the `data` slot is skipped.
