### PR TITLE
[python] Add 3.11 to `classifiers=` in `setup.py`

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -247,6 +247,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),


### PR DESCRIPTION
**Issue and/or context:** Resolves #1470, since we've had full support for Python 3.11 since [1.2.2](https://github.com/single-cell-data/TileDB-SOMA/releases/tag/1.2.2).