### PR TITLE
[c++] Removed unused-variable warning

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -365,7 +365,6 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                         arrow_array_ptr, arrow_schema_ptr);
 
                     auto coords = array.attr("tolist")();
-                    int data_index = arrow_array.n_buffers - 1;
 
                     if (!strcmp(arrow_schema.format, "l")) {
                         reader.set_dim_points(


### PR DESCRIPTION
A nit, but one easy to neaten