### PR TITLE
[python] Check that `update_obs`/`update_var` do not update row counts

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1216,12 +1216,8 @@ def _update_dataframe(
         # Until we someday support deletes, this is the correct check on the existing,
         # contiguous soma join IDs compared to the new contiguous ones about to be created.
         old_jids = sorted(
-            [
-                e.as_py()
-                for e in sdf_r.read(column_names=["soma_joinid"]).concat()[
-                    "soma_joinid"
-                ]
-            ]
+            e.as_py()
+            for e in sdf_r.read(column_names=["soma_joinid"]).concat()["soma_joinid"]
         )
         new_jids = list(range(len(new_data)))
         if old_jids != new_jids:

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import anndata
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -130,3 +131,51 @@ def test_change(adata):
 
     assert o1 == o2
     assert v1 == v2
+
+
+@pytest.mark.parametrize("shift_and_exc", [[0, None], [1, ValueError]])
+def test_change_counts(adata, shift_and_exc):
+    shift, exc = shift_and_exc
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+    tiledbsoma.io.from_anndata(output_path, adata, measurement_name="RNA")
+
+    with tiledbsoma.Experiment.open(output_path) as exp:
+        o1 = exp.obs.schema
+        v1 = exp.ms["RNA"].var.schema
+
+    old_nobs = len(adata.obs)
+    old_nvar = len(adata.var)
+
+    new_nobs = old_nobs + shift
+    new_nvar = old_nvar + shift
+
+    new_obs = pd.DataFrame(
+        data={
+            "somebool": np.asarray([True] * new_nobs),
+        },
+        index=np.arange(new_nobs).astype(str),
+    )
+    new_var = pd.DataFrame(
+        data={
+            "somebool": np.asarray([True] * new_nvar),
+        },
+        index=np.arange(new_nvar).astype(str),
+    )
+
+    if exc is None:
+        with tiledbsoma.Experiment.open(output_path, "w") as exp:
+            tiledbsoma.io.ingest.update_obs(exp, new_obs)
+            tiledbsoma.io.ingest.update_var(exp, new_var, measurement_name="RNA")
+
+    else:
+        with tiledbsoma.Experiment.open(output_path, "w") as exp:
+            with pytest.raises(exc):
+                tiledbsoma.io.ingest.update_obs(exp, new_obs)
+            with pytest.raises(exc):
+                tiledbsoma.io.ingest.update_var(exp, new_var, measurement_name="RNA")
+        with tiledbsoma.Experiment.open(output_path) as exp:
+            o2 = exp.obs.schema
+            v2 = exp.ms["RNA"].var.schema
+            assert o1 == o2
+            assert v1 == v2


### PR DESCRIPTION
These should be used to mutate columns only.