### PR TITLE
[r] Tweak CI rules for extended runs for macOS (closes #1774)

### DIFF
--- a/apis/r/tests/testthat.R
+++ b/apis/r/tests/testthat.R
@@ -2,5 +2,4 @@ library(testthat)
 library(tiledbsoma)
 
 tiledbsoma::show_package_versions()
-# more verbose reporting:  test_check("tiledbsoma", reporter=default_reporter())
 test_check("tiledbsoma", reporter=default_reporter())

--- a/apis/r/tests/testthat/helper-test-tiledb-objects.R
+++ b/apis/r/tests/testthat/helper-test-tiledb-objects.R
@@ -14,7 +14,14 @@ create_empty_test_array <- function(uri) {
 extended_tests <- function() {
     ## check if at CI, if so extended test
     ## could add if pre-release number ie 1.4.3.1 instead of 1.4.3
-    Sys.getenv("CI", "") != ""
+    ci_set <- Sys.getenv("CI", "") != ""
+    ## check for macOS
+    macos <- Sys.info()["sysname"] == "Darwin"
+    ## check for possible override of 'force' or 'Force'
+    ci_override <- tolower(Sys.getenv("CI", "")) == "force"
+    ## run extended tests if CI is set, or if on macOS and 'force' has not been set
+    ## (ie setting 'force' will enable on macOS too)
+    ci_set && (!macos || ci_override)
 }
 
 covr_tests <- function() {

--- a/apis/r/tests/testthat/helper-test-tiledb-objects.R
+++ b/apis/r/tests/testthat/helper-test-tiledb-objects.R
@@ -19,7 +19,7 @@ extended_tests <- function() {
     macos <- Sys.info()["sysname"] == "Darwin"
     ## check for possible override of 'force' or 'Force'
     ci_override <- tolower(Sys.getenv("CI", "")) == "force"
-    ## run extended tests if CI is set, or if on macOS and 'force' has not been set
+    ## run extended tests if CI is set, and if either not macOS or 'force' has been set
     ## (ie setting 'force' will enable on macOS too)
     ci_set && (!macos || ci_override)
 }


### PR DESCRIPTION
**Issue and/or context:**

As noted in #1774, recent runs of CI on macOS experienced instability and failures we had not seen.  This PR aims to address these.
 
**Changes:**

We reduce the test surface for macOS in a way that is equivalent to the non-CI tests, while allowing an override option.

**Notes for Reviewer:**

[SC-35423](https://app.shortcut.com/tiledb-inc/story/35423/r-macos-ci-woes-of-late)
