### PR TITLE
[python] Ingest uns string arrays as single-attr SOMADataFrame

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1395,7 +1395,7 @@ def _ingest_uns_node(
             logging.log_io(msg, msg)
             return
 
-        if value.dtype.char == "U" or value.dtype.char == "O":
+        if value.dtype.char in ("U", "O"):
             # In the wild it's quite common to see arrays of strings in uns data.
             # Frequent example: uns["louvain_colors"].
             _ingest_uns_string_array(
@@ -1455,8 +1455,8 @@ def _ingest_uns_string_array(
     df_uri = _util.uri_joinpath(coll.uri, key)
     df = pd.DataFrame(
         data={
-            "soma_joinid": np.asarray(range(n), dtype=np.int64),
-            "values": [str(e) for e in value],
+            "soma_joinid": np.arange(n, dtype=np.int64),
+            "values": [str(e) if e else "" for e in value],
         }
     )
     df.set_index("soma_joinid", inplace=True)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -678,9 +678,6 @@ def _write_dataframe(
     platform_config: Optional[PlatformConfig] = None,
     context: Optional[SOMATileDBContext] = None,
 ) -> DataFrame:
-    _util.get_start_stamp()
-    logging.log_io(None, f"START  WRITING {df_uri}")
-
     df[SOMA_JOINID] = np.arange(len(df), dtype=np.int64)
 
     df.reset_index(inplace=True)
@@ -1441,6 +1438,10 @@ def _ingest_uns_string_array(
     """
     Ingest an uns string array. In the SOMA data model, we have NDArrays _of number only_ ...
     so we need to make this a SOMADataFrame.
+
+    Ideally we don't want to an index column "soma_joinid" -- "index", maybe.
+    However, ``SOMADataFrame`` _requires_ that soma_joinid be present, either
+    as an index column, or as a data column. The former is less confusing.
     """
     if len(value.shape) != 1:
         msg = (
@@ -1454,9 +1455,6 @@ def _ingest_uns_string_array(
     df_uri = _util.uri_joinpath(coll.uri, key)
     df = pd.DataFrame(
         data={
-            # Ideally we don't want to call this "soma_joinid" -- "index", maybe.
-            # However, SOMADataFrame _requires_ that soma_joinid be present, either
-            # as an index column, or as a data column. The former is less confusing.
             "soma_joinid": np.asarray(range(n), dtype=np.int64),
             "values": [str(e) for e in value],
         }

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -327,6 +327,7 @@ def test_ingest_uns(tmp_path: pathlib.Path, h5ad_file_extended):
         assert set(uns) == {
             "draw_graph",
             "louvain",
+            "louvain_colors",
             "neighbors",
             "pca",
             "rank_genes_groups",


### PR DESCRIPTION
**Issue and/or context:** Resolves #1400

**Changes:** As discussed on #1400

**Notes for Reviewer:**

```
>>> import tiledbsoma

>>> exp = tiledbsoma.Experiment.open("./pbmc3k")


>>> exp.ms["RNA"]["uns"]["louvain_colors"].read().concat()
pyarrow.Table
soma_joinid: int64
values: large_string
----
soma_joinid: [[0,1,2,3,4,5,6,7]]
values: [["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#8c564b","#e377c2","#bcbd22"]]

>>> exp.ms["RNA"]["uns"]["louvain_colors"].read().concat().to_pandas()
   soma_joinid   values
0            0  #1f77b4
1            1  #ff7f0e
2            2  #2ca02c
3            3  #d62728
4            4  #9467bd
5            5  #8c564b
6            6  #e377c2
7            7  #bcbd22
```