### PR TITLE
[python] Avoid unnecessary slowdown on empty sparse arrays

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -107,7 +107,7 @@ jobs:
       shell: bash
       run: |
         mkdir -p test/soco
-        ./apis/python/devtools/ingestor --soco -o test/soco -n data/pbmc3k_processed.h5ad data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
+        ./apis/python/devtools/ingestor --debug --soco -o test/soco -n data/pbmc3k_processed.h5ad data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
 
     - name: Run pytests
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src

--- a/apis/python/src/tiledbsoma/eta.py
+++ b/apis/python/src/tiledbsoma/eta.py
@@ -57,8 +57,8 @@ class Tracker:
         y = np.array(self.chunk_percents)
         A = np.vstack([x, np.ones(len(x))]).T
         m, b = np.linalg.lstsq(A, y, rcond=None)[0]
-        # Solve for x where y == 100
-        done_cumu_seconds = (100.0 - b) / m
+        # Solve for x where y == 100.
+        done_cumu_seconds = (100.0 - b) / m if m > 0 else 0
 
         return float(done_cumu_seconds) - self.cumulative_seconds[-1]
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1650,10 +1650,11 @@ def _write_matrix_to_sparseNDArray(
             chunk_size = _find_sparse_chunk_size(  # type: ignore [unreachable]
                 matrix, i, stride_axis, goal_chunk_nnz
             )
-        if chunk_size == -1 and i > 0:  # completely empty array; nothing to write
-            break
-        else:
-            chunk_size = 1
+        if chunk_size == -1:  # completely empty array; nothing to write
+            if i > 0:
+                break
+            else:
+                chunk_size = 1
 
         i2 = i + chunk_size
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1491,7 +1491,7 @@ def _find_sparse_chunk_size(
     matrix: SparseMatrix, start_index: int, axis: int, goal_chunk_nnz: int
 ) -> int:
     """Given a sparse matrix and a start index, return a step size, on the stride axis,
-    which will achieve the cumulative nnz desired.
+    which will achieve the cumulative nnz desired. If the array is entirely empty, returns -1.
 
     Args:
         matrix:
@@ -1529,7 +1529,7 @@ def _find_sparse_chunk_size(
         chunk_size += 1
 
     if sum_nnz == 0:  # completely empty sparse array (corner case)
-        return 1
+        return -1
 
     if sum_nnz > goal_chunk_nnz:
         return chunk_size
@@ -1650,6 +1650,10 @@ def _write_matrix_to_sparseNDArray(
             chunk_size = _find_sparse_chunk_size(  # type: ignore [unreachable]
                 matrix, i, stride_axis, goal_chunk_nnz
             )
+        if chunk_size == -1 and i > 0:  # completely empty array; nothing to write
+            break
+        else:
+            chunk_size = 1
 
         i2 = i + chunk_size
 


### PR DESCRIPTION
**Issue and/or context:** Found while doing development and corner-case testing for #1648.

**Changes:** For completely empty sparse arrays, we were getting `chunk_size=1` and doing lots of loops over zero-element chunks. Now, we detect that; do a single write (for metadata consistency), then stop.

After (`z.h5ad` which you can find in our sandbox at `s3://tiledb-johnkerl/s/a/z.h5ad` has empty `X`):

```
$ ingestor.py --debug ~/s/a/z.h5ad z
START  Experiment.from_h5ad /Users/johnkerl/s/a/z.h5ad
START  READING /Users/johnkerl/s/a/z.h5ad
FINISH READING /Users/johnkerl/s/a/z.h5ad TIME 0.019 seconds
Registration: registering isolated AnnData object.
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 0.001 seconds
START  WRITING z
START  WRITING z/obs
START  WRITING z/obs
FINISH WRITING z/obs TIME 0.035 seconds
START  WRITING z/ms/RNA/var
START  WRITING z/ms/RNA/var
FINISH WRITING z/ms/RNA/var TIME 0.028 seconds
START  WRITING z/ms/RNA/X/data
START  WRITING z/ms/RNA/X/data TIME 0.006 seconds
START  chunk rows 0..0 of 2638 (0.000%), nnz=0
FINISH chunk in 0.145 seconds,   0.000% done, ETA -0.15 seconds
FINISH WRITING z/ms/RNA/X/data TIME 0.251 seconds
FINISH WRITING z TIME 0.362 seconds
FINISH Experiment.from_h5ad /Users/johnkerl/s/a/z.h5ad z TIME 0.382 seconds
```

Before:

```
$ ingestor.py --debug ~/s/a/z.h5ad z0
START  Experiment.from_h5ad /Users/johnkerl/s/a/z.h5ad
START  READING /Users/johnkerl/s/a/z.h5ad
FINISH READING /Users/johnkerl/s/a/z.h5ad TIME 0.019 seconds
Registration: registering isolated AnnData object.
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 0.001 seconds
START  WRITING z0
START  WRITING z0/obs
START  WRITING z0/obs
FINISH WRITING z0/obs TIME 0.036 seconds
START  WRITING z0/ms/RNA/var
START  WRITING z0/ms/RNA/var
FINISH WRITING z0/ms/RNA/var TIME 0.025 seconds
START  WRITING z0/ms/RNA/X/data
START  WRITING z0/ms/RNA/X/data TIME 0.005 seconds
START  chunk rows 0..0 of 2638 (0.000%), nnz=0
/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/eta.py:61: RuntimeWarning: divide by zero encountered in double_scalars
  done_cumu_seconds = (100.0 - b) / m
FINISH chunk in 0.110 seconds,   0.000% done, ETA -inf seconds
START  chunk rows 1..1 of 2638 (0.038%), nnz=0
FINISH chunk in 0.104 seconds,   0.038% done, ETA 4.59 minutes
START  chunk rows 2..2 of 2638 (0.076%), nnz=0
FINISH chunk in 0.100 seconds,   0.076% done, ETA 4.48 minutes
START  chunk rows 3..3 of 2638 (0.114%), nnz=0
FINISH chunk in 0.103 seconds,   0.114% done, ETA 4.48 minutes
START  chunk rows 4..4 of 2638 (0.152%), nnz=0
...
```