### PR TITLE
[r] Add bounding box to arrays

### DIFF
--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -165,7 +165,7 @@ SOMASparseNDArray <- R6::R6Class(
         }
         bbox[[x]] <- xrange
       }
-      names(bbox) <- paste0(names(bbox), '_DOMAIN')
+      names(bbox) <- paste0(names(bbox), '_domain')
       self$set_metadata(bbox)
       private$.write_coo_dataframe(coo)
     },

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -95,6 +95,10 @@ SOMASparseNDArray <- R6::R6Class(
         names(bbox) <- dnames
       }
       if (!is_named(bbox, allow_empty = FALSE)) {
+        # Determine which indexes of `bbox` are unnamed (incl empty strings "")
+        # Python equivalent:
+        # bbox = pandas.Series([[0, 99], [0, 299]], index=["soma_dim_0", ""])
+        # [i for i, key in enumerate(bbox.keys()) if not len(key)]
         idx <- which(!nzchar(names(bbox)))
         names(bbox)[idx] <- dnames[idx]
       }

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -62,6 +62,8 @@ SOMASparseNDArray <- R6::R6Class(
     #' @param values Any `matrix`-like object coercible to a
     #' [`TsparseMatrix`][`Matrix::TsparseMatrix-class`]. Character dimension
     #' names are ignored because `SOMANDArray`'s use integer indexing.
+    #' @param bbox A vector of integers describing the upper bounds of each
+    #' dimension of `values`. Generally should be `NULL`.
     #'
     write = function(values, bbox = NULL) {
       stopifnot(

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -143,7 +143,7 @@ SOMASparseNDArray <- R6::R6Class(
         xrange <- sort(bit64::as.integer64(xrange))
         if (length(xrange) != 2L) {
           stop(
-            "Ranges in the bounding box must be two 64-bit integers",
+            "Ranges in the bounding box must consist of two integerish values",
             call. = FALSE
           )
         }

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -156,7 +156,7 @@ TileDBArray <- R6::R6Class(
       utilized <- vector(mode = 'list', length = length(dims))
       names(utilized) <- dims
       for (i in seq_along(along.with = utilized)) {
-        key <- paste0(dims[i], '_DOMAIN')
+        key <- paste0(dims[i], '_domain')
         utilized[[i]] <- self$get_metadata(key) %||% bit64::NA_integer64_
       }
       if (any(vapply_lgl(utilized, rlang::is_na))) {

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -144,7 +144,7 @@ TileDBArray <- R6::R6Class(
     #'  explicitly written.
     #' @param simplify Return a vector of [`bit64:integer64`]s containing only
     #' the upper bounds.
-    #' @param index1 Return the used shape with 1-based indices.
+    #' @param index1 Return the used shape with 1-based indices (0-based indices are returned by default)
     #' @return A list containing the lower and upper bounds for the used shape.
     #' If `simplify = TRUE`, returns a vector of only the upper bounds.
     used_shape = function(simplify = FALSE, index1 = FALSE) {

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -140,6 +140,13 @@ TileDBArray <- R6::R6Class(
       ))
     },
 
+    #' @description Retrieve the range of indexes for a dimension that were
+    #'  explicitly written.
+    #' @param simplify Return a vector of [`bit64:integer64`]s containing only
+    #' the upper bounds.
+    #' @param index1 Return the used shape with 1-based indices.
+    #' @return A list containing the lower and upper bounds for the used shape.
+    #' If `simplify = TRUE`, returns a vector of only the upper bounds.
     used_shape = function(simplify = FALSE, index1 = FALSE) {
       stopifnot(
         isTRUE(simplify) || isFALSE(simplify),
@@ -189,6 +196,12 @@ TileDBArray <- R6::R6Class(
       return(utilized)
     },
 
+    #' @description Retrieve the non-empty domain for each dimension. This
+    #' method calls [`tiledb::tiledb_array_get_non_empty_domain_from_name`] for
+    #' each dimension in the array.
+    #' @param index1 Return the non-empty domain with 1-based indices.
+    #' @return A vector of [`bit64::integer64`]s with one entry for
+    #' each dimension.
     non_empty_domain = function(index1 = FALSE) {
       dims <- self$dimnames()
       ned <- bit64::integer64(length = length(dims))

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -160,25 +160,10 @@ TileDBArray <- R6::R6Class(
         utilized[[i]] <- self$get_metadata(key) %||% bit64::NA_integer64_
       }
       if (any(vapply_lgl(utilized, rlang::is_na))) {
-        ned <- self$non_empty_domain(index1 = FALSE)
-        ned[!ned] <- NA_integer_
-        idx <- which(vapply_lgl(utilized, rlang::is_na))
-        msg <- paste(
-          strwrap(paste0(
-            "The following dimensions have no bounding box, non-empty domain used instead:\n",
-            paste(sQuote(dims[idx]), collapse = ', ')
-          )),
-          collapse = '\n'
+        stop(
+          "This array was not written with bounding box support; for an approximation, please use `$non_empty_domain()` instead",
+          call. = FALSE
         )
-        spdl::warn(msg)
-        warning(msg)
-        for (j in idx) {
-          utilized[[j]] <- if (rlang::is_na(ned[j])) {
-            ned[j]
-          } else {
-            c(bit64::as.integer64(0L), ned[j])
-          }
-        }
       }
       if (index1) {
         for (i in seq_along(utilized)) {

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -42,6 +42,7 @@ experimental)
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsoma::TileDBArray$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -49,6 +50,7 @@ experimental)
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -39,6 +39,7 @@ row and is intended to act as a join key for other objects, such as
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsoma::TileDBArray$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -46,6 +47,7 @@ row and is intended to act as a join key for other objects, such as
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -54,6 +54,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsoma::TileDBArray$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -61,6 +62,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="SOMANDArrayBase" data-id="create"><a href='../../tiledbsoma/html/SOMANDArrayBase.html#method-SOMANDArrayBase-create'><code>tiledbsoma::SOMANDArrayBase$create()</code></a></span></li>
 </ul>
 </details>

--- a/apis/r/man/SOMANDArrayBase.Rd
+++ b/apis/r/man/SOMANDArrayBase.Rd
@@ -36,6 +36,7 @@ Adds NDArray-specific functionality to the \code{\link{SOMAArrayBase}} class.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsoma::TileDBArray$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -43,6 +44,7 @@ Adds NDArray-specific functionality to the \code{\link{SOMAArrayBase}} class.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -52,6 +52,7 @@ the object are overwritten and new index values are added. (lifecycle: experimen
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsoma::TileDBArray$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -59,6 +60,7 @@ the object are overwritten and new index values are added. (lifecycle: experimen
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="SOMANDArrayBase" data-id="create"><a href='../../tiledbsoma/html/SOMANDArrayBase.html#method-SOMANDArrayBase-create'><code>tiledbsoma::SOMANDArrayBase$create()</code></a></span></li>
 </ul>
 </details>
@@ -103,7 +105,7 @@ read. List elements can be named when specifying a subset of dimensions.}
 \subsection{Method \code{write()}}{
 Write matrix-like data to the array. (lifecycle: experimental)
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$write(values)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMASparseNDArray$write(values, bbox = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -112,6 +114,9 @@ Write matrix-like data to the array. (lifecycle: experimental)
 \item{\code{values}}{Any \code{matrix}-like object coercible to a
 \code{\link[Matrix:TsparseMatrix-class]{TsparseMatrix}}. Character dimension
 names are ignored because \code{SOMANDArray}'s use integer indexing.}
+
+\item{\code{bbox}}{A vector of integers describing the upper bounds of each
+dimension of \code{values}. Generally should be \code{NULL}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/TileDBArray.Rd
+++ b/apis/r/man/TileDBArray.Rd
@@ -32,6 +32,8 @@ Base class for representing an individual TileDB array.
 \item \href{#method-TileDBArray-tiledb_schema}{\code{TileDBArray$tiledb_schema()}}
 \item \href{#method-TileDBArray-dimensions}{\code{TileDBArray$dimensions()}}
 \item \href{#method-TileDBArray-shape}{\code{TileDBArray$shape()}}
+\item \href{#method-TileDBArray-used_shape}{\code{TileDBArray$used_shape()}}
+\item \href{#method-TileDBArray-non_empty_domain}{\code{TileDBArray$non_empty_domain()}}
 \item \href{#method-TileDBArray-ndim}{\code{TileDBArray$ndim()}}
 \item \href{#method-TileDBArray-attributes}{\code{TileDBArray$attributes()}}
 \item \href{#method-TileDBArray-dimnames}{\code{TileDBArray$dimnames()}}
@@ -212,6 +214,54 @@ array.  Rather, it is the bounds outside of which no data may be written.
 
 \subsection{Returns}{
 A named vector of dimension length (and the same type as the dimension)
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TileDBArray-used_shape"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-used_shape}{}}}
+\subsection{Method \code{used_shape()}}{
+Retrieve the range of indexes for a dimension that were
+explicitly written.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TileDBArray$used_shape(simplify = FALSE, index1 = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{simplify}}{Return a vector of \code{\link{bit64:integer64}}s containing only
+the upper bounds.}
+
+\item{\code{index1}}{Return the used shape with 1-based indices.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A list containing the lower and upper bounds for the used shape.
+If \code{simplify = TRUE}, returns a vector of only the upper bounds.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TileDBArray-non_empty_domain"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-non_empty_domain}{}}}
+\subsection{Method \code{non_empty_domain()}}{
+Retrieve the non-empty domain for each dimension. This
+method calls \code{\link[tiledb:tiledb_array_get_non_empty_domain_from_name]{tiledb::tiledb_array_get_non_empty_domain_from_name}} for
+each dimension in the array.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TileDBArray$non_empty_domain(index1 = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index1}}{Return the non-empty domain with 1-based indices.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A vector of \code{\link[bit64:bit64-package]{bit64::integer64}}s with one entry for
+each dimension.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -441,7 +441,7 @@ test_that("SOMASparseNDArray without bounding box", {
   expect_true(all(vapply(bbox, inherits, logical(1L), what = 'integer64')))
 })
 
-test_that("SOMASparseNDArray without failed bounding box", {
+test_that("SOMASparseNDArray with failed bounding box", {
   uri <- withr::local_tempdir("sparse-ndarray-failed-bbox")
   nrows <- 100L
   ncols <- 500L

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -531,6 +531,7 @@ test_that("Bounding box assertions", {
   nrows <- 100L
   ncols <- 500L
   ndarray <- SOMASparseNDArrayCreate(uri, type = arrow::int32(), shape = c(nrows, ncols))
+  on.exit(ndarray$close())
 
   mat <- create_sparse_matrix_with_int_dims(nrows, ncols)
 

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -389,9 +389,9 @@ test_that("SOMASparseNDArray bounding box", {
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
 
-  expect_true(all(paste0(dnames, '_DOMAIN') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_true(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
   for (i in seq_along(dnames)) {
-    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_DOMAIN')), 'integer64')
+    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_domain')), 'integer64')
     expect_equal(xrange, bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
   }
 
@@ -431,7 +431,7 @@ test_that("SOMASparseNDArray without bounding box", {
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
 
-  expect_false(all(paste0(dnames, '_DOMAIN') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_warning(bbox <- ndarray$used_shape())
   expect_type(bbox, 'list')
@@ -461,7 +461,7 @@ test_that("SOMASparseNDArray with failed bounding box", {
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
 
-  expect_false(all(paste0(dnames, '_DOMAIN') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_warning(bbox <- ndarray$used_shape())
   expect_type(bbox, 'list')
@@ -487,9 +487,9 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
 
-  expect_true(all(paste0(dnames, '_DOMAIN') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_true(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
   for (i in seq_along(dnames)) {
-    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_DOMAIN')), 'integer64')
+    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_domain')), 'integer64')
     expect_equal(xrange, bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
   }
 

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -433,12 +433,7 @@ test_that("SOMASparseNDArray without bounding box", {
 
   expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
-  expect_warning(bbox <- ndarray$used_shape())
-  expect_type(bbox, 'list')
-  expect_equal(names(bbox), dnames)
-  expect_true(all(vapply(bbox, length, integer(1L)) == 1L))
-  expect_true(all(vapply(bbox, rlang::is_na, logical(1L))))
-  expect_true(all(vapply(bbox, inherits, logical(1L), what = 'integer64')))
+  expect_error(ndarray$used_shape())
 })
 
 test_that("SOMASparseNDArray with failed bounding box", {
@@ -463,14 +458,7 @@ test_that("SOMASparseNDArray with failed bounding box", {
 
   expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
-  expect_warning(bbox <- ndarray$used_shape())
-  expect_type(bbox, 'list')
-  expect_equal(names(bbox), dnames)
-  expect_true(all(vapply(bbox, length, integer(1L)) == 2L))
-  expect_true(all(vapply(bbox, inherits, logical(1L), what = 'integer64')))
-  for (i in seq_along(bbox)) {
-    expect_equal(bbox[[i]], bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
-  }
+  expect_error(ndarray$used_shape())
 })
 
 test_that("SOMASparseNDArray bounding box implicitly-stored values", {


### PR DESCRIPTION
Add support for encoding and retrieving bounding box information from arrays. The bounding box stored in array-level metadata and created during write

Bounding box metadata is structured as `{<DIMENSION_NAME>_DOMAIN: [<lower_bound>, <upper_bound>]}` (for example, `{soma_dim_0_DOMAIN: [0, 79]}`). The bounds are 0-based, inclusive, and stored as 64-bit integers

New SOMA Methods
  - `TileDBArray$non_empty_domain()`: retrieves the maximal value of the non-empty domain via `tiledb::tiledb_array_get_non_empty_domain_from_name()`
    - parameter `index1`: return the one-based index for the non-empty domain; defaults to `FALSE`
  - `TileDBArray$used_shape()`: retrieves the bounding box for array-level meta data
    - parameter `simplify`: return only the maximal bounds of the used shape (essentially assumes the lower bound is zero); defaults to `FALSE`
    - parameter `index`: return the one-based index for the non-empty domain; defaults to `FALSE`
 
Modified SOMA Methods
  - `SOMASparseNDArray$write()`: now takes a parameter `bbox` for an optional bounding box. By default, is `NULL` and bounding box is taken from `values`; encodes bounding box in array meta data as 64-bit integers

Context: #1445 