### PR TITLE
Restore `SOMASparseNDArray$read_sparse_matrix()`

### DIFF
--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -188,7 +188,6 @@ SOMASparseNDArray <- R6::R6Class(
       log_level = "warn"
     ) {
       private$check_open_for_read()
-      repr <- repr[1L]
       repr <- match.arg(repr)
       dims <- self$dimensions()
       attr <- self$attributes()

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -174,7 +174,59 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param coords Optional `list` of integer vectors, one for each dimension, with a
     #' length equal to the number of values to read. If `NULL`, all values are
     #' read. List elements can be named when specifying a subset of dimensions.
-    #' @template param-result-order
+    #' @param repr Optional one-character code for sparse matrix representation type
+    #' @param iterated Option boolean indicated whether data is read in call (when
+    #' `FALSE`, the default value) or in several iterated steps.
+    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @return A sparse matrix whose exact representation
+    #' is determined by \code{repr}.
+    read_sparse_matrix = function(
+      coords = NULL,
+      result_order = "auto",
+      repr = c("C", "T", "R"),
+      iterated = FALSE,
+      log_level = "warn"
+    ) {
+      private$check_open_for_read()
+      repr <- repr[1L]
+      repr <- match.arg(repr)
+      dims <- self$dimensions()
+      attr <- self$attributes()
+      stopifnot("Array must have two dimensions" = length(dims) == 2,
+                "Array must contain columns 'soma_dim_0' and 'soma_dim_1'" =
+                  all.equal(c("soma_dim_0", "soma_dim_1"), names(dims)),
+                "Array must contain column 'soma_data'" = all.equal("soma_data", names(attr)))
+
+      if (isFALSE(iterated)) {
+        tbl <- self$read_arrow_table(coords = coords, result_order = result_order, log_level = log_level)
+        mat <- Matrix::sparseMatrix(
+          i = as.numeric(tbl$GetColumnByName("soma_dim_0")),
+          j = as.numeric(tbl$GetColumnByName("soma_dim_1")),
+          x = as.numeric(tbl$GetColumnByName("soma_data")),
+          index1 = FALSE,
+          dims = as.integer(self$shape()),
+          repr = repr
+        )
+        return(mat)
+      } else {
+        ## should we error if this isn't null?
+        if (!is.null(private$soma_reader_pointer)) {
+          warning("pointer not null, skipping")
+        } else {
+          private$soma_reader_setup()
+          private$sparse_repr <- repr
+          if (rlang::is_na(private$read_next)) {
+            private$zero_based <- FALSE
+          }
+        }
+        invisible(NULL)
+      }
+    },
+
+    #' @description Read as a zero-indexed sparse matrix (lifecycle: experimental)
+    #' @param coords Optional `list` of integer vectors, one for each dimension, with a
+    #' length equal to the number of values to read. If `NULL`, all values are
+    #' read. List elements can be named when specifying a subset of dimensions.
     #' @param repr Optional one-character code for sparse matrix representation type
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
@@ -191,40 +243,39 @@ SOMASparseNDArray <- R6::R6Class(
       iterated = FALSE,
       log_level = "warn"
     ) {
-      private$check_open_for_read()
+      # If we're setting up an iterated reader, set the tracker for zero-based
+      # and use `self$read_sparse_matrix()` for the rest of the setup
 
-      repr <- match.arg(repr)
-      dims <- self$dimensions()
-      attr <- self$attributes()
-      stopifnot("Array must have two dimensions" = length(dims) == 2,
-                "Array must contain columns 'soma_dim_0' and 'soma_dim_1'" =
-                    all.equal(c("soma_dim_0", "soma_dim_1"), names(dims)),
-                "Array must contain column 'soma_data'" = all.equal("soma_data", names(attr)))
-
-      if (isFALSE(iterated)) {
-          tbl <- self$read_arrow_table(coords = coords, result_order = result_order, log_level = log_level)
-          # To instantiate the one-based Matrix::sparseMatrix, we need to add 1 to the
-          # zero-based soma_dim_0 and soma_dim_1. But, because these dimensions are
-          # usually populated with soma_joinid, users will need to access the matrix
-          # using the original, possibly-zero IDs. Therefore, we'll wrap the one-based
-          # sparseMatrix with a shim providing basic access with zero-based indexes.
-          # If needed, user can then explicitly ask the shim for the underlying
-          # sparseMatrix using `as.one.based()`.
-          mat <- Matrix::sparseMatrix(i = 1 + as.numeric(tbl$GetColumnByName("soma_dim_0")),
-                                      j = 1 + as.numeric(tbl$GetColumnByName("soma_dim_1")),
-                                      x = as.numeric(tbl$GetColumnByName("soma_data")),
-                                      dims = as.integer(self$shape()), repr = repr)
-          matrixZeroBasedView(mat)
-      } else {
-          ## should we error if this isn't null?
-          if (!is.null(self$soma_reader_pointer)) {
-              warning("pointer not null, skipping")
-          } else {
-              private$soma_reader_setup()
-              private$sparse_repr <- repr
-          }
-          invisible(NULL)
+      # Use `!ifFALSE()` as the logic in `self$read_sparse_matrix()` says
+      # if iterated is FALSE, do non-iterated
+      # otherwise, do iterated
+      if (!isFALSE(iterated) && is.null(private$soma_reader_pointer)) {
+        private$zero_based <- TRUE
       }
+      mat <- self$read_sparse_matrix(
+        coords = coords,
+        result_order = result_order,
+        repr = repr,
+        iterated = iterated,
+        log_level = log_level
+      )
+      # Wrap in zero-based view
+      if (isFALSE(iterated)) {
+        return(matrixZeroBasedView(mat))
+      }
+      return(invisible(NULL))
+    },
+
+    #' @description Read the next chunk of an iterated read. (lifecycle: experimental)
+    read_next = function() {
+      res <- super$read_next()
+      # If we've reached the end of iteration, reset the tracker for
+      # zero or one-based matrices
+      if (is.null(res)) {
+        private$zero_based <- NA
+        return(invisible(NULL))
+      }
+      return(res)
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: experimental)
@@ -272,20 +323,29 @@ SOMASparseNDArray <- R6::R6Class(
     ## refined from base class
     soma_reader_transform = function(x) {
       tbl <- as_arrow_table(x)
-      if (private$sparse_repr == "") {
-          tbl
-      } else {
-          mat <- Matrix::sparseMatrix(i = 1 + as.numeric(tbl$GetColumnByName("soma_dim_0")),
-                                      j = 1 + as.numeric(tbl$GetColumnByName("soma_dim_1")),
-                                      x = as.numeric(tbl$GetColumnByName("soma_data")),
-                                      dims = as.integer(self$shape()), repr = private$sparse_repr)
-          # see read_sparse_matrix_zero_based() abave
-          matrixZeroBasedView(mat)
+      if (!nzchar(private$sparse_repr)) {
+        return(tbl)
       }
+      mat <- Matrix::sparseMatrix(
+        i = as.numeric(tbl$GetColumnByName("soma_dim_0")),
+        j = as.numeric(tbl$GetColumnByName("soma_dim_1")),
+        x = as.numeric(tbl$GetColumnByName("soma_data")),
+        index1 = FALSE,
+        dims = as.integer(self$shape()),
+        repr = private$sparse_repr
+      )
+      # see read_sparse_matrix_zero_based() above
+      if (isTRUE(private$zero_based)) {
+        mat <- matrixZeroBasedView(mat)
+      }
+      return(mat)
     },
 
     ## internal 'repr' state variable, by default 'unset'
-    sparse_repr = ""
+    sparse_repr = "",
+
+    # Internal marking of one or zero based matrices for iterated reads
+    zero_based = NA
 
   )
 )

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -30,7 +30,9 @@ the object are overwritten and new index values are added. (lifecycle: experimen
 \itemize{
 \item \href{#method-SOMASparseNDArray-create}{\code{SOMASparseNDArray$create()}}
 \item \href{#method-SOMASparseNDArray-read_arrow_table}{\code{SOMASparseNDArray$read_arrow_table()}}
+\item \href{#method-SOMASparseNDArray-read_sparse_matrix}{\code{SOMASparseNDArray$read_sparse_matrix()}}
 \item \href{#method-SOMASparseNDArray-read_sparse_matrix_zero_based}{\code{SOMASparseNDArray$read_sparse_matrix_zero_based()}}
+\item \href{#method-SOMASparseNDArray-read_next}{\code{SOMASparseNDArray$read_next()}}
 \item \href{#method-SOMASparseNDArray-write}{\code{SOMASparseNDArray$write()}}
 \item \href{#method-SOMASparseNDArray-nnz}{\code{SOMASparseNDArray$nnz()}}
 \item \href{#method-SOMASparseNDArray-clone}{\code{SOMASparseNDArray$clone()}}
@@ -64,7 +66,6 @@ the object are overwritten and new index values are added. (lifecycle: experimen
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="SOMAArrayBase" data-id="read_complete"><a href='../../tiledbsoma/html/SOMAArrayBase.html#method-SOMAArrayBase-read_complete'><code>tiledbsoma::SOMAArrayBase$read_complete()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="SOMAArrayBase" data-id="read_next"><a href='../../tiledbsoma/html/SOMAArrayBase.html#method-SOMAArrayBase-read_next'><code>tiledbsoma::SOMAArrayBase$read_next()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -122,9 +123,6 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{result_order}}{Optional order of read results. This can be one of either
 \verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
-\item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
-
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
@@ -137,10 +135,49 @@ An \code{\link[arrow:Table]{arrow::Table}}.
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMASparseNDArray-read_sparse_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMASparseNDArray-read_sparse_matrix}{}}}
+\subsection{Method \code{read_sparse_matrix()}}{
+Read as a sparse matrix (lifecycle: experimental)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$read_sparse_matrix(
+  coords = NULL,
+  result_order = "auto",
+  repr = c("C", "T", "R"),
+  iterated = FALSE,
+  log_level = "warn"
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{coords}}{Optional \code{list} of integer vectors, one for each dimension, with a
+length equal to the number of values to read. If \code{NULL}, all values are
+read. List elements can be named when specifying a subset of dimensions.}
+
+\item{\code{result_order}}{Optional order of read results. This can be one of either
+\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
+
+\item{\code{repr}}{Optional one-character code for sparse matrix representation type}
+
+\item{\code{iterated}}{Option boolean indicated whether data is read in call (when
+\code{FALSE}, the default value) or in several iterated steps.}
+
+\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A sparse matrix whose exact representation
+is determined by \code{repr}.
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMASparseNDArray-read_sparse_matrix_zero_based"></a>}}
 \if{latex}{\out{\hypertarget{method-SOMASparseNDArray-read_sparse_matrix_zero_based}{}}}
 \subsection{Method \code{read_sparse_matrix_zero_based()}}{
-Read as a sparse matrix (lifecycle: experimental)
+Read as a zero-indexed sparse matrix (lifecycle: experimental)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$read_sparse_matrix_zero_based(
   coords = NULL,
@@ -161,9 +198,6 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{result_order}}{Optional order of read results. This can be one of either
 \verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
 
-\item{\code{result_order}}{Optional order of read results. This can be one of either
-\verb{"ROW_MAJOR, }"COL_MAJOR"\verb{, or }"auto"` (default).}
-
 \item{\code{repr}}{Optional one-character code for sparse matrix representation type}
 
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
@@ -180,6 +214,16 @@ only basic access operations with zero-based indexes as well as \code{dim()},
 sparse matrix object supporting more advanced operations (with one-based
 indexing).
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMASparseNDArray-read_next"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMASparseNDArray-read_next}{}}}
+\subsection{Method \code{read_next()}}{
+Read the next chunk of an iterated read. (lifecycle: experimental)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$read_next()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMASparseNDArray-write"></a>}}


### PR DESCRIPTION
Restore reading of one-based sparse matrices. Zero-based sparse matrices cause issues with the downstream ecosystems (eg. #1279). This PR brings back support for reading one-based matrices while retaining ability to read zero-based sparse matrices. Code is shared between both readers to reduce duplication.

Also makes uses of `Matrix::sparseMatrix(index1 = FALSE)` to reduce the amount of coercion from zero-based in SOMA &rarr; 1-based in call to `Matrix::sparseMatrix()` &rarr; 0-based internally within Matrix