### PR TITLE
[c++] Add new constructor, factor validation helper

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -112,6 +112,29 @@ class SOMAArray {
     //===================================================================
     //= public non-static
     //===================================================================
+
+    /**
+     * @brief Construct a new SOMAArray object
+     *
+     * @param mode TILEDB_READ or TILEDB_WRITE
+     * @param uri URI of the array
+     * @param name name of the array
+     * @param platform_config Config parameter dictionary
+     * @param column_names Columns to read
+     * @param batch_size Batch size
+     * @param result_order Result order
+     * @param timestamp Timestamp
+     */
+    SOMAArray(
+        tiledb_query_type_t mode,
+        std::string_view uri,
+        std::string_view name,
+        std::map<std::string, std::string> platform_config,
+        std::vector<std::string> column_names,
+        std::string_view batch_size,
+        std::string_view result_order,
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
+
     /**
      * @brief Construct a new SOMAArray object
      *
@@ -535,6 +558,14 @@ class SOMAArray {
      * be opened in READ mode, otherwise the function will error out.
      */
     uint64_t metadata_num() const;
+
+    /**
+     * Validates input parameters before opening array.
+     */
+    void validate(
+        tiledb_query_type_t mode,
+        std::string_view name,
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
    private:
     //===================================================================


### PR DESCRIPTION
**Issue and/or context:**

The (non-static) constructor for SOMAArray contains a shared_ptr<Context> making the lifetime management from R a little trickier.  An easier alternative is to also offer a map<string,string> platform_config from which a Config and Context can be derived -- as in the two static ctors.

**Changes:**

This PR adds a second constructor with platform_config interface and places the validation code into a new helper function both non-static constructors call.

**Notes for Reviewer:**

[SC-32281](https://app.shortcut.com/tiledb-inc/story/32281/c-additional-constructor-for-somaarray)
