### PR TITLE
[r] Add ability to install BioC packages to r-ci.sh [ci skip]

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -37,12 +37,9 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
-      - name: Install 'old' tiledb-r to satisfy its dependencies
-        run: cd apis/r && tools/r-ci.sh tiledb-r
-
-      - name: Install new tiledb-r 0.20.2
-        run: cd apis/r && Rscript -e 'if (Sys.info()[["sysname"]] == "Linux") bspm::disable(); install.packages("tiledb", repos = c("https://tiledb-inc.r-universe.dev", "https://cloud.r-project.org"))'
-
+      - name: Install BioConductor package SingleCellExperiment
+        run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
+        
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
 

--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -17,7 +17,7 @@ set -e
 
 CRAN=${CRAN:-"https://cloud.r-project.org"}
 OS=$(uname -s)
-RVER=${RVER:-"4.3.0"}
+RVER=${RVER:-"4.3.1"}
 
 ## Optional drat repos, unset by default
 DRAT_REPOS=${DRAT_REPOS:-""}
@@ -301,6 +301,17 @@ RInstall() {
     sudo Rscript -e 'install.packages(commandArgs(TRUE))' "$@"
 }
 
+BiocInstall() {
+    if [[ "" == "$*" ]]; then
+        echo "No arguments to bioc_install"
+        exit 1
+    fi
+
+    echo "Installing R Bioconductor package(s): $@"
+    Rscript -e 'if (!requireNamespace("BiocManager", quietly=TRUE)) install.packages("BiocManager")'
+    Rscript -e "BiocManager::install(commandArgs(TRUE), update=FALSE)" "$@"
+}
+
 RBinaryInstall() {
     if [[ -z "$#" ]]; then
         echo "No arguments to r_binary_install"
@@ -449,6 +460,11 @@ case $COMMAND in
     ## Install an R dependency from CRAN
     "install_r"|"r_install")
         RInstall "$@"
+        ;;
+    ##
+    ## Install an R dependency from Bioconductor
+    "install_bioc"|"bioc_install")
+        BiocInstall "$@"
         ;;
     ##
     ## Install an R dependency as a binary (via c2d4u PPA)


### PR DESCRIPTION
**Issue and/or context:**

We use a copy of script `r-ci.sh` which (for ease of use with tiledb-r) had the ability to install BioConductor repos removed.  This does of course limit SOMA's ability to test with BioConductor packages so this PR restores this ability,

It has been tested on macOS and Linux with shortened one-off CI setup, see below the fold.

<details>

#### Linux

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/1bff6a9f-98af-4be5-a734-55b890e9e8dc)

#### macOS

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/c13244eb-bf03-43de-af6f-f8f24a73abd8)

</details>



**Changes:**

The 'command' `install_bioc` is added which installs package `BiocManager` and uses it to install the named packages.

**Notes for Reviewer:**

[SC 32783](https://app.shortcut.com/tiledb-inc/story/32783/add-ability-to-install-bioconductor-packages-to-r-ci-sh)
