### PR TITLE
[r] Refactor iterated reader lifetime

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -91,10 +91,6 @@ sr_next <- function(sr) {
     .Call(`_tiledbsoma_sr_next`, sr)
 }
 
-sr_finalize <- function(sr) {
-    invisible(.Call(`_tiledbsoma_sr_finalize`, sr))
-}
-
 #' TileDB SOMA statistics
 #'
 #' These functions expose the TileDB Core functionality for performance measurements

--- a/apis/r/R/ReadIter.R
+++ b/apis/r/R/ReadIter.R
@@ -11,9 +11,8 @@ ReadIter <- R6::R6Class(
 
     #' @description Create (lifecycle: experimental)
     #' @param sr soma read pointer
-    initialize = function(rl) {
-      private$soma_reader_pointer <- rl$sr
-      private$ctx_pointer <- rl$ctx
+    initialize = function(sr) {
+      private$soma_reader_pointer <- sr
     },
 
     #' @description Check if iterated read is complete or not. (lifecycle: experimental)
@@ -55,32 +54,12 @@ ReadIter <- R6::R6Class(
 
     # Internal 'external pointer' object used for iterated reads
     soma_reader_pointer = NULL,
-    ctx_pointer = NULL,
+    #ctx_pointer = NULL,
 
     # to be refined in derived classes
     soma_reader_transform = function(x) {
       .NotYetImplemented()
-    },
-
-    finalize = function() {
-      spdl::debug("[finalizer] Entered")
-      if (!is.null(private$soma_reader_pointer)) {
-        spdl::debug("[finalizer] Calling sr_finalize")
-        sr_finalize(private$soma_reader_pointer)
-        private$soma_reader_pointer <- NULL
-      }
     }
-
-    ## finalize = function() {
-    ##   spdl::debug("[finalizer] Entered")
-    ##   if (!is.null(private$soma_reader_pointer)) {
-    ##     #spdl::debug("[finalizer] Calling sr_finalize")
-    ##     #sr_finalize(private$soma_reader_pointer, private$ctx_pointer)
-    ##     private$soma_reader_pointer <- NULL
-    ##     private$ctx_pointer <- NULL
-    ##   }
-    ## }
-
 
   )
 )

--- a/apis/r/R/ReadIter.R
+++ b/apis/r/R/ReadIter.R
@@ -11,8 +11,9 @@ ReadIter <- R6::R6Class(
 
     #' @description Create (lifecycle: experimental)
     #' @param sr soma read pointer
-    initialize = function(sr) {
-      private$soma_reader_pointer <- sr
+    initialize = function(rl) {
+      private$soma_reader_pointer <- rl$sr
+      private$ctx_pointer <- rl$ctx
     },
 
     #' @description Check if iterated read is complete or not. (lifecycle: experimental)
@@ -54,6 +55,7 @@ ReadIter <- R6::R6Class(
 
     # Internal 'external pointer' object used for iterated reads
     soma_reader_pointer = NULL,
+    ctx_pointer = NULL,
 
     # to be refined in derived classes
     soma_reader_transform = function(x) {
@@ -68,6 +70,17 @@ ReadIter <- R6::R6Class(
         private$soma_reader_pointer <- NULL
       }
     }
+
+    ## finalize = function() {
+    ##   spdl::debug("[finalizer] Entered")
+    ##   if (!is.null(private$soma_reader_pointer)) {
+    ##     #spdl::debug("[finalizer] Calling sr_finalize")
+    ##     #sr_finalize(private$soma_reader_pointer, private$ctx_pointer)
+    ##     private$soma_reader_pointer <- NULL
+    ##     private$ctx_pointer <- NULL
+    ##   }
+    ## }
+
 
   )
 )

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -209,7 +209,7 @@ SOMADataFrame <- R6::R6Class(
       }
 
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      sr <- sr_setup(uri = self$uri,
+      rl <- sr_setup(uri = self$uri,
                      config = cfg,
                      colnames = column_names,
                      qc = value_filter,
@@ -217,7 +217,7 @@ SOMADataFrame <- R6::R6Class(
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
 
-      TableReadIter$new(sr)
+      TableReadIter$new(rl)
     },
 
     #' @description Update (lifecycle: experimental)

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -216,8 +216,8 @@ SOMADataFrame <- R6::R6Class(
                      dim_points = coords,
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
-
-      TableReadIter$new(rl)
+      private$ctx_ptr <- rl$ctx
+      TableReadIter$new(rl$sr)
     },
 
     #' @description Update (lifecycle: experimental)
@@ -369,7 +369,9 @@ SOMADataFrame <- R6::R6Class(
       }
 
       schema
-    }
+    },
 
+    # Internal variable to hold onto context returned by sr_setup
+    ctx_ptr = NULL
   )
 )

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -47,14 +47,14 @@ SOMASparseNDArray <- R6::R6Class(
       }
 
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      sr <- sr_setup(uri = self$uri,
+      rl <- sr_setup(uri = self$uri,
                      config = cfg,
                      dim_points = coords,
                      result_order = result_order,
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
 
-      SOMASparseNDArrayRead$new(sr, shape = self$shape())
+      SOMASparseNDArrayRead$new(rl$sr, shape = self$shape())
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: experimental)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -53,7 +53,7 @@ SOMASparseNDArray <- R6::R6Class(
                      result_order = result_order,
                      timestamp_end = private$tiledb_timestamp,
                      loglevel = log_level)
-
+      private$ctx_ptr <- rl$ctx
       SOMASparseNDArrayRead$new(rl$sr, shape = self$shape())
     },
 
@@ -226,7 +226,10 @@ SOMASparseNDArray <- R6::R6Class(
     },
 
     # Internal marking of one or zero based matrices for iterated reads
-    zero_based = NA
+    zero_based = NA,
+
+    # Internal variable to hold onto context returned by sr_setup
+    ctx_ptr = NULL
 
   )
 )

--- a/apis/r/inst/include/tiledbsoma_types.h
+++ b/apis/r/inst/include/tiledbsoma_types.h
@@ -19,5 +19,6 @@
 #include <tiledb/tiledb>					// for QueryCondition etc
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
 #include <tiledbsoma/tiledbsoma>
+#include "rutilities.h"
 
 namespace tdbs = tiledbsoma;

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -140,16 +140,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// sr_finalize
-void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr);
-RcppExport SEXP _tiledbsoma_sr_finalize(SEXP srSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::XPtr<tdbs::SOMAArray> >::type sr(srSEXP);
-    sr_finalize(sr);
-    return R_NilValue;
-END_RCPP
-}
 // tiledbsoma_stats_enable
 void tiledbsoma_stats_enable();
 RcppExport SEXP _tiledbsoma_tiledbsoma_stats_enable() {
@@ -219,7 +209,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_sr_next", (DL_FUNC) &_tiledbsoma_sr_next, 1},
-    {"_tiledbsoma_sr_finalize", (DL_FUNC) &_tiledbsoma_sr_finalize, 1},
     {"_tiledbsoma_tiledbsoma_stats_enable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_enable, 0},
     {"_tiledbsoma_tiledbsoma_stats_disable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_disable, 0},
     {"_tiledbsoma_tiledbsoma_stats_reset", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_reset, 0},

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -99,7 +99,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // sr_setup
-Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::Datetime> timestamp_end, const std::string& loglevel);
+Rcpp::List sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::Datetime> timestamp_end, const std::string& loglevel);
 RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamp_endSEXP, SEXP loglevelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -19,7 +19,6 @@
 #include "xptr-utils.h"         // xptr taggging utilitie
 Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64_t n_children);
 Rcpp::XPtr<ArrowArray> array_setup_struct(Rcpp::XPtr<ArrowArray> arrxp, int64_t n_children);
-void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr);
 
 namespace tdbs = tiledbsoma;
 
@@ -236,52 +235,3 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAArray> sr) {
                                       Rcpp::Named("schema") = schemaxp);
    return as;
 }
-
-// Helper function to register a finalizer -- eg for debugging purposes
-// R_Finalizer_t is 'typedef void (*R_CFinalizer_t)(SEXP);'
-inline void registerXptrFinalizer(SEXP s, R_CFinalizer_t f, bool onexit = true) {
-    R_RegisterCFinalizerEx(s, f, onexit ? TRUE : FALSE);
-}
-// Finalizer helper with void f(SEXP) signature
-void SOMAArrayFinalizer(SEXP sx) {
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] entered"));
-    // if (sx == R_NilValue || sx == NULL || R_ExternalPtrAddr(sx) == NULL) return;
-    // Rcpp::XPtr<tdbs::SOMAArray> xp(sx);
-    // //spdl::trace(tfm::format("[SOMAArrayFinalizer] instantiated"));
-    // if (xp == R_NilValue) return;
-    // check_xptr_tag<tdbs::SOMAArray>(xp);
-    // //spdl::trace(tfm::format("[SOMAArrayFinalizer] checked"));
-    // std::shared_ptr<tiledb::Context> ctx = xp->ctx();
-    // //spdl::trace(tfm::format("[SOMAArrayFinalizer] referenced once"));
-    // if (ctx == nullptr) return;
-    // std::shared_ptr<tiledb_ctx_t> ctx_cptr = ctx->ptr();
-    // if (ctx_cptr == nullptr) return;
-    // spdl::debug(tfm::format("[SOMAArrayFinalizer] count on ctx %d cptr %d",
-    //                         ctx.use_count(), ctx_cptr.use_count()));
-    // tiledb_ctx_t* ptr = ctx_cptr.get();
-    // if (ptr == nullptr) return;
-    // tiledb_ctx_free(&ptr);
-    // ptr = nullptr;
-    // ctx_cptr.reset();
-    // ctx.reset();
-    spdl::debug(tfm::format("[SOMAArrayFinalizer] done"));
-}
-// Finalizer helper with void f(SEXP) signature
-void ContextWrapperFinalizer(SEXP sx) {
-    spdl::debug(tfm::format("[ContextWrapperFinalizer] entered"));
-    if (sx == R_NilValue || sx == NULL || R_ExternalPtrAddr(sx) == NULL) return;
-    Rcpp::XPtr<ctx_wrap_t> xp(sx);
-    if (xp == R_NilValue) return;
-    // check_xptr_tag<tdbs::SOMAArray>(xp);
-    std::shared_ptr<tiledb::Context> ctx = xp->ctxptr;
-    ctx.reset();
-    spdl::debug(tfm::format("[ContextWrapperFinalizer] done"));
-}
-
-// // [ [ Rcpp::export]]
-// void sr_finalize(Rcpp::XPtr<tdbs::SOMAArray> sr, Rcpp::XPtr<ctx_wrap_t> cw) {
-//     spdl::debug(tfm::format("[sr_finalize] entered"));
-//     check_xptr_tag<tdbs::SOMAArray>(sr);
-//     // not yet tagges
-//     registerXptrFinalizer(sr, SOMAArrayFinalizer);
-// }

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -51,6 +51,7 @@ inline std::vector<int64_t> getInt64Vector(Rcpp::NumericVector vec) {
     return num;
 }
 
+
 // Applies (named list of) vectors of points to the named dimensions
 void apply_dim_points(
     tdbs::SOMAArray* sr,
@@ -90,3 +91,10 @@ inline ResultOrder get_tdb_result_order(std::string result_order){
 	};
 	return result_order_map[result_order];
 }
+
+struct ContextWrapper {
+    //ContextWrapper(std::shared_ptr<tiledb::Context> ctx_ptr_) : ctxptr(std::move(ctx_ptr_)) {}
+    ContextWrapper(std::shared_ptr<tiledb::Context> ctx_ptr_) : ctxptr(ctx_ptr_) {}
+    std::shared_ptr<tiledb::Context> ctxptr;
+};
+typedef struct ContextWrapper ctx_wrap_t;

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -14,9 +14,9 @@ test_that("Iterated Interface from SOMAArrayReader", {
 
     ctx <- tiledb::tiledb_ctx()
     config <- tiledb::config(ctx)
-    sr <- sr_setup(uri, config = as.character(config), loglevel = "warn")
+    srret <- sr_setup(uri, config = as.character(config), loglevel = "warn")
+    sr <- srret$sr
     expect_true(inherits(sr, "externalptr"))
-    sr_finalize(sr)
 
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -31,11 +31,11 @@ test_that("Iterated Interface from SOMAArrayReader", {
     expect_equal(ncol(rl), 3)
 
     rm(sr)
-    gc()
+    #gc()
 
-    sr <- sr_setup(uri, config=as.character(config), dim_points=list(soma_dim_0=as.integer64(1)))
+    srret <- sr_setup(uri, config=as.character(config), dim_points=list(soma_dim_0=as.integer64(1)))
+    sr <- srret$sr
     expect_true(inherits(sr, "externalptr"))
-    sr_finalize(sr)
 
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -50,11 +50,11 @@ test_that("Iterated Interface from SOMAArrayReader", {
     expect_equal(ncol(rl), 3)
 
     rm(sr)
-    gc()
+    #gc()
 
-    sr <- sr_setup(uri, config=as.character(config), dim_range=list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
+    srret <- sr_setup(uri, config=as.character(config), dim_range=list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
+    sr <- srret$sr
     expect_true(inherits(sr, "externalptr"))
-    sr_finalize(sr)
 
     rl <- data.frame()
     while (!tiledbsoma:::sr_complete(sr)) {
@@ -70,7 +70,8 @@ test_that("Iterated Interface from SOMAArrayReader", {
 
     ## test completeness predicate on shorter data
     uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
-    sr <- sr_setup(uri, config=as.character(config))
+    srret <- sr_setup(uri, config=as.character(config))
+    sr <- srret$sr
 
     expect_false(tiledbsoma:::sr_complete(sr))
     dat <- sr_next(sr)
@@ -197,8 +198,9 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim points
     coords <- list(soma_dim_0=bit64::as.integer64(0:5),
                    soma_dim_1=bit64::as.integer64(0:5))
-    sr <- sr_setup(uri = X$uri, config = config, dim_points = coords)
-    sr_finalize(sr)
+    srret <- sr_setup(uri = X$uri, config = config, dim_points = coords)
+    sr <- srret$sr
+
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(arrow::RecordBatch$import_from_c(chunk$array_data, chunk$schema))
     expect_equal(at$num_rows, 5)
@@ -209,8 +211,9 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim ranges
     ranges <- list(soma_dim_0=matrix(bit64::as.integer64(c(1,4)),1),
                    soma_dim_1=matrix(bit64::as.integer64(c(1,4)),1))
-    sr <- sr_setup(uri = X$uri, config = config, dim_ranges = ranges)
-    sr_finalize(sr)
+    srret <- sr_setup(uri = X$uri, config = config, dim_ranges = ranges)
+    sr <- srret$sr
+
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(arrow::RecordBatch$import_from_c(chunk$array_data, chunk$schema))
     expect_equal(at$num_rows, 2)


### PR DESCRIPTION
**Issue and/or context:**

PR #1636 has been seen "to work in theory yet not in practice" so the lifetime management of the iterated reader and its SOMArray object has been refactored.

**Changes:**

A struct is wrapped around the shared pointer which allows for R lifetime management (of an external pointer to the struct) to coexist with the C++ shared_pointer (inside the struct).  No more explicit finalizer.

**Notes for Reviewer:**

[SC 33659](https://app.shortcut.com/tiledb-inc/story/33659/r-refactor-iterated-reader-lifetime)
