### PR TITLE
[python] Restore efficiency on zero-cell `X`

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1760,7 +1760,7 @@ def _find_sparse_chunk_size(
         chunk_size += 1
 
     if sum_nnz == 0:  # completely empty sparse array (corner case)
-        return 1
+        return -1
 
     if sum_nnz > goal_chunk_nnz:
         return chunk_size


### PR DESCRIPTION
**Issue and/or context:**

This was fixed on #1649. But a bad merge on #1648 here undid it:
https://github.com/single-cell-data/TileDB-SOMA/commit/a21e43fa8456b539d6ae1908fef728866ba56b01#r127159208

**Changes:**

**Notes for Reviewer:**

