### PR TITLE
Pass user configuration/timestamp to query condition init

### DIFF
--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -7,7 +7,7 @@
 filtering query results on attribute values.
 """
 import ast
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import attrs
 import numpy as np
@@ -15,6 +15,7 @@ import tiledb
 
 from . import pytiledbsoma as clib
 from ._exception import SOMAError
+from ._types import OpenTimestamp
 
 # In Python 3.7, a boolean literal like `True` is of type `ast.NameConstant`.
 # Above that, it's of type `ast.Constant`.
@@ -128,8 +129,16 @@ class QueryCondition:
                 "(Is this an empty expression?)"
             )
 
-    def init_query_condition(self, uri: str, query_attrs: List[str]):
-        qctree = QueryConditionTree(tiledb.open(uri), query_attrs)
+    def init_query_condition(
+        self,
+        uri: str,
+        query_attrs: List[str],
+        config: Optional[dict],
+        timestamps: Optional[Tuple[OpenTimestamp, OpenTimestamp]],
+    ):
+        qctree = QueryConditionTree(
+            tiledb.open(uri, ctx=tiledb.Ctx(config), timestamp=timestamps), query_attrs
+        )
         self.c_obj = qctree.visit(self.tree.body)
 
         if not isinstance(self.c_obj, clib.PyQueryCondition):

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -221,7 +221,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                             // Column names will be updated with columns present
                             // in the query condition
                             auto new_column_names =
-                                init_pyqc(uri, column_names)
+                                init_pyqc(uri, column_names, platform_config, timestamp)
                                     .cast<std::vector<std::string>>();
 
                             // Update the column_names list if it was not empty,
@@ -292,10 +292,15 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                         "init_query_condition");
 
                     try {
+                        // Convert TileDB::Config to std::unordered map for pybind11 passing
+                        std::unordered_map<std::string, std::string> cfg;
+                        for (const auto& it : reader.ctx()->config()) {
+                            cfg[it.first] = it.second;
+                        }
                         // Column names will be updated with columns present in
                         // the query condition
                         auto new_column_names =
-                            init_pyqc(reader.uri(), column_names)
+                            init_pyqc(reader.uri(), column_names, cfg, reader.timestamp())
                                 .cast<std::vector<std::string>>();
 
                         // Update the column_names list if it was not empty,

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -571,4 +571,8 @@ void SOMAArray::validate(
     }
 }
 
+std::optional<std::pair<uint64_t, uint64_t>> SOMAArray::timestamp() {
+    return timestamp_;
+}
+
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -178,9 +178,9 @@ class SOMAArray {
     const std::string& uri() const;
 
     /**
-     * @brief Get URI of the SOMAArray.
+     * @brief Get Ctx of the SOMAArray.
      *
-     * @return std::string URI
+     * @return std::shared_ptr<Context>
      */
     std::shared_ptr<Context> ctx();
 
@@ -607,6 +607,11 @@ class SOMAArray {
         OpenMode mode,
         std::string_view name,
         std::optional<std::pair<uint64_t, uint64_t>> timestamp);
+
+    /**
+     * Return optional timestamp pair SOMAArray was opened with.
+     */
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp();
 
    private:
     //===================================================================


### PR DESCRIPTION
The query condition init needs the array schema and the enumeration values. Fetching the enumeration values requires opening the array. This was previously changed but the opening of the array did not properly consider the the user configurations or timestamps. This change passes the user config and timestamps to the array open in python inside the query condition.

The overall design needs significant improvement. Opening the array inside the query condition is likely to cause other issues as now there are additional context created and additional performance impacts of opening the array and closing it after enumerations are fetched.

It is left to a followup pull request to change the design to a sustainable one that users enumerations from C++, in a similar way to the previous passing of array schemas which avoided multiple array opens.