### PR TITLE
[c++] `SOMACollection` Takes Start and End Timestamp

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -77,7 +77,7 @@ class SOMAArray {
      * @param batch_size Read batch size
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(
@@ -102,7 +102,7 @@ class SOMAArray {
      * @param batch_size Read batch size
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -77,6 +77,7 @@ class SOMAArray {
      * @param batch_size Read batch size
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(
@@ -101,6 +102,7 @@ class SOMAArray {
      * @param batch_size Read batch size
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAArray> SOMAArray
      */
     static std::unique_ptr<SOMAArray> open(

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -56,14 +56,21 @@ std::unique_ptr<SOMACollection> SOMACollection::create(
 std::unique_ptr<SOMACollection> SOMACollection::open(
     std::string_view uri,
     OpenMode mode,
-    std::map<std::string, std::string> platform_config) {
+    std::map<std::string, std::string> platform_config,
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     return SOMACollection::open(
-        uri, mode, std::make_shared<Context>(Config(platform_config)));
+        uri,
+        mode,
+        std::make_shared<Context>(Config(platform_config)),
+        timestamp);
 }
 
 std::unique_ptr<SOMACollection> SOMACollection::open(
-    std::string_view uri, OpenMode mode, std::shared_ptr<Context> ctx) {
-    return std::make_unique<SOMACollection>(mode, uri, ctx);
+    std::string_view uri,
+    OpenMode mode,
+    std::shared_ptr<Context> ctx,
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    return std::make_unique<SOMACollection>(mode, uri, ctx, timestamp);
 }
 
 //===================================================================
@@ -74,7 +81,7 @@ SOMACollection::SOMACollection(
     OpenMode mode,
     std::string_view uri,
     std::shared_ptr<Context> ctx,
-    std::optional<uint64_t> timestamp) {
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
     group_ = std::make_shared<SOMAGroup>(mode, uri, "", ctx, timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -81,12 +81,14 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param platform_config Config parameter dictionary
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
         std::string_view uri,
         OpenMode mode,
-        std::map<std::string, std::string> platform_config = {});
+        std::map<std::string, std::string> platform_config = {},
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open a group at the specified URI and return SOMACollection
@@ -95,10 +97,14 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param ctx TileDB context
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
-        std::string_view uri, OpenMode mode, std::shared_ptr<Context> ctx);
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<Context> ctx,
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
     //= public non-static
@@ -111,12 +117,13 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param ctx TileDB context
      * @param key key of the array
+     * @param timestamp Pair indicating timestamp start and end
      */
     SOMACollection(
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
-        std::optional<uint64_t> timestamp = std::nullopt);
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
     SOMACollection() = delete;
     SOMACollection(const SOMACollection&) = default;

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -81,7 +81,7 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param platform_config Config parameter dictionary
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
@@ -97,7 +97,7 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param mode read or write
      * @param ctx TileDB context
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::shared_ptr<SOMACollection> SOMACollection
      */
     static std::unique_ptr<SOMACollection> open(
@@ -117,7 +117,7 @@ class SOMACollection : public SOMAObject {
      * @param uri URI of the array
      * @param ctx TileDB context
      * @param key key of the array
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      */
     SOMACollection(
         OpenMode mode,

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -30,10 +30,12 @@
  *   This file defines the SOMADataFrame class.
  */
 
-#include "soma_dataframe.h"
+#include <filesystem>
+
 #include <tiledb/tiledb>
 #include "array_buffers.h"
 #include "soma_array.h"
+#include "soma_dataframe.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -94,10 +96,11 @@ SOMADataFrame::SOMADataFrame(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::string array_name = std::filesystem::path(uri).filename();
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        uri,  // label used when debugging
+        array_name,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -97,7 +97,7 @@ SOMADataFrame::SOMADataFrame(
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        "unnamed",  // name
+        uri,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -30,8 +30,10 @@
  *   This file defines the SOMADenseNDArray class.
  */
 
-#include "soma_dense_ndarray.h"
+#include <filesystem>
+
 #include "soma_array.h"
+#include "soma_dense_ndarray.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -95,10 +97,11 @@ SOMADenseNDArray::SOMADenseNDArray(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::string array_name = std::filesystem::path(uri).filename();
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        uri,  // label used when debugging
+        array_name,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -98,7 +98,7 @@ SOMADenseNDArray::SOMADenseNDArray(
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        "unnamed",  // name
+        uri,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -77,7 +77,7 @@ class SOMAExperiment : public SOMACollection {
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
-        std::optional<uint64_t> timestamp = std::nullopt)
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt)
         : SOMACollection(mode, uri, ctx, timestamp) {
     }
 

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -70,7 +70,7 @@ class SOMAGroup {
      * @param uri URI of the group
      * @param name Name of the group
      * @param platform_config Config parameter dictionary
-     * @param timestamp Timestamp
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
@@ -78,7 +78,7 @@ class SOMAGroup {
         std::string_view uri,
         std::string_view name = "unnamed",
         std::map<std::string, std::string> platform_config = {},
-        std::optional<uint64_t> timestamp = std::nullopt);
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * @brief Open a group at the specified URI and return SOMAGroup
@@ -88,7 +88,7 @@ class SOMAGroup {
      * @param ctx TileDB context
      * @param uri URI of the group
      * @param name Name of the group
-     * @param timestamp Timestamp
+     * @param timestamp Pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
@@ -96,7 +96,7 @@ class SOMAGroup {
         std::shared_ptr<Context> ctx,
         std::string_view uri,
         std::string_view name = "unnamed",
-        std::optional<uint64_t> timestamp = std::nullopt);
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     //===================================================================
     //= public non-static
@@ -109,14 +109,14 @@ class SOMAGroup {
      * @param uri URI of the group
      * @param name Name of the group
      * @param ctx TileDB context
-     * @param timestamp Timestamp
+     * @param timestamp Pair indicating timestamp start and end
      */
     SOMAGroup(
         OpenMode mode,
         std::string_view uri,
         std::string_view name,
         std::shared_ptr<Context> ctx,
-        std::optional<uint64_t> timestamp = std::nullopt);
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     SOMAGroup() = delete;
     SOMAGroup(const SOMAGroup&) = delete;
@@ -127,9 +127,11 @@ class SOMAGroup {
      * Open the SOMAGroup object.
      *
      * @param mode read or write
-     * @param timestamp Timestamp
+     * @param timestamp Pair indicating timestamp start and end
      */
-    void open(OpenMode mode, std::optional<uint64_t> timestamp = std::nullopt);
+    void open(
+        OpenMode mode,
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
 
     /**
      * Close the SOMAGroup object.

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -70,7 +70,7 @@ class SOMAGroup {
      * @param uri URI of the group
      * @param name Name of the group
      * @param platform_config Config parameter dictionary
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
@@ -88,7 +88,7 @@ class SOMAGroup {
      * @param ctx TileDB context
      * @param uri URI of the group
      * @param name Name of the group
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      * @return std::unique_ptr<SOMAGroup> SOMAGroup
      */
     static std::unique_ptr<SOMAGroup> open(
@@ -109,7 +109,7 @@ class SOMAGroup {
      * @param uri URI of the group
      * @param name Name of the group
      * @param ctx TileDB context
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      */
     SOMAGroup(
         OpenMode mode,
@@ -127,7 +127,7 @@ class SOMAGroup {
      * Open the SOMAGroup object.
      *
      * @param mode read or write
-     * @param timestamp Pair indicating timestamp start and end
+     * @param timestamp Optional pair indicating timestamp start and end
      */
     void open(
         OpenMode mode,

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -77,7 +77,7 @@ class SOMAMeasurement : public SOMACollection {
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<Context> ctx,
-        std::optional<uint64_t> timestamp = std::nullopt)
+        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt)
         : SOMACollection(mode, uri, ctx, timestamp) {
     }
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -98,7 +98,7 @@ SOMASparseNDArray::SOMASparseNDArray(
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        "unnamed",  // name
+        uri,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -30,8 +30,10 @@
  *   This file defines the SOMASparseNDArray class.
  */
 
-#include "soma_sparse_ndarray.h"
+#include <filesystem>
+
 #include "soma_array.h"
+#include "soma_sparse_ndarray.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -95,10 +97,11 @@ SOMASparseNDArray::SOMASparseNDArray(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::string array_name = std::filesystem::path(uri).filename();
     array_ = std::make_shared<SOMAArray>(
         mode,
         uri,
-        uri,  // label used when debugging
+        array_name,  // label used when debugging
         ctx,
         column_names,
         "auto",  // batch_size,

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -162,12 +162,16 @@ TEST_CASE("SOMAGroup: basic") {
     auto [uri_sub_array, expected_nnz] = create_array("mem://sub-array", *ctx);
 
     auto soma_group = SOMAGroup::open(
-        OpenMode::write, ctx, uri_main_group, "metadata", 1);
+        OpenMode::write,
+        ctx,
+        uri_main_group,
+        "metadata",
+        std::pair<uint64_t, uint64_t>(0, 1));
     soma_group->add_member(uri_sub_group, URIType::absolute, "subgroup");
     soma_group->add_member(uri_sub_array, URIType::absolute, "subarray");
     soma_group->close();
 
-    soma_group->open(OpenMode::read, 1);
+    soma_group->open(OpenMode::read, std::pair<uint64_t, uint64_t>(0, 2));
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->get_length() == 2);
@@ -178,11 +182,11 @@ TEST_CASE("SOMAGroup: basic") {
     REQUIRE(soma_group->get_member("subarray").type() == Object::Type::Array);
     soma_group->close();
 
-    soma_group->open(OpenMode::write, 3);
+    soma_group->open(OpenMode::write, std::pair<uint64_t, uint64_t>(0, 3));
     soma_group->remove_member("subgroup");
     soma_group->close();
 
-    soma_group->open(OpenMode::read, 4);
+    soma_group->open(OpenMode::read, std::pair<uint64_t, uint64_t>(0, 4));
     REQUIRE(soma_group->get_length() == 1);
     REQUIRE(soma_group->has_member("subgroup") == false);
     REQUIRE(soma_group->has_member("subarray") == true);
@@ -194,12 +198,17 @@ TEST_CASE("SOMAGroup: metadata") {
 
     std::string uri = "mem://unit-test-group";
     Group::create(*ctx, uri);
-    auto soma_group = SOMAGroup::open(OpenMode::write, ctx, uri, "metadata", 1);
+    auto soma_group = SOMAGroup::open(
+        OpenMode::write,
+        ctx,
+        uri,
+        "metadata",
+        std::pair<uint64_t, uint64_t>(1, 1));
     int32_t val = 100;
     soma_group->set_metadata("md", TILEDB_INT32, 1, &val);
     soma_group->close();
 
-    soma_group->open(OpenMode::read, 1);
+    soma_group->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
     REQUIRE(soma_group->has_metadata("md") == true);
     REQUIRE(soma_group->metadata_num() == 1);
 
@@ -216,11 +225,11 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
     soma_group->close();
 
-    soma_group->open(OpenMode::write, 2);
+    soma_group->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
     soma_group->delete_metadata("md");
     soma_group->close();
 
-    soma_group->open(OpenMode::read, 3);
+    soma_group->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
     REQUIRE(soma_group->has_metadata("md") == false);
     REQUIRE(soma_group->metadata_num() == 0);
     soma_group->close();


### PR DESCRIPTION
**Issue and/or context:**

#1575

**Changes:**

* `SOMAGroup` derived objects (ie. `SOMA{Collection,Measurement,Experiment}`) now take in both the start and end timestamps which is consistent with `SOMAArray` derived objects
* Set the `name` (label used by `ManagedQuery` when debugging) of the `SOMAArray` to the URI 
