### PR TITLE
[r] Add three valgrind options

### DIFF
--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -24,6 +24,6 @@ jobs:
         run: cd apis/r && R CMD build --no-build-vignettes --no-manual .
       - name: Check Package under valgrind
         # we unsetting environment variable CI for non-extended set of tests
-        run: cd apis/r && CI="" R CMD check --use-valgrind --no-vignettes --no-manual $(ls -1tr *.tar.gz | tail -1)
+        run: cd apis/r && CI="" VALGRIND_OPTS="-s --leak-check=full --max-threads=1024" R CMD check --use-valgrind --no-vignettes --no-manual $(ls -1tr *.tar.gz | tail -1)
       - name: Display Test Output
         run: cd apis/r/tiledbsoma.Rcheck/tests && cat testthat.Rout


### PR DESCRIPTION
**Issue and/or context:**

Valgrind summaries are a little sparse by default. 

**Changes:**

Three options are added at the `valgrind` invocation in the GitHub Action

**Notes for Reviewer:**

[SC-33661](https://app.shortcut.com/tiledb-inc/story/33661/r-add-valgrind-options)
