### PR TITLE
[python] Generalize `add_X_layer` URI handling

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -907,7 +907,7 @@ def add_matrix_to_collection(
     # whereas storage URIs (for the same object) look like
     # tiledb://namespace/uuid.  When the caller passes a creation URI (which
     # they must) via exp.uri, we need to follow that.
-    extend_creation_uri: bool = exp.uri.startswith("tiledb://")
+    extend_creation_uri = exp.uri.startswith("tiledb://")
 
     with exp.ms[measurement_name] as meas:
         if extend_creation_uri:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -899,23 +899,38 @@ def add_matrix_to_collection(
     Lifecycle:
         Experimental.
     """
+
     ingestion_params = IngestionParams(ingest_mode)
+
+    # For local disk and S3, creation and storage URIs are identical.  For
+    # cloud, creation URIs look like tiledb://namespace/s3://bucket/path/to/obj
+    # whereas storage URIs (for the same object) look like
+    # tiledb://namespace/uuid.  When the caller passes a creation URI (which
+    # they must) via exp.uri, we need to follow that.
+    extend_creation_uri: bool = exp.uri.startswith("tiledb://")
+
     with exp.ms[measurement_name] as meas:
+        if extend_creation_uri:
+            coll_uri = f"{exp.uri}/ms/{measurement_name}/{collection_name}"
+        else:
+            coll_uri = f"{meas.uri}/{collection_name}"
+
         if collection_name in meas:
             coll = cast(Collection[RawHandle], meas[collection_name])
         else:
             coll = _create_or_open_coll(
                 Collection,
-                f"{meas.uri}/{collection_name}",
+                coll_uri,
                 ingestion_params=ingestion_params,
                 context=context,
             )
             _maybe_set(meas, collection_name, coll, use_relative_uri=use_relative_uri)
         with coll:
-            uri = f"{coll.uri}/{matrix_name}"
+            matrix_uri = f"{coll_uri}/{matrix_name}"
+
             with _create_from_matrix(
                 SparseNDArray,
-                uri,
+                matrix_uri,
                 matrix_data,
                 ingestion_params=ingestion_params,
                 context=context,


### PR DESCRIPTION
**Issue and/or context:**

For local disk and S3, creation and readback URIs are the same. For Cloud, there is a syntactical difference:

* Creation: `tiledb://namespace/s3://bucket/path/to/exp/ms/RNA/X`
* Readback (for the same object): `tiledb://namespace/uuid`

For the former, we can append to make `tiledb://namespace/s3://bucket/path/to/exp/ms/RNA/X/newlayer`; for the latter we cannot.

**Changes:**

Respect the syntax and semantics for different storage URIs.

**Notes for Reviewer:**

This repository is an open-source repository which does not have unit tests that rely on cloud infrastructure. For this reason, it's correct and appropriate that this PR does not introduce new unit-test cases. Test cases are appropriately placed in cloud-specific repositores.

For the record, here is a test script:

`axl.py`
```
#!/usr/bin/env python

import tiledbsoma, tiledbsoma.io, tiledbsoma.logging
import anndata as ad
import sys

if len(sys.argv) != 3:
    print("Need input path and output URI as argumentst", file=sys.stderr)
    sys.exit(1)
input_path = sys.argv[1]
output_uri = sys.argv[2]

tiledbsoma.logging.debug()

adata = ad.read_h5ad(input_path)
tiledbsoma.io.from_anndata(
    output_uri,
    adata,
    measurement_name="RNA",
)

with tiledbsoma.open(output_uri, "w") as exp_w:
    tiledbsoma.io.add_X_layer(
        exp_w, measurement_name="RNA", X_layer_name="second", X_layer_data=adata.X
    )
```

This may be driven and verified via:

```
axl.py ./pbmc-small.h5ad /tmp/axl-20230721-132038
axl.py ./pbmc-small.h5ad s3://tiledb-johnkerl/scratch/axl-20230721-134114
axl.py ./pbmc-small.h5ad tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch/axl-20230721-134113
```