### PR TITLE
[c++] Avoid intermittent CI fail building `catch2`

### DIFF
--- a/libtiledbsoma/cmake/Modules/FindCatch_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindCatch_EP.cmake
@@ -9,7 +9,7 @@ Include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.1
+  GIT_TAG        v3.4.0
 )
 
 cmake_host_system_information(RESULT OS_RELEASE QUERY OS_RELEASE)


### PR DESCRIPTION
As on https://github.com/single-cell-data/TileDB-SOMA/actions/runs/6640942410/job/18042371782

Advice from @davisp given https://github.com/catchorg/Catch2/commit/52066dbc2a53f4c3ab2a418d03f93200a8245451