### PR TITLE
[python][release-1.5] Revert to numba 0.57 until it's available in Conda

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -271,13 +271,21 @@ setuptools.setup(
         "anndata < 0.9; python_version<'3.8'",
         "anndata; python_version>='3.8'",
         "attrs>=22.2",
-        "numba~=0.58.0; python_version>='3.8'",
-        # Older numba version needed for Python3.7.
-        # This older numba version was also incompatble with newer numpy
-        # versions, and the old pip solver (<=2020) needed us to explicate
-        # that constraint here (issue #1051).
-        "numba==0.56.4; python_version<'3.8'",
-        "numpy>=1.18,<1.24; python_version<'3.8'",
+        # Pinning numba & its particular numpy constraints:
+        # The old pip solver (<=2020) doesn't deal with the transitive
+        # requirements (scanpy -> numba -> numpy) properly resulting in broken
+        # installation of incompatible numpy>=1.24. Issue #1051
+        # These pins can be removed either when there's a new numba release
+        # with less-particular numpy version constraints, or if we decide we no
+        # longer need to support the old pip solver (default on ubuntu 20.04).
+        #
+        # Also: numba doesn't support Python 3.11 until 0.57.0rc1.
+        # It' not preferable to pin to an RC dependency, so we only do this
+        # when we must, which is for 3.11.
+        "numba==0.56.4; python_version<'3.11'",
+        "numba==0.57; python_version=='3.11'",
+        "numpy>=1.18,<1.24; python_version<'3.11'",
+        "numpy>=1.18,<1.25; python_version=='3.11'",
         "pandas",
         "pyarrow>=9.0.0",
         "scanpy>=1.9.2",


### PR DESCRIPTION
**Issue and/or context:** For #1733. Today we cannot build TileDB-SOMA in Conda with numba at 0.58.

**Changes:**

**Notes for Reviewer:**

This is only for the release-1.5 branch (cc @thetorpedodog and @mlin) for the immediate term. #1723 still stands on `main` as tracked on #1733.

