### PR TITLE
[python] `update_obs`/`update_var` with original or readback source

### DIFF
--- a/apis/python/src/tiledbsoma/io/_registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/_registration/signatures.py
@@ -70,7 +70,11 @@ def _string_dict_from_pandas_dataframe(
     df = df.head(1)  # since reset_index can be expensive on full data
     if df.index.name is None or df.index.name == "index":
         df.reset_index(inplace=True)
-        df.rename(columns={"index": default_index_name}, inplace=True)
+        if default_index_name in df:
+            if "index" in df:
+                df.drop(columns=["index"], inplace=True)
+        else:
+            df.rename(columns={"index": default_index_name}, inplace=True)
     else:
         df.reset_index(inplace=True)
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1131,8 +1131,11 @@ def _write_dataframe(
 
     df.reset_index(inplace=True)
     if id_column_name is not None:
-        df.rename(columns={"index": id_column_name}, inplace=True)
-        id_column_name = "index"
+        if id_column_name in df:
+            if "index" in df:
+                df.drop(columns=["index"], inplace=True)
+        else:
+            df.rename(columns={"index": id_column_name}, inplace=True)
 
     df[SOMA_JOINID] = np.asarray(axis_mapping.data)
 

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -156,6 +156,162 @@ def soma1(tmp_path, h5ad1):
     return uri
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        # SOMA ID column is to be obs_id, and it is the Pandas index named "obs_id"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"obs_id": "string", "alt_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and it is the Pandas index named "index"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": "index",
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"obs_id": "string", "alt_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and it is the Pandas unnamed index
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"obs_id": "string", "alt_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and the Pandas index is named something else
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and the Pandas index is unnamed
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"obs_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and the Pandas index is named "index"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": "index",
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"obs_id": "string"},
+        },
+        # SOMA ID column is to be obs_id, and the Pandas index is implicitized integers
+        {
+            "do_set_index": False,
+            "index_name_to_set": None,
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "obs_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and it is the Pandas index named "alt_id"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and it is the Pandas index named "index"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": "index",
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and it is the Pandas unnamed index
+        {
+            "do_set_index": True,
+            "index_name_to_set": "alt_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and the Pandas index is named something else
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"obs_id": "string", "alt_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and the Pandas index is unnamed
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and the Pandas index is named "index"
+        {
+            "do_set_index": True,
+            "index_name_to_set": "obs_id",
+            "do_rename_axis": True,
+            "axis_name_to_set": "index",
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string"},
+        },
+        # SOMA ID column is to be alt_id, and the Pandas index is implicitized integers
+        {
+            "do_set_index": False,
+            "index_name_to_set": None,
+            "do_rename_axis": False,
+            "axis_name_to_set": None,
+            "registration_index_column_name": "alt_id",
+            "expected_signature": {"alt_id": "string", "obs_id": "string"},
+        },
+    ],
+)
+def test_pandas_indexing(args):
+    """
+    The index-column name for registration can take a variety of forms.
+    This test exercises all of them.
+    """
+
+    df = pd.DataFrame(
+        data={
+            "soma_joinid": np.arange(3, dtype=np.int64),
+            "alt_id": ["A", "C", "G"],
+            "obs_id": ["AT", "CT", "GT"],
+        }
+    )
+    if args["do_set_index"]:
+        df.set_index(args["index_name_to_set"], inplace=True)
+    if args["do_rename_axis"]:
+        df.rename_axis(args["axis_name_to_set"], inplace=True)
+
+    actual_signature = registration.signatures._string_dict_from_pandas_dataframe(
+        df,
+        args["registration_index_column_name"],
+    )
+    assert actual_signature == args["expected_signature"]
+
+
 def test_axis_mappings(anndata1):
     mapping = registration.AxisIDMapping.identity(10)
     assert mapping.data == tuple(range(10))


### PR DESCRIPTION
**Issue and/or context:** #1718

**Changes:**

* Accept `obs` / `var` either from mutations of the original source data or mutations of readback data
* Split out unit tests for fine-grained testing of signature computation, given a variety of places the SOMA index-column name may be located within a Pandas DataFrame (including a finer test for the problem reported on #1718)
* Parameterize `test_update_dataframes.py` to take a flag for use-mutated-original or use-mutated-readback

**Notes for Reviewer:**

