### PR TITLE
Pd/add output on failure

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
         python-version: ['3.10', '3.7']
         include:
           - runs-on: ubuntu-22.04

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -112,7 +112,7 @@ jobs:
         cd ..
 
     - name: Run libtiledbsoma unit tests
-      run: ctest --test-dir build/libtiledbsoma -C Release --verbose
+      run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
 
     - name: Run pytests for C++
       # Setting PYTHONPATH ensures the tests load the in-tree source code unde apis/python/src

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "pybind11[global]>=2.10.0",
     "setuptools>=65.5.1",
     "wheel>=0.37.1",
-    "cmake>=3.21,<=3.24",
+    "cmake>=3.21",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "pybind11[global]>=2.10.0",
     "setuptools>=65.5.1",
     "wheel>=0.37.1",
-    "cmake>=3.21",
+    "cmake>=3.21,<=3.24",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/scripts/bld
+++ b/scripts/bld
@@ -84,5 +84,5 @@ rm -rf build
 mkdir -p build
 cmake -B build -S libtiledbsoma -DCMAKE_BUILD_TYPE=${build} ${extra_opts}
 cmake --build build -j ${nproc}
-sudo cmake --build build --target install-libtiledbsoma
+cmake --build build --target install-libtiledbsoma
 cmake --build build/libtiledbsoma --target build_tests -j ${nproc}


### PR DESCRIPTION
**Issue and/or context:**

I spent some time debugging the failure in #1685 and as near as I can tell it was ephemeral. All of the test runs on [my fork's repo](https://github.com/davisp/TileDB-SOMA/actions) have been passing since I tweaked the version script to get it to build the first time.

This change just includes @johnkerl's branch from #1685 and an option for ctest to output logs on failures. Regardless of whether this change discovers some wild difference between upstream and my fork's testing environments, it'll still be helpful for ctest failures going forward.

**Changes:**

Add `--output-on-failure` when invoking `ctest`.

**Notes for Reviewer:**

Narps.