### PR TITLE
[c++,r] Use knowing whether read is initial or not when reading 'next' result set

### DIFF
--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -69,12 +69,12 @@ namespace tdbs = tiledbsoma;
 //' @export
 // [[Rcpp::export]]
 Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
-                                           Rcpp::CharacterVector config,
-                                           Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
-                                           Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
-                                           Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
-                                           Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
-                                           const std::string& loglevel = "auto") {
+                                     Rcpp::CharacterVector config,
+                                     Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
+                                     const std::string& loglevel = "auto") {
 
     if (loglevel != "auto") {
         spdl::set_level(loglevel);
@@ -159,6 +159,12 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAArray> sr) {
    if (sr_complete(sr)) {
        spdl::trace("[sr_next] complete {} num_cells {}",
                    sr->is_complete(true), sr->total_num_cells());
+       return Rcpp::List::create(R_NilValue, R_NilValue);
+   }
+
+   if (!sr->is_initial_read() && sr->total_num_cells() == 0) {
+       spdl::trace("[sr_next] is_initial_read {} num_cells {}",
+                   sr->is_initial_read(), sr->total_num_cells());
        return Rcpp::List::create(R_NilValue, R_NilValue);
    }
 

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -62,7 +62,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
     sr <- sr_setup(uri, config=as.character(config(ctx)))
 
     expect_false(tiledbsoma:::sr_complete(sr))
-    dat <- dat <- sr_next(sr)
+    dat <- sr_next(sr)
     expect_true(tiledbsoma:::sr_complete(sr))
 })
 
@@ -84,14 +84,14 @@ test_that("Iterated Interface from SOMA Classes", {
                       sparse = SOMASparseNDArray$new(uri, internal_use_only = "allowed_use"))
         expect_true(inherits(sdf, "SOMAArrayBase"))
         sdf$open("READ", internal_use_only = "allowed_use")
-      
+
         iterator <- switch(tc,
                            data.frame = sdf$read(),
                            sparse = sdf$read()$tables())
-                           
+
         expect_true(inherits(iterator, "ReadIter"))
         expect_true(inherits(iterator, "TableReadIter"))
-        
+
         # Test $concat()
         expect_false(iterator$read_complete())
         dat <- iterator$concat()
@@ -99,33 +99,33 @@ test_that("Iterated Interface from SOMA Classes", {
         expect_true(inherits(dat, "Table"))
         expect_equal(dat$num_columns, 3)
         expect_equal(dat$num_rows, 2238732)
-        
+
         rm(iterator)
-        
+
         # Test $read_next()
         iterator <- switch(tc,
                            data.frame = sdf$read(),
                            sparse = sdf$read()$tables())
-        
+
         expect_false(iterator$read_complete())
         for (i in 1:2) {
-            
+
             expect_false(iterator$read_complete())
             dat_slice <- iterator$read_next()
             expect_true(inherits(dat_slice, "Table"))
             expect_equal(dat_slice$num_columns, 3)
-            
+
             if (i < 2) {
                 expect_equal(dat_slice$num_rows, 2097152)
             } else {
                 expect_equal(dat_slice$num_rows, 141580)
             }
         }
-        
+
         expect_true(iterator$read_complete())
         expect_null(iterator$read_next())
         expect_warning(iterator$read_next())
-        
+
         rm(sdf)
     }
 
@@ -156,11 +156,11 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
         # the shard dims always match the shape of the whole sparse matrix
         expect_equal(dim(dat), as.integer(sdf$shape()))
     }
-    
+
     expect_true(iterator$read_complete())
     expect_null(iterator$read_next())
     expect_warning(iterator$read_next())
-    
+
     expect_equal(nnzTotal, Matrix::nnzero(sdf$read()$sparse_matrix(T)$concat()$get_one_based_matrix()))
     expect_equal(nnzTotal, 2238732)
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -337,6 +337,16 @@ class SOMAArray {
     }
 
     /**
+     * @brief Return whether next read is the initial read, or a subsequent
+     * read of a previous incomplete query.
+     *
+     * @return bool Logical value if initial read or not
+     */
+    bool is_initial_read() {
+        return first_read_next_;
+    }
+
+    /**
      * @brief Get the total number of unique cells in the array.
      *
      * @return uint64_t Total number of unique cells


### PR DESCRIPTION
Fixes #1420

**Issue and/or context:**

A non-initial read of an incomplete query object (for a query that has in fact no data) would crash assumed there was data to be had.  

**Changes:**

The internal SOMA Array class already had a predicate to indicate whether the read was initial or not.  Together with the existing accessor for the number of data cells ("rows" so to speak) read, we can identify non-initial but unsatisfiable queries.

**Notes for Reviewer:**

Note that we expand one `libtiledbsoma` header file so if using thiss with a system-wide `libtiledbsoma` a quick rebuild is needed.

Percolating this result to higher-level functions will be addressed next in a subsequent PR.

#1420 
[SC 29567](https://app.shortcut.com/tiledb-inc/story/29567/c-r-ensure-subsequent-reads-on-empty-queries-do-not-crash)
