### PR TITLE
[r] Ensure numeric axis query coordinates are converted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ apis/r/.editorconfig
 .coverage
 coverage.xml
 coverage.info
+
+# Catch-all wildcard
+local-*

--- a/apis/r/R/utils-assertions.R
+++ b/apis/r/R/utils-assertions.R
@@ -167,13 +167,13 @@ validate_read_value_filter <- function(value_filter) {
 #' This is needed as we may receive (named or unnamed) list and/or plain vectors
 #' @noRd
 recursively_make_integer64 <- function(x) {
-    if (is.null(x) || is.character(x) || is.double(x) || is.factor(x) || is.ordered(x)) {
+    if (is.null(x) || is.character(x) || is.factor(x) || is.ordered(x)) {
         x 	# do nothing
     } else if (is.list(x)) {
         for (i in seq_along(x)) {
             x[[i]] <- recursively_make_integer64(x[[i]])
         }
-    } else if (is.integer(x)) {
+    } else if (is.integer(x) || is.double(x)) {
         x <- bit64::as.integer64(x)
     } else {
         warning("encountered ", class(x))

--- a/apis/r/tests/testthat/test-SOMAAxisQuery.R
+++ b/apis/r/tests/testthat/test-SOMAAxisQuery.R
@@ -42,4 +42,15 @@ test_that("SOMAAxisQuery", {
     SOMAAxisQuery$new(coords = list(foo = letters)),
     "'coords' must be a list of numeric vectors"
   )
+
+  ## check for numeric arguments becoming integer64 (issue #1537)
+  expt <- load_dataset("soma-exp-pbmc-small")
+  intq <- SOMAAxisQuery$new(coords = 1:2) 		# int as : operator creates ints
+  numq <- SOMAAxisQuery$new(coords = c(1, 2))   # numeric
+  expt_query <- SOMAExperimentAxisQuery$new(expt, "RNA", var_query = intq, obs_query = numq)
+  op <- getOption("arrow.int64_downcast")
+  options("arrow.int64_downcast"=FALSE) # else it becomes int
+  expect_true(inherits(expt_query$var_joinids()$as_vector(), "integer64"))
+  expect_true(inherits(expt_query$obs_joinids()$as_vector(), "integer64"))
+  options("arrow.int64_downcast"=op)
 })


### PR DESCRIPTION
closes #1537

**Issue and/or context:**

As seen in #1537, passing numeric coordinates for an axis query leads to these being silently dropped.

**Changes:**

Numeric coordinates now get converted explicitly to `integer64`.  As small test has been added.

**Notes for Reviewer:**

[SC-31919](https://app.shortcut.com/tiledb-inc/story/31919/somaexperimentaxisquery-drops-numeric-query-coordinates)
[SC-29979](https://app.shortcut.com/tiledb-inc/story/29979/r-add-support-for-querying-non-numeric-coordinates)

I also snuck a one-liner addition to `.gitignore` which helps with some local scripts I keep. This can of course be reverted if need be.
