### PR TITLE
[python] Categorical-write corner-case

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -419,12 +419,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 else:
                     # Schema is non-categorical but the user is writing categorical.
                     # Simply decategoricalize for them.
-                    pvalues = []
-                    for chunk in col.chunks:
-                        pvalues += [
-                            chunk.dictionary[i.as_py()].as_py() for i in chunk.indices
-                        ]
-                    cols_map[name] = pd.Series(pvalues)
+                    cols_map[name] = pa.chunked_array(
+                        [chunk.dictionary_decode() for chunk in col.chunks]
+                    )
             else:
                 cols_map[name] = col.to_pandas()
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -412,9 +412,22 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             n = len(col)
             cols_map = dim_cols_map if name in dim_names_set else attr_cols_map
             if pa.types.is_dictionary(col.type) and col.num_chunks != 0:
-                cols_map[name] = col.chunk(0).indices.to_pandas()
+                attr = self._handle.schema.attr(name)
+                if attr.enum_label is not None:
+                    # Normal case: writing categorical data to categorical schema.
+                    cols_map[name] = col.chunk(0).indices.to_pandas()
+                else:
+                    # Schema is non-categorical but the user is writing categorical.
+                    # Simply decategoricalize for them.
+                    pvalues = []
+                    for chunk in col.chunks:
+                        pvalues += [
+                            chunk.dictionary[i.as_py()].as_py() for i in chunk.indices
+                        ]
+                    cols_map[name] = pd.Series(pvalues)
             else:
                 cols_map[name] = col.to_pandas()
+
         if n is None:
             raise ValueError(f"did not find any column names in {values.schema.names}")
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -81,6 +81,8 @@ py::tuple get_enum(SOMAArray& sr, std::string attr_name){
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
             return py::tuple(py::cast(enmr.as_vector<std::string>()));
+        case TILEDB_BOOL:
+            return py::tuple(py::cast(enmr.as_vector<bool>()));
         default:
             throw TileDBSOMAError("Unsupported enumeration type.");
     }

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -833,10 +833,9 @@ def test_write_categorical_types(tmp_path):
             ("int-ordered", pa.dictionary(pa.int8(), pa.int8())),
             ("int-unordered", pa.dictionary(pa.int8(), pa.int8())),
             ("int-compat", pa.int64()),
-            # RuntimeError: Unsupported enumeration type.
-            # ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_())),
-            # ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
-            # ("bool-compat", pa.bool_()),
+            ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_())),
+            ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
+            ("bool-compat", pa.bool_()),
         ]
     )
     with soma.DataFrame.create(
@@ -848,8 +847,8 @@ def test_write_categorical_types(tmp_path):
             "enum-string-unordered": ["b", "a"],
             "enum-int-ordered": [888888888, 777777777],
             "enum-int-unordered": [888888888, 777777777],
-            # "enum-bool-ordered": [True, False],
-            # "enum-bool-unordered": [True, False],
+            "enum-bool-ordered": [True, False],
+            "enum-bool-unordered": [True, False],
         },
         ordered_enumerations=[
             "enum-string-ordered",
@@ -861,8 +860,8 @@ def test_write_categorical_types(tmp_path):
             "string-unordered": "enum-string-unordered",
             "int-ordered": "enum-int-ordered",
             "int-unordered": "enum-int-unordered",
-            # "bool-ordered": "enum-bool-ordered",
-            # "bool-unordered": "enum-bool-unordered",
+            "bool-ordered": "enum-bool-ordered",
+            "bool-unordered": "enum-bool-unordered",
         },
     ) as sdf:
         df = pd.DataFrame(
@@ -892,21 +891,21 @@ def test_write_categorical_types(tmp_path):
                     ordered=False,
                     categories=[777777777, 888888888],
                 ),
-                # "bool-ordered": pd.Categorical(
-                # [True, False, True, False],
-                # ordered=True,
-                # categories=[False, True],
-                # ),
-                # "bool-unordered": pd.Categorical(
-                # [True, False, True, False],
-                # ordered=False,
-                # categories=[False, True],
-                # ),
-                # "bool-compat": pd.Categorical(
-                # [True, False, True, False],
-                # ordered=False,
-                # categories=[True, False],
-                # ),
+                "bool-ordered": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=True,
+                    categories=[False, True],
+                ),
+                "bool-unordered": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=False,
+                    categories=[True, False],
+                ),
+                "bool-compat": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=False,
+                    categories=[True, False],
+                ),
             }
         )
         sdf.write(pa.Table.from_pandas(df))

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -829,6 +829,7 @@ def test_write_categorical_types(tmp_path):
             ("soma_joinid", pa.int64()),
             ("A", pa.dictionary(pa.int64(), pa.large_string())),
             ("B", pa.dictionary(pa.int64(), pa.large_string())),
+            ("C", pa.large_string()),
         ]
     )
     with soma.DataFrame.create(
@@ -847,6 +848,9 @@ def test_write_categorical_types(tmp_path):
                 ),
                 "B": pd.Categorical(
                     ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
+                ),
+                "C": pd.Categorical(
+                    ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
                 ),
             }
         )


### PR DESCRIPTION
**Issue and/or context:** As discussed with @bkmartinjr. Parent context: #866.

**Changes:** When schema indicates non-categorical, permit auto-flattening write of categorical dataframe data in order to smooth the transition from tiledbsoma-without-categories to tiledbsoma-with-categories.

**Notes for Reviewer:**

