### PR TITLE
[python] Ingest `anndata.layers` by default in `tiledbsoma.io`

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -337,7 +337,7 @@ def from_anndata(
                     with create_from_matrix(
                         X_kind,
                         _util.uri_joinpath(measurement_X_uri, key),
-                        anndata.X,
+                        anndata.layers[key],
                         platform_config,
                         ingest_mode,
                         context,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -333,17 +333,17 @@ def from_anndata(
                 ) as data:
                     _maybe_set(x, "data", data, use_relative_uri=use_relative_uri)
 
-                for key in anndata.layers:
+                for layer_name, layer in anndata.layers.items():
                     with create_from_matrix(
                         X_kind,
-                        _util.uri_joinpath(measurement_X_uri, key),
-                        anndata.layers[key],
+                        _util.uri_joinpath(measurement_X_uri, layer_name),
+                        layer,
                         platform_config,
                         ingest_mode,
                         context,
                     ) as layer_data:
                         _maybe_set(
-                            x, key, layer_data, use_relative_uri=use_relative_uri
+                            x, layer_name, layer_data, use_relative_uri=use_relative_uri
                         )
 
                 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -333,6 +333,19 @@ def from_anndata(
                 ) as data:
                     _maybe_set(x, "data", data, use_relative_uri=use_relative_uri)
 
+                for key in anndata.layers.keys():
+                    with create_from_matrix(
+                        X_kind,
+                        _util.uri_joinpath(measurement_X_uri, key),
+                        anndata.X,
+                        platform_config,
+                        ingest_mode,
+                        context,
+                    ) as layer_data:
+                        _maybe_set(
+                            x, key, layer_data, use_relative_uri=use_relative_uri
+                        )
+
                 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                 # MS/meas/OBSM,VARM,OBSP,VARP
                 if len(anndata.obsm.keys()) > 0:  # do not create an empty collection

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -333,7 +333,7 @@ def from_anndata(
                 ) as data:
                     _maybe_set(x, "data", data, use_relative_uri=use_relative_uri)
 
-                for key in anndata.layers.keys():
+                for key in anndata.layers:
                     with create_from_matrix(
                         X_kind,
                         _util.uri_joinpath(measurement_X_uri, key),

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -64,6 +64,8 @@ def test_import_anndata(adata, ingest_modes, X_kind):
     metakey = _constants.SOMA_OBJECT_TYPE_METADATA_KEY  # keystroke-saver
     all2d = (slice(None), slice(None))  # keystroke-saver
 
+    adata.layers["plus1"] = adata.X + 1
+
     for ingest_mode in ingest_modes:
         uri = tiledbsoma.io.from_anndata(
             output_path,
@@ -124,21 +126,22 @@ def test_import_anndata(adata, ingest_modes, X_kind):
         assert exp.ms["RNA"].X.metadata.get(metakey) == "SOMACollection"
 
         # Check X/data (dense in the H5AD)
-        if X_kind == tiledbsoma.SparseNDArray:
-            assert exp.ms["RNA"].X["data"].metadata.get(metakey) == "SOMASparseNDArray"
-            table = exp.ms["RNA"].X["data"].read(coords=all2d).tables().concat()
-            if have_ingested:
-                assert table.shape[0] == orig.X.shape[0] * orig.X.shape[1]
+        for key in ["data", "plus1"]:
+            if X_kind == tiledbsoma.SparseNDArray:
+                assert exp.ms["RNA"].X[key].metadata.get(metakey) == "SOMASparseNDArray"
+                table = exp.ms["RNA"].X[key].read(coords=all2d).tables().concat()
+                if have_ingested:
+                    assert table.shape[0] == orig.X.shape[0] * orig.X.shape[1]
+                else:
+                    assert table.shape[0] == 0
             else:
-                assert table.shape[0] == 0
-        else:
-            assert exp.ms["RNA"].X["data"].metadata.get(metakey) == "SOMADenseNDArray"
-            if have_ingested:
-                matrix = exp.ms["RNA"].X["data"].read(coords=all2d)
-                assert matrix.size == orig.X.size
-            else:
-                with pytest.raises(ValueError):
-                    exp.ms["RNA"].X["data"].read(coords=all2d)
+                assert exp.ms["RNA"].X[key].metadata.get(metakey) == "SOMADenseNDArray"
+                if have_ingested:
+                    matrix = exp.ms["RNA"].X[key].read(coords=all2d)
+                    assert matrix.size == orig.X.size
+                else:
+                    with pytest.raises(ValueError):
+                        exp.ms["RNA"].X[key].read(coords=all2d)
 
         # Check raw/X/data (sparse)
         assert exp.ms["raw"].X["data"].metadata.get(metakey) == "SOMASparseNDArray"


### PR DESCRIPTION
**Issue and/or context:** This arose in response to a user-support request in the TileDB Community Slack's `#genomics` channel.

**Changes:** Add `anndata.layers` by default, without need for a manual step afterward.

**Notes for Reviewer:**

