### PR TITLE
[r] Return empty arrow table on empty results set

### DIFF
--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -123,8 +123,8 @@ test_that("Iterated Interface from SOMA Classes", {
         }
 
         expect_true(iterator$read_complete())
-        expect_null(iterator$read_next())
-        expect_warning(iterator$read_next())
+        expect_warning(iterator$read_next()) # returns NULL with warning
+        expect_warning(iterator$read_next()) # returns NULL with warning
 
         rm(sdf)
     }
@@ -158,9 +158,8 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
     }
 
     expect_true(iterator$read_complete())
-    expect_null(iterator$read_next())
-    expect_warning(iterator$read_next())
-
+    expect_warning(iterator$read_next()) # returns NULL with warning
+    expect_warning(iterator$read_next()) # returns NULL with warning
     expect_equal(nnzTotal, Matrix::nnzero(sdf$read()$sparse_matrix(T)$concat()$get_one_based_matrix()))
     expect_equal(nnzTotal, 2238732)
 

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -228,38 +228,36 @@ test_that("querying by both coordinates and value filters", {
   experiment$close()
 })
 
-# TODO include when sr_setup and sr_next support empty results
-#test_that("queries with empty results", {
-#  uri <- withr::local_tempdir("soma-experiment-query-empty-results")
-#  n_obs <- 1001L
-#  n_var <- 99L
-#
-#  experiment <- create_and_populate_experiment(
-#    uri = uri,
-#    n_obs = n_obs,
-#    n_var = n_var,
-#    X_layer_names = c("counts", "logcounts"),
-#    mode = "READ"
-#  )
-#  on.exit(experiment$close())
-#
-#  # obs/var slice and value filter
-#  query <- SOMAExperimentAxisQuery$new(
-#    experiment = experiment,
-#    measurement_name = "RNA",
-#    obs_query = SOMAAxisQuery$new(
-#      value_filter = "baz == 'does-not-exist'"
-#    ),
-#    var_query = SOMAAxisQuery$new(
-#      value_filter = "quux == 'does-not-exist'"
-#    )
-#  )
-#
-#  expect_equal(query$obs()$num_rows, 0)
-#  expect_equal(query$var()$num_rows, 0)
-#
-#  experiment$close()
-#})
+test_that("queries with empty results", {
+  uri <- withr::local_tempdir("soma-experiment-query-empty-results")
+  n_obs <- 1001L
+  n_var <- 99L
+
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = c("counts", "logcounts"),
+    mode = "READ"
+  )
+  on.exit(experiment$close())
+
+  # obs/var slice and value filter
+  query <- SOMAExperimentAxisQuery$new(
+    experiment = experiment,
+    measurement_name = "RNA",
+    obs_query = SOMAAxisQuery$new(
+      value_filter = "baz == 'does-not-exist'"
+    ),
+    var_query = SOMAAxisQuery$new(
+      value_filter = "quux == 'does-not-exist'"
+    )
+    )
+  expect_equal(query$obs()$num_rows, 0)
+  expect_equal(query$var()$num_rows, 0)
+  expect_equal(4L/2L, 2L)
+  experiment$close()
+})
 
 test_that("retrieving query results in supported formats", {
   uri <- withr::local_tempdir("soma-experiment-query-results-formats1")

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -255,8 +255,6 @@ test_that("queries with empty results", {
     )
   expect_equal(query$obs()$num_rows, 0)
   expect_equal(query$var()$num_rows, 0)
-  expect_equal(4L/2L, 2L)
-  experiment$close()
 })
 
 test_that("retrieving query results in supported formats", {


### PR DESCRIPTION
**Issue and/or context:**

With the change in #1422 we can return an empty arrow table (as the usual two `void*` of its C API) rather than just two `NULL`.  This allows transparent use through the different query access paths.

**Changes:**

The change also required a small change in how the check for completeness of a query is determined, and affects two test conditions in the unit test file.  It also lets us enable a largers from the experiment query test which required this change.

**Notes for Reviewer:**

[SC 29587](https://app.shortcut.com/tiledb-inc/story/29587/minor-refactoring-of-iterated-read-results-when-result-set-is-empty)