### PR TITLE
Manually backport #1757

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Intended to be used for single-cell data, TileDB-SOMA provides Python and R APIs
 TileDB-SOMA provides interoperability with existing single-cell toolkits:
 
 * Load and create [AnnData](https://anndata.readthedocs.io/en/latest/) objects.
-* Load and create [Seurat](https://satijalab.org/seurat/) objects. *Coming soon*.
+* Load and create [Seurat](https://satijalab.org/seurat/) objects.
 
 TileDB-SOMA provides interoperability with existing Python or R data structures:
 


### PR DESCRIPTION
For some reason despite the tag `backport release-1.5` on #1757 we didn't get a backport. This is a manual replacement.