### PR TITLE
[r] Add a finalizer for the SOMAArray instance and assure valgrind tests pass

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -11,6 +11,7 @@ on:
   push:
     paths-ignore:
       - 'apis/r/**'
+      - '.github/workflows/**'
 
 jobs:
   build:

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -11,7 +11,6 @@ on:
   push:
     paths-ignore:
       - 'apis/r/**'
-      - '.github/workflows/**'
 
 jobs:
   build:

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -1,0 +1,28 @@
+name: r-valgrind
+
+on:
+  # push may be too frequent but needed during PR
+  push:
+  # allows for 'as needed', can be complemented by scheduled runs
+  workflow_dispatch:
+
+jobs:
+  r-valgrind:
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/r2u:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: SessionInfo
+        run: R -q -e 'sessionInfo()'
+      - name: System Dependencies
+        run: apt update -qq && apt install --yes --no-install-recommends valgrind cmake git
+      - name: Package Dependencies
+        run: cd apis/r && R -q -e 'remotes::install_deps(".", dependencies=TRUE)'
+      - name: Build Package
+        run: cd apis/r && R CMD build --no-build-vignettes --no-manual .
+      - name: Check Package under valgrind
+        # we unsetting environment variable CI for non-extended set of tests
+        run: cd apis/r && CI="" R CMD check --use-valgrind --no-vignettes --no-manual $(ls -1tr *.tar.gz | tail -1)
+      - name: Display Test Output
+        run: cd apis/r/tiledbsoma.Rcheck/tests && cat testthat.Rout

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -1,8 +1,6 @@
 name: r-valgrind
 
 on:
-  # push may be too frequent but needed during PR
-  push:
   # allows for 'as needed', can be complemented by scheduled runs
   workflow_dispatch:
 

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -1,8 +1,11 @@
 name: r-valgrind
 
 on:
-  # allows for 'as needed', can be complemented by scheduled runs
+  # allows for 'as needed' manual trigger
   workflow_dispatch:
+  # use a regular nighly build as well (time is UTC)
+  schedule:
+    - cron: "23 4 * * *"
 
 jobs:
   r-valgrind:

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 1.4.3.1
+Version: 1.4.3.3
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 1.4.3.3
+Version: 1.4.3
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 1.4.3
+Version: 1.4.3.1
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -91,6 +91,10 @@ sr_next <- function(sr) {
     .Call(`_tiledbsoma_sr_next`, sr)
 }
 
+sr_finalize <- function(sr) {
+    invisible(.Call(`_tiledbsoma_sr_finalize`, sr))
+}
+
 #' TileDB SOMA statistics
 #'
 #' These functions expose the TileDB Core functionality for performance measurements

--- a/apis/r/R/ReadIter.R
+++ b/apis/r/R/ReadIter.R
@@ -58,6 +58,15 @@ ReadIter <- R6::R6Class(
     # to be refined in derived classes
     soma_reader_transform = function(x) {
       .NotYetImplemented()
+    },
+
+    finalize = function() {
+      spdl::debug("[finalizer] Entered")
+      if (!is.null(private$soma_reader_pointer)) {
+        spdl::debug("[finalizer] Calling sr_finalize")
+        sr_finalize(private$soma_reader_pointer)
+        private$soma_reader_pointer <- NULL
+      }
     }
 
   )

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -140,6 +140,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// sr_finalize
+void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr);
+RcppExport SEXP _tiledbsoma_sr_finalize(SEXP srSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<tdbs::SOMAArray> >::type sr(srSEXP);
+    sr_finalize(sr);
+    return R_NilValue;
+END_RCPP
+}
 // tiledbsoma_stats_enable
 void tiledbsoma_stats_enable();
 RcppExport SEXP _tiledbsoma_tiledbsoma_stats_enable() {
@@ -209,6 +219,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_sr_next", (DL_FUNC) &_tiledbsoma_sr_next, 1},
+    {"_tiledbsoma_sr_finalize", (DL_FUNC) &_tiledbsoma_sr_finalize, 1},
     {"_tiledbsoma_tiledbsoma_stats_enable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_enable, 0},
     {"_tiledbsoma_tiledbsoma_stats_disable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_disable, 0},
     {"_tiledbsoma_tiledbsoma_stats_reset", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_reset, 0},

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -19,6 +19,7 @@
 #include "xptr-utils.h"         // xptr taggging utilitie
 Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64_t n_children);
 Rcpp::XPtr<ArrowArray> array_setup_struct(Rcpp::XPtr<ArrowArray> arrxp, int64_t n_children);
+void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr);
 
 namespace tdbs = tiledbsoma;
 
@@ -88,14 +89,7 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
 
     std::string_view name = "unnamed";
     std::vector<std::string> column_names = {};
-
-    std::shared_ptr<tiledb::Context> ctxptr = nullptr;
-
     std::map<std::string, std::string> platform_config = config_vector_to_map(Rcpp::wrap(config));
-    tiledb::Config cfg(platform_config);
-    spdl::debug("[sr_setup] creating ctx object with supplied config");
-    ctxptr = std::make_shared<tiledb::Context>(cfg);
-
     if (!colnames.isNull()) {
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
     }
@@ -109,7 +103,8 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
 
     auto tdb_result_order = get_tdb_result_order(result_order);
 
-    auto ptr = new tdbs::SOMAArray(OpenMode::read, uri, name, ctxptr, column_names, batch_size,
+    auto ptr = new tdbs::SOMAArray(OpenMode::read, uri, name, platform_config,
+                                   column_names, batch_size,
                                    tdb_result_order, std::make_pair(ts_start, ts_end));
 
     std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
@@ -229,4 +224,28 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAArray> sr) {
    Rcpp::List as = Rcpp::List::create(Rcpp::Named("array_data") = arrayxp,
                                       Rcpp::Named("schema") = schemaxp);
    return as;
+}
+
+// Helper function to register a finalizer -- eg for debugging purposes
+// R_Finalizer_t is 'typedef void (*R_CFinalizer_t)(SEXP);'
+inline void registerXptrFinalizer(SEXP s, R_CFinalizer_t f, bool onexit = true) {
+    R_RegisterCFinalizerEx(s, f, onexit ? TRUE : FALSE);
+}
+// Finalizer helper with void f(SEXP) signature
+void SOMAArrayFinalizer(SEXP sx) {
+    Rcpp::XPtr<tdbs::SOMAArray> xp(sx);
+    check_xptr_tag<tdbs::SOMAArray>(xp);
+    std::shared_ptr<tiledb::Context> ctx = xp->ctx();
+    std::shared_ptr<tiledb_ctx_t> ctx_cptr = ctx->ptr();
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] count on ctx %d cptr %d",
+                            ctx.use_count(), ctx_cptr.use_count()));
+    tiledb_ctx_t* ptr = ctx_cptr.get();
+    tiledb_ctx_free(&ptr);
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] freed"));
+}
+
+// [[Rcpp::export]]
+void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr) {
+   check_xptr_tag<tdbs::SOMAArray>(sr);
+   registerXptrFinalizer(sr, SOMAArrayFinalizer);
 }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -234,12 +234,14 @@ inline void registerXptrFinalizer(SEXP s, R_CFinalizer_t f, bool onexit = true) 
 // Finalizer helper with void f(SEXP) signature
 void SOMAArrayFinalizer(SEXP sx) {
     spdl::debug(tfm::format("[SOMAArrayFinalizer] entered"));
+    if (sx == R_NilValue || sx == NULL || R_ExternalPtrAddr(sx) == NULL) return;
     Rcpp::XPtr<tdbs::SOMAArray> xp(sx);
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] instantiated"));
+    //spdl::trace(tfm::format("[SOMAArrayFinalizer] instantiated"));
+    if (xp == R_NilValue) return;
     check_xptr_tag<tdbs::SOMAArray>(xp);
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] checked"));
+    //spdl::trace(tfm::format("[SOMAArrayFinalizer] checked"));
     std::shared_ptr<tiledb::Context> ctx = xp->ctx();
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] referenced once"));
+    //spdl::trace(tfm::format("[SOMAArrayFinalizer] referenced once"));
     if (ctx == nullptr) return;
     std::shared_ptr<tiledb_ctx_t> ctx_cptr = ctx->ptr();
     if (ctx_cptr == nullptr) return;
@@ -249,7 +251,9 @@ void SOMAArrayFinalizer(SEXP sx) {
     if (ptr == nullptr) return;
     tiledb_ctx_free(&ptr);
     ptr = nullptr;
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] freed"));
+    ctx_cptr.reset();
+    ctx.reset();
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] done"));
 }
 
 // [[Rcpp::export]]

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -146,12 +146,12 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
 
 // [[Rcpp::export]]
 bool sr_complete(Rcpp::XPtr<tdbs::SOMAArray> sr) {
-   check_xptr_tag<tdbs::SOMAArray>(sr);
-   bool complt = sr->is_complete(true);
-   bool initial = sr->is_initial_read();
-   bool res = complt && !initial; // completed transfer if query status complete and query ran once
-   spdl::debug("[sr_complete] Complete query test {} (compl {} initial {})", res, complt, initial);
-   return res;
+    check_xptr_tag<tdbs::SOMAArray>(sr);
+    bool complt = sr->is_complete(true);
+    bool initial = sr->is_initial_read();
+    bool res = complt && !initial; // completed transfer if query status complete and query ran once
+    spdl::debug("[sr_complete] Complete query test {} (compl {} initial {})", res, complt, initial);
+    return res;
 }
 
 Rcpp::List create_empty_arrow_table() {
@@ -233,14 +233,22 @@ inline void registerXptrFinalizer(SEXP s, R_CFinalizer_t f, bool onexit = true) 
 }
 // Finalizer helper with void f(SEXP) signature
 void SOMAArrayFinalizer(SEXP sx) {
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] entered"));
     Rcpp::XPtr<tdbs::SOMAArray> xp(sx);
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] instantiated"));
     check_xptr_tag<tdbs::SOMAArray>(xp);
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] checked"));
     std::shared_ptr<tiledb::Context> ctx = xp->ctx();
+    spdl::debug(tfm::format("[SOMAArrayFinalizer] referenced once"));
+    if (ctx == nullptr) return;
     std::shared_ptr<tiledb_ctx_t> ctx_cptr = ctx->ptr();
+    if (ctx_cptr == nullptr) return;
     spdl::debug(tfm::format("[SOMAArrayFinalizer] count on ctx %d cptr %d",
                             ctx.use_count(), ctx_cptr.use_count()));
     tiledb_ctx_t* ptr = ctx_cptr.get();
+    if (ptr == nullptr) return;
     tiledb_ctx_free(&ptr);
+    ptr = nullptr;
     spdl::debug(tfm::format("[SOMAArrayFinalizer] freed"));
 }
 

--- a/apis/r/tests/testthat.R
+++ b/apis/r/tests/testthat.R
@@ -2,4 +2,5 @@ library(testthat)
 library(tiledbsoma)
 
 tiledbsoma::show_package_versions()
+# more verbose reporting:  test_check("tiledbsoma", reporter=default_reporter())
 test_check("tiledbsoma")

--- a/apis/r/tests/testthat/helper-test-tiledb-objects.R
+++ b/apis/r/tests/testthat/helper-test-tiledb-objects.R
@@ -10,3 +10,9 @@ create_empty_test_array <- function(uri) {
   tiledb::tiledb_array_create(uri, schema)
   return(uri)
 }
+
+extended_tests <- function() {
+    ## check if at CI, if so extended test
+    ## could add if pre-release number ie 1.4.3.1 instead of 1.4.3
+    Sys.getenv("CI", "") != ""
+}

--- a/apis/r/tests/testthat/test-EphemeralCollection.R
+++ b/apis/r/tests/testthat/test-EphemeralCollection.R
@@ -1,4 +1,5 @@
 test_that("Ephemeral Colelction mechanics", {
+  skip_if(!extended_tests())
   # Create a new collection
   uri <- withr::local_tempdir('ephemeral-collection')
   expect_warning(EphemeralCollection$new(uri = uri))

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -1,4 +1,5 @@
 test_that("DataFrame Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # Check that straight use of new() errors, but 'with handshake' passes
@@ -19,6 +20,7 @@ test_that("DataFrame Factory", {
 })
 
 test_that("DataFrame Factory with specified index_column_names", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # Check creation of a DF
@@ -39,6 +41,7 @@ test_that("DataFrame Factory with specified index_column_names", {
 })
 
 test_that("SparseNDArray Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # check that straight use of new() errors, but 'with handshake' passes
@@ -55,7 +58,7 @@ test_that("SparseNDArray Factory", {
     # check opening to read
     expect_silent(s3 <- SOMASparseNDArrayOpen(uri))
     expect_equal(s3$mode(), "READ")
-    
+
     #TODO test when sr_setup has an argument "result_order"
     #expect_silent(chk <- s3$read(result_order = "COL_MAJOR")$tables()$concat())
     #expect_identical(
@@ -68,6 +71,7 @@ test_that("SparseNDArray Factory", {
 })
 
 test_that("SparseNDArray Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # check that straight use of new() errors, but 'with handshake' passes
@@ -91,6 +95,7 @@ test_that("SparseNDArray Factory", {
 })
 
 test_that("Collection Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # check that straight use of new() errors, but 'with handshake' passes
@@ -108,6 +113,7 @@ test_that("Collection Factory", {
 })
 
 test_that("Measurement Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # check that straight use of new() errors, but 'with handshake' passes
@@ -125,6 +131,7 @@ test_that("Measurement Factory", {
 })
 
 test_that("Experiment Factory", {
+    skip_if(!extended_tests())
     uri <- tempfile()
 
     # check that straight use of new() errors, but 'with handshake' passes

--- a/apis/r/tests/testthat/test-SCEOutgest.R
+++ b/apis/r/tests/testthat/test-SCEOutgest.R
@@ -1,4 +1,5 @@
 test_that("Load SCE object from ExperimentQuery mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c'))
   uri <- withr::local_tempdir("sce-experiment-query-whole")
   n_obs <- 20L
@@ -194,6 +195,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
 })
 
 test_that("Load SCE object from sliced ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c'))
   uri <- withr::local_tempdir("sce-experiment-query-sliced")
   n_obs <- 1001L
@@ -271,6 +273,7 @@ test_that("Load SCE object from sliced ExperimentQuery", {
 })
 
 test_that("Load SCE object from indexed ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c'))
   uri <- withr::local_tempdir("sce-experiment-query-value-filters")
   n_obs <- 1001L

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Arrow.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Arrow.R
@@ -1,4 +1,5 @@
 test_that("Arrow Interface from SOMAArrayReader", {
+    skip_if(!extended_tests())
     library(arrow)
     library(tiledb)
 
@@ -30,19 +31,23 @@ test_that("Arrow Interface from SOMAArrayReader", {
     expect_equal(tb3$num_columns, 6)
 
     # read a subset of rows and columns
-    tb4 <- soma_array_reader(uri = uri,
+    tb4 <- soma_array_to_arrow_table(soma_array_reader(uri = uri,
                 colnames = c("obs_id", "percent_mito", "n_counts", "louvain"),
                 dim_ranges = list(soma_joinid = rbind(bit64::as.integer64(c(1000, 1004)),
                                                   bit64::as.integer64(c(2000, 2004)))),
-                dim_points=list(soma_joinid = bit64::as.integer64(seq(0, 100, by = 20)))) |>
-        soma_array_to_arrow_table()
+                dim_points=list(soma_joinid = bit64::as.integer64(seq(0, 100, by = 20)))))
+
 
     expect_equal(tb4$num_rows, 16)
     expect_equal(tb4$num_columns, 4)
+
+    rm(z, tb, rb, tb1, arr, tb2, tb3, tb4)
+    gc()
 })
 
 
 test_that("SOMAArrayReader result order", {
+    skip_if(!extended_tests())
     uri <- withr::local_tempdir("soma-dense-ndarray")
     ndarray <- SOMADenseNDArrayCreate(uri, arrow::int32(), shape = c(4, 4))
 
@@ -50,15 +55,12 @@ test_that("SOMAArrayReader result order", {
     ndarray$write(M)
     ndarray$close()
 
-    M1 <- soma_array_reader(uri = uri, result_order = "auto") |>
-        soma_array_to_arrow_table()
+    M1 <- soma_array_to_arrow_table(soma_array_reader(uri = uri, result_order = "auto"))
     expect_equal(M, matrix(M1$soma_data, 4, 4, byrow = TRUE))
 
-    M2 <- soma_array_reader(uri = uri, result_order = "row-major") |>
-        soma_array_to_arrow_table()
+    M2 <- soma_array_to_arrow_table(soma_array_reader(uri = uri, result_order = "row-major"))
     expect_equal(M, matrix(M2$soma_data, 4, 4, byrow = TRUE))
 
-    M3 <- soma_array_reader(uri = uri, result_order = "column-major") |>
-        soma_array_to_arrow_table()
+    M3 <- soma_array_to_arrow_table(soma_array_reader(uri = uri, result_order = "column-major"))
     expect_equal(M, matrix(M3$soma_data, 4, 4, byrow = FALSE))
 })

--- a/apis/r/tests/testthat/test-SOMAAxisQuery.R
+++ b/apis/r/tests/testthat/test-SOMAAxisQuery.R
@@ -1,4 +1,5 @@
 test_that("SOMAAxisQuery", {
+  skip_if(!extended_tests())
   query <- SOMAAxisQuery$new()
   expect_null(query$value_filter)
   expect_null(query$coords)

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -1,5 +1,6 @@
 
 test_that("SOMACollection basics", {
+  skip_if(!extended_tests())
   uri <- file.path(withr::local_tempdir(), "new-collection")
 
   # Create an empty collection
@@ -67,6 +68,7 @@ test_that("SOMACollection basics", {
 })
 
 test_that("SOMACollection timestamped ops", {
+  skip_if(!extended_tests())
   # Create a collection @ t0
   uri <- file.path(withr::local_tempdir(), "timestamped-collection")
   collection <- SOMACollectionCreate(uri)
@@ -108,6 +110,7 @@ test_that("SOMACollection timestamped ops", {
 })
 
 test_that("Platform config and context are respected by add_ methods", {
+  skip_if(!extended_tests())
   uri <- file.path(withr::local_tempdir(), "new-collection")
 
   # Set params in the config and context

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -1,4 +1,5 @@
 test_that("Basic mechanics", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
   asch <- create_arrow_schema()
 
@@ -102,9 +103,13 @@ test_that("Basic mechanics", {
   expect_true(tiledb::is.sparse(sch))
   expect_false(tiledb::allows_dups(sch))
   sdf$close()
+
+  rm(sdf, tbl0, tbl1, rb0, rb1)
+  gc()
 })
 
 test_that("Basic mechanics with default index_column_names", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe-soma-joinid")
   asch <- create_arrow_schema(foo_first=FALSE)
 
@@ -147,10 +152,13 @@ test_that("Basic mechanics with default index_column_names", {
     as.list(tbl0),
     ignore_attr = TRUE
   )
+
+  rm(sdf, tbl0)
+  gc()
 })
 
 test_that("creation with all supported dimension data types", {
-
+  skip_if(!extended_tests())
   sch <- arrow::schema(
     arrow::field("int8", arrow::int8(), nullable = FALSE),
     arrow::field("int16", arrow::int16(), nullable = FALSE),
@@ -181,9 +189,13 @@ test_that("creation with all supported dimension data types", {
     expect_true(sdf$exists())
     sdf$close()
   }
+
+  rm(sdf, tbl0)
+  gc()
 })
 
 test_that("int64 values are stored correctly", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
   asch <- arrow::schema(
     arrow::field("foo", arrow::int32(), nullable = FALSE),
@@ -205,37 +217,46 @@ test_that("int64 values are stored correctly", {
   # verify int64_downcast option was restored
   expect_equal(getOption("arrow.int64_downcast"), orig_downcast_value)
   sdf$close()
+
+  rm(sdf, tbl0, tbl1)
+  gc()
 })
 
 test_that("SOMADataFrame read", {
-    uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
+  skip_if(!extended_tests())
+  uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
 
-    sdf <- SOMADataFrameOpen(uri)
-    z <- sdf$read()$concat()
-    expect_equal(z$num_rows, 2638L)
-    expect_equal(z$num_columns, 6L)
-    sdf$close()
+  sdf <- SOMADataFrameOpen(uri)
+  z <- sdf$read()$concat()
+  expect_equal(z$num_rows, 2638L)
+  expect_equal(z$num_columns, 6L)
+  sdf$close()
 
-    columns <- c("n_counts", "n_genes", "louvain")
-    sdf <- SOMADataFrameOpen(uri)
-    z <- sdf$read(column_names=columns)$concat()
-    expect_equal(z$num_columns, 3L)
-    expect_equal(z$ColumnNames(), columns)
-    sdf$close()
+  columns <- c("n_counts", "n_genes", "louvain")
+  sdf <- SOMADataFrameOpen(uri)
+  z <- sdf$read(column_names=columns)$concat()
+  expect_equal(z$num_columns, 3L)
+  expect_equal(z$ColumnNames(), columns)
+  sdf$close()
 
-    columns <- c("n_counts", "does_not_exist")
-    sdf <- SOMADataFrameOpen(uri)
-    expect_error(sdf$read(column_names=columns))
-    sdf$close()
+  columns <- c("n_counts", "does_not_exist")
+  sdf <- SOMADataFrameOpen(uri)
+  expect_error(sdf$read(column_names=columns))
+  sdf$close()
 
-    coords <- bit64::as.integer64(seq(100, 109))
-    sdf <- SOMADataFrameOpen(uri)
-    z <- sdf$read(coords = list(soma_joinid=coords))$concat()
-    expect_equal(z$num_rows, 10L)
-    sdf$close()
+  coords <- bit64::as.integer64(seq(100, 109))
+  sdf <- SOMADataFrameOpen(uri)
+  z <- sdf$read(coords = list(soma_joinid=coords))$concat()
+  expect_equal(z$num_rows, 10L)
+  sdf$close()
+
+  rm(sdf, z)
+  gc()
+
 })
 
 test_that("soma_ prefix is reserved", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
   asch <- create_arrow_schema()
 
@@ -252,6 +273,7 @@ test_that("soma_ prefix is reserved", {
 })
 
 test_that("soma_joinid is added on creation", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
   asch <- create_arrow_schema()
   asch <- asch$RemoveField(match("soma_joinid", asch$names) - 1)
@@ -264,6 +286,7 @@ test_that("soma_joinid is added on creation", {
 })
 
 test_that("soma_joinid validations", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
   asch <- create_arrow_schema()
 
@@ -281,6 +304,7 @@ test_that("soma_joinid validations", {
 })
 
 test_that("platform_config is respected", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
 
   # Set Arrow schema
@@ -376,6 +400,7 @@ test_that("platform_config is respected", {
 })
 
 test_that("platform_config defaults", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe")
 
   # Set Arrow schema
@@ -410,6 +435,7 @@ test_that("platform_config defaults", {
 })
 
 test_that("Metadata", {
+  skip_if(!extended_tests())
   uri <- file.path(withr::local_tempdir(), "sdf-metadata")
   asch <- create_arrow_schema()
   sdf <- SOMADataFrameCreate(uri, asch)
@@ -435,6 +461,7 @@ test_that("Metadata", {
 })
 
 test_that("SOMADataFrame timestamped ops", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe-timestamps")
 
   sch <- arrow::schema(arrow::field("soma_joinid", arrow::int64(), nullable=FALSE),

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -1,4 +1,5 @@
 test_that("SOMADenseNDArray creation", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("dense-ndarray")
 
   ndarray <- SOMADenseNDArrayCreate(uri, arrow::int32(), shape = c(10, 5))
@@ -77,6 +78,7 @@ test_that("SOMADenseNDArray creation", {
 })
 
 test_that("platform_config is respected", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dense-nd-array")
 
   # Set tiledb create options
@@ -177,6 +179,7 @@ test_that("platform_config is respected", {
 })
 
 test_that("platform_config defaults", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dense-nd-array")
 
   # Set tiledb create options
@@ -213,6 +216,7 @@ test_that("platform_config defaults", {
 })
 
 test_that("SOMADenseNDArray timestamped ops", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dense-nd-array-timestamps")
 
   t10 <- Sys.time()

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -1,4 +1,5 @@
 test_that("matrix outgest with all results", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
   experiment <- load_dataset("soma-exp-pbmc-small")
@@ -62,6 +63,7 @@ test_that("matrix outgest with all results", {
 })
 
 test_that("matrix outgest with filtered results", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   # Subset the pbmc_small object to match the filtered results
   pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
@@ -139,6 +141,7 @@ test_that("matrix outgest with filtered results", {
 })
 
 test_that("matrix outgest assertions", {
+  skip_if(!extended_tests())
   experiment <- load_dataset("soma-exp-pbmc-small")
 
   query <- SOMAExperimentAxisQuery$new(
@@ -214,6 +217,7 @@ test_that("matrix outgest assertions", {
 })
 
 test_that("matrix outgest with implicitly-stored axes", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("matrix-implicit")
   set.seed(seed = 42L)
   n_obs <- 15L

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -1,4 +1,5 @@
 test_that("returns all coordinates by default", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-all")
   n_obs <- 20L
   n_var <- 10L
@@ -55,6 +56,7 @@ test_that("returns all coordinates by default", {
 })
 
 test_that("querying by dimension coordinates", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-coords")
   n_obs <- 1001L
   n_var <- 99L
@@ -102,6 +104,7 @@ test_that("querying by dimension coordinates", {
 })
 
 test_that("querying by value filters", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-value-filters")
   n_obs <- 1001L
   n_var <- 99L
@@ -145,6 +148,7 @@ test_that("querying by value filters", {
 })
 
 test_that("querying by both coordinates and value filters", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-coords-and-value-filters")
 
   n_obs <- 1001L
@@ -235,6 +239,7 @@ test_that("querying by both coordinates and value filters", {
 })
 
 test_that("queries with empty results", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-empty-results")
   n_obs <- 1001L
   n_var <- 99L
@@ -264,6 +269,7 @@ test_that("queries with empty results", {
 })
 
 test_that("retrieving query results in supported formats", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-results-formats1")
   n_obs <- 1001L
   n_var <- 99L
@@ -295,6 +301,7 @@ test_that("retrieving query results in supported formats", {
 })
 
 test_that("query result value indexer", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-results-indexer")
   n_obs <- 1001L
   n_var <- 99L
@@ -361,6 +368,7 @@ test_that("query result value indexer", {
 })
 
 test_that("query result value indexer upcast", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment-query-results-indexer-upcast")
   n_obs <- 1001L
   n_var <- 99L

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -1,4 +1,5 @@
 test_that("SOMASparseNDArray creation", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("sparse-ndarray")
   ndarray <- SOMASparseNDArrayCreate(uri, arrow::int32(), shape = c(10, 10))
 
@@ -74,6 +75,7 @@ test_that("SOMASparseNDArray creation", {
 })
 
 test_that("SOMASparseNDArray read_sparse_matrix", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("sparse-ndarray-3")
   ndarray <- SOMASparseNDArrayCreate(uri, arrow::int32(), shape = c(10, 10))
 
@@ -102,6 +104,7 @@ test_that("SOMASparseNDArray read_sparse_matrix", {
 })
 
 test_that("SOMASparseNDArray read_sparse_matrix_zero_based", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("sparse-ndarray")
   ndarray <- SOMASparseNDArrayCreate(uri, arrow::int32(), shape = c(10, 10))
 
@@ -140,6 +143,7 @@ test_that("SOMASparseNDArray read_sparse_matrix_zero_based", {
 })
 
 test_that("SOMASparseNDArray creation with duplicates", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("sparse-ndarray")
 
   set.seed(42)
@@ -174,6 +178,7 @@ test_that("SOMASparseNDArray creation with duplicates", {
 })
 
 test_that("platform_config is respected", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-sparse-nd-array")
 
   # Set tiledb create options
@@ -274,6 +279,7 @@ test_that("platform_config is respected", {
 })
 
 test_that("platform_config defaults", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-sparse-nd-array")
 
   # Set tiledb create options
@@ -310,6 +316,7 @@ test_that("platform_config defaults", {
 })
 
 test_that("SOMASparseNDArray timestamped ops", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-sparse-nd-array-timestamps")
 
   # t=10: create 2x2 array and write 1 into top-left entry
@@ -337,6 +344,7 @@ test_that("SOMASparseNDArray timestamped ops", {
 })
 
 test_that("SOMASparseNDArray compatibility with shape >= 2^31 - 1", {
+  skip_if(!extended_tests())
   uri <- create_and_populate_32bit_sparse_nd_array(
     uri = withr::local_tempdir("soma-32bit-sparse-nd-array")
   )

--- a/apis/r/tests/testthat/test-SOMATileDBContext.R
+++ b/apis/r/tests/testthat/test-SOMATileDBContext.R
@@ -1,4 +1,5 @@
 test_that("SOMATileDBContext mechanics", {
+  skip_if(!extended_tests())
   ctx <- SOMATileDBContext$new()
   expect_true(length(ctx) >= 1L)
   expect_identical(length(ctx), ctx$length())
@@ -13,6 +14,7 @@ test_that("SOMATileDBContext mechanics", {
 })
 
 test_that("SOMATileDBContext SOMA mechanics", {
+  skip_if(!extended_tests())
   ctx <- SOMATileDBContext$new()
   ntiledb <- length(x = ctx$.__enclos_env__$private$.tiledb_ctx_names())
   expect_no_condition(ctx$set('member_uris_are_relative', TRUE))
@@ -38,6 +40,7 @@ test_that("SOMATileDBContext SOMA mechanics", {
 })
 
 test_that("SOMATileDBContext TileDB mechanics", {
+  skip_if(!extended_tests())
   ctx <- SOMATileDBContext$new()
   tiledb_names <- ctx$.__enclos_env__$private$.tiledb_ctx_names()
   expect_identical(ctx$keys(), tiledb_names)
@@ -58,6 +61,7 @@ test_that("SOMATileDBContext TileDB mechanics", {
 })
 
 test_that("SOMATileDBContext SOMA + TileDB mechanics", {
+  skip_if(!extended_tests())
   ctx <- SOMATileDBContext$new()
   tiledb_names <- ctx$.__enclos_env__$private$.tiledb_ctx_names()
   expect_error(ctx <- SOMATileDBContext$new(c(

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -1,6 +1,7 @@
 ##spdl::set_level('warn')
 
 test_that("Write Assay mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
 
   uri <- withr::local_tempdir("write-assay")
@@ -134,6 +135,7 @@ test_that("Write Assay mechanics", {
 })
 
 test_that("Write DimReduc mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
 
   uri <- withr::local_tempdir("write-reduction")
@@ -195,6 +197,7 @@ test_that("Write DimReduc mechanics", {
 })
 
 test_that("Write Graph mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
 
   uri <- withr::local_tempdir("write-graph")
@@ -322,6 +325,7 @@ test_that("Write Graph mechanics", {
 })
 
 test_that("Write DimReduc mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("write-reduction-2")
   collection <- SOMACollectionCreate(uri)
@@ -380,6 +384,7 @@ test_that("Write DimReduc mechanics", {
 })
 
 test_that("Write Graph mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("write-graph")
   collection <- SOMACollectionCreate(uri)

--- a/apis/r/tests/testthat/test-SeuratOutgest-assay.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-assay.R
@@ -1,4 +1,5 @@
 test_that("Load assay from ExperimentQuery mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
 
   uri <- withr::local_tempdir("assay-experiment-query-whole")
@@ -117,6 +118,7 @@ test_that("Load assay from ExperimentQuery mechanics", {
 })
 
 test_that("Load assay from sliced ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
 
   uri <- withr::local_tempdir("assay-experiment-query-sliced")
@@ -161,6 +163,7 @@ test_that("Load assay from sliced ExperimentQuery", {
 })
 
 test_that("Load assay from indexed ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("soma-experiment-query-value-filters")
   n_obs <- 1001L

--- a/apis/r/tests/testthat/test-SeuratOutgest-graph.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-graph.R
@@ -1,4 +1,5 @@
 test_that("Load graph from ExperimentQuery mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("graph-experiment-query-whole")
   n_obs <- 20L
@@ -63,6 +64,7 @@ test_that("Load graph from ExperimentQuery mechanics", {
 })
 
 test_that("Load graph from sliced ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("graph-experiment-query-sliced")
   n_obs <- 1001L
@@ -111,6 +113,7 @@ test_that("Load graph from sliced ExperimentQuery", {
 })
 
 test_that("Load graph from indexed ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("graph-experiment-query-value-filters")
   n_obs <- 1001L

--- a/apis/r/tests/testthat/test-SeuratOutgest-object.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-object.R
@@ -1,4 +1,5 @@
 test_that("Load Seurat object from ExperimentQuery mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("seurat-experiment-query-whole")
   n_obs <- 20L
@@ -179,6 +180,7 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
 })
 
 test_that("Load Seurat object from sliced ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("seurat-experiment-query-sliced")
   n_obs <- 1001L
@@ -241,6 +243,7 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
 })
 
 test_that("Load Seurat object from indexed ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("seurat-experiment-query-value-filters")
   n_obs <- 1001L

--- a/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
@@ -1,4 +1,5 @@
 test_that("Load reduction from ExperimentQuery mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("reduc-experiment-query-whole")
   n_obs <- 20L
@@ -196,6 +197,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
 })
 
 test_that("Load reduction from sliced ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("reduction-experiment-query-sliced")
   n_obs <- 1001L
@@ -322,6 +324,7 @@ test_that("Load reduction from sliced ExperimentQuery", {
 })
 
 test_that("Load reduction from indexed ExperimentQuery", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   uri <- withr::local_tempdir("reduction-experiment-query-value-filters")
   n_obs <- 1001L

--- a/apis/r/tests/testthat/test-Stats.R
+++ b/apis/r/tests/testthat/test-Stats.R
@@ -1,4 +1,5 @@
 test_that("Stats generation", {
+    skip_if(!extended_tests())
     uri <- tempfile()
     sdf <- create_and_populate_soma_dataframe(uri, mode = "READ")
     on.exit(sdf$close())
@@ -11,5 +12,4 @@ test_that("Stats generation", {
     tiledbsoma_stats_reset()
     txt <- tiledbsoma_stats_dump()
     expect_true(nchar(txt) < 100) # almost empty JSON string
-
 })


### PR DESCRIPTION
**Issue and/or context:**

The SOMAArray instance used by the iterated reader contains a shared pointer to a Context instance.  This PR adds a finalizer to ensure this is properly unwould.  Unit tests are refactored to test under `valgrind` and an actions has been added.

**Changes:**

Addiition of a finalizer function, refactored tests and added valgrind action

**Notes for Reviewer:**

[SC 33353](https://app.shortcut.com/tiledb-inc/story/33353/added-finalizers-as-well-test-restructuring-for-valgrind-compliance) and the notion doc referenced therein
