### PR TITLE
Minor follow-up to #1695

### DIFF
--- a/apis/python/version.py
+++ b/apis/python/version.py
@@ -85,6 +85,9 @@ _GIT_DESCRIPTION_RE = r"^(?P<ver>%s)-(?P<commits>\d+)-g(?P<sha>[\da-f]+)$" % (
 
 
 def readGitVersion():
+    # NOTE: this will fail if on a fork with unsynchronized tags.
+    #       use `git fetch --tags upstream`
+    #       and `git push --tags <your fork>`
     try:
         proc = subprocess.Popen(
             ("git", "describe", "--long", "--tags", "--match", "[0-9]*.*"),

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -62,13 +62,13 @@ Logger::Logger() {
     logger_ = spdlog::get(CONSOLE_LOGGER);
     if (logger_ == nullptr) {
         logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
+        logger_->set_pattern(LOG_PATTERN);
 #if !defined(_WIN32)
         // change color of critical messages
         auto console_sink = static_cast<spdlog::sinks::stdout_color_sink_mt*>(
             logger_->sinks().back().get());
         console_sink->set_color(
             spdlog::level::critical, console_sink->red_bold);
-        logger_->set_pattern(LOG_PATTERN);
 #endif
     }
     set_level("INFO");

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Spdlog_EP REQUIRED)
 
 find_package(Catch_EP REQUIRED)
 
-add_executable(unit_soma EXCLUDE_FROM_ALL
+add_executable(unit_soma
     $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
     unit_column_buffer.cc
     unit_managed_query.cc


### PR DESCRIPTION
**Issue and/or context:**

Minor follow-up to https://github.com/single-cell-data/TileDB-SOMA/pull/1695

**Changes:**

- `logger->set_pattern` call should run unconditionally (currently runs on "!windows")

Also:
- remove `EXCLUDE_FROM_ALL` cmake annotation on `unit_soma` so that the target updates reliably
- add a note about a failure mode of `readGitVersion` when working from an unsynchronized fork

**Notes for Reviewer:**

