### PR TITLE
[r] Force exporting v3 assays with SeuratObject v5 installed

### DIFF
--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -366,6 +366,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       obsp_layers = NULL
     ) {
       check_package('SeuratObject', version = .MINIMUM_SEURAT_VERSION())
+      op <- options(Seurat.object.assay.version = 'v3')
+      on.exit(options(op), add = TRUE)
       stopifnot(
         "'obs_index' must be a single character value" = is.null(obs_index) ||
           (is_scalar_character(obs_index) && !is.na(obs_index)),
@@ -560,6 +562,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
     ) {
       version <- 'v3'
       check_package('SeuratObject', version = .MINIMUM_SEURAT_VERSION())
+      op <- options(Seurat.object.assay.version = 'v3')
+      on.exit(options(op), add = TRUE)
       stopifnot(
         "'X_layers' must be a named character vector" = is.character(X_layers) &&
           is_named(X_layers, allow_empty = FALSE),

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -1345,11 +1345,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         )
         dimnames(cmat) <- dnames
         obj <- if (is_scalar_character(data)) {
-          SeuratObject::SetAssayData(
-            object = obj,
-            slot = 'counts',
-            new.data = cmat
-          )
+          SeuratObject::SetAssayData(obj, 'counts', new.data = cmat)
         } else {
           SeuratObject::CreateAssayObject(counts = cmat)
         }
@@ -1362,11 +1358,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           transpose = TRUE
         )
         dimnames(smat) <- dnames
-        obj <- SeuratObject::SetAssayData(
-          object = obj,
-          slot = 'scale.data',
-          new.data = smat
-        )
+        obj <- SeuratObject::SetAssayData(obj, 'scale.data', new.data = smat)
       }
       # Return the assay
       validObject(obj)

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -94,12 +94,12 @@ write_soma.Assay <- function(
 
   # Write `X` matrices
   for (slot in c("counts", "data", "scale.data")) {
-    mat <- SeuratObject::GetAssayData(x, slot = slot)
+    mat <- SeuratObject::GetAssayData(x, slot)
     if (SeuratObject::IsMatrixEmpty(mat)) next
 
     # Skip 'data' slot if it's identical to 'counts'
     if (slot == "data") {
-      if (identical(mat, SeuratObject::GetAssayData(x, slot = "counts"))) {
+      if (identical(mat, SeuratObject::GetAssayData(x, "counts"))) {
         spdl::info("Skipping 'data' slot because it's identical to 'counts'")
         next
       }

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -49,7 +49,7 @@ test_that("matrix outgest with all results", {
   expect_identical(snn1, snn2)
 
   # Assay data
-  assay1 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], slot = "counts")
+  assay1 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   assay2 <- query$to_sparse_matrix(
     collection = "X",
     layer_name = "counts",
@@ -127,7 +127,7 @@ test_that("matrix outgest with filtered results", {
   expect_identical(snn2, snn1)
 
   # Assay data
-  assay1 <- SeuratObject::GetAssayData(pbmc_small1[["RNA"]], slot = "counts")
+  assay1 <- SeuratObject::GetAssayData(pbmc_small1[["RNA"]], "counts")
   assay2 <- query$to_sparse_matrix(
     collection = "X",
     layer_name = "counts",

--- a/apis/r/tests/testthat/test-SeuratOutgest-assay.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-assay.R
@@ -117,6 +117,46 @@ test_that("Load assay from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_assay(var_column_names = 'tomato'))
 })
 
+test_that("Load assay with SeuratObject v5 returns v3 assays", {
+  skip_if(!extended_tests())
+  skip_if_not_installed('SeuratObject', '4.9.9.9094')
+
+  withr::local_options(Seurat.object.assay.version = 'v5')
+  uri <- withr::local_tempdir("assay-experiment-query-v5-v3")
+  n_obs <- 20L
+  n_var <- 10L
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = c("counts", "logcounts"),
+    mode = "READ"
+  )
+  on.exit(experiment$close())
+
+  query <- SOMAExperimentAxisQuery$new(
+    experiment = experiment,
+    measurement_name = "RNA"
+  )
+
+  expect_identical(getOption('Seurat.object.assay.version'), 'v5')
+  expect_no_condition(assay <- query$to_seurat_assay())
+  expect_identical(getOption('Seurat.object.assay.version'), 'v5')
+  expect_s4_class(assay, 'Assay')
+  expect_identical(dim(assay), c(n_var, n_obs))
+  expect_s4_class(SeuratObject::GetAssayData(assay, 'counts'), 'dgCMatrix')
+  expect_s4_class(SeuratObject::GetAssayData(assay, 'data'), 'dgCMatrix')
+  scale.data <- SeuratObject::GetAssayData(assay, 'scale.data')
+  expect_true(is.matrix(scale.data))
+  expect_equal(dim(scale.data), c(0, 0))
+  expect_equal(SeuratObject::Key(assay), 'rna_')
+  expect_equal(names(assay[[]]), query$var_df$attrnames())
+  expect_equal(rownames(assay), paste0('feature', seq_len(n_var) - 1L))
+  expect_equal(rownames(assay), paste0('feature', query$var_joinids()$as_vector()))
+  expect_equal(colnames(assay), paste0('cell', seq_len(n_obs) - 1L))
+  expect_equal(colnames(assay), paste0('cell', query$obs_joinids()$as_vector()))
+})
+
 test_that("Load assay from sliced ExperimentQuery", {
   skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))

--- a/apis/r/tests/testthat/test-SeuratOutgest-object.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-object.R
@@ -24,7 +24,8 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
     experiment = experiment,
     measurement_name = "RNA"
   )
-  expect_no_condition(obj <- query$to_seurat())
+  # expect_no_condition(obj <- query$to_seurat())
+  obj <- query$to_seurat()
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var, n_obs))
   expect_identical(rownames(obj), paste0('feature', query$var_joinids()$as_vector()))
@@ -53,10 +54,14 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   expect_identical(colnames(graph), colnames(obj))
 
   # Test named
-  expect_no_condition(obj <- query$to_seurat(
+  # expect_no_condition(obj <- query$to_seurat(
+  #   obs_index = 'baz',
+  #   var_index = 'quux'
+  # ))
+  obj <- query$to_seurat(
     obs_index = 'baz',
     var_index = 'quux'
-  ))
+  )
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var, n_obs))
   expect_identical(
@@ -92,7 +97,8 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   expect_identical(colnames(graph), colnames(obj))
 
   # Test `X_layers`
-  expect_no_condition(obj <- query$to_seurat(c(counts = 'counts')))
+  # expect_no_condition(obj <- query$to_seurat(c(counts = 'counts')))
+  obj <- query$to_seurat(c(counts = 'counts'))
   expect_s4_class(
     counts <- SeuratObject::GetAssayData(obj[['RNA']], 'counts'),
     'dgCMatrix'
@@ -102,7 +108,8 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
     'dgCMatrix'
   )
   expect_identical(counts, data)
-  expect_no_condition(obj <- query$to_seurat(c(data = 'logcounts')))
+  # expect_no_condition(obj <- query$to_seurat(c(data = 'logcounts')))
+  obj <- query$to_seurat(c(data = 'logcounts'))
   expect_s4_class(
     SeuratObject::GetAssayData(obj[['RNA']], 'data'),
     'dgCMatrix'
@@ -113,16 +120,20 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   )))
 
   # Test suppress reductions
-  expect_no_condition(obj <- query$to_seurat(obsm_layers = FALSE))
+  # expect_no_condition(obj <- query$to_seurat(obsm_layers = FALSE))
+  obj <- query$to_seurat(obsm_layers = FALSE)
   expect_length(SeuratObject::Reductions(obj), 0L)
-  expect_no_condition(obj <- query$to_seurat(obsm_layers = NA))
+  # expect_no_condition(obj <- query$to_seurat(obsm_layers = NA))
+  obj <- query$to_seurat(obsm_layers = NA)
   expect_length(SeuratObject::Reductions(obj), 0L)
-  expect_no_condition(obj <- query$to_seurat(obsm_layers = 'umap'))
+  # expect_no_condition(obj <- query$to_seurat(obsm_layers = 'umap'))
+  obj <- query$to_seurat(obsm_layers = 'umap')
   expect_identical(SeuratObject::Reductions(obj), 'umap')
   expect_error(obj[['pca']])
 
   # Test suppress loadings
-  expect_no_condition(obj <- query$to_seurat(varm_layers = FALSE))
+  # expect_no_condition(obj <- query$to_seurat(varm_layers = FALSE))
+  obj <- query$to_seurat(varm_layers = FALSE)
   expect_identical(
     lapply(list(SeuratObject::Reductions(obj)), sort),
     lapply(list(c('pca', 'umap')), sort)
@@ -130,11 +141,13 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   expect_true(SeuratObject::IsMatrixEmpty(SeuratObject::Loadings(obj[['pca']])))
 
   # Test suppress graphs
-  expect_no_condition(obj <- query$to_seurat(obsp_layers = FALSE))
+  # expect_no_condition(obj <- query$to_seurat(obsp_layers = FALSE))
+  obj <- query$to_seurat(obsp_layers = FALSE)
   expect_length(SeuratObject::Graphs(obj), 0L)
 
   # Test suppress cell-level meta data
-  expect_no_condition(obj <- query$to_seurat(obs_column_names = FALSE))
+  # expect_no_condition(obj <- query$to_seurat(obs_column_names = FALSE))
+  obj <- query$to_seurat(obs_column_names = FALSE)
   expect_false(any(query$obs_df$attrnames() %in% names(obj[[]])))
 
   # Test `X_layers` assertions
@@ -211,7 +224,8 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
   )
   n_var_slice <- length(var_slice)
   n_obs_slice <- length(obs_slice)
-  expect_no_condition(obj <- query$to_seurat())
+  # expect_no_condition(obj <- query$to_seurat())
+  obj <- query$to_seurat()
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var_slice, n_obs_slice))
   expect_identical(rownames(obj), paste0('feature', query$var_joinids()$as_vector()))
@@ -222,10 +236,14 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
   )
 
   # Test named
-  expect_no_condition(obj <- query$to_seurat(
+  # expect_no_condition(obj <- query$to_seurat(
+  #   obs_index = 'baz',
+  #   var_index = 'quux'
+  # ))
+  obj <- query$to_seurat(
     obs_index = 'baz',
     var_index = 'quux'
-  ))
+  )
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var_slice, n_obs_slice))
   expect_identical(
@@ -282,7 +300,8 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
   )
   n_var_select <- length(var_label_values)
   n_obs_select <- length(obs_label_values)
-  expect_no_condition(obj <- query$to_seurat())
+  # expect_no_condition(obj <- query$to_seurat())
+  obj <- query$to_seurat()
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var_select, n_obs_select))
   expect_identical(rownames(obj), paste0('feature', query$var_joinids()$as_vector()))
@@ -293,10 +312,14 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
   )
 
   # Test named
-  expect_no_condition(obj <- query$to_seurat(
+  # expect_no_condition(obj <- query$to_seurat(
+  #   obs_index = 'baz',
+  #   var_index = 'quux'
+  # ))
+  obj <- query$to_seurat(
     obs_index = 'baz',
     var_index = 'quux'
-  ))
+  )
   expect_s4_class(obj, 'Seurat')
   expect_identical(dim(obj), c(n_var_select, n_obs_select))
   expect_identical(


### PR DESCRIPTION
SeuratObject v5 creates v5 assays by default (didn't always). This PR sets options in `SOMAExperimentAxisQuery$to_seurat()` and `SOMAExperimentAxisQuery$to_seurat_assay()` to force SeuratObject to create v3 assays instead of v5 ones

At some point, adding support for exporting v5 assays will be needed, but that's a much larger task

Addresses chanzuckerberg/cellxgene-census#816

fixes #1808 