### PR TITLE
[python] Support default-coord reads of corner-written dense ND arrays

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple
 
 import pyarrow as pa
 import somacore
+import tiledb
 from somacore import options
 from typing_extensions import Self
 
@@ -71,6 +72,18 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
     __slots__ = ()
 
+    def non_empty_domain(self) -> Tuple[Tuple[int, int], ...]:
+        """
+        Retrieves the non-empty domain for each dimension, namely the smallest
+        and largest indices in each dimension for which the sparse array has
+        data occupied.  This is nominally the same as the domain used at
+        creation time, but if for example only a corner of the available domain
+        has actually had data written, this function will return a tighter
+        range.
+        """
+        with tiledb.open(self.uri, ctx=self.context.tiledb_ctx) as A:
+            return A.nonempty_domain()  # type: ignore
+
     def read(
         self,
         coords: options.DenseNDCoords = (),
@@ -108,8 +121,23 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         self._check_open_read()
         result_order = somacore.ResultOrder(result_order)
 
-        schema = self._handle.schema
-        target_shape = dense_indices_to_shape(coords, schema.shape, result_order)
+        # The dense_indices_to_shape includes, as one of its roles, how to handle default
+        # coordinates -- e.g. `dnda.read()`. The default for a DenseNDArray should be "all the data"
+        # -- but what is that? If the schema shape matches the non-empty domain -- e.g. at create,
+        # shape was 100x200, and at write, 100x200 cells were written, those are both the same. But
+        # if the array was written with room for growth -- e.g. created with shape
+        # 1,000,000x1,000,000 but only 100x200 cells were written -- then we need the non-empty
+        # domain.
+        #
+        # The non-empty domain is the corret choice in either case.
+        #
+        # The only exception is if the array has been created but no data have been written at
+        # all, in which case the best we can do is use the schema shape.
+        data_shape = self._handle.schema.shape
+        ned = self.non_empty_domain()
+        if ned is not None:
+            data_shape = tuple(slot[1] + 1 for slot in ned)
+        target_shape = dense_indices_to_shape(coords, data_shape, result_order)
 
         sr = self._soma_reader(result_order=result_order)
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -11,7 +11,6 @@ from typing import Optional, Tuple
 
 import pyarrow as pa
 import somacore
-import tiledb
 from somacore import options
 from typing_extensions import Self
 
@@ -71,18 +70,6 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     """
 
     __slots__ = ()
-
-    def non_empty_domain(self) -> Tuple[Tuple[int, int], ...]:
-        """
-        Retrieves the non-empty domain for each dimension, namely the smallest
-        and largest indices in each dimension for which the sparse array has
-        data occupied.  This is nominally the same as the domain used at
-        creation time, but if for example only a corner of the available domain
-        has actually had data written, this function will return a tighter
-        range.
-        """
-        with tiledb.open(self.uri, ctx=self.context.tiledb_ctx) as A:
-            return A.nonempty_domain()  # type: ignore
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -342,17 +342,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             retval[i] = (min(ned_lower, bbox_lower), max(ned_upper, bbox_upper))
         return tuple(retval)
 
-    def non_empty_domain(self) -> Tuple[Tuple[int, int], ...]:
-        """
-        Retrieves the non-empty domain for each dimension, namely the smallest and
-        largest indices in each dimension for which the sparse array has data occupied.
-        This is nominally the same as ``used_shape``, but if for example the
-        leading/trailing rows/columns of the sparse array are entirely unoccupied, this
-        function will return a tighter range.
-        """
-        with tiledb.open(self.uri, ctx=self.context.tiledb_ctx) as A:
-            return A.nonempty_domain()  # type: ignore
-
     def _compute_bounding_box_metadata(
         self,
         maxes: Sequence[int],

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -18,6 +18,7 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -192,6 +193,17 @@ class ArrayWrapper(Wrapper[tiledb.Array]):
     @property
     def schema(self) -> tiledb.ArraySchema:
         return self._handle.schema
+
+    def non_empty_domain(self) -> Tuple[Tuple[int, int], ...]:
+        """
+        Retrieves the non-empty domain for each dimension, namely the smallest
+        and largest indices in each dimension for which the array/dataframe has
+        data occupied.  This is nominally the same as the domain used at
+        creation time, but if for example only a portion of the available domain
+        has actually had data written, this function will return a tighter
+        range.
+        """
+        return self._handle.nonempty_domain()  # type: ignore
 
 
 @attrs.define(frozen=True)

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -74,8 +74,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         has actually had data written, this function will return a tighter
         range.
         """
-        with tiledb.open(self.uri, ctx=self.context.tiledb_ctx) as A:
-            return A.nonempty_domain()  # type: ignore
+        return self._handle.non_empty_domain()
 
     def _tiledb_array_schema(self) -> tiledb.ArraySchema:
         """Returns the TileDB array schema, for internal use."""

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -65,6 +65,18 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         """
         return tiledb_schema_to_arrow(self._tiledb_array_schema(), self.uri, self._ctx)
 
+    def non_empty_domain(self) -> Tuple[Tuple[int, int], ...]:
+        """
+        Retrieves the non-empty domain for each dimension, namely the smallest
+        and largest indices in each dimension for which the array/dataframe has
+        data occupied.  This is nominally the same as the domain used at
+        creation time, but if for example only a portion of the available domain
+        has actually had data written, this function will return a tighter
+        range.
+        """
+        with tiledb.open(self.uri, ctx=self.context.tiledb_ctx) as A:
+            return A.nonempty_domain()  # type: ignore
+
     def _tiledb_array_schema(self) -> tiledb.ArraySchema:
         """Returns the TileDB array schema, for internal use."""
         return self._handle.schema

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -132,6 +132,23 @@ def test_dense_nd_array_requires_shape(tmp_path, shape_is_numeric):
             soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
 
 
+def test_dense_nd_array_ned_write(tmp_path):
+    uri = tmp_path.as_posix()
+
+    with soma.DenseNDArray.create(
+        uri=uri,
+        type=pa.int32(),
+        shape=[1000000],
+    ) as dnda:
+        dnda.write(
+            (slice(0, 4),),
+            pa.Tensor.from_numpy(np.asarray([100, 101, 102, 103])),
+        )
+
+    with soma.DenseNDArray.open(uri) as dnda:
+        assert (dnda.read().to_numpy() == np.asarray([100, 101, 102, 103])).all()
+
+
 @pytest.mark.parametrize(
     "io",
     [


### PR DESCRIPTION
**Issue and/or context:** In support of PR #1768 with issue #1769.

Needles to thread for `update_uns`:

The existing `tiledbsoma.io.update_obs`, `tiledbsoma.io.update_var`, `tiledbsoma.io.add_X_layer` methods all take as argument a `tiledbsoma.Experiment` which is already open for writing. Goal: do the same for `tiledbsoma.io.update_uns`.

Common use-case:
* Ingest data from AnnData to SOMA
* Outgest to AnnData; run ScanPy, curation, etc
* Write the updates back to SOMA

Technical factors:
* Whereas all the `X`, `obsm`, `varm`, `obsp`, `varp` are `SparseNDArray`, `uns` can contain `DenseNDArray` which are ingested from `numpy.ndarray`
* If the after-uns has `numpy.ndarray` that the before-uns didn't (new data on update), there is no problem
* If the after-uns has `numpy.ndarray` of the same dimensions as the before-uns, there is no problem
* Schema evolution does not support modification of dense domains
* We can try delete-and-re-add:
  * `tiledb.Array.delete_array` of the array accompanied by tiledb-group operations to delete the key/URI pair and re-add the key/URI pair
  * Note that for local-disk and S3, the new URI will be the same as the old URI; for cloud the new and old URIs will always be different URIs
  * Problem with that: we cannot delete-and-re-add at the same timestamp
  * If we do `del collection[key]` and `collection[key] = new_dense_nd_array` then we get `tiledbsoma._exception.SOMAError: replacing key 'a' is unsupported` which is a check that must remain (see links below)
* Also we cannot do: del collection[key], close the collection, and re-open at the same timestamp because of
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.5.0rc2/apis/python/src/tiledbsoma/_collection.py#L567-L570
  * https://github.com/single-cell-data/TileDB-SOMA/pull/957
  * https://github.com/single-cell-data/TileDB-SOMA/issues/919
* We could have `update_uns` do two opens-for-write: one to remove any shape-changing dense arrays, and one shifted by a millisecond to do the rest of the work
  * However this would mean `tiledbsoma.io.update_uns` would take a URI as first argument, different from all the other updaters in `tiledbsoma.io` which take an `Experiment` opened for write as first argument

Good feedback from @isaiah and @seth: simply have `tiledbsoma.io`'s `uns`-ingestion logic write bigger-than-necessary arrays for dense ND arrays -- as we already do for sparse.

This is compliant with the [SOMA specification](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md#indexing-and-slicing).

**Changes:** As above.

**Notes for Reviewer:**

