### PR TITLE
Manually backport #1779

### DIFF
--- a/apis/r/tests/testthat.R
+++ b/apis/r/tests/testthat.R
@@ -2,5 +2,4 @@ library(testthat)
 library(tiledbsoma)
 
 tiledbsoma::show_package_versions()
-# more verbose reporting:  test_check("tiledbsoma", reporter=default_reporter())
 test_check("tiledbsoma", reporter=default_reporter())

--- a/apis/r/tests/testthat/helper-test-tiledb-objects.R
+++ b/apis/r/tests/testthat/helper-test-tiledb-objects.R
@@ -14,7 +14,14 @@ create_empty_test_array <- function(uri) {
 extended_tests <- function() {
     ## check if at CI, if so extended test
     ## could add if pre-release number ie 1.4.3.1 instead of 1.4.3
-    Sys.getenv("CI", "") != ""
+    ci_set <- Sys.getenv("CI", "") != ""
+    ## check for macOS
+    macos <- Sys.info()["sysname"] == "Darwin"
+    ## check for possible override of 'force' or 'Force'
+    ci_override <- tolower(Sys.getenv("CI", "")) == "force"
+    ## run extended tests if CI is set, and if either not macOS or 'force' has been set
+    ## (ie setting 'force' will enable on macOS too)
+    ci_set && (!macos || ci_override)
 }
 
 covr_tests <- function() {


### PR DESCRIPTION
For some reason despite the tag `backport release-1.5` on #1779 we didn't get a backport. This is a manual replacement.