### PR TITLE
[r] Run coverage in parallel instead of sequentially after test

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -17,8 +17,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-latest }
-          - { os: macOS-latest }
+          - name: linux
+            os: ubuntu-latest
+            covr: 'no'
+          - name: macos
+            os: macOS-latest
+            covr: 'no'
+          - name: coverage
+            os: ubuntu-latest
+            covr: 'yes'
 
     runs-on: ${{ matrix.os }}
 
@@ -34,8 +41,8 @@ jobs:
       - name: CMake
         uses: lukka/get-cmake@latest
 
-      - name: MkVars
-        run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
+      #- name: MkVars
+      #  run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
       #- name: Build and install libtiledbsoma
       #  run: sudo scripts/bld --prefix=/usr/local 
@@ -45,6 +52,7 @@ jobs:
       #  run: sudo ldconfig
         
       - name: Test
+        if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests
 
       - name: View Install Output
@@ -52,5 +60,5 @@ jobs:
         if: failure()
 
       - name: Coverage
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' }}
         run: cd apis/r && tools/r-ci.sh coverage


### PR DESCRIPTION
fixes #1406

**Issue and/or context:**

Total time for CI is currently the time for tests _plus_ the time for coverage where it runs making the 'linux' run slower than macOS.  We can safe a bit of total CI time by running coverage while the normal unit tests run, making the net total time the time of slower unit test setup, currently macOS.

**Changes:**

Expand the CI matrix to include field 'covr', run unit tests as before when the field is not but run coverage when it is yes.

**Notes for Reviewer:**

#1406, [SC 29906](https://app.shortcut.com/tiledb-inc/story/29906/r-run-coverage-in-parallel)