### PR TITLE
Initialize TileDB Contexts extremely lazily.

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -5,10 +5,10 @@
 
 import datetime
 import functools
+import threading
 import time
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
-import attrs
 import tiledb
 from typing_extensions import Self
 
@@ -16,19 +16,25 @@ from .._types import OpenTimestamp
 from .._util import ms_to_datetime, to_timestamp_ms
 
 
-@functools.lru_cache(maxsize=None)
-def _default_global_ctx() -> tiledb.Ctx:
-    """Build a TileDB context starting with reasonable defaults,
-    and overriding and updating with user-provided config options.
+def _default_config(
+    override: Mapping[str, Union[str, float]]
+) -> Dict[str, Union[str, float]]:
+    """Returns a fresh dictionary with TileDB config values.
+
+    These should be reasonable defaults that can be used out-of-the-box.
+    ``override`` does exactly what it says: overrides default entries.
     """
-
-    # Note: Defaults must provide positive out-of-the-box UX!
-
     cfg: Dict[str, Union[str, float]] = {
         "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3
     }
+    cfg.update(override)
+    return cfg
 
-    return tiledb.Ctx(cfg)
+
+@functools.lru_cache(maxsize=None)
+def _default_global_ctx() -> tiledb.Ctx:
+    """Lazily builds a default TileDB Context with the default config."""
+    return tiledb.Ctx(_default_config({}))
 
 
 def _maybe_timestamp_ms(input: Optional[OpenTimestamp]) -> Optional[int]:
@@ -37,61 +43,169 @@ def _maybe_timestamp_ms(input: Optional[OpenTimestamp]) -> Optional[int]:
     return to_timestamp_ms(input)
 
 
-@attrs.define(frozen=True, kw_only=True)
+_SENTINEL = object()
+"""Sentinel object to distinguish default parameters from None."""
+
+
 class SOMATileDBContext:
     """Maintains TileDB-specific context for TileDB-SOMA objects.
     This context can be shared across multiple objects,
     including having a child object inherit it from its parent.
 
+    Treat this as immutable. Only code internal to the ``_soma_tiledb_context``
+    module should be modifying this. Use the ``replace`` method to construct
+    a new ``SOMATileDBContext`` with new values.
+
     Lifecycle:
         Experimental.
     """
 
-    tiledb_ctx: tiledb.Ctx = attrs.field(factory=_default_global_ctx)
+    def __init__(
+        self,
+        tiledb_ctx: Optional[tiledb.Ctx] = None,
+        tiledb_config: Optional[Dict[str, Union[str, float]]] = None,
+        timestamp: Optional[OpenTimestamp] = None,
+    ) -> None:
+        """Initializes a new SOMATileDBContext.
 
-    timestamp_ms: Optional[int] = attrs.field(
-        default=None, converter=_maybe_timestamp_ms, alias="timestamp"
-    )
-    """
-    Default timestamp for operations on SOMA objects, in milliseconds since the Unix epoch.
+        Either ``tiledb_ctx`` or ``tiledb_config`` may be provided, or both may
+        be left at their default. If neither are provided, this will use a
+        single shared :class:`tiledb.Ctx` instantiated upon first use.
+        If ``tiledb_ctx`` is provided, that exact :class:`tiledb.Ctx` is used.
+        If a ``tiledb_config`` is provided (in the form of a ``dict``),
+        it is used to construct a new ``Ctx``.
 
-    WARNING: This should not be set unless you are *absolutely* sure you want to
-    use the same timestamp across multiple operations. If multiple writes to the
-    same object are performed at the same timestamp, they have no defined order.
-    In most cases, it is better to pass a timestamp to a single ``open`` call,
-    or to simply use the default behavior.
+        Args:
+            tiledb_ctx: An existing TileDB Context for use as the TileDB Context
+                in this configuration.
 
-    This is used when a timestamp is not provided to an ``open`` operation.
+            tiledb_config: A set of TileDB configuration options to use,
+                overriding the default configuration.
 
-    ``None``, the default, sets the timestamp on each root ``open`` operation.
-    That is, if you ``open`` a collection, and access individual members of the
-    collection through indexing or ``add_new``, the timestamp of all of those
-    operations will be that of the time you called ``open``.
+            timestamp: The default timestamp for operations on SOMA objects,
+                provided either as a ``datetime.datetime`` or a number of
+                milliseconds since the Unix epoch.
 
-    If a value is passed, that timestamp (representing milliseconds since
-    the Unix epoch) is used as the timestamp to record all operations.
+                WARNING: This should not be set unless you are *absolutely* sure
+                you want to use the same timestamp across multiple operations.
+                If multiple writes to the same object are performed at the same
+                timestamp, they have no defined order. In almost all cases,
+                it is better to pass a timestamp to a single ``open`` call,
+                or to simply use the default behavior.
 
-    Set to 0xFFFFFFFFFFFFFFFF (UINT64_MAX) to get the absolute latest revision
-    (i.e., including changes that occur "after" the current wall time) as of
-    when *each* object is opened.
-    """
+                This is used when a timestamp is not provided to
+                an ``open`` operation.
+
+                ``None``, the default, sets the timestamp on each root ``open``
+                operation. That is, if you ``open`` a collection, and access
+                individual members of the collection through indexing or
+                ``add_new``, the timestamp of all of those operations will be
+                that of the time you called ``open``.
+
+                If a value is passed, that timestamp is used as the timestamp
+                to record all operations.
+
+                Set to 0xFFFFFFFFFFFFFFFF (UINT64_MAX) to get the absolute
+                latest revision (i.e., including changes that occur "after"
+                the current wall time) as of when *each* object is opened.
+        """
+        if tiledb_ctx is not None and tiledb_config is not None:
+            raise ValueError(
+                "only one of tiledb_ctx or tiledb_config"
+                " may be set when constructing a SOMATileDBContext"
+            )
+        self._lock = threading.Lock()
+        """A lock to ensure single initialization of ``_tiledb_ctx``."""
+        self._initial_config = (
+            None if tiledb_config is None else _default_config(tiledb_config)
+        )
+        """A dictionary of options to override the default TileDB config.
+
+        This includes both the user-provided options and the default options
+        that we provide to TileDB. If this is unset, then either we were
+        provided with a TileDB Ctx, or we need to use The Default Global Ctx.
+        """
+        self._tiledb_ctx = tiledb_ctx
+        """The TileDB context to use, either provided or lazily constructed."""
+        self._timestamp_ms = _maybe_timestamp_ms(timestamp)
+
+    @property
+    def timestamp_ms(self) -> Optional[int]:
+        """
+        The default timestamp for SOMA operations, as milliseconds since
+        the Unix epoch, or ``None`` if not provided.
+        """
+        return self._timestamp_ms
 
     @property
     def timestamp(self) -> Optional[datetime.datetime]:
+        """
+        The default timestamp for SOMA operations, or ``None`` if not provided.
+        """
         if self.timestamp_ms is None:
             return None
         return ms_to_datetime(self.timestamp_ms)
 
+    @property
+    def tiledb_ctx(self) -> tiledb.Ctx:
+        """The TileDB Context for this SOMA context."""
+        with self._lock:
+            if self._tiledb_ctx is None:
+                if self._initial_config is None:
+                    # Special case: we need to use the One Global Default.
+                    self._tiledb_ctx = _default_global_ctx()
+                else:
+                    self._tiledb_ctx = tiledb.Ctx(self._initial_config)
+            return self._tiledb_ctx
+
+    @property
+    def tiledb_config(self) -> Dict[str, Union[str, float]]:
+        """The TileDB configuration dictionary for this SOMA context.
+
+        If this ``SOMATileDBContext`` already has a ``tiledb_ctx``, this will
+        return the full set of values from that TileDB Context; otherwise, this
+        will only return the values that will be passed into the ``tiledb.Ctx``
+        constructor, including both SOMA defaults and the ``tiledb_config``
+        parameter passed into this object's constructor.
+
+        This always returns a fresh dictionary.
+        """
+        with self._lock:
+            return self._internal_tiledb_config()
+
+    def _internal_tiledb_config(self) -> Dict[str, Union[str, float]]:
+        """Internal function for getting the TileDB Config.
+
+        Returns a new dict with the contents. Caller must hold ``_lock``.
+        """
+        if self._tiledb_ctx is None:
+            # Our TileDB Context has not yet been built.
+            # We return what will be passed into `tiledb.Ctx()`.
+            return (
+                dict(self._initial_config)
+                if self._initial_config is not None
+                else _default_config({})
+            )
+        # We *do* have a TileDB Context. Return its actual config.
+        return dict(self._tiledb_ctx.config())
+
     def replace(
-        self, *, tiledb_config: Optional[Dict[str, Any]] = None, **changes: Any
+        self,
+        *,
+        tiledb_config: Optional[Dict[str, Any]] = None,
+        tiledb_ctx: Optional[tiledb.Ctx] = None,
+        timestamp: Optional[OpenTimestamp] = _SENTINEL,  # type: ignore[assignment]
     ) -> Self:
         """Create a copy of the context, merging changes.
 
         Args:
             tiledb_config:
                 A dictionary of parameters for `tiledb.Config() <https://tiledb-inc-tiledb.readthedocs-hosted.com/projects/tiledb-py/en/stable/python-api.html#config>`_.
-            changes:
-                Any other parameters will be passed to the class ``__init__``.
+            tiledb_ctx:
+                A TileDB Context to replace the current context with.
+            timestamp:
+                A timestamp to replace the current timestamp with.
+                Explicitly passing ``None`` will remove the timestamp.
 
         Lifecycle:
             Experimental.
@@ -101,11 +215,23 @@ class SOMATileDBContext:
 
             >>> context.replace(tiledb_config={"vfs.s3.region": "us-east-2"})
         """
-        if tiledb_config:
-            new_config = self.tiledb_ctx.config()
-            new_config.update(tiledb_config)
-            changes["tiledb_ctx"] = tiledb.Ctx(config=new_config)
-        return attrs.evolve(self, **changes)
+        with self._lock:
+            if tiledb_config is not None:
+                if tiledb_ctx:
+                    raise ValueError(
+                        "Either tiledb_config or tiledb_ctx may be provided"
+                        " to replace(), but not both."
+                    )
+                new_config = dict()
+                new_config = self._internal_tiledb_config()
+                new_config.update(tiledb_config)
+                tiledb_config = new_config
+            if timestamp is _SENTINEL:
+                # Keep the existing timestamp if not overridden.
+                timestamp = self._timestamp_ms
+        return type(self)(
+            tiledb_config=tiledb_config, tiledb_ctx=tiledb_ctx, timestamp=timestamp
+        )
 
     def _open_timestamp_ms(self, in_timestamp: Optional[OpenTimestamp]) -> int:
         """Returns the real timestamp that should be used to open an object."""

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -35,6 +35,13 @@ def test_lazy_replace_config():
         mock_ctx.assert_not_called()
 
 
+def test_delete_config_entry():
+    context = stc.SOMATileDBContext(tiledb_config={"hither": "yon"})
+    new_context = context.replace(tiledb_config={"hither": None})
+    # We've removed the only non-default entry; this should work.
+    assert new_context.tiledb_config == stc._default_config({})
+
+
 def test_shared_ctx():
     """Verifies that one global context is shared by default."""
     ctx = stc.SOMATileDBContext()

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -18,7 +18,9 @@ def test_lazy_init():
     """Verifies we don't construct a Ctx until we have to."""
     with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:
         context = stc.SOMATileDBContext(tiledb_config={})
-        assert context.tiledb_config == stc._default_config({})
+        assert context.tiledb_config == {
+            "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3
+        }
         mock_ctx.assert_not_called()
         assert context._tiledb_ctx is None
         # Invoke the @property twice to ensure we only build one Ctx.
@@ -31,15 +33,24 @@ def test_lazy_replace_config():
     with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:
         context = stc.SOMATileDBContext()
         new_context = context.replace(tiledb_config={"hello": "goodbye"})
-        assert new_context.tiledb_config == stc._default_config({"hello": "goodbye"})
+        assert new_context.tiledb_config == {
+            "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3,
+            "hello": "goodbye",
+        }
         mock_ctx.assert_not_called()
 
 
 def test_delete_config_entry():
     context = stc.SOMATileDBContext(tiledb_config={"hither": "yon"})
+    assert context.tiledb_config == {
+        "hither": "yon",
+        "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3,
+    }
     new_context = context.replace(tiledb_config={"hither": None})
     # We've removed the only non-default entry; this should work.
-    assert new_context.tiledb_config == stc._default_config({})
+    assert new_context.tiledb_config == {
+        "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3
+    }
 
 
 def test_shared_ctx():

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -1,0 +1,101 @@
+import datetime
+import time
+from unittest import mock
+
+import pytest
+import tiledb
+
+import tiledbsoma.options._soma_tiledb_context as stc
+
+
+@pytest.fixture(autouse=True)
+def global_ctx_reset():
+    stc._default_global_ctx.cache_clear()
+    yield
+
+
+def test_lazy_init():
+    """Verifies we don't construct a Ctx until we have to."""
+    with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:
+        context = stc.SOMATileDBContext(tiledb_config={})
+        assert context.tiledb_config == stc._default_config({})
+        mock_ctx.assert_not_called()
+        assert context._tiledb_ctx is None
+        # Invoke the @property twice to ensure we only build one Ctx.
+        assert context.tiledb_ctx is context.tiledb_ctx
+        mock_ctx.assert_called_once()
+
+
+def test_lazy_replace_config():
+    """Verifies we don't construct a Ctx even if we call ``.replace``."""
+    with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:
+        context = stc.SOMATileDBContext()
+        new_context = context.replace(tiledb_config={"hello": "goodbye"})
+        assert new_context.tiledb_config == stc._default_config({"hello": "goodbye"})
+        mock_ctx.assert_not_called()
+
+
+def test_shared_ctx():
+    """Verifies that one global context is shared by default."""
+    ctx = stc.SOMATileDBContext()
+    ctx_2 = stc.SOMATileDBContext()
+    assert ctx.tiledb_ctx is ctx_2.tiledb_ctx
+
+
+def test_unshared_ctx():
+    """Verifies that contexts are not shared when not appropriate."""
+    ctx = stc.SOMATileDBContext()
+    ctx_2 = stc.SOMATileDBContext(tiledb_config={})
+    ctx_3 = stc.SOMATileDBContext(tiledb_config={})
+    assert ctx.tiledb_ctx is not ctx_2.tiledb_ctx
+    assert ctx_2.tiledb_ctx is not ctx_3.tiledb_ctx
+
+
+def test_replace_timestamp():
+    orig_ctx = stc.SOMATileDBContext()
+    assert orig_ctx.timestamp is None
+    assert orig_ctx.timestamp_ms is None
+    ts_ctx = orig_ctx.replace(timestamp=1683817200000)
+    assert ts_ctx.timestamp == datetime.datetime(
+        2023, 5, 11, 15, 0, tzinfo=datetime.timezone.utc
+    )
+    assert ts_ctx.timestamp_ms == 1683817200000
+    same_ts_ctx = ts_ctx.replace()  # replace nothing!
+    assert ts_ctx.timestamp == same_ts_ctx.timestamp
+    no_ts_ctx = ts_ctx.replace(timestamp=None)
+    assert no_ts_ctx.timestamp is None
+
+
+def test_replace_context():
+    orig_ctx = stc.SOMATileDBContext()
+    new_tdb_ctx = tiledb.Ctx({"vfs.s3.region": "hy-central-1"})
+    new_ctx = orig_ctx.replace(tiledb_ctx=new_tdb_ctx)
+    assert new_ctx.tiledb_ctx is new_tdb_ctx
+
+
+def test_replace_config_after_construction():
+    context = stc.SOMATileDBContext()
+
+    # verify defaults expected by subsequent tests
+    assert context.timestamp_ms is None
+    assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
+
+    now = int(time.time() * 1000)
+    open_ts = context._open_timestamp_ms(None)
+    assert -100 < now - open_ts < 100
+    assert 999 == context._open_timestamp_ms(999)
+
+    context_ts_1 = context.replace(timestamp=1)
+
+    assert context_ts_1.timestamp_ms == 1
+    assert context_ts_1._open_timestamp_ms(None) == 1
+    assert context_ts_1._open_timestamp_ms(2) == 2
+
+    with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:
+        # verify that the new context is lazily initialized.
+        new_soma_ctx = context.replace(tiledb_config={"vfs.s3.region": "us-west-2"})
+        assert new_soma_ctx.tiledb_config["vfs.s3.region"] == "us-west-2"
+        mock_ctx.assert_not_called()
+        new_tdb_ctx = new_soma_ctx.tiledb_ctx
+        mock_ctx.assert_called_once()
+        assert new_tdb_ctx.config()["vfs.s3.region"] == "us-west-2"

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -1,5 +1,4 @@
 import tempfile
-import time
 from pathlib import Path
 
 import anndata
@@ -145,26 +144,3 @@ def test_dig_platform_config():
     # Unrecognized type (at tip)
     with pytest.raises(TypeError):
         tco._dig_platform_config({"a": {"b": "invalid"}}, int, ("a", "b"))
-
-
-def test_SOMATileDBContext_evolve():
-    context = tiledbsoma.options.SOMATileDBContext()
-
-    # verify defaults expected by subsequent tests
-    assert context.timestamp_ms is None
-    assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
-
-    now = int(time.time() * 1000)
-    open_ts = context._open_timestamp_ms(None)
-    assert -100 < now - open_ts < 100
-    assert 999 == context._open_timestamp_ms(999)
-
-    context_ts_1 = context.replace(timestamp=1)
-
-    assert context_ts_1.timestamp_ms == 1
-    assert context_ts_1._open_timestamp_ms(None) == 1
-    assert context_ts_1._open_timestamp_ms(2) == 2
-
-    # verify tiledb_ctx
-    new_tdb_context = context.replace(tiledb_config={"vfs.s3.region": "us-west-2"})
-    assert new_tdb_context.tiledb_ctx.config()["vfs.s3.region"] == "us-west-2"


### PR DESCRIPTION
To allow users to mess with their TileDB configs and modify them without actually instantiating an actual TileDB Context (which entails allocation of significant resources), we lazily wait until the caller actually requests the Context to create it just in time. This ensures that we don't waste resources that are not easy to reclaim (particularly the shared global context, which is never GCable).

Further addresses #1550. It may fix it; I leave it to @bkmartinjr et al to see if it completely addresses their issues once this change is deployed.