### PR TITLE
[r] Replace three local utility functions with use of RcppInt64

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -48,7 +48,8 @@ Imports:
     tibble
 LinkingTo:
     Rcpp,
-    RcppSpdlog
+    RcppSpdlog,
+    RcppInt64
 Additional_repositories: https://ghrr.github.io/drat
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>               // for R interface to C++
 #include <nanoarrow.h>          // for C interface to Arrow
+#include <RcppInt64>            // for fromInteger64
 
 // we currently get deprecation warnings by default which are noisy
 #ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
@@ -233,5 +234,5 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 Rcpp::NumericVector shape(const std::string& uri,
                           Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
-    return makeInteger64(sr->shape());
+    return Rcpp::toInteger64(sr->shape());
 }

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -6,6 +6,7 @@
 
 #include <Rcpp.h>               // for R interface to C++
 #include <nanoarrow.h>          // for C interface to Arrow
+#include <RcppInt64>            // for fromInteger64
 
 // We get these via nanoarrow and must cannot include carrow.h again
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
@@ -26,7 +27,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
         bool suitable = false;
         if (tp == TILEDB_UINT64) {
             Rcpp::NumericVector payload = lst[nm];
-            std::vector<int64_t> iv = getInt64Vector(payload);
+            std::vector<int64_t> iv = Rcpp::fromInteger64(payload, false);
             std::vector<uint64_t> uv(iv.size());
             const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
             for (size_t i=0; i<iv.size(); i++) {
@@ -39,7 +40,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
             }
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericVector payload = lst[nm];
-            std::vector<int64_t> iv = getInt64Vector(payload);
+            std::vector<int64_t> iv = Rcpp::fromInteger64(payload, false);
             const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
             for (size_t i=0; i<iv.size(); i++) {
                 if (iv[i] >= pr.first && iv[i] <= pr.second) {
@@ -103,8 +104,8 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
             std::vector<std::pair<uint64_t, uint64_t>> vp(mm.nrow());
             const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
             for (int i=0; i<mm.nrow(); i++) {
-                uint64_t l = static_cast<uint64_t>(makeScalarInteger64(lo[i]));
-                uint64_t h = static_cast<uint64_t>(makeScalarInteger64(hi[i]));
+                uint64_t l = static_cast<uint64_t>(Rcpp::fromInteger64(lo[i]));
+                uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
                 vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
                 spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
                 suitable = l < pr.second && h > pr.first; // lower must be less than max, higher more than min
@@ -112,8 +113,8 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
             if (suitable) sr->set_dim_ranges<uint64_t>(nm, vp);
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericMatrix mm = lst[nm];
-            std::vector<int64_t> lo = getInt64Vector(mm.column(0));
-            std::vector<int64_t> hi = getInt64Vector(mm.column(1));
+            std::vector<int64_t> lo = Rcpp::fromInteger64(mm.column(0), false);
+            std::vector<int64_t> hi = Rcpp::fromInteger64(mm.column(1), false);
             std::vector<std::pair<int64_t, int64_t>> vp(mm.nrow());
             const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
             for (int i=0; i<mm.nrow(); i++) {

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -12,45 +12,9 @@ namespace tdbs = tiledbsoma;
 #define TileDB_Version(v, m, p) (((v)*65536) + ((m)*256) + (p))
 
 // current build is encoded in TILEDB_VERSION
-#define TILEDB_VERSION \
-    TileDB_Version(    \
-        TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH)
-
-// Create a integer64 object
-//
-// Integer64 is an S3 class. Integers in R are 32-bits. To handle C++
-// signed 64-bit integers (int64_t), the full bits may be stored using double '
-// as an intermediary which then can be coereced to Integer64.
-// For more on this see e.g.
-// https://gallery.rcpp.org/articles/creating-integer64-and-nanotime-vectors/
-//
-inline Rcpp::NumericVector makeInteger64(const std::vector<int64_t>& vec) {
-    size_t n = vec.size();
-
-    Rcpp::NumericVector num(n);
-    std::memcpy(&(num[0]), vec.data(), n * sizeof(double));
-
-    num.attr("class") = "integer64";
-    return (num);
-}
-
-// Convert to a scalar int64_t
-//
-inline int64_t makeScalarInteger64(const double val) {
-    int64_t newval;
-    memcpy(&newval, &val, sizeof(double));
-    return newval;
-}
-
-// Create a int64_t vector from a NumericVector
-//
-inline std::vector<int64_t> getInt64Vector(Rcpp::NumericVector vec) {
-    size_t n = vec.size();
-    std::vector<int64_t> num(n);
-    std::memcpy(&(num[0]), &(vec[0]), n * sizeof(double));
-    return num;
-}
-
+#define TILEDB_VERSION TileDB_Version(TILEDB_VERSION_MAJOR, \
+                                      TILEDB_VERSION_MINOR, \
+                                      TILEDB_VERSION_PATCH)
 
 // Applies (named list of) vectors of points to the named dimensions
 void apply_dim_points(


### PR DESCRIPTION
**Issue and/or context:**

This PR reduces the code surface by replacing three `integer64` conversion utility functions with use from the [RcppInt64](https://cran.r-project.org/package=RcppInt64) package.  A similar change was made to the tiledb-r package in a recent PR.

**Changes:**

Remove three helper functions, add a header import in two C++ files.

**Notes for Reviewer:**

[SC 34753](https://app.shortcut.com/tiledb-inc/story/34753/r-replace-two-utility-functions-with-use-of-rcppint64-package-equivalents)
