### PR TITLE
[c++] Support return of `ordered` enumerations

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -40,7 +40,15 @@ jobs:
 
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
-       
+
+      - name: Install r-universe build of tiledb-r (macOS)
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
+
+      - name: Install r-universe build of tiledb-r (linux)
+        if: ${{ matrix.os != 'macOS-latest' }}
+        run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"  
+        
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -112,6 +112,7 @@ class ColumnBuffer {
      * @param is_var Column type is variable length
      * @param is_nullable Column can contain null values
      * @param enumeration Optional Enumeration associated with column
+     * @param is_ordered Optional Enumeration is ordered
      */
     ColumnBuffer(
         std::string_view name,
@@ -120,7 +121,8 @@ class ColumnBuffer {
         size_t num_bytes,
         bool is_var = false,
         bool is_nullable = false,
-        std::optional<Enumeration> enumeration = std::nullopt);
+        std::optional<Enumeration> enumeration = std::nullopt,
+        bool is_ordered = false);
 
     ColumnBuffer() = delete;
     ColumnBuffer(const ColumnBuffer&) = delete;
@@ -328,6 +330,13 @@ class ColumnBuffer {
         return tcb::span<char>(enum_str_.data(), enum_str_.length());
     }
 
+    /**
+     * @brief Return true if the buffer contains an ordered enumeration.
+     */
+    bool is_ordered() const {
+        return is_ordered_;
+    }
+
    private:
     //===================================================================
     //= private static
@@ -342,6 +351,7 @@ class ColumnBuffer {
      * @param is_var True if variable length data
      * @param is_nullable True if nullable data
      * @param enumeration Optional Enumeration associated with column
+     * @param is_ordered Optional Enumeration is ordered
      * @return ColumnBuffer
      */
     static std::shared_ptr<ColumnBuffer> alloc(
@@ -350,7 +360,8 @@ class ColumnBuffer {
         tiledb_datatype_t type,
         bool is_var,
         bool is_nullable,
-        std::optional<Enumeration> enumeration);
+        std::optional<Enumeration> enumeration,
+        bool is_ordered);
 
     //===================================================================
     //= private non-static
@@ -395,6 +406,7 @@ class ColumnBuffer {
     // Enumerations (optional) as string and offsets
     std::string enum_str_;
     std::vector<uint32_t> enum_offsets_;
+    bool is_ordered_ = false;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -148,6 +148,9 @@ class ArrowAdapter {
             column->validity_to_bitmap();
             array->buffers[0] = column->validity().data();
         }
+        if (column->is_ordered()) {
+            schema->flags |= ARROW_FLAG_DICTIONARY_ORDERED;
+        }
 
         /* Workaround to cast TILEDB_BOOL from uint8 to 1-bit Arrow boolean. */
         if (column->type() == TILEDB_BOOL) {


### PR DESCRIPTION
**Issue and/or context:**

Enumerations also support `ordered` variants of `factor` types. This PR adds support.

**Changes:**

The 'ordered' state is now reflected in the column buffer type, and the appropriate Arrow flag is set for the schema.

**Notes for Reviewer:**

[SC 34679](https://app.shortcut.com/tiledb-inc/story/34679/soma-iterated-readers-cannot-handle-ordered-columns)
