### PR TITLE
[ci] CI canary [WIP/RFC]

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      #fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-12]
         python-version: ['3.10', '3.7']

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -24,12 +24,16 @@ jobs:
           - runs-on: ubuntu-22.04
             cc: gcc-11
             cxx: g++-11
+          - runs-on: macos-12
+            cc: clang
+            cxx: clang++
     uses: ./.github/workflows/python-ci-single.yml
     with:
       os: ${{ matrix.os }}
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
+      is_mac: ${{ contains(matrix.os, 'macos') }}
       report_codecov: ${{ matrix.python-version == '3.10' }}
       run_lint: ${{ matrix.python-version == '3.10' }}
     secrets: inherit

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -43,14 +43,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
-        cache: pip
-        cache-dependency-path: ./.github/workflows/python-ci-single.yml
+        #cache: pip
+        #cache-dependency-path: ./.github/workflows/python-ci-single.yml
 
-    - name: Restore pre-commit cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('.github/workflows/python-ci-single.yml') }}
+#    - name: Restore pre-commit cache
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/.cache/pre-commit
+#        key: pre-commit-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('.github/workflows/python-ci-single.yml') }}
 
     - name: Run pre-commit hooks on all files
       run: python -m pip -v install pre-commit && pre-commit run -a -v
@@ -77,16 +77,16 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
-        cache: pip
-        cache-dependency-path: ./apis/python/setup.py
+        #cache: pip
+        #cache-dependency-path: ./apis/python/setup.py
 
-    - name: Cache native libraries
-      uses: actions/cache@v3
-      with:
-        path: |
-          build
-          dist
-        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
+#    - name: Cache native libraries
+#      uses: actions/cache@v3
+#      with:
+#        path: |
+#          build
+#          dist
+#        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
       run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools

--- a/libtiledbsoma/src/soma/logger_public.h
+++ b/libtiledbsoma/src/soma/logger_public.h
@@ -56,22 +56,22 @@ void LOG_SET_FILE(const std::string& logfile);
 bool LOG_DEBUG_ENABLED();
 
 /** Logs a trace message. */
-__attribute__((visibility("default"))) void LOG_TRACE(const std::string& msg);
+__attribute__((visibility("default"))) void LOG_TRACE(std::string const& msg);
 
 /** Logs a debug message. */
-__attribute__((visibility("default"))) void LOG_DEBUG(const std::string& msg);
+__attribute__((visibility("default"))) void LOG_DEBUG(std::string const& msg);
 
 /** Logs an info message. */
-__attribute__((visibility("default"))) void LOG_INFO(const std::string& msg);
+__attribute__((visibility("default"))) void LOG_INFO(std::string const& msg);
 
 /** Logs a warning. */
-__attribute__((visibility("default"))) void LOG_WARN(const std::string& msg);
+__attribute__((visibility("default"))) void LOG_WARN(std::string const& msg);
 
 /** Logs an error. */
-void LOG_ERROR(const std::string& msg);
+void LOG_ERROR(std::string const& msg);
 
 /** Logs a critical error and exits with a non-zero status. */
-void LOG_FATAL(const std::string& msg);
+void LOG_FATAL(std::string const& msg);
 
 /** Convert TileDB timestamp (in ms) to human readable timestamp. */
 std::string asc_timestamp(uint64_t timestamp_ms);

--- a/libtiledbsoma/src/soma/logger_public.h
+++ b/libtiledbsoma/src/soma/logger_public.h
@@ -54,22 +54,22 @@ void LOG_SET_FILE(const std::string& logfile);
 bool LOG_DEBUG_ENABLED();
 
 /** Logs a trace message. */
-__attribute__((visibility("default"))) void LOG_TRACE(std::string const& msg);
+__attribute__((visibility("default"))) void LOG_TRACE(const std::string& msg);
 
 /** Logs a debug message. */
-__attribute__((visibility("default"))) void LOG_DEBUG(std::string const& msg);
+__attribute__((visibility("default"))) void LOG_DEBUG(const std::string& msg);
 
 /** Logs an info message. */
-__attribute__((visibility("default"))) void LOG_INFO(std::string const& msg);
+__attribute__((visibility("default"))) void LOG_INFO(const std::string& msg);
 
 /** Logs a warning. */
-__attribute__((visibility("default"))) void LOG_WARN(std::string const& msg);
+__attribute__((visibility("default"))) void LOG_WARN(const std::string& msg);
 
 /** Logs an error. */
-void LOG_ERROR(std::string const& msg);
+void LOG_ERROR(const std::string& msg);
 
 /** Logs a critical error and exits with a non-zero status. */
-void LOG_FATAL(std::string const& msg);
+void LOG_FATAL(const std::string& msg);
 
 /** Convert TileDB timestamp (in ms) to human readable timestamp. */
 std::string asc_timestamp(uint64_t timestamp_ms);

--- a/libtiledbsoma/src/soma/logger_public.h
+++ b/libtiledbsoma/src/soma/logger_public.h
@@ -38,8 +38,6 @@
 
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 
-#include <spdlog/spdlog.h>
-
 namespace tiledbsoma {
 
 /** Set log level for global logger and optionally set a logfile. */

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -36,7 +36,7 @@
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/sinks/basic_file_sink.h>
-//#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace tiledbsoma {
 
@@ -50,7 +50,7 @@ namespace tiledbsoma {
 // text to log...
 // %$ : end color range
 const std::string LOG_PATTERN =
-    "[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %P] [Thread: %t] [%l] %v";
+    "%^[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %P] [Thread: %t] [%l] %v%$";
 const std::string CONSOLE_LOGGER = "tiledbsoma";
 const std::string FILE_LOGGER = "tiledbsoma-file";
 
@@ -195,32 +195,32 @@ bool LOG_DEBUG_ENABLED() {
 }
 
 /** Logs a trace message. */
-void LOG_TRACE(std::string const& msg) {
+void LOG_TRACE(const std::string& msg) {
     global_logger().trace(msg.c_str());
 }
 
 /** Logs a debug message. */
-void LOG_DEBUG(std::string const& msg) {
+void LOG_DEBUG(const std::string& msg) {
     global_logger().debug(msg.c_str());
 }
 
 /** Logs an info message. */
-void LOG_INFO(std::string const& msg) {
+void LOG_INFO(const std::string& msg) {
     global_logger().info(msg.c_str());
 }
 
 /** Logs a warning. */
-void LOG_WARN(std::string const& msg) {
+void LOG_WARN(const std::string& msg) {
     global_logger().warn(msg.c_str());
 }
 
 /** Logs an error. */
-void LOG_ERROR(std::string const& msg) {
+void LOG_ERROR(const std::string& msg) {
     global_logger().error(msg.c_str());
 }
 
 /** Logs a critical error and exits with a non-zero status. */
-void LOG_FATAL(std::string const& msg) {
+void LOG_FATAL(const std::string& msg) {
     global_logger().critical(msg.c_str());
     exit(1);
 }

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -60,18 +60,17 @@ const std::string FILE_LOGGER = "tiledbsoma-file";
 
 Logger::Logger() {
     logger_ = spdlog::get(CONSOLE_LOGGER);
-    //    if (logger_ == nullptr) {
-    //        logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
-    //#if !defined(_WIN32)
-    //        // change color of critical messages
-    //        auto console_sink =
-    //        static_cast<spdlog::sinks::stdout_color_sink_mt*>(
-    //            logger_->sinks().back().get());
-    //        console_sink->set_color(
-    //            spdlog::level::critical, console_sink->red_bold);
-    //#endif
-    //    }
-    logger_->set_pattern(LOG_PATTERN);
+    if (logger_ == nullptr) {
+        logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
+#if !defined(_WIN32)
+        // change color of critical messages
+        auto console_sink = static_cast<spdlog::sinks::stdout_color_sink_mt*>(
+            logger_->sinks().back().get());
+        console_sink->set_color(
+            spdlog::level::critical, console_sink->red_bold);
+        logger_->set_pattern(LOG_PATTERN);
+#endif
+    }
     set_level("INFO");
 }
 

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -50,7 +50,7 @@ namespace tiledbsoma {
 // text to log...
 // %$ : end color range
 const std::string LOG_PATTERN =
-    "%^[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %P] [Thread: %t] [%l] %v%$";
+    "[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %P] [Thread: %t] [%l] %v";
 const std::string CONSOLE_LOGGER = "tiledbsoma";
 const std::string FILE_LOGGER = "tiledbsoma-file";
 

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -195,32 +195,32 @@ bool LOG_DEBUG_ENABLED() {
 }
 
 /** Logs a trace message. */
-void LOG_TRACE(const std::string& msg) {
+void LOG_TRACE(std::string const& msg) {
     global_logger().trace(msg.c_str());
 }
 
 /** Logs a debug message. */
-void LOG_DEBUG(const std::string& msg) {
+void LOG_DEBUG(std::string const& msg) {
     global_logger().debug(msg.c_str());
 }
 
 /** Logs an info message. */
-void LOG_INFO(const std::string& msg) {
+void LOG_INFO(std::string const& msg) {
     global_logger().info(msg.c_str());
 }
 
 /** Logs a warning. */
-void LOG_WARN(const std::string& msg) {
+void LOG_WARN(std::string const& msg) {
     global_logger().warn(msg.c_str());
 }
 
 /** Logs an error. */
-void LOG_ERROR(const std::string& msg) {
+void LOG_ERROR(std::string const& msg) {
     global_logger().error(msg.c_str());
 }
 
 /** Logs a critical error and exits with a non-zero status. */
-void LOG_FATAL(const std::string& msg) {
+void LOG_FATAL(std::string const& msg) {
     global_logger().critical(msg.c_str());
     exit(1);
 }

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -36,7 +36,7 @@
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
+//#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace tiledbsoma {
 
@@ -60,16 +60,17 @@ const std::string FILE_LOGGER = "tiledbsoma-file";
 
 Logger::Logger() {
     logger_ = spdlog::get(CONSOLE_LOGGER);
-    if (logger_ == nullptr) {
-        logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
-#if !defined(_WIN32)
-        // change color of critical messages
-        auto console_sink = static_cast<spdlog::sinks::stdout_color_sink_mt*>(
-            logger_->sinks().back().get());
-        console_sink->set_color(
-            spdlog::level::critical, console_sink->red_bold);
-#endif
-    }
+    //    if (logger_ == nullptr) {
+    //        logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
+    //#if !defined(_WIN32)
+    //        // change color of critical messages
+    //        auto console_sink =
+    //        static_cast<spdlog::sinks::stdout_color_sink_mt*>(
+    //            logger_->sinks().back().get());
+    //        console_sink->set_color(
+    //            spdlog::level::critical, console_sink->red_bold);
+    //#endif
+    //    }
     logger_->set_pattern(LOG_PATTERN);
     set_level("INFO");
 }


### PR DESCRIPTION
Internal-only/debug-only canary to examine CI issues arising simultaneously with #1691, while apparently not caused by #1691.

Our post-merge CI has fail-fast set to false -- run all tests to completion -- while our pre-merge CI has fail-fast set to true. This is, generally, a good idea as a large chunk of our CI compute resources are absorbed by pre-merge CI. However, on #1691 I want to see if the Python 3.7 fail there is related _only_ to 3.7. As is on #1691, with fail-fast set to true, the 3.7 fail is cancelling signal from the other CI jobs.

Parent context: #866.