### PR TITLE
[r] Improve handling of arrays with with domains greater than 2^31 - 1

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9028
+Version: 0.0.0.9029
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -867,21 +867,21 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       }
       # Check provided graph name
       obsp_layer <- match.arg(arg = obsp_layer, choices = ms_graph)
-      mat <- self$ms$obsp$get(obsp_layer)$read()$sparse_matrix(zero_based=TRUE)$concat()$get_one_based_matrix()
-      mat <- as(mat, "CsparseMatrix")
-      idx <- self$obs_joinids()$as_vector() + 1L
-      mat <- mat[idx, idx]
-      mat <- as(mat, 'Graph')
-      cells <- if (is.null(obs_index)) {
-        paste0('cell', self$obs_joinids()$as_vector())
-      } else {
-        obs_index <- match.arg(
-          arg = obs_index,
-          choices = self$obs_df$attrnames()
-        )
-        self$obs(obs_index)$GetColumnByName(obs_index)$as_vector()
+
+      # Retrieve the named TsparseMatrix
+      mat <- self$to_sparse_matrix(
+        collection = "obsp",
+        layer_name = obsp_layer,
+        obs_index = obs_index
+      )
+
+      # Convert to Seurat graph by way of a CsparseMatrix
+      mat <- as(as(mat, "CsparseMatrix"), "Graph")
+
+      if (is.null(obs_index)) {
+        dimnames(mat) <- lapply(dimnames(mat), function(x) paste0("cell", x))
       }
-      dimnames(mat) <- list(cells, cells)
+
       SeuratObject::DefaultAssay(mat) <- private$.measurement_name
       validObject(mat)
       return(mat)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -124,12 +124,21 @@ SOMASparseNDArray <- R6::R6Class(
 
       uri <- self$uri
 
-      if (self$nnz() > .Machine$integer.max) {
-          warning("Iteration results cannot be concatenated on its entirety because ",
-                  "array has non-zero elements greater than '.Machine$integer.max'.")
-      }
+      # if (self$nnz() > .Machine$integer.max) {
+      #     warning("Iteration results cannot be concatenated on its entirety because ",
+      #             "array has non-zero elements greater than '.Machine$integer.max'.")
+      # }
 
       result_order <- map_query_layout(match_query_layout(result_order))
+
+      shape <- self$shape()
+      if (any(shape >= .Machine$integer.max)) {
+        warning(
+          "Array has dimensions greater than '.Machine$integer.max'.",
+          "Results will be truncated to include only coordinates less than 2^31 - 1."
+        )
+        shape <- pmin(shape, .Machine$integer.max)
+      }
 
       if (!is.null(coords)) {
         coords <- private$convert_coords(coords)
@@ -143,7 +152,7 @@ SOMASparseNDArray <- R6::R6Class(
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
 
-      SOMASparseNDArrayRead$new(sr, shape = self$shape())
+      SOMASparseNDArrayRead$new(sr, shape = shape)
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: experimental)
@@ -206,6 +215,15 @@ SOMASparseNDArray <- R6::R6Class(
 
       ## if unnamed (and test for length has passed in previous statement) set names
       if (is.null(names(coords))) names(coords) <- self$dimnames()
+
+      # Remove any coordinates that exceed .Machine$integer.max
+      if (any(vapply_lgl(coords, function(x) any(x >= .Machine$integer.max)))) {
+        warning(
+          "Removing coordinates that exceed '.Machine$integer.max'.",
+          call. = FALSE
+        )
+        coords <- lapply(coords, function(x) x[x < .Machine$integer.max])
+      }
 
       ## convert integer to integer64 to match dimension type
       coords <- lapply(coords, function(x) if (inherits(x, "integer")) bit64::as.integer64(x) else x)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -199,15 +199,6 @@ SOMASparseNDArray <- R6::R6Class(
       ## if unnamed (and test for length has passed in previous statement) set names
       if (is.null(names(coords))) names(coords) <- self$dimnames()
 
-      # Remove any coordinates that exceed .Machine$integer.max
-      if (any(vapply_lgl(coords, function(x) any(x >= .Machine$integer.max)))) {
-        warning(
-          "Removing coordinates that exceed '.Machine$integer.max'.",
-          call. = FALSE
-        )
-        coords <- lapply(coords, function(x) x[x < .Machine$integer.max])
-      }
-
       ## convert integer to integer64 to match dimension type
       coords <- lapply(coords, function(x) if (inherits(x, "integer")) bit64::as.integer64(x) else x)
 

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -121,38 +121,21 @@ SOMASparseNDArray <- R6::R6Class(
       log_level = "auto"
     ) {
       private$check_open_for_read()
-
-      uri <- self$uri
-
-      # if (self$nnz() > .Machine$integer.max) {
-      #     warning("Iteration results cannot be concatenated on its entirety because ",
-      #             "array has non-zero elements greater than '.Machine$integer.max'.")
-      # }
-
       result_order <- map_query_layout(match_query_layout(result_order))
-
-      shape <- self$shape()
-      if (any(shape >= .Machine$integer.max)) {
-        warning(
-          "Array has dimensions greater than '.Machine$integer.max'.",
-          "Results will be truncated to include only coordinates less than 2^31 - 1."
-        )
-        shape <- pmin(shape, .Machine$integer.max)
-      }
 
       if (!is.null(coords)) {
         coords <- private$convert_coords(coords)
       }
 
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      sr <- sr_setup(uri = uri,
+      sr <- sr_setup(uri = self$uri,
                      config = cfg,
                      dim_points = coords,
                      result_order = result_order,
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
 
-      SOMASparseNDArrayRead$new(sr, shape = shape)
+      SOMASparseNDArrayRead$new(sr, shape = self$shape())
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: experimental)

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -24,7 +24,19 @@ SOMASparseNDArrayRead <- R6::R6Class(
     #' @return \link{SparseReadIter}
     sparse_matrix = function(zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
-      SparseReadIter$new(sr = private$sr, shape = private$shape, zero_based=zero_based)
+
+      shape <- private$shape
+      if (any(shape >= .Machine$integer.max)) {
+        warning(
+          "Array domain exceeds '.Machine$integer.max'.\n",
+          "  - Result will only include coordinates within [0, 2^31].\n",
+          "  - The full range of coordinates can be obtained with $tables().",
+          call. = FALSE
+        )
+        shape <- pmin(shape, .Machine$integer.max)
+      }
+
+      SparseReadIter$new(private$sr, shape = shape, zero_based = zero_based)
     },
 
     #' @description Read as a arrow::\link[arrow]{Table} (lifecycle: experimental).

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -25,10 +25,11 @@ SOMASparseNDArrayRead <- R6::R6Class(
     sparse_matrix = function(zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
 
+
       if (any(private$shape >= .Machine$integer.max)) {
         warning(
-          "Array domain exceeds '.Machine$integer.max'.\n",
-          "  - Result will only include coordinates within [0, 2^31].\n",
+          "Array's 0-based domain exceeds '.Machine$integer.max'.\n",
+          "  - Result will only include coordinates within [0, 2^31 - 1).\n",
           "  - The full range of coordinates can be obtained with $tables().",
           call. = FALSE,
           immediate. = TRUE

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -25,18 +25,17 @@ SOMASparseNDArrayRead <- R6::R6Class(
     sparse_matrix = function(zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
 
-      shape <- private$shape
-      if (any(shape >= .Machine$integer.max)) {
+      if (any(private$shape >= .Machine$integer.max)) {
         warning(
           "Array domain exceeds '.Machine$integer.max'.\n",
           "  - Result will only include coordinates within [0, 2^31].\n",
           "  - The full range of coordinates can be obtained with $tables().",
           call. = FALSE
         )
-        shape <- pmin(shape, .Machine$integer.max)
+        private$shape <- pmin(private$shape, .Machine$integer.max - 1L)
       }
 
-      SparseReadIter$new(private$sr, shape = shape, zero_based = zero_based)
+      SparseReadIter$new(private$sr, private$shape, zero_based = zero_based)
     },
 
     #' @description Read as a arrow::\link[arrow]{Table} (lifecycle: experimental).

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -30,7 +30,8 @@ SOMASparseNDArrayRead <- R6::R6Class(
           "Array domain exceeds '.Machine$integer.max'.\n",
           "  - Result will only include coordinates within [0, 2^31].\n",
           "  - The full range of coordinates can be obtained with $tables().",
-          call. = FALSE
+          call. = FALSE,
+          immediate. = TRUE
         )
         private$shape <- pmin(private$shape, .Machine$integer.max - 1L)
       }

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -26,15 +26,15 @@ SOMASparseNDArrayRead <- R6::R6Class(
       #TODO implement zero_based argument, currently doesn't do anything
 
 
-      if (any(private$shape >= .Machine$integer.max)) {
+      if (any(private$shape > .Machine$integer.max)) {
         warning(
-          "Array's 0-based domain exceeds '.Machine$integer.max'.\n",
+          "Array's shape exceeds '.Machine$integer.max'.\n",
           "  - Result will only include coordinates within [0, 2^31 - 1).\n",
           "  - The full range of coordinates can be obtained with $tables().",
           call. = FALSE,
           immediate. = TRUE
         )
-        private$shape <- pmin(private$shape, .Machine$integer.max - 1L)
+        private$shape <- pmin(private$shape, .Machine$integer.max)
       }
 
       SparseReadIter$new(private$sr, private$shape, zero_based = zero_based)

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -19,8 +19,8 @@ SparseReadIter <- R6::R6Class(
     #' otherwise \link{matrixZeroBasedView}.
     initialize = function(sr, shape, zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
-      stopifnot("Array must have two dimensions" = length(shape) == 2,
-                "Array dimensions must not exceed '.Machine$integer.max'" = any(shape < .Machine$integer.max))
+      # stopifnot("Array must have two dimensions" = length(shape) == 2,
+      #           "Array dimensions must not exceed '.Machine$integer.max'" = any(shape < .Machine$integer.max))
 
       # Initiate super class
         super$initialize(sr)

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -20,8 +20,8 @@ SparseReadIter <- R6::R6Class(
     initialize = function(sr, shape, zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
       stopifnot("'shape' must have two dimensions" = length(shape) == 2,
-                "'shape' (0-based) must be less than '.Machine$integer.max'" =
-                  all(shape < .Machine$integer.max))
+                "'shape' must not exceed '.Machine$integer.max'" =
+                  all(shape <= .Machine$integer.max))
 
       # Initiate super class
       super$initialize(sr)

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -20,8 +20,8 @@ SparseReadIter <- R6::R6Class(
     initialize = function(sr, shape, zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
       stopifnot("'shape' must have two dimensions" = length(shape) == 2,
-                "'shape' must not exceed '.Machine$integer.max'" =
-                  any(shape < .Machine$integer.max))
+                "'shape' (0-based) must be less than '.Machine$integer.max'" =
+                  all(shape < .Machine$integer.max))
 
       # Initiate super class
         super$initialize(sr)

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -19,8 +19,9 @@ SparseReadIter <- R6::R6Class(
     #' otherwise \link{matrixZeroBasedView}.
     initialize = function(sr, shape, zero_based=FALSE) {
       #TODO implement zero_based argument, currently doesn't do anything
-      # stopifnot("Array must have two dimensions" = length(shape) == 2,
-      #           "Array dimensions must not exceed '.Machine$integer.max'" = any(shape < .Machine$integer.max))
+      stopifnot("'shape' must have two dimensions" = length(shape) == 2,
+                "'shape' must not exceed '.Machine$integer.max'" =
+                  any(shape < .Machine$integer.max))
 
       # Initiate super class
         super$initialize(sr)

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -24,10 +24,10 @@ SparseReadIter <- R6::R6Class(
                   all(shape < .Machine$integer.max))
 
       # Initiate super class
-        super$initialize(sr)
-        private$repr <- "T"
-        private$shape <- shape
-        private$zero_based <- zero_based
+      super$initialize(sr)
+      private$repr <- "T"
+      private$shape <- shape
+      private$zero_based <- zero_based
     },
 
 

--- a/apis/r/R/utils-readerTransformers.R
+++ b/apis/r/R/utils-readerTransformers.R
@@ -37,9 +37,12 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
     shape <- c(max(tbl$soma_dim_0)$as_vector(), max(tbl$soma_dim_1)$as_vector())
   }
 
-  if (any(shape > .Machine$integer.max)) {
-    stop("'shape' must not exceed '.Machine$integer.max'.", call. = FALSE)
-  }
+  stopifnot(
+    "'shape' must not exceed '.Machine$integer.max'." =
+      all(shape <= .Machine$integer.max),
+    "A Matrix::sparseMatrix cannot hold more than 2^31 - 1 non-zero values" =
+      nrow(tbl) <= .Machine$integer.max
+  )
 
   exceedsInt32Limit <- (
     tbl$soma_dim_0 >= .Machine$integer.max | tbl$soma_dim_1 >= .Machine$integer.max

--- a/apis/r/R/utils-readerTransformers.R
+++ b/apis/r/R/utils-readerTransformers.R
@@ -42,10 +42,10 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
       shape <- c(max(soma_dim_0_one_based), max(soma_dim_1_one_based))
   }
 
-  if(any(shape > .Machine$integer.max)) {
-      stop("The shape of the array is larger than supported by Matrix::sparseMatrix",
-           call. = FALSE)
-  }
+  # if(any(shape > .Machine$integer.max)) {
+  #     stop("The shape of the array is larger than supported by Matrix::sparseMatrix",
+  #          call. = FALSE)
+  # }
 
   mat <- Matrix::sparseMatrix(i = soma_dim_0_one_based,
                               j = soma_dim_1_one_based,

--- a/apis/r/R/utils-readerTransformers.R
+++ b/apis/r/R/utils-readerTransformers.R
@@ -33,24 +33,35 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
   # If needed, user can then explicitly ask the shim for the underlying
   # sparseMatrix using `as.one.based()`.
 
-  soma_dim_0_one_based <- 1 + as.numeric(tbl$GetColumnByName("soma_dim_0"))
-  soma_dim_1_one_based <- 1 + as.numeric(tbl$GetColumnByName("soma_dim_1"))
-
-  soma_data <- as.numeric(tbl$GetColumnByName("soma_data"))
-
   if (is.null(shape)) {
-      shape <- c(max(soma_dim_0_one_based), max(soma_dim_1_one_based))
+    shape <- c(max(tbl$soma_dim_0)$as_vector(), max(tbl$soma_dim_1)$as_vector())
   }
 
   if (any(shape >= .Machine$integer.max)) {
     stop("'shape' must not exceed '.Machine$integer.max'.", call. = FALSE)
   }
 
-  mat <- Matrix::sparseMatrix(i = soma_dim_0_one_based,
-                              j = soma_dim_1_one_based,
-                              x = soma_data,
-                              dims = shape, repr = repr)
-  if(zero_based) {
+  exceedsInt32Limit <- (
+    tbl$soma_dim_0 >= .Machine$integer.max | tbl$soma_dim_1 >= .Machine$integer.max
+  )
+
+  if (any(exceedsInt32Limit)$as_vector()) {
+    stop(
+      "Query contains 0-based coordinates outside '[0, 2^31 - 1)'.\n",
+      "  - Matrix::sparseMatrix cannot be created with these values",
+      call. = FALSE
+    )
+  }
+
+  # Shape is always 0-based but sparseMatrix treats dims as 1-based, even when
+  # index1 = FALSE, so we need to add 1 to the shape.
+  mat <- Matrix::sparseMatrix(i = tbl$soma_dim_0$as_vector(),
+                              j = tbl$soma_dim_1$as_vector(),
+                              x = tbl$soma_data$as_vector(),
+                              dims = shape + 1L,
+                              repr = repr,
+                              index1 = FALSE)
+  if (zero_based) {
       matrixZeroBasedView$new(mat)
   } else {
       mat

--- a/apis/r/R/utils-readerTransformers.R
+++ b/apis/r/R/utils-readerTransformers.R
@@ -42,10 +42,9 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
       shape <- c(max(soma_dim_0_one_based), max(soma_dim_1_one_based))
   }
 
-  # if(any(shape > .Machine$integer.max)) {
-  #     stop("The shape of the array is larger than supported by Matrix::sparseMatrix",
-  #          call. = FALSE)
-  # }
+  if (any(shape >= .Machine$integer.max)) {
+    stop("'shape' must not exceed '.Machine$integer.max'.", call. = FALSE)
+  }
 
   mat <- Matrix::sparseMatrix(i = soma_dim_0_one_based,
                               j = soma_dim_1_one_based,

--- a/apis/r/R/utils-readerTransformers.R
+++ b/apis/r/R/utils-readerTransformers.R
@@ -37,7 +37,7 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
     shape <- c(max(tbl$soma_dim_0)$as_vector(), max(tbl$soma_dim_1)$as_vector())
   }
 
-  if (any(shape >= .Machine$integer.max)) {
+  if (any(shape > .Machine$integer.max)) {
     stop("'shape' must not exceed '.Machine$integer.max'.", call. = FALSE)
   }
 
@@ -53,12 +53,10 @@ arrow_table_to_sparse <- function(tbl, repr = c("C", "T", "R"), shape = NULL, ze
     )
   }
 
-  # Shape is always 0-based but sparseMatrix treats dims as 1-based, even when
-  # index1 = FALSE, so we need to add 1 to the shape.
   mat <- Matrix::sparseMatrix(i = tbl$soma_dim_0$as_vector(),
                               j = tbl$soma_dim_1$as_vector(),
                               x = tbl$soma_data$as_vector(),
-                              dims = shape + 1L,
+                              dims = shape,
                               repr = repr,
                               index1 = FALSE)
   if (zero_based) {


### PR DESCRIPTION
**Issue and/or context:** #1487

**Changes:** This makes a few adjustment to improve our handling of arrays with domains greater than 2^31-1.

- `SOMASparseNDArray$read()` no longer warns if `nnz() > .Machine$integer.max`, since these arrays can be read without issue using `SOMASparseNDArray$read()$tables()`
- `SOMASparseNDArrayRead$sparse_matrix()` truncates `shape` to `2^31 - 1` if `shape > 2^31-1` and lets the user know via a warning. I decided to add this logic here rather than deeper in the stack so that it executes only once when reading sparse matrices, rather than once per iteration.
- Fixed `SparseReaditer`'s `shape` assertion
- `arrow_table_to_sparse` adds a final check to ensure that `shape` is `<= 2^31 - 1` and all coordinates are within `[0, 2^31 - 1)` (since `shape` is 1-based and `coords` are 0-based)
- `arrow_table_to_sparse` was also slightly simplified to work directly with 0-based coords and leverage `Matrix::sparseMatrix()`'s `index1` argument
- `SOMAExperimentAxisQuery$to_seurat_graph()` was refactored to leverage `$to_sparse_matrix()` and avoid the costly creation of a `dgCMatrix` with domains `.Machine$integer.max`