### PR TITLE
[ci] Backport Ubuntu-image update

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Backport
     steps:
       - name: Backport

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Backport

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
**Issue and/or context:** #1335

**Changes:** See PR diff

**Notes for Reviewer:**

Following on @eddelbuettel 's comments on #1506 -- in my tiptoe into backport-bot for `TileDB-SOMA`, I thought to imitate core as closely as possible (since known-good), then tweak versions after. However we found that `ubuntu-18.04` actually resulted in launch failures so let's try `ubuntu-20.04`.