### PR TITLE
[python] Update numba/numpy versions for Python 3.11

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -283,8 +283,9 @@ setuptools.setup(
         # It' not preferable to pin to an RC dependency, so we only do this
         # when we must, which is for 3.11.
         "numba==0.56.4; python_version<'3.11'",
-        "numba==0.57.0rc1; python_version=='3.11'",
-        "numpy>=1.18,<1.24",
+        "numba==0.57; python_version=='3.11'",
+        "numpy>=1.18,<1.24; python_version<'3.11'",
+        "numpy>=1.18,<1.25; python_version=='3.11'",
         "pandas",
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",


### PR DESCRIPTION
**Issue and/or context:**

Fixes #1463 

**Changes:**

Pins for numba and numpy updated on Python 3.11

**Notes for Reviewer:**

Will manually run the GHA for python-ci-full as this tests the full matrix ([run link](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/5246123389))
