### PR TITLE
[docs] Some doc-link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,18 @@ TileDB-SOMA provides interoperability with existing Python or R data structures:
 channel `#cellxgene-census-users`.
 
 
-## Quick Start
+## APIs Installation and Quick Start
 
-### Documentation
+* [Python installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/Python-quick-start)
+* [R installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/R-quick-start)
+
+## API Documentation
 
 The TileDB-SOMA doc-site ([Python](https://tiledbsoma.readthedocs.io/en/latest/python-api.html)|[R](https://single-cell-data.github.io/TileDB-SOMA/)), contains the reference documentation and tutorials.
 
 Reference documentation can also be accessed directly from Python `help(tiledsoma)` or R `help(package = "tiledbsoma")`.
 
-### Main SOMA Objects
+## Main SOMA Objects
 
 The capabilities of TileDB-SOMA lay on the different read, access, and query patterns that each of the main implementations of SOMA objects provide:
 
@@ -68,11 +71,6 @@ The capabilities of TileDB-SOMA lay on the different read, access, and query pat
 * `Experiment` is a class that represents a single-cell experiment. It always contains two objects:
 	* `obs`: a  `DataFrame` with primary annotations on the observation axis.
 	* `ms`: a  `Collection` of measurements, each composed of `X` matrices and axis annotation matrices or data frames (e.g. `var`, `varm`, `obsm`, etc).
-
-### APIs Installation and Quick Start
-
-* [Python installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/Python-quick-start)
-* [R installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/R-quick-start)
 
 ## Who Is Using SOMA?
 

--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -4,12 +4,14 @@ This is a Python implementation of the [SOMA API specification](https://github.c
 
 # Installation
 
-## Using pip
+TileDB-SOMA is available on [PyPI](https://pypi.org/project/tiledbsoma/) and [Conda](https://anaconda.org/tiledb/tiledbsoma-py), and can be installed via `pip` or `mamba` as indicated below.
 
-This code is hosted at [PyPI](https://pypi.org/project/tiledbsoma/), so you can install using `pip`:
+```bash
+python -m pip install tiledbsoma
+```
 
-```shell
-$ python -m pip install tiledbsoma
+```bash
+mamba install -c conda-forge -c tiledb tiledbsoma-py
 ```
 
 To install a specific version:

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -9,14 +9,16 @@ Please also see the `main-old` branch for an implementation of the [original spe
 
 ## Using R-universe
 
-This package is hosted at R-universe so you can do
+TileDB-SOMA is available on  R-universe and [Conda](https://anaconda.org/tiledb/r-tiledbsoma), and can be installed directly from R or `mambda` as indicated below.
 
-```shell
-> install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
-                                           'https://cloud.r-project.org'))
+```r
+install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
+                                         'https://cloud.r-project.org'))
 ```
 
-to install it directly (as a pre-made binary on macOS, or from source on Linux) along with all its dependencies.
+```bash
+mamba install -c conda-forge -c tiledb r-tiledbsoma
+```
 
 ## From source
 


### PR DESCRIPTION
**Issue and/or context:** The quick-start pages at https://github.com/single-cell-data/TileDB-SOMA/wiki instruct the user to click into `apis/python/README.md` and `apis/r/README.md` for "full installation instructions". So, it's important that the latter have as much conda-install information as the former do.

Tracking issue: #1387