### PR TITLE
[c++] Don't use Python to generate C++ test inputs

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -133,6 +133,12 @@ jobs:
         ls -l test
         echo ls -l test/soco
         ls -l test/soco
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
         echo
         PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests libtiledbsoma/test
 

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -111,6 +111,8 @@ jobs:
         cd test
         tar zxf soco.tgz
         cd ..
+        ls -l test
+        ls -l test/soco
 
     - name: Run pytests
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -110,15 +110,7 @@ jobs:
         mkdir -p test
         cd test
         tar zxf soco.tgz
-        rm -f soco.tgz
         cd ..
-
-        echo pwd
-        pwd
-        echo ls -l test
-        ls -l test
-        echo ls -l test/soco
-        ls -l test/soco
 
     - name: Run libtiledbsoma unit tests
       run: ctest --test-dir build/libtiledbsoma -C Release --verbose
@@ -127,43 +119,13 @@ jobs:
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
       # instead of copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: |
-        echo pwd
-        pwd
-        echo ls -l test
-        ls -l test
-        echo ls -l test/soco
-        ls -l test/soco
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs/*
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs/*
-        echo
-        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml libtiledbsoma/test
+      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml libtiledbsoma/test
 
     - name: Run pytests for Python
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
       # instead of copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: |
-        echo pwd
-        pwd
-        echo ls -l test
-        ls -l test
-        echo ls -l test/soco
-        ls -l test/soco
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
-        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
-        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
-        echo
-        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests
+      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -119,14 +119,14 @@ jobs:
         echo ls -l test/soco
         ls -l test/soco
 
+    - name: Run libtiledbsoma unit tests
+      run: ctest --test-dir build/libtiledbsoma -C Release --verbose
+
     - name: Run pytests
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
       # instead of copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
       run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests libtiledbsoma/test
-
-    - name: Run libtiledbsoma unit tests
-      run: ctest --test-dir build/libtiledbsoma -C Release --verbose
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Run libtiledbsoma unit tests
       run: ctest --test-dir build/libtiledbsoma -C Release --verbose
 
-    - name: Run pytests
+    - name: Run pytests for C++
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
       # instead of copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
@@ -141,7 +141,27 @@ jobs:
         echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
         ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
         echo
-        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests libtiledbsoma/test
+        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml libtiledbsoma/test
+
+    - name: Run pytests for Python
+      # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
+      # instead of copy we `pip install`ed to site-packages above. That's needed for the code
+      # coverage analysis to work.
+      run: |
+        echo pwd
+        pwd
+        echo ls -l test
+        ls -l test
+        echo ls -l test/soco
+        ls -l test/soco
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
+        echo
+        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -106,9 +106,8 @@ jobs:
     - name: Obtain test data
       shell: bash
       run: |
-        rm -rf test/soco
-        mkdir -p test
         cd test
+        rm -rf soco
         tar zxf soco.tgz
         cd ..
 

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -111,7 +111,12 @@ jobs:
         cd test
         tar zxf soco.tgz
         cd ..
+
+        echo pwd
+        pwd
+        echo ls -l test
         ls -l test
+        echo ls -l test/soco
         ls -l test/soco
 
     - name: Run pytests

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -107,7 +107,7 @@ jobs:
       shell: bash
       run: |
         rm -rf test/soco
-        mkdir -p test/soco
+        mkdir -p test
         cd test
         tar zxf soco.tgz
         cd ..

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -110,6 +110,7 @@ jobs:
         mkdir -p test
         cd test
         tar zxf soco.tgz
+        rm -f soco.tgz
         cd ..
 
         echo pwd

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -140,6 +140,8 @@ jobs:
         ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed
         echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
         ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs
+        echo ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs/*
+        ls -l /home/runner/work/TileDB-SOMA/TileDB-SOMA/libtiledbsoma/test/../../test/soco/pbmc3k_processed/obs/*
         echo
         PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml libtiledbsoma/test
 

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -103,11 +103,14 @@ jobs:
     - name: Show XCode version
       run: clang --version
 
-    - name: Generate test data
+    - name: Obtain test data
       shell: bash
       run: |
+        rm -rf test/soco
         mkdir -p test/soco
-        ./apis/python/devtools/ingestor --debug --soco -o test/soco -n data/pbmc3k_processed.h5ad data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
+        cd test
+        tar zxf soco.tgz
+        cd ..
 
     - name: Run pytests
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -126,7 +126,15 @@ jobs:
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src
       # instead of copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests libtiledbsoma/test
+      run: |
+        echo pwd
+        pwd
+        echo ls -l test
+        ls -l test
+        echo ls -l test/soco
+        ls -l test/soco
+        echo
+        PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests libtiledbsoma/test
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ core/obj/*
 core/lib/*
 core/include/temp
 core/src/temp
-test/*
+test/soco
 test/inputs/arrays/read_compatibility_test*
 Doxyfile.log
 doxyfile.inc

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,19 @@
+soco.tgz was created by running the following from the repo base directory (.. from here):
+
+```
+apis/python/devtools/ingestor --debug --soco -o test/soco -n \
+  data/pbmc3k_processed.h5ad data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
+```
+
+while versions were at
+
+```
+>>> import tiledbsoma
+>>> tiledbsoma.show_package_versions()
+tiledbsoma.__version__        1.2.7
+TileDB-Py tiledb.version()    (0, 21, 6)
+TileDB core version           2.15.4
+libtiledbsoma version()       libtiledb=2.15.2
+python version                3.10.6.final.0
+OS version                    Linux 5.19.0-1025-aws
+```


### PR DESCRIPTION
**Issue and/or context:** Found in #1511 / #866 et al. while attempting pre-tag/pre-merge tests with core 2.17.0-rc0. Here we use `tiledbsoma-py` to generate test data for `libtiledbsoma` code. That's currently failing due to `tiledbsoma-py` in the generator step being built with core 2.16 rather than 2.17. But this highlights a bigger issue: let's not be circular in our test paths. Rather, let's validate C++ code using C++ and shell tools; then move up the testing stack to Python and R.

**Changes:** Simply can the generated inputs into `test/soco.tgz`. As an added bonus we get some backward-compatilbility test here.

**Notes for Reviewer:**

