### PR TITLE
[python] Backport #1471 from `main` to `release-1.2` branch

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -247,6 +247,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),


### PR DESCRIPTION
Backport #1471 from `main` to `release-1.2` in prep for 1.2.6