### PR TITLE
[r] Respect global log level

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -95,7 +95,7 @@ shape <- function(uri, config = NULL) {
 #' \dontrun{
 #' ctx <- tiledb::tiledb_ctx()
 #' uri <- "test/soco/pbmc3k_processed/obs"
-#' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="warn")
+#' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="auto")
 #' rl <- data.frame()
 #' while (!sr_complete(sr)) {
 #'     sr |>

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -177,14 +177,14 @@ SOMADataFrame <- R6::R6Class(
     #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return An [`arrow::Table`].
     read = function(coords = NULL,
                     column_names = NULL,
                     value_filter = NULL,
                     result_order = "auto",
                     iterated = FALSE,
-                    log_level = "warn") {
+                    log_level = "auto") {
 
       private$check_open_for_read()
 

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -116,13 +116,13 @@ SOMADenseNDArray <- R6::R6Class(
     #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return An [`arrow::Table`].
     read_arrow_table = function(
       coords = NULL,
       result_order = "auto",
       iterated = FALSE,
-      log_level = "warn"
+      log_level = "auto"
     ) {
       private$check_open_for_read()
 
@@ -181,13 +181,13 @@ SOMADenseNDArray <- R6::R6Class(
     #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return A `matrix` object
     read_dense_matrix = function(
       coords = NULL,
       result_order = "ROW_MAJOR",
       iterated = FALSE,
-      log_level = "warn"
+      log_level = "auto"
     ) {
       private$check_open_for_read()
 

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -113,13 +113,13 @@ SOMASparseNDArray <- R6::R6Class(
     #' @template param-result-order
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return An [`arrow::Table`].
     read_arrow_table = function(
       coords = NULL,
       result_order = "auto",
       iterated = FALSE,
-      log_level = "warn"
+      log_level = "auto"
     ) {
       private$check_open_for_read()
 
@@ -177,7 +177,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param repr Optional one-character code for sparse matrix representation type
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return A sparse matrix whose exact representation
     #' is determined by \code{repr}.
     read_sparse_matrix = function(
@@ -185,7 +185,7 @@ SOMASparseNDArray <- R6::R6Class(
       result_order = "auto",
       repr = c("C", "T", "R"),
       iterated = FALSE,
-      log_level = "warn"
+      log_level = "auto"
     ) {
       private$check_open_for_read()
       repr <- match.arg(repr)
@@ -229,14 +229,14 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param repr Optional one-character code for sparse matrix representation type
     #' @param iterated Option boolean indicated whether data is read in call (when
     #' `FALSE`, the default value) or in several iterated steps.
-    #' @param log_level Optional logging level with default value of `"warn"`.
+    #' @param log_level Optional logging level with default value of `"auto"`.
     #' @return A \link{matrixZeroBasedView}
     read_sparse_matrix_zero_based = function(
       coords = NULL,
       result_order = "auto",
       repr = c("C", "T", "R"),
       iterated = FALSE,
-      log_level = "warn"
+      log_level = "auto"
     ) {
       # If we're setting up an iterated reader, set the tracker for zero-based
       # and use `self$read_sparse_matrix()` for the rest of the setup

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -132,7 +132,7 @@ default), the object's URI is assumed to be relative unless it is a
 \subsection{Method \code{get()}}{
 Retrieve a SOMA object by name. (lifecycle: experimental)
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$get(name, mode = "READ")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$get(name)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -118,7 +118,7 @@ column, and optionally filtered.
   value_filter = NULL,
   result_order = "auto",
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -140,7 +140,7 @@ more information.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -110,7 +110,7 @@ Read as an 'arrow::Table' (lifecycle: experimental)
   coords = NULL,
   result_order = "auto",
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -130,7 +130,7 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -148,7 +148,7 @@ Read as a dense matrix (lifecycle: experimental)
   coords = NULL,
   result_order = "ROW_MAJOR",
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -168,7 +168,7 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -109,7 +109,7 @@ Read as an 'arrow::Table' (lifecycle: experimental)
   coords = NULL,
   result_order = "auto",
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -126,7 +126,7 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -145,7 +145,7 @@ Read as a sparse matrix (lifecycle: experimental)
   result_order = "auto",
   repr = c("C", "T", "R"),
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -164,7 +164,7 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -184,7 +184,7 @@ Read as a zero-indexed sparse matrix (lifecycle: experimental)
   result_order = "auto",
   repr = c("C", "T", "R"),
   iterated = FALSE,
-  log_level = "warn"
+  log_level = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -203,16 +203,12 @@ read. List elements can be named when specifying a subset of dimensions.}
 \item{\code{iterated}}{Option boolean indicated whether data is read in call (when
 \code{FALSE}, the default value) or in several iterated steps.}
 
-\item{\code{log_level}}{Optional logging level with default value of \code{"warn"}.}
+\item{\code{log_level}}{Optional logging level with default value of \code{"auto"}.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{matrix}-like object accessed using zero-based indexes. It supports
-only basic access operations with zero-based indexes as well as \code{dim()},
-\code{nrow()}, and \code{ncol()}. Use \code{as.one.based()} to get a fully-featured
-sparse matrix object supporting more advanced operations (with one-based
-indexing).
+A \link{matrixZeroBasedView}
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/TileDBGroup.Rd
+++ b/apis/r/man/TileDBGroup.Rd
@@ -136,9 +136,9 @@ default), the object's URI is assumed to be relative unless it is a
 \if{latex}{\out{\hypertarget{method-TileDBGroup-get}{}}}
 \subsection{Method \code{get()}}{
 Retrieve a group member by name. If the member isn't already
-open, it is opened for read. (lifecycle: experimental)
+open, it is opened in the same mode as the parent. (lifecycle: experimental)
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$get(name, mode = "READ")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$get(name)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/apis/r/man/sr_setup.Rd
+++ b/apis/r/man/sr_setup.Rd
@@ -59,7 +59,7 @@ class so that iterative access over parts of a (large) array is possible.
 \dontrun{
 ctx <- tiledb::tiledb_ctx()
 uri <- "test/soco/pbmc3k_processed/obs"
-sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="warn")
+sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="auto")
 rl <- data.frame()
 while (!sr_complete(sr)) {
     sr |>

--- a/apis/r/man/write_soma.Rd
+++ b/apis/r/man/write_soma.Rd
@@ -20,7 +20,7 @@ configuration}}
 }
 \value{
 The URI to the resulting \code{\link{SOMAExperiment}} generated from
-the data contained in \code{x}
+the data contained in \code{x}, returned opened for write
 }
 \description{
 Convert \R objects to their appropriate SOMA counterpart

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/write_seurat.R
 \name{write_soma.Seurat}
 \alias{write_soma.Seurat}
-\title{Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA}
+\title{Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA, returned opened for write}
 \usage{
 \method{write_soma}{Seurat}(x, uri, ..., platform_config = NULL, tiledbsoma_ctx = NULL)
 }
@@ -20,10 +20,10 @@ configuration}}
 }
 \value{
 The URI to the resulting \code{\link{SOMAExperiment}} generated from
-the data contained in \code{x}
+the data contained in \code{x}, returned opened for write
 }
 \description{
-Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA
+Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA, returned opened for write
 }
 \section{Writing Cell-Level Meta Data}{
 

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -96,7 +96,7 @@ determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 }
 \value{
 The resulting SOMA \link[tiledbsoma:SOMASparseNDArray]{array} or
-\link[tiledbsoma:SOMADataFrame]{data frame}
+\link[tiledbsoma:SOMADataFrame]{data frame}, returned opened for write
 }
 \description{
 Various helpers to write R objects to SOMA

--- a/apis/r/man/write_soma_seurat_sub.Rd
+++ b/apis/r/man/write_soma_seurat_sub.Rd
@@ -5,7 +5,7 @@
 \alias{write_soma.Assay}
 \alias{write_soma.DimReduc}
 \alias{write_soma.Graph}
-\title{Convert a \pkg{Seurat} Sub-Object to a SOMA Object}
+\title{Convert a \pkg{Seurat} Sub-Object to a SOMA Object, returned opened for write}
 \usage{
 \method{write_soma}{Assay}(
   x,
@@ -70,10 +70,10 @@ relative or aboslute}
 }
 \value{
 \code{Assay} method: a \code{\link{SOMAMeasurement}} with the
-data from \code{x}
+data from \code{x}, returned opened for write
 
 \code{DimReduc} and \code{Graph} methods: invisibly returns
-\code{soma_parent} with the values of \code{x} added to it
+\code{soma_parent}, opened for write, with the values of \code{x} added to it
 }
 \description{
 Various helpers to write \pkg{Seurat} sub-objects to SOMA objects.

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -53,7 +53,7 @@ namespace tdbs = tiledbsoma;
 //' \dontrun{
 //' ctx <- tiledb::tiledb_ctx()
 //' uri <- "test/soco/pbmc3k_processed/obs"
-//' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="warn")
+//' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)), loglevel="auto")
 //' rl <- data.frame()
 //' while (!sr_complete(sr)) {
 //'     sr |>


### PR DESCRIPTION
**Issue and/or context:**

Individual object-readers were resetting a requested global log level.

Example:

```
tiledbsoma:::set_log_level('debug')
experiment <- SOMAExperimentOpen('/var/s/v/ileum')
query <- SOMAExperimentAxisQuery$new(experiment = experiment, measurement_name = "RNA")
obj <- query$to_seurat(X_layers = c(data = 'data'))
print(obj)
```

At line 1 the log level is set. But desired log lines were not appearing because of:

* https://github.com/single-cell-data/TileDB-SOMA/blob/1.2.4/apis/r/R/SOMADataFrame.R#L187 (and simillar lines)
* https://github.com/single-cell-data/TileDB-SOMA/blob/1.2.4/apis/r/src/rinterface.cpp#L82-L85

when the `read` methods were invoked through the `query` callchain.

**Changes:**

Set the log level to `"auto"` as intended.
