### PR TITLE
[r/docs] Fine-tune article display in pkgdown setup

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,2 +1,0 @@
-template:
-  bootstrap: 5

--- a/apis/r/_pkgdown.yml
+++ b/apis/r/_pkgdown.yml
@@ -1,0 +1,25 @@
+template:
+  bootstrap: 5
+
+reference:
+- title: TileDB-SOMA
+  contents:
+  - matches(".*")
+
+## Cf https://pkgdown.r-lib.org/articles/customise.html
+navbar:
+  components:
+    articles:
+      text: Vignettes
+      menu:
+      - text: SOMA Introduction
+      - text: SOMA Objects Overview
+        href: articles/soma-objects.html
+      - text: Reading From SOMA Objects
+        href: articles/soma-reading.html
+      - text: Querying a SOMA Experiment
+        href: articles/soma-experiment-queries.html
+      - text: -------
+      - text: SOMA Configuration
+      - text: Using PlatformConfig
+        href: articles/UsingPlatformConfig.html


### PR DESCRIPTION
Fixes #1376

**Issue and/or context:**

As discussed in #1376, the order of articles ("vignettes") presented is rule-based (by filename) and not ideal.

**Changes:**

We impose an explicit ordering and segmentation in the navigation bar:

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/a6ced7f4-ad87-468a-9d79-997ff50c3a81)

We also update the basic rendering to bootstrap5 which uses crisper CSS all-around.  The logic in the GitHub Action should be unaffected the basic `build_site()` is embedded in the 'update and push to gh-pages' step.

**Notes for Reviewer:**

#1376
[SC 29399](https://app.shortcut.com/tiledb-inc/story/29399/fine-tune-pkdown-listing-of-vignettes_
