### PR TITLE
Don't accept lists for Python metadata entries, but on purpose.

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 import attrs
-import numpy as np
 import tiledb
 from somacore import options
 from typing_extensions import Literal, Self
@@ -353,14 +352,12 @@ class MetadataWrapper(MutableMapping[str, Any]):
 def _check_metadata_type(key: str, obj: object) -> None:
     """Pre-checks that a metadata entry can be stored in an array.
 
-    These checks are reproduced from the TileDB Python metadata-setting methods.
-    We have to do this since we don't commit our changes until the very end.
+    These checks are reproduced from the TileDB Python metadata-setting methods,
+    but are slightly more restrictive than what TileDB allows in general.
+    We have to pre-check since we don't write metadata changes until closing.
     """
     if not isinstance(key, str):
         raise TypeError(f"metadata keys must be strings, not {type(key)}")
-    if isinstance(obj, (bytes, float, int, str, np.ndarray)):
+    if isinstance(obj, (bytes, float, int, str)):
         return
-    if isinstance(obj, (list, tuple)):
-        # Will raise a TypeError if it can't convert the contents.
-        np.array(obj)
     raise TypeError(f"cannot store {type(obj)} instance as metadata")

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any, Dict
 
+import numpy as np
 import pyarrow as pa
 import pytest
 
@@ -202,13 +203,13 @@ def test_metadata_marshalling_OK(soma_object, test_value):
 
 
 @pytest.mark.parametrize(
-    "test_value",
-    [["a", "b", "c"], {"a": False}],
+    "bad_value",
+    [["a", "b", "c"], {"a": False}, [1, 2, 3], np.arange(10)],
 )
-def test_metadata_marshalling_FAIL(soma_object, test_value):
-    """Test the various data type marshalling we expect to FAIL"""
+def test_metadata_marshalling_FAIL(soma_object, bad_value):
+    """Verify that unsupported metadata types raise an error immediately."""
 
     with pytest.raises(TypeError):
-        soma_object.metadata["test_value"] = test_value
+        soma_object.metadata["test_value"] = bad_value
 
     assert "test_value" not in soma_object.metadata


### PR DESCRIPTION
We (the royal we) accidentally forgot a return statement in the metadata type-checking function. However, this turned out to be the right thing to do anyway, so ¯\_(°_o)_/¯.

This change removes the superfluous if block entirely and tightens up the types that we do accept to match the SOMA specification:

- primitives
- strings
- nothing else