### PR TITLE
[c++] Take In Arrow Structs For `create` Methods

### DIFF
--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -46,13 +46,14 @@ using namespace tiledb;
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri,
-    ArrowSchema* schema,
+    ArrowSchema& schema,
     std::map<std::string, std::string> platform_config,
     std::vector<std::string> index_column_names,
-    std::vector<ArrowArray*> domain) {
+    ArrowArray& domains,
+    ArrowArray& extents) {
     auto ctx = std::make_shared<Context>(Config(platform_config));
     ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
-        ctx, schema, index_column_names, domain);
+        ctx, schema, index_column_names, domains, extents);
     SOMAArray::create(ctx, uri, tdb_schema, "SOMADataFrame");
     return SOMADataFrame::open(uri, OpenMode::read, ctx);
 }

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -33,6 +33,7 @@
 #include <filesystem>
 
 #include <tiledb/tiledb>
+#include "../utils/arrow_adapter.h"
 #include "array_buffers.h"
 #include "soma_dataframe.h"
 
@@ -42,6 +43,19 @@ using namespace tiledb;
 //===================================================================
 //= public static
 //===================================================================
+
+std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
+    std::string_view uri,
+    ArrowSchema* schema,
+    std::map<std::string, std::string> platform_config,
+    std::vector<std::string> index_column_names,
+    std::vector<ArrowArray*> domain) {
+    auto ctx = std::make_shared<Context>(Config(platform_config));
+    ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
+        ctx, schema, index_column_names, domain);
+    SOMAArray::create(ctx, uri, tdb_schema, "SOMADataFrame");
+    return SOMADataFrame::open(uri, OpenMode::read, ctx);
+}
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri,

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -66,10 +66,11 @@ class SOMADataFrame : public SOMAObject {
      */
     static std::unique_ptr<SOMADataFrame> create(
         std::string_view uri,
-        ArrowSchema* schema,
-        std::map<std::string, std::string> platform_config = {},
-        std::vector<std::string> index_column_names = {},
-        std::vector<ArrowArray*> domain = {});
+        ArrowSchema& schema,
+        std::map<std::string, std::string> platform_config,
+        std::vector<std::string> index_column_names,
+        ArrowArray& domains,
+        ArrowArray& extents);
 
     /**
      * @brief Create a SOMADataFrame object at the given URI.

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -34,6 +34,7 @@
 #define SOMA_DATAFRAME
 
 #include <tiledb/tiledb>
+#include "../utils/arrow_adapter.h"
 #include "enums.h"
 #include "soma_array.h"
 #include "soma_object.h"
@@ -50,6 +51,25 @@ class SOMADataFrame : public SOMAObject {
     //===================================================================
     //= public static
     //===================================================================
+
+    /**
+     * @brief Create a SOMADataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMADataFrame
+     * @param schema ArrowSchema*
+     * @param platform_config Optional config parameter dictionary
+     * @param index_column_names Optional Vector of column names to use
+     * @param domain Optional Vector of ArrowArray* specifying the domain of
+     * each index column. If not provided, the domain will use the min and max
+     * possible values for the column's datatype
+     * @return std::shared_ptr<SOMADataFrame> opened in read mode
+     */
+    static std::unique_ptr<SOMADataFrame> create(
+        std::string_view uri,
+        ArrowSchema* schema,
+        std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> index_column_names = {},
+        std::vector<ArrowArray*> domain = {});
 
     /**
      * @brief Create a SOMADataFrame object at the given URI.

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -43,13 +43,14 @@ using namespace tiledb;
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri,
-    ArrowSchema* schema,
+    ArrowSchema& schema,
     std::map<std::string, std::string> platform_config,
     std::vector<std::string> index_column_names,
-    std::vector<ArrowArray*> domain) {
+    ArrowArray& domains,
+    ArrowArray& extents) {
     auto ctx = std::make_shared<Context>(Config(platform_config));
     ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
-        ctx, schema, index_column_names, domain);
+        ctx, schema, index_column_names, domains, extents);
     SOMAArray::create(ctx, uri, tdb_schema, "SOMADenseNDArray");
     return SOMADenseNDArray::open(uri, OpenMode::read, ctx);
 }

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -43,6 +43,19 @@ using namespace tiledb;
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri,
+    ArrowSchema* schema,
+    std::map<std::string, std::string> platform_config,
+    std::vector<std::string> index_column_names,
+    std::vector<ArrowArray*> domain) {
+    auto ctx = std::make_shared<Context>(Config(platform_config));
+    ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
+        ctx, schema, index_column_names, domain);
+    SOMAArray::create(ctx, uri, tdb_schema, "SOMADenseNDArray");
+    return SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+}
+
+std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
+    std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
     return SOMADenseNDArray::create(

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -65,10 +65,11 @@ class SOMADenseNDArray : public SOMAObject {
      */
     static std::unique_ptr<SOMADenseNDArray> create(
         std::string_view uri,
-        ArrowSchema* schema,
-        std::map<std::string, std::string> platform_config = {},
-        std::vector<std::string> index_column_names = {},
-        std::vector<ArrowArray*> domain = {});
+        ArrowSchema& schema,
+        std::map<std::string, std::string> platform_config,
+        std::vector<std::string> index_column_names,
+        ArrowArray& domains,
+        ArrowArray& extents);
 
     /**
      * @brief Create a SOMADenseNDArray object at the given URI.

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -34,6 +34,7 @@
 #define SOMA_DENSE_NDARRAY
 
 #include <tiledb/tiledb>
+#include "../utils/arrow_adapter.h"
 #include "enums.h"
 #include "soma_array.h"
 #include "soma_object.h"
@@ -50,6 +51,24 @@ class SOMADenseNDArray : public SOMAObject {
     //===================================================================
     //= public static
     //===================================================================
+    /**
+     * @brief Create a SOMADenseNDArray object at the given URI.
+     *
+     * @param uri URI to create the SOMADenseNDArray
+     * @param schema ArrowSchema*
+     * @param platform_config Optional config parameter dictionary
+     * @param index_column_names Optional Vector of column names to use
+     * @param domain Optional Vector of ArrowArray* specifying the domain of
+     * each index column. If not provided, the domain will use the min and max
+     * possible values for the column's datatype
+     * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
+     */
+    static std::unique_ptr<SOMADenseNDArray> create(
+        std::string_view uri,
+        ArrowSchema* schema,
+        std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> index_column_names = {},
+        std::vector<ArrowArray*> domain = {});
 
     /**
      * @brief Create a SOMADenseNDArray object at the given URI.

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -43,13 +43,14 @@ using namespace tiledb;
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri,
-    ArrowSchema* schema,
+    ArrowSchema& schema,
     std::map<std::string, std::string> platform_config,
     std::vector<std::string> index_column_names,
-    std::vector<ArrowArray*> domain) {
+    ArrowArray& domains,
+    ArrowArray& extents) {
     auto ctx = std::make_shared<Context>(Config(platform_config));
     ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
-        ctx, schema, index_column_names, domain);
+        ctx, schema, index_column_names, domains, extents);
     SOMAArray::create(ctx, uri, tdb_schema, "SOMASparseNDArray");
     return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
 }

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -43,6 +43,19 @@ using namespace tiledb;
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri,
+    ArrowSchema* schema,
+    std::map<std::string, std::string> platform_config,
+    std::vector<std::string> index_column_names,
+    std::vector<ArrowArray*> domain) {
+    auto ctx = std::make_shared<Context>(Config(platform_config));
+    ArraySchema tdb_schema = ArrowAdapter::arrow_schema_to_tiledb_schema(
+        ctx, schema, index_column_names, domain);
+    SOMAArray::create(ctx, uri, tdb_schema, "SOMASparseNDArray");
+    return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
+}
+
+std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
+    std::string_view uri,
     ArraySchema schema,
     std::map<std::string, std::string> platform_config) {
     return SOMASparseNDArray::create(

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -66,10 +66,11 @@ class SOMASparseNDArray : public SOMAObject {
      */
     static std::unique_ptr<SOMASparseNDArray> create(
         std::string_view uri,
-        ArrowSchema* schema,
-        std::map<std::string, std::string> platform_config = {},
-        std::vector<std::string> index_column_names = {},
-        std::vector<ArrowArray*> domain = {});
+        ArrowSchema& schema,
+        std::map<std::string, std::string> platform_config,
+        std::vector<std::string> index_column_names,
+        ArrowArray& domains,
+        ArrowArray& extents);
 
     /**
      * @brief Create a SOMASparseNDArray object at the given URI.

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -34,6 +34,7 @@
 #define SOMA_SPARSE_NDARRAY
 
 #include <tiledb/tiledb>
+#include "../utils/arrow_adapter.h"
 #include "enums.h"
 #include "soma_array.h"
 #include "soma_object.h"
@@ -50,6 +51,25 @@ class SOMASparseNDArray : public SOMAObject {
     //===================================================================
     //= public static
     //===================================================================
+
+    /**
+     * @brief Create a SOMASparseNDArray object at the given URI.
+     *
+     * @param uri URI to create the SOMASparseNDArray
+     * @param schema ArrowSchema*
+     * @param platform_config Optional config parameter dictionary
+     * @param index_column_names Optional Vector of column names to use
+     * @param domain Optional Vector of ArrowArray* specifying the domain of
+     * each index column. If not provided, the domain will use the min and max
+     * possible values for the column's datatype
+     * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
+     */
+    static std::unique_ptr<SOMASparseNDArray> create(
+        std::string_view uri,
+        ArrowSchema* schema,
+        std::map<std::string, std::string> platform_config = {},
+        std::vector<std::string> index_column_names = {},
+        std::vector<ArrowArray*> domain = {});
 
     /**
      * @brief Create a SOMASparseNDArray object at the given URI.


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/1714

Split off from https://github.com/single-cell-data/TileDB-SOMA/pull/1640.

**Changes:**

* Add converter for ArrowSchema to TileDB ArraySchema
* Add `create` static method that takes in Arrow structs for DataFrame, NDSparseArray, and NDDenseArray

**Notes for Reviewer:**

- [ ] Handle enumerations
    - [ ]  Pass argument ArrowArray* where each child array holds the enumation label and index values
    - [ ]  Pass argument map<string, string> to link attribute name to enumeration label
- [x] Set nullable attributes
- [ ] Set filters
- [ ] Switch out raw pointers with pass-by-reference or `unique_ptr`
- [ ] Add unit tests
