### PR TITLE
Backport #1690 to `release-1.4`

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -29,6 +29,7 @@ jobs:
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
+      is_mac: ${{ contains(matrix.os, 'macos') }}
       report_codecov: ${{ matrix.python-version == '3.10' }}
       run_lint: ${{ matrix.python-version == '3.10' }}
     secrets: inherit

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'release-*'
+  workflow_dispatch:
 
 env:
   COVERAGE_FLAGS: "r"
@@ -37,11 +38,28 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
-      - name: Install 'old' tiledb-r to satisfy its dependencies
-        run: cd apis/r && tools/r-ci.sh tiledb-r
+      - name: Install BioConductor package SingleCellExperiment
+        run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
 
-      - name: Install new tiledb-r 0.20.2
-        run: cd apis/r && Rscript -e 'if (Sys.info()[["sysname"]] == "Linux") bspm::disable(); install.packages("tiledb", repos = c("https://tiledb-inc.r-universe.dev", "https://cloud.r-project.org"))'
+      # The next two stanzas are necessary given propagation delay for binaries at
+      # https://r2u.stat.illinois.edu/ which may lack binaries (for short periods of usually a day)
+      # when sources have been updated. The default installation could switch to installation from
+      # sources --- but that would require installing all build dependencies. To see what the most
+      # recent binary is run e.g.  docker run --rm -ti rocker/r2u bash -c 'apt update -qq &&
+      # apt-cache show r-cran-tiledb' Using the r-universe builds (as below) is a suitable fallback
+      # as they update more frequently than CRAN.
+
+      # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
+      # which source is available but binaries are not yet:
+
+      #- name: Install r-universe build of tiledb-r (macOS)
+      #  if: ${{ matrix.os == 'macOS-latest' }}
+      #  run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
+
+      #   docker run --rm -ti rocker/r2u Rscript -e 'install.packages("tiledb")'
+      #- name: Install r-universe build of tiledb-r (linux)
+      #  if: ${{ matrix.os != 'macOS-latest' }}
+      #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
@@ -58,6 +76,9 @@ jobs:
       #- name: Call ldconfig
       #  if: ${{ matrix.os == 'ubuntu-latest' }}
       #  run: sudo ldconfig
+      #
+      - name: Update Packages
+        run: Rscript -e 'update.packages(ask=FALSE)'
 
       - name: Test
         if: ${{ matrix.covr == 'no' }}
@@ -65,6 +86,10 @@ jobs:
 
       - name: View Install Output
         run: cat $HOME/work/TileDB-SOMA/TileDB-SOMA/apis/r/tiledbsoma.Rcheck/00install.out
+        if: failure()
+
+      - name: View Test Output
+        run: cat $HOME/work/TileDB-SOMA/TileDB-SOMA/apis/r/tiledbsoma.Rcheck/00check.log
         if: failure()
 
       - name: Coverage

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
+      - name: Pin TileDB-R
+        run: Rscript -e 'remotes::install_github(repo="TileDB-Inc/TileDB-R@0.20.3")'
+
       - name: Test
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   COVERAGE_FLAGS: "r"
   COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   ci:

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -14,6 +14,9 @@ on:
       - 'release-*'
   workflow_dispatch:
 
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   ci:
     strategy:

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -41,13 +41,16 @@ jobs:
       - name: MkVars
         run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
-      - name: Install r-universe build of tiledb-r (macOS)
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
+      #- name: Install r-universe build of tiledb-r (macOS)
+      #  if: ${{ matrix.os == 'macOS-latest' }}
+      #  run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
+#
+      #- name: Install r-universe build of tiledb-r (linux)
+      #  if: ${{ matrix.os != 'macOS-latest' }}
+      #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
-      - name: Install r-universe build of tiledb-r (linux)
-        if: ${{ matrix.os != 'macOS-latest' }}
-        run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
+      - name: Pin TileDB-R
+        run: Rscript -e 'remotes::install_github(repo="TileDB-Inc/TileDB-R@0.20.3")'
 
       - name: Build and install libtiledbsoma
         run: sudo scripts/bld --prefix=/usr/local && sudo ldconfig

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -2,14 +2,17 @@ name: TileDB-SOMA R-Python interop testing
 
 on:
   pull_request:
-    paths:
-      - "apis/python/**"
-      - "apis/r/**"
-      - "apis/system/**"
+    # TODO: leave this enabled for pre-merge signal for now. At some point we may want to go back to
+    # only having this signal post-merge.
+    #paths:
+    #  - "apis/python/**"
+    #  - "apis/r/**"
+    #  - "apis/system/**"
   push:
     branches:
       - main
       - 'release-*'
+  workflow_dispatch:
 
 jobs:
   ci:
@@ -38,6 +41,14 @@ jobs:
       - name: MkVars
         run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
+      - name: Install r-universe build of tiledb-r (macOS)
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
+
+      - name: Install r-universe build of tiledb-r (linux)
+        if: ${{ matrix.os != 'macOS-latest' }}
+        run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
+
       - name: Build and install libtiledbsoma
         run: sudo scripts/bld --prefix=/usr/local && sudo ldconfig
 
@@ -47,6 +58,9 @@ jobs:
           R CMD build --no-build-vignettes --no-manual .
           FILE=$(ls -1t *.tar.gz | head -n 1)
           R CMD INSTALL $FILE
+
+      - name: Show R package versions
+        run: Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Install testing prereqs
         run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools
@@ -61,8 +75,13 @@ jobs:
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python
 
-      - name: Show package versions
-        run: python scripts/show-versions.py
+      - name: Show Python package versions
+        run: |
+          python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
+          python scripts/show-versions.py
+
+      - name: Update Packages
+        run: Rscript -e 'update.packages(ask=FALSE)'
 
       - name: Interop Tests
         run: python -m pytest apis/system/tests/

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -172,9 +172,12 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         """
         _util.check_type("values", values, (pa.Tensor,))
 
-        del platform_config  # Currently unused.
         self._handle.writer[coords] = values.to_numpy()
-        self._consolidate_and_vacuum_fragment_metadata()
+        tiledb_create_options = TileDBCreateOptions.from_platform_config(
+            platform_config
+        )
+        if tiledb_create_options.consolidate_and_vacuum:
+            self._consolidate_and_vacuum()
         return self
 
     @classmethod

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -143,6 +143,9 @@ class TileDBCreateOptions:
     attrs: Mapping[str, _ColumnConfig] = attrs_.field(
         factory=dict, converter=_normalize_columns
     )
+    consolidate_and_vacuum: bool = attrs_.field(
+        validator=vld.instance_of(bool), default=False
+    )
 
     @classmethod
     def from_platform_config(


### PR DESCRIPTION
Following https://github.com/single-cell-data/TileDB-SOMA/pull/1690#issuecomment-1766455633

To get green CI I needed to update R CI to install 0.20.3 which gets core 2.16, which is essential since 0.21/2.17 do now exist