### PR TITLE
[r] Support updating obs and var

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.4.3
+Version: 1.4.3.1
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -306,7 +306,7 @@ SOMADataFrame <- R6::R6Class(
           is_arrow_schema(schema),
         is.character(index_column_names) && length(index_column_names) > 0,
         "All 'index_column_names' must be defined in the 'schema'" =
-          assert_subset(index_column_names, schema$names, type = "field"),
+          assert_subset(index_column_names, schema$names, "indexed field"),
         "Column names must not start with reserved prefix 'soma_'" =
           all(!startsWith(setdiff(schema$names, "soma_joinid"), "soma_"))
       )

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -221,13 +221,16 @@ SOMADataFrame <- R6::R6Class(
     },
 
     #' @description Update (lifecycle: experimental)
-    #' @param values An [`arrow::Table`] or [`arrow::RecordBatch`].
+    #' @param values A `data.frame`, [`arrow::Table`], or
+    #' [`arrow::RecordBatch`].
     update = function(values) {
       private$check_open_for_write()
       stopifnot(
-        "'values' must be an Arrow Table or RecordBatch" =
-          (is_arrow_table(values) || is_arrow_record_batch(values))
+        "'values' must be a data.frame, Arrow Table or RecordBatch" =
+          is.data.frame(values) || is_arrow_table(values) || is_arrow_record_batch(values)
       )
+
+      if (is.data.frame(values)) values <- arrow::as_arrow_table(values)
 
       # Retrieve existing soma_joinids from array to:
       # - validate number of rows in values matches number of rows in array

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -230,7 +230,10 @@ SOMADataFrame <- R6::R6Class(
     #'   `values` will be added
     #' - any columns present in both will be left alone, with the exception that
     #'   if `values` has a different type for the column, the entire update
-    #'   will because attribute types cannot be changed
+    #'   will fail because attribute types cannot be changed
+    #'
+    #' Furthermore, `values` must contain the same number of rows as the current
+    #' `SOMADataFrame`.
     #'
     #' @param values A `data.frame`, [`arrow::Table`], or
     #' [`arrow::RecordBatch`].

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -221,6 +221,17 @@ SOMADataFrame <- R6::R6Class(
     },
 
     #' @description Update (lifecycle: experimental)
+    #' @details
+    #' Update the existing `SOMADataFrame` to add or remove columns based on the
+    #' input:
+    #' - columns present in the current the `SOMADataFrame` but absent from the
+    #'   new `values` will be dropped
+    #' - columns absent in current `SOMADataFrame` but present in the new
+    #'   `values` will be added
+    #' - any columns present in both will be left alone, with the exception that
+    #'   if `values` has a different type for the column, the entire update
+    #'   will because attribute types cannot be changed
+    #'
     #' @param values A `data.frame`, [`arrow::Table`], or
     #' [`arrow::RecordBatch`].
     update = function(values) {

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -94,16 +94,9 @@ SOMADataFrame <- R6::R6Class(
 
       for (field_name in attr_column_names) {
         field <- schema$GetFieldByName(field_name)
-        field_type <- tiledb_type_from_arrow_type(field$type)
-
-        tdb_attrs[[field_name]] <- tiledb::tiledb_attr(
-          name = field_name,
-          type = field_type,
-          nullable = field$nullable,
-          ncells = if (field_type == "ASCII") NA_integer_ else 1L,
-          filter_list = tiledb::tiledb_filter_list(
-            tiledb_create_options$attr_filters(field_name)
-          )
+        tdb_attrs[[field_name]] <- tiledb_attr_from_arrow_field(
+          schema$GetFieldByName(field_name),
+          tiledb_create_options = tiledb_create_options
         )
       }
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -263,6 +263,7 @@ SOMADataFrame <- R6::R6Class(
       # Drop columns
       se <- tiledb::tiledb_array_schema_evolution()
       for (drop_col in drop_cols) {
+        spdl::info("[SOMADataFrame update]: dropping column '{}'", drop_col)
         se <- tiledb::tiledb_array_schema_evolution_drop_attribute(
           object = se,
           attrname = drop_col
@@ -271,6 +272,7 @@ SOMADataFrame <- R6::R6Class(
 
       # Add columns
       for (add_col in add_cols) {
+        spdl::info("[SOMADataFrame update]: adding column '{}'", add_col)
         se <- tiledb::tiledb_array_schema_evolution_add_attribute(
           object = se,
           attr = tiledb_attr_from_arrow_field(
@@ -285,6 +287,7 @@ SOMADataFrame <- R6::R6Class(
       # Reopen array for writing with new schema
       self$close()
       self$open("WRITE", internal_use_only = "allowed_use")
+      spdl::info("[SOMADataFrame update]: Writing new data")
       self$write(values)
     }
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -230,7 +230,7 @@ SOMADataFrame <- R6::R6Class(
     #'   `values` will be added
     #' - any columns present in both will be left alone, with the exception that
     #'   if `values` has a different type for the column, the entire update
-    #'   will fail because attribute types cannot be changed
+    #'   will fail because attribute types cannot be changed.
     #'
     #' Furthermore, `values` must contain the same number of rows as the current
     #' `SOMADataFrame`.

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -260,11 +260,23 @@ SOMADataFrame <- R6::R6Class(
         new_schema[common_cols]
       )
 
+      # Drop columns
       se <- tiledb::tiledb_array_schema_evolution()
       for (drop_col in drop_cols) {
         se <- tiledb::tiledb_array_schema_evolution_drop_attribute(
           object = se,
           attrname = drop_col
+        )
+      }
+
+      # Add columns
+      for (add_col in add_cols) {
+        se <- tiledb::tiledb_array_schema_evolution_add_attribute(
+          object = se,
+          attr = tiledb_attr_from_arrow_field(
+            field = new_schema$GetFieldByName(add_col),
+            tiledb_create_options = tiledb_create_options
+          )
         )
       }
 

--- a/apis/r/R/SOMAExperiment.R
+++ b/apis/r/R/SOMAExperiment.R
@@ -7,6 +7,11 @@
 #'
 #' @templateVar class SOMAExperiment
 #' @template section-add-object-to-collection
+ #' @param row_index_name An optional scalar character. If provided, and if
+#' the `values` argument is a `data.frame` with row names, then the row
+#' names will be extracted and added as a new column to the `data.frame`
+#' prior to performing the update. The name of this new column will be set
+#' to the value specified by `row_index_name`.
 #'
 #' @export
 SOMAExperiment <- R6::R6Class(
@@ -27,6 +32,30 @@ SOMAExperiment <- R6::R6Class(
         obs_query = obs_query,
         var_query = var_query
       )
+    },
+
+    #' @description Update the obs [`SOMADataFrame`] to add or remove columns.
+    #' See [`SOMADataFrame$update()`][`SOMADataFrame`] for details.
+    #' @param values A `data.frame`, [`arrow::Table`], or
+    #' [`arrow::RecordBatch`].
+    update_obs = function(values, row_index_name = NULL) {
+      self$obs$update(values, row_index_name)
+    },
+
+    #' @description Update the var `SOMADataFrame` to add or remove columns.
+    #' See [`SOMADataFrame$update()`][`SOMADataFrame`] for details.
+    #' @param values A `data.frame`, [`arrow::Table`], or
+    #' [`arrow::RecordBatch`].
+    #' @param measurement_name The name of the [`SOMAMeasurement`] whose `var`
+    #' will be updated.
+    update_var = function(values, measurement_name, row_index_name = NULL) {
+      stopifnot(
+        "Must specify a single measurement name" =
+          is_scalar_character(measurement_name),
+        "Measurement does not exist in the experiment" =
+          measurement_name %in% self$ms$names()
+      )
+      self$ms$get(measurement_name)$var$update(values, row_index_name)
     }
   ),
 

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -15,11 +15,14 @@ TileDBArray <- R6::R6Class(
     #' @param internal_use_only Character value to signal this is a 'permitted' call,
     #' as `open()` is considered internal and should not be called directly.
     #' @return The object, invisibly
-    open = function(mode=c("READ", "WRITE"), internal_use_only = NULL) {
+    open = function(mode = c("READ", "WRITE"), internal_use_only = NULL) {
       mode <- match.arg(mode)
       if (is.null(internal_use_only) || internal_use_only != "allowed_use") {
-        stop(paste("Use of the open() method is for internal use only. Consider using a",
-                   "factory method as e.g. 'SOMADataFrameOpen()'."), call. = FALSE)
+        stop(
+          "Use of the open() method is for internal use only.\n",
+          "  - Consider using a factory method as e.g. 'SOMADataFrameOpen()'.",
+          call. = FALSE
+        )
       }
 
       private$.mode <- mode
@@ -285,6 +288,18 @@ TileDBArray <- R6::R6Class(
   ),
 
   private = list(
+
+    # Reopen the array in a different mode
+    reopen = function(mode = c("READ", "WRITE")) {
+      mode <- match.arg(mode)
+      if (private$.mode == mode) {
+        return(invisible(self))
+      }
+      self$close()
+      invisible(
+        self$open(mode = mode, internal_use_only = "allowed_use")
+      )
+    },
 
     # Internal pointer to the TileDB array.
     #

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -189,3 +189,77 @@ check_arrow_pointers <- function(arrlst) {
     stopifnot("First argument must be an external pointer to ArrowArray" = check_arrow_array_tag(arrlst[[1]]),
               "Second argument must be an external pointer to ArrowSchema" = check_arrow_schema_tag(arrlst[[2]]))
 }
+
+#' Validate compatibility of Arrow data types
+#'
+#' For most data types, this is a simple equality check but it also provides
+#' allowances for certain comparisons:
+#'
+#' - string and large_string
+#'
+#' @param from an [`arrow::DataType`]
+#' @param to an [`arrow::DataType`]
+#' @return a logical indicating whether the data types are compatible
+#' @noRd
+check_arrow_data_types <- function(from, to) {
+  stopifnot(
+    "'from' and 'to' must both be Arrow DataTypes"
+      = is_arrow_data_type(from) && is_arrow_data_type(to)
+  )
+
+  is_string <- function(x) {
+    x$ToString() %in% c("string", "large_string")
+  }
+
+  compatible <- if (is_string(from) && is_string(to)) {
+    TRUE
+  } else {
+    from$Equals(to)
+  }
+
+  compatible
+}
+
+#' Validate compatibility of Arrow schemas
+#'
+#' This is essentially a vectorized version of [`check_arrow_data_types`] that
+#' checks the compatibility of each field in the schemas.
+#' @param from an [`arrow::Schema`]
+#' @param to an [`arrow::Schema`] with the same set of fields as `from`
+#' @return `TRUE` if the schemas are compatible, otherwise an error is thrown
+#' @noRd
+check_arrow_schema_data_types <- function(from, to) {
+  stopifnot(
+    "'from' and 'to' must both be Arrow Schemas"
+      = is_arrow_schema(from) && is_arrow_schema(to),
+    "'from' and 'to' must have the same number of fields"
+      = length(from) == length(to),
+    "'from' and 'to' must have the same field names"
+      = identical(sort(names(from)), sort(names(to)))
+  )
+
+  fields <- names(from)
+  msgs <- character(0L)
+  for (field in fields) {
+    from_type <- from[[field]]$type
+    to_type <- to[[field]]$type
+    if (!check_arrow_data_types(from_type, to_type)) {
+      msg <- sprintf(
+        "  - field '%s': %s != %s\n",
+        field,
+        from_type$ToString(),
+        to_type$ToString()
+      )
+      msgs <- c(msgs, msg)
+    }
+  }
+
+  if (length(msgs) > 0L) {
+    stop(
+      "Schemas are incompatible:\n",
+      string_collapse(msgs, sep = "\n"),
+      call. = FALSE
+    )
+  }
+  return(TRUE)
+}

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -1,6 +1,6 @@
 #' @importFrom glue glue_collapse
 string_collapse <- function(x, sep = ", ") {
-  glue::glue_collapse(x, sep = ", ", width = getOption("width", Inf))
+  glue::glue_collapse(x, sep = sep, width = getOption("width", Inf))
 }
 
 n_unique <- function(x) {

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -180,8 +180,11 @@ new \code{values} will be dropped
 \code{values} will be added
 \item any columns present in both will be left alone, with the exception that
 if \code{values} has a different type for the column, the entire update
-will because attribute types cannot be changed
+will fail because attribute types cannot be changed
 }
+
+Furthermore, \code{values} must contain the same number of rows as the current
+\code{SOMADataFrame}
 }
 
 }

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -18,6 +18,7 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-create}{\code{SOMADataFrame$create()}}
 \item \href{#method-SOMADataFrame-write}{\code{SOMADataFrame$write()}}
 \item \href{#method-SOMADataFrame-read}{\code{SOMADataFrame$read()}}
+\item \href{#method-SOMADataFrame-update}{\code{SOMADataFrame$update()}}
 \item \href{#method-SOMADataFrame-clone}{\code{SOMADataFrame$clone()}}
 }
 }
@@ -145,6 +146,44 @@ more information.}
 \subsection{Returns}{
 arrow::\link[arrow]{Table} or \link{TableReadIter}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-update"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-update}{}}}
+\subsection{Method \code{update()}}{
+Update (lifecycle: experimental)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$update(values, row_index_name = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{A \code{data.frame}, \code{\link[arrow:Table]{arrow::Table}}, or
+\code{\link[arrow:RecordBatch]{arrow::RecordBatch}}.}
+
+\item{\code{row_index_name}}{An optional scalar character. If provided, and if
+the \code{values} argument is a \code{data.frame} with row names, then the row
+names will be extracted and added as a new column to the \code{data.frame}
+prior to performing the update. The name of this new column will be set
+to the value specified by \code{row_index_name}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+Update the existing \code{SOMADataFrame} to add or remove columns based on the
+input:
+\itemize{
+\item columns present in the current the \code{SOMADataFrame} but absent from the
+new \code{values} will be dropped
+\item columns absent in current \code{SOMADataFrame} but present in the new
+\code{values} will be added
+\item any columns present in both will be left alone, with the exception that
+if \code{values} has a different type for the column, the entire update
+will because attribute types cannot be changed
+}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMADataFrame-clone"></a>}}

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -41,6 +41,8 @@ observation index domain, \code{obs_id}. All observations for the
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-SOMAExperiment-axis_query}{\code{SOMAExperiment$axis_query()}}
+\item \href{#method-SOMAExperiment-update_obs}{\code{SOMAExperiment$update_obs()}}
+\item \href{#method-SOMAExperiment-update_var}{\code{SOMAExperiment$update_var()}}
 \item \href{#method-SOMAExperiment-clone}{\code{SOMAExperiment$clone()}}
 }
 }
@@ -94,6 +96,59 @@ axis.}
 }
 \subsection{Returns}{
 A \code{\link{SOMAExperimentAxisQuery}} object.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperiment-update_obs"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperiment-update_obs}{}}}
+\subsection{Method \code{update_obs()}}{
+Update the obs \code{\link{SOMADataFrame}} to add or remove columns.
+See \code{\link[=SOMADataFrame]{SOMADataFrame$update()}} for details.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperiment$update_obs(values, row_index_name = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{A \code{data.frame}, \code{\link[arrow:Table]{arrow::Table}}, or
+\code{\link[arrow:RecordBatch]{arrow::RecordBatch}}.}
+
+\item{\code{row_index_name}}{An optional scalar character. If provided, and if
+the \code{values} argument is a \code{data.frame} with row names, then the row
+names will be extracted and added as a new column to the \code{data.frame}
+prior to performing the update. The name of this new column will be set
+to the value specified by \code{row_index_name}.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperiment-update_var"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperiment-update_var}{}}}
+\subsection{Method \code{update_var()}}{
+Update the var \code{SOMADataFrame} to add or remove columns.
+See \code{\link[=SOMADataFrame]{SOMADataFrame$update()}} for details.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperiment$update_var(values, measurement_name, row_index_name = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{A \code{data.frame}, \code{\link[arrow:Table]{arrow::Table}}, or
+\code{\link[arrow:RecordBatch]{arrow::RecordBatch}}.}
+
+\item{\code{measurement_name}}{The name of the \code{\link{SOMAMeasurement}} whose \code{var}
+will be updated.}
+
+\item{\code{row_index_name}}{An optional scalar character. If provided, and if
+the \code{values} argument is a \code{data.frame} with row names, then the row
+names will be extracted and added as a new column to the \code{data.frame}
+prior to performing the update. The name of this new column will be set
+to the value specified by \code{row_index_name}.}
+}
+\if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/TileDBArray.Rd
+++ b/apis/r/man/TileDBArray.Rd
@@ -232,7 +232,7 @@ explicitly written.
 \item{\code{simplify}}{Return a vector of \code{\link{bit64:integer64}}s containing only
 the upper bounds.}
 
-\item{\code{index1}}{Return the used shape with 1-based indices.}
+\item{\code{index1}}{Return the used shape with 1-based indices (0-based indices are returned by default)}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -80,3 +80,41 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   expect_equal(length(arrow_schema$fields), 4)
   expect_equal(names(arrow_schema), c("dim0", "dim1", "attr0", "attr1"))
 })
+
+test_that("Validating arrow data type compatibility", {
+  expect_false(check_arrow_data_types(arrow::int32(), arrow::float32()))
+  expect_true(check_arrow_data_types(arrow::int32(), arrow::int32()))
+  # strings and large strings are compatible
+  expect_true(check_arrow_data_types(arrow::string(), arrow::large_utf8()))
+
+  expect_error(
+    check_arrow_data_types("not an arrow data type", arrow::int32())
+  )
+})
+
+test_that("Validating arrow schema data type compatibility", {
+  from <- arrow::schema(foo = arrow::int32())
+  to <- arrow::schema(foo = arrow::int32())
+  expect_true(check_arrow_schema_data_types(from, to))
+
+  # Add incompatible fields
+  from$bar <- arrow::int16()
+  to$bar <- arrow::float16()
+  expect_error(
+    check_arrow_schema_data_types(from, to),
+    "Schemas are incompatible"
+  )
+
+  # Schemas with different fields
+  from$baz <- arrow::string()
+  expect_error(
+    check_arrow_schema_data_types(from, to),
+    "'from' and 'to' must have the same number of fields"
+  )
+
+  to$fizz <- arrow::string()
+  expect_error(
+    check_arrow_schema_data_types(from, to),
+    "'from' and 'to' must have the same field names"
+  )
+})

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -5,7 +5,7 @@ test_that("Basic mechanics", {
 
   expect_error(
     SOMADataFrameCreate(uri, asch, index_column_names = "qux"),
-    "The following field does not exist: qux"
+    "The following indexed field does not exist: qux"
   )
 
   sdf <- SOMADataFrameCreate(uri, asch, index_column_names = "foo")
@@ -116,7 +116,7 @@ test_that("Basic mechanics with default index_column_names", {
   sdf <- SOMADataFrame$new(uri, internal_use_only = "allowed_use")
   expect_error(
     sdf$create(asch, index_column_names = "qux", internal_use_only = "allowed_use"),
-    "The following field does not exist: qux"
+    "The following indexed field does not exist: qux"
   )
 
   sdf$create(asch, internal_use_only = "allowed_use")

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -544,4 +544,12 @@ test_that("SOMADataFrame can be updated", {
     SOMADataFrameOpen(uri, mode = "WRITE")$update(tbl0),
     "Schemas are incompatible"
   )
+  tbl0 <- tbl1
+
+  # Error if the number of rows changes
+  tbl0 <- tbl0$Slice(offset = 1, length = tbl0$num_rows - 1)
+  expect_error(
+    SOMADataFrameOpen(uri, mode = "WRITE")$update(tbl0),
+    "Number of rows in 'values' must match number of rows in array"
+  )
 })

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -512,17 +512,14 @@ test_that("SOMADataFrame can be updated", {
   sdf <- create_and_populate_soma_dataframe(uri, nrows = 10L)
 
   # Retrieve the table from disk
-  sdf <- SOMADataFrameOpen(uri, "READ")
-  tbl0 <- sdf$read()$concat()
+  tbl0 <- SOMADataFrameOpen(uri, "READ")$read()$concat()
 
   # Remove a column and update
   tbl0$bar <- NULL
-  sdf <- SOMADataFrameOpen(uri, "WRITE")
-  sdf$update(tbl0)
+  sdf <- SOMADataFrameOpen(uri, "WRITE")$update(tbl0)
 
   # Verify attribute was removed on disk
-  sdf <- SOMADataFrameOpen(uri, "READ")
-  tbl1 <- sdf$read()$concat()
+  tbl1 <- SOMADataFrameOpen(uri, "READ")$read()$concat()
   expect_true(tbl1$Equals(tbl0))
 
   # # Add a new column and update

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -501,3 +501,22 @@ test_that("SOMADataFrame timestamped ops", {
   sdf$close()
 
 })
+
+test_that("SOMADataFrame can be updated", {
+  uri <- withr::local_tempdir("soma-dataframe-update-3")
+  sdf <- create_and_populate_soma_dataframe(uri, nrows = 10L)
+
+  # Retrieve the table from disk
+  sdf <- SOMADataFrameOpen(uri, "READ")
+  tbl0 <- sdf$read()$concat()
+
+  # Remove a column and update
+  tbl0$bar <- NULL
+  sdf <- SOMADataFrameOpen(uri, "WRITE")
+  sdf$update(tbl0)
+
+  # Verify attribute was removed on disk
+  sdf <- SOMADataFrameOpen(uri, "READ")
+  tbl1 <- sdf$read()$concat()
+  expect_true(tbl1$Equals(tbl0))
+})


### PR DESCRIPTION
**Issue and/or context:** #1591 

**Changes:**  Adds `update_obs` and `update_var` methods to the `SOMAExperiment` class. These methods accept either an arrow table, arrow record batch, or a `data.frame` as input and update the existing `SOMADataFrame` on disk. The core logic for these methods is implemented in `SOMADataFrame$update`.

Other changes:

- `SOMADataFrame` attribute filters now default to ZSTD compression if no filter is specified in the `platform_config`, previously we were defaulting to no compression.

- Added new internal utility to create tiledb attributes from arrow fields (`tiledb_attr_from_arrow_field()`), which is now used by `SOMADataFrame$create` and `SOMADataFrame$update`

- `TileDBArray` class now has a private method for reopening an array in a different mode

**Notes for Reviewer:**

