### PR TITLE
[c++] Support reading member-to-uri mapping in read and write mode

### DIFF
--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -294,9 +294,9 @@ class SOMAGroup {
     //===================================================================
 
     /**
-     * Fills the metadata cache upon opening the array.
+     * Fills the metadata and member-to-uri caches upon opening the array.
      */
-    void fill_metadata_cache();
+    void fill_caches();
 
     // TileDB context
     std::shared_ptr<Context> ctx_;
@@ -312,6 +312,9 @@ class SOMAGroup {
 
     // Metadata cache
     std::map<std::string, MetadataValue> metadata_;
+
+    // Member-to-URI cache
+    std::map<std::string, std::string> member_to_uri_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -96,9 +96,13 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, true);
 
+    std::map<std::string, std::string> expected_map{
+        {"sparse_ndarray", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_sparse = soma_collection->add_new_sparse_ndarray(
         "sparse_ndarray", sub_uri, URIType::absolute, ctx, schema);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_sparse->uri() == sub_uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -111,8 +115,6 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{
-        {"sparse_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
@@ -125,9 +127,12 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
+    std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_dense = soma_collection->add_new_dense_ndarray(
         "dense_ndarray", sub_uri, URIType::absolute, ctx, schema);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -139,7 +144,6 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
@@ -152,9 +156,12 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
+    std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_dataframe = soma_collection->add_new_dataframe(
         "dataframe", sub_uri, URIType::absolute, ctx, schema);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -167,7 +174,6 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
@@ -180,16 +186,18 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
+    std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
@@ -202,9 +210,12 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
+    std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
         "experiment", sub_uri, URIType::absolute, ctx, schema);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -212,7 +223,6 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }
@@ -225,9 +235,12 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     SOMACollection::create(base_uri, ctx);
     auto schema = create_schema(*ctx, false);
 
+    std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
+
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
         "measurement", sub_uri, URIType::absolute, ctx, schema);
+    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -235,7 +248,6 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     soma_collection->close();
 }

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -171,18 +171,20 @@ TEST_CASE("SOMAGroup: basic") {
     soma_group->add_member(uri_sub_array, URIType::absolute, "subarray");
     soma_group->close();
 
+    std::map<std::string, std::string> expected_map{
+        {"subgroup", uri_sub_group}, {"subarray", uri_sub_array}};
+
     soma_group->open(OpenMode::read, std::pair<uint64_t, uint64_t>(0, 2));
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->get_length() == 2);
-    std::map<std::string, std::string> expected_map{
-        {"subgroup", uri_sub_group}, {"subarray", uri_sub_array}};
     REQUIRE(expected_map == soma_group->member_to_uri_mapping());
     REQUIRE(soma_group->get_member("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get_member("subarray").type() == Object::Type::Array);
     soma_group->close();
 
     soma_group->open(OpenMode::write, std::pair<uint64_t, uint64_t>(0, 3));
+    REQUIRE(expected_map == soma_group->member_to_uri_mapping());
     soma_group->remove_member("subgroup");
     soma_group->close();
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/1623

**Changes:**

Extend caching introduced in #1584 to also store `SOMAGroup` member-to-uri mapping so that this information can also be accessed in both read and write mode.

**Notes for Reviewer:**

N/A

