### PR TITLE
[c++] Correct `results_complete`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -176,6 +176,8 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::submit_read() {
     // complete.
     if (status == Query::Status::INCOMPLETE) {
         results_complete_ = false;
+    } else if (status == Query::Status::COMPLETE) {
+        results_complete_ = true;
     }
 
     // Update ColumnBuffer size to match query results

--- a/libtiledbsoma/test/test_soma_array.py
+++ b/libtiledbsoma/test/test_soma_array.py
@@ -53,14 +53,10 @@ def test_soma_array_var_x_data():
     # The := "walrus" operator is really the appropriate thing here, but alas, is not
     # supported in Python 3.7 which we do wish to preserve compatibility with.
     # while arrow_table := sr.read_next():
-    while True:
+    while not sr.results_complete():
         arrow_table = sr.read_next()
-        if not arrow_table:
-            break
         total_num_rows += arrow_table.num_rows
 
-    # test that all results are not present in the arrow table (incomplete queries)
-    assert not sr.results_complete()
     assert total_num_rows == 4848644
 
 


### PR DESCRIPTION
**Issue and/or context:**

[sc-35642]

**Changes:**

* After setting `results_complete = false` for incomplete queries, the variable was not updated to `true` once it completed
