### PR TITLE
reformat c++ code post #1429

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -50,7 +50,8 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     std::string_view batch_size,
     std::string_view result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    LOG_DEBUG(fmt::format("[SOMAArray] static method 'cfg' opening array '{}'", uri));
+    LOG_DEBUG(
+        fmt::format("[SOMAArray] static method 'cfg' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
         mode,
         uri,
@@ -71,7 +72,8 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     std::string_view batch_size,
     std::string_view result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    LOG_DEBUG(fmt::format("[SOMAArray] static method 'ctx' opening array '{}'", uri));
+    LOG_DEBUG(
+        fmt::format("[SOMAArray] static method 'ctx' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
         mode,
         uri,
@@ -111,8 +113,11 @@ SOMAArray::SOMAArray(
             arr_->set_open_timestamp_end(timestamp->second);
             arr_->close();
             arr_->open(mode);
-            LOG_DEBUG(fmt::format("[SOMAArray] timestamp_start = {}", arr_->open_timestamp_start()));
-            LOG_DEBUG(fmt::format("[SOMAArray] timestamp_end = {}", arr_->open_timestamp_end()));
+            LOG_DEBUG(fmt::format(
+                "[SOMAArray] timestamp_start = {}",
+                arr_->open_timestamp_start()));
+            LOG_DEBUG(fmt::format(
+                "[SOMAArray] timestamp_end = {}", arr_->open_timestamp_end()));
         }
         mq_ = std::make_unique<ManagedQuery>(arr_, name);
     } catch (const std::exception& e) {


### PR DESCRIPTION
Seems the C++ lint job didn't run in the #1429 PR CI, and it broke main instead -- https://github.com/single-cell-data/TileDB-SOMA/actions/runs/5181154790/jobs/9336276515