### PR TITLE
[c++] Build and upload library artifacts for Mac (arm, x86) and Linux

### DIFF
--- a/.github/workflows/library-artifacts.yaml
+++ b/.github/workflows/library-artifacts.yaml
@@ -7,10 +7,11 @@ on:
   #    - ".pre-commit-config.yaml"
   #push:
   #  branches: [main, master]
+  workflow_dispatch:
   release:
     types:
       - created
-
+      
 env:
   ## for workflows triggered by release this is the release tag created (cf https://docs.github.com/en/actions/learn-github-actions/contexts)
   ## note that this is filtered below and then used via 'steps.versubstr.outputs.substring'

--- a/.github/workflows/library-artifacts.yaml
+++ b/.github/workflows/library-artifacts.yaml
@@ -11,7 +11,7 @@ on:
   release:
     types:
       - created
-      
+
 env:
   ## for workflows triggered by release this is the release tag created (cf https://docs.github.com/en/actions/learn-github-actions/contexts)
   ## note that this is filtered below and then used via 'steps.versubstr.outputs.substring'
@@ -44,7 +44,7 @@ jobs:
             ARTIFACT_OS: 'macos'
             ARTIFACT_ARCH: 'arm64'
           - environ: "linux"
-            imageName: "ubuntu-latest"
+            imageName: "ubuntu-20.04"
             CMAKE_OSX_ARCHITECTURES: ""
             MACOSX_DEPLOYMENT_TARGET: ""
             ARTIFACT_OS: 'linux'

--- a/.github/workflows/library-artifacts.yaml
+++ b/.github/workflows/library-artifacts.yaml
@@ -1,0 +1,104 @@
+name: artifacts
+
+on:
+  pull_request:
+    paths-ignore:
+      - "apis/**"
+      - ".pre-commit-config.yaml"
+  push:
+    branches: [main, master]
+  release:
+
+env:
+  TILEDBSOMA_SHA: "dev"
+  TILEDBSOMA_BUILD: "${{ github.workspace }}/tiledb_build"
+  TILEDBSOMA_SOURCE: "${{ github.workspace }}/libtiledbsoma"
+  TILEDBSOMA_INSTALL: "${{ github.workspace }}/.tiledbsoma_dist/$TILEDBSOMA_SHA"
+    
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        #considering https://stackoverflow.com/questions/65035256/how-to-access-matrix-variables-in-github-actions
+        environ: [macos_x86, macos_arm, linux]
+        include:
+          - environ: 'macos_x86'
+            imageName: "macOS-11"
+            CMAKE_OSX_ARCHITECTURES: "x86_64"
+            MACOSX_DEPLOYMENT_TARGET: 10.14
+            ARTIFACT_OS: 'macos'
+            ARTIFACT_ARCH: 'x86_64'
+          - environ: 'macos_arm'
+            imageName: "macOS-11"
+            CMAKE_OSX_ARCHITECTURES: "arm64"
+            MACOSX_DEPLOYMENT_TARGET: 11 
+            ARTIFACT_OS: 'macos'
+            ARTIFACT_ARCH: 'arm64'
+          - environ: "linux"
+            imageName: "ubuntu-latest"
+            CMAKE_OSX_ARCHITECTURES: ""
+            MACOSX_DEPLOYMENT_TARGET: ""
+            ARTIFACT_OS: 'linux'
+            ARTIFACT_ARCH: "x86_64"
+
+    runs-on: ${{ matrix.imageName }}
+
+    steps:
+
+          - uses: actions/checkout@v3
+ 
+          - name: "Echo variables"
+            run: |
+              echo "Vars are "
+              echo "  image   ${{ matrix.imageName }}"
+              echo "  osxarch ${{ matrix.CMAKE_OSX_ARCHITECTURES }}"
+              echo "  build   ${{ env.TILEDBSOMA_BUILD }}"
+              echo "  install ${{ env.TILEDBSOMA_INSTALL }}"
+              echo "  wkspce  ${{ github.workspace }}"
+
+          - name: "Add pkg-config"
+            run: brew install pkg-config
+            if: ${{ matrix.ARTIFACT_OS == 'macos' }}
+
+          - name: "Check cmake"
+            run: cmake --version
+
+          - name: "Build"
+            run: |
+              set -xe pipefail
+              #
+              cd libtiledbsoma
+              #
+              mkdir -p ${{ env.TILEDBSOMA_BUILD }}
+              cd ${{ env.TILEDBSOMA_BUILD }}
+              #
+              #
+              cmake -B ${{ env.TILEDBSOMA_BUILD }} \
+                    -S ${{ env.TILEDBSOMA_SOURCE }} \
+               	    -DDOWNLOAD_TILEDB_PREBUILT=ON \
+              	    -DTILEDBSOMA_BUILD_CLI=OFF \
+              	    -DTILEDBSOMA_ENABLE_TESTING=OFF \
+                    -DOVERRIDE_INSTALL_PREFIX=OFF \
+                    -DCMAKE_INSTALL_PREFIX=${{ env.TILEDBSOMA_INSTALL }} \
+                    -DCMAKE_OSX_ARCHITECTURES=${{ matrix.CMAKE_OSX_ARCHITECTURES }}
+              #
+              cmake --build ${{ env.TILEDBSOMA_BUILD }} --config Release -j4
+              cmake --build ${{ env.TILEDBSOMA_BUILD }} --target install-libtiledbsoma --config Release
+              #
+              # this should not be needed -- the tiledb core library gets 'co-installed'
+              rm -vf ${{ env.TILEDBSOMA_INSTALL }}/lib/libtiledb.{so,dylib}*
+
+          - name: "Inspect installation output"
+            run: ls -lR ${{ env.TILEDBSOMA_INSTALL }}
+
+          - name: "Archive files"
+            run: |
+              cd ${{ env.TILEDBSOMA_INSTALL }}
+              tar -cvf ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar *
+              gzip -9v ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar
+              
+          - uses: actions/upload-artifact@v3
+            with:
+              name: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+              path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar.gz

--- a/.github/workflows/library-artifacts.yaml
+++ b/.github/workflows/library-artifacts.yaml
@@ -1,28 +1,34 @@
 name: artifacts
 
 on:
-  pull_request:
-    paths-ignore:
-      - "apis/**"
-      - ".pre-commit-config.yaml"
-  push:
-    branches: [main, master]
+  #pull_request:
+  #  paths-ignore:
+  #    - "apis/**"
+  #    - ".pre-commit-config.yaml"
+  #push:
+  #  branches: [main, master]
   release:
+    types:
+      - created
 
 env:
-  TILEDBSOMA_VER: "1.2.4"
-  TILEDBSOMA_SHA: "1169798"
+  ## for workflows triggered by release this is the release tag created (cf https://docs.github.com/en/actions/learn-github-actions/contexts)
+  ## note that this is filtered below and then used via 'steps.versubstr.outputs.substring'
+  TILEDBSOMA_VER: "${{ github.ref }}"
+  ## the commit sha that triggered the workflow (cf https://docs.github.com/en/actions/learn-github-actions/contexts)
+  ## note that this is shortened below from the full-length sha1 sum to the common first seven letters, used via steps.shasubstr.outputs.substring
+  TILEDBSOMA_SHA: "${{ github.sha }}"
+  ## three variables for scratch space while this runs, defined off the current 'workspace'
   TILEDBSOMA_BUILD: "${{ github.workspace }}/tiledb_build"
   TILEDBSOMA_SOURCE: "${{ github.workspace }}/libtiledbsoma"
-  TILEDBSOMA_INSTALL: "${{ github.workspace }}/.tiledbsoma_dist/$TILEDBSOMA_VER-$TILEDBSOMA_SHA"
-    
+  TILEDBSOMA_INSTALL: "${{ github.workspace }}/.tiledbsoma_dist/${{ github.sha }}"
+
 jobs:
   build:
     
     strategy:
       matrix:
         #considering https://stackoverflow.com/questions/65035256/how-to-access-matrix-variables-in-github-actions
-        environ: [macos_x86, macos_arm, linux]
         include:
           - environ: 'macos_x86'
             imageName: "macOS-11"
@@ -93,13 +99,49 @@ jobs:
           - name: "Inspect installation output"
             run: ls -lR ${{ env.TILEDBSOMA_INSTALL }}
 
+          - name: "Get VER Substring"
+            uses: bhowell2/github-substring-action@1.0.2
+            id: versubstr
+            with:
+              value: ${{ env.TILEDBSOMA_VER }}
+              index_of_str: "refs/tags/"
+              fail_if_not_found: false
+              default_return_value: "unset"
+
+          - name: "Get SHA Substring"
+            uses: bhowell2/github-substring-action@1.0.2
+            id: shasubstr
+            with:
+              value: ${{ env.TILEDBSOMA_SHA }}
+              length_from_start: 7
+
+          - name: "Show Substrings"
+            run: echo "VER " ${{ steps.versubstr.outputs.substring }} " and SHA " ${{ steps.shasubstr.outputs.substring }}
+
           - name: "Archive files"
             run: |
               cd ${{ env.TILEDBSOMA_INSTALL }}
-              tar -cvf ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar *
-              gzip -9v ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar
-              
-          - uses: actions/upload-artifact@v3
+              tar -cvf ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ steps.versubstr.outputs.substring }}-${{ steps.shasubstr.outputs.substring }}.tar *
+              gzip -9v ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ steps.versubstr.outputs.substring }}-${{ steps.shasubstr.outputs.substring }}.tar
+            
+          # an 'artifact' is downloadable by clicking on it but has no # external URL
+          #- name: "Artifact"
+          #  uses: actions/upload-artifact@v3
+          #  with:
+          #    name: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+          #    path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+
+          #- name: "Release"
+          #  uses: softprops/action-gh-release@v1
+          #  if: startsWith(github.ref, 'refs/tags/')
+          #  with:
+          #    files: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+
+          - name: "Release"
+            uses: shogo82148/actions-upload-release-asset@v1
+            if: startsWith(github.ref, 'refs/tags/')
             with:
-              name: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
-              path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+              github_token: ${{ secrets.PAT }}
+              upload_url: ${{ github.event.release.upload_url }}
+              asset_path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ steps.versubstr.outputs.substring }}-${{ steps.shasubstr.outputs.substring }}.tar.gz
+              overwrite: true

--- a/.github/workflows/library-artifacts.yaml
+++ b/.github/workflows/library-artifacts.yaml
@@ -10,10 +10,11 @@ on:
   release:
 
 env:
-  TILEDBSOMA_SHA: "dev"
+  TILEDBSOMA_VER: "1.2.4"
+  TILEDBSOMA_SHA: "1169798"
   TILEDBSOMA_BUILD: "${{ github.workspace }}/tiledb_build"
   TILEDBSOMA_SOURCE: "${{ github.workspace }}/libtiledbsoma"
-  TILEDBSOMA_INSTALL: "${{ github.workspace }}/.tiledbsoma_dist/$TILEDBSOMA_SHA"
+  TILEDBSOMA_INSTALL: "${{ github.workspace }}/.tiledbsoma_dist/$TILEDBSOMA_VER-$TILEDBSOMA_SHA"
     
 jobs:
   build:
@@ -95,10 +96,10 @@ jobs:
           - name: "Archive files"
             run: |
               cd ${{ env.TILEDBSOMA_INSTALL }}
-              tar -cvf ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar *
-              gzip -9v ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar
+              tar -cvf ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar *
+              gzip -9v ${{ github.workspace }}/libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar
               
           - uses: actions/upload-artifact@v3
             with:
-              name: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
-              path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+              name: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz
+              path: libtiledbsoma-${{ matrix.ARTIFACT_OS }}-${{ matrix.ARTIFACT_ARCH }}-${{ env.TILEDBSOMA_VER }}-${{ env.TILEDBSOMA_SHA }}.tar.gz


### PR DESCRIPTION
**NOTE: Do not merge yet.** The PR has been updated and now works off a _release_ but requires a PAT to upload. We may want to take care of the PAT first.

See also #1454 which depends on this.

**Issue and/or context:**

Deployment benefits from having pre-made artifacts which lowers the installation 'cost' for users and smoothes deployments.  Similar to how TileDB Core has binaries for the key architecture and OS combinations, SOMA would benefit from having this.

**Changes:**

GitHub Actions are set up to create and upload artifacts for macOS (both old x86_64 and new arm64) and linux.  

**Notes for Reviewer:**

This should still be considered draft as it will likely benefit from refinements such as tagging to actual release version, switching the linux container to a manylinux one for more portable use and so on. 

[SC 29249](https://app.shortcut.com/tiledb-inc/story/29249/c-create-libtiledbsoma-build-artifacts) / #1401
