### PR TITLE
[r] Optimize export of obsm/varm arrays to Seurat

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -60,7 +60,7 @@ The principal persistent types provided by SOMA are:
   and value type.
 - :class:`SparseNDArray` -- a sparse multi-dimensional array, storing
   Arrow primitive data types, i.e., int, float, etc.
-- :class:`DenseNDArray` -- a dnese multi-dimensional array, storing
+- :class:`DenseNDArray` -- a dense multi-dimensional array, storing
   Arrow primitive data types, i.e., int, float, etc.
 - :class:`Experiment` -- a specialized :class:`Collection`, representing an
   annotated 2-D matrix of measurements.

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 0.0.0.9030
+Version: 0.0.0.9031
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -667,29 +667,6 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           (is_scalar_character(var_index) && !is.na(var_index))
       )
 
-      # Validate layers are SOMASparseNDArrays
-      assert_layer_is_sparse <- function(collection_name, layer) {
-        stopifnot(is_scalar_character(collection_name))
-        is_sparse <- inherits(layer, "SOMASparseNDArray")
-        if (!is_sparse) {
-          msg1 <- sprintf(
-            "Values for '%s' are encoded as dense instead of sparse\n",
-            basename(layer$uri)
-          )
-          msg2 <- sprintf(
-            "  - all '%s' arrays should be saved as 'SOMASparseNDArrays'\n",
-            collection_name
-          )
-          warning(
-            msg1,
-            msg2,
-            # "  - returning 'NULL' and skipping this dimension reduction",
-            call. = FALSE
-          )
-        }
-        invisible(is_sparse)
-      }
-
       # Check embeddings/loadings
       ms_embed <- tryCatch(expr = self$ms$obsm$names(), error = null)
       ms_load <- tryCatch(expr = self$ms$varm$names(), error = null)
@@ -774,7 +751,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       }
 
       spdl::info("Reading obsm layer '{}' into memory", obsm_layer)
-      assert_layer_is_sparse("obsm", self$ms$obsm$get(obsm_layer))
+      warn_if_dense("obsm", self$ms$obsm$get(obsm_layer))
       embed_mat <- self$to_sparse_matrix(
         collection = "obsm",
         layer_name = obsm_layer,
@@ -805,7 +782,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         }
 
         spdl::info("Reading varm layer '{}' into memory", varm_layer)
-        assert_layer_is_sparse("varm", self$ms$varm$get(varm_layer))
+        warn_if_dense("varm", self$ms$varm$get(varm_layer))
         load_mat <- self$to_sparse_matrix(
           collection = "varm",
           layer_name = varm_layer,

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -661,6 +661,30 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         "'var_index' must be a single character value" = is.null(var_index) ||
           (is_scalar_character(var_index) && !is.na(var_index))
       )
+
+      # Validate layers are SOMASparseNDArrays
+      assert_layer_is_sparse <- function(collection_name, layer) {
+        stopifnot(is_scalar_character(collection_name))
+        is_sparse <- inherits(layer, "SOMASparseNDArray")
+        if (!is_sparse) {
+          msg1 <- sprintf(
+            "Values for '%s' are encoded as dense instead of sparse\n",
+            basename(layer$uri)
+          )
+          msg2 <- sprintf(
+            "  - all '%s' arrays should be saved as 'SOMASparseNDArrays'\n",
+            collection_name
+          )
+          warning(
+            msg1,
+            msg2,
+            "  - returning 'NULL' and skipping this dimension reduction",
+            call. = FALSE
+          )
+        }
+        is_sparse
+      }
+
       # Check embeddings/loadings
       ms_embed <- tryCatch(expr = self$ms$obsm$names(), error = null)
       ms_load <- tryCatch(expr = self$ms$varm$names(), error = null)
@@ -686,6 +710,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       } else {
         names(ms_load) <- .anndata_to_seurat_reduc(ms_load, 'loadings')
       }
+
       # Check provided names
       assert_subset(
         x = obsm_layer,
@@ -742,115 +767,71 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       if (obsm_layer %in% names(ms_embed)) {
         obsm_layer <- ms_embed[obsm_layer]
       }
-      # Get cell names
-      cells <- if (is.null(obs_index)) {
-        paste0('cell', self$obs_joinids()$as_vector())
-      } else {
-        obs_index <- match.arg(
-          arg = obs_index,
-          choices = self$obs_df$attrnames()
-        )
-        self$obs(obs_index)$concat()$GetColumnByName(obs_index)$as_vector()
+
+      if (!assert_layer_is_sparse("obsm", self$ms$obsm$get(obsm_layer))) {
+        return(NULL)
       }
-      embed <- self$ms$obsm$get(obsm_layer)
-      coords <- list(
-        cells = self$obs_joinids()$as_vector(),
-        dims = seq_len(as.integer(embed$shape()[2L])) - 1L
+      spdl::info("Reading obsm layer '{}' into memory", obsm_layer)
+      embed_mat <- self$to_sparse_matrix(
+        collection = "obsm",
+        layer_name = obsm_layer,
+        obs_index = obs_index
       )
-      embed_mat <- if (inherits(embed, 'SOMASparseNDArray')) {
-        this_mat <- embed$read()$sparse_matrix(zero_based=TRUE)$concat()
-        this_mat <- this_mat$take(coords$cells, coords$dims)
-        this_mat <- this_mat$get_one_based_matrix()
-        this_mat <- as(this_mat, "CsparseMatrix")
-        as.matrix(this_mat)
-      } else if (inherits(embed, 'SOMADenseNDArray')) {
-        warning(
-          paste(
-            strwrap(paste(
-              "Embeddings for",
-              sQuote(obsm_layer),
-              "are encoded as dense instead of sparse; all arrays should be saved as",
-              sQuote('SOMASparseNDArrays')
-            )),
-            collapse = '\n'
-          ),
-          call. = FALSE
-        )
-        embed$read_dense_matrix(unname(coords))
-      } else {
-        stop("Unknown SOMA Array type: ", class(embed)[1L], call. = FALSE)
-      }
+
       # Set matrix names
-      rownames(embed_mat) <- cells
+      if (is.null(obs_index)) {
+        rownames(embed_mat) <- paste0("cell", rownames(embed_mat))
+      }
       colnames(embed_mat) <- paste0(key, seq_len(ncol(embed_mat)))
+      spdl::debug("Converting '{}' dgTMatrix to matrix", obsm_layer)
+      embed_mat <- as.matrix(embed_mat)
+
       # Autoset loadings if needed
       if (is.null(varm_layer) || isTRUE(varm_layer)) {
         if (seurat %in% c(names(ms_load), ms_load)) {
           varm_layer <- seurat
         }
       }
-      # Read in feature loadings
+
+      # Read in feature loadings (if present)
+      load_mat <- NULL
       if (is_scalar_character(varm_layer)) {
         # Translate Seurat name to AnnData name
         if (varm_layer %in% names(ms_load)) {
           varm_layer <- ms_load[varm_layer]
         }
-        # Get feature names
-        features <- if (is.null(var_index)) {
-          paste0('feature', self$var_joinids()$as_vector())
-        } else {
-          var_index <- match.arg(
-            arg = var_index,
-            choices = self$var_df$attrnames()
-          )
-          self$var(var_index)$concat()$GetColumnByName(var_index)$as_vector()
+
+        if (!assert_layer_is_sparse("varm", self$ms$varm$get(varm_layer))) {
+          return(NULL)
         }
-        loads <- self$ms$varm$get(varm_layer)
-        coords <- list(
-          features = self$var_joinids()$as_vector(),
-          dims = seq_len(as.integer(loads$shape()[2L])) - 1L
+        spdl::info("Reading varm layer '{}' into memory", varm_layer)
+        load_mat <- self$to_sparse_matrix(
+          collection = "varm",
+          layer_name = varm_layer,
+          var_index = var_index
         )
-        load_mat <- if (inherits(loads, 'SOMASparseNDArray')) {
-          this_mat <- loads$read()$sparse_matrix(zero_based=TRUE)$concat()
-          this_mat <- this_mat$take(coords$features, coords$dims)
-          this_mat <- this_mat$get_one_based_matrix()
-          this_mat <- as(this_mat, "CsparseMatrix")
-          as.matrix(this_mat)
-        } else if (inherits(loads, 'SOMADenseNDArray')) {
-          warning(
-            paste(
-              strwrap(paste(
-                "Loadings for",
-                sQuote(varm_layer),
-                "are encoded as dense instead of sparse; all arrays should be saved as",
-                sQuote('SOMASparseNDArrays')
-              )),
-              collapse = '\n'
-            ),
-            call. = FALSE,
-            immediate. = TRUE
-          )
-          loads$read_dense_matrix(unname(coords))
-        } else {
-          stop("Unknown SOMA Array type: ", class(loads)[1L], call. = FALSE)
-        }
+
         # Set matrix names
-        rownames(load_mat) <- features
+        if (is.null(var_index)) {
+          rownames(load_mat) <- paste0('feature', rownames(load_mat))
+        }
         colnames(load_mat) <- paste0(key, seq_len(ncol(load_mat)))
+        spdl::debug("Converting '{}' dgTMatrix to matrix", varm_layer)
+        load_mat <- as.matrix(load_mat)
+
         if (!is.null(embed_mat) && ncol(load_mat) != ncol(embed_mat)) {
           stop("The loadings do not match the embeddings", call. = FALSE)
         }
-      } else {
-        load_mat <- NULL
       }
+
       # Create the DimReduc
-      return(SeuratObject::CreateDimReducObject(
+      SeuratObject::CreateDimReducObject(
         embeddings = embed_mat,
         loadings = load_mat %||% methods::new('matrix'),
         assay = private$.measurement_name,
         global = !seurat %in% c('pca', 'ica'),
         key = key
-      ))
+      )
     },
     #' @description Loads the query as a Seurat \link[SeuratObject:Graph]{graph}
     #'

--- a/apis/r/R/utils-assertions.R
+++ b/apis/r/R/utils-assertions.R
@@ -208,7 +208,7 @@ warn_if_dense <- function(collection_name, layer) {
       "  - all '%s' arrays should be saved as 'SOMASparseNDArrays'\n",
       collection_name
     )
-    warning(msg1, msg2, call. = FALSE, .immediate = TRUE)
+    warning(msg1, msg2, call. = FALSE, immediate. = TRUE)
   }
   invisible(is_sparse)
 }

--- a/apis/r/R/utils-assertions.R
+++ b/apis/r/R/utils-assertions.R
@@ -185,3 +185,30 @@ recursively_make_integer64 <- function(x) {
     }
     x
 }
+
+#' Warn if using a SOMADenseNDArray
+#' @param collection_name name of the SOMA collection
+#' @param layer a SOMASparseNDArray or SOMADenseNDArray
+#' @return Invisible logical indicating if the layer is sparse
+#' @references https://github.com/single-cell-data/TileDB-SOMA/issues/1245
+#' @noRd
+
+warn_if_dense <- function(collection_name, layer) {
+  stopifnot(
+    is_scalar_character(collection_name),
+    inherits(layer, "SOMASparseNDArray") || inherits(layer, "SOMADenseNDArray")
+  )
+  is_sparse <- inherits(layer, "SOMASparseNDArray")
+  if (!is_sparse) {
+    msg1 <- sprintf(
+      "Values for '%s' are encoded as dense instead of sparse\n",
+      basename(layer$uri)
+    )
+    msg2 <- sprintf(
+      "  - all '%s' arrays should be saved as 'SOMASparseNDArrays'\n",
+      collection_name
+    )
+    warning(msg1, msg2, call. = FALSE, .immediate = TRUE)
+  }
+  invisible(is_sparse)
+}


### PR DESCRIPTION
**Issue and/or context:** #1518

**Changes:** In #1504 `SOMAExperimentAxisQuery$to_seurat_graph()` was updated to leverage the newer `to_sparse_matrix()`, which  avoided the expensive creation of CsparseMatrix objects with dimensions equal to the underlying array's domain. This carries over the same change to `SOMAExperimentAxisQuery$to_seurat_graph()`.

This also addresses the CI issues described [here](https://github.com/single-cell-data/TileDB-SOMA/pull/1440#issuecomment-1614953938) and blocking #1440.

**Notes for Reviewer:** I'm on the fence about whether or not we need to throw a warning every time a user attempts to call `to_seurat_reduction()` on a dense ND array. It should be an incredibly rare occurrence and I'm not sure what value the warning provides. Let me know if you have thoughts.

