### PR TITLE
[python] Add a missing log-line for uns ndarray ingest

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1543,6 +1543,7 @@ def _ingest_uns_ndarray(
             platform_config=platform_config,
         )
     msg = f"Wrote   {soma_arr.uri} (uns ndarray)"
+    logging.log_io(msg, msg)
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
**Issue and/or context:** This made debugging https://forum.tiledb.com/t/tiledberror-tiledb-s3-error-storing-h5ad-with-soma-format/602 a bit confusing.

**Changes:** Add the missing log-line.

**Notes for Reviewer:**

