### PR TITLE
Fix pandas categorical test

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -894,7 +894,7 @@ def test_write_categorical_types(tmp_path):
                 "bool-ordered": pd.Categorical(
                     [True, False, True, False],
                     ordered=True,
-                    categories=[False, True],
+                    categories=[True, False],
                 ),
                 "bool-unordered": pd.Categorical(
                     [True, False, True, False],


### PR DESCRIPTION
The ordering if the boolean orderes test waa inversed between the TileDB enumeration definition and the Pandas test dataframe.

**Issue and/or context:** #866 and PR #1691

**Changes:**

**Notes for Reviewer:**

