### PR TITLE
[r] Adjust `SOMAExperimentAxisQuery$to_sparse_matrix()` to handle gapped matrices

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9028
+Version: 0.0.0.9029
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -319,30 +319,12 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       # Use joinids if the dimension names are empty
       dim_names <- Map("%||%", dim_names, coords)
 
-      dims <- switch(
-        EXPR = collection,
-        X = list(
-          self$indexer$by_obs(coords$soma_dim_0),
-          self$indexer$by_var(coords$soma_dim_1)
-        ),
-        obsm = list(
-          self$indexer$by_obs(coords$soma_dim_0),
-          mat_coords$j
-        ),
-        varm = list(
-          self$indexer$by_var(coords$soma_dim_0),
-          mat_coords$j
-        ),
-        obsp = lapply(coords, self$indexer$by_obs),
-        varp = lapply(coords, self$indexer$by_var)
-      )
-
       Matrix::sparseMatrix(
         i = mat_coords$i$as_vector(),
         j = mat_coords$j$as_vector(),
         x = tbl$soma_data$as_vector(),
         index1 = FALSE,
-        dims = vapply_int(dims, function(x) max(range(x$as_vector()))) + 1L,
+        dims = vapply_int(dim_names, length),
         dimnames = dim_names,
         repr = "T"
       )

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -182,6 +182,13 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     #' uniquely identifies each record by specifying the `obs_index` and
     #' `var_index` arguments.
     #'
+    #' For layers in \code{obsm} or \code{varm}, the column axis (the axis not
+    #' indexed by \dQuote{\code{obs}} or \dQuote{\code{var}}) is set to the
+    #' range of values present in \dQuote{\code{soma_dim_1}}; this ensures
+    #' that gaps in this axis are preserved (eg. when a query for
+    #' \dQuote{\code{obs}} that results in selecting entries that are all zero
+    #' for a given PC)
+    #'
     #' @param collection The [`SOMACollection`] containing the layer of
     #' interest, either: `"X"`, `"obsm"`, `"varm"`, `"obsp"`, or `"varp"`.
     #' @param layer_name Name of the layer to retrieve from the `collection`.

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -208,6 +208,13 @@ in the specified layer's dimensions (e.g., \code{soma_dim_0}). However,
 dimensions can be named using values from any \code{obs} or \code{var} column that
 uniquely identifies each record by specifying the \code{obs_index} and
 \code{var_index} arguments.
+
+For layers in \code{obsm} or \code{varm}, the column axis (the axis not
+indexed by \dQuote{\code{obs}} or \dQuote{\code{var}}) is set to the
+range of values present in \dQuote{\code{soma_dim_1}}; this ensures
+that gaps in this axis are preserved (eg. when a query for
+\dQuote{\code{obs}} that results in selecting entries that are all zero
+for a given PC)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$to_sparse_matrix(
   collection,

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -62,6 +62,7 @@ test_that("matrix outgest with all results", {
 })
 
 test_that("matrix outgest with filtered results", {
+  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   # Subset the pbmc_small object to match the filtered results
   pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
   pbmc_small1 <- pbmc_small[

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -209,3 +209,130 @@ test_that("matrix outgest assertions", {
     "All obs_index values must be unique"
   )
 })
+
+test_that("matrix outgest with implicitly-stored axes", {
+  uri <- withr::local_tempdir("matrix-implicit")
+  set.seed(seed = 42L)
+  n_obs <- 15L
+  n_var <- 10L
+  n_dims <- 5L
+  m_key <- "X_dims"
+  p_key <- "graph"
+  shape <- rep_len(.Machine$integer.max - 1L, length.out = 2L)
+  # Create our experiment
+  experiment <- SOMAExperimentCreate(uri = uri)
+  experiment$obs <- create_and_populate_obs(
+    uri = file.path(experiment$uri, "obs"),
+    nrows = n_obs
+  )
+  experiment$ms <- SOMACollectionCreate(file.path(experiment$uri, "ms"))
+  ms_rna <- SOMAMeasurementCreate(file.path(experiment$ms$uri, "RNA"))
+  experiment$ms$add_new_collection(object = ms_rna, key = "RNA")
+  ms_rna$var <- create_and_populate_var(
+    uri = file.path(ms_rna$uri, "var"),
+    nrows = n_var
+  )
+  # Generate X matrix
+  ms_rna$X <- SOMACollectionCreate(file.path(ms_rna$uri, "X"))
+  X_counts <- Matrix::rsparsematrix(
+    nrow = n_obs,
+    ncol = n_var,
+    density = 0.3,
+    repr = "T"
+  )
+  X_counts[nrow(X_counts) %/% 2L, ] <- 0
+  X_counts[, ncol(X_counts) %/% 2L] <- 0
+  X_array <- SOMASparseNDArrayCreate(
+    uri = file.path(ms_rna$X$uri, "counts"),
+    type = arrow::infer_type(x = X_counts@x),
+    shape = shape
+  )
+  X_array$write(X_counts)
+  X_array$close()
+  ms_rna$X$set(object = X_array, name = "counts")
+  ms_rna$X$close()
+  # Generate obsm
+  ms_rna$obsm <- SOMACollectionCreate(file.path(ms_rna$uri, "obsm"))
+  obsm <- Matrix::rsparsematrix(
+    nrow = n_obs,
+    ncol = n_dims,
+    density = 0.7,
+    repr = "T"
+  )
+  obsm[nrow(obsm) %/% 2L, ] <- 0
+  obsm[, ncol(obsm) %/% 2L] <- 0
+  ms_rna$obsm$add_new_sparse_ndarray(
+    key = m_key,
+    type = arrow::infer_type(x = obsm@x),
+    shape = shape
+  )
+  ms_rna$obsm$get(m_key)$write(obsm)
+  ms_rna$obsm$close()
+  # Generate varm
+  ms_rna$varm <- SOMACollectionCreate(file.path(ms_rna$uri, "varm"))
+  varm <- Matrix::rsparsematrix(
+    nrow = n_var,
+    ncol = n_dims,
+    density = 0.7,
+    repr = "T"
+  )
+  varm[nrow(varm) %/% 2L, ] <- 0
+  varm[, ncol(varm) %/% 2L] <- 0
+  ms_rna$varm$add_new_sparse_ndarray(
+    key = m_key,
+    type = arrow::infer_type(x = varm@x),
+    shape = shape
+  )
+  ms_rna$varm$get(m_key)$write(varm)
+  ms_rna$varm$close()
+  # Generate obsp
+  ms_rna$obsp <- SOMACollectionCreate(file.path(ms_rna$uri, "obsp"))
+  obsp <- Matrix::rsparsematrix(
+    nrow = n_obs,
+    ncol = n_obs,
+    density = 0.3,
+    repr = "T"
+  )
+  obsp[nrow(obsp) %/% 2L, ] <- 0
+  obsp[, ncol(obsp) %/% 2L] <- 0
+  ms_rna$obsp$add_new_sparse_ndarray(
+    key = p_key,
+    type = arrow::infer_type(x = obsp@x),
+    shape = shape
+  )
+  ms_rna$obsp$get(p_key)$write(obsp)
+  ms_rna$obsp$close()
+  # Generate varp
+  ms_rna$varp <- SOMACollectionCreate(file.path(ms_rna$uri, "varp"))
+  varp <- Matrix::rsparsematrix(
+    nrow = n_var,
+    ncol = n_var,
+    density = 0.3,
+    repr = "T"
+  )
+  varp[nrow(varp) %/% 2L, ] <- 0
+  varp[, ncol(varp) %/% 2L] <- 0
+  ms_rna$varp$add_new_sparse_ndarray(
+    key = p_key,
+    type = arrow::infer_type(x = varp@x),
+    shape = shape
+  )
+  ms_rna$varp$get(p_key)$write(varp)
+  ms_rna$varp$close()
+  # Close and reopen
+  ms_rna$close()
+  experiment$close()
+  experiment <- SOMAExperimentOpen(experiment$uri)
+  query <- SOMAExperimentAxisQuery$new(experiment, "RNA")
+  # Read in matrices
+  expect_s4_class(X_read <- query$to_sparse_matrix("X", "counts"), "dgTMatrix")
+  expect_identical(dim(X_read), dim(X_counts))
+  expect_s4_class(obsm_read <- query$to_sparse_matrix("obsm", m_key), "dgTMatrix")
+  expect_identical(dim(obsm_read), dim(obsm))
+  expect_s4_class(varm_read <- query$to_sparse_matrix("varm", m_key), "dgTMatrix")
+  expect_identical(dim(varm_read), dim(varm))
+  expect_s4_class(obsp_read <- query$to_sparse_matrix("obsp", p_key), "dgTMatrix")
+  expect_identical(dim(obsp_read), dim(obsp))
+  expect_s4_class(varp_read <- query$to_sparse_matrix("varp", p_key), "dgTMatrix")
+  expect_identical(dim(varp_read), dim(varp))
+})


### PR DESCRIPTION
Change `SOMAExperimentAxisQuery$to_sparse_matrix()` to utilize soma join IDs for dims instead of labels. This better handles gaps (all implicitly stored) in the arrays, which can happen by storage or by query

For obsm/varm, utilize span of `soma_dim_1` for columns (`dim()[2L]`) as there is no join ID for this axis