### PR TITLE
[r] Update `SOMADataFrame$create()` to automatically mark `ordered()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.4.3.1
+Version: 1.4.3.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -4,6 +4,7 @@
 
 * Add support for writing `SummarizedExperiment` and `SingleCellExperiment` object to SOMAs
 * Add support for bounding boxes for sparse arrays
+* Add support for creating `SOMADataFrames` with `ordered()` columns
 
 
 # tiledbsoma 1.4.0

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -97,6 +97,11 @@ SOMADataFrame <- R6::R6Class(
         field <- schema$GetFieldByName(field_name)
         field_type <- tiledb_type_from_arrow_type(field$type)
 
+        # Check if the field is ordered and mark it as such
+        if (!is.null(x = levels[[field_name]]) && isTRUE(field$type$ordered)) {
+          attr(levels[[field_name]], 'ordered') <- attr(levels[[field_name]], 'ordered', TRUE) %||% TRUE
+        }
+
         tdb_attrs[[field_name]] <- tiledb::tiledb_attr(
           name = field_name,
           type = field_type,

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -99,7 +99,7 @@ SOMADataFrame <- R6::R6Class(
 
         # Check if the field is ordered and mark it as such
         if (!is.null(x = levels[[field_name]]) && isTRUE(field$type$ordered)) {
-          attr(levels[[field_name]], 'ordered') <- attr(levels[[field_name]], 'ordered', TRUE) %||% TRUE
+          attr(levels[[field_name]], 'ordered') <- attr(levels[[field_name]], 'ordered', exact = TRUE) %||% TRUE
         }
 
         tdb_attrs[[field_name]] <- tiledb::tiledb_attr(


### PR DESCRIPTION
Add an check in `SOMADataFrame$create()` to detect if a column in the schema is ordered. If so, automatically mark the enumerations as such.

Note: this only happens if
- there are enumerations for the column
- the column in the arrow schema is marked as ordered
- there is no attribute `'ordered'` on the enumerations for the column
