### PR TITLE
[r] Adjust bounding box to be spec compliant

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -4,7 +4,7 @@ Title: TileDB SOMA
 Description: Interface for working with 'TileDB'-based Stack of Matrices,
     Annotated ('SOMA'): an open data model for representing annotated matrices,
     like those commonly used for single cell data analysis.
-Version: 1.4.3
+Version: 1.4.4
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 * Add support for writing `SummarizedExperiment` and `SingleCellExperiment` object to SOMAs
+* Add support for bounding boxes for sparse arrays
 
 
 # tiledbsoma 1.4.0

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -171,7 +171,7 @@ SOMASparseNDArray <- R6::R6Class(
       for (i in seq_along(bbox)) {
         bbox_flat[[index]] <- bbox[[i]][1L]
         bbox_flat[[index + 1L]] <- bbox[[i]][2L]
-        names(bbox_flat)[index:(index + 1L)] <- paste0(names(bbox)[i], c('_lo', '_hi'))
+        names(bbox_flat)[index:(index + 1L)] <- paste0(names(bbox)[i], c('_lower', '_upper'))
         index <- index + 2L
       }
       self$set_metadata(bbox_flat)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -166,7 +166,15 @@ SOMASparseNDArray <- R6::R6Class(
         bbox[[x]] <- xrange
       }
       names(bbox) <- paste0(names(bbox), '_domain')
-      self$set_metadata(bbox)
+      bbox_flat <- vector(mode = 'list', length = length(x = bbox) * 2L)
+      index <- 1L
+      for (i in seq_along(bbox)) {
+        bbox_flat[[index]] <- bbox[[i]][1L]
+        bbox_flat[[index + 1L]] <- bbox[[i]][2L]
+        names(bbox_flat)[index:(index + 1L)] <- paste0(names(bbox)[i], c('_lo', '_hi'))
+        index <- index + 2L
+      }
+      self$set_metadata(bbox_flat)
       private$.write_coo_dataframe(coo)
     },
 

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -158,7 +158,7 @@ TileDBArray <- R6::R6Class(
       for (i in seq_along(along.with = utilized)) {
         key <- paste0(dims[i], '_domain')
         dom <- bit64::integer64(2L)
-        names(dom) <- c('_lo', '_hi')
+        names(dom) <- c('_lower', '_upper')
         for (type in names(dom)) {
           dom[type] <- self$get_metadata(paste0(key, type)) %||% bit64::NA_integer64_
           if (any(is.na(dom))) {

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -157,7 +157,16 @@ TileDBArray <- R6::R6Class(
       names(utilized) <- dims
       for (i in seq_along(along.with = utilized)) {
         key <- paste0(dims[i], '_domain')
-        utilized[[i]] <- self$get_metadata(key) %||% bit64::NA_integer64_
+        dom <- bit64::integer64(2L)
+        names(dom) <- c('_lo', '_hi')
+        for (type in names(dom)) {
+          dom[type] <- self$get_metadata(paste0(key, type)) %||% bit64::NA_integer64_
+          if (any(is.na(dom))) {
+            dom <- bit64::NA_integer64_
+          }
+          utilized[[i]] <- unname(dom)
+        }
+        # utilized[[i]] <- self$get_metadata(key) %||% bit64::NA_integer64_
       }
       if (any(vapply_lgl(utilized, rlang::is_na))) {
         stop(

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -390,7 +390,7 @@ test_that("SOMASparseNDArray bounding box", {
   dnames <- ndarray$dimnames()
   bbox_names <- vector('character', length(dnames) * 2L)
   for (i in seq_along(bbox_names)) {
-    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    type <- c('_upper', '_lower')[(i %% 2) + 1L]
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
@@ -441,7 +441,7 @@ test_that("SOMASparseNDArray without bounding box", {
   dnames <- ndarray$dimnames()
   bbox_names <- vector('character', length(dnames) * 2L)
   for (i in seq_along(bbox_names)) {
-    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    type <- c('_upper', '_lower')[(i %% 2) + 1L]
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
@@ -471,7 +471,7 @@ test_that("SOMASparseNDArray with failed bounding box", {
   dnames <- ndarray$dimnames()
   bbox_names <- vector('character', length(dnames) * 2L)
   for (i in seq_along(bbox_names)) {
-    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    type <- c('_upper', '_lower')[(i %% 2) + 1L]
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
@@ -495,7 +495,7 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
   dnames <- ndarray$dimnames()
   bbox_names <- vector('character', length(dnames) * 2L)
   for (i in seq_along(bbox_names)) {
-    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    type <- c('_upper', '_lower')[(i %% 2) + 1L]
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -388,11 +388,20 @@ test_that("SOMASparseNDArray bounding box", {
 
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
+  bbox_names <- vector('character', length(dnames) * 2L)
+  for (i in seq_along(bbox_names)) {
+    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
+  }
 
-  expect_true(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
-  for (i in seq_along(dnames)) {
-    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_domain')), 'integer64')
-    expect_equal(xrange, bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
+  expect_true(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  for (i in seq_along(bbox_names)) {
+    expect_s3_class(x <- ndarray$get_metadata(bbox_names[i]), 'integer64')
+    if (i %% 2) {
+      expect_equal(x, bit64::as.integer64(0L))
+    } else {
+      expect_equal(x, bit64::as.integer64(dim(mat)[ceiling(i / 2)] - 1L))
+    }
   }
 
   expect_type(bbox <- ndarray$used_shape(index1 = TRUE), 'list')
@@ -430,8 +439,13 @@ test_that("SOMASparseNDArray without bounding box", {
 
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
+  bbox_names <- vector('character', length(dnames) * 2L)
+  for (i in seq_along(bbox_names)) {
+    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
+  }
 
-  expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_error(ndarray$used_shape())
 })
@@ -455,8 +469,13 @@ test_that("SOMASparseNDArray with failed bounding box", {
 
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
+  bbox_names <- vector('character', length(dnames) * 2L)
+  for (i in seq_along(bbox_names)) {
+    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
+  }
 
-  expect_false(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_error(ndarray$used_shape())
 })
@@ -474,11 +493,20 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
 
   ndarray <- SOMASparseNDArrayOpen(uri)
   dnames <- ndarray$dimnames()
+  bbox_names <- vector('character', length(dnames) * 2L)
+  for (i in seq_along(bbox_names)) {
+    type <- c('_hi', '_lo')[(i %% 2) + 1L]
+    bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
+  }
 
-  expect_true(all(paste0(dnames, '_domain') %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
-  for (i in seq_along(dnames)) {
-    expect_s3_class(xrange <- ndarray$get_metadata(paste0(dnames[i], '_domain')), 'integer64')
-    expect_equal(xrange, bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
+  expect_true(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
+  for (i in seq_along(bbox_names)) {
+    expect_s3_class(x <- ndarray$get_metadata(bbox_names[i]), 'integer64')
+    if (i %% 2) {
+      expect_equal(x, bit64::as.integer64(0L))
+    } else {
+      expect_equal(x, bit64::as.integer64(dim(mat)[ceiling(i / 2)] - 1L))
+    }
   }
 
   expect_type(bbox <- ndarray$used_shape(index1 = TRUE), 'list')


### PR DESCRIPTION
Flatten out the bounding box metadata to be single integer64 values instead of arrays of two integer64 values. Instead of just `<dimname>_domain`, bounding boxes are now stored as `<dimname>_domain_lo` and `<dimname>_domain_hi`

`SOMASparseArray$write()` is now modified to flatten the bounding box before writing and `TileDBArray$used_shape()` is modified to read four metadata values instead of two

The inputs and to `SOMASparseNDArray$write(bbox =)` and `TileDBArray$used_shape()` are unchanged

Context: issue #1445; follow-on to PR #1513.