### PR TITLE
[r] Remove duplicated step in workflow

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
-      - name: Update packages
-        run: Rscript -e 'update.packages(ask=FALSE)'
-
       - name: Test
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests


### PR DESCRIPTION
**Issue and/or context:**

The r-ci.yml workflow duplicates one step in what may have been a copy and paste error.

**Changes:**

Remove extra step.

**Notes for Reviewer:**

[SC 35048](https://app.shortcut.com/tiledb-inc/story/35048/undo-copy-and-paste-error-in-workflow-file)
