### PR TITLE
[python] Fix For #1456: Invalid Result With PyArrow Array Coords

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -303,124 +303,72 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     array.attr("_export_to_c")(
                         arrow_array_ptr, arrow_schema_ptr);
 
+                    auto coords = array.attr("to_pylist")();
+
                     int data_index = arrow_array.n_buffers - 1;
 
                     if (!strcmp(arrow_schema.format, "l")) {
-                        tcb::span<int64_t> data{
-                            (int64_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<int64_t>>());
                     } else if (!strcmp(arrow_schema.format, "i")) {
-                        tcb::span<int32_t> data{
-                            (int32_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<int32_t>>());
                     } else if (!strcmp(arrow_schema.format, "s")) {
-                        tcb::span<int16_t> data{
-                            (int16_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<int16_t>>());
                     } else if (!strcmp(arrow_schema.format, "c")) {
-                        tcb::span<int8_t> data{
-                            (int8_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<int8_t>>());
                     } else if (!strcmp(arrow_schema.format, "L")) {
-                        tcb::span<uint64_t> data{
-                            (uint64_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<uint64_t>>());
                     } else if (!strcmp(arrow_schema.format, "I")) {
-                        tcb::span<uint32_t> data{
-                            (uint32_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<uint32_t>>());
                     } else if (!strcmp(arrow_schema.format, "S")) {
-                        tcb::span<uint16_t> data{
-                            (uint16_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<uint16_t>>());
                     } else if (!strcmp(arrow_schema.format, "C")) {
-                        tcb::span<uint8_t> data{
-                            (uint8_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<uint8_t>>());
                     } else if (!strcmp(arrow_schema.format, "f")) {
-                        tcb::span<float> data{
-                            (float*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<float>>());
                     } else if (!strcmp(arrow_schema.format, "g")) {
-                        tcb::span<double> data{
-                            (double*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
-
+                            dim, coords.cast<std::vector<double>>());
                     } else if (
                         !strcmp(arrow_schema.format, "u") ||
                         !strcmp(arrow_schema.format, "z")) {
-                        // TODO: partitioning is not supported for string/bytes
-                        // dims
-                        const char* data = (const char*)(arrow_array
-                                                             .buffers[2]);
-                        const uint32_t*
-                            offsets = (const uint32_t*)(arrow_array.buffers[1]);
+                        // // TODO: partitioning is not supported for string/bytes
+                        // // dims
+                        // const char* data = (const char*)(arrow_array
+                        //                                      .buffers[2]);
+                        // const uint32_t*
+                        //     offsets = (const uint32_t*)(arrow_array.buffers[1]);
 
-                        for (int32_t i = 0; i < arrow_array.length; i++) {
-                            auto value = std::string{
-                                data + offsets[i], offsets[i + 1] - offsets[i]};
-                            reader.set_dim_point(dim, value);
-                        }
-
+                        // for (int32_t i = 0; i < arrow_array.length; i++) {
+                        //     auto value = std::string{
+                        //         data + offsets[i], offsets[i + 1] - offsets[i]};
+                        //     reader.set_dim_point(dim, value);
+                        // }
+                        reader.set_dim_points(
+                            dim, coords.cast<std::vector<std::string>>());
                     } else if (
                         !strcmp(arrow_schema.format, "tss:") ||
                         !strcmp(arrow_schema.format, "tsm:") ||
                         !strcmp(arrow_schema.format, "tsu:") ||
                         !strcmp(arrow_schema.format, "tsn:")) {
-                        tcb::span<int64_t> data{
-                            (int64_t*)arrow_array.buffers[data_index],
-                            (uint64_t)arrow_array.length};
                         reader.set_dim_points(
-                            dim, data, partition_index, partition_count);
+                            dim, coords.cast<std::vector<int64_t>>());
 
                         // TODO:
                         // (pa.bool_(),) * 2,
-
                     } else if (
                         !strcmp(arrow_schema.format, "U") ||
                         !strcmp(arrow_schema.format, "Z")) {
-                        // TODO: partitioning is not supported for string/bytes
-                        // dims
-                        const char* data = (const char*)(arrow_array
-                                                             .buffers[2]);
-                        const uint64_t*
-                            offsets = (const uint64_t*)(arrow_array.buffers[1]);
-
-                        for (int64_t i = 0; i < arrow_array.length; i++) {
-                            auto value = std::string{
-                                data + offsets[i], offsets[i + 1] - offsets[i]};
-                            reader.set_dim_point(dim, value);
-                        }
-
+                        reader.set_dim_points(
+                            dim, coords.cast<std::vector<std::string>>());
                     } else {
                         throw TileDBSOMAError(fmt::format(
                             "[pytiledbsoma] set_dim_points: type={} not "

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -303,8 +303,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     array.attr("_export_to_c")(
                         arrow_array_ptr, arrow_schema_ptr);
 
-                    auto coords = array.attr("to_pylist")();
-
+                    auto coords = array.attr("tolist")();
                     int data_index = arrow_array.n_buffers - 1;
 
                     if (!strcmp(arrow_schema.format, "l")) {
@@ -340,18 +339,6 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     } else if (
                         !strcmp(arrow_schema.format, "u") ||
                         !strcmp(arrow_schema.format, "z")) {
-                        // // TODO: partitioning is not supported for string/bytes
-                        // // dims
-                        // const char* data = (const char*)(arrow_array
-                        //                                      .buffers[2]);
-                        // const uint32_t*
-                        //     offsets = (const uint32_t*)(arrow_array.buffers[1]);
-
-                        // for (int32_t i = 0; i < arrow_array.length; i++) {
-                        //     auto value = std::string{
-                        //         data + offsets[i], offsets[i + 1] - offsets[i]};
-                        //     reader.set_dim_point(dim, value);
-                        // }
                         reader.set_dim_points(
                             dim, coords.cast<std::vector<std::string>>());
                     } else if (
@@ -359,11 +346,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                         !strcmp(arrow_schema.format, "tsm:") ||
                         !strcmp(arrow_schema.format, "tsu:") ||
                         !strcmp(arrow_schema.format, "tsn:")) {
+                        // convert the Arrow Array to int64
+                        auto pa = py::module::import("pyarrow");
+                        coords = array.attr("cast")(pa.attr("int64")()).attr("tolist")();
                         reader.set_dim_points(
                             dim, coords.cast<std::vector<int64_t>>());
-
-                        // TODO:
-                        // (pa.bool_(),) * 2,
                     } else if (
                         !strcmp(arrow_schema.format, "U") ||
                         !strcmp(arrow_schema.format, "Z")) {

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -675,21 +675,26 @@ def test_experiment_query_column_names(soma_experiment):
         assert set(ad.obs.keys()) == {"soma_joinid", "label"}
         assert set(ad.var.keys()) == {"soma_joinid", "label"}
 
+
 @pytest.mark.parametrize("n_obs,n_vars", [(1001, 99)])
-def test_experiment_query_mp_disjoint_arrow_coords(soma_experiment):  
+def test_experiment_query_mp_disjoint_arrow_coords(soma_experiment):
     """
-    Verify Pyarrow join ids that are offset are correctly handled. 
-    """   
-    all_ids = pa.array(range(30))
-    slices = [all_ids[i * 10:i * 10 + 10]
-              for i in range(3)] 
-    
+    Verify Pyarrow join ids that are offset are correctly handled.
+    """
+    pa.array(range(30))
+    slices = [
+        pa.array(range(10)),
+        pa.array(range(10, 20)),
+        pa.array(range(20, 30)),
+    ]
+
     for ids in slices:
         with soma_experiment.axis_query(
             "RNA",
             obs_query=soma.AxisQuery(coords=(ids,)),
         ) as query:
             assert query.obs_joinids() == ids
+
 
 """
 Fixture support & utility functions below.

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -676,7 +676,10 @@ def test_experiment_query_column_names(soma_experiment):
         assert set(ad.var.keys()) == {"soma_joinid", "label"}
 
 @pytest.mark.parametrize("n_obs,n_vars", [(1001, 99)])
-def test_experiment_query_mp_disjoint_arrow_coords(soma_experiment):     
+def test_experiment_query_mp_disjoint_arrow_coords(soma_experiment):  
+    """
+    Verify Pyarrow join ids that are offset are correctly handled. 
+    """   
     all_ids = pa.array(range(30))
     slices = [all_ids[i * 10:i * 10 + 10]
               for i in range(3)] 

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -675,6 +675,18 @@ def test_experiment_query_column_names(soma_experiment):
         assert set(ad.obs.keys()) == {"soma_joinid", "label"}
         assert set(ad.var.keys()) == {"soma_joinid", "label"}
 
+@pytest.mark.parametrize("n_obs,n_vars", [(1001, 99)])
+def test_experiment_query_mp_disjoint_arrow_coords(soma_experiment):     
+    all_ids = pa.array(range(30))
+    slices = [all_ids[i * 10:i * 10 + 10]
+              for i in range(3)] 
+    
+    for ids in slices:
+        with soma_experiment.axis_query(
+            "RNA",
+            obs_query=soma.AxisQuery(coords=(ids,)),
+        ) as query:
+            assert query.obs_joinids() == ids
 
 """
 Fixture support & utility functions below.


### PR DESCRIPTION
**Issue and/or context:**

#1456

The PyArrow `_export_to_c` function sets a pointer to the beginning of the given Arrow array. However, input data may not always point to the start. The coordinates listed in the bug report uses disjointed slices that are offset.

**Changes:**

Directly convert the input Arrow array into a Python list using PyArrow's `Array.tolist`. Then convert the Python list into a C++ vector using Pybind11's `cast`. Pass this into `SOMAArray::set_dim_points`.

The option for passing partitioning indexes to `set_dim_points_arrow` has been removed for simplicity as this is not used anywhere in TileDB-SOMA-Py.
