### PR TITLE
[r] Remove workaround for tiledb-r 0.20.3 while CRAN was on break

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -10,9 +10,6 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 
-# Temporary
-${R_HOME}/bin/Rscript -e 'if (packageVersion("tiledb") < "0.20.3") install.packages("tiledb", repos = c("https://tiledb-inc.r-universe.dev", "https://cloud.r-project.org"))'
-
 ## Check for pkg-config and use it to inquire about tiledb and tiledbsoma build options
 pkg-config --version >/dev/null 2>&1
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
**Issue and/or context:**

Versions 0.20.2 and 0.20.3 (current) could not be uploaded to CRAN while CRAN was on break, but provided an update to TileDB Embedded that was needed.  To obtain it, installation relied on a temporary installation via r-universe.  With version 0.20.3 now on CRAN this is no longer needed.

**Changes:**

Removal of a temporary accomation.

**Notes for Reviewer:**

[SC-32602](https://app.shortcut.com/tiledb-inc/story/32602/remove-temporary-cran-accomodation)
