### PR TITLE
[python] Append-mode pre-check logic

### DIFF
--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, Union
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 import pyarrow as pa
 import tiledb
 
@@ -159,3 +160,31 @@ def tiledb_schema_to_arrow(tdb_schema: tiledb.ArraySchema) -> pa.Schema:
         arrow_schema_dict[name] = arrow_type_from_tiledb_dtype(attr.dtype, attr.isascii)
 
     return pa.schema(arrow_schema_dict)
+
+
+def df_to_arrow(df: pd.DataFrame) -> pa.Table:
+    """
+    Categoricals are not yet well supported, so we must flatten.
+    Also replace Numpy/Pandas-style nulls with Arrow-style nulls.
+    """
+    null_fields = set()
+    for k in df:
+        if df[k].dtype == "category":
+            df[k] = df[k].astype(df[k].cat.categories.dtype)
+        if df[k].isnull().any():
+            if df[k].isnull().all():
+                df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
+            else:
+                df[k].where(
+                    df[k].notnull(),
+                    pd.Series(pa.nulls(df[k].isnull().sum(), pa.infer_type(df[k]))),
+                    inplace=True,
+                )
+            null_fields.add(k)
+    arrow_table = pa.Table.from_pandas(df)
+    if null_fields:
+        md = arrow_table.schema.metadata
+        md.update(dict.fromkeys(null_fields, "nullable"))
+        arrow_table = arrow_table.replace_schema_metadata(md)
+
+    return arrow_table

--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -168,6 +168,7 @@ def df_to_arrow(df: pd.DataFrame) -> pa.Table:
     Also replace Numpy/Pandas-style nulls with Arrow-style nulls.
     """
     null_fields = set()
+    # Not for name, col in df.items() since we need df[k] on the left-hand sides
     for k in df:
         if df[k].dtype == "category":
             df[k] = df[k].astype(df[k].cat.categories.dtype)

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -41,8 +41,7 @@ def _string_dict_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]:
     # pre-check an AnnData/H5AD input to see if it's appendable to an existing SOMA experiment, we
     # must not punish the AnnData/H5AD input for it not having a soma_joinid column in its obs and
     # var.
-    if "soma_joinid" in retval:
-        del retval["soma_joinid"]
+    retval.pop("soma_joinid", None)
     return retval
 
 

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -110,7 +110,7 @@ class Signature:
     varm_dtypes: Dict[str, str]
 
     @classmethod
-    def fromAnnData(
+    def from_anndata(
         cls,
         adata: ad.AnnData,
         *,
@@ -175,7 +175,7 @@ class Signature:
         )
 
     @classmethod
-    def fromH5AD(
+    def from_h5ad(
         cls,
         h5ad_file_name: str,
         *,
@@ -184,13 +184,13 @@ class Signature:
         default_X_layer_name: str = "data",
     ) -> Self:
         """
-        See ``fromAnnData``.
+        See ``from_anndata``.
         """
         adata = ad.read_h5ad(h5ad_file_name, "r")
-        return cls.fromAnnData(adata, default_X_layer_name=default_X_layer_name)
+        return cls.from_anndata(adata, default_X_layer_name=default_X_layer_name)
 
     @classmethod
-    def fromSOMAExperiment(cls, uri: str, measurement_name: str = "RNA") -> Self:
+    def from_soma_experiment(cls, uri: str, measurement_name: str = "RNA") -> Self:
         """
         Constructs a pre-check signature from a SOMA experiment, which can be compared against
         another signature from AnnData/H5AD or SOMA experiment.

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -271,6 +271,13 @@ class Signature:
         to be handled a level up by simply showing the user the failed signature pair.
         """
 
+        # Implementation note: _at present_ this could be implemented as `self == other`.  But
+        # "coming soon" we'll allow people the ability to do things like coercing one input's
+        # float64 to another's float32 and the evolution will be toward more iffing, not less.  As
+        # well, in that case, we'll need to also fine-grain the error-reporting to clearly spell out
+        # what we coudn't handle -- rather than just showing the user the two signatures' .toJSON()
+        # output as we do today.
+
         if self.obs_schema != other.obs_schema:
             return False
 

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -1,8 +1,8 @@
 import json
-from dataclasses import dataclass
 from typing import Dict, Optional
 
 import anndata as ad
+import attrs
 import pandas as pd
 import pyarrow as pa
 from typing_extensions import Self
@@ -74,7 +74,7 @@ def _string_dict_from_pandas_dataframe(
     return _string_dict_from_arrow_schema(arrow_schema)
 
 
-@dataclass
+@attrs.define
 class Signature:
     """
     This is support for compatibility pre-check for append-mode SOMA ingestion.
@@ -298,7 +298,9 @@ class Signature:
 
     def toJSON(self) -> str:
         """Presents a signature as JSON which is suitable for distributed logging."""
-        return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+        return json.dumps(
+            self, default=lambda o: attrs.asdict(o), sort_keys=True, indent=4
+        )
 
     @classmethod
     def fromJSON(cls, s: str) -> Self:

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -1,0 +1,305 @@
+import json
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import anndata as ad
+import pandas as pd
+import pyarrow as pa
+from typing_extensions import Self
+
+import tiledbsoma
+import tiledbsoma.logging
+from tiledbsoma._arrow_types import df_to_arrow
+
+
+def _string_dict_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]:
+    """
+    Converts an Arrow schema to a string/string dict, which is easier on the eyes,
+    easier to convert from/to JSON for distributed logging, and easier to do del-key on.
+    """
+
+    def stringify_type(t: pa.DataType) -> str:
+        retval = str(t)
+        # As noted in the Signature class, we pre-check logic from the ingestor.
+        # As detailed elsewhere, Arrow string and large_string must map to TileDB
+        # string, which is large-only. Thus string and large_string form an equivalence
+        # class. Similarly for Arrow binary and large_binary.
+        if retval == "large_string":
+            return "string"
+        if retval == "large_binary":
+            return "binary"
+        return retval
+
+    retval = {name: stringify_type(schema.field(name).type) for name in schema.names}
+
+    # The soma_joinid field is specific to SOMA data but does not exist in AnnData/H5AD.  When we
+    # pre-check an AnnData/H5AD input to see if it's appendable to an existing SOMA experiment, we
+    # must not punish the AnnData/H5AD input for it not having a soma_joinid column in its obs and
+    # var.
+    if "soma_joinid" in retval:
+        del retval["soma_joinid"]
+    return retval
+
+
+def _string_dict_from_pandas_dataframe(
+    df: pd.DataFrame,
+    default_index_name: str,
+) -> Dict[str, str]:
+    """
+    Here we provide compatiblity with the ingestor.
+
+    SOMA experiments are indexed by int64 soma_joinid and this is SOMA-only.
+
+    AnnData inputs have a column offered as the index. This can be: named explicitly "obs_id",
+    "var_id", etc.; unnamed: adata.obs.index.name is None; named "index".
+
+    In the latter two cases the ingestor allows a rename to the user's choice
+    such as "obs_id" and "var_id". Here in the appender pre-check logic, we
+    allow the same.
+    """
+
+    df = df.head(1)  # since reset_index can be expensive on full data
+    if df.index.name is None or df.index.name == "index":
+        df.reset_index(inplace=True)
+        df.rename(columns={"index": default_index_name}, inplace=True)
+    else:
+        df.reset_index(inplace=True)
+
+    arrow_table = df_to_arrow(df)
+    arrow_schema = arrow_table.schema.remove_metadata()
+    return _string_dict_from_arrow_schema(arrow_schema)
+
+
+@dataclass
+class Signature:
+    """
+    This is support for compatibility pre-check for append-mode SOMA ingestion.
+
+    If a SOMA experiment already exists and the user wants to append another AnnData/H5AD to it ---
+    or, if no SOMA experiment exists yet but the user has two or more AnnData/H5AD inputs --- we
+    provide a fail-fast schema-compatibility check.  Use of this pre-check ensures that we flag
+    non-appendable data before any data writes start. In particular, we avoid having a SOMA
+    experiment half-appended to.
+
+    At present we require that all schemas are identical, both within the ingestor and this
+    pre-checker. This includes ``obs`` and ``var`` field names and exact dtypes, as well as ``X``,
+    ``obsm``, and ``varm`` dtypes.
+
+    Later, we can relax constraints: if say the SOMA experiment has ``float64`` dtype for ``X``
+    and an H5AD append has ``float32``, we can do the coercion in the ingestor as well as allowing
+    it within this pre-checker. Thus, this pre-checker logic will evolve over time as the ingestor
+    logic evolves over time.
+    """
+
+    # Note: string/string dicts are easier to serialize/deserialize than pa.Schema
+    obs_schema: Dict[str, str]
+    var_schema: Dict[str, str]
+    raw_var_schema: Optional[Dict[str, str]]
+
+    # TODO include 'raw' in X_dtypes or no? Different for AnnData and for SOMA. When in doubt,
+    # lean SOMA.
+    X_dtypes: Dict[str, str]
+    raw_X_dtype: Optional[str]
+
+    obsm_dtypes: Dict[str, str]
+    varm_dtypes: Dict[str, str]
+
+    @classmethod
+    def fromAnnData(
+        cls,
+        adata: ad.AnnData,
+        *,
+        default_obs_field_name: str = "obs_id",
+        default_var_field_name: str = "var_id",
+        default_X_layer_name: str = "data",
+    ) -> Self:
+        """
+        Constructs a pre-check signature from AnnData/H5AD input, which can be compared
+        against another signature from AnnData/H5AD or SOMA experiment.
+
+        AnnData inputs have a column offered as the index. This can be: named explicitly "obs_id",
+        "var_id", etc.; unnamed: adata.obs.index.name is None; named "index".
+
+        In the latter two cases the ingestor allows a rename to the user's choice such as "obs_id"
+        and "var_id". Here in the appender pre-check logic, we allow the same.
+        """
+
+        obs_schema = _string_dict_from_pandas_dataframe(
+            adata.obs, default_obs_field_name
+        )
+        var_schema = _string_dict_from_pandas_dataframe(
+            adata.var, default_var_field_name
+        )
+
+        X_dtypes = {}
+        X_dtypes[default_X_layer_name] = str(
+            tiledbsoma._arrow_types.arrow_type_from_tiledb_dtype(adata.X.dtype)
+        )
+        for X_layer_name, X_layer in adata.layers.items():
+            X_dtypes[X_layer_name] = str(
+                tiledbsoma._arrow_types.arrow_type_from_tiledb_dtype(X_layer.dtype)
+            )
+
+        raw_X_dtype = None
+        raw_var_schema = None
+        if adata.raw is not None:
+            raw_X_dtype = str(
+                tiledbsoma._arrow_types.arrow_type_from_tiledb_dtype(adata.raw.X.dtype)
+            )
+            raw_var_schema = _string_dict_from_pandas_dataframe(
+                adata.raw.var, default_var_field_name
+            )
+
+        obsm_dtypes = {
+            k: str(tiledbsoma._arrow_types.arrow_type_from_tiledb_dtype(v.dtype))
+            for k, v in adata.obsm.items()
+        }
+        varm_dtypes = {
+            k: str(tiledbsoma._arrow_types.arrow_type_from_tiledb_dtype(v.dtype))
+            for k, v in adata.varm.items()
+        }
+
+        return cls(
+            obs_schema=obs_schema,
+            var_schema=var_schema,
+            X_dtypes=X_dtypes,
+            raw_X_dtype=raw_X_dtype,
+            raw_var_schema=raw_var_schema,
+            obsm_dtypes=obsm_dtypes,
+            varm_dtypes=varm_dtypes,
+        )
+
+    @classmethod
+    def fromH5AD(
+        cls,
+        h5ad_file_name: str,
+        *,
+        default_obs_field_name: str = "obs_id",
+        default_var_field_name: str = "var_id",
+        default_X_layer_name: str = "data",
+    ) -> Self:
+        """
+        See ``fromAnnData``.
+        """
+        adata = ad.read_h5ad(h5ad_file_name, "r")
+        return cls.fromAnnData(adata, default_X_layer_name=default_X_layer_name)
+
+    @classmethod
+    def fromSOMAExperiment(cls, uri: str, measurement_name: str = "RNA") -> Self:
+        """
+        Constructs a pre-check signature from a SOMA experiment, which can be compared against
+        another signature from AnnData/H5AD or SOMA experiment.
+        """
+
+        with tiledbsoma.Experiment.open(uri) as exp:
+
+            obs_schema = _string_dict_from_arrow_schema(exp.obs.schema)
+
+            var_schema = _string_dict_from_arrow_schema(
+                exp.ms[measurement_name].var.schema
+            )
+
+            X_dtypes = {}
+            for X_layer_name in exp.ms[measurement_name].X.keys():
+                X = exp.ms[measurement_name].X[X_layer_name]
+                X_dtypes[X_layer_name] = str(X.schema.field("soma_data").type)
+
+            raw_X_dtype = None
+            raw_var_schema = None
+            if "raw" in exp.ms:
+                raw_var_schema = _string_dict_from_arrow_schema(
+                    exp.ms["raw"].var.schema
+                )
+
+                X = exp.ms["raw"].X[X_layer_name]
+                raw_X_dtype = str(X.schema.field("soma_data").type)
+
+            obsm_dtypes: Dict[str, str] = {}
+            obsm_dtypes = {}
+            if "obsm" in exp.ms[measurement_name]:
+                for obsm_layer_name in exp.ms[measurement_name].obsm.keys():
+                    obsm = exp.ms[measurement_name].obsm[obsm_layer_name]
+                    obsm_dtypes[obsm_layer_name] = str(
+                        obsm.schema.field("soma_data").type
+                    )
+
+            varm_dtypes: Dict[str, str] = {}
+            if "varm" in exp.ms[measurement_name]:
+                for varm_layer_name in exp.ms[measurement_name].varm.keys():
+                    varm = exp.ms[measurement_name].varm[varm_layer_name]
+                    varm_dtypes[varm_layer_name] = str(
+                        varm.schema.field("soma_data").type
+                    )
+
+            return cls(
+                obs_schema=obs_schema,
+                var_schema=var_schema,
+                X_dtypes=X_dtypes,
+                raw_X_dtype=raw_X_dtype,
+                raw_var_schema=raw_var_schema,
+                obsm_dtypes=obsm_dtypes,
+                varm_dtypes=varm_dtypes,
+            )
+
+    @classmethod
+    def compatible(cls, signatures: Dict[str, Self]) -> Tuple[bool, Optional[str]]:
+        """
+        Determines if two signatures from SOMA experiment or AnnData/H5AD will be safe from
+        schema-incompatibility at ingestion time. On success, the second argument is None; on
+        failure, the second argument can be used for reporting to the user.
+        """
+        if len(signatures) < 2:
+            return (True, None)
+        names = list(signatures.keys())
+        first_name = names[0]
+        for other_name in names[1:]:
+            siga = signatures[first_name]
+            sigb = signatures[other_name]
+            if not siga.compatibleWith(sigb):
+                msg = f"Incompatible signatures {first_name!r}, {other_name!r}:\n{siga.toJSON()}\n{sigb.toJSON()}"
+                return (False, msg)
+        return (True, None)
+
+    def compatibleWith(self, other: Self) -> bool:
+        """
+        Pairwise helper method for ``compatible``. Reasons for incompatibility are currently advised
+        to be handled a level up by simply showing the user the failed signature pair.
+        """
+
+        if self.obs_schema != other.obs_schema:
+            return False
+
+        if self.var_schema != other.var_schema:
+            return False
+
+        if self.X_dtypes != other.X_dtypes:
+            return False
+
+        if self.raw_X_dtype != other.raw_X_dtype:
+            return False
+        if self.raw_var_schema != other.raw_var_schema:
+            return False
+
+        if self.obsm_dtypes != other.obsm_dtypes:
+            return False
+        if self.varm_dtypes != other.varm_dtypes:
+            return False
+
+        return True
+
+    def toJSON(self) -> str:
+        """Presents a signature as JSON which is suitable for distributed logging."""
+        return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
+    @classmethod
+    def fromJSON(cls, s: str) -> Self:
+        dikt = json.loads(s)
+        return cls(
+            dikt["obs_schema"],
+            dikt["var_schema"],
+            dikt["raw_var_schema"],
+            dikt["X_dtypes"],
+            dikt["raw_X_dtype"],
+            dikt["obsm_dtypes"],
+            dikt["varm_dtypes"],
+        )

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -306,12 +306,4 @@ class Signature:
     @classmethod
     def fromJSON(cls, s: str) -> Self:
         dikt = json.loads(s)
-        return cls(
-            dikt["obs_schema"],
-            dikt["var_schema"],
-            dikt["raw_var_schema"],
-            dikt["X_dtypes"],
-            dikt["raw_X_dtype"],
-            dikt["obsm_dtypes"],
-            dikt["varm_dtypes"],
-        )
+        return cls(**dikt)

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -75,7 +75,7 @@ def _string_dict_from_pandas_dataframe(
     return _string_dict_from_arrow_schema(arrow_schema)
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class Signature:
     """
     This is support for compatibility pre-check for append-mode SOMA ingestion.

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -11,6 +11,11 @@ import tiledbsoma
 import tiledbsoma.logging
 from tiledbsoma._arrow_types import df_to_arrow
 
+_EQUIVALENCES = {
+    "large_string": "string",
+    "large_binary": "binary",
+}
+
 
 def _stringify_type(t: pa.DataType) -> str:
     """
@@ -21,10 +26,6 @@ def _stringify_type(t: pa.DataType) -> str:
     Arrow string and large_string must map to TileDB string, which is large-only. Thus string and
     large_string form an equivalence class. Similarly for Arrow binary and large_binary.
     """
-    _EQUIVALENCES = {
-        "large_string": "string",
-        "large_binary": "binary",
-    }
     str_t = str(t)
     return _EQUIVALENCES.get(str_t, str_t)
 
@@ -259,7 +260,7 @@ class Signature:
         for nameb, sigb in items[1:]:
             if not siga._compatible_with(sigb):
                 raise ValueError(
-                    f"Incompatible signatures {namea!r}, {nameb!r}:\n{siga.toJSON()}\n{sigb.toJSON()}"
+                    f"Incompatible signatures {namea!r}, {nameb!r}:\n{siga.to_json()}\n{sigb.to_json()}"
                 )
 
     def _compatible_with(self, other: Self) -> bool:
@@ -272,7 +273,7 @@ class Signature:
         # "coming soon" we'll allow people the ability to do things like coercing one input's
         # float64 to another's float32 and the evolution will be toward more iffing, not less.  As
         # well, in that case, we'll need to also fine-grain the error-reporting to clearly spell out
-        # what we coudn't handle -- rather than just showing the user the two signatures' .toJSON()
+        # what we coudn't handle -- rather than just showing the user the two signatures' .to_json()
         # output as we do today.
 
         if self.obs_schema != other.obs_schema:
@@ -296,13 +297,11 @@ class Signature:
 
         return True
 
-    def toJSON(self) -> str:
+    def to_json(self) -> str:
         """Presents a signature as JSON which is suitable for distributed logging."""
-        return json.dumps(
-            self, default=lambda o: attrs.asdict(o), sort_keys=True, indent=4
-        )
+        return json.dumps(self, default=attrs.asdict, sort_keys=True, indent=4)
 
     @classmethod
-    def fromJSON(cls, s: str) -> Self:
+    def from_json(cls, s: str) -> Self:
         dikt = json.loads(s)
         return cls(**dikt)

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -255,13 +255,11 @@ class Signature:
         """
         if len(signatures) < 2:
             return (True, None)
-        names = list(signatures.keys())
-        first_name = names[0]
-        for other_name in names[1:]:
-            siga = signatures[first_name]
-            sigb = signatures[other_name]
+        items = list(signatures.items())
+        namea, siga = items[0]
+        for nameb, sigb in items[1:]:
             if not siga.compatibleWith(sigb):
-                msg = f"Incompatible signatures {first_name!r}, {other_name!r}:\n{siga.toJSON()}\n{sigb.toJSON()}"
+                msg = f"Incompatible signatures {namea!r}, {nameb!r}:\n{siga.toJSON()}\n{sigb.toJSON()}"
                 return (False, msg)
         return (True, None)
 

--- a/apis/python/src/tiledbsoma/io/registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/registration/signatures.py
@@ -249,8 +249,8 @@ class Signature:
     @classmethod
     def compatible(cls, signatures: Dict[str, Self]) -> Tuple[bool, Optional[str]]:
         """
-        Determines if two signatures from SOMA experiment or AnnData/H5AD will be safe from
-        schema-incompatibility at ingestion time. On success, the second argument is None; on
+        Determines if any number of signatures from SOMA experiment or AnnData/H5AD will be safe
+        from schema-incompatibility at ingestion time. On success, the second argument is None; on
         failure, the second argument can be used for reporting to the user.
         """
         if len(signatures) < 2:

--- a/apis/python/tests/test_registration_signatures.py
+++ b/apis/python/tests/test_registration_signatures.py
@@ -23,14 +23,14 @@ def canned_anndata(canned_h5ad_file):
 
 def test_signature_serdes(canned_h5ad_file, canned_anndata):
     sig = signatures.Signature.from_h5ad(canned_h5ad_file.as_posix())
-    text1 = sig.toJSON()
+    text1 = sig.to_json()
     assert "obs_schema" in text1
     assert "var_schema" in text1
-    assert sig == signatures.Signature.fromJSON(text1)
+    assert sig == signatures.Signature.from_json(text1)
 
     sig = signatures.Signature.from_anndata(canned_anndata)
-    text2 = sig.toJSON()
-    assert sig == signatures.Signature.fromJSON(text2)
+    text2 = sig.to_json()
+    assert sig == signatures.Signature.from_json(text2)
 
     assert text1 == text2
 
@@ -38,8 +38,8 @@ def test_signature_serdes(canned_h5ad_file, canned_anndata):
     output_path = tempdir.name
     uri = tiledbsoma.io.from_anndata(output_path, canned_anndata, "RNA")
     sig = signatures.Signature.from_soma_experiment(uri)
-    text3 = sig.toJSON()
-    assert sig == signatures.Signature.fromJSON(text3)
+    text3 = sig.to_json()
+    assert sig == signatures.Signature.from_json(text3)
 
     assert text1 == text3
 

--- a/apis/python/tests/test_registration_signatures.py
+++ b/apis/python/tests/test_registration_signatures.py
@@ -47,9 +47,7 @@ def test_signature_serdes(canned_h5ad_file, canned_anndata):
 def test_compatible(canned_anndata):
 
     # Check that zero inputs result in zero incompatibility
-    ok, msg = signatures.Signature.compatible({})
-    assert ok
-    assert msg is None
+    signatures.Signature.check_compatible({})
 
     sig1 = signatures.Signature.from_anndata(canned_anndata)
 
@@ -59,32 +57,23 @@ def test_compatible(canned_anndata):
     sig2 = signatures.Signature.from_soma_experiment(uri)
 
     # Check that single inputs result in zero incompatibility
-    ok, msg = signatures.Signature.compatible({"anndata": sig1})
-    assert ok
-    assert msg is None
-
-    ok, msg = signatures.Signature.compatible({"experiment": sig2})
-    assert ok
-    assert msg is None
+    signatures.Signature.check_compatible({"anndata": sig1})  # no throw
+    signatures.Signature.check_compatible({"experiment": sig2})  # no throw
 
     # Check that AnnData/H5AD is compatible with itself; likewise with SOMA Experiment
-    ok, msg = signatures.Signature.compatible({"anndata": sig1, "same": sig1})
-    assert ok
-    assert msg is None
-
-    ok, msg = signatures.Signature.compatible({"experiment": sig2, "same": sig2})
-    assert ok
-    assert msg is None
+    signatures.Signature.check_compatible({"anndata": sig1, "same": sig1})  # no throw
+    signatures.Signature.check_compatible(
+        {"experiment": sig2, "same": sig2}
+    )  # no throw
 
     # Check compatibility of identical AnnData / SOMA experiment.
-    ok, msg = signatures.Signature.compatible({"anndata": sig1, "experiment": sig2})
-    assert ok
-    assert msg is None
+    signatures.Signature.check_compatible(
+        {"anndata": sig1, "experiment": sig2}
+    )  # no throw
 
     # Check incompatibility of modified AnnData
     adata3 = canned_anndata
     del adata3.obs["groups"]
     sig3 = signatures.Signature.from_anndata(adata3)
-    ok, msg = signatures.Signature.compatible({"orig": sig1, "anndata3": sig3})
-    assert not ok
-    assert msg is not None
+    with pytest.raises(ValueError):
+        signatures.Signature.check_compatible({"orig": sig1, "anndata3": sig3})

--- a/apis/python/tests/test_registration_signatures.py
+++ b/apis/python/tests/test_registration_signatures.py
@@ -22,13 +22,13 @@ def canned_anndata(canned_h5ad_file):
 
 
 def test_signature_serdes(canned_h5ad_file, canned_anndata):
-    sig = signatures.Signature.fromH5AD(canned_h5ad_file.as_posix())
+    sig = signatures.Signature.from_h5ad(canned_h5ad_file.as_posix())
     text1 = sig.toJSON()
     assert "obs_schema" in text1
     assert "var_schema" in text1
     assert sig == signatures.Signature.fromJSON(text1)
 
-    sig = signatures.Signature.fromAnnData(canned_anndata)
+    sig = signatures.Signature.from_anndata(canned_anndata)
     text2 = sig.toJSON()
     assert sig == signatures.Signature.fromJSON(text2)
 
@@ -37,7 +37,7 @@ def test_signature_serdes(canned_h5ad_file, canned_anndata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
     uri = tiledbsoma.io.from_anndata(output_path, canned_anndata, "RNA")
-    sig = signatures.Signature.fromSOMAExperiment(uri)
+    sig = signatures.Signature.from_soma_experiment(uri)
     text3 = sig.toJSON()
     assert sig == signatures.Signature.fromJSON(text3)
 
@@ -51,12 +51,12 @@ def test_compatible(canned_anndata):
     assert ok
     assert msg is None
 
-    sig1 = signatures.Signature.fromAnnData(canned_anndata)
+    sig1 = signatures.Signature.from_anndata(canned_anndata)
 
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
     uri = tiledbsoma.io.from_anndata(output_path, canned_anndata, "RNA")
-    sig2 = signatures.Signature.fromSOMAExperiment(uri)
+    sig2 = signatures.Signature.from_soma_experiment(uri)
 
     # Check that single inputs result in zero incompatibility
     ok, msg = signatures.Signature.compatible({"anndata": sig1})
@@ -84,7 +84,7 @@ def test_compatible(canned_anndata):
     # Check incompatibility of modified AnnData
     adata3 = canned_anndata
     del adata3.obs["groups"]
-    sig3 = signatures.Signature.fromAnnData(adata3)
+    sig3 = signatures.Signature.from_anndata(adata3)
     ok, msg = signatures.Signature.compatible({"orig": sig1, "anndata3": sig3})
     assert not ok
     assert msg is not None

--- a/apis/python/tests/test_registration_signatures.py
+++ b/apis/python/tests/test_registration_signatures.py
@@ -1,0 +1,90 @@
+import tempfile
+from pathlib import Path
+
+import anndata as ad
+import pytest
+
+import tiledbsoma.io
+import tiledbsoma.io.registration.signatures as signatures
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def canned_h5ad_file(request):
+    input_path = HERE.parent / "testdata/pbmc-small.h5ad"
+    return input_path
+
+
+@pytest.fixture
+def canned_anndata(canned_h5ad_file):
+    return ad.read_h5ad(canned_h5ad_file)
+
+
+def test_signature_serdes(canned_h5ad_file, canned_anndata):
+    sig = signatures.Signature.fromH5AD(canned_h5ad_file.as_posix())
+    text1 = sig.toJSON()
+    assert "obs_schema" in text1
+    assert "var_schema" in text1
+    assert sig == signatures.Signature.fromJSON(text1)
+
+    sig = signatures.Signature.fromAnnData(canned_anndata)
+    text2 = sig.toJSON()
+    assert sig == signatures.Signature.fromJSON(text2)
+
+    assert text1 == text2
+
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+    uri = tiledbsoma.io.from_anndata(output_path, canned_anndata, "RNA")
+    sig = signatures.Signature.fromSOMAExperiment(uri)
+    text3 = sig.toJSON()
+    assert sig == signatures.Signature.fromJSON(text3)
+
+    assert text1 == text3
+
+
+def test_compatible(canned_anndata):
+
+    # Check that zero inputs result in zero incompatibility
+    ok, msg = signatures.Signature.compatible({})
+    assert ok
+    assert msg is None
+
+    sig1 = signatures.Signature.fromAnnData(canned_anndata)
+
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+    uri = tiledbsoma.io.from_anndata(output_path, canned_anndata, "RNA")
+    sig2 = signatures.Signature.fromSOMAExperiment(uri)
+
+    # Check that single inputs result in zero incompatibility
+    ok, msg = signatures.Signature.compatible({"anndata": sig1})
+    assert ok
+    assert msg is None
+
+    ok, msg = signatures.Signature.compatible({"experiment": sig2})
+    assert ok
+    assert msg is None
+
+    # Check that AnnData/H5AD is compatible with itself; likewise with SOMA Experiment
+    ok, msg = signatures.Signature.compatible({"anndata": sig1, "same": sig1})
+    assert ok
+    assert msg is None
+
+    ok, msg = signatures.Signature.compatible({"experiment": sig2, "same": sig2})
+    assert ok
+    assert msg is None
+
+    # Check compatibility of identical AnnData / SOMA experiment.
+    ok, msg = signatures.Signature.compatible({"anndata": sig1, "experiment": sig2})
+    assert ok
+    assert msg is None
+
+    # Check incompatibility of modified AnnData
+    adata3 = canned_anndata
+    del adata3.obs["groups"]
+    sig3 = signatures.Signature.fromAnnData(adata3)
+    ok, msg = signatures.Signature.compatible({"orig": sig1, "anndata3": sig3})
+    assert not ok
+    assert msg is not None


### PR DESCRIPTION
**Issue and/or context:**

Tracking issue: #1278 

**Changes:**

* Create the `Signature` class which will be used for append-mode pre-check on an upcoming PR
* Unit-test that

**Notes for Reviewer:**

* This is a split-out PR -- created for mercifulness to reviewers -- as a line-count reduction from raw material on #1498.
* Question for @aaronwolen @mojaveazure : If an input file has raw and non-raw data do we want them both to be ingested? Or just one or the other? This is actually a design question -- which I'll also put in our tracking doc.