### PR TITLE
[r] Update installed packages in workflow

### DIFF
--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: SessionInfo
         run: R -q -e 'sessionInfo()'
       - name: System Dependencies
-        run: apt update -qq && apt install --yes --no-install-recommends valgrind cmake git
+        run: apt update -qq && apt upgrade --yes && apt install --yes --no-install-recommends valgrind cmake git
       - name: Package Dependencies
         run: cd apis/r && R -q -e 'remotes::install_deps(".", dependencies=TRUE)'
       - name: Build Package


### PR DESCRIPTION
**Issue and/or context:**

The nightly valgrind jobs have been failing since a recent (unrelated) R package update now requiring the newest version of package Matrix.

**Changes:**

An `apt upgrade` step ensures the already installed Matrix package updates to the most recent version that one of R packages depends upon.  It also does not hurt to update the other packages.  

The change was validated in a local Docker run and should restore the scheduled nightly job.

**Notes for Reviewer:**

We can do this as a pure `apt` step (rather than via `update.packages()`) as this is an Ubuntu-only workflow.

[SC 35052](https://app.shortcut.com/tiledb-inc/story/35052/r-restore-valgrind-job)
