### PR TITLE
[docs][python] Add autosummary

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -6,7 +6,7 @@ motivated by use cases from single-cell biology. The ``tiledbsoma``
 Python package is an implementation of SOMA using the
 `TileDB Embedded <https://github.com/TileDB-Inc/TileDB>`_ engine.
 
-Provides:
+Provides
 ----------
   1. The ability to store, query, and retrieve larger-than-core datasets,
      resident in both cloud (object-store) and local (file) systems.
@@ -17,7 +17,7 @@ Provides:
 See the `SOMA GitHub repo <https://github.com/single-cell-data/SOMA>`_ for more
 information on the SOMA project.
 
-Using the documentation:
+Using the documentation
 -------------------------
 
 Documentation is also available via the Python builtin ``help`` function. We
@@ -26,7 +26,7 @@ recommend exploring the package. For example:
 >>> import tiledbsoma
 >>> help(tiledbsoma.DataFrame)
 
-API maturity tags:
+API maturity tags
 ------------------
 
 Classes and functions are annotated with API maturity tags, for example:
@@ -49,7 +49,7 @@ the RStudio lifecycle stage model. Tags are:
 
 If no tag is present, the state is ``experimental``.
 
-Data types:
+Data types
 ------------
 
 The principal persistent types provided by SOMA are:
@@ -76,7 +76,7 @@ system and memory model for its in-memory type system and schema. For
 example, the schema of a :class:`DataFrame` is expressed as an
 `Arrow Schema <https://arrow.apache.org/docs/python/generated/pyarrow.Schema.html>`_.
 
-Error handling:
+Error handling
 ---------------
 Most errors will be signaled with a raised Exception. Of note:
 
@@ -87,9 +87,6 @@ Most errors will be signaled with a raised Exception. Of note:
 
 Most errors will raise an appropriate Python error, e.g., ::class:`TypeError` or
 :class:`ValueError`.
-
-Classes and functions:
-----------------------
 """
 
 # ^^ the rest is autogen whether viewed from Python on-line help, Sphinx/readthedocs, etc.  It's

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,8 +39,11 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
     "nbsphinx",
 ]
+
+autosummary_generate = True
 
 # Mapping for linking between RTD subprojects.
 if readthedocs:

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -23,4 +23,5 @@ Features:
    :maxdepth: 2
 
    python-tiledbsoma
-   python-tiledbsomaio
+   python-tiledbsoma-io
+   python-tiledbsoma-logging

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -18,17 +18,9 @@ Features:
 * Enables out-of-core access to data aggregations much larger than single-host main memory
 * Enables distributed computation over datasets
 
-The tiledbsoma module
----------------------
-.. automodule:: tiledbsoma
-   :members:
 
-The tiledbsoma.io module
-------------------------
-.. automodule:: tiledbsoma.io
-   :members:
+.. toctree:: 
+   :maxdepth: 2
 
-The tiledbsoma.logging module
------------------------------
-.. automodule:: tiledbsoma.logging
-   :members:
+   python-tiledbsoma
+   python-tiledbsomaio

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -13,10 +13,10 @@ Functions
     :toctree: _autosummary/
     :nosignatures:
 
+    tiledbsoma.io.from_h5ad
+    tiledbsoma.io.from_anndata
     tiledbsoma.io.add_X_layer
     tiledbsoma.io.add_matrix_to_collection
     tiledbsoma.io.create_from_matrix
-    tiledbsoma.io.from_anndata
-    tiledbsoma.io.from_h5ad
-    tiledbsoma.io.to_anndata
     tiledbsoma.io.to_h5ad
+    tiledbsoma.io.to_anndata

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -1,0 +1,22 @@
+The tiledbsoma.io module
+=====================
+
+.. currentmodule:: tiledbsoma.io
+
+.. automodule:: tiledbsoma.io
+
+
+Functions
+-------
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    tiledbsoma.io.add_X_layer
+    tiledbsoma.io.add_matrix_to_collection
+    tiledbsoma.io.create_from_matrix
+    tiledbsoma.io.from_anndata
+    tiledbsoma.io.from_h5ad
+    tiledbsoma.io.to_anndata
+    tiledbsoma.io.to_h5ad

--- a/doc/source/python-tiledbsoma-logging.rst
+++ b/doc/source/python-tiledbsoma-logging.rst
@@ -1,0 +1,19 @@
+The tiledbsoma.logging module
+=====================
+
+.. currentmodule:: tiledbsoma.logging
+
+.. automodule:: tiledbsoma.logging
+
+
+Functions
+-------
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    tiledbsoma.logging.debug
+    tiledbsoma.logging.info
+    tiledbsoma.logging.log_io
+    tiledbsoma.logging.warning

--- a/doc/source/python-tiledbsoma-logging.rst
+++ b/doc/source/python-tiledbsoma-logging.rst
@@ -16,4 +16,3 @@ Functions
     tiledbsoma.logging.info
     tiledbsoma.logging.debug
     tiledbsoma.logging.warning
-    tiledbsoma.logging.log_io

--- a/doc/source/python-tiledbsoma-logging.rst
+++ b/doc/source/python-tiledbsoma-logging.rst
@@ -13,7 +13,7 @@ Functions
     :toctree: _autosummary/
     :nosignatures:
 
-    tiledbsoma.logging.debug
     tiledbsoma.logging.info
-    tiledbsoma.logging.log_io
+    tiledbsoma.logging.debug
     tiledbsoma.logging.warning
+    tiledbsoma.logging.log_io

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -5,25 +5,42 @@ The tiledbsoma module
 
 .. automodule:: tiledbsoma
 
-Testing
+Classes
 -------
 
 .. autosummary::
     :toctree: _autosummary/
+    :nosignatures:
 
     tiledbsoma.AxisColumnNames
     tiledbsoma.AxisQuery
     tiledbsoma.Collection
     tiledbsoma.DataFrame
     tiledbsoma.DenseNDArray
-    tiledbsoma.DoesNotExistError
     tiledbsoma.Experiment
     tiledbsoma.ExperimentAxisQuery
     tiledbsoma.Measurement   
     tiledbsoma.ResultOrder
-    tiledbsoma.SOMAError
     tiledbsoma.SOMATileDBContext
     tiledbsoma.SparseNDArray
+
+Exceptions
+----------
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    tiledbsoma.DoesNotExistError
+    tiledbsoma.SOMAError
+
+Functions
+---------
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
     tiledbsoma.get_implementation
     tiledbsoma.get_implementation_version
     tiledbsoma.get_storage_engine

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -45,11 +45,14 @@ Functions
     :toctree: _autosummary/
     :nosignatures:
 
+    tiledbsoma.open
+
+    tiledbsoma.show_package_versions
+
     tiledbsoma.get_implementation
     tiledbsoma.get_implementation_version
     tiledbsoma.get_storage_engine
-    tiledbsoma.open
-    tiledbsoma.show_package_versions
+
     tiledbsoma.tiledbsoma_stats_disable
     tiledbsoma.tiledbsoma_stats_dump
     tiledbsoma.tiledbsoma_stats_enable

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -12,17 +12,21 @@ Classes
     :toctree: _autosummary/
     :nosignatures:
 
+    tiledbsoma.Collection
+    tiledbsoma.Experiment
+    tiledbsoma.Measurement   
+
+    tiledbsoma.DataFrame
+    tiledbsoma.SparseNDArray
+    tiledbsoma.DenseNDArray
+
+      tiledbsoma.ResultOrder
+
     tiledbsoma.AxisColumnNames
     tiledbsoma.AxisQuery
-    tiledbsoma.Collection
-    tiledbsoma.DataFrame
-    tiledbsoma.DenseNDArray
-    tiledbsoma.Experiment
     tiledbsoma.ExperimentAxisQuery
-    tiledbsoma.Measurement   
-    tiledbsoma.ResultOrder
+    
     tiledbsoma.SOMATileDBContext
-    tiledbsoma.SparseNDArray
 
 Exceptions
 ----------

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -1,0 +1,35 @@
+The tiledbsoma module
+=====================
+
+.. currentmodule:: tiledbsoma
+
+.. automodule:: tiledbsoma
+
+Testing
+-------
+
+.. autosummary::
+    :toctree: _autosummary/
+
+    tiledbsoma.AxisColumnNames
+    tiledbsoma.AxisQuery
+    tiledbsoma.Collection
+    tiledbsoma.DataFrame
+    tiledbsoma.DenseNDArray
+    tiledbsoma.DoesNotExistError
+    tiledbsoma.Experiment
+    tiledbsoma.ExperimentAxisQuery
+    tiledbsoma.Measurement   
+    tiledbsoma.ResultOrder
+    tiledbsoma.SOMAError
+    tiledbsoma.SOMATileDBContext
+    tiledbsoma.SparseNDArray
+    tiledbsoma.get_implementation
+    tiledbsoma.get_implementation_version
+    tiledbsoma.get_storage_engine
+    tiledbsoma.open
+    tiledbsoma.show_package_versions
+    tiledbsoma.tiledbsoma_stats_disable
+    tiledbsoma.tiledbsoma_stats_dump
+    tiledbsoma.tiledbsoma_stats_enable
+    tiledbsoma.tiledbsoma_stats_reset


### PR DESCRIPTION
**Issue and/or context:**
Fixes #1326 

**Changes:**
- Adds `autosummary` to the docs. This creates auto-generated pages for each doc entry (functions, classes etc) and groups them using a hierarchical toctree that shows up in the sidebar

**Notes for Reviewer:**
- Preview here: https://tiledbsoma.readthedocs.io/en/ebezzi-autosummary/
