### PR TITLE
[python] Export `TileDBCreateOptions` at the top level, and add to docs

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -112,7 +112,7 @@ from ._general_utilities import (
 )
 from ._measurement import Measurement
 from ._sparse_nd_array import SparseNDArray
-from .options import SOMATileDBContext
+from .options import SOMATileDBContext, TileDBCreateOptions
 from .pytiledbsoma import (
     tiledbsoma_stats_disable,
     tiledbsoma_stats_dump,
@@ -137,12 +137,13 @@ __all__ = [
     "get_storage_engine",
     "Measurement",
     "open",
-    "show_package_versions",
-    "SOMAError",
     "ResultOrder",
-    "SOMATileDBContext",
+    "show_package_versions",
     "SOMA_JOINID",
+    "SOMAError",
+    "SOMATileDBContext",
     "SparseNDArray",
+    "TileDBCreateOptions",
     "tiledbsoma_stats_disable",
     "tiledbsoma_stats_dump",
     "tiledbsoma_stats_enable",

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -95,8 +95,11 @@ class CollectionBase(
             uri:
                 The location to create this SOMA collection at.
             platform_config:
-                Platform-specific options used to create this collection, provided in the form
-                ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}``.
+                Platform-specific options used to create this collection.
+                This may be provided as settings in a dictionary, with options
+                located in the ``{'tiledb': {'create': ...}}`` key,
+                or as a :class:`~tiledbsoma.TileDBCreateOptions` object.
+                (Currently unused for collections.)
             context:
                 If provided, the :class:`SOMATileDBContext` to use when creating and
                 opening this collection.

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -59,8 +59,10 @@ class NDArray(TileDBArray, somacore.NDArray):
                 possible int64 will be used.  This makes a :class:`SparseNDArray`
                 growable.
             platform_config:
-                Platform-specific options used to create this array, provided in the form
-                ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}``.
+                Platform-specific options used to create this array.
+                This may be provided as settings in a dictionary, with options
+                located in the ``{'tiledb': {'create': ...}}`` key,
+                or as a :class:`~tiledbsoma.TileDBCreateOptions` object.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -160,8 +160,10 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 possible values for the column's datatype.  This makes a
                 :class:`DataFrame` growable.
             platform_config:
-                Platform-specific options used to create this array, provided in the form
-                ``{"tiledb": {"create": {"dataframe_dim_zstd_level": 7}}}``.
+                Platform-specific options used to create this array.
+                This may be provided as settings in a dictionary, with options
+                located in the ``{'tiledb': {'create': ...}}`` key,
+                or as a :class:`~tiledbsoma.TileDBCreateOptions` object.
             tiledb_timestamp:
                 If specified, overrides the default timestamp
                 used to open this object. If unset, uses the timestamp provided by


### PR DESCRIPTION
Finishes the Python side of #1394.