### PR TITLE
[python] Ingest 2D uns string arrays (e.g. color labels)

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2263,7 +2263,7 @@ def _ingest_uns_2d_string_array(
     num_rows, num_cols = value.shape
     data: Dict[str, Any] = {"soma_joinid": np.arange(num_rows, dtype=np.int64)}
     for j in range(num_cols):
-        column_name = f"values_{str(j)}"
+        column_name = f"values_{j}"
         data[column_name] = [str(e) if e else "" for e in value[:, j]]
     df = pd.DataFrame(data=data)
     df.set_index("soma_joinid", inplace=True)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2256,7 +2256,10 @@ def _ingest_uns_2d_string_array(
     use_relative_uri: Optional[bool],
     ingestion_params: IngestionParams,
 ) -> None:
-    """Helper for ``_ingest_uns_string_array``"""
+    """Helper for ``_ingest_uns_string_array``. Even if the 2D array is 1xN or Nx1, we
+    must nonetheless keep this as 2D rather than flattening to length-N 1D. That's because
+    this ``uns`` data is solely of interest for AnnData ingest/outgest, and it must go
+    back out the way it came in."""
     num_rows, num_cols = value.shape
     data: Dict[str, Any] = {"soma_joinid": np.arange(num_rows, dtype=np.int64)}
     for j in range(num_cols):


### PR DESCRIPTION
**Issue and/or context:** #1764

**Changes:** As part of uns-outgest testing, I am also seeing we're not ingesting uns in all cases.

Namely, the code looks like this:
https://github.com/single-cell-data/TileDB-SOMA/blob/1.5.0rc1/apis/python/src/tiledbsoma/io/ingest.py#L2190-L2196

when AnnData inputs look like this:

```
>>> adata.uns.keys()
dict_keys(['age_colors', 'celltype_colors', 'hvg', 'leiden', 'louvain', 'louvain_colors', 'neighbors', 'pca', 'tissue_colors', 'umap'])

>>> adata.uns["age_colors"]
array([['#e1f3b2']], dtype=object)

>>> adata.uns["celltype_colors"]
array([['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080'],
       ['#808080']], dtype=object)

>>> adata.uns["louvain_colors"]
array([['#FFFF00'],
       ['#1CE6FF'],
       ['#FF34FF'],
       ['#FF4A46'],
       ['#A30059'],
       ['#FFDBE5'],
       ['#0000A6'],
       ['#8FB0FF'],
       ['#FF2F80'],
       ['#B903AA'],
       ['#A079BF'],
       ['#CC0744'],
       ['#C0B9B2'],
       ['#6F0062']], dtype=object)

>>> adata.uns["tissue_colors"]
array([['#e7cb94']], dtype=object)
```

**Notes for the reviewer:**