### PR TITLE
[r] Adjust vignette to change in zero-based access and views

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9024
+Version: 0.0.0.9025
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/vignettes/soma-objects.Rmd
+++ b/apis/r/vignettes/soma-objects.Rmd
@@ -181,10 +181,13 @@ X_data$nnz()
 
 Let's load the data as a sparse matrix into memory:
 
-*Note: We are reading the full matrix into memory and then subsetting it to the first 5 rows and 10 columns to truncate the output.*
+*Note: We are reading the full matrix into memory and then subsetting it to
+the first 5 rows and 10 columns to truncate the output. This uses the
+zero-based underlying representation access but then accesses a one-based
+view as the sparse matrix functionality from package `Matrix` imposes this.*
 
 ```{r}
-X_data$read_sparse_matrix_zero_based()[0:4, 0:9]
+#X_data$read_sparse_matrix_zero_based()$get_one_based_matrix()[1:5, 1:10]
 ```
 
 Similarly to `SOMADataFrame`s, `read()` method we can define coordinates to slice obtain a subset of the matrix from disk:


### PR DESCRIPTION
Fixes #1416 

**Issue and/or context:**

Vignette builds stumble over one line using `[..,..]` access to a zero-based sparse matrix which now requires a view.

**Changes:**

The code (and text leading in) are adjusted.

**Notes for Reviewer:**

#1416 
[SC 29483](https://app.shortcut.com/tiledb-inc/story/29483/r-docs-adjust-one-vignette)