### PR TITLE
[r] Temporarily install tiledb-r from r-universe

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -37,11 +37,13 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
-      - name: Dependencies
-        run: cd apis/r && tools/r-ci.sh install_all
-
       - name: Temporarily install tiledb-r 0.20.2 from testing
         run: sudo Rscript -e 'install.packages("tiledb", repos = c("https://cloud.r-project.org", "https://tiledb-inc.r-universe.dev"))'
+        env:
+          USE_BPSM: FALSE
+
+      - name: Dependencies
+        run: cd apis/r && tools/r-ci.sh install_all
 
       - name: CMake
         uses: lukka/get-cmake@latest
@@ -50,12 +52,12 @@ jobs:
       #  run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
       #- name: Build and install libtiledbsoma
-      #  run: sudo scripts/bld --prefix=/usr/local 
+      #  run: sudo scripts/bld --prefix=/usr/local
 
       #- name: Call ldconfig
       #  if: ${{ matrix.os == 'ubuntu-latest' }}
       #  run: sudo ldconfig
-        
+
       - name: Test
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -37,10 +37,11 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
-      - name: Temporarily install tiledb-r 0.20.2 from testing
-        run: sudo Rscript -e 'install.packages("tiledb", repos = c("https://cloud.r-project.org", "https://tiledb-inc.r-universe.dev"))'
-        env:
-          USE_BPSM: FALSE
+      - name: Install 'old' tiledb-r to satisfy its dependencies
+        run: cd apis/r && tools/r-ci.sh tiledb-r
+
+      - name: Install new tiledb-r 0.20.2
+        run: cd apis/r && Rscript -e 'if (Sys.info()[["sysname"]] == "Linux") bspm::disable(); install.packages("tiledb", repos = c("https://tiledb-inc.r-universe.dev", "https://cloud.r-project.org"))'
 
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
 
+      - name: Temporarily install tiledb-r 0.20.2 from testing
+        run: sudo Rscript -e 'install.packages("tiledb", repos = c("https://cloud.r-project.org", "https://tiledb-inc.r-universe.dev"))'
+
       - name: CMake
         uses: lukka/get-cmake@latest
 

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     Matrix,
     stats,
     bit64,
-    tiledb (>= 0.20.0),
+    tiledb (>= 0.20.2),
     arrow,
     utils,
     fs,


### PR DESCRIPTION
**Issue and/or context:** #1567

**Changes:** This bumps the minimum required version of tiledb-r to 0.20.2. Also modifies the R API's CI to install tiledb-r from r-universe. tiledbsoma 1.4.0 now requires tiledb-r >= 0.20.2 (built against TileDB 2.16.1). We won't be able to upload tiledb-r 0.20.2 to CRAN until they return from break on Aug 7. In the meantime, we can install tiledb-r builds from R-universe, which already has 0.20.2 available.

Thanks to @eddelbuettel for the assist.