### PR TITLE
[python] Create separate `set_condition`

### DIFF
--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -131,12 +131,11 @@ class QueryCondition:
 
     def init_query_condition(
         self,
+        ctx: tiledb.Ctx,
         uri: str,
-        query_attrs: List[str],
-        config: Optional[dict],
+        query_attrs: Optional[List[str]],
         timestamps: Optional[Tuple[OpenTimestamp, OpenTimestamp]],
     ):
-        ctx = tiledb.Ctx(config)
         qctree = QueryConditionTree(
             ctx, tiledb.open(uri, ctx=ctx, timestamp=timestamps), query_attrs
         )

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -15,7 +15,6 @@ import tiledb
 
 from . import pytiledbsoma as clib
 from ._exception import SOMAError
-from ._types import OpenTimestamp
 
 # In Python 3.7, a boolean literal like `True` is of type `ast.NameConstant`.
 # Above that, it's of type `ast.Constant`.

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -131,14 +131,11 @@ class QueryCondition:
 
     def init_query_condition(
         self,
-        ctx: tiledb.Ctx,
-        uri: str,
+        schema: tiledb.ArraySchema,
+        enum_to_dtype: dict,
         query_attrs: Optional[List[str]],
-        timestamps: Optional[Tuple[OpenTimestamp, OpenTimestamp]],
     ):
-        qctree = QueryConditionTree(
-            ctx, tiledb.open(uri, ctx=ctx, timestamp=timestamps), query_attrs
-        )
+        qctree = QueryConditionTree(schema, enum_to_dtype, query_attrs)
         self.c_obj = qctree.visit(self.tree.body)
 
         if not isinstance(self.c_obj, clib.PyQueryCondition):
@@ -152,8 +149,8 @@ class QueryCondition:
 
 @attrs.define
 class QueryConditionTree(ast.NodeVisitor):
-    ctx: tiledb.Ctx
-    array: tiledb.Array
+    schema: tiledb.ArraySchema
+    enum_to_dtype: dict
     query_attrs: List[str]
 
     def visit_BitOr(self, node):
@@ -230,14 +227,14 @@ class QueryConditionTree(ast.NodeVisitor):
             variable = node.left.id
             values = [self.get_val_from_node(val) for val in self.visit(rhs)]
 
-            if self.array.schema.has_attr(variable):
-                enum_label = self.array.attr(variable).enum_label
+            if self.schema.has_attr(variable):
+                enum_label = self.schema.attr(variable).enum_label
                 if enum_label is not None:
-                    dt = self.array.enum(enum_label).dtype
+                    dt = self.enum_to_dtype[enum_label]
                 else:
-                    dt = self.array.attr(variable).dtype
+                    dt = self.schema.attr(variable).dtype
             else:
-                dt = self.array.schema.attr_or_dim_dtype(variable)
+                dt = self.schema.attr_or_dim_dtype(variable)
 
             # sdf.read(column_names=["foo"], value_filter='bar == 999') should
             # result in bar being added to the column names. See also
@@ -248,7 +245,7 @@ class QueryConditionTree(ast.NodeVisitor):
 
             dtype = "string" if dt.kind in "SUa" else dt.name
             op = clib.TILEDB_IN if isinstance(operator, ast.In) else clib.TILEDB_NOT_IN
-            result = self.create_pyqc(dtype)(self.ctx, node.left.id, values, op)
+            result = self.create_pyqc(dtype)(node.left.id, values, op)
 
         return result
 
@@ -262,11 +259,11 @@ class QueryConditionTree(ast.NodeVisitor):
 
         att = self.get_att_from_node(att)
         val = self.get_val_from_node(val)
-        enum_label = self.array.attr(att).enum_label
+        enum_label = self.schema.attr(att).enum_label
         if enum_label is not None:
-            dt = self.array.enum(enum_label).dtype
+            dt = self.enum_to_dtype[enum_label]
         else:
-            dt = self.array.attr(att).dtype
+            dt = self.schema.attr(att).dtype
         dtype = "string" if dt.kind in "SUa" else dt.name
         val = self.cast_val_to_dtype(val, dtype)
 
@@ -346,8 +343,8 @@ class QueryConditionTree(ast.NodeVisitor):
                 f"Incorrect type for attribute name: {ast.dump(node)}"
             )
 
-        if not self.array.schema.has_attr(att):
-            if self.array.schema.domain.has_dim(att):
+        if not self.schema.has_attr(att):
+            if self.schema.domain.has_dim(att):
                 raise tiledb.TileDBError(
                     f"`{att}` is a dimension. QueryConditions currently only "
                     "work on attributes."

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -105,8 +105,6 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         #     kwargs["schema"] = schema
         if column_names:
             kwargs["column_names"] = column_names
-        if query_condition:
-            kwargs["query_condition"] = query_condition
         if result_order:
             result_order_map = {
                 "auto": clib.ResultOrder.automatic,
@@ -115,13 +113,19 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
             }
             result_order_enum = result_order_map[ResultOrder(result_order).value]
             kwargs["result_order"] = result_order_enum
-        return clib.SOMAArray(
+
+        soma_array = clib.SOMAArray(
             self.uri,
             name=f"{self} reader",
             platform_config=self._ctx.config().dict(),
             timestamp=(0, self.tiledb_timestamp_ms),
             **kwargs,
         )
+
+        if query_condition:
+            soma_array.set_condition(query_condition)
+
+        return soma_array
 
     def _set_reader_coords(self, sr: clib.SOMAArray, coords: Sequence[object]) -> None:
         """Parses the given coords and sets them on the SOMA Reader."""

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -123,7 +123,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         )
 
         if query_condition:
-            soma_array.set_condition(query_condition)
+            soma_array.set_condition(query_condition, self._tiledb_array_schema())
 
         return soma_array
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -36,18 +36,7 @@ import pyarrow as pa
 import scipy.sparse as sp
 import tiledb
 from anndata._core import file_backing
-from packaging import version
-
-# * When the user provides AnnData in non-backed mode, e.g. adata =
-#   ad.read_h5ad('foo.h5ad'), we have matrices like scipy.csr_matrix.
-# * When the user provides AnnData in backed mode, e.g. adata =
-#   ad.read_h5ad('foo.h5ad', 'r'), we have matrices like SparseDataset.
-# * AnnData 0.10.0 split SparseDataset into CSCDataSet and CSRDataSet.
-if version.parse(ad.__version__) < version.parse("0.10.0"):
-    from anndata._core.sparse_dataset import SparseDataset
-else:
-    from anndata._core.sparse_dataset import CSCDataSet, CSRDataSet
-
+from anndata._core.sparse_dataset import SparseDataset
 from somacore.options import PlatformConfig
 
 from .. import (
@@ -84,10 +73,7 @@ from ._registration import (
     signatures,
 )
 
-if version.parse(ad.__version__) < version.parse("0.10.0"):
-    SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
-else:
-    SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSCDataSet, CSRDataSet]
+SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 _NDArr = TypeVar("_NDArr", bound=NDArray)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -36,7 +36,18 @@ import pyarrow as pa
 import scipy.sparse as sp
 import tiledb
 from anndata._core import file_backing
-from anndata._core.sparse_dataset import SparseDataset
+from packaging import version
+
+# * When the user provides AnnData in non-backed mode, e.g. adata =
+#   ad.read_h5ad('foo.h5ad'), we have matrices like scipy.csr_matrix.
+# * When the user provides AnnData in backed mode, e.g. adata =
+#   ad.read_h5ad('foo.h5ad', 'r'), we have matrices like SparseDataset.
+# * AnnData 0.10.0 split SparseDataset into CSCDataSet and CSRDataSet.
+if version.parse(ad.__version__) < version.parse("0.10.0"):
+    from anndata._core.sparse_dataset import SparseDataset
+else:
+    from anndata._core.sparse_dataset import CSCDataSet, CSRDataSet
+
 from somacore.options import PlatformConfig
 
 from .. import (
@@ -73,7 +84,10 @@ from ._registration import (
     signatures,
 )
 
-SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
+if version.parse(ad.__version__) < version.parse("0.10.0"):
+    SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
+else:
+    SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSCDataSet, CSRDataSet]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 _NDArr = TypeVar("_NDArr", bound=NDArray)

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -157,7 +157,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .value("rowmajor", ResultOrder::rowmajor)
         .value("colmajor", ResultOrder::colmajor);
 
-    tiledbpy::init_query_condition(m);
+    tiledbpy::load_query_condition(m);
 
     m.doc() = "SOMA acceleration library";
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -49,6 +49,93 @@ using namespace py::literals;
 
 namespace tiledbsoma {
 
+std::unordered_map<tiledb_datatype_t, std::string> _tdb_to_np_name_dtype = {
+    {TILEDB_INT32, "int32"},
+    {TILEDB_INT64, "int64"},
+    {TILEDB_FLOAT32, "float32"},
+    {TILEDB_FLOAT64, "float64"},
+    {TILEDB_INT8, "int8"},
+    {TILEDB_UINT8, "uint8"},
+    {TILEDB_INT16, "int16"},
+    {TILEDB_UINT16, "uint16"},
+    {TILEDB_UINT32, "uint32"},
+    {TILEDB_UINT64, "uint64"},
+    {TILEDB_STRING_ASCII, "S"},
+    {TILEDB_STRING_UTF8, "U1"},
+    {TILEDB_CHAR, "S1"},
+    {TILEDB_DATETIME_YEAR, "M8[Y]"},
+    {TILEDB_DATETIME_MONTH, "M8[M]"},
+    {TILEDB_DATETIME_WEEK, "M8[W]"},
+    {TILEDB_DATETIME_DAY, "M8[D]"},
+    {TILEDB_DATETIME_HR, "M8[h]"},
+    {TILEDB_DATETIME_MIN, "M8[m]"},
+    {TILEDB_DATETIME_SEC, "M8[s]"},
+    {TILEDB_DATETIME_MS, "M8[ms]"},
+    {TILEDB_DATETIME_US, "M8[us]"},
+    {TILEDB_DATETIME_NS, "M8[ns]"},
+    {TILEDB_DATETIME_PS, "M8[ps]"},
+    {TILEDB_DATETIME_FS, "M8[fs]"},
+    {TILEDB_DATETIME_AS, "M8[as]"},
+    {TILEDB_TIME_HR, "m8[h]"},
+    {TILEDB_TIME_MIN, "m8[m]"},
+    {TILEDB_TIME_SEC, "m8[s]"},
+    {TILEDB_TIME_MS, "m8[ms]"},
+    {TILEDB_TIME_US, "m8[us]"},
+    {TILEDB_TIME_NS, "m8[ns]"},
+    {TILEDB_TIME_PS, "m8[ps]"},
+    {TILEDB_TIME_FS, "m8[fs]"},
+    {TILEDB_TIME_AS, "m8[as]"},
+    {TILEDB_BLOB, "byte"},
+    {TILEDB_BOOL, "bool"},
+};
+
+py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
+  if (type == TILEDB_CHAR || type == TILEDB_STRING_UTF8 ||
+      type == TILEDB_STRING_ASCII) {
+    std::string base_str = (type == TILEDB_STRING_UTF8) ? "|U" : "|S";
+    if (cell_val_num < TILEDB_VAR_NUM)
+      base_str += std::to_string(cell_val_num);
+    return py::dtype(base_str);
+  }
+
+  if (cell_val_num == 1) {
+    if (type == TILEDB_STRING_UTF16 || type == TILEDB_STRING_UTF32)
+      TileDBSOMAError("Unimplemented UTF16 or UTF32 string conversion!");
+    if (type == TILEDB_STRING_UCS2 || type == TILEDB_STRING_UCS4)
+      TileDBSOMAError("Unimplemented UCS2 or UCS4 string conversion!");
+
+    if (_tdb_to_np_name_dtype.count(type) == 1)
+      return py::dtype(_tdb_to_np_name_dtype[type]);
+  }
+
+  if (cell_val_num == 2) {
+    if (type == TILEDB_FLOAT32)
+      return py::dtype("complex64");
+    if (type == TILEDB_FLOAT64)
+      return py::dtype("complex128");
+  }
+
+  if (cell_val_num == TILEDB_VAR_NUM)
+    return tdb_to_np_dtype(type, 1);
+
+  if (cell_val_num > 1) {
+    py::dtype base_dtype = tdb_to_np_dtype(type, 1);
+    py::tuple rec_elem = py::make_tuple("", base_dtype);
+    py::list rec_list;
+    for (size_t i = 0; i < cell_val_num; i++)
+      rec_list.append(rec_elem);
+    // note: we call the 'dtype' constructor b/c py::dtype does not accept
+    // list
+    auto np = py::module::import("numpy");
+    auto np_dtype = np.attr("dtype");
+    return np_dtype(rec_list);
+  }
+
+  TileDBSOMAError("tiledb datatype not understood ('" +
+                tiledb::impl::type_to_str(type) +
+                "', cell_val_num: " + std::to_string(cell_val_num) + ")");
+}
+
 py::tuple get_enum(SOMAArray& sr, std::string attr_name){
     auto attr_to_enmrs = sr.get_attr_to_enum_mapping();
     if(attr_to_enmrs.count(attr_name) == 0)
@@ -233,7 +320,14 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def(
             "set_condition", 
             [](SOMAArray& reader, 
-               py::object py_query_condition){
+               py::object py_query_condition,
+               py::object py_schema){
+                   auto attr_to_enum = reader.get_attr_to_enum_mapping();
+                   std::map<std::string, py::dtype> enum_to_dtype;
+                   for(auto const& [attr, enmr] : attr_to_enum){
+                        enum_to_dtype[attr] = tdb_to_np_dtype(
+                            enmr.type(), enmr.cell_val_num());
+                   }   
                    auto column_names = reader.column_names();
                    // Handle query condition based on
                    // TileDB-Py::PyQuery::set_attr_cond()
@@ -245,7 +339,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                            // Column names will be updated with columns present
                            // in the query condition
                            auto new_column_names =
-                               init_pyqc(*reader.ctx(), reader.uri(), column_names, reader.timestamp())
+                               init_pyqc(py_schema, enum_to_dtype, column_names)
                                    .cast<std::vector<std::string>>();   
                            // Update the column_names list if it was not empty,
                            // otherwise continue selecting all columns with an
@@ -271,7 +365,8 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                        reader.set_condition(*qc);
                    }
                 }, 
-            "py_query_condition"_a)
+            "py_query_condition"_a,
+            "py_schema"_a)
 
         .def(
             "reset",

--- a/apis/python/src/tiledbsoma/query_condition.cc
+++ b/apis/python/src/tiledbsoma/query_condition.cc
@@ -65,7 +65,16 @@ private:
   shared_ptr<QueryCondition> qc_;
 
 public:
-  PyQueryCondition() = delete;
+  PyQueryCondition(){
+    try {
+      // create one global context for all query conditions
+      static Context context = Context();
+      ctx_ = context;
+      qc_ = shared_ptr<QueryCondition>(new QueryCondition(ctx_));
+    } catch (TileDBError &e) {
+      TPY_ERROR_LOC(e.what());
+    }
+  }
 
   PyQueryCondition(py::object ctx) {
     (void)ctx;
@@ -104,9 +113,9 @@ public:
 
   template <typename T>
   static PyQueryCondition
-  create(py::object pyctx, const std::string &field_name,
+  create(const std::string &field_name,
          const std::vector<T> &values, tiledb_query_condition_op_t op) {
-    auto pyqc = PyQueryCondition(pyctx);
+    auto pyqc = PyQueryCondition();
 
     const Context ctx = std::as_const(pyqc.ctx_);
 
@@ -218,57 +227,57 @@ void load_query_condition(py::module &m) {
       .def_static(
           "create_string",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<std::string> &,
+              const std::string &, const std::vector<std::string> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint64",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<uint64_t> &,
+              const std::string &, const std::vector<uint64_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int64",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<int64_t> &,
+              const std::string &, const std::vector<int64_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint32",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<uint32_t> &,
+              const std::string &, const std::vector<uint32_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int32",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<int32_t> &,
+              const std::string &, const std::vector<int32_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint16",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<uint16_t> &,
+              const std::string &, const std::vector<uint16_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int8",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<int8_t> &,
+              const std::string &, const std::vector<int8_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint16",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<uint16_t> &,
+              const std::string &, const std::vector<uint16_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int8",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<int8_t> &,
+              const std::string &, const std::vector<int8_t> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_float32",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<float> &,
+              const std::string &, const std::vector<float> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_float64",
           static_cast<PyQueryCondition (*)(
-              py::object, const std::string &, const std::vector<double> &,
+              const std::string &, const std::vector<double> &,
               tiledb_query_condition_op_t)>(&PyQueryCondition::create))
 
       .def("__capsule__", &PyQueryCondition::__capsule__);

--- a/apis/python/src/tiledbsoma/query_condition.cc
+++ b/apis/python/src/tiledbsoma/query_condition.cc
@@ -153,7 +153,7 @@ private:
   }
 }; // namespace tiledbpy
 
-void init_query_condition(py::module &m) {
+void load_query_condition(py::module &m) {
   py::class_<PyQueryCondition>(m, "PyQueryCondition", py::module_local())
       .def(py::init<py::object>(), py::arg("ctx") = py::none())
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -88,6 +88,15 @@ class ManagedQuery {
         const std::vector<std::string>& names, bool if_not_empty = false);
 
     /**
+     * @brief Returns the column names set by the query.
+     *
+     * @return std::vector<std::string>
+     */
+    std::vector<std::string> column_names() {
+        return columns_;
+    }
+
+    /**
      * @brief Select dimension ranges to query.
      *
      * @tparam T Dimension type

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -346,6 +346,15 @@ class SOMAArray {
     }
 
     /**
+     * @brief Returns the column names set by the query.
+     *
+     * @return std::vector<std::string>
+     */
+    std::vector<std::string> column_names() {
+        return mq_->column_names();
+    }
+
+    /**
      * @brief Read the next chunk of results from the query. If all results
      * have already been read, std::nullopt is returned.
      *

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -27,7 +27,8 @@ def pandas_query(uri, condition):
 
 def soma_query(uri, condition):
     qc = QueryCondition(condition)
-    sr = clib.SOMAArray(uri, query_condition=qc)
+    sr = clib.SOMAArray(uri)
+    sr.set_condition(qc)
     arrow_table = sr.read_next()
     assert sr.results_complete()
 
@@ -106,7 +107,8 @@ def test_query_condition_select_columns():
 
     qc = QueryCondition(condition)
 
-    sr = clib.SOMAArray(uri, query_condition=qc, column_names=["n_genes"])
+    sr = clib.SOMAArray(uri, column_names=["n_genes"])
+    sr.set_condition(qc)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -120,7 +122,8 @@ def test_query_condition_all_columns():
 
     qc = QueryCondition(condition)
 
-    sr = clib.SOMAArray(uri, query_condition=qc)
+    sr = clib.SOMAArray(uri)
+    sr.set_condition(qc)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -134,7 +137,8 @@ def test_query_condition_reset():
 
     qc = QueryCondition(condition)
 
-    sr = clib.SOMAArray(uri, query_condition=qc)
+    sr = clib.SOMAArray(uri)
+    sr.set_condition(qc)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -145,7 +149,8 @@ def test_query_condition_reset():
     # ---------------------------------------------------------------
     condition = "percent_mito < 0.02"
     qc = QueryCondition(condition)
-    sr.reset(column_names=["percent_mito"], query_condition=qc)
+    sr.reset(column_names=["percent_mito"])
+    sr.set_condition(qc)
 
     arrow_table = sr.read_next()
 
@@ -213,7 +218,8 @@ def test_eval_error_conditions(malformed_condition):
     #
     with pytest.raises(RuntimeError):
         qc = QueryCondition(malformed_condition)
-        sr = clib.SOMAArray(uri, query_condition=qc)
+        sr = clib.SOMAArray(uri)
+        sr.set_condition(qc)
         sr.read_next()
 
 

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+
 import pytest
 import tiledb
 

--- a/libtiledbsoma/test/test_query_condition.py
+++ b/libtiledbsoma/test/test_query_condition.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import os
-
 import pytest
+import tiledb
 
 import tiledbsoma.pytiledbsoma as clib
 from tiledbsoma._exception import SOMAError
@@ -28,7 +28,8 @@ def pandas_query(uri, condition):
 def soma_query(uri, condition):
     qc = QueryCondition(condition)
     sr = clib.SOMAArray(uri)
-    sr.set_condition(qc)
+    schema = tiledb.open(uri).schema
+    sr.set_condition(qc, schema)
     arrow_table = sr.read_next()
     assert sr.results_complete()
 
@@ -106,9 +107,10 @@ def test_query_condition_select_columns():
     condition = "percent_mito > 0.02"
 
     qc = QueryCondition(condition)
+    schema = tiledb.open(uri).schema
 
     sr = clib.SOMAArray(uri, column_names=["n_genes"])
-    sr.set_condition(qc)
+    sr.set_condition(qc, schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -121,9 +123,10 @@ def test_query_condition_all_columns():
     condition = "percent_mito > 0.02"
 
     qc = QueryCondition(condition)
+    schema = tiledb.open(uri).schema
 
     sr = clib.SOMAArray(uri)
-    sr.set_condition(qc)
+    sr.set_condition(qc, schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -136,9 +139,10 @@ def test_query_condition_reset():
     condition = "percent_mito > 0.02"
 
     qc = QueryCondition(condition)
+    schema = tiledb.open(uri).schema
 
     sr = clib.SOMAArray(uri)
-    sr.set_condition(qc)
+    sr.set_condition(qc, schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -150,7 +154,7 @@ def test_query_condition_reset():
     condition = "percent_mito < 0.02"
     qc = QueryCondition(condition)
     sr.reset(column_names=["percent_mito"])
-    sr.set_condition(qc)
+    sr.set_condition(qc, schema)
 
     arrow_table = sr.read_next()
 
@@ -218,8 +222,9 @@ def test_eval_error_conditions(malformed_condition):
     #
     with pytest.raises(RuntimeError):
         qc = QueryCondition(malformed_condition)
+        schema = tiledb.open(uri).schema
         sr = clib.SOMAArray(uri)
-        sr.set_condition(qc)
+        sr.set_condition(qc, schema)
         sr.read_next()
 
 


### PR DESCRIPTION
**Issue and/or context:** 

Issue #1742. Necessary prerequisite for #1756.

**Changes:**

- Separate `set_condition` from `SOMAArray` constructor
- `init_query_condition` function no longer takes `config` argument; now replaced by `ArraySchema` and a mapping of enumeration labels to NumPy datatype
- Rename `query_condition.cc` module loader to `load_query_condition`
- `PyQueryCondition::combine` static method no longer takes a ctx argument. Instead it uses the global ctx created by the `PyQueryCondition` constructor
