### PR TITLE
[python] Update lifecycle tags

### DIFF
--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -12,7 +12,7 @@ import tiledb
 class SOMAError(Exception):
     """Base error type for SOMA-specific exceptions.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
 
     pass
@@ -21,7 +21,7 @@ class SOMAError(Exception):
 class DoesNotExistError(SOMAError):
     """Raised when attempting to open a non-existent or inaccessible SOMA object.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
 
     pass
@@ -30,8 +30,7 @@ class DoesNotExistError(SOMAError):
 def is_does_not_exist_error(e: tiledb.TileDBError) -> bool:
     """Given a TileDBError, return true if it indicates the object does not exist
 
-    Lifecycle:
-        Experimental.
+    Lifecycle: maturing
 
     Example:
         try:
@@ -60,7 +59,7 @@ def is_duplicate_group_key_error(e: tiledb.TileDBError) -> bool:
     """Given a TileDBError, return try if it indicates a duplicate member
     add request in a tiledb.Group.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     stre = str(e)
     if "member already exists in group" in stre:

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -18,7 +18,7 @@ from .pytiledbsoma import version as libtiledbsoma_version
 def get_SOMA_version() -> str:
     """Returns semver-compatible version of the supported SOMA API.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     return "0.2.0-dev"
 
@@ -26,7 +26,7 @@ def get_SOMA_version() -> str:
 def get_implementation() -> str:
     """Returns the implementation name, e.g., "python-tiledb".
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     return "python-tiledb"
 
@@ -34,7 +34,7 @@ def get_implementation() -> str:
 def get_implementation_version() -> str:
     """Returns the package implementation version as a semver.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     try:
         return get_distribution("tiledbsoma").version
@@ -45,7 +45,7 @@ def get_implementation_version() -> str:
 def get_storage_engine() -> str:
     """Returns underlying storage engine name, e.g., "tiledb".
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     return "tiledb"
 
@@ -54,7 +54,7 @@ def show_package_versions() -> None:
     """Nominal use is for bug reports, so issue filers and issue fixers can be on
     the same page.
 
-    Lifecycle: Experimental.
+    Lifecycle: maturing
     """
     print("tiledbsoma.__version__       ", get_implementation_version())
     print("TileDB-Py tiledb.version()   ", tiledb.version())


### PR DESCRIPTION

Fixes: #1402

Update public API lifecycle tags from `experimental` to `maturing`.  See also single-cell-data/SOMA#167.

Note to reviewers: please consider if there are any exceptions to this update (i.e., API that should remain experimental).