### PR TITLE
[r] More tweaks for tests

### DIFF
--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -508,6 +508,7 @@ test_that("SOMADataFrame timestamped ops", {
 })
 
 test_that("SOMADataFrame can be updated", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe-update")
   sdf <- create_and_populate_soma_dataframe(uri, nrows = 10L)
 
@@ -555,6 +556,7 @@ test_that("SOMADataFrame can be updated", {
 })
 
 test_that("SOMADataFrame can be updated from a data frame", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-dataframe-update")
   sdf <- create_and_populate_soma_dataframe(uri, nrows = 10L)
 

--- a/apis/r/tests/testthat/test-SOMAExperiment.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment.R
@@ -1,4 +1,5 @@
 test_that("Basic mechanics", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("soma-experiment")
 
   experiment <- SOMAExperimentCreate(uri)
@@ -36,6 +37,7 @@ test_that("Basic mechanics", {
 })
 
 test_that("Configured SOMAExperiment", {
+  skip_if(!extended_tests())
   cfg <- PlatformConfig$new()
   cfg$set(
     'tiledb',
@@ -62,6 +64,7 @@ test_that("Configured SOMAExperiment", {
 })
 
 test_that("Update obs and var", {
+  skip_if(!extended_tests())
   # Update mechanics are tested more thoroughly in the SOMADataFrame tests
   uri <- withr::local_tempdir("soma-experiment-update")
   create_and_populate_experiment(

--- a/apis/r/tests/testthat/test-SingleCellExperimentIngest.R
+++ b/apis/r/tests/testthat/test-SingleCellExperimentIngest.R
@@ -1,7 +1,7 @@
 test_that("Write SingleCellExperiment mechanics", {
-  skip_if(covr_tests())
-  skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c'))
+  skip_if(!extended_tests() || covr_tests())
   skip_if_not_installed('pbmc3k.sce')
+  suppressMessages(skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c')))
 
   sce <- get_data('pbmc3k.final', package = 'pbmc3k.sce')
   SingleCellExperiment::mainExpName(sce) <- 'RNA'
@@ -65,7 +65,7 @@ test_that("Write SingleCellExperiment mechanics", {
 })
 
 test_that("SingleCellExperiment mainExpName mechanics", {
-  skip_if(covr_tests())
+  skip_if(!extended_tests() || covr_tests())
   skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c'))
   skip_if_not_installed('pbmc3k.sce')
 

--- a/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
@@ -1,5 +1,5 @@
 test_that("Write SummarizedExperiment mechanics", {
-  skip_if_not_installed('SummarizedExperiment', '1.28.0')
+  suppressMessages(skip_if_not_installed('SummarizedExperiment', '1.28.0'))
   skip_if_not_installed('pbmc3k.sce')
 
   se <- get_data('pbmc3k.final', package = 'pbmc3k.sce')


### PR DESCRIPTION
**Issue and/or context:**

The nightly valgrind run revealed a more nagging notes.

**Changes:**

A few more tests have been conditioned on the existing variable.

Two checks are wrapped in `suppressMessages()` as a change at BioConductor currently leads to a fresh warning.

**Notes for Reviewer:**

[SC 33688](https://app.shortcut.com/tiledb-inc/story/33688/r-more-test-tweaking)
