### PR TITLE
[c++] `ColumnBuffer` Constructor Should Call `alloc` Method

### DIFF
--- a/libtiledbsoma/src/utils/column_buffer.h
+++ b/libtiledbsoma/src/utils/column_buffer.h
@@ -275,7 +275,7 @@ class ColumnBuffer {
      * @return ColumnBuffer
      */
     static std::shared_ptr<ColumnBuffer> alloc(
-        std::shared_ptr<Array> array,
+        ArraySchema schema,
         std::string_view name,
         tiledb_datatype_t type,
         bool is_var,

--- a/libtiledbsoma/test/unit_column_buffer.cc
+++ b/libtiledbsoma/test/unit_column_buffer.cc
@@ -99,16 +99,3 @@ TEST_CASE("ColumnBuffer: Create from array") {
         REQUIRE(buffers->is_nullable() == true);
     }
 }
-
-// TEST_CASE("ColumnBuffer: Read buffer size from config") {
-//     std::string uri = "mem://unit-buffer-size-config";
-
-//     Config cfg;
-//     cfg["soma.init_buffer_bytes"] = 10;
-//     Context ctx(cfg);
-
-//     auto array = create_array(uri, ctx);
-//     auto buffers = ColumnBuffer::create(array, "a1");
-
-//     REQUIRE(buffers->data_.size() == 29384239048);
-// }

--- a/libtiledbsoma/test/unit_column_buffer.cc
+++ b/libtiledbsoma/test/unit_column_buffer.cc
@@ -99,3 +99,16 @@ TEST_CASE("ColumnBuffer: Create from array") {
         REQUIRE(buffers->is_nullable() == true);
     }
 }
+
+// TEST_CASE("ColumnBuffer: Read buffer size from config") {
+//     std::string uri = "mem://unit-buffer-size-config";
+
+//     Config cfg;
+//     cfg["soma.init_buffer_bytes"] = 10;
+//     Context ctx(cfg);
+
+//     auto array = create_array(uri, ctx);
+//     auto buffers = ColumnBuffer::create(array, "a1");
+
+//     REQUIRE(buffers->data_.size() == 29384239048);
+// }

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -398,3 +398,25 @@ TEST_CASE("SOMAArray: metadata") {
     REQUIRE(soma_array->metadata_num() == 0);
     soma_array->close();
 }
+
+TEST_CASE("SOMAArray: Test buffer size") {
+    // Test soma.init_buffer_bytes by making buffer small
+    // enough to read one byte at a time so that read_next
+    // must be called 10 times instead of placing all data 
+    // in buffer within a single read
+    Config cfg;
+    cfg["soma.init_buffer_bytes"] = 8;
+    auto ctx = std::make_shared<Context>(cfg);
+
+    std::string base_uri = "mem://unit-test-array";
+    auto [uri, expected_nnz] = create_array(base_uri, *ctx);
+    auto [expected_d0, expected_a0] = write_array(uri, ctx);
+    auto soma_array = SOMAArray::open(TILEDB_READ, ctx, uri);
+
+    size_t loops = 0;
+    soma_array->submit();
+    while (auto batch = soma_array->read_next())
+        ++loops;
+    REQUIRE(loops == 10);
+    soma_array->close();
+}

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -402,7 +402,7 @@ TEST_CASE("SOMAArray: metadata") {
 TEST_CASE("SOMAArray: Test buffer size") {
     // Test soma.init_buffer_bytes by making buffer small
     // enough to read one byte at a time so that read_next
-    // must be called 10 times instead of placing all data 
+    // must be called 10 times instead of placing all data
     // in buffer within a single read
     Config cfg;
     cfg["soma.init_buffer_bytes"] = 8;


### PR DESCRIPTION
**Issue and/or context:**

#1488

**Changes:**

Previously the `ColumnBuffer` called `alloc` which correctly allocated buffer sizes by checking config. This was inadvertently removed in #1439 and now reverted.