### PR TITLE
[c++] Support reading `SOMAObject` metadata in read and write mode

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -546,18 +546,8 @@ class SOMAArray {
      * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
      * uint32_t, const void*>)
      */
-    MetadataValue get_metadata(const std::string& key) const;
-
-    /**
-     * @brief Given an index, get the associated value datatype, number of
-     * values, and value in binary form. The array must be opened in READ mode,
-     * otherwise the function will error out.
-     *
-     * @param index The index used to get the metadata.
-     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
-     * uint32_t, const void*>)
-     */
-    MetadataValue get_metadata(uint64_t index) const;
+    std::map<std::string, MetadataValue> get_metadata();
+    std::optional<MetadataValue> get_metadata(const std::string& key);
 
     /**
      * Check if the key exists in metadata from an open array. The array must
@@ -588,6 +578,11 @@ class SOMAArray {
     //= private non-static
     //===================================================================
 
+    /**
+     * Fills the metadata cache upon opening the array.
+     */
+    void fill_metadata_cache();
+
     // TileDB context
     std::shared_ptr<Context> ctx_;
 
@@ -599,6 +594,9 @@ class SOMAArray {
 
     // Result order
     ResultOrder result_order_;
+
+    // Metadata cache
+    std::map<std::string, MetadataValue> metadata_;
 
     // Read timestamp range (start, end)
     std::optional<std::pair<uint64_t, uint64_t>> timestamp_;

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -85,8 +85,9 @@ SOMACollection::SOMACollection(
     group_ = std::make_shared<SOMAGroup>(mode, uri, "", ctx, timestamp);
 }
 
-void SOMACollection::open(OpenMode mode) {
-    group_->open(mode);
+void SOMACollection::open(
+    OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    group_->open(mode, timestamp);
 }
 
 void SOMACollection::close() {

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -136,7 +136,8 @@ class SOMACollection : public SOMAObject {
      * @param mode read or write
      * @param timestamp Timestamp
      */
-    void open(OpenMode mode);
+    void open(
+        OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
     /**
      * Closes the SOMACollection object.
@@ -302,6 +303,96 @@ class SOMACollection : public SOMAObject {
         URIType uri_type,
         std::shared_ptr<Context> ctx,
         ArraySchema schema);
+
+    /**
+     * Set metadata key-value items to a SOMACollection. The SOMACollection must
+     * opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value) {
+        group_->set_metadata(key, value_type, value_num, value);
+    }
+
+    /**
+     * Delete a metadata key-value item from an open SOMACollection. The
+     * SOMACollection must be opened in WRITE mode, otherwise the function will
+     * error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the group.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key) {
+        group_->delete_metadata(key);
+    }
+
+    /**
+     * @brief Given a key, get the associated value datatype, number of
+     * values, and value in binary form.
+     *
+     * The value may consist of more than one items of the same datatype. Keys
+     * that do not exist in the metadata will be return NULL for the value.
+     *
+     * **Example:**
+     * @code{.cpp}
+     * // Open the group for reading
+     * tiledbsoma::SOMAGroup soma_group = SOMAGroup::open(TILEDB_READ,
+     "s3://bucket-name/group-name");
+     * tiledbsoma::MetadataValue meta_val = soma_group->get_metadata("key");
+     * std::string key = std::get<MetadataInfo::key>(meta_val);
+     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
+     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
+     * const void* value = *((const
+     int32_t*)std::get<MetadataInfo::value>(meta_val));
+     * @endcode
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+     *     are acceptable.
+     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
+     * uint32_t, const void*>)
+     */
+    std::map<std::string, MetadataValue> get_metadata() {
+        return group_->get_metadata();
+    }
+
+    std::optional<MetadataValue> get_metadata(const std::string& key) {
+        return group_->get_metadata(key);
+    }
+
+    /**
+     * Check if the key exists in metadata from an open SOMACollection.
+     *
+     * @param key The key of the metadata item to be checked. UTF-8 encodings
+     *     are acceptable.
+     * @return true if the key exists, else false.
+     */
+    bool has_metadata(const std::string& key) {
+        return group_->has_metadata(key);
+    }
+
+    /**
+     * Return then number of metadata items in an open SOMACollection. The group
+     * must be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const {
+        return group_->metadata_num();
+    }
 
    protected:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -34,7 +34,6 @@
 
 #include <tiledb/tiledb>
 #include "array_buffers.h"
-#include "soma_array.h"
 #include "soma_dataframe.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -32,7 +32,6 @@
 
 #include <filesystem>
 
-#include "soma_array.h"
 #include "soma_dense_ndarray.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -35,6 +35,7 @@
 
 #include <tiledb/tiledb>
 #include "enums.h"
+#include "soma_array.h"
 #include "soma_object.h"
 
 namespace tiledbsoma {
@@ -231,6 +232,96 @@ class SOMADenseNDArray : public SOMAObject {
      * @param buffers The ArrayBuffers to write
      */
     void write(std::shared_ptr<ArrayBuffers> buffers);
+
+    /**
+     * Set metadata key-value items to a SOMADenseNDArray. The SOMADenseNDArray
+     * must opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value) {
+        array_->set_metadata(key, value_type, value_num, value);
+    }
+
+    /**
+     * Delete a metadata key-value item from an open SOMADenseNDArray. The
+     * SOMADenseNDArray must be opened in WRITE mode, otherwise the function
+     * will error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the group.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key) {
+        array_->delete_metadata(key);
+    }
+
+    /**
+     * @brief Given a key, get the associated value datatype, number of
+     * values, and value in binary form.
+     *
+     * The value may consist of more than one items of the same datatype. Keys
+     * that do not exist in the metadata will be return NULL for the value.
+     *
+     * **Example:**
+     * @code{.cpp}
+     * // Open the group for reading
+     * tiledbsoma::SOMAGroup soma_group = SOMAGroup::open(TILEDB_READ,
+     "s3://bucket-name/group-name");
+     * tiledbsoma::MetadataValue meta_val = soma_group->get_metadata("key");
+     * std::string key = std::get<MetadataInfo::key>(meta_val);
+     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
+     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
+     * const void* value = *((const
+     int32_t*)std::get<MetadataInfo::value>(meta_val));
+     * @endcode
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+     *     are acceptable.
+     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
+     * uint32_t, const void*>)
+     */
+    std::map<std::string, MetadataValue> get_metadata() {
+        return array_->get_metadata();
+    }
+
+    std::optional<MetadataValue> get_metadata(const std::string& key) {
+        return array_->get_metadata(key);
+    }
+
+    /**
+     * Check if the key exists in metadata from an open SOMADenseNDArray.
+     *
+     * @param key The key of the metadata item to be checked. UTF-8 encodings
+     *     are acceptable.
+     * @return true if the key exists, else false.
+     */
+    bool has_metadata(const std::string& key) {
+        return array_->has_metadata(key);
+    }
+
+    /**
+     * Return then number of metadata items in an open SOMADenseNDArray. The
+     * group must be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const {
+        return array_->metadata_num();
+    }
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -99,6 +99,29 @@ SOMAGroup::SOMAGroup(
         std::string(uri),
         mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE,
         cfg);
+
+    fill_metadata_cache();
+}
+
+void SOMAGroup::fill_metadata_cache() {
+    std::shared_ptr<Group> grp;
+    if (group_->query_type() == TILEDB_WRITE) {
+        grp = std::make_shared<Group>(*ctx_, uri_, TILEDB_READ);
+    } else {
+        grp = group_;
+    }
+
+    for (uint64_t idx = 0; idx < grp->metadata_num(); ++idx) {
+        std::string key;
+        tiledb_datatype_t value_type;
+        uint32_t value_num;
+        const void* value;
+        grp->get_metadata_from_index(
+            idx, &key, &value_type, &value_num, &value);
+        MetadataValue mdval(value_type, value_num, value);
+        std::pair<std::string, const MetadataValue> mdpair(key, mdval);
+        metadata_.insert(mdpair);
+    }
 }
 
 void SOMAGroup::open(
@@ -176,38 +199,42 @@ void SOMAGroup::set_metadata(
     tiledb_datatype_t value_type,
     uint32_t value_num,
     const void* value) {
+    if (key.compare("soma_object_type") == 0) {
+        throw TileDBSOMAError("soma_object_type cannot be modified.");
+    }
+
     group_->put_metadata(key, value_type, value_num, value);
+    MetadataValue mdval(value_type, value_num, value);
+    std::pair<std::string, const MetadataValue> mdpair(key, mdval);
+    metadata_.insert(mdpair);
 }
 
 void SOMAGroup::delete_metadata(const std::string& key) {
+    if (key.compare("soma_object_type") == 0) {
+        throw TileDBSOMAError("soma_object_type cannot be deleted.");
+    }
+
     group_->delete_metadata(key);
+    metadata_.erase(key);
 }
 
-MetadataValue SOMAGroup::get_metadata(const std::string& key) const {
-    tiledb_datatype_t value_type;
-    uint32_t value_num;
-    const void* value;
-    group_->get_metadata(key, &value_type, &value_num, &value);
-    return MetadataValue(key, value_type, value_num, value);
+std::map<std::string, MetadataValue> SOMAGroup::get_metadata() {
+    return metadata_;
 }
 
-MetadataValue SOMAGroup::get_metadata(uint64_t index) const {
-    std::string key;
-    tiledb_datatype_t value_type;
-    uint32_t value_num;
-    const void* value;
-    group_->get_metadata_from_index(
-        index, &key, &value_type, &value_num, &value);
-    return MetadataValue(key, value_type, value_num, value);
+std::optional<MetadataValue> SOMAGroup::get_metadata(const std::string& key) {
+    if (metadata_.count(key) == 0) {
+        return std::nullopt;
+    }
+    return metadata_[key];
 }
 
 bool SOMAGroup::has_metadata(const std::string& key) {
-    tiledb_datatype_t value_type;
-    return group_->has_metadata(key, &value_type);
+    return metadata_.count(key) != 0;
 }
 
 uint64_t SOMAGroup::metadata_num() const {
-    return group_->metadata_num();
+    return metadata_.size();
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -269,18 +269,8 @@ class SOMAGroup {
      * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
      * uint32_t, const void*>)
      */
-    MetadataValue get_metadata(const std::string& key) const;
-
-    /**
-     * @brief Given an index, get the associated value datatype, number of
-     * values, and value in binary form. The group must be opened in READ mode,
-     * otherwise the function will error out.
-     *
-     * @param index The index used to get the metadata.
-     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
-     * uint32_t, const void*>)
-     */
-    MetadataValue get_metadata(uint64_t index) const;
+    std::map<std::string, MetadataValue> get_metadata();
+    std::optional<MetadataValue> get_metadata(const std::string& key);
 
     /**
      * Check if the key exists in metadata from an open group. The group must
@@ -303,6 +293,11 @@ class SOMAGroup {
     //= private non-static
     //===================================================================
 
+    /**
+     * Fills the metadata cache upon opening the array.
+     */
+    void fill_metadata_cache();
+
     // TileDB context
     std::shared_ptr<Context> ctx_;
 
@@ -313,7 +308,10 @@ class SOMAGroup {
     std::string name_;
 
     // TileDBGroup associated with the SOMAGroup
-    std::unique_ptr<Group> group_;
+    std::shared_ptr<Group> group_;
+
+    // Metadata cache
+    std::map<std::string, MetadataValue> metadata_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -28,7 +28,7 @@
  * @section DESCRIPTION
  *
  * This file defines the SOMAObject class. SOMAObject is an abstract base
- * class for all public SOMA classes: SOMACollection, SOMAExperiment,
+ * class for all public SOMA classes: SOMAObject, SOMAExperiment,
  * SOMAMeasurement, SOMA{Sparse,Dense}NdArray, and SOMADataFrame.
  */
 
@@ -79,6 +79,86 @@ class SOMAObject {
      * @brief Check if the SOMAObject is open.
      */
     virtual bool is_open() const = 0;
+
+    /**
+     * Set metadata key-value items to a SOMAObject. The SOMAObject must
+     * opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value);
+
+    /**
+     * Delete a metadata key-value item from an open SOMAObject. The
+     * SOMAObject must be opened in WRITE mode, otherwise the function will
+     * error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the group.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key);
+
+    /**
+     * @brief Given a key, get the associated value datatype, number of
+     * values, and value in binary form.
+     *
+     * The value may consist of more than one items of the same datatype.
+     Keys
+     * that do not exist in the metadata will be return NULL for the value.
+     *
+     * **Example:**
+     * @code{.cpp}
+     * // Open the group for reading
+     * tiledbsoma::SOMAGroup soma_group = SOMAGroup::open(TILEDB_READ,
+     "s3://bucket-name/group-name");
+     * tiledbsoma::MetadataValue meta_val = soma_group->get_metadata("key");
+     * std::string key = std::get<MetadataInfo::key>(meta_val);
+     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
+     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
+     * const void* value = *((const
+     int32_t*)std::get<MetadataInfo::value>(meta_val));
+     * @endcode
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8
+     encodings
+     *     are acceptable.
+     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
+     * uint32_t, const void*>)
+     */
+    std::map<std::string, MetadataValue> get_metadata();
+
+    std::optional<MetadataValue> get_metadata(const std::string& key);
+
+    /**
+     * Check if the key exists in metadata from an open SOMAObject.
+     *
+     * @param key The key of the metadata item to be checked. UTF-8 encodings
+     *     are acceptable.
+     * @return true if the key exists, else false.
+     */
+    bool has_metadata(const std::string& key);
+
+    /**
+     * Return then number of metadata items in an open SOMAObject. The group
+     * must be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -32,7 +32,6 @@
 
 #include <filesystem>
 
-#include "soma_array.h"
 #include "soma_sparse_ndarray.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -35,6 +35,7 @@
 
 #include <tiledb/tiledb>
 #include "enums.h"
+#include "soma_array.h"
 #include "soma_object.h"
 
 namespace tiledbsoma {
@@ -238,6 +239,97 @@ class SOMASparseNDArray : public SOMAObject {
      * @param buffers The ArrayBuffers to write
      */
     void write(std::shared_ptr<ArrayBuffers> buffers);
+
+    /**
+     * Set metadata key-value items to a SOMASparseNDArray. The
+     * SOMASparseNDArray must opened in WRITE mode, otherwise the function will
+     * error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value) {
+        array_->set_metadata(key, value_type, value_num, value);
+    }
+
+    /**
+     * Delete a metadata key-value item from an open SOMASparseNDArray. The
+     * SOMASparseNDArray must be opened in WRITE mode, otherwise the function
+     * will error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the group.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key) {
+        array_->delete_metadata(key);
+    }
+
+    /**
+     * @brief Given a key, get the associated value datatype, number of
+     * values, and value in binary form.
+     *
+     * The value may consist of more than one items of the same datatype. Keys
+     * that do not exist in the metadata will be return NULL for the value.
+     *
+     * **Example:**
+     * @code{.cpp}
+     * // Open the group for reading
+     * tiledbsoma::SOMAGroup soma_group = SOMAGroup::open(TILEDB_READ,
+     "s3://bucket-name/group-name");
+     * tiledbsoma::MetadataValue meta_val = soma_group->get_metadata("key");
+     * std::string key = std::get<MetadataInfo::key>(meta_val);
+     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
+     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
+     * const void* value = *((const
+     int32_t*)std::get<MetadataInfo::value>(meta_val));
+     * @endcode
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+     *     are acceptable.
+     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
+     * uint32_t, const void*>)
+     */
+    std::map<std::string, MetadataValue> get_metadata() {
+        return array_->get_metadata();
+    }
+
+    std::optional<MetadataValue> get_metadata(const std::string& key) {
+        return array_->get_metadata(key);
+    }
+
+    /**
+     * Check if the key exists in metadata from an open SOMASparseNDArray.
+     *
+     * @param key The key of the metadata item to be checked. UTF-8 encodings
+     *     are acceptable.
+     * @return true if the key exists, else false.
+     */
+    bool has_metadata(const std::string& key) {
+        return array_->has_metadata(key);
+    }
+
+    /**
+     * Return then number of metadata items in an open SOMASparseNDArray. The
+     * group must be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const {
+        return array_->metadata_num();
+    }
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -39,9 +39,8 @@
 
 namespace tiledbsoma {
 
-using MetadataValue =
-    std::tuple<std::string, tiledb_datatype_t, uint32_t, const void*>;
-enum MetadataInfo { key = 0, dtype, num, value };
+using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
+enum MetadataInfo { dtype = 0, num, value };
 
 class TileDBSOMAError : public std::runtime_error {
    public:

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -42,15 +42,14 @@ VarlenBufferPair to_varlen_buffers(std::vector<T> data, bool arrow) {
         nbytes += elem.size();
     }
 
-    std::vector<std::byte> result(nbytes);
+    std::string result;
     std::vector<uint64_t> offsets(data.size() + 1);
     size_t offset = 0;
     size_t idx = 0;
 
     for (auto& elem : data) {
-        std::memcpy(result.data() + offset, elem.data(), elem.size());
+        result += elem;
         offsets[idx++] = offset;
-
         offset += elem.size();
     }
     offsets[idx] = offset;

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -40,8 +40,7 @@
 
 namespace tiledbsoma::util {
 
-using VarlenBufferPair =
-    std::pair<std::vector<std::byte>, std::vector<uint64_t>>;
+using VarlenBufferPair = std::pair<std::string, std::vector<uint64_t>>;
 
 template <typename T>
 VarlenBufferPair to_varlen_buffers(std::vector<T> data, bool arrow = true);

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -386,29 +386,28 @@ TEST_CASE("SOMAArray: metadata") {
     soma_array->close();
 
     soma_array->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_array->metadata_num() == 2);
+    REQUIRE(soma_array->has_metadata("soma_object_type") == true);
     REQUIRE(soma_array->has_metadata("md") == true);
-    REQUIRE(soma_array->metadata_num() == 1);
 
-    auto mdval = soma_array->get_metadata(0);
-    REQUIRE(std::get<MetadataInfo::key>(mdval) == "md");
-    REQUIRE(std::get<MetadataInfo::dtype>(mdval) == TILEDB_INT32);
-    REQUIRE(std::get<MetadataInfo::num>(mdval) == 1);
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
-
-    mdval = soma_array->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::key>(mdval) == "md");
-    REQUIRE(std::get<MetadataInfo::dtype>(mdval) == TILEDB_INT32);
-    REQUIRE(std::get<MetadataInfo::num>(mdval) == 1);
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(mdval)) == 100);
+    auto mdval = soma_array->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_array->close();
 
     soma_array->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_array->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_array->delete_metadata("md");
+    mdval = soma_array->get_metadata("md");
+    REQUIRE(!mdval.has_value());
     soma_array->close();
 
     soma_array->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
     REQUIRE(soma_array->has_metadata("md") == false);
-    REQUIRE(soma_array->metadata_num() == 0);
+    REQUIRE(soma_array->metadata_num() == 1);
     soma_array->close();
 }
 

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -239,3 +239,115 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
+
+TEST_CASE("SOMACollection: metadata") {
+    auto ctx = std::make_shared<Context>();
+
+    std::string uri = "mem://unit-test-collection";
+    SOMACollection::create(uri, ctx);
+    auto soma_collection = SOMACollection::open(
+        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+    int32_t val = 100;
+    soma_collection->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_collection->close();
+
+    soma_collection->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_collection->metadata_num() == 2);
+    REQUIRE(soma_collection->has_metadata("soma_object_type") == true);
+    REQUIRE(soma_collection->has_metadata("md") == true);
+
+    auto mdval = soma_collection->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_collection->close();
+
+    soma_collection->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_collection->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_collection->delete_metadata("md");
+    mdval = soma_collection->get_metadata("md");
+    REQUIRE(!mdval.has_value());
+    soma_collection->close();
+
+    soma_collection->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
+    REQUIRE(soma_collection->has_metadata("md") == false);
+    REQUIRE(soma_collection->metadata_num() == 1);
+    soma_collection->close();
+}
+
+TEST_CASE("SOMAExperiment: metadata") {
+    auto ctx = std::make_shared<Context>();
+
+    std::string uri = "mem://unit-test-experiment";
+    SOMAExperiment::create(uri, create_schema(*ctx), ctx);
+    auto soma_experiment = SOMAExperiment::open(
+        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+    int32_t val = 100;
+    soma_experiment->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_experiment->close();
+
+    soma_experiment->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_experiment->metadata_num() == 2);
+    REQUIRE(soma_experiment->has_metadata("soma_object_type") == true);
+    REQUIRE(soma_experiment->has_metadata("md") == true);
+
+    auto mdval = soma_experiment->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_experiment->close();
+
+    soma_experiment->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_experiment->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_experiment->delete_metadata("md");
+    mdval = soma_experiment->get_metadata("md");
+    REQUIRE(!mdval.has_value());
+    soma_experiment->close();
+
+    soma_experiment->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
+    REQUIRE(soma_experiment->has_metadata("md") == false);
+    REQUIRE(soma_experiment->metadata_num() == 1);
+    soma_experiment->close();
+}
+
+TEST_CASE("SOMAMeasurement: metadata") {
+    auto ctx = std::make_shared<Context>();
+
+    std::string uri = "mem://unit-test-measurement";
+    SOMAMeasurement::create(uri, create_schema(*ctx), ctx);
+    auto soma_measurement = SOMAMeasurement::open(
+        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+    int32_t val = 100;
+    soma_measurement->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_measurement->close();
+
+    soma_measurement->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_measurement->metadata_num() == 2);
+    REQUIRE(soma_measurement->has_metadata("soma_object_type") == true);
+    REQUIRE(soma_measurement->has_metadata("md") == true);
+
+    auto mdval = soma_measurement->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_measurement->close();
+
+    soma_measurement->open(
+        OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_measurement->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_measurement->delete_metadata("md");
+    mdval = soma_measurement->get_metadata("md");
+    REQUIRE(!mdval.has_value());
+    soma_measurement->close();
+
+    soma_measurement->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
+    REQUIRE(soma_measurement->has_metadata("md") == false);
+    REQUIRE(soma_measurement->metadata_num() == 1);
+    soma_measurement->close();
+}

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -118,3 +118,45 @@ TEST_CASE("SOMADataFrame: basic") {
     }
     soma_dataframe->close();
 }
+
+TEST_CASE("SOMADataFrame: metadata") {
+    auto ctx = std::make_shared<Context>();
+
+    std::string uri = "mem://unit-test-collection";
+    SOMADataFrame::create(uri, create_schema(*ctx), ctx);
+    auto soma_dataframe = SOMADataFrame::open(
+        uri,
+        OpenMode::write,
+        ctx,
+        {},
+        ResultOrder::automatic,
+        std::pair<uint64_t, uint64_t>(1, 1));
+    int32_t val = 100;
+    soma_dataframe->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_dataframe->close();
+
+    soma_dataframe->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_dataframe->metadata_num() == 2);
+    REQUIRE(soma_dataframe->has_metadata("soma_object_type") == true);
+    REQUIRE(soma_dataframe->has_metadata("md") == true);
+
+    auto mdval = soma_dataframe->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_dataframe->close();
+
+    soma_dataframe->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_dataframe->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_dataframe->delete_metadata("md");
+    mdval = soma_dataframe->get_metadata("md");
+    REQUIRE(!mdval.has_value());
+    soma_dataframe->close();
+
+    soma_dataframe->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
+    REQUIRE(soma_dataframe->has_metadata("md") == false);
+    REQUIRE(soma_dataframe->metadata_num() == 1);
+    soma_dataframe->close();
+}

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -117,3 +117,45 @@ TEST_CASE("SOMADenseNDArray: basic") {
     }
     soma_dense->close();
 }
+
+TEST_CASE("SOMADenseNDArray: metadata") {
+    auto ctx = std::make_shared<Context>();
+
+    std::string uri = "mem://unit-test-dense-ndarray";
+    SOMADenseNDArray::create(uri, create_schema(*ctx), ctx);
+    auto soma_dense = SOMADenseNDArray::open(
+        uri,
+        OpenMode::write,
+        ctx,
+        {},
+        ResultOrder::automatic,
+        std::pair<uint64_t, uint64_t>(1, 1));
+    int32_t val = 100;
+    soma_dense->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_dense->close();
+
+    soma_dense->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
+    REQUIRE(soma_dense->metadata_num() == 2);
+    REQUIRE(soma_dense->has_metadata("soma_object_type") == true);
+    REQUIRE(soma_dense->has_metadata("md") == true);
+
+    auto mdval = soma_dense->get_metadata("md");
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_dense->close();
+
+    soma_dense->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // Metadata should also be retrievable in write mode
+    mdval = soma_dense->get_metadata("md");
+    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+    soma_dense->delete_metadata("md");
+    mdval = soma_dense->get_metadata("md");
+    REQUIRE(!mdval.has_value());
+    soma_dense->close();
+
+    soma_dense->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
+    REQUIRE(soma_dense->has_metadata("md") == false);
+    REQUIRE(soma_dense->metadata_num() == 1);
+    soma_dense->close();
+}


### PR DESCRIPTION
**Issue and/or context:**

- #1577
- https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md#somametadatamapping

**Changes:**

* Cache metadata values  when opening the array or group so that it can be accessed in either read or write mode If the `SOMAArray` or `SOMAGroup` is already open in read mode, fill the cache by using `metadata_num` and `get_metadata_from_index`. If it is open in write, open a temp handle in read mode to fill the metadata mapping and then close the temp handle.
* Add metadata functions and accompanying unit tests for `SOMAObject`s
* `get_metadata` checks if key exists and returns `std::nullopt` if DNE

**Notes for Reviewer:**

N/A