### PR TITLE
[r] Update README.md installation instructions in preparation for 1.0[rc]

### DIFF
--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -7,12 +7,12 @@ Please also see the `main-old` branch for an implementation of the [original spe
 
 # Installation
 
-## Using R-universe
+## Release packages
 
-TileDB-SOMA is available on  R-universe and [Conda](https://anaconda.org/tiledb/r-tiledbsoma), and can be installed directly from R or `mambda` as indicated below.
+TileDB-SOMA releases are available on R-universe and [Conda](https://anaconda.org/tiledb/r-tiledbsoma), and can be installed directly from R or `mamba` as indicated below.
 
 ```r
-install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
+install.packages('tiledbsoma', repos = c('https://chanzuckerberg.r-universe.dev',
                                          'https://cloud.r-project.org'))
 ```
 
@@ -21,6 +21,12 @@ mamba install -c conda-forge -c tiledb r-tiledbsoma
 ```
 
 ## From source
+
+To install the very latest tiledbsoma development version (our `main` branch), use [`devtools::install_github()`](https://cran.r-project.org/web/packages/githubinstall/vignettes/githubinstall.html):
+
+```r
+devtools::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir="apis/r")
+```
 
 ### Requirements
 
@@ -31,7 +37,9 @@ mamba install -c conda-forge -c tiledb r-tiledbsoma
 * In addition, this R package also depends on the [`libtiledbsoma` library](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma) from this repository. It is either installed with the package (as described in the next section), or can be used as a system library (if one is found). A system installation can be provided by following the steps in the [`libtiledbsoma` directory](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma).
 
 
-### Step-by-step
+### Development setup
+
+To set up & install from a local clone of this git repository:
 
 * Clone this repository: `git clone https://github.com/single-cell-data/TileDB-SOMA.git`.
 * Change into the R API package directory: `cd TileDB-SOMA/apis/r`.

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -22,10 +22,10 @@ mamba install -c conda-forge -c tiledb r-tiledbsoma
 
 ## From source
 
-To install the very latest tiledbsoma development version (our `main` branch), use [`devtools::install_github()`](https://cran.r-project.org/web/packages/githubinstall/vignettes/githubinstall.html):
+To install the very latest tiledbsoma development version (our `main` branch), use [`remotes::install_github()`](https://cran.r-project.org/web/packages/remotes/readme/README.html):
 
 ```r
-devtools::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir="apis/r")
+remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir="apis/r")
 ```
 
 ### Requirements

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -41,7 +41,7 @@ remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdi
 
 ### Development setup
 
-To set up & install from a local clone of this git repository:
+To set up and install from a local clone of this git repository:
 
 * Clone this repository: `git clone https://github.com/single-cell-data/TileDB-SOMA.git`.
 * Change into the R API package directory: `cd TileDB-SOMA/apis/r`.

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -12,13 +12,15 @@ Please also see the `main-old` branch for an implementation of the [original spe
 TileDB-SOMA releases are available on R-universe and [Conda](https://anaconda.org/tiledb/r-tiledbsoma), and can be installed directly from R or `mamba` as indicated below.
 
 ```r
-install.packages('tiledbsoma', repos = c('https://chanzuckerberg.r-universe.dev',
+install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
                                          'https://cloud.r-project.org'))
 ```
 
 ```bash
 mamba install -c conda-forge -c tiledb r-tiledbsoma
 ```
+
+The r-universe repo serves macOS binaries and the source package for other Unix-like platforms. The conda channel serves binaries for multiple architectures.
 
 ## From source
 


### PR DESCRIPTION
* ~~Change above-the-fold installation instructions to use chanzuckerberg R-universe (which serves the latest GitHub Release of tiledbsoma) instead of TileDB-Inc (which serves the head of `main`). As agreed in #1427~~
* Add `install_github()` instruction for users who do desire the head of `main`
* Rebrand existing source installation instructions as developer setup

Note: the chanzuckerberg R-universe serves tiledbsoma but not TileDB-R. Users following the instructions in a fresh environment will get the GitHub-Released version of tiledbsoma, and the CRAN version of tiledb. Consequently, to release tiledbsoma we must ensure any necessary changes to TileDB-R have made it out to CRAN. (We do plan to publish tiledbsoma on CRAN once ready, so this just pulls that constraint forward a bit.)