### PR TITLE
[c++] Addition of `SOMAArray::create` and `SOMAArray::write`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -53,7 +53,8 @@ void ManagedQuery::reset() {
     query_ = std::make_unique<Query>(schema_->context(), *array_);
     subarray_ = std::make_unique<Subarray>(schema_->context(), *array_);
 
-    if (array_->schema().array_type() == TILEDB_SPARSE) {
+    if (this->query_type() == TILEDB_WRITE ||
+        array_->schema().array_type() == TILEDB_SPARSE) {
         query_->set_layout(TILEDB_UNORDERED);
     } else {
         query_->set_layout(TILEDB_ROW_MAJOR);
@@ -90,7 +91,7 @@ void ManagedQuery::select_columns(
     }
 }
 
-void ManagedQuery::submit() {
+void ManagedQuery::submit_read() {
     // Throw error if submit is called again before reading the results
     if (query_submitted_) {
         throw TileDBSOMAError(fmt::format(
@@ -156,6 +157,10 @@ void ManagedQuery::submit() {
         query_->submit();
     }
     query_submitted_ = true;
+}
+
+void ManagedQuery::submit_write() {
+    query_->submit();
 }
 
 std::shared_ptr<ArrayBuffers> ManagedQuery::results() {

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- *   This declares the managed query API
+ *   This declares the managed query API.
  */
 
 #ifndef MANAGED_QUERY_H
@@ -167,10 +167,26 @@ class ManagedQuery {
     }
 
     /**
-     * @brief Submit the query.
+     * @brief Set column data for write query.
+     *
+     * @param column_buffer Column data
+     */
+    template <typename T>
+    void set_column_data(std::string column_name, std::vector<T>& buf) {
+        query_->set_data_buffer(column_name, buf);
+    }
+
+    /**
+     * @brief Submit the read query.
      *
      */
-    void submit();
+    void submit_read();
+
+    /**
+     * @brief Submit the write query.
+     *
+     */
+    void submit_write();
 
     /**
      * @brief Check if the query is complete.
@@ -281,6 +297,15 @@ class ManagedQuery {
      */
     bool is_empty_query() {
         return subarray_range_set_ && subarray_range_empty_;
+    }
+
+    /**
+     * @brief Return the query type.
+     *
+     * @return TILEDB_READ or TILEDB_WRITE
+     */
+    tiledb_query_type_t query_type() const {
+        return query_->query_type();
     }
 
    private:

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- *   This declares the SOMAArray
+ *   This declares the SOMAArray class.
  */
 
 #ifndef SOMA_ARRAY
@@ -49,6 +49,8 @@ class SOMAArray {
     //===================================================================
     //= public static
     //===================================================================
+
+    static void create(std::string_view uri, ArraySchema schema);
 
     /**
      * @brief Open an array at the specified URI and return SOMAArray
@@ -258,9 +260,7 @@ class SOMAArray {
      *
      * @param qc Query condition
      */
-    void set_condition(QueryCondition& qc) {
-        mq_->set_condition(qc);
-    }
+    void set_condition(QueryCondition& qc);
 
     /**
      * @brief Select columns names to query (dim and attr). If the
@@ -272,9 +272,7 @@ class SOMAArray {
      * @param if_not_empty Prevent changing an "empty" selection of all columns
      */
     void select_columns(
-        const std::vector<std::string>& names, bool if_not_empty = false) {
-        mq_->select_columns(names, if_not_empty);
-    }
+        const std::vector<std::string>& names, bool if_not_empty = false);
 
     /**
      * @brief Submit the query
@@ -298,6 +296,16 @@ class SOMAArray {
      */
     std::optional<std::shared_ptr<ArrayBuffers>> read_next();
 
+    template <typename T>
+    void set_column_data(std::string_view column_name, std::vector<T>& buf) {
+        mq_->set_column_data(std::string(column_name), buf);
+    }
+
+    /**
+     * @brief Write ArrayBuffers data to the array.
+     */
+    void write();
+
     /**
      * @brief Check if the query is complete.
      *
@@ -311,9 +319,7 @@ class SOMAArray {
      * @param query_status_only Query complete mode.
      * @return true if the query is complete, as described above
      */
-    bool is_complete(bool query_status_only = false) {
-        return mq_->is_complete(query_status_only);
-    }
+    bool is_complete(bool query_status_only = false);
 
     /**
      * @brief Return true if `read_next` returned all results from the
@@ -322,9 +328,7 @@ class SOMAArray {
      * @return True if last call to `read_next` returned all results of the
      * query
      */
-    bool results_complete() {
-        return mq_->results_complete();
-    }
+    bool results_complete();
 
     /**
      * @brief Return the total number of cells read so far, including any
@@ -332,9 +336,7 @@ class SOMAArray {
      *
      * @return size_t Total number of cells read
      */
-    size_t total_num_cells() {
-        return mq_->total_num_cells();
-    }
+    size_t total_num_cells();
 
     /**
      * @brief Return whether next read is the initial read, or a subsequent

--- a/libtiledbsoma/src/utils/array_buffers.h
+++ b/libtiledbsoma/src/utils/array_buffers.h
@@ -37,9 +37,9 @@
 
 #include <tiledb/tiledb>
 
+#include "../utils/common.h"
+#include "../utils/logger.h"
 #include "column_buffer.h"
-#include "common.h"
-#include "logger.h"
 #include "span/span.hpp"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/utils/column_buffer.h
+++ b/libtiledbsoma/src/utils/column_buffer.h
@@ -37,8 +37,8 @@
 
 #include <tiledb/tiledb>
 
-#include "common.h"
-#include "logger.h"
+#include "../utils/common.h"
+#include "../utils/logger.h"
 #include "span/span.hpp"
 
 namespace tiledbsoma {
@@ -68,6 +68,16 @@ class ColumnBuffer {
      */
     static std::shared_ptr<ColumnBuffer> create(
         std::shared_ptr<Array> array, std::string_view name);
+
+    /**
+     * @brief Create a ColumnBuffer from a schema and column name.
+     *
+     * @param schema TileDB schema
+     * @param name TileDB dimension or attribute name
+     * @return ColumnBuffer
+     */
+    static std::shared_ptr<ColumnBuffer> create(
+        ArraySchema schema, std::string_view name);
 
     /**
      * @brief Convert a bytemap to a bitmap in place.

--- a/libtiledbsoma/test/unit_managed_query.cc
+++ b/libtiledbsoma/test/unit_managed_query.cc
@@ -122,7 +122,7 @@ TEST_CASE("ManagedQuery: Basic execution test") {
     auto [array, d0, a0, _] = create_array(uri, ctx);
 
     auto mq = ManagedQuery(array);
-    mq.submit();
+    mq.submit_read();
 
     auto results = mq.results();
     REQUIRE(mq.results_complete());
@@ -142,7 +142,7 @@ TEST_CASE("ManagedQuery: Select test") {
     auto mq = ManagedQuery(array);
     mq.select_columns({"a0"});
     mq.select_points<std::string>("d0", {"a"});
-    mq.submit();
+    mq.submit_read();
 
     auto results = mq.results();
     REQUIRE(mq.results_complete());
@@ -164,7 +164,7 @@ TEST_CASE("ManagedQuery: Validity test") {
     auto [array, d0, a0, a0_valids] = create_array(uri, ctx);
 
     auto mq = ManagedQuery(array);
-    mq.submit();
+    mq.submit_read();
 
     auto results = mq.results();
     REQUIRE(mq.results_complete());


### PR DESCRIPTION
**Issue and/or context:**
#1364

**Changes:**
* Add `SOMAArray::create`
* Add `SOMAArray::write`
* Add `SOMAArray::set_column_data`

**Notes for Reviewer:**
In a future PR, the write function should take an Arrow data structure as specified in the abstract spec instead of a vector. The create function should also take in an Arrow struct instead of a TileDB ArraySchema.

