### PR TITLE
[r] Include system prerequisites in install notes

### DIFF
--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -14,18 +14,15 @@ install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
                                           'https://cloud.r-project.org'))
  ```
 
-Installing on Unix-like platforms without binaries requires `cmake` and `git`.
+Installing from source on Unix-like platforms requires `cmake` and `git`.
 
 Alternatively, tiledbsoma can be installed directly from [Conda](https://anaconda.org/tiledb/r-tiledbsoma), which serves binaries for multiple architectures.
 
- ```bash
- mamba install -c conda-forge -c tiledb r-tiledbsoma
- ```
+```bash
+mamba install -c conda-forge -c tiledb r-tiledbsoma
+```
 
 *Note, we're using `mamba` here as a drop-in replacement for `conda` to accelerate the install process.*
-
-The r-universe repo serves macOS binaries and the source package for other Unix-like platforms. The
-conda channel serves binaries for multiple architectures.
 
 ## From source
 

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -6,20 +6,26 @@ This is the R implementation of the [SOMA API specification](https://github.com/
 
 ## Release packages
 
-TileDB-SOMA releases are available on R-universe and [Conda](https://anaconda.org/tiledb/r-tiledbsoma), and can be installed directly from R or `mamba` as indicated below.
+TileDB-SOMA releases can be installed from R-universe, which serves macOS binaries and the source
+package for other Unix-like platforms.
 
 ```r
 install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
-                                         'https://cloud.r-project.org'))
-```
+                                          'https://cloud.r-project.org'))
+ ```
 
-System prerequisites include `cmake` and `git`.
+Installing on Unix-like platforms without binaries requires `cmake` and `git`.
 
-```bash
-mamba install -c conda-forge -c tiledb r-tiledbsoma
-```
+Alternatively, tiledbsoma can be installed directly from [Conda](https://anaconda.org/tiledb/r-tiledbsoma), which serves binaries for multiple architectures.
 
-The r-universe repo serves macOS binaries and the source package for other Unix-like platforms. The conda channel serves binaries for multiple architectures.
+ ```bash
+ mamba install -c conda-forge -c tiledb r-tiledbsoma
+ ```
+
+*Note, we're using `mamba` here as a drop-in replacement for `conda` to accelerate the install process.*
+
+The r-universe repo serves macOS binaries and the source package for other Unix-like platforms. The
+conda channel serves binaries for multiple architectures.
 
 ## From source
 

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -13,6 +13,8 @@ install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
                                          'https://cloud.r-project.org'))
 ```
 
+System prerequisites include `cmake` and `git`.
+
 ```bash
 mamba install -c conda-forge -c tiledb r-tiledbsoma
 ```


### PR DESCRIPTION
Testing installs of 1.4.0 on fresh EC2 instances, and Docker images.

With `cmake` and `git`, I can successfully install with R 4.1 or 4.3.