### PR TITLE
[c++] Addition of `SOMACollection`, `SOMAMeasurement`, `SOMAExperiment`

### DIFF
--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -108,8 +108,13 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         if query_condition:
             kwargs["query_condition"] = query_condition
         if result_order:
-            result_order_str = ResultOrder(result_order).value
-            kwargs["result_order"] = result_order_str
+            result_order_map = {
+                "auto": clib.ResultOrder.automatic,
+                "row-major": clib.ResultOrder.rowmajor,
+                "column-major": clib.ResultOrder.colmajor,
+            }
+            result_order_enum = result_order_map[ResultOrder(result_order).value]
+            kwargs["result_order"] = result_order_enum
         return clib.SOMAArray(
             self.uri,
             name=f"{self} reader",

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -90,6 +90,15 @@ py::object to_table(std::shared_ptr<ArrayBuffers> array_buffers) {
  *
  */
 PYBIND11_MODULE(pytiledbsoma, m) {
+    py::enum_<OpenMode>(m, "OpenMode")
+        .value("read", OpenMode::read)
+        .value("write", OpenMode::write);
+
+    py::enum_<ResultOrder>(m, "ResultOrder")
+        .value("automatic", ResultOrder::automatic)
+        .value("rowmajor", ResultOrder::rowmajor)
+        .value("colmajor", ResultOrder::colmajor);
+
     tiledbpy::init_query_condition(m);
 
     m.doc() = "SOMA acceleration library";
@@ -137,7 +146,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                    py::object py_query_condition,
                    py::object py_schema,
                    std::string_view batch_size,
-                   std::string_view result_order,
+                   ResultOrder result_order,
                    std::map<std::string, std::string> platform_config,
                    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
                     // Handle optional args
@@ -181,7 +190,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     py::gil_scoped_release release;
 
                     auto reader = SOMAArray::open(
-                        TILEDB_READ,
+                        OpenMode::read,
                         uri,
                         name,
                         platform_config,
@@ -204,7 +213,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
             "query_condition"_a = py::none(),
             "schema"_a = py::none(),
             "batch_size"_a = "auto",
-            "result_order"_a = "auto",
+            "result_order"_a = ResultOrder::automatic,
             "platform_config"_a = py::dict(),
             "timestamp"_a = py::none())
 
@@ -215,7 +224,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                py::object py_query_condition,
                py::object py_schema,
                std::string_view batch_size,
-               std::string_view result_order) {
+               ResultOrder result_order) {
                 // Handle optional args
                 std::vector<std::string> column_names;
                 if (column_names_in) {
@@ -268,7 +277,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
             "query_condition"_a = py::none(),
             "schema"_a = py::none(),
             "batch_size"_a = "auto",
-            "result_order"_a = "auto")
+            "result_order"_a = ResultOrder::automatic)
 
         // After this are short functions expected to be invoked when the coords
         // are Python list/tuple, or NumPy arrays.  Arrow arrays are in this

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -72,14 +72,16 @@ Rcpp::List soma_array_reader(const std::string& uri,
         spdl::debug("[soma_array_reader] Selecting {} columns", column_names.size());
     }
 
+    auto tdb_result_order = get_tdb_result_order(result_order);
+
     // Read selected columns from the uri (return is unique_ptr<SOMAArray>)
-    auto sr = tdbs::SOMAArray::open(TILEDB_READ,
-                                    uri,
+    auto sr = tdbs::SOMAArray::open(OpenMode::read,
+				    uri,
                                     "unnamed",         // name parameter could be added
                                     platform_config,   // to add, done in iterated reader
                                     column_names,
                                     batch_size,
-                                    result_order);
+                                    tdb_result_order);
 
     std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = sr->schema();
@@ -177,7 +179,7 @@ void set_log_level(const std::string& level) {
 Rcpp::CharacterVector get_column_types(const std::string& uri,
                                        const std::vector<std::string>& colnames) {
 
-    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri);
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri);
     sr->submit();
     auto sr_data = sr->read_next();
     size_t n = colnames.size();
@@ -194,7 +196,7 @@ Rcpp::CharacterVector get_column_types(const std::string& uri,
 //' @export
 // [[Rcpp::export]]
 double nnz(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
-    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri, "unnamed", config_vector_to_map(config));
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(config));
     return static_cast<double>(sr->nnz());
 }
 
@@ -217,6 +219,6 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 // [[Rcpp::export]]
 Rcpp::NumericVector shape(const std::string& uri,
                           Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
-    auto sr = tdbs::SOMAArray::open(TILEDB_READ, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
     return makeInteger64(sr->shape());
 }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -107,8 +107,10 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
         spdl::info(tfm::format("[sr_setup] ts_end set to %ld", ts_end));
     }
 
-    auto ptr = new tdbs::SOMAArray(TILEDB_READ, uri, name, ctxptr, column_names, batch_size,
-                                   result_order, std::make_pair(ts_start, ts_end));
+    auto tdb_result_order = get_tdb_result_order(result_order);
+
+    auto ptr = new tdbs::SOMAArray(OpenMode::read, uri, name, ctxptr, column_names, batch_size,
+                                   tdb_result_order, std::make_pair(ts_start, ts_end));
 
     std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = ptr->schema();

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -81,3 +81,12 @@ inline std::map<std::string, std::string> config_vector_to_map(Rcpp::Nullable<Rc
 
     return platform_config;
 }
+
+inline ResultOrder get_tdb_result_order(std::string result_order){
+	std::map<std::string, ResultOrder> result_order_map{
+		{"auto", ResultOrder::automatic},
+		{"row", ResultOrder::rowmajor},
+		{"col", ResultOrder::colmajor}
+	};
+	return result_order_map[result_order];
+}

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -85,8 +85,8 @@ inline std::map<std::string, std::string> config_vector_to_map(Rcpp::Nullable<Rc
 inline ResultOrder get_tdb_result_order(std::string result_order){
 	std::map<std::string, ResultOrder> result_order_map{
 		{"auto", ResultOrder::automatic},
-		{"row", ResultOrder::rowmajor},
-		{"col", ResultOrder::colmajor}
+		{"row-major", ResultOrder::rowmajor},
+		{"column-major", ResultOrder::colmajor}
 	};
 	return result_order_map[result_order];
 }

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -46,6 +46,9 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/managed_query.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dense_ndarray.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_sparse_ndarray.cc
@@ -178,10 +181,13 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer.h  
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.h 
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h 
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.h 
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.h 
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dense_ndarray.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_sparse_ndarray.h 
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.h 
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.h 
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h 
   DESTINATION "include/tiledbsoma/soma"
 )
 

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -175,6 +175,7 @@ endif()
 # )
 
 install(FILES 
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/enums.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/logger_public.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/managed_query.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/array_buffers.h  

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -30,6 +30,7 @@
  * This file is currently a sandbox for C++ API experiments
  */
 
+#include "soma/enums.h"
 #include "soma/soma_array.h"
 #include "utils/arrow_adapter.h"
 
@@ -45,12 +46,12 @@ void test_sdf(const std::string& uri) {
     // config["sm.mem.total_budget"] = "1118388608";
 
     // Read all values from the obs array
-    auto obs = SOMAArray::open(TILEDB_READ, uri + "/obs", "obs");
+    auto obs = SOMAArray::open(OpenMode::read, uri + "/obs", "obs");
     obs->submit();
     auto obs_data = obs->read_next();
 
     // Read all values from the var array
-    auto var = SOMAArray::open(TILEDB_READ, uri + "/ms/RNA/var", "var");
+    auto var = SOMAArray::open(OpenMode::read, uri + "/ms/RNA/var", "var");
     var->submit();
     auto var_data = var->read_next();
 
@@ -61,7 +62,7 @@ void test_sdf(const std::string& uri) {
 
     // Read all values from the X/data array
     auto x_data = SOMAArray::open(
-        TILEDB_READ, uri + "/ms/RNA/X/data", "X/data", config);
+        OpenMode::read, uri + "/ms/RNA/X/data", "X/data", config);
     x_data->submit();
 
     int batches = 0;
@@ -80,7 +81,7 @@ void test_sdf(const std::string& uri) {
 namespace tdbs = tiledbsoma;
 void test_arrow(const std::string& uri) {
     const std::vector<std::string>& colnames{"n_counts", "n_genes", "louvain"};
-    auto obs = tdbs::SOMAArray::open(TILEDB_READ, uri, "", {}, colnames);
+    auto obs = tdbs::SOMAArray::open(OpenMode::read, uri, "", {}, colnames);
     obs->submit();
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto obs_data = obs->read_next();

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -1,11 +1,11 @@
 /**
- * @file   tiledbsoma
+ * @file   enums.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,39 +27,14 @@
  *
  * @section DESCRIPTION
  *
- * This is the main import header for the C++ API
+ *   This file defines enumerated values.
  */
 
-#ifndef __TILEDBSOMA__
-#define __TILEDBSOMA__
+#ifndef SOMA_ENUMS
+#define SOMA_ENUMS
 
-// TODO Uncomment after finishing Python and R bindings
-// #include "soma_collection.h"
-// #include "soma_dataframe.h"
-// #include "soma_dense_ndarray.h"
-// #include "soma_experiment.h"
-// #include "soma_measurement.h"
-// #include "soma_object.h"
-// #include "soma_sparse_ndarray.h"
+enum class OpenMode { read, write };
+enum class ResultOrder { automatic, rowmajor, colmajor };
+enum class URIType { automatic, absolute, relative };
 
-#include "utils/arrow_adapter.h"
-#include "utils/common.h"
-#include "utils/stats.h"
-#include "utils/version.h"
-#include "soma/enums.h"
-#include "soma/logger_public.h"
-#include "soma/managed_query.h"
-#include "soma/array_buffers.h"
-#include "soma/column_buffer.h"
-#include "soma/soma_array.h"
-#include "soma/soma_collection.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_group.h"
-#include "soma/soma_experiment.h"
-#include "soma/soma_measurement.h"
-#include "soma/soma_object.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_dense_ndarray.h"
-#include "soma/soma_sparse_ndarray.h"
-
-#endif
+#endif  // SOMA_ENUMS

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -33,8 +33,14 @@
 #ifndef SOMA_ENUMS
 #define SOMA_ENUMS
 
-enum class OpenMode { read, write };
-enum class ResultOrder { automatic, rowmajor, colmajor };
-enum class URIType { automatic, absolute, relative };
+/** Defines whether the SOMAObject should be opened in read or write mode */
+enum class OpenMode { read = 0, write };
+
+/** Defines whether the result should be opened in row-major or column-major
+ * order */
+enum class ResultOrder { automatic = 0, rowmajor, colmajor };
+
+/** Defines whether the SOMAGroup URI is absolute or relative */
+enum class URIType { automatic = 0, absolute, relative };
 
 #endif  // SOMA_ENUMS

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -45,11 +45,11 @@ void SOMAArray::create(
     std::shared_ptr<Context> ctx,
     std::string_view uri,
     ArraySchema schema,
-    std::string soma_object_type) {
+    std::string soma_type) {
     Array::create(std::string(uri), schema);
     auto array = Array(*ctx, std::string(uri), TILEDB_WRITE);
     array.put_metadata(
-        "soma_object_type", TILEDB_STRING_UTF8, 1, soma_object_type.c_str());
+        "soma_object_type", TILEDB_STRING_UTF8, 1, soma_type.c_str());
     array.close();
 }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -197,6 +197,15 @@ class SOMAArray {
     void close();
 
     /**
+     * Check if the SOMAArray is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const {
+        return arr_->is_open();
+    }
+
+    /**
      * @brief Reset the state of this SOMAArray object to prepare for a
      * new query, while holding the array open.
      *

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -56,12 +56,13 @@ class SOMAArray {
      * @param ctx TileDB context
      * @param uri URI to create the SOMAArray
      * @param schema TileDB ArraySchema
+     * @param soma_type SOMADataFrame, SOMADenseNDArray, or SOMASparseNDArray
      */
     static void create(
         std::shared_ptr<Context> ctx,
         std::string_view uri,
         ArraySchema schema,
-        std::string soma_object_type);
+        std::string soma_type);
 
     /**
      * @brief Open an array at the specified URI and return SOMAArray

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -39,6 +39,7 @@
 
 #include <tiledb/tiledb>
 
+#include "enums.h"
 #include "managed_query.h"
 
 namespace tiledbsoma {
@@ -68,46 +69,48 @@ class SOMAArray {
      * @brief Open an array at the specified URI and return SOMAArray
      * object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param name Name of the array
      * @param platform_config Config parameter dictionary
      * @param column_names Columns to read
      * @param batch_size Read batch size
-     * @param result_order Read result order
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::string_view name = "unnamed",
         std::map<std::string, std::string> platform_config = {},
         std::vector<std::string> column_names = {},
         std::string_view batch_size = "auto",
-        std::string_view result_order = "auto",
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open an array at the specified URI and return SOMAArray
      * object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param ctx TileDB context
      * @param uri URI of the array
      * @param name Name of the array
      * @param column_names Columns to read
      * @param batch_size Read batch size
-     * @param result_order Read result order
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::shared_ptr<Context> ctx,
         std::string_view uri,
         std::string_view name = "unnamed",
         std::vector<std::string> column_names = {},
         std::string_view batch_size = "auto",
-        std::string_view result_order = "auto",
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
@@ -139,23 +142,24 @@ class SOMAArray {
     /**
      * @brief Construct a new SOMAArray object
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param name name of the array
      * @param ctx TileDB context
      * @param column_names Columns to read
      * @param batch_size Batch size
-     * @param result_order Result order
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp Timestamp
      */
     SOMAArray(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::string_view name,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names,
         std::string_view batch_size,
-        std::string_view result_order,
+        ResultOrder result_order,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     SOMAArray() = delete;
@@ -180,11 +184,11 @@ class SOMAArray {
     /**
      * Open the SOMAArray object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param timestamp Timestamp
      */
     void open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -203,7 +207,7 @@ class SOMAArray {
     void reset(
         std::vector<std::string> column_names = {},
         std::string_view batch_size = "auto",
-        std::string_view result_order = "auto");
+        ResultOrder result_order = ResultOrder::automatic);
 
     /**
      * @brief Set the dimension slice using one point
@@ -583,7 +587,7 @@ class SOMAArray {
     std::string batch_size_;
 
     // Result order
-    std::string result_order_;
+    ResultOrder result_order_;
 
     // Read timestamp range (start, end)
     std::optional<std::pair<uint64_t, uint64_t>> timestamp_;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -120,7 +120,7 @@ class SOMAArray {
     /**
      * @brief Construct a new SOMAArray object
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param name name of the array
      * @param platform_config Config parameter dictionary
@@ -130,13 +130,13 @@ class SOMAArray {
      * @param timestamp Timestamp
      */
     SOMAArray(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::string_view name,
         std::map<std::string, std::string> platform_config,
         std::vector<std::string> column_names,
         std::string_view batch_size,
-        std::string_view result_order,
+        ResultOrder result_order,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -577,7 +577,7 @@ class SOMAArray {
      * Validates input parameters before opening array.
      */
     void validate(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view name,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -42,23 +42,29 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMACollection> SOMACollection::create(
-    std::shared_ptr<Context> ctx, std::string_view uri) {
+    std::string_view uri, std::map<std::string, std::string> platform_config) {
+    return SOMACollection::create(
+        uri, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMACollection> SOMACollection::create(
+    std::string_view uri, std::shared_ptr<Context> ctx) {
     SOMAGroup::create(ctx, uri, "SOMACollection");
     return std::make_unique<SOMACollection>(TILEDB_READ, uri, ctx);
 }
 
 std::unique_ptr<SOMACollection> SOMACollection::open(
-    tiledb_query_type_t mode,
     std::string_view uri,
+    tiledb_query_type_t mode,
     std::map<std::string, std::string> platform_config) {
-    return std::make_unique<SOMACollection>(
-        mode, uri, std::make_shared<Context>(Config(platform_config)));
+    return SOMACollection::open(
+        uri, mode, std::make_shared<Context>(Config(platform_config)));
 }
 
 std::unique_ptr<SOMACollection> SOMACollection::open(
+    std::string_view uri,
     tiledb_query_type_t mode,
-    std::shared_ptr<Context> ctx,
-    std::string_view uri) {
+    std::shared_ptr<Context> ctx) {
     return std::make_unique<SOMACollection>(mode, uri, ctx);
 }
 
@@ -100,17 +106,17 @@ std::unique_ptr<SOMAObject> SOMACollection::get(const std::string& key) {
     std::string soma_object_type = this->type();
 
     if (soma_object_type.compare("SOMACollection") == 0)
-        return SOMACollection::open(TILEDB_READ, member.uri());
+        return SOMACollection::open(member.uri(), TILEDB_READ);
     else if (soma_object_type.compare("SOMAExperiment") == 0)
-        return SOMAExperiment::open(TILEDB_READ, member.uri());
+        return SOMAExperiment::open(member.uri(), TILEDB_READ);
     else if (soma_object_type.compare("SOMAMeasurement") == 0)
-        return SOMAMeasurement::open(TILEDB_READ, member.uri());
+        return SOMAMeasurement::open(member.uri(), TILEDB_READ);
     else if (soma_object_type.compare("SOMADataFrame") == 0)
-        return SOMADataFrame::open(TILEDB_READ, member.uri());
+        return SOMADataFrame::open(member.uri(), TILEDB_READ);
     else if (soma_object_type.compare("SOMASparseNDArray") == 0)
-        return SOMASparseNDArray::open(TILEDB_READ, member.uri());
+        return SOMASparseNDArray::open(member.uri(), TILEDB_READ);
     else if (soma_object_type.compare("SOMADenseNDArray") == 0)
-        return SOMADenseNDArray::open(TILEDB_READ, member.uri());
+        return SOMADenseNDArray::open(member.uri(), TILEDB_READ);
 
     throw TileDBSOMAError("Saw invalid SOMA object.");
 }
@@ -137,7 +143,7 @@ std::unique_ptr<SOMACollection> SOMACollection::add_new_collection(
     std::string_view uri,
     bool relative,
     std::shared_ptr<Context> ctx) {
-    auto member = SOMACollection::create(ctx, uri);
+    auto member = SOMACollection::create(uri, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }
@@ -148,7 +154,7 @@ std::unique_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     bool relative,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMAExperiment::create(ctx, uri, schema);
+    auto member = SOMAExperiment::create(uri, schema, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }
@@ -159,7 +165,7 @@ std::unique_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     bool relative,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMAMeasurement::create(ctx, uri, schema);
+    auto member = SOMAMeasurement::create(uri, schema, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }
@@ -170,7 +176,7 @@ std::unique_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     bool relative,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMADataFrame::create(ctx, uri, schema);
+    auto member = SOMADataFrame::create(uri, schema, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }
@@ -181,7 +187,7 @@ std::unique_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     bool relative,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMADenseNDArray::create(ctx, uri, schema);
+    auto member = SOMADenseNDArray::create(uri, schema, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }
@@ -192,7 +198,7 @@ std::unique_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     bool relative,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMASparseNDArray::create(ctx, uri, schema);
+    auto member = SOMASparseNDArray::create(uri, schema, ctx);
     group_->add_member(std::string(uri), relative, std::string(key));
     return member;
 }

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -41,19 +41,19 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMACollection> SOMACollection::create(
+std::unique_ptr<SOMACollection> SOMACollection::create(
     std::string_view uri, std::map<std::string, std::string> platform_config) {
     return SOMACollection::create(
         uri, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMACollection> SOMACollection::create(
+std::unique_ptr<SOMACollection> SOMACollection::create(
     std::string_view uri, std::shared_ptr<Context> ctx) {
     SOMAGroup::create(ctx, uri, "SOMACollection");
-    return std::make_shared<SOMACollection>(OpenMode::read, uri, ctx);
+    return SOMACollection::open(uri, OpenMode::read, ctx);
 }
 
-std::shared_ptr<SOMACollection> SOMACollection::open(
+std::unique_ptr<SOMACollection> SOMACollection::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config) {
@@ -61,9 +61,9 @@ std::shared_ptr<SOMACollection> SOMACollection::open(
         uri, mode, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMACollection> SOMACollection::open(
+std::unique_ptr<SOMACollection> SOMACollection::open(
     std::string_view uri, OpenMode mode, std::shared_ptr<Context> ctx) {
-    return std::make_shared<SOMACollection>(mode, uri, ctx);
+    return std::make_unique<SOMACollection>(mode, uri, ctx);
 }
 
 //===================================================================
@@ -146,7 +146,8 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     std::string_view uri,
     URIType uri_type,
     std::shared_ptr<Context> ctx) {
-    auto member = SOMACollection::create(uri, ctx);
+    // auto member = SOMACollection::create(uri, ctx);
+    std::shared_ptr<SOMACollection> member = SOMACollection::create(uri, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -158,7 +159,9 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     URIType uri_type,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMAExperiment::create(uri, schema, ctx);
+    // auto member = SOMAExperiment::create(uri, schema, ctx);
+    std::shared_ptr<SOMAExperiment> member = SOMAExperiment::create(
+        uri, schema, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -170,7 +173,9 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     URIType uri_type,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMAMeasurement::create(uri, schema, ctx);
+    // auto member = SOMAMeasurement::create(uri, schema, ctx);
+    std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::create(
+        uri, schema, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -182,7 +187,9 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     URIType uri_type,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMADataFrame::create(uri, schema, ctx);
+    // auto member = SOMADataFrame::create(uri, schema, ctx);
+    std::shared_ptr<SOMADataFrame> member = SOMADataFrame::create(
+        uri, schema, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -194,7 +201,9 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     URIType uri_type,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMADenseNDArray::create(uri, schema, ctx);
+    // auto member = SOMADenseNDArray::create(uri, schema, ctx);
+    std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::create(
+        uri, schema, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -206,7 +215,9 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     URIType uri_type,
     std::shared_ptr<Context> ctx,
     ArraySchema schema) {
-    auto member = SOMASparseNDArray::create(uri, schema, ctx);
+    // auto member = SOMASparseNDArray::create(uri, schema, ctx);
+    std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::create(
+        uri, schema, ctx);
     group_->add_member(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -1,0 +1,200 @@
+/**
+ * @file   soma_collection.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMACollection class.
+ */
+
+#include "soma_collection.h"
+#include "soma_experiment.h"
+#include "soma_measurement.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+//===================================================================
+//= public static
+//===================================================================
+
+std::unique_ptr<SOMACollection> SOMACollection::create(
+    std::shared_ptr<Context> ctx, std::string_view uri) {
+    SOMAGroup::create(ctx, uri, "SOMACollection");
+    return std::make_unique<SOMACollection>(TILEDB_READ, uri, ctx);
+}
+
+std::unique_ptr<SOMACollection> SOMACollection::open(
+    tiledb_query_type_t mode,
+    std::string_view uri,
+    std::map<std::string, std::string> platform_config) {
+    return std::make_unique<SOMACollection>(
+        mode, uri, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMACollection> SOMACollection::open(
+    tiledb_query_type_t mode,
+    std::shared_ptr<Context> ctx,
+    std::string_view uri) {
+    return std::make_unique<SOMACollection>(mode, uri, ctx);
+}
+
+//===================================================================
+//= public non-static
+//===================================================================
+
+SOMACollection::SOMACollection(
+    tiledb_query_type_t mode,
+    std::string_view uri,
+    std::shared_ptr<Context> ctx,
+    std::optional<uint64_t> timestamp) {
+    group_ = std::make_shared<SOMAGroup>(mode, uri, "", ctx, timestamp);
+}
+
+void SOMACollection::open(tiledb_query_type_t mode) {
+    group_->open(mode);
+}
+
+void SOMACollection::close() {
+    group_->close();
+}
+
+const std::string SOMACollection::uri() const {
+    return group_->uri();
+}
+
+std::shared_ptr<Context> SOMACollection::ctx() {
+    return group_->ctx();
+}
+
+void SOMACollection::set(
+    std::string_view uri, bool relative, const std::string& key) {
+    group_->add_member(std::string(uri), relative, key);
+}
+
+std::unique_ptr<SOMAObject> SOMACollection::get(const std::string& key) {
+    auto member = group_->get_member(key);
+    std::string soma_object_type = this->type();
+
+    if (soma_object_type.compare("SOMACollection") == 0)
+        return SOMACollection::open(TILEDB_READ, member.uri());
+    else if (soma_object_type.compare("SOMAExperiment") == 0)
+        return SOMAExperiment::open(TILEDB_READ, member.uri());
+    else if (soma_object_type.compare("SOMAMeasurement") == 0)
+        return SOMAMeasurement::open(TILEDB_READ, member.uri());
+    else if (soma_object_type.compare("SOMADataFrame") == 0)
+        return SOMADataFrame::open(TILEDB_READ, member.uri());
+    else if (soma_object_type.compare("SOMASparseNDArray") == 0)
+        return SOMASparseNDArray::open(TILEDB_READ, member.uri());
+    else if (soma_object_type.compare("SOMADenseNDArray") == 0)
+        return SOMADenseNDArray::open(TILEDB_READ, member.uri());
+
+    throw TileDBSOMAError("Saw invalid SOMA object.");
+}
+
+bool SOMACollection::has(const std::string& key) {
+    return group_->has_member(key);
+}
+
+uint64_t SOMACollection::count() const {
+    return group_->get_length();
+}
+
+void SOMACollection::del(const std::string& key) {
+    group_->remove_member(key);
+}
+
+std::map<std::string, std::string> SOMACollection::member_to_uri_mapping()
+    const {
+    return group_->member_to_uri_mapping();
+};
+
+std::unique_ptr<SOMACollection> SOMACollection::add_new_collection(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx) {
+    auto member = SOMACollection::create(ctx, uri);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+std::unique_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx,
+    ArraySchema schema) {
+    auto member = SOMAExperiment::create(ctx, uri, schema);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+std::unique_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx,
+    ArraySchema schema) {
+    auto member = SOMAMeasurement::create(ctx, uri, schema);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+std::unique_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx,
+    ArraySchema schema) {
+    auto member = SOMADataFrame::create(ctx, uri, schema);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+std::unique_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx,
+    ArraySchema schema) {
+    auto member = SOMADenseNDArray::create(ctx, uri, schema);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+std::unique_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
+    std::string_view key,
+    std::string_view uri,
+    bool relative,
+    std::shared_ptr<Context> ctx,
+    ArraySchema schema) {
+    auto member = SOMASparseNDArray::create(ctx, uri, schema);
+    group_->add_member(std::string(uri), relative, std::string(key));
+    return member;
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -84,7 +84,9 @@ void SOMACollection::open(OpenMode mode) {
 
 void SOMACollection::close() {
     for (auto mem : children_) {
-        mem.second->close();
+        if (mem.second->is_open()) {
+            mem.second->close();
+        }
     }
     group_->close();
 }

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -1,0 +1,289 @@
+/**
+ * @file   soma_collection.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMACollection class.
+ */
+
+#ifndef SOMA_COLLECTION
+#define SOMA_COLLECTION
+
+#include <tiledb/tiledb>
+
+#include "soma_dataframe.h"
+#include "soma_dense_ndarray.h"
+#include "soma_group.h"
+#include "soma_object.h"
+#include "soma_sparse_ndarray.h"
+
+namespace tiledbsoma {
+
+class SOMAExperiment;
+class SOMAMeasurement;
+
+using namespace tiledb;
+
+class SOMACollection : public SOMAObject {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMACollection object at the given URI.
+     *
+     * @param ctx TileDB context
+     * @param uri URI to create the SOMACollection
+     */
+    static std::unique_ptr<SOMACollection> create(
+        std::shared_ptr<Context> ctx, std::string_view uri);
+
+    /**
+     * @brief Open a group at the specified URI and return SOMACollection
+     * object.
+     *
+     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param uri URI of the array
+     * @param platform_config Config parameter dictionary
+     * @return std::unique_ptr<SOMACollection> SOMACollection
+     */
+    static std::unique_ptr<SOMACollection> open(
+        tiledb_query_type_t mode,
+        std::string_view uri,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Open a group at the specified URI and return SOMACollection
+     * object.
+     *
+     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param ctx TileDB context
+     * @param uri URI of the array
+     * @return std::unique_ptr<SOMACollection> SOMACollection
+     */
+    static std::unique_ptr<SOMACollection> open(
+        tiledb_query_type_t mode,
+        std::shared_ptr<Context> ctx,
+        std::string_view uri);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    /**
+     * @brief Construct a new SOMACollection object.
+     *
+     * @param ctx TileDB context
+     * @param key key of the array
+     */
+    SOMACollection(
+        tiledb_query_type_t mode,
+        std::string_view uri,
+        std::shared_ptr<Context> ctx,
+        std::optional<uint64_t> timestamp = std::nullopt);
+
+    SOMACollection() = delete;
+    SOMACollection(const SOMACollection&) = delete;
+    SOMACollection(SOMACollection&&) = default;
+    ~SOMACollection() = default;
+
+    /**
+     * Open the SOMACollection object.
+     *
+     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param timestamp Timestamp
+     */
+    void open(tiledb_query_type_t mode);
+
+    /**
+     * Closes the SOMACollection object.
+     */
+    void close();
+
+    /**
+     * Return the constant "SOMACollection".
+     *
+     * @return std::string
+     */
+    const std::string type() const {
+        return "SOMACollection";
+    }
+
+    /**
+     * Get the SOMACollection URI.
+     */
+    const std::string uri() const;
+
+    /**
+     * Get the Context associated with the SOMACollection.
+     *
+     * @return std::shared_ptr<Context>
+     */
+    std::shared_ptr<Context> ctx();
+
+    /**
+     * Set an already existing SOMAObject with the given key.
+     *
+     * @param key of member
+     * @param object SOMA object to add
+     */
+    void set(std::string_view uri, bool relative, const std::string& key);
+
+    /**
+     * Get the SOMAObject associated with the key.
+     *
+     * @param key of member
+     */
+    std::unique_ptr<SOMAObject> get(const std::string& key);
+
+    /**
+     * Check if the SOMACollection contains the given key.
+     *
+     * @param key of member
+     */
+    bool has(const std::string& key);
+
+    /**
+     * Get the number of SOMAObjects in the SOMACollection.
+     */
+    uint64_t count() const;
+
+    /**
+     * Delete the SOMAObject associated with the key.
+     *
+     * @param key of member
+     */
+    void del(const std::string& key);
+
+    /**
+     * Get the member key to URI mapping of the SOMACollection.
+     */
+    std::map<std::string, std::string> member_to_uri_mapping() const;
+
+    /**
+     * Create and add a SOMACollection to the SOMACollection.
+     *
+     * @param key of collection
+     * @param uri of SOMACollection to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMACollection> add_new_collection(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx);
+
+    /**
+     * Create and add a SOMAExperiment to the SOMACollection.
+     *
+     * @param key of collection
+     * @param uri of SOMAExperiment to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMAExperiment> add_new_experiment(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx,
+        ArraySchema schema);
+    // std::string_view obs_uri,
+    // std::string_view ms_uri);
+
+    /**
+     * Create and add a SOMAMeasurement to the SOMACollection.
+     *
+     * @param key of collection
+     * @param uri of SOMAMeasurement to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMAMeasurement> add_new_measurement(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx,
+        ArraySchema schema);
+    // std::string_view var_uri,
+    // std::string_view X_uri,
+    // std::string_view obsm_uri,
+    // std::string_view obsp_uri,
+    // std::string_view varm_uri,
+    // std::string_view varp_uri);
+
+    /**
+     * Create and add a SOMADataFrame to the SOMACollection.
+     *
+     * @param key of dataframe
+     * @param uri of SOMADataFrame to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMADataFrame> add_new_dataframe(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx,
+        ArraySchema schema);
+
+    /**
+     * Create and add a SOMADenseNDArray to the SOMACollection.
+     *
+     * @param key of dense array
+     * @param uri of SOMADenseNDArray to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMADenseNDArray> add_new_dense_ndarray(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx,
+        ArraySchema schema);
+
+    /**
+     * Create and add a SOMASparseNDArray to the SOMACollection.
+     *
+     * @param key of sparse array
+     * @param uri of SOMASparseNDArray to add
+     * @param relative whether the given URI is relative
+     */
+    std::unique_ptr<SOMASparseNDArray> add_new_sparse_ndarray(
+        std::string_view key,
+        std::string_view uri,
+        bool relative,
+        std::shared_ptr<Context> ctx,
+        ArraySchema schema);
+
+   protected:
+    //===================================================================
+    //= protected non-static
+    //===================================================================
+
+    // SOMAGroup
+    std::shared_ptr<SOMAGroup> group_;
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_COLLECTION

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -61,7 +61,7 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param platform_config Optional config parameter dictionary
      */
-    static std::unique_ptr<SOMACollection> create(
+    static std::shared_ptr<SOMACollection> create(
         std::string_view uri,
         std::map<std::string, std::string> platform_config = {});
 
@@ -71,7 +71,7 @@ class SOMACollection : public SOMAObject {
      * @param ctx TileDB context
      * @param uri URI to create the SOMACollection
      */
-    static std::unique_ptr<SOMACollection> create(
+    static std::shared_ptr<SOMACollection> create(
         std::string_view uri, std::shared_ptr<Context> ctx);
 
     /**
@@ -81,9 +81,9 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param platform_config Config parameter dictionary
-     * @return std::unique_ptr<SOMACollection> SOMACollection
+     * @return std::shared_ptr<SOMACollection> SOMACollection
      */
-    static std::unique_ptr<SOMACollection> open(
+    static std::shared_ptr<SOMACollection> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {});
@@ -95,9 +95,9 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param ctx TileDB context
-     * @return std::unique_ptr<SOMACollection> SOMACollection
+     * @return std::shared_ptr<SOMACollection> SOMACollection
      */
-    static std::unique_ptr<SOMACollection> open(
+    static std::shared_ptr<SOMACollection> open(
         std::string_view uri, OpenMode mode, std::shared_ptr<Context> ctx);
 
     //===================================================================
@@ -119,7 +119,7 @@ class SOMACollection : public SOMAObject {
         std::optional<uint64_t> timestamp = std::nullopt);
 
     SOMACollection() = delete;
-    SOMACollection(const SOMACollection&) = delete;
+    SOMACollection(const SOMACollection&) = default;
     SOMACollection(SOMACollection&&) = default;
     ~SOMACollection() = default;
 
@@ -135,6 +135,15 @@ class SOMACollection : public SOMAObject {
      * Closes the SOMACollection object.
      */
     void close();
+
+    /**
+     * Check if the SOMACollection is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const {
+        return group_->is_open();
+    }
 
     /**
      * Return the constant "SOMACollection".
@@ -172,7 +181,7 @@ class SOMACollection : public SOMAObject {
      *
      * @param key of member
      */
-    std::unique_ptr<SOMAObject> get(const std::string& key);
+    std::shared_ptr<SOMAObject> get(const std::string& key);
 
     /**
      * Check if the SOMACollection contains the given key.
@@ -206,7 +215,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMACollection> add_new_collection(
+    std::shared_ptr<SOMACollection> add_new_collection(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -220,7 +229,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMAExperiment> add_new_experiment(
+    std::shared_ptr<SOMAExperiment> add_new_experiment(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -235,7 +244,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMAMeasurement> add_new_measurement(
+    std::shared_ptr<SOMAMeasurement> add_new_measurement(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -250,7 +259,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMADataFrame> add_new_dataframe(
+    std::shared_ptr<SOMADataFrame> add_new_dataframe(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -265,7 +274,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMADenseNDArray> add_new_dense_ndarray(
+    std::shared_ptr<SOMADenseNDArray> add_new_dense_ndarray(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -280,7 +289,7 @@ class SOMACollection : public SOMAObject {
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
      */
-    std::unique_ptr<SOMASparseNDArray> add_new_sparse_ndarray(
+    std::shared_ptr<SOMASparseNDArray> add_new_sparse_ndarray(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
@@ -294,6 +303,9 @@ class SOMACollection : public SOMAObject {
 
     // SOMAGroup
     std::shared_ptr<SOMAGroup> group_;
+
+    // Members of the SOMACollection
+    std::map<std::string, std::shared_ptr<SOMAObject>> children_;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -61,7 +61,7 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param platform_config Optional config parameter dictionary
      */
-    static std::shared_ptr<SOMACollection> create(
+    static std::unique_ptr<SOMACollection> create(
         std::string_view uri,
         std::map<std::string, std::string> platform_config = {});
 
@@ -71,7 +71,7 @@ class SOMACollection : public SOMAObject {
      * @param ctx TileDB context
      * @param uri URI to create the SOMACollection
      */
-    static std::shared_ptr<SOMACollection> create(
+    static std::unique_ptr<SOMACollection> create(
         std::string_view uri, std::shared_ptr<Context> ctx);
 
     /**
@@ -83,7 +83,7 @@ class SOMACollection : public SOMAObject {
      * @param platform_config Config parameter dictionary
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
-    static std::shared_ptr<SOMACollection> open(
+    static std::unique_ptr<SOMACollection> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {});
@@ -97,7 +97,7 @@ class SOMACollection : public SOMAObject {
      * @param ctx TileDB context
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
-    static std::shared_ptr<SOMACollection> open(
+    static std::unique_ptr<SOMACollection> open(
         std::string_view uri, OpenMode mode, std::shared_ptr<Context> ctx);
 
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -58,10 +58,20 @@ class SOMACollection : public SOMAObject {
      * @brief Create a SOMACollection object at the given URI.
      *
      * @param ctx TileDB context
+     * @param platform_config Optional config parameter dictionary
+     */
+    static std::unique_ptr<SOMACollection> create(
+        std::string_view uri,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMACollection object at the given URI.
+     *
+     * @param ctx TileDB context
      * @param uri URI to create the SOMACollection
      */
     static std::unique_ptr<SOMACollection> create(
-        std::shared_ptr<Context> ctx, std::string_view uri);
+        std::string_view uri, std::shared_ptr<Context> ctx);
 
     /**
      * @brief Open a group at the specified URI and return SOMACollection
@@ -73,8 +83,8 @@ class SOMACollection : public SOMAObject {
      * @return std::unique_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
-        tiledb_query_type_t mode,
         std::string_view uri,
+        tiledb_query_type_t mode,
         std::map<std::string, std::string> platform_config = {});
 
     /**
@@ -87,9 +97,9 @@ class SOMACollection : public SOMAObject {
      * @return std::unique_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
+        std::string_view uri,
         tiledb_query_type_t mode,
-        std::shared_ptr<Context> ctx,
-        std::string_view uri);
+        std::shared_ptr<Context> ctx);
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -42,7 +42,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMADataFrame> SOMADataFrame::create(
+std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -50,13 +50,13 @@ std::shared_ptr<SOMADataFrame> SOMADataFrame::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMADataFrame> SOMADataFrame::create(
+std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     SOMAArray::create(ctx, uri, schema, "SOMADataFrame");
     return SOMADataFrame::open(uri, OpenMode::read, ctx);
 }
 
-std::shared_ptr<SOMADataFrame> SOMADataFrame::open(
+std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -72,14 +72,14 @@ std::shared_ptr<SOMADataFrame> SOMADataFrame::open(
         timestamp);
 }
 
-std::shared_ptr<SOMADataFrame> SOMADataFrame::open(
+std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_shared<SOMADataFrame>(
+    return std::make_unique<SOMADataFrame>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -42,7 +42,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
+std::shared_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -50,13 +50,13 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
+std::shared_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     SOMAArray::create(ctx, uri, schema, "SOMADataFrame");
     return SOMADataFrame::open(uri, OpenMode::read, ctx);
 }
 
-std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
+std::shared_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -72,14 +72,14 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
         timestamp);
 }
 
-std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
+std::shared_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_unique<SOMADataFrame>(
+    return std::make_shared<SOMADataFrame>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -53,32 +53,34 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
 std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     SOMAArray::create(ctx, uri, schema, "SOMADataFrame");
-    return std::make_unique<SOMADataFrame>(
-        TILEDB_READ, uri, ctx, std::vector<std::string>(), std::nullopt);
+    return SOMADataFrame::open(uri, OpenMode::read, ctx);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::map<std::string, std::string> platform_config,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return SOMADataFrame::open(
         uri,
         mode,
         std::make_shared<Context>(Config(platform_config)),
         column_names,
+        result_order,
         timestamp);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::string_view uri,
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return std::make_unique<SOMADataFrame>(
-        mode, uri, ctx, column_names, timestamp);
+        mode, uri, ctx, column_names, result_order, timestamp);
 }
 
 //===================================================================
@@ -86,10 +88,11 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
 //===================================================================
 
 SOMADataFrame::SOMADataFrame(
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::string_view uri,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     array_ = std::make_shared<SOMAArray>(
         mode,
@@ -98,15 +101,14 @@ SOMADataFrame::SOMADataFrame(
         ctx,
         column_names,
         "auto",  // batch_size,
-        "auto",  // result_order,
+        result_order,
         timestamp);
     array_->reset();
     array_->submit();
 }
 
 void SOMADataFrame::open(
-    tiledb_query_type_t mode,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     array_->open(mode, timestamp);
     array_->reset();
     array_->submit();

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -105,7 +105,7 @@ void SOMADataFrame::close() {
     array_->close();
 }
 
-const std::string& SOMADataFrame::uri() const {
+const std::string SOMADataFrame::uri() const {
     return array_->uri();
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -118,6 +118,10 @@ void SOMADataFrame::close() {
     array_->close();
 }
 
+bool SOMADataFrame::is_open() const {
+    return array_->is_open();
+}
+
 const std::string SOMADataFrame::uri() const {
     return array_->uri();
 }

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -43,27 +43,38 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
-    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string_view uri,
+    ArraySchema schema,
+    std::map<std::string, std::string> platform_config) {
+    return SOMADataFrame::create(
+        uri, schema, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
+    std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     SOMAArray::create(ctx, uri, schema, "SOMADataFrame");
     return std::make_unique<SOMADataFrame>(
         TILEDB_READ, uri, ctx, std::vector<std::string>(), std::nullopt);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
-    tiledb_query_type_t mode,
     std::string_view uri,
-    std::vector<std::string> column_names,
+    tiledb_query_type_t mode,
     std::map<std::string, std::string> platform_config,
+    std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    auto ctx = std::make_shared<Context>(Config(platform_config));
-    return std::make_unique<SOMADataFrame>(
-        mode, uri, ctx, column_names, timestamp);
+    return SOMADataFrame::open(
+        uri,
+        mode,
+        std::make_shared<Context>(Config(platform_config)),
+        column_names,
+        timestamp);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
+    std::string_view uri,
     tiledb_query_type_t mode,
     std::shared_ptr<Context> ctx,
-    std::string_view uri,
     std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return std::make_unique<SOMADataFrame>(

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -166,6 +166,13 @@ class SOMADataFrame : public SOMAObject {
     void close();
 
     /**
+     * Check if the SOMADataFrame is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const;
+
+    /**
      * Return the constant "SOMADataFrame".
      *
      * @return std::string

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -52,13 +52,26 @@ class SOMADataFrame : public SOMAObject {
     /**
      * @brief Create a SOMADataFrame object at the given URI.
      *
-     * @param ctx TileDB context
      * @param uri URI to create the SOMADataFrame
      * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
      * @return std::unique_ptr<SOMADataFrame> opened in read mode
      */
     static std::unique_ptr<SOMADataFrame> create(
-        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+        std::string_view uri,
+        ArraySchema schema,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMADataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMADataFrame
+     * @param schema TileDB ArraySchema
+     * @param ctx TileDB context
+     * @return std::unique_ptr<SOMADataFrame> opened in read mode
+     */
+    static std::unique_ptr<SOMADataFrame> create(
+        std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
      * @brief Open and return a SOMADataFrame object at the given URI.
@@ -75,10 +88,10 @@ class SOMADataFrame : public SOMAObject {
      * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
      */
     static std::unique_ptr<SOMADataFrame> open(
-        tiledb_query_type_t mode,
         std::string_view uri,
-        std::vector<std::string> column_names = {},
+        tiledb_query_type_t mode,
         std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -96,9 +109,9 @@ class SOMADataFrame : public SOMAObject {
      * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
      */
     static std::unique_ptr<SOMADataFrame> open(
+        std::string_view uri,
         tiledb_query_type_t mode,
         std::shared_ptr<Context> ctx,
-        std::string_view uri,
         std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -58,7 +58,7 @@ class SOMADataFrame : public SOMAObject {
      * @param platform_config Optional config parameter dictionary
      * @return std::shared_ptr<SOMADataFrame> opened in read mode
      */
-    static std::shared_ptr<SOMADataFrame> create(
+    static std::unique_ptr<SOMADataFrame> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -71,7 +71,7 @@ class SOMADataFrame : public SOMAObject {
      * @param ctx TileDB context
      * @return std::shared_ptr<SOMADataFrame> opened in read mode
      */
-    static std::shared_ptr<SOMADataFrame> create(
+    static std::unique_ptr<SOMADataFrame> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -90,7 +90,7 @@ class SOMADataFrame : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::shared_ptr<SOMADataFrame> SOMADataFrame
      */
-    static std::shared_ptr<SOMADataFrame> open(
+    static std::unique_ptr<SOMADataFrame> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -114,7 +114,7 @@ class SOMADataFrame : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::shared_ptr<SOMADataFrame> SOMADataFrame
      */
-    static std::shared_ptr<SOMADataFrame> open(
+    static std::unique_ptr<SOMADataFrame> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -34,6 +34,7 @@
 #define SOMA_DATAFRAME
 
 #include <tiledb/tiledb>
+#include "enums.h"
 #include "soma_object.h"
 
 namespace tiledbsoma {
@@ -76,43 +77,49 @@ class SOMADataFrame : public SOMAObject {
     /**
      * @brief Open and return a SOMADataFrame object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI to create the SOMADataFrame
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
      * @param platform_config Platform-specific options used to create this
      * DataFrame
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
      */
     static std::unique_ptr<SOMADataFrame> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMADataFrame object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param ctx TileDB context
      * @param uri URI to create the SOMADataFrame
      * @param schema TileDB ArraySchema
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
      */
     static std::unique_ptr<SOMADataFrame> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
@@ -122,17 +129,20 @@ class SOMADataFrame : public SOMAObject {
     /**
      * @brief Construct a new SOMADataFrame object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param ctx TileDB context
      * @param column_names Columns to read
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp Timestamp
      */
     SOMADataFrame(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names,
+        ResultOrder result_order,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     SOMADataFrame() = delete;
@@ -143,11 +153,11 @@ class SOMADataFrame : public SOMAObject {
     /**
      * Open the SOMADataFrame object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param timestamp Timestamp
      */
     void open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -207,6 +217,7 @@ class SOMADataFrame : public SOMAObject {
 
     /**
      * @brief Write data to the dataframe.
+     * @param buffers The ArrayBuffers to write
      */
     void write(std::shared_ptr<ArrayBuffers> buffers);
 

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -120,7 +120,7 @@ class SOMADataFrame : public SOMAObject {
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp);
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     SOMADataFrame() = delete;
     SOMADataFrame(const SOMADataFrame&) = delete;
@@ -147,7 +147,7 @@ class SOMADataFrame : public SOMAObject {
      *
      * @return std::string
      */
-    std::string type() const {
+    const std::string type() const {
         return "SOMADataFrame";
     }
 
@@ -156,7 +156,7 @@ class SOMADataFrame : public SOMAObject {
      *
      * @return std::string URI
      */
-    const std::string& uri() const;
+    const std::string uri() const;
 
     /**
      * Get the Context associated with the SOMADataFrame.

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -56,9 +56,9 @@ class SOMADataFrame : public SOMAObject {
      * @param uri URI to create the SOMADataFrame
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
-     * @return std::unique_ptr<SOMADataFrame> opened in read mode
+     * @return std::shared_ptr<SOMADataFrame> opened in read mode
      */
-    static std::unique_ptr<SOMADataFrame> create(
+    static std::shared_ptr<SOMADataFrame> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -69,9 +69,9 @@ class SOMADataFrame : public SOMAObject {
      * @param uri URI to create the SOMADataFrame
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
-     * @return std::unique_ptr<SOMADataFrame> opened in read mode
+     * @return std::shared_ptr<SOMADataFrame> opened in read mode
      */
-    static std::unique_ptr<SOMADataFrame> create(
+    static std::shared_ptr<SOMADataFrame> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -88,9 +88,9 @@ class SOMADataFrame : public SOMAObject {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
+     * @return std::shared_ptr<SOMADataFrame> SOMADataFrame
      */
-    static std::unique_ptr<SOMADataFrame> open(
+    static std::shared_ptr<SOMADataFrame> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -112,9 +112,9 @@ class SOMADataFrame : public SOMAObject {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
+     * @return std::shared_ptr<SOMADataFrame> SOMADataFrame
      */
-    static std::unique_ptr<SOMADataFrame> open(
+    static std::shared_ptr<SOMADataFrame> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -40,7 +40,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -48,7 +48,7 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_DENSE)
         throw TileDBSOMAError("ArraySchema must be set to dense.");
@@ -57,7 +57,7 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     return SOMADenseNDArray::open(uri, OpenMode::read, ctx);
 }
 
-std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
+std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -73,14 +73,14 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
         timestamp);
 }
 
-std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
+std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_unique<SOMADenseNDArray>(
+    return std::make_shared<SOMADenseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -119,6 +119,10 @@ void SOMADenseNDArray::close() {
     array_->close();
 }
 
+bool SOMADenseNDArray::is_open() const {
+    return array_->is_open();
+}
+
 const std::string SOMADenseNDArray::uri() const {
     return array_->uri();
 }

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -40,7 +40,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -48,7 +48,7 @@ std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_DENSE)
         throw TileDBSOMAError("ArraySchema must be set to dense.");
@@ -57,7 +57,7 @@ std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     return SOMADenseNDArray::open(uri, OpenMode::read, ctx);
 }
 
-std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -73,14 +73,14 @@ std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
         timestamp);
 }
 
-std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_shared<SOMADenseNDArray>(
+    return std::make_unique<SOMADenseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -106,7 +106,7 @@ void SOMADenseNDArray::close() {
     array_->close();
 }
 
-const std::string& SOMADenseNDArray::uri() const {
+const std::string SOMADenseNDArray::uri() const {
     return array_->uri();
 }
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -41,7 +41,15 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
-    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string_view uri,
+    ArraySchema schema,
+    std::map<std::string, std::string> platform_config) {
+    return SOMADenseNDArray::create(
+        uri, schema, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+    std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_DENSE)
         throw TileDBSOMAError("ArraySchema must be set to dense.");
 
@@ -51,20 +59,23 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
 }
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
-    tiledb_query_type_t mode,
     std::string_view uri,
-    std::vector<std::string> column_names,
+    tiledb_query_type_t mode,
     std::map<std::string, std::string> platform_config,
+    std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    auto ctx = std::make_shared<Context>(Config(platform_config));
-    return std::make_unique<SOMADenseNDArray>(
-        mode, uri, ctx, column_names, timestamp);
+    return SOMADenseNDArray::open(
+        uri,
+        mode,
+        std::make_shared<Context>(Config(platform_config)),
+        column_names,
+        timestamp);
 }
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
+    std::string_view uri,
     tiledb_query_type_t mode,
     std::shared_ptr<Context> ctx,
-    std::string_view uri,
     std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return std::make_unique<SOMADenseNDArray>(

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -52,13 +52,26 @@ class SOMADenseNDArray : public SOMAObject {
     /**
      * @brief Create a SOMADenseNDArray object at the given URI.
      *
-     * @param ctx TileDB context
      * @param uri URI to create the SOMADenseNDArray
      * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
      * @return std::unique_ptr<SOMADenseNDArray> opened in read mode
      */
     static std::unique_ptr<SOMADenseNDArray> create(
-        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+        std::string_view uri,
+        ArraySchema schema,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMADenseNDArray object at the given URI.
+     *
+     * @param uri URI to create the SOMADenseNDArray
+     * @param schema TileDB ArraySchema
+     * @param ctx TileDB context
+     * @return std::unique_ptr<SOMADenseNDArray> opened in read mode
+     */
+    static std::unique_ptr<SOMADenseNDArray> create(
+        std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
      * @brief Open and return a SOMADenseNDArray object at the given URI.
@@ -75,10 +88,10 @@ class SOMADenseNDArray : public SOMAObject {
      * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
     static std::unique_ptr<SOMADenseNDArray> open(
-        tiledb_query_type_t mode,
         std::string_view uri,
-        std::vector<std::string> column_names = {},
+        tiledb_query_type_t mode,
         std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -96,9 +109,9 @@ class SOMADenseNDArray : public SOMAObject {
      * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
     static std::unique_ptr<SOMADenseNDArray> open(
+        std::string_view uri,
         tiledb_query_type_t mode,
         std::shared_ptr<Context> ctx,
-        std::string_view uri,
         std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -56,9 +56,9 @@ class SOMADenseNDArray : public SOMAObject {
      * @param uri URI to create the SOMADenseNDArray
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
-     * @return std::unique_ptr<SOMADenseNDArray> opened in read mode
+     * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
      */
-    static std::unique_ptr<SOMADenseNDArray> create(
+    static std::shared_ptr<SOMADenseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -69,9 +69,9 @@ class SOMADenseNDArray : public SOMAObject {
      * @param uri URI to create the SOMADenseNDArray
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
-     * @return std::unique_ptr<SOMADenseNDArray> opened in read mode
+     * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
      */
-    static std::unique_ptr<SOMADenseNDArray> create(
+    static std::shared_ptr<SOMADenseNDArray> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -88,9 +88,9 @@ class SOMADenseNDArray : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
-     * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
+     * @return std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
-    static std::unique_ptr<SOMADenseNDArray> open(
+    static std::shared_ptr<SOMADenseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -112,9 +112,9 @@ class SOMADenseNDArray : public SOMAObject {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
+     * @return std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
-    static std::unique_ptr<SOMADenseNDArray> open(
+    static std::shared_ptr<SOMADenseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -58,7 +58,7 @@ class SOMADenseNDArray : public SOMAObject {
      * @param platform_config Optional config parameter dictionary
      * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
      */
-    static std::shared_ptr<SOMADenseNDArray> create(
+    static std::unique_ptr<SOMADenseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -71,7 +71,7 @@ class SOMADenseNDArray : public SOMAObject {
      * @param ctx TileDB context
      * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
      */
-    static std::shared_ptr<SOMADenseNDArray> create(
+    static std::unique_ptr<SOMADenseNDArray> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -90,7 +90,7 @@ class SOMADenseNDArray : public SOMAObject {
      * colmajor
      * @return std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
-    static std::shared_ptr<SOMADenseNDArray> open(
+    static std::unique_ptr<SOMADenseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -114,7 +114,7 @@ class SOMADenseNDArray : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
-    static std::shared_ptr<SOMADenseNDArray> open(
+    static std::unique_ptr<SOMADenseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -142,7 +142,7 @@ class SOMADenseNDArray : public SOMAObject {
      *
      * @return std::string
      */
-    std::string type() const {
+    const std::string type() const {
         return "SOMADenseNDArray";
     }
 
@@ -167,7 +167,7 @@ class SOMADenseNDArray : public SOMAObject {
      *
      * @return std::string URI
      */
-    const std::string& uri() const;
+    const std::string uri() const;
 
     /**
      * Return data schema, in the form of a TileDB ArraySchema.

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -160,6 +160,13 @@ class SOMADenseNDArray : public SOMAObject {
     void close();
 
     /**
+     * Check if the SOMADenseNDArray is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const;
+
+    /**
      * Returns the constant "SOMADenseNDArray".
      *
      * @return std::string

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -34,6 +34,7 @@
 #define SOMA_DENSE_NDARRAY
 
 #include <tiledb/tiledb>
+#include "enums.h"
 #include "soma_object.h"
 
 namespace tiledbsoma {
@@ -76,43 +77,49 @@ class SOMADenseNDArray : public SOMAObject {
     /**
      * @brief Open and return a SOMADenseNDArray object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI to create the SOMADenseNDArray
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
      * @param platform_config Platform-specific options used to create this
-     * DataFrame
+     * SOMADenseNDArray
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
     static std::unique_ptr<SOMADenseNDArray> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMADenseNDArray object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param ctx TileDB context
      * @param uri URI to create the SOMADenseNDArray
      * @param schema TileDB ArraySchema
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray
      */
     static std::unique_ptr<SOMADenseNDArray> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
@@ -122,27 +129,29 @@ class SOMADenseNDArray : public SOMAObject {
     /**
      * @brief Construct a new SOMADenseNDArray object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param ctx TileDB context
-     * @param column_names Columns to read
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp Timestamp
      */
     SOMADenseNDArray(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names,
+        ResultOrder result_order,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
     /**
      * Open the SOMADenseNDArray object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param timestamp Timestamp
      */
     void open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -212,8 +221,9 @@ class SOMADenseNDArray : public SOMAObject {
 
     /**
      * @brief Write ArrayBuffers data to the dataframe.
+     * @param buffers The ArrayBuffers to write
      */
-    void write(std::shared_ptr<ArrayBuffers>);
+    void write(std::shared_ptr<ArrayBuffers> buffers);
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -42,12 +42,20 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
-    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string_view uri,
+    ArraySchema schema,
+    std::map<std::string, std::string> platform_config) {
+    return SOMAExperiment::create(
+        uri, schema, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
+    std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
     SOMAGroup::create(ctx, exp_uri, "SOMAExperiment");
-    SOMADataFrame::create(ctx, exp_uri + "/obs", schema);
-    SOMACollection::create(ctx, exp_uri + "/ms");
+    SOMADataFrame::create(exp_uri + "/obs", schema, ctx);
+    SOMACollection::create(exp_uri + "/ms", ctx);
 
     auto group = SOMAGroup::open(TILEDB_WRITE, ctx, exp_uri);
     group->add_member(exp_uri + "/obs", false, "obs");

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -41,7 +41,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
+std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -49,7 +49,7 @@ std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
+std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
@@ -62,6 +62,6 @@ std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
     group->add_member(exp_uri + "/ms", URIType::absolute, "ms");
     group->close();
 
-    return std::make_unique<SOMAExperiment>(OpenMode::read, exp_uri, ctx);
+    return std::make_shared<SOMAExperiment>(OpenMode::read, exp_uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -41,7 +41,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
+std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -49,7 +49,7 @@ std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
+std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
@@ -62,6 +62,6 @@ std::shared_ptr<SOMAExperiment> SOMAExperiment::create(
     group->add_member(exp_uri + "/ms", URIType::absolute, "ms");
     group->close();
 
-    return std::make_shared<SOMAExperiment>(OpenMode::read, exp_uri, ctx);
+    return std::make_unique<SOMAExperiment>(OpenMode::read, exp_uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -1,11 +1,11 @@
 /**
- * @file   tiledbsoma
+ * @file   soma_experiment.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,38 +27,33 @@
  *
  * @section DESCRIPTION
  *
- * This is the main import header for the C++ API
+ *   This file defines the SOMAExperiment class.
  */
 
-#ifndef __TILEDBSOMA__
-#define __TILEDBSOMA__
+#include "soma_experiment.h"
+#include "soma_collection.h"
+#include "soma_measurement.h"
 
-// TODO Uncomment after finishing Python and R bindings
-// #include "soma_collection.h"
-// #include "soma_dataframe.h"
-// #include "soma_dense_ndarray.h"
-// #include "soma_experiment.h"
-// #include "soma_measurement.h"
-// #include "soma_object.h"
-// #include "soma_sparse_ndarray.h"
+namespace tiledbsoma {
+using namespace tiledb;
 
-#include "utils/arrow_adapter.h"
-#include "utils/common.h"
-#include "utils/stats.h"
-#include "utils/version.h"
-#include "soma/logger_public.h"
-#include "soma/managed_query.h"
-#include "soma/array_buffers.h"
-#include "soma/column_buffer.h"
-#include "soma/soma_array.h"
-#include "soma/soma_collection.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_group.h"
-#include "soma/soma_experiment.h"
-#include "soma/soma_measurement.h"
-#include "soma/soma_object.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_dense_ndarray.h"
-#include "soma/soma_sparse_ndarray.h"
+//===================================================================
+//= public static
+//===================================================================
 
-#endif
+std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
+    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string exp_uri(uri);
+
+    SOMAGroup::create(ctx, exp_uri, "SOMAExperiment");
+    SOMADataFrame::create(ctx, exp_uri + "/obs", schema);
+    SOMACollection::create(ctx, exp_uri + "/ms");
+
+    auto group = SOMAGroup::open(TILEDB_WRITE, ctx, exp_uri);
+    group->add_member(exp_uri + "/obs", false, "obs");
+    group->add_member(exp_uri + "/ms", false, "ms");
+    group->close();
+
+    return std::make_unique<SOMAExperiment>(TILEDB_READ, exp_uri, ctx);
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -57,11 +57,11 @@ std::unique_ptr<SOMAExperiment> SOMAExperiment::create(
     SOMADataFrame::create(exp_uri + "/obs", schema, ctx);
     SOMACollection::create(exp_uri + "/ms", ctx);
 
-    auto group = SOMAGroup::open(TILEDB_WRITE, ctx, exp_uri);
-    group->add_member(exp_uri + "/obs", false, "obs");
-    group->add_member(exp_uri + "/ms", false, "ms");
+    auto group = SOMAGroup::open(OpenMode::write, ctx, exp_uri);
+    group->add_member(exp_uri + "/obs", URIType::absolute, "obs");
+    group->add_member(exp_uri + "/ms", URIType::absolute, "ms");
     group->close();
 
-    return std::make_unique<SOMAExperiment>(TILEDB_READ, exp_uri, ctx);
+    return std::make_unique<SOMAExperiment>(OpenMode::read, exp_uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -50,11 +50,24 @@ class SOMAExperiment : public SOMACollection {
     /**
      * @brief Create a SOMAExperiment object at the given URI.
      *
-     * @param ctx TileDB context
      * @param uri URI to create the SOMAExperiment
+     * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
      */
     static std::unique_ptr<SOMAExperiment> create(
-        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+        std::string_view uri,
+        ArraySchema schema,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMAExperiment object at the given URI.
+     *
+     * @param uri URI to create the SOMAExperiment
+     * @param schema TileDB ArraySchema
+     * @param ctx TileDB context
+     */
+    static std::unique_ptr<SOMAExperiment> create(
+        std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -54,7 +54,7 @@ class SOMAExperiment : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
      */
-    static std::shared_ptr<SOMAExperiment> create(
+    static std::unique_ptr<SOMAExperiment> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -66,7 +66,7 @@ class SOMAExperiment : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
      */
-    static std::shared_ptr<SOMAExperiment> create(
+    static std::unique_ptr<SOMAExperiment> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -54,7 +54,7 @@ class SOMAExperiment : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
      */
-    static std::unique_ptr<SOMAExperiment> create(
+    static std::shared_ptr<SOMAExperiment> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -66,7 +66,7 @@ class SOMAExperiment : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
      */
-    static std::unique_ptr<SOMAExperiment> create(
+    static std::shared_ptr<SOMAExperiment> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================
@@ -101,10 +101,10 @@ class SOMAExperiment : public SOMACollection {
     //===================================================================
 
     // Primary annotations on the observation axis
-    std::unique_ptr<SOMADataFrame> obs_;
+    std::shared_ptr<SOMADataFrame> obs_;
 
     // A collection of named measurements
-    std::unique_ptr<SOMACollection> ms_;
+    std::shared_ptr<SOMACollection> ms_;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -74,7 +74,7 @@ class SOMAExperiment : public SOMACollection {
     //===================================================================
 
     SOMAExperiment(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::optional<uint64_t> timestamp = std::nullopt)

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -1,0 +1,98 @@
+/**
+ * @file   soma_experiment.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAExperiment class.
+ */
+
+#ifndef SOMA_EXPERIMENT
+#define SOMA_EXPERIMENT
+
+#include <tiledb/tiledb>
+
+#include "soma_collection.h"
+#include "soma_dataframe.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+class SOMAExperiment : public SOMACollection {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMAExperiment object at the given URI.
+     *
+     * @param ctx TileDB context
+     * @param uri URI to create the SOMAExperiment
+     */
+    static std::unique_ptr<SOMAExperiment> create(
+        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    SOMAExperiment(
+        tiledb_query_type_t mode,
+        std::string_view uri,
+        std::shared_ptr<Context> ctx,
+        std::optional<uint64_t> timestamp = std::nullopt)
+        : SOMACollection(mode, uri, ctx, timestamp) {
+    }
+
+    SOMAExperiment() = delete;
+    SOMAExperiment(const SOMAExperiment&) = delete;
+    SOMAExperiment(SOMAExperiment&&) = default;
+    ~SOMAExperiment() = default;
+
+    /**
+     * Return the constant "SOMAExperiment".
+     *
+     * @return std::string
+     */
+    const std::string type() const {
+        return "SOMAExperiment";
+    }
+
+   private:
+    //===================================================================
+    //= private non-static
+    //===================================================================
+
+    // Primary annotations on the observation axis
+    std::unique_ptr<SOMADataFrame> obs_;
+
+    // A collection of named measurements
+    std::unique_ptr<SOMACollection> ms_;
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_EXPERIMENT

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -41,6 +41,15 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
+void SOMAGroup::create(
+    std::shared_ptr<Context> ctx, std::string_view uri, std::string soma_type) {
+    Group::create(*ctx, std::string(uri));
+    auto group = Group(*ctx, std::string(uri), TILEDB_WRITE);
+    group.put_metadata(
+        "soma_object_type", TILEDB_STRING_UTF8, 1, soma_type.c_str());
+    group.close();
+}
+
 std::unique_ptr<SOMAGroup> SOMAGroup::open(
     tiledb_query_type_t mode,
     std::string_view uri,
@@ -98,7 +107,7 @@ void SOMAGroup::close() {
     group_->close();
 }
 
-std::string SOMAGroup::uri() const {
+const std::string SOMAGroup::uri() const {
     return group_->uri();
 }
 

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -137,6 +137,15 @@ class SOMAGroup {
     void close();
 
     /**
+     * Check if the SOMAObject is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const {
+        return group_->is_open();
+    }
+
+    /**
      * Get the SOMAGroup URI.
      */
     const std::string uri() const;

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -39,6 +39,7 @@
 #include <tiledb/tiledb_experimental>
 
 #include "../utils/common.h"
+#include "enums.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -65,7 +66,7 @@ class SOMAGroup {
      * @brief Open a group at the specified URI and return SOMAGroup
      * object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the group
      * @param name Name of the group
      * @param platform_config Config parameter dictionary
@@ -73,7 +74,7 @@ class SOMAGroup {
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::string_view name = "unnamed",
         std::map<std::string, std::string> platform_config = {},
@@ -83,7 +84,7 @@ class SOMAGroup {
      * @brief Open a group at the specified URI and return SOMAGroup
      * object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param ctx TileDB context
      * @param uri URI of the group
      * @param name Name of the group
@@ -91,7 +92,7 @@ class SOMAGroup {
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::shared_ptr<Context> ctx,
         std::string_view uri,
         std::string_view name = "unnamed",
@@ -104,14 +105,14 @@ class SOMAGroup {
     /**
      * @brief Construct a new SOMAGroup object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the group
      * @param name Name of the group
      * @param ctx TileDB context
      * @param timestamp Timestamp
      */
     SOMAGroup(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::string_view name,
         std::shared_ptr<Context> ctx,
@@ -125,12 +126,10 @@ class SOMAGroup {
     /**
      * Open the SOMAGroup object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param timestamp Timestamp
      */
-    void open(
-        tiledb_query_type_t mode,
-        std::optional<uint64_t> timestamp = std::nullopt);
+    void open(OpenMode mode, std::optional<uint64_t> timestamp = std::nullopt);
 
     /**
      * Close the SOMAGroup object.
@@ -174,11 +173,12 @@ class SOMAGroup {
      * Add a named member to a SOMAGroup.
      *
      * @param uri of member to add
-     * @param relative is the URI relative to the SOMAGroup location
+     * @param uri_type whether the given URI is automatic (default), absolute,
+     * or relative
      * @param name of member
      */
     void add_member(
-        const std::string& uri, bool relative, const std::string& name);
+        const std::string& uri, URIType uri_type, const std::string& name);
 
     /**
      * Get the number of members in the SOMAGroup.

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -137,7 +137,7 @@ class SOMAGroup {
     void close();
 
     /**
-     * Check if the SOMAObject is open.
+     * Check if the SOMAGroup is open.
      *
      * @return bool true if open
      */

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -50,6 +50,18 @@ class SOMAGroup {
     //===================================================================
 
     /**
+     * @brief Create a SOMAGroup object at the given URI.
+     *
+     * @param ctx TileDB context
+     * @param uri URI to create the SOMAGroup
+     * @param soma_type SOMACollection, SOMAMeasurement, or SOMAExperiment
+     */
+    static void create(
+        std::shared_ptr<Context> ctx,
+        std::string_view uri,
+        std::string soma_type);
+
+    /**
      * @brief Open a group at the specified URI and return SOMAGroup
      * object.
      *
@@ -128,7 +140,7 @@ class SOMAGroup {
     /**
      * Get the SOMAGroup URI.
      */
-    std::string uri() const;
+    const std::string uri() const;
 
     /**
      * Get the Context associated with the SOMAGroup.

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -42,16 +42,24 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
-    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string_view uri,
+    ArraySchema schema,
+    std::map<std::string, std::string> platform_config) {
+    return SOMAMeasurement::create(
+        uri, schema, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
+    std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
     SOMAGroup::create(ctx, exp_uri, "SOMAMeasurement");
-    SOMADataFrame::create(ctx, exp_uri + "/var", schema);
-    SOMACollection::create(ctx, exp_uri + "/X");
-    SOMACollection::create(ctx, exp_uri + "/obsm");
-    SOMACollection::create(ctx, exp_uri + "/obsp");
-    SOMACollection::create(ctx, exp_uri + "/varm");
-    SOMACollection::create(ctx, exp_uri + "/varp");
+    SOMADataFrame::create(exp_uri + "/var", schema, ctx);
+    SOMACollection::create(exp_uri + "/X", ctx);
+    SOMACollection::create(exp_uri + "/obsm", ctx);
+    SOMACollection::create(exp_uri + "/obsp", ctx);
+    SOMACollection::create(exp_uri + "/varm", ctx);
+    SOMACollection::create(exp_uri + "/varp", ctx);
 
     auto group = SOMAGroup::open(TILEDB_WRITE, ctx, uri);
     group->add_member(exp_uri + "/var", false, "var");

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -61,15 +61,15 @@ std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
     SOMACollection::create(exp_uri + "/varm", ctx);
     SOMACollection::create(exp_uri + "/varp", ctx);
 
-    auto group = SOMAGroup::open(TILEDB_WRITE, ctx, uri);
-    group->add_member(exp_uri + "/var", false, "var");
-    group->add_member(exp_uri + "/X", false, "X");
-    group->add_member(exp_uri + "/obsm", false, "obsm");
-    group->add_member(exp_uri + "/obsp", false, "obsp");
-    group->add_member(exp_uri + "/varm", false, "varm");
-    group->add_member(exp_uri + "/varp", false, "varp");
+    auto group = SOMAGroup::open(OpenMode::write, ctx, uri);
+    group->add_member(exp_uri + "/var", URIType::absolute, "var");
+    group->add_member(exp_uri + "/X", URIType::absolute, "X");
+    group->add_member(exp_uri + "/obsm", URIType::absolute, "obsm");
+    group->add_member(exp_uri + "/obsp", URIType::absolute, "obsp");
+    group->add_member(exp_uri + "/varm", URIType::absolute, "varm");
+    group->add_member(exp_uri + "/varp", URIType::absolute, "varp");
     group->close();
 
-    return std::make_unique<SOMAMeasurement>(TILEDB_READ, uri, ctx);
+    return std::make_unique<SOMAMeasurement>(OpenMode::read, uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -41,7 +41,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
+std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -49,7 +49,7 @@ std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
+std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
@@ -70,6 +70,6 @@ std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
     group->add_member(exp_uri + "/varp", URIType::absolute, "varp");
     group->close();
 
-    return std::make_shared<SOMAMeasurement>(OpenMode::read, uri, ctx);
+    return std::make_unique<SOMAMeasurement>(OpenMode::read, uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -1,0 +1,67 @@
+/**
+ * @file   soma_measurement.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAMeasurement class.
+ */
+
+#include "soma_measurement.h"
+#include "soma_collection.h"
+#include "soma_experiment.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+//===================================================================
+//= public static
+//===================================================================
+
+std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
+    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string exp_uri(uri);
+
+    SOMAGroup::create(ctx, exp_uri, "SOMAMeasurement");
+    SOMADataFrame::create(ctx, exp_uri + "/var", schema);
+    SOMACollection::create(ctx, exp_uri + "/X");
+    SOMACollection::create(ctx, exp_uri + "/obsm");
+    SOMACollection::create(ctx, exp_uri + "/obsp");
+    SOMACollection::create(ctx, exp_uri + "/varm");
+    SOMACollection::create(ctx, exp_uri + "/varp");
+
+    auto group = SOMAGroup::open(TILEDB_WRITE, ctx, uri);
+    group->add_member(exp_uri + "/var", false, "var");
+    group->add_member(exp_uri + "/X", false, "X");
+    group->add_member(exp_uri + "/obsm", false, "obsm");
+    group->add_member(exp_uri + "/obsp", false, "obsp");
+    group->add_member(exp_uri + "/varm", false, "varm");
+    group->add_member(exp_uri + "/varp", false, "varp");
+    group->close();
+
+    return std::make_unique<SOMAMeasurement>(TILEDB_READ, uri, ctx);
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -41,7 +41,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
+std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -49,7 +49,7 @@ std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
+std::shared_ptr<SOMAMeasurement> SOMAMeasurement::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     std::string exp_uri(uri);
 
@@ -70,6 +70,6 @@ std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
     group->add_member(exp_uri + "/varp", URIType::absolute, "varp");
     group->close();
 
-    return std::make_unique<SOMAMeasurement>(OpenMode::read, uri, ctx);
+    return std::make_shared<SOMAMeasurement>(OpenMode::read, uri, ctx);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -74,7 +74,7 @@ class SOMAMeasurement : public SOMACollection {
     //= public non-static
     //===================================================================
     SOMAMeasurement(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::optional<uint64_t> timestamp = std::nullopt)

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -1,0 +1,112 @@
+/**
+ * @file   soma_measurement.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAMeasurement class.
+ */
+
+#ifndef SOMA_MEASUREMENT
+#define SOMA_MEASUREMENT
+
+#include <tiledb/tiledb>
+
+#include "soma_collection.h"
+#include "soma_dataframe.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+
+class SOMAMeasurement : public SOMACollection {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMAMeasurement object at the given URI.
+     *
+     * @param ctx TileDB context
+     * @param uri URI to create the SOMAMeasurement
+     */
+    static std::unique_ptr<SOMAMeasurement> create(
+        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+    SOMAMeasurement(
+        tiledb_query_type_t mode,
+        std::string_view uri,
+        std::shared_ptr<Context> ctx,
+        std::optional<uint64_t> timestamp = std::nullopt)
+        : SOMACollection(mode, uri, ctx, timestamp) {
+    }
+
+    SOMAMeasurement() = delete;
+    SOMAMeasurement(const SOMAMeasurement&) = delete;
+    SOMAMeasurement(SOMAMeasurement&&) = default;
+    ~SOMAMeasurement() = default;
+
+    /**
+     * Return the constant "SOMAMeasurement".
+     *
+     * @return std::string
+     */
+    const std::string type() const {
+        return "SOMAMeasurement";
+    }
+
+   private:
+    //===================================================================
+    //= private non-static
+    //===================================================================
+
+    // Primary annotations on the variable axis
+    std::unique_ptr<SOMADataFrame> var_;
+
+    // A collection of matrices, each containing measured feature values
+    std::unique_ptr<SOMACollection> X_;
+
+    // A collection of dense matrices containing annotations of each obs row
+    std::unique_ptr<SOMACollection> obsm_;
+
+    // A collection of sparse matrices containing pairwise annotations of each
+    // obs row
+    std::unique_ptr<SOMACollection> obsp_;
+
+    // A collection of dense matrices containing annotations of each var row
+    std::unique_ptr<SOMACollection> varm_;
+
+    // A collection of sparse matrices containing pairwise annotations of each
+    // var row
+    std::unique_ptr<SOMACollection> varp_;
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_MEASUREMENT

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -55,7 +55,7 @@ class SOMAMeasurement : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
      */
-    static std::unique_ptr<SOMAMeasurement> create(
+    static std::shared_ptr<SOMAMeasurement> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -67,7 +67,7 @@ class SOMAMeasurement : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
      */
-    static std::unique_ptr<SOMAMeasurement> create(
+    static std::shared_ptr<SOMAMeasurement> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================
@@ -101,24 +101,24 @@ class SOMAMeasurement : public SOMACollection {
     //===================================================================
 
     // Primary annotations on the variable axis
-    std::unique_ptr<SOMADataFrame> var_;
+    std::shared_ptr<SOMADataFrame> var_;
 
     // A collection of matrices, each containing measured feature values
-    std::unique_ptr<SOMACollection> X_;
+    std::shared_ptr<SOMACollection> X_;
 
     // A collection of dense matrices containing annotations of each obs row
-    std::unique_ptr<SOMACollection> obsm_;
+    std::shared_ptr<SOMACollection> obsm_;
 
     // A collection of sparse matrices containing pairwise annotations of each
     // obs row
-    std::unique_ptr<SOMACollection> obsp_;
+    std::shared_ptr<SOMACollection> obsp_;
 
     // A collection of dense matrices containing annotations of each var row
-    std::unique_ptr<SOMACollection> varm_;
+    std::shared_ptr<SOMACollection> varm_;
 
     // A collection of sparse matrices containing pairwise annotations of each
     // var row
-    std::unique_ptr<SOMACollection> varp_;
+    std::shared_ptr<SOMACollection> varp_;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -51,11 +51,24 @@ class SOMAMeasurement : public SOMACollection {
     /**
      * @brief Create a SOMAMeasurement object at the given URI.
      *
-     * @param ctx TileDB context
      * @param uri URI to create the SOMAMeasurement
+     * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
      */
     static std::unique_ptr<SOMAMeasurement> create(
-        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+        std::string_view uri,
+        ArraySchema schema,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMAMeasurement object at the given URI.
+     *
+     * @param uri URI to create the SOMAMeasurement
+     * @param schema TileDB ArraySchema
+     * @param ctx TileDB context
+     */
+    static std::unique_ptr<SOMAMeasurement> create(
+        std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -55,7 +55,7 @@ class SOMAMeasurement : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
      */
-    static std::shared_ptr<SOMAMeasurement> create(
+    static std::unique_ptr<SOMAMeasurement> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -67,7 +67,7 @@ class SOMAMeasurement : public SOMACollection {
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
      */
-    static std::shared_ptr<SOMAMeasurement> create(
+    static std::unique_ptr<SOMAMeasurement> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -54,14 +54,14 @@ class SOMAObject {
      *
      * @return std::string SOMA type
      */
-    virtual std::string type() const = 0;
+    virtual const std::string type() const = 0;
 
     /**
      * @brief Get URI of the SOMAObject.
      *
      * @return std::string URI
      */
-    virtual const std::string& uri() const = 0;
+    virtual const std::string uri() const = 0;
 
     /**
      * Get the context associated with the SOMAObject.

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -64,11 +64,21 @@ class SOMAObject {
     virtual const std::string uri() const = 0;
 
     /**
-     * Get the context associated with the SOMAObject.
+     * @brief Get the context associated with the SOMAObject.
      *
      * @return std::shared_ptr<Context>
      */
     virtual std::shared_ptr<Context> ctx() = 0;
+
+    /**
+     * @brief Close the SOMAObject.
+     */
+    virtual void close() = 0;
+
+    /**
+     * @brief Check if the SOMAObject is open.
+     */
+    virtual bool is_open() const = 0;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -119,6 +119,10 @@ void SOMASparseNDArray::close() {
     array_->close();
 }
 
+bool SOMASparseNDArray::is_open() const {
+    return array_->is_open();
+}
+
 const std::string SOMASparseNDArray::uri() const {
     return array_->uri();
 }

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -41,7 +41,15 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
-    std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema) {
+    std::string_view uri,
+    ArraySchema schema,
+    std::map<std::string, std::string> platform_config) {
+    return SOMASparseNDArray::create(
+        uri, schema, std::make_shared<Context>(Config(platform_config)));
+}
+
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+    std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_SPARSE)
         throw TileDBSOMAError("ArraySchema must be set to sparse.");
 
@@ -51,20 +59,23 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
-    tiledb_query_type_t mode,
     std::string_view uri,
-    std::vector<std::string> column_names,
+    tiledb_query_type_t mode,
     std::map<std::string, std::string> platform_config,
+    std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    auto ctx = std::make_shared<Context>(Config(platform_config));
-    return std::make_unique<SOMASparseNDArray>(
-        mode, uri, ctx, column_names, timestamp);
+    return SOMASparseNDArray::open(
+        uri,
+        mode,
+        std::make_shared<Context>(Config(platform_config)),
+        column_names,
+        timestamp);
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
+    std::string_view uri,
     tiledb_query_type_t mode,
     std::shared_ptr<Context> ctx,
-    std::string_view uri,
     std::vector<std::string> column_names,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return std::make_unique<SOMASparseNDArray>(

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -54,32 +54,34 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
         throw TileDBSOMAError("ArraySchema must be set to sparse.");
 
     SOMAArray::create(ctx, uri, schema, "SOMASparseNDArray");
-    return std::make_unique<SOMASparseNDArray>(
-        TILEDB_READ, uri, ctx, std::vector<std::string>(), std::nullopt);
+    return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::map<std::string, std::string> platform_config,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return SOMASparseNDArray::open(
         uri,
         mode,
         std::make_shared<Context>(Config(platform_config)),
         column_names,
+        result_order,
         timestamp);
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return std::make_unique<SOMASparseNDArray>(
-        mode, uri, ctx, column_names, timestamp);
+        mode, uri, ctx, column_names, result_order, timestamp);
 }
 
 //===================================================================
@@ -87,10 +89,11 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
 //===================================================================
 
 SOMASparseNDArray::SOMASparseNDArray(
-    tiledb_query_type_t mode,
+    OpenMode mode,
     std::string_view uri,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
+    ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     array_ = std::make_shared<SOMAArray>(
         mode,
@@ -99,15 +102,14 @@ SOMASparseNDArray::SOMASparseNDArray(
         ctx,
         column_names,
         "auto",  // batch_size,
-        "auto",  // result_order,
+        result_order,
         timestamp);
     array_->reset();
     array_->submit();
 }
 
 void SOMASparseNDArray::open(
-    tiledb_query_type_t mode,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     array_->open(mode, timestamp);
     array_->reset();
     array_->submit();

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -106,7 +106,7 @@ void SOMASparseNDArray::close() {
     array_->close();
 }
 
-const std::string& SOMASparseNDArray::uri() const {
+const std::string SOMASparseNDArray::uri() const {
     return array_->uri();
 }
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -40,7 +40,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -48,7 +48,7 @@ std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_SPARSE)
         throw TileDBSOMAError("ArraySchema must be set to sparse.");
@@ -57,7 +57,7 @@ std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
 }
 
-std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -73,14 +73,14 @@ std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
         timestamp);
 }
 
-std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_shared<SOMASparseNDArray>(
+    return std::make_unique<SOMASparseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -40,7 +40,7 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
@@ -48,7 +48,7 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
         uri, schema, std::make_shared<Context>(Config(platform_config)));
 }
 
-std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx) {
     if (schema.array_type() != TILEDB_SPARSE)
         throw TileDBSOMAError("ArraySchema must be set to sparse.");
@@ -57,7 +57,7 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
 }
 
-std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
+std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::map<std::string, std::string> platform_config,
@@ -73,14 +73,14 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
         timestamp);
 }
 
-std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
+std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<Context> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    return std::make_unique<SOMASparseNDArray>(
+    return std::make_shared<SOMASparseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -142,7 +142,7 @@ class SOMASparseNDArray : public SOMAObject {
      *
      * @return std::string
      */
-    std::string type() const {
+    const std::string type() const {
         return "SOMASparseNDArray";
     }
 
@@ -167,7 +167,7 @@ class SOMASparseNDArray : public SOMAObject {
      *
      * @return std::string URI
      */
-    const std::string& uri() const;
+    const std::string uri() const;
 
     /**
      * Return data schema, in the form of a TileDB ArraySchema.

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -56,9 +56,9 @@ class SOMASparseNDArray : public SOMAObject {
      * @param uri URI to create the SOMASparseNDArray
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
-     * @return std::unique_ptr<SOMASparseNDArray> opened in read mode
+     * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
      */
-    static std::unique_ptr<SOMASparseNDArray> create(
+    static std::shared_ptr<SOMASparseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -69,9 +69,9 @@ class SOMASparseNDArray : public SOMAObject {
      * @param uri URI to create the SOMASparseNDArray
      * @param schema TileDB ArraySchema
      * @param ctx TileDB context
-     * @return std::unique_ptr<SOMASparseNDArray> opened in read mode
+     * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
      */
-    static std::unique_ptr<SOMASparseNDArray> create(
+    static std::shared_ptr<SOMASparseNDArray> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -88,9 +88,9 @@ class SOMASparseNDArray : public SOMAObject {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
+     * @return std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
-    static std::unique_ptr<SOMASparseNDArray> open(
+    static std::shared_ptr<SOMASparseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -112,9 +112,9 @@ class SOMASparseNDArray : public SOMAObject {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
+     * @return std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
-    static std::unique_ptr<SOMASparseNDArray> open(
+    static std::shared_ptr<SOMASparseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -52,13 +52,26 @@ class SOMASparseNDArray : public SOMAObject {
     /**
      * @brief Create a SOMASparseNDArray object at the given URI.
      *
-     * @param ctx TileDB context
      * @param uri URI to create the SOMASparseNDArray
      * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
      * @return std::unique_ptr<SOMASparseNDArray> opened in read mode
      */
     static std::unique_ptr<SOMASparseNDArray> create(
-        std::shared_ptr<Context> ctx, std::string_view uri, ArraySchema schema);
+        std::string_view uri,
+        ArraySchema schema,
+        std::map<std::string, std::string> platform_config = {});
+
+    /**
+     * @brief Create a SOMASparseNDArray object at the given URI.
+     *
+     * @param uri URI to create the SOMASparseNDArray
+     * @param schema TileDB ArraySchema
+     * @param ctx TileDB context
+     * @return std::unique_ptr<SOMASparseNDArray> opened in read mode
+     */
+    static std::unique_ptr<SOMASparseNDArray> create(
+        std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
      * @brief Open and return a SOMASparseNDArray object at the given URI.
@@ -75,10 +88,10 @@ class SOMASparseNDArray : public SOMAObject {
      * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
     static std::unique_ptr<SOMASparseNDArray> open(
-        tiledb_query_type_t mode,
         std::string_view uri,
-        std::vector<std::string> column_names = {},
+        tiledb_query_type_t mode,
         std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -96,9 +109,9 @@ class SOMASparseNDArray : public SOMAObject {
      * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
     static std::unique_ptr<SOMASparseNDArray> open(
+        std::string_view uri,
         tiledb_query_type_t mode,
         std::shared_ptr<Context> ctx,
-        std::string_view uri,
         std::vector<std::string> column_names = {},
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -160,6 +160,13 @@ class SOMASparseNDArray : public SOMAObject {
     void close();
 
     /**
+     * Check if the SOMASparseNDArray is open.
+     *
+     * @return bool true if open
+     */
+    bool is_open() const;
+
+    /**
      * Returns the constant "SOMASparseNDArray".
      *
      * @return std::string

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -58,7 +58,7 @@ class SOMASparseNDArray : public SOMAObject {
      * @param platform_config Optional config parameter dictionary
      * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
      */
-    static std::shared_ptr<SOMASparseNDArray> create(
+    static std::unique_ptr<SOMASparseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
         std::map<std::string, std::string> platform_config = {});
@@ -71,7 +71,7 @@ class SOMASparseNDArray : public SOMAObject {
      * @param ctx TileDB context
      * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
      */
-    static std::shared_ptr<SOMASparseNDArray> create(
+    static std::unique_ptr<SOMASparseNDArray> create(
         std::string_view uri, ArraySchema schema, std::shared_ptr<Context> ctx);
 
     /**
@@ -90,7 +90,7 @@ class SOMASparseNDArray : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
-    static std::shared_ptr<SOMASparseNDArray> open(
+    static std::unique_ptr<SOMASparseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
@@ -114,7 +114,7 @@ class SOMASparseNDArray : public SOMAObject {
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
-    static std::shared_ptr<SOMASparseNDArray> open(
+    static std::unique_ptr<SOMASparseNDArray> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -34,6 +34,7 @@
 #define SOMA_SPARSE_NDARRAY
 
 #include <tiledb/tiledb>
+#include "enums.h"
 #include "soma_object.h"
 
 namespace tiledbsoma {
@@ -76,43 +77,49 @@ class SOMASparseNDArray : public SOMAObject {
     /**
      * @brief Open and return a SOMASparseNDArray object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI to create the SOMASparseNDArray
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
      * @param platform_config Platform-specific options used to create this
-     * DataFrame
+     * SOMASparseNDArray
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
     static std::unique_ptr<SOMASparseNDArray> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::map<std::string, std::string> platform_config = {},
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMASparseNDArray object at the given URI.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param ctx TileDB context
      * @param uri URI to create the SOMASparseNDArray
      * @param schema TileDB ArraySchema
      * @param column_names A list of column names to use as user-defined index
      * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
      * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
      * @return std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray
      */
     static std::unique_ptr<SOMASparseNDArray> open(
         std::string_view uri,
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
@@ -122,27 +129,29 @@ class SOMASparseNDArray : public SOMAObject {
     /**
      * @brief Construct a new SOMASparseNDArray object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param uri URI of the array
      * @param ctx TileDB context
-     * @param column_names Columns to read
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
      * @param timestamp Timestamp
      */
     SOMASparseNDArray(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
         std::vector<std::string> column_names,
+        ResultOrder result_order,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
     /**
      * Open the SOMASparseNDArray object.
      *
-     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param mode read or write
      * @param timestamp Timestamp
      */
     void open(
-        tiledb_query_type_t mode,
+        OpenMode mode,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
@@ -219,8 +228,9 @@ class SOMASparseNDArray : public SOMAObject {
 
     /**
      * @brief Write ArrayBuffers data to the dataframe.
+     * @param buffers The ArrayBuffers to write
      */
-    void write(std::shared_ptr<ArrayBuffers>);
+    void write(std::shared_ptr<ArrayBuffers> buffers);
 
    private:
     //===================================================================

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(unit_soma EXCLUDE_FROM_ALL
     unit_soma_dataframe.cc
     unit_soma_dense_ndarray.cc
     unit_soma_sparse_ndarray.cc
+    unit_soma_collection.cc
 # TODO: uncomment when thread_pool is enabled
 #    unit_thread_pool.cc
 )

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -81,7 +81,7 @@ TEST_CASE("SOMACollection: basic") {
     auto ctx = std::make_shared<Context>();
     std::string uri = "mem://unit-test-collection-basic";
 
-    auto soma_collection = SOMACollection::create(ctx, uri);
+    auto soma_collection = SOMACollection::create(uri, ctx);
     REQUIRE(soma_collection->uri() == uri);
     REQUIRE(soma_collection->ctx() == ctx);
     REQUIRE(soma_collection->type() == "SOMACollection");
@@ -93,10 +93,10 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     std::string base_uri = "mem://unit-test-add-sparse-ndarray";
     std::string sub_uri = "mem://unit-test-add-sparse-ndarray/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, true);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_sparse = soma_collection->add_new_sparse_ndarray(
         "sparse_ndarray", sub_uri, false, ctx, schema);
     REQUIRE(soma_sparse->uri() == sub_uri);
@@ -110,7 +110,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_sparse->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{
         {"sparse_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
@@ -122,10 +122,10 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     std::string base_uri = "mem://unit-test-add-dense-ndarray";
     std::string sub_uri = "mem://unit-test-add-dense-ndarray/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_dense = soma_collection->add_new_dense_ndarray(
         "dense_ndarray", sub_uri, false, ctx, schema);
     REQUIRE(soma_dense->uri() == sub_uri);
@@ -138,7 +138,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     REQUIRE(soma_dense->shape() == std::vector<int64_t>{1001});
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -149,10 +149,10 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     std::string base_uri = "mem://unit-test-add-dataframe";
     std::string sub_uri = "mem://unit-test-add-dataframe/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_dataframe = soma_collection->add_new_dataframe(
         "dataframe", sub_uri, false, ctx, schema);
     REQUIRE(soma_dataframe->uri() == sub_uri);
@@ -166,7 +166,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     REQUIRE(soma_dataframe->count() == 1);
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -177,10 +177,10 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     std::string base_uri = "mem://unit-test-add-collection";
     std::string sub_uri = "mem://unit-test-add-collection/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, false, ctx);
     REQUIRE(soma_subcollection->uri() == sub_uri);
@@ -188,7 +188,7 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -199,10 +199,10 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     std::string base_uri = "mem://unit-test-add-measurement";
     std::string sub_uri = "mem://unit-test-add-measurement/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
         "experiment", sub_uri, false, ctx, schema);
     REQUIRE(soma_experiment->uri() == sub_uri);
@@ -211,7 +211,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_experiment->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -222,10 +222,10 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     std::string base_uri = "mem://unit-test-add-experiment";
     std::string sub_uri = "mem://unit-test-add-experiment/sub";
 
-    SOMACollection::create(ctx, base_uri);
+    SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
         "measurement", sub_uri, false, ctx, schema);
     REQUIRE(soma_measurement->uri() == sub_uri);
@@ -234,7 +234,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_measurement->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
     std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -1,0 +1,241 @@
+/**
+ * @file   unit_soma_collection.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for the SOMACollection class
+ */
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_predicate.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+#include <numeric>
+#include <random>
+
+#include <tiledb/tiledb>
+#include <tiledbsoma/tiledbsoma>
+#include "utils/util.h"
+
+using namespace tiledb;
+using namespace tiledbsoma;
+using namespace Catch::Matchers;
+
+#ifndef TILEDBSOMA_SOURCE_ROOT
+#define TILEDBSOMA_SOURCE_ROOT "not_defined"
+#endif
+
+const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
+
+namespace {
+ArraySchema create_schema(
+    Context& ctx, bool sparse = false, bool allow_duplicates = false) {
+    // Create schema
+    ArraySchema schema(ctx, sparse ? TILEDB_SPARSE : TILEDB_DENSE);
+
+    auto dim = Dimension::create<int64_t>(ctx, "d0", {0, 1000});
+
+    Domain domain(ctx);
+    domain.add_dimension(dim);
+    schema.set_domain(domain);
+
+    auto attr = Attribute::create<int>(ctx, "a0");
+    schema.add_attribute(attr);
+    schema.set_allows_dups(allow_duplicates);
+    schema.check();
+
+    return schema;
+}
+};  // namespace
+
+TEST_CASE("SOMACollection: basic") {
+    auto ctx = std::make_shared<Context>();
+    std::string uri = "mem://unit-test-collection-basic";
+
+    auto soma_collection = SOMACollection::create(ctx, uri);
+    REQUIRE(soma_collection->uri() == uri);
+    REQUIRE(soma_collection->ctx() == ctx);
+    REQUIRE(soma_collection->type() == "SOMACollection");
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMASparseNDArray") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-sparse-ndarray";
+    std::string sub_uri = "mem://unit-test-add-sparse-ndarray/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, true);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_sparse = soma_collection->add_new_sparse_ndarray(
+        "sparse_ndarray", sub_uri, false, ctx, schema);
+    REQUIRE(soma_sparse->uri() == sub_uri);
+    REQUIRE(soma_sparse->ctx() == ctx);
+    REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
+    REQUIRE(soma_sparse->is_sparse() == true);
+    REQUIRE(soma_sparse->schema()->has_attribute("a0"));
+    REQUIRE(soma_sparse->schema()->domain().has_dimension("d0"));
+    REQUIRE(soma_sparse->ndim() == 1);
+    REQUIRE(soma_sparse->nnz() == 0);
+    soma_sparse->close();
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{
+        {"sparse_ndarray", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMADenseNDArray") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-dense-ndarray";
+    std::string sub_uri = "mem://unit-test-add-dense-ndarray/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, false);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_dense = soma_collection->add_new_dense_ndarray(
+        "dense_ndarray", sub_uri, false, ctx, schema);
+    REQUIRE(soma_dense->uri() == sub_uri);
+    REQUIRE(soma_dense->ctx() == ctx);
+    REQUIRE(soma_dense->type() == "SOMADenseNDArray");
+    REQUIRE(soma_dense->is_sparse() == false);
+    REQUIRE(soma_dense->schema()->has_attribute("a0"));
+    REQUIRE(soma_dense->schema()->domain().has_dimension("d0"));
+    REQUIRE(soma_dense->ndim() == 1);
+    REQUIRE(soma_dense->shape() == std::vector<int64_t>{1001});
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMADataFrame") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-dataframe";
+    std::string sub_uri = "mem://unit-test-add-dataframe/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, false);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_dataframe = soma_collection->add_new_dataframe(
+        "dataframe", sub_uri, false, ctx, schema);
+    REQUIRE(soma_dataframe->uri() == sub_uri);
+    REQUIRE(soma_dataframe->ctx() == ctx);
+    REQUIRE(soma_dataframe->type() == "SOMADataFrame");
+    REQUIRE(soma_dataframe->schema()->has_attribute("a0"));
+    REQUIRE(soma_dataframe->schema()->domain().has_dimension("d0"));
+    std::vector<std::string> expected_index_column_names = {"d0"};
+    REQUIRE(
+        soma_dataframe->index_column_names() == expected_index_column_names);
+    REQUIRE(soma_dataframe->count() == 1);
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMACollection") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-collection";
+    std::string sub_uri = "mem://unit-test-add-collection/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, false);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_subcollection = soma_collection->add_new_collection(
+        "subcollection", sub_uri, false, ctx);
+    REQUIRE(soma_subcollection->uri() == sub_uri);
+    REQUIRE(soma_subcollection->ctx() == ctx);
+    REQUIRE(soma_subcollection->type() == "SOMACollection");
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMAExperiment") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-measurement";
+    std::string sub_uri = "mem://unit-test-add-measurement/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, false);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_experiment = soma_collection->add_new_experiment(
+        "experiment", sub_uri, false, ctx, schema);
+    REQUIRE(soma_experiment->uri() == sub_uri);
+    REQUIRE(soma_experiment->ctx() == ctx);
+    REQUIRE(soma_experiment->type() == "SOMAExperiment");
+    soma_experiment->close();
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMACollection: add SOMAMeasurement") {
+    auto ctx = std::make_shared<Context>();
+    std::string base_uri = "mem://unit-test-add-experiment";
+    std::string sub_uri = "mem://unit-test-add-experiment/sub";
+
+    SOMACollection::create(ctx, base_uri);
+    auto schema = create_schema(*ctx, false);
+
+    auto soma_collection = SOMACollection::open(TILEDB_WRITE, ctx, base_uri);
+    auto soma_measurement = soma_collection->add_new_measurement(
+        "measurement", sub_uri, false, ctx, schema);
+    REQUIRE(soma_measurement->uri() == sub_uri);
+    REQUIRE(soma_measurement->ctx() == ctx);
+    REQUIRE(soma_measurement->type() == "SOMAMeasurement");
+    soma_measurement->close();
+    soma_collection->close();
+
+    soma_collection = SOMACollection::open(TILEDB_READ, ctx, base_uri);
+    std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    soma_collection->close();
+}

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -96,9 +96,9 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, true);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_sparse = soma_collection->add_new_sparse_ndarray(
-        "sparse_ndarray", sub_uri, false, ctx, schema);
+        "sparse_ndarray", sub_uri, URIType::absolute, ctx, schema);
     REQUIRE(soma_sparse->uri() == sub_uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -110,7 +110,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_sparse->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{
         {"sparse_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
@@ -125,9 +125,9 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_dense = soma_collection->add_new_dense_ndarray(
-        "dense_ndarray", sub_uri, false, ctx, schema);
+        "dense_ndarray", sub_uri, URIType::absolute, ctx, schema);
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -138,7 +138,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     REQUIRE(soma_dense->shape() == std::vector<int64_t>{1001});
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -152,9 +152,9 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_dataframe = soma_collection->add_new_dataframe(
-        "dataframe", sub_uri, false, ctx, schema);
+        "dataframe", sub_uri, URIType::absolute, ctx, schema);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -166,7 +166,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     REQUIRE(soma_dataframe->count() == 1);
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -180,15 +180,15 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
-        "subcollection", sub_uri, false, ctx);
+        "subcollection", sub_uri, URIType::absolute, ctx);
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -196,22 +196,22 @@ TEST_CASE("SOMACollection: add SOMACollection") {
 
 TEST_CASE("SOMACollection: add SOMAExperiment") {
     auto ctx = std::make_shared<Context>();
-    std::string base_uri = "mem://unit-test-add-measurement";
-    std::string sub_uri = "mem://unit-test-add-measurement/sub";
+    std::string base_uri = "mem://unit-test-add-experiment";
+    std::string sub_uri = "mem://unit-test-add-experiment/sub";
 
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
-        "experiment", sub_uri, false, ctx, schema);
+        "experiment", sub_uri, URIType::absolute, ctx, schema);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
     soma_experiment->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
@@ -219,22 +219,22 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
 
 TEST_CASE("SOMACollection: add SOMAMeasurement") {
     auto ctx = std::make_shared<Context>();
-    std::string base_uri = "mem://unit-test-add-experiment";
-    std::string sub_uri = "mem://unit-test-add-experiment/sub";
+    std::string base_uri = "mem://unit-test-add-measurement";
+    std::string sub_uri = "mem://unit-test-add-measurement/sub";
 
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
-    auto soma_collection = SOMACollection::open(base_uri, TILEDB_WRITE, ctx);
+    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
-        "measurement", sub_uri, false, ctx, schema);
+        "measurement", sub_uri, URIType::absolute, ctx, schema);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
     soma_measurement->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, TILEDB_READ, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
     std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -82,7 +82,7 @@ TEST_CASE("SOMADataFrame: basic") {
 
     SOMADataFrame::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_dataframe = SOMADataFrame::open(uri, TILEDB_READ, ctx);
+    auto soma_dataframe = SOMADataFrame::open(uri, OpenMode::read, ctx);
     REQUIRE(soma_dataframe->uri() == uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -102,11 +102,11 @@ TEST_CASE("SOMADataFrame: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(*schema, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(*schema, "d0", d0));
 
-    soma_dataframe->open(TILEDB_WRITE);
+    soma_dataframe->open(OpenMode::write);
     soma_dataframe->write(array_buffer);
     soma_dataframe->close();
 
-    soma_dataframe->open(TILEDB_READ);
+    soma_dataframe->open(OpenMode::read);
     while (auto batch = soma_dataframe->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -80,9 +80,9 @@ TEST_CASE("SOMADataFrame: basic") {
     auto ctx = std::make_shared<Context>();
     std::string uri = "mem://unit-test-dataframe-basic";
 
-    SOMADataFrame::create(ctx, uri, create_schema(*ctx));
+    SOMADataFrame::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_dataframe = SOMADataFrame::open(TILEDB_READ, ctx, uri);
+    auto soma_dataframe = SOMADataFrame::open(uri, TILEDB_READ, ctx);
     REQUIRE(soma_dataframe->uri() == uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -80,9 +80,9 @@ TEST_CASE("SOMADenseNDArray: basic") {
     auto ctx = std::make_shared<Context>();
     std::string uri = "mem://unit-test-dense-ndarray-basic";
 
-    SOMADenseNDArray::create(ctx, uri, create_schema(*ctx));
+    SOMADenseNDArray::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_dense = SOMADenseNDArray::open(TILEDB_READ, ctx, uri);
+    auto soma_dense = SOMADenseNDArray::open(uri, TILEDB_READ, ctx);
     REQUIRE(soma_dense->uri() == uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -82,17 +82,17 @@ TEST_CASE("SOMADenseNDArray: basic") {
 
     SOMADenseNDArray::create(ctx, uri, create_schema(*ctx));
 
-    auto soma_sparse = SOMADenseNDArray::open(TILEDB_READ, ctx, uri);
-    REQUIRE(soma_sparse->uri() == uri);
-    REQUIRE(soma_sparse->ctx() == ctx);
-    REQUIRE(soma_sparse->type() == "SOMADenseNDArray");
-    REQUIRE(soma_sparse->is_sparse() == false);
-    auto schema = soma_sparse->schema();
+    auto soma_dense = SOMADenseNDArray::open(TILEDB_READ, ctx, uri);
+    REQUIRE(soma_dense->uri() == uri);
+    REQUIRE(soma_dense->ctx() == ctx);
+    REQUIRE(soma_dense->type() == "SOMADenseNDArray");
+    REQUIRE(soma_dense->is_sparse() == false);
+    auto schema = soma_dense->schema();
     REQUIRE(schema->has_attribute("a0"));
     REQUIRE(schema->domain().has_dimension("d0"));
-    REQUIRE(soma_sparse->ndim() == 1);
-    REQUIRE(soma_sparse->shape() == std::vector<int64_t>{1001});
-    soma_sparse->close();
+    REQUIRE(soma_dense->ndim() == 1);
+    REQUIRE(soma_dense->shape() == std::vector<int64_t>{1001});
+    soma_dense->close();
 
     std::vector<int64_t> d0{1, 10};
     std::vector<int> a0(10, 1);
@@ -101,12 +101,12 @@ TEST_CASE("SOMADenseNDArray: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(*schema, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(*schema, "d0", d0));
 
-    soma_sparse->open(TILEDB_WRITE);
-    soma_sparse->write(array_buffer);
-    soma_sparse->close();
+    soma_dense->open(TILEDB_WRITE);
+    soma_dense->write(array_buffer);
+    soma_dense->close();
 
-    soma_sparse->open(TILEDB_READ);
-    while (auto batch = soma_sparse->read_next()) {
+    soma_dense->open(TILEDB_READ);
+    while (auto batch = soma_dense->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();
         auto a0span = arrbuf->at("a0")->data<int>();
@@ -115,5 +115,5 @@ TEST_CASE("SOMADenseNDArray: basic") {
             std::vector<int64_t>(d0span.begin(), d0span.end()));
         REQUIRE(a0 == std::vector<int>(a0span.begin(), a0span.end()));
     }
-    soma_sparse->close();
+    soma_dense->close();
 }

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -82,7 +82,7 @@ TEST_CASE("SOMADenseNDArray: basic") {
 
     SOMADenseNDArray::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_dense = SOMADenseNDArray::open(uri, TILEDB_READ, ctx);
+    auto soma_dense = SOMADenseNDArray::open(uri, OpenMode::read, ctx);
     REQUIRE(soma_dense->uri() == uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -101,11 +101,11 @@ TEST_CASE("SOMADenseNDArray: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(*schema, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(*schema, "d0", d0));
 
-    soma_dense->open(TILEDB_WRITE);
+    soma_dense->open(OpenMode::write);
     soma_dense->write(array_buffer);
     soma_dense->close();
 
-    soma_dense->open(TILEDB_READ);
+    soma_dense->open(OpenMode::read);
     while (auto batch = soma_dense->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -162,12 +162,12 @@ TEST_CASE("SOMAGroup: basic") {
     auto [uri_sub_array, expected_nnz] = create_array("mem://sub-array", *ctx);
 
     auto soma_group = SOMAGroup::open(
-        TILEDB_WRITE, ctx, uri_main_group, "metadata", 1);
-    soma_group->add_member(uri_sub_group, false, "subgroup");
-    soma_group->add_member(uri_sub_array, false, "subarray");
+        OpenMode::write, ctx, uri_main_group, "metadata", 1);
+    soma_group->add_member(uri_sub_group, URIType::absolute, "subgroup");
+    soma_group->add_member(uri_sub_array, URIType::absolute, "subarray");
     soma_group->close();
 
-    soma_group->open(TILEDB_READ, 1);
+    soma_group->open(OpenMode::read, 1);
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->get_length() == 2);
@@ -178,11 +178,11 @@ TEST_CASE("SOMAGroup: basic") {
     REQUIRE(soma_group->get_member("subarray").type() == Object::Type::Array);
     soma_group->close();
 
-    soma_group->open(TILEDB_WRITE, 3);
+    soma_group->open(OpenMode::write, 3);
     soma_group->remove_member("subgroup");
     soma_group->close();
 
-    soma_group->open(TILEDB_READ, 4);
+    soma_group->open(OpenMode::read, 4);
     REQUIRE(soma_group->get_length() == 1);
     REQUIRE(soma_group->has_member("subgroup") == false);
     REQUIRE(soma_group->has_member("subarray") == true);
@@ -194,12 +194,12 @@ TEST_CASE("SOMAGroup: metadata") {
 
     std::string uri = "mem://unit-test-group";
     Group::create(*ctx, uri);
-    auto soma_group = SOMAGroup::open(TILEDB_WRITE, ctx, uri, "metadata", 1);
+    auto soma_group = SOMAGroup::open(OpenMode::write, ctx, uri, "metadata", 1);
     int32_t val = 100;
     soma_group->set_metadata("md", TILEDB_INT32, 1, &val);
     soma_group->close();
 
-    soma_group->open(TILEDB_READ, 1);
+    soma_group->open(OpenMode::read, 1);
     REQUIRE(soma_group->has_metadata("md") == true);
     REQUIRE(soma_group->metadata_num() == 1);
 
@@ -216,11 +216,11 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
     soma_group->close();
 
-    soma_group->open(TILEDB_WRITE, 2);
+    soma_group->open(OpenMode::write, 2);
     soma_group->delete_metadata("md");
     soma_group->close();
 
-    soma_group->open(TILEDB_READ, 3);
+    soma_group->open(OpenMode::read, 3);
     REQUIRE(soma_group->has_metadata("md") == false);
     REQUIRE(soma_group->metadata_num() == 0);
     soma_group->close();

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -154,10 +154,10 @@ TEST_CASE("SOMAGroup: basic") {
     auto ctx = std::make_shared<Context>();
 
     std::string uri_main_group = "mem://main-group";
-    Group::create(*ctx, uri_main_group);
+    SOMAGroup::create(ctx, uri_main_group, "NONE");
 
     std::string uri_sub_group = "mem://sub-group";
-    Group::create(*ctx, uri_sub_group);
+    SOMAGroup::create(ctx, uri_sub_group, "NONE");
 
     auto [uri_sub_array, expected_nnz] = create_array("mem://sub-array", *ctx);
 

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -82,7 +82,7 @@ TEST_CASE("SOMASparseNDArray: basic") {
 
     SOMASparseNDArray::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_sparse = SOMASparseNDArray::open(uri, TILEDB_READ, ctx);
+    auto soma_sparse = SOMASparseNDArray::open(uri, OpenMode::read, ctx);
     REQUIRE(soma_sparse->uri() == uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -103,11 +103,11 @@ TEST_CASE("SOMASparseNDArray: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(*schema, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(*schema, "d0", d0));
 
-    soma_sparse->open(TILEDB_WRITE);
+    soma_sparse->open(OpenMode::write);
     soma_sparse->write(array_buffer);
     soma_sparse->close();
 
-    soma_sparse->open(TILEDB_READ);
+    soma_sparse->open(OpenMode::read);
     while (auto batch = soma_sparse->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -80,9 +80,9 @@ TEST_CASE("SOMASparseNDArray: basic") {
     auto ctx = std::make_shared<Context>();
     std::string uri = "mem://unit-test-sparse-ndarray-basic";
 
-    SOMASparseNDArray::create(ctx, uri, create_schema(*ctx));
+    SOMASparseNDArray::create(uri, create_schema(*ctx), ctx);
 
-    auto soma_sparse = SOMASparseNDArray::open(TILEDB_READ, ctx, uri);
+    auto soma_sparse = SOMASparseNDArray::open(uri, TILEDB_READ, ctx);
     REQUIRE(soma_sparse->uri() == uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");


### PR DESCRIPTION
**Issue and/or context:**

#1256 
#1354 
#1355 

**Changes:**

- Addition of `SOMACollection`, `SOMAMeasurement`, `SOMAExperiment`
- Use [enumeration types](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md#enumeration-types) as listed in spec: `OpenMode`, `ResultOrder`, and `URIType`
- Add `result_order` and `column_names` for all `SOMAArray` derived objects