### PR TITLE
[python] Handle string columns with all-NaN values

### DIFF
--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -201,14 +201,12 @@ def df_to_arrow(df: pd.DataFrame) -> pa.Table:
                 # math.NaN, for which pa.infer_type fails with "Could not
                 # convert <NA> with type NAType".
                 #
-                # Problem: with
+                # Note: with
                 #   anndata.obs['new_col'] = pd.Series(data=np.nan, dtype=np.dtype(str))
                 # the dtype comes in to us via `tiledbsoma.io.from_anndata` not
-                # as `pd.StringDtype()` but rather as `object`, so, the
-                # if-branch is not taken. :(
-                if df[k].dtype == pd.StringDtype():
+                # as `pd.StringDtype()` but rather as `object`.
+                if df[k].dtype == pd.StringDtype() or df[k].dtype.name == 'object':
                     df[k] = pd.Series([None] * df.shape[0], dtype=pd.StringDtype())
-                    pass
                 else:
                     df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))
             else:

--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -205,7 +205,7 @@ def df_to_arrow(df: pd.DataFrame) -> pa.Table:
                 #   anndata.obs['new_col'] = pd.Series(data=np.nan, dtype=np.dtype(str))
                 # the dtype comes in to us via `tiledbsoma.io.from_anndata` not
                 # as `pd.StringDtype()` but rather as `object`.
-                if df[k].dtype == pd.StringDtype() or df[k].dtype.name == 'object':
+                if df[k].dtype == pd.StringDtype() or df[k].dtype.name == "object":
                     df[k] = pd.Series([None] * df.shape[0], dtype=pd.StringDtype())
                 else:
                     df[k] = pa.nulls(df.shape[0], pa.infer_type(df[k]))

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -934,3 +934,31 @@ def test_uns_io(tmp_path, outgest_uns_keys):
 
     else:
         assert set(b.keys()) == set(outgest_uns_keys)
+
+@pytest.mark.parametrize("write_index", [0, 1])
+def test_string_nan_columns(tmp_path, adata, write_index):
+    # Use case:
+    #
+    # 1. Anndata has column filled with np.nan
+    # 2. Import AnnData to SOMA
+    # 3. Export SOMA back to AnnData
+    # 4. Fill all/part of empty column with string values
+
+    # Step 1
+    adata.obs['new_col'] = pd.Series(data=np.nan, dtype=np.dtype(str))
+
+    # Step 2
+    uri = tmp_path.as_posix()
+    tiledbsoma.io.from_anndata(uri, adata, measurement_name='RNA')
+
+    # Step 3
+    with tiledbsoma.open(uri, 'r') as exp:
+        bdata = tiledbsoma.io.to_anndata(exp, measurement_name='RNA')
+
+    # Step 4
+    bdata.obs['new_col'][write_index] = 'abc'
+    with tiledbsoma.open(uri, 'w') as exp:
+        # Implicit assert here that nothing throws
+        tiledbsoma.io.update_obs(exp, bdata.obs)
+
+    # TODO: asserts

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -935,6 +935,7 @@ def test_uns_io(tmp_path, outgest_uns_keys):
     else:
         assert set(b.keys()) == set(outgest_uns_keys)
 
+
 @pytest.mark.parametrize("write_index", [0, 1])
 def test_string_nan_columns(tmp_path, adata, write_index):
     # Use case:
@@ -945,19 +946,19 @@ def test_string_nan_columns(tmp_path, adata, write_index):
     # 4. Fill all/part of empty column with string values
 
     # Step 1
-    adata.obs['new_col'] = pd.Series(data=np.nan, dtype=np.dtype(str))
+    adata.obs["new_col"] = pd.Series(data=np.nan, dtype=np.dtype(str))
 
     # Step 2
     uri = tmp_path.as_posix()
-    tiledbsoma.io.from_anndata(uri, adata, measurement_name='RNA')
+    tiledbsoma.io.from_anndata(uri, adata, measurement_name="RNA")
 
     # Step 3
-    with tiledbsoma.open(uri, 'r') as exp:
-        bdata = tiledbsoma.io.to_anndata(exp, measurement_name='RNA')
+    with tiledbsoma.open(uri, "r") as exp:
+        bdata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
 
     # Step 4
-    bdata.obs['new_col'][write_index] = 'abc'
-    with tiledbsoma.open(uri, 'w') as exp:
+    bdata.obs["new_col"][write_index] = "abc"
+    with tiledbsoma.open(uri, "w") as exp:
         # Implicit assert here that nothing throws
         tiledbsoma.io.update_obs(exp, bdata.obs)
 


### PR DESCRIPTION
**Issue and/or context:** WIP-only in the context of https://github.com/TileDB-Inc/TileDB-Py/pull/1848 especially https://github.com/TileDB-Inc/TileDB-Py/pull/1848#issuecomment-1782023905. cc @nguyenv.

**Changes:**

**Notes for Reviewer:** Passes with https://github.com/TileDB-Inc/TileDB-Py/pull/1848 installed localy. Will pass CI once we depend on TileDB-Py 0.23.4.