### PR TITLE
[python] Adding missing context in ingest uns ndarray

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1513,7 +1513,7 @@ def _ingest_uns_ndarray(
         logging.log_io(msg, msg)
         return
     try:
-        soma_arr = _factory.open(arr_uri, "w", soma_type=DenseNDArray)
+        soma_arr = _factory.open(arr_uri, "w", soma_type=DenseNDArray, context=context)
     except DoesNotExistError:
         soma_arr = DenseNDArray.create(
             arr_uri,


### PR DESCRIPTION
**Issue and/or context:** Hypothesized cause of https://forum.tiledb.com/t/tiledberror-tiledb-s3-error-storing-h5ad-with-soma-format/602/1 -- although I cannot yet repro this myself on a cross-region write.

**Changes:** Add the visibly missing `context` argument in the particular `.open`

**Notes for Reviewer:**

