### PR TITLE
[r] Add `to_sparse_matrix()` method to `SOMAExperimentAxisQuery`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9027
+Version: 0.0.0.9028
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -19,3 +19,4 @@
 * Add methods for listing and accessing bundled datasets, which now includes a `SOMAExperiment` containing the pbmc_small dataset from the SeuratObject package
 * New vignettes describing SOMA objects, reading data from them, and querying SOMA experiments
 * Objects added to `SOMACollection`-based classes using the `add_new_*()` methods now pass through their parent context and platform config
+* `SOMAExperimentAxisQuery` gained a `to_sparse_matrix()` method for retrieving data as a named sparse matrix

--- a/apis/r/R/SOMAAxisIndexer.R
+++ b/apis/r/R/SOMAAxisIndexer.R
@@ -58,7 +58,7 @@ SOMAAxisIndexer <- R6::R6Class("SOMAAxisIndexer",
     .validate_coords = function(coords) {
       stopifnot(
         "'coords' must be a numeric vector or arrow Array" =
-          is.numeric(coords) || is_arrow_array(coords)
+          is.numeric(coords) || is_arrow_array(coords) || is_arrow_chunked_array(coords)
       )
       coords
     }

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -173,8 +173,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     #' @description Retrieve  layer as a sparse matrix.
     #' @param collection The [`SOMACollection`] containing the layer of
     #' interest, either: `"X"`, `"obsm"`, `"varm"`, `"obsp"`, or `"varp"`.
-    #' @param layer_name The name of the layer to retrieve. Defaults to the
-    #' first layer within the `collection`.
+    #' @param layer_name The name of the layer to retrieve.
     #' @param obs_index Name of the column in `obs` to use as dimension labels. The dimension the values are applied to is determined by the selected  `collection`:
     #' - `X` and `obsm`: row names
     #' - `obsp`: row and column names
@@ -187,7 +186,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     #' @param repr Optional one-character code for sparse matrix representation type.
     #' @return A [`Matrix::sparseMatrix-class`]
     to_matrix = function(
-      collection, layer_name = NULL, obs_index = NULL, var_index = NULL) {
+      collection, layer_name, obs_index = NULL, var_index = NULL
+    ) {
       stopifnot(
         assert_subset(
           x = collection,
@@ -195,8 +195,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           type = "collection"
         ),
 
-        "Must specify a single layer name" =
-          is.null(layer_name) || is_scalar_character(layer_name),
+        "Must specify a single layer name" = is_scalar_character(layer_name),
         assert_subset(layer_name, self$ms[[collection]]$names(), "layer"),
 
         "Must specify a single obs index" =

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -299,6 +299,9 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         varp = list(var_labels, var_labels)
       )
 
+      # Use joinids if the dimension names are empty
+      dim_names <- Map("%||%", dim_names, coords)
+
       Matrix::sparseMatrix(
         i = mat_coords$i$as_vector(),
         j = mat_coords$j$as_vector(),

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -187,7 +187,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     #' @param repr Optional one-character code for sparse matrix representation type.
     #' @return A [`Matrix::sparseMatrix-class`]
     to_matrix = function(
-      collection, layer_name = NULL, obs_index = NULL, var_index = NULL, repr = "T") {
+      collection, layer_name = NULL, obs_index = NULL, var_index = NULL) {
       stopifnot(
         assert_subset(
           x = collection,

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -259,14 +259,16 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       layer <- self$ms[[collection]]$get(layer_name)
       mat <- layer$read(coords)$sparse_matrix()$concat()
 
-      # Apply dimension labels
-      dimnames(mat) <- switch(collection,
-        X = list(obs_labels, var_labels),
-        obsm = list(obs_labels, NULL),
-        varm = list(var_labels, NULL),
-        obsp = list(obs_labels, obs_labels),
-        varp = list(var_labels, var_labels)
-      )
+      # Apply dimension labels if obs/var_index is specified
+      if (!is.null(obs_labels) || !is.null(var_labels)) {
+        dimnames(mat) <- switch(collection,
+          X = list(obs_labels, var_labels),
+          obsm = list(obs_labels, NULL),
+          varm = list(var_labels, NULL),
+          obsp = list(obs_labels, obs_labels),
+          varp = list(var_labels, var_labels)
+        )
+      }
       mat
     },
 

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -170,20 +170,22 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       )
     },
 
-    #' @description Retrieve  layer as a sparse matrix.
+    #' @description Retrieve layer as a sparse matrix.
     #' @param collection The [`SOMACollection`] containing the layer of
     #' interest, either: `"X"`, `"obsm"`, `"varm"`, `"obsp"`, or `"varp"`.
     #' @param layer_name The name of the layer to retrieve.
-    #' @param obs_index Name of the column in `obs` to use as dimension labels. The dimension the values are applied to is determined by the selected  `collection`:
-    #' - `X` and `obsm`: row names
-    #' - `obsp`: row and column names
-    #' - `varm` and `varp`: ignored
-    #' @param var_index Name of the column in `var` to use as dimension labels. The dimension the values are applied to is determined by the selected  `collection`:
-    #' - `X`: column names
-    #' - `varm`: row names
-    #' - `varp`: row and column names
-    #' - `obsm` and `obsp`: ignored.
-    #' @param repr Optional one-character code for sparse matrix representation type.
+    #' @param obs_index,var_index Name of the column in `obs` or `var`
+    #' (`var_index`) containing values that should be used as dimension labels
+    #' in the resulting matrix. Whether the values are used as row or column
+    #' labels depends on the selected `collection`:
+    #'
+    #' | Collection | `obs_index`          | `var_index`          |
+    #' |-----------:|:---------------------|:---------------------|
+    #' | `X`        | row names            | column names         |
+    #' | `obsm`     | row names            | ignored              |
+    #' | `varm`     | ignored              | row names            |
+    #' | `obsp`     | row and column names | ignored              |
+    #' | `varp`     | ignored              | row and column names |
     #' @return A [`Matrix::sparseMatrix-class`]
     to_matrix = function(
       collection, layer_name, obs_index = NULL, var_index = NULL

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -170,10 +170,21 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       )
     },
 
-    #' @description Retrieve layer as a sparse matrix.
+    #' @description Retrieve a collection layer as a sparse matrix with named
+    #' dimensions.
+    #'
+    #' Load any layer from the `X`, `obsm`, `varm`, `obsp`, or `varp`
+    #' collections as a [sparse matrix][Matrix::sparseMatrix-class].
+    #'
+    #' By default the matrix dimensions are named using the `soma_joinid` values
+    #' in the specified layer's dimensions (e.g., `soma_dim_0`). However,
+    #' dimensions can be named using values from any `obs` or `var` column that
+    #' uniquely identifies each record by specifying the `obs_index` and
+    #' `var_index` arguments.
+    #'
     #' @param collection The [`SOMACollection`] containing the layer of
     #' interest, either: `"X"`, `"obsm"`, `"varm"`, `"obsp"`, or `"varp"`.
-    #' @param layer_name The name of the layer to retrieve.
+    #' @param layer_name Name of the layer to retrieve from the `collection`.
     #' @param obs_index,var_index Name of the column in `obs` or `var`
     #' (`var_index`) containing values that should be used as dimension labels
     #' in the resulting matrix. Whether the values are used as row or column
@@ -187,7 +198,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     #' | `obsp`     | row and column names | ignored              |
     #' | `varp`     | ignored              | row and column names |
     #' @return A [`Matrix::sparseMatrix-class`]
-    to_matrix = function(
+    to_sparse_matrix = function(
       collection, layer_name, obs_index = NULL, var_index = NULL
     ) {
       stopifnot(
@@ -265,8 +276,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       # Reindex the coordinates
       # Constructing a matrix with the joinids produces a matrix with
       # the same shape as the original array, which is not we want. To create
-      # a matrix containing only values in the query result we use order to
-      # project the joinids to a 1-based index of contiguous values.
+      # a matrix containing only values in the query result we need to
+      # reindex the coordinates.
       mat_coords <- switch(collection,
         X = list(
           i = self$indexer$by_obs(tbl$soma_dim_0),

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -18,6 +18,10 @@ is_arrow_array <- function(x) {
   is_arrow_object(x) && inherits(x, "Array")
 }
 
+is_arrow_chunked_array <- function(x) {
+  is_arrow_object(x) && inherits(x, "ChunkedArray")
+}
+
 is_arrow_table <- function(x) {
   is_arrow_object(x) && inherits(x, "Table")
 }

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -60,6 +60,7 @@ this in the class.
 \item \href{#method-SOMAExperimentAxisQuery-var_joinids}{\code{SOMAExperimentAxisQuery$var_joinids()}}
 \item \href{#method-SOMAExperimentAxisQuery-X}{\code{SOMAExperimentAxisQuery$X()}}
 \item \href{#method-SOMAExperimentAxisQuery-read}{\code{SOMAExperimentAxisQuery$read()}}
+\item \href{#method-SOMAExperimentAxisQuery-to_sparse_matrix}{\code{SOMAExperimentAxisQuery$to_sparse_matrix()}}
 \item \href{#method-SOMAExperimentAxisQuery-to_seurat}{\code{SOMAExperimentAxisQuery$to_seurat()}}
 \item \href{#method-SOMAExperimentAxisQuery-to_seurat_assay}{\code{SOMAExperimentAxisQuery$to_seurat_assay()}}
 \item \href{#method-SOMAExperimentAxisQuery-to_seurat_reduction}{\code{SOMAExperimentAxisQuery$to_seurat_reduction()}}
@@ -190,6 +191,56 @@ from the resulting Tables.
 \code{var} and \code{obs} dataframes to read and return.}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperimentAxisQuery-to_sparse_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-to_sparse_matrix}{}}}
+\subsection{Method \code{to_sparse_matrix()}}{
+Retrieve a collection layer as a sparse matrix with named
+dimensions.
+
+Load any layer from the \code{X}, \code{obsm}, \code{varm}, \code{obsp}, or \code{varp}
+collections as a \link[Matrix:sparseMatrix-class]{sparse matrix}.
+
+By default the matrix dimensions are named using the \code{soma_joinid} values
+in the specified layer's dimensions (e.g., \code{soma_dim_0}). However,
+dimensions can be named using values from any \code{obs} or \code{var} column that
+uniquely identifies each record by specifying the \code{obs_index} and
+\code{var_index} arguments.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$to_sparse_matrix(
+  collection,
+  layer_name,
+  obs_index = NULL,
+  var_index = NULL
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{collection}}{The \code{\link{SOMACollection}} containing the layer of
+interest, either: \code{"X"}, \code{"obsm"}, \code{"varm"}, \code{"obsp"}, or \code{"varp"}.}
+
+\item{\code{layer_name}}{Name of the layer to retrieve from the \code{collection}.}
+
+\item{\code{obs_index, var_index}}{Name of the column in \code{obs} or \code{var}
+(\code{var_index}) containing values that should be used as dimension labels
+in the resulting matrix. Whether the values are used as row or column
+labels depends on the selected \code{collection}:\tabular{rll}{
+   Collection \tab \code{obs_index} \tab \code{var_index} \cr
+   \code{X} \tab row names \tab column names \cr
+   \code{obsm} \tab row names \tab ignored \cr
+   \code{varm} \tab ignored \tab row names \cr
+   \code{obsp} \tab row and column names \tab ignored \cr
+   \code{varp} \tab ignored \tab row and column names \cr
+}}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A \code{\link[Matrix:sparseMatrix-class]{Matrix::sparseMatrix}}
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -1,0 +1,52 @@
+test_that("matrix outgest with all results", {
+  experiment <- load_dataset("soma-exp-pbmc-small")
+
+  query <- SOMAExperimentAxisQuery$new(
+    experiment = experiment,
+    measurement_name = "RNA"
+  )
+
+  # Loadings
+  pcs1 <- SeuratObject::Loadings(pbmc_small, "pca")
+  pcs2 <- query$to_matrix(
+    collection = "varm",
+    layer_name = "PCs",
+    var_index = "var_id"
+  )
+  # Need to manually name the columns since we don't store them
+  colnames(pcs2) <- paste0("PC_", 1:ncol(pcs2))
+  expect_identical(pcs1, as.matrix(pcs2[rownames(pcs1), colnames(pcs2)]))
+
+  # Embeddings
+  pcas1 <- SeuratObject::Embeddings(pbmc_small, "pca")
+  pcas2 <- query$to_matrix(
+    collection = "obsm",
+    layer_name = "X_pca",
+    obs_index = "obs_id"
+  )
+  colnames(pcas2) <- paste0("PC_", 1:ncol(pcas2))
+  expect_identical(pcas1, as.matrix(pcas2[rownames(pcas1), colnames(pcas1)]))
+
+  # Graphs
+  # Need to coerce original and retrieved graphs to dgCMatrices for comparison
+  snn1 <- as(SeuratObject::Graphs(pbmc_small, "RNA_snn"), "CsparseMatrix")
+  snn2 <- query$to_matrix(
+    collection = "obsp",
+    layer_name = "RNA_snn",
+    obs_index = "obs_id"
+  ) |> as("CsparseMatrix")
+  expect_identical(snn1, snn2)
+
+
+  assay1 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], slot = "counts")
+  assay2 <- query$to_matrix(
+    collection = "X",
+    layer_name = "counts",
+    obs_index = "obs_id",
+    var_index = "var_id"
+  )
+
+  # Transpose and coerce to dGCMatrix for comparison
+  assay2 <- as(t(assay2), "CsparseMatrix")
+  expect_equal(assay2, assay1)
+})

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -13,9 +13,13 @@ test_that("matrix outgest with all results", {
     layer_name = "PCs",
     var_index = "var_id"
   )
-  # Need to manually name the columns since we don't store them
+  # Column names are unset since we don't store them
+  expect_null(colnames(pcs2))
+  # Manually name the columns for comparison
   colnames(pcs2) <- paste0("PC_", 1:ncol(pcs2))
-  expect_identical(pcs1, as.matrix(pcs2[rownames(pcs1), colnames(pcs2)]))
+  # Coerce to dense matrix and reorder for comparison
+  as.matrix(pcs2[rownames(pcs1), colnames(pcs2)])
+  expect_identical(pcs2, pcs1)
 
   # Embeddings
   pcas1 <- SeuratObject::Embeddings(pbmc_small, "pca")
@@ -24,8 +28,10 @@ test_that("matrix outgest with all results", {
     layer_name = "X_pca",
     obs_index = "obs_id"
   )
+  expect_null(colnames(pcs2))
   colnames(pcas2) <- paste0("PC_", 1:ncol(pcas2))
-  expect_identical(pcas1, as.matrix(pcas2[rownames(pcas1), colnames(pcas1)]))
+  pcas2 <- as.matrix(pcas2[rownames(pcas1), colnames(pcas1)])
+  expect_identical(pcas2, pcas1)
 
   # Graphs
   # Need to coerce original and retrieved graphs to dgCMatrices for comparison
@@ -37,7 +43,7 @@ test_that("matrix outgest with all results", {
   ) |> as("CsparseMatrix")
   expect_identical(snn1, snn2)
 
-
+  # Assay data
   assay1 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], slot = "counts")
   assay2 <- query$to_matrix(
     collection = "X",

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -1,4 +1,5 @@
 test_that("matrix outgest with all results", {
+  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
   experiment <- load_dataset("soma-exp-pbmc-small")
 

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -9,7 +9,7 @@ test_that("matrix outgest with all results", {
 
   # Loadings
   pcs1 <- SeuratObject::Loadings(pbmc_small, "pca")
-  pcs2 <- query$to_matrix(
+  pcs2 <- query$to_sparse_matrix(
     collection = "varm",
     layer_name = "PCs",
     var_index = "var_id"
@@ -26,7 +26,7 @@ test_that("matrix outgest with all results", {
 
   # Embeddings
   pcas1 <- SeuratObject::Embeddings(pbmc_small, "pca")
-  pcas2 <- query$to_matrix(
+  pcas2 <- query$to_sparse_matrix(
     collection = "obsm",
     layer_name = "X_pca",
     obs_index = "obs_id"
@@ -39,7 +39,7 @@ test_that("matrix outgest with all results", {
   # Graphs
   # Need to coerce original and retrieved graphs to dgCMatrices for comparison
   snn1 <- as(SeuratObject::Graphs(pbmc_small, "RNA_snn"), "CsparseMatrix")
-  snn2 <- query$to_matrix(
+  snn2 <- query$to_sparse_matrix(
     collection = "obsp",
     layer_name = "RNA_snn",
     obs_index = "obs_id"
@@ -48,7 +48,7 @@ test_that("matrix outgest with all results", {
 
   # Assay data
   assay1 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], slot = "counts")
-  assay2 <- query$to_matrix(
+  assay2 <- query$to_sparse_matrix(
     collection = "X",
     layer_name = "counts",
     obs_index = "obs_id",
@@ -86,7 +86,7 @@ test_that("matrix outgest with filtered results", {
 
   # Loadings
   pcs1 <- SeuratObject::Loadings(pbmc_small1, "pca")
-  pcs2 <- query$to_matrix(
+  pcs2 <- query$to_sparse_matrix(
     collection = "varm",
     layer_name = "PCs",
     var_index = "var_id"
@@ -100,7 +100,7 @@ test_that("matrix outgest with filtered results", {
 
   # Embeddings
   pcas1 <- SeuratObject::Embeddings(pbmc_small1, "pca")
-  pcas2 <- query$to_matrix(
+  pcas2 <- query$to_sparse_matrix(
     collection = "obsm",
     layer_name = "X_pca",
     obs_index = "obs_id"
@@ -115,7 +115,7 @@ test_that("matrix outgest with filtered results", {
   snn1 <- as(SeuratObject::Graphs(pbmc_small, "RNA_snn"), "CsparseMatrix")
   snn1 <- snn1[colnames(pbmc_small1), colnames(pbmc_small1)]
 
-  snn2 <- query$to_matrix(
+  snn2 <- query$to_sparse_matrix(
     collection = "obsp",
     layer_name = "RNA_snn",
     obs_index = "obs_id"
@@ -124,7 +124,7 @@ test_that("matrix outgest with filtered results", {
 
   # Assay data
   assay1 <- SeuratObject::GetAssayData(pbmc_small1[["RNA"]], slot = "counts")
-  assay2 <- query$to_matrix(
+  assay2 <- query$to_sparse_matrix(
     collection = "X",
     layer_name = "counts",
     obs_index = "obs_id",
@@ -145,46 +145,46 @@ test_that("matrix outgest assertions", {
   )
 
   expect_error(
-    query$to_matrix(collection = "foo"),
+    query$to_sparse_matrix(collection = "foo"),
     "The following collection does not exist: foo"
   )
 
   expect_error(
-    query$to_matrix(collection = "X", layer_name = "foo"),
+    query$to_sparse_matrix(collection = "X", layer_name = "foo"),
     "The following layer does not exist: foo"
   )
 
   expect_error(
-    query$to_matrix(collection = "X", layer_name = "counts", obs_index = "foo"),
+    query$to_sparse_matrix(collection = "X", layer_name = "counts", obs_index = "foo"),
     "The following column does not exist: foo"
   )
 
   # joinds are used as default dimnames if no obs/var_index is provided
   expect_identical(
-    dimnames(query$to_matrix("X", "counts")),
+    dimnames(query$to_sparse_matrix("X", "counts")),
     list(as.character(query$obs_joinids()), as.character(query$var_joinids()))
   )
 
   # error if specified obs/var_index does not exist
   expect_error(
-    query$to_matrix("X", "counts", obs_index = "foo"),
+    query$to_sparse_matrix("X", "counts", obs_index = "foo"),
     "The following column does not exist: foo"
   )
   expect_error(
-    query$to_matrix("X", "counts", var_index = "foo"),
+    query$to_sparse_matrix("X", "counts", var_index = "foo"),
     "The following column does not exist: foo"
   )
 
   # only one of obs_index or var_index can be provided
   expect_identical(
-    dimnames(query$to_matrix("X", "counts", obs_index = "obs_id")),
+    dimnames(query$to_sparse_matrix("X", "counts", obs_index = "obs_id")),
     list(
       as.character(query$obs(column_names = "obs_id")$obs_id),
       as.character(query$var_joinids())
     )
   )
   expect_identical(
-    dimnames(query$to_matrix("X", "counts", var_index = "var_id")),
+    dimnames(query$to_sparse_matrix("X", "counts", var_index = "var_id")),
     list(
       as.character(query$obs_joinids()),
       query$var(column_names = "var_id")$var_id$as_vector()
@@ -193,17 +193,17 @@ test_that("matrix outgest assertions", {
 
   # a warning is issued if an index is unnecessarily provided
   expect_output(
-    query$to_matrix("obsm", "X_pca", var_index = "var_id"),
+    query$to_sparse_matrix("obsm", "X_pca", var_index = "var_id"),
     "The var_index is ignored for obsm collections"
   )
   expect_output(
-    query$to_matrix("varm", "PCs", obs_index = "obs_id"),
+    query$to_sparse_matrix("varm", "PCs", obs_index = "obs_id"),
     "The obs_index is ignored for varm collections"
   )
 
   # retrieved labels must be unique
   expect_error(
-    query$to_matrix("obsm", "X_pca", obs_index = "groups"),
+    query$to_sparse_matrix("obsm", "X_pca", obs_index = "groups"),
     "All obs_index values must be unique"
   )
 })

--- a/apis/r/vignettes/soma-experiment-queries.Rmd
+++ b/apis/r/vignettes/soma-experiment-queries.Rmd
@@ -113,9 +113,54 @@ We can also access the expression data for these filtered cells via `X()`:
 query$X(layer_name = "counts")
 ```
 
-## Seurat support
+## Export to a sparse matrix
 
-The `query` object also contains methods for loading in the results as a Seurat object (or any of Seurat's component classes).
+Any component of the queried `SOMAExperiment` can be exported to a [sparse matrix][Matrix::sparseMatrix-class] using the `to_sparse_matrix()` method.
+
+For example, let's create a sparse matrix of the filtered expression data. We'll create a new query that returns a smaller subset of the data to make the output easier to read.
+
+```{r}
+query <- SOMAExperimentAxisQuery$new(
+  experiment = experiment,
+  measurement_name = "RNA",
+  obs_query = SOMAAxisQuery$new(coords = 0:9),
+  var_query = SOMAAxisQuery$new(coords = 0:9)
+)
+```
+
+Then we indicate that we want to access the `"counts"` layer of the `"X"` collection.
+
+```{r}
+query$to_sparse_matrix(
+  collection = "X",
+  layer = "counts"
+)
+```
+
+By default, the dimensions are named using `soma_joinid` values which are unique to each observation and variable. However, dimension names can come from any column in the `obs` and `var` arrays that uniquely identifies each record. For an expression matrix it makes sense to name the dimensions using cell barcodes and gene names, which are stored in the `obs_id` and `var_id` columns, respectively.
+
+```{r}
+query$to_sparse_matrix(
+  collection = "X",
+  layer = "counts",
+  obs_index = "obs_id",
+  var_index = "var_id"
+)
+```
+
+We can use this method for any of the `SOMAExperiment`'s collections. Let's access the t-SNE coordinates stored in the `obsm` collection's `X_tsne` layer, populating the row names with cell barcodes.
+
+```{r}
+query$to_sparse_matrix(
+  collection = "obsm",
+  layer = "X_tsne",
+  obs_index = "obs_id"
+)
+```
+
+## Export to Seurat
+
+The `query` object also contains methods for loading in results as a Seurat object (or any of Seurat's component classes). As with the `to_sparse_matrix()` method, we can specify the `obs_index` and `var_index` to use for naming the dimensions of the resulting object.
 
 ```{r eval=requireNamespace("SeuratObject", quietly = TRUE)}
 query$to_seurat(

--- a/apis/r/vignettes/soma-experiment-queries.Rmd
+++ b/apis/r/vignettes/soma-experiment-queries.Rmd
@@ -163,6 +163,11 @@ query$to_sparse_matrix(
 The `query` object also contains methods for loading in results as a Seurat object (or any of Seurat's component classes). As with the `to_sparse_matrix()` method, we can specify the `obs_index` and `var_index` to use for naming the dimensions of the resulting object.
 
 ```{r eval=requireNamespace("SeuratObject", quietly = TRUE)}
+query <- SOMAExperimentAxisQuery$new(
+  experiment = experiment,
+  measurement_name = "RNA"
+)
+
 query$to_seurat(
   X_layers = c(counts = "counts", data = "data"),
   obs_index = "obs_id",


### PR DESCRIPTION
**Changes:** This PR adds a new method to `SOMAExperimentAxisQuery` that allows users to load any layer from the queried experiment as a sparse matrix with _named_ dimensions (i.e., row and column names are populated).

As noted in the docs, dimension names default to joinids but may come from any obs or var column (depending on the collection type) containing values that uniquely identify each record.

Quick example:

```r
library(tiledbsoma)
experiment <- load_dataset("soma-exp-pbmc-small")

query <- SOMAExperimentAxisQuery$new(
  experiment = experiment,
  measurement_name = "RNA",
  obs_query = SOMAAxisQuery$new(coords = 0:9),
  var_query = SOMAAxisQuery$new(coords = 0:9)
)

query$to_sparse_matrix(
  collection = "X",
  layer = "counts",
  obs_index = "obs_id",
  var_index = "var_id"
)

## 10 x 10 sparse Matrix of class "dgTMatrix"
##   [[ suppressing 10 column names ‘MS4A1’, ‘CD79B’, ‘CD79A’ ... ]]
##
## ATGCCAGAACGACT . 1 . . . 1 . .  3 .
## CATGGCCTGTGCAT . . . 1 . . . .  7 .
## GAACCTGATGAACC . . . . . . . . 11 .
## TGACTGGATTCTCA . . . . . . . . 13 .
## AGTCAGACTGCACA . . . 1 . . . .  3 .
## TCTGATACACGTGT . . . 1 . . . .  4 .
## TGGTATCTAAACAG . . . . . . . .  6 .
## GCAGCTCTGTTTCT . . . 1 . . . .  4 .
## GATATAACACGCAT . . . . . . . .  2 .
## AATGTTGACAGTCA . 1 . . . . . . 21 .
```

More usage examples are available in the new unit tests and updated soma-experiment-queries vignette.

[sc-30317]

**Notes for Reviewer:** This was a feature request from a user who wanted an easier way to create named matrices without having to go through Seurat. IMO this was a great suggestion and I think it will be useful for many users.

The current implementation does not support specifying a sparse encoding via the typical `repr` argument because converting from a dgT (coo) matrix to dgC (csc) can be expensive and I don't want our method to silently bear that cost when a) the operation can be easily performed by the user after the fact and b) a fast c++ implementation of this operation is on the horizon.
