### PR TITLE
[r] Accomodate RedHat install path in package-internal path

### DIFF
--- a/apis/r/tools/build_libtiledbsoma.sh.in
+++ b/apis/r/tools/build_libtiledbsoma.sh.in
@@ -25,4 +25,12 @@ make
 
 make install-libtiledbsoma
 
+cd ${cwd}
+
 rm -rf src/libtiledbsoma/build-lib
+
+## Case of RedHat and related distros
+if [ -d inst/tiledbsoma/lib64 ]; then
+    ## we can assume lib/ exists as the libtiledb.so.* is already there
+    mv -v inst/tiledbsoma/lib64/* inst/tiledbsoma/lib/
+fi


### PR DESCRIPTION
**Issue and/or context:**

Installation in RedHat-family distributions, when using the local build of `libtiledbsoma` as triggered by `R CMD INSTALL` when no system library is found, was not accomodating the `lib64` directory and failed to link.

**Changes:**

When local installation is used and the results are placed in `lib64` these files are now moved to `lib`.  This only affects the internal use of `libtiledbsoma` by the R package.  The location is not exported making this change minimal.

The change has been tested under Fedora 38.

**Notes for Reviewer:**

[SC-33364](https://app.shortcut.com/tiledb-inc/story/33364/support-from-source-installation-on-redhat-alike-distros)
