### PR TITLE
Improve stack traces on collection create/open in the ingestor.

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -577,12 +577,14 @@ def _create_or_open_coll(
     try:
         thing = cls.open(uri, "w", context=context)
     except DoesNotExistError:
-        # This is always OK. Make a new one.
-        return cls.create(uri, context=context)
-    # It already exists. Are we resuming?
-    if ingest_mode == "resume":
-        return thing
-    raise SOMAError(f"{uri} already exists")
+        pass  # This is always OK; make a new one.
+    else:
+        # It already exists. Are we resuming?
+        if ingest_mode == "resume":
+            return thing
+        raise SOMAError(f"{uri} already exists")
+
+    return cls.create(uri, context=context)
 
 
 def _write_dataframe(


### PR DESCRIPTION
To avoid unnecessary "during the handling of exception A, exception B was raised" messages (since "collection doesn't exist yet" isn't really an error condition), this pulls the "create" step out of the exception handler for the "open" step, breaking the exception causation chain. (The other does-not-exist blocks should probably be changed similarly, but those would require more work than this minor fix.)