### PR TITLE
[c++] `SOMAArray::write` Modified To Take in `ArrayBuffers`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -169,11 +169,15 @@ class ManagedQuery {
     /**
      * @brief Set column data for write query.
      *
-     * @param column_buffer Column data
+     * @param column_name Column name
+     * @param buff Buffer array pointer with elements of the column type.
+     * @param nelements Number of array elements in buffer
      */
-    template <typename T>
-    void set_column_data(std::string column_name, std::vector<T>& buf) {
-        query_->set_data_buffer(column_name, buf);
+    void set_column_data(
+        std::string column_name, std::shared_ptr<ColumnBuffer> column_buffer) {
+        auto data = column_buffer->data<std::byte>();
+        query_->set_data_buffer(
+            column_name, (void*)data.data(), data.size_bytes());
     }
 
     /**

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -260,7 +260,9 @@ class SOMAArray {
      *
      * @param qc Query condition
      */
-    void set_condition(QueryCondition& qc);
+    void set_condition(QueryCondition& qc) {
+        mq_->set_condition(qc);
+    }
 
     /**
      * @brief Select columns names to query (dim and attr). If the
@@ -272,7 +274,9 @@ class SOMAArray {
      * @param if_not_empty Prevent changing an "empty" selection of all columns
      */
     void select_columns(
-        const std::vector<std::string>& names, bool if_not_empty = false);
+        const std::vector<std::string>& names, bool if_not_empty = false) {
+        mq_->select_columns(names, if_not_empty);
+    }
 
     /**
      * @brief Submit the query
@@ -296,15 +300,12 @@ class SOMAArray {
      */
     std::optional<std::shared_ptr<ArrayBuffers>> read_next();
 
-    template <typename T>
-    void set_column_data(std::string_view column_name, std::vector<T>& buf) {
-        mq_->set_column_data(std::string(column_name), buf);
-    }
-
     /**
      * @brief Write ArrayBuffers data to the array.
+     *
+     * @param buffers ArrayBuffers with containing the data to be written.
      */
-    void write();
+    void write(std::shared_ptr<ArrayBuffers> buffers);
 
     /**
      * @brief Check if the query is complete.
@@ -319,7 +320,9 @@ class SOMAArray {
      * @param query_status_only Query complete mode.
      * @return true if the query is complete, as described above
      */
-    bool is_complete(bool query_status_only = false);
+    bool is_complete(bool query_status_only = false) {
+        return mq_->is_complete(query_status_only);
+    }
 
     /**
      * @brief Return true if `read_next` returned all results from the
@@ -328,7 +331,9 @@ class SOMAArray {
      * @return True if last call to `read_next` returned all results of the
      * query
      */
-    bool results_complete();
+    bool results_complete() {
+        return mq_->results_complete();
+    }
 
     /**
      * @brief Return the total number of cells read so far, including any
@@ -336,7 +341,9 @@ class SOMAArray {
      *
      * @return size_t Total number of cells read
      */
-    size_t total_num_cells();
+    size_t total_num_cells() {
+        return mq_->total_num_cells();
+    }
 
     /**
      * @brief Return whether next read is the initial read, or a subsequent

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/utils/column_buffer.h
+++ b/libtiledbsoma/src/utils/column_buffer.h
@@ -80,6 +80,26 @@ class ColumnBuffer {
         ArraySchema schema, std::string_view name);
 
     /**
+     * @brief Create a ColumnBuffer from a schema, column name, and data.
+     *
+     * @param schema TileDB schema
+     * @param name TileDB dimension or attribute name
+     * @param data Data to set in buffer
+     * @return ColumnBuffer
+     */
+    template <typename T>
+    static std::shared_ptr<ColumnBuffer> create(
+        ArraySchema schema, std::string_view name, std::vector<T> data) {
+        auto column_buff = ColumnBuffer::create(schema, name);
+        column_buff->num_cells_ = data.size();
+        column_buff->data_.resize(data.size());
+        column_buff->data_.assign(
+            reinterpret_cast<std::byte*>(data.data()),
+            reinterpret_cast<std::byte*>(data.data() + data.size()));
+        return column_buff;
+    }
+
+    /**
      * @brief Convert a bytemap to a bitmap in place.
      *
      */

--- a/libtiledbsoma/src/utils/column_buffer.h
+++ b/libtiledbsoma/src/utils/column_buffer.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/utils/column_buffer.h
+++ b/libtiledbsoma/src/utils/column_buffer.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -150,11 +150,14 @@ std::tuple<std::vector<int64_t>, std::vector<int>> write_array(
         }
         std::vector<int> a0(num_cells_per_fragment, frag_num);
 
+        auto schema = *soma_array->schema();
+        auto array_buffer = std::make_shared<ArrayBuffers>();
+        array_buffer->emplace("a0", ColumnBuffer::create(schema, "a0", a0));
+        array_buffer->emplace("d0", ColumnBuffer::create(schema, "d0", d0));
+
         // Write data to array
         soma_array->submit();
-        soma_array->set_column_data("d0", d0);
-        soma_array->set_column_data("a0", a0);
-        soma_array->write();
+        soma_array->write(array_buffer);
         soma_array->close();
     }
 

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Issue and/or context:**

Separated out from PR https://github.com/single-cell-data/TileDB-SOMA/pull/1449.

**Changes:**

Previously, `SOMAArray` write buffers were set with `set_column_buffer`. The `write` function now takes in an `ArrayBuffers` data structure directly.

**Notes for Reviewer:**

N/A

