### PR TITLE
[python] Raise on `add_X_layer` if collection not open

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -533,6 +533,8 @@ def _maybe_set(
     *,
     use_relative_uri: Optional[bool],
 ) -> None:
+    if coll.closed or coll.mode != "w":
+        raise SOMAError(f"Collection must be open for write: {coll.uri}")
     try:
         coll.set(key, value, use_relative_uri=use_relative_uri)
     except SOMAError:
@@ -764,6 +766,8 @@ def add_X_layer(
     Lifecycle:
         Experimental.
     """
+    if exp.closed or exp.mode != "w":
+        raise SOMAError(f"Experiment must be open for write: {exp.uri}")
     add_matrix_to_collection(
         exp,
         measurement_name,

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -347,6 +347,9 @@ def test_add_matrix_to_collection(adata):
     with _factory.open(output_path) as exp_r:
         assert list(exp_r.ms["RNA"].X.keys()) == ["data"]
 
+    with _factory.open(output_path, "r") as exp:
+        with pytest.raises(tiledbsoma.SOMAError):
+            tiledbsoma.io.add_X_layer(exp, "RNA", "data2", adata.X)
     with _factory.open(output_path, "w") as exp:
         tiledbsoma.io.add_X_layer(exp, "RNA", "data2", adata.X)
     with _factory.open(output_path) as exp_r:


### PR DESCRIPTION
**Issue and/or context:** Found on #1459. Doing `add_X_layer` after ingest, without opening the experiment for write, was failing to fail. This is due to an overswallowed exception here: https://github.com/single-cell-data/TileDB-SOMA/blob/1.2.5/apis/python/src/tiledbsoma/io/ingest.py#L538-L540

**Changes:** Add a pre-condition that the experiment is open for write.

**Notes for Reviewer:**

Repro from #1459:

```
adata = ad.read_h5ad('E-HCAD-9.project.h5ad')

exp = tiledbsoma.Experiment.open('E-HCAD-9.project') # Note no 'w'
tiledbsoma.io.add_X_layer(exp, "RNA", "filtered", adata.layers["filtered"]) # No error, and no successful add
exp.close()
```
