### PR TITLE
[c++/python] Expanded enumeration support in `ArrowAdapter::to_arrow`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -429,6 +429,11 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     # only extend if there are new values
                     if update_vals:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
+                        if not (
+                            np.issubdtype(enmr.dtype.type, np.str_)
+                            or np.issubdtype(enmr.dtype.type, np.bytes_)
+                        ):
+                            update_vals = np.array(update_vals, enmr.dtype)
                         new_enmr = enmr.extend(update_vals)
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -420,7 +420,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
                     enmr = self._handle.enum(attr.name)
 
-                    # get new enumeration values
+                    # get new enumeration values, maintain original ordering
                     update_vals = []
                     for new_val in col.chunk(0).dictionary.tolist():
                         if new_val not in enmr.values():
@@ -429,12 +429,13 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     # only extend if there are new values
                     if update_vals:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
-                        if not (
-                            np.issubdtype(enmr.dtype.type, np.str_)
-                            or np.issubdtype(enmr.dtype.type, np.bytes_)
-                        ):
-                            update_vals = np.array(update_vals, enmr.dtype)
-                        new_enmr = enmr.extend(update_vals)
+                        if np.issubdtype(enmr.dtype.type, np.str_):
+                            extend_vals = np.array(update_vals, "U")
+                        elif np.issubdtype(enmr.dtype.type, np.bytes_):
+                            extend_vals = np.array(update_vals, "S")
+                        else:
+                            extend_vals = np.array(update_vals, enmr.dtype)
+                        new_enmr = enmr.extend(extend_vals)
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -199,7 +199,7 @@ py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {
 
     for (auto& name : buffers->names()) {
         auto column = buffers->at(name);
-        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(column, true);
+        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(column);
         auto array = pa_array_import(py::capsule(pa_array.get()), 
                                      py::capsule(pa_schema.get()));
         array_list.append(array);

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -183,51 +183,41 @@ bool get_enum_is_ordered(SOMAArray& sr, std::string attr_name){
 }
 
 /**
- * @brief Convert ColumnBuffer to Arrow array.
- *
- * @param column_buffer ColumnBuffer
- * @return py::object Arrow array
- */
-py::object to_array(std::shared_ptr<ColumnBuffer> column_buffer) {
-    auto pa = py::module::import("pyarrow");
-    auto pa_array_import = pa.attr("Array").attr("_import_from_c");
-
-    auto [array, schema] = ArrowAdapter::to_arrow(column_buffer);
-    return pa_array_import(py::capsule(array.get()), py::capsule(schema.get()));
-}
-
-/**
  * @brief Convert ArrayBuffers to Arrow table.
  *
  * @param cbs ArrayBuffers
  * @return py::object
  */
-py::object to_table(SOMAArray& sr, std::shared_ptr<ArrayBuffers> array_buffers) {
+py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {
     auto pa = py::module::import("pyarrow");
     auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
-    auto pa_dict_from_arrays = pa.attr("DictionaryArray").attr("from_arrays");
+    auto pa_array_import = pa.attr("Array").attr("_import_from_c");
+    auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");
 
+    py::list array_list;
     py::list names;
-    py::list arrays;
 
-    for (auto& name : array_buffers->names()) {
-        auto column = array_buffers->at(name);
+    for (auto& name : buffers->names()) {
+        auto column = buffers->at(name);
+        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(column, true);
+        auto array = pa_array_import(py::capsule(pa_array.get()), 
+                                     py::capsule(pa_schema.get()));
+        array_list.append(array);
         names.append(name);
-
-        if(sr.get_attr_to_enum_mapping().count(name) == 0){
-            arrays.append(to_array(column));
-        }else{
-            arrays.append(pa_dict_from_arrays(
-                to_array(column),
-                get_enum(sr, name),
-                py::none(),
-                get_enum_is_ordered(sr, name)));
-        }
     }
 
-    auto pa_table = pa_table_from_arrays(arrays, names);
+    return pa_table_from_arrays(array_list, names);
+}
 
-    return pa_table;
+std::optional<py::object> to_table(
+    std::optional<std::shared_ptr<ArrayBuffers>> buffers){
+    // If more data was read, convert it to an arrow table and return
+    if (buffers.has_value()) {
+        return _buffer_to_table(*buffers);
+    }
+
+    // No data was read, the query is complete, return nullopt
+    return std::nullopt;
 }
 
 /**
@@ -681,7 +671,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                 if (buffers.has_value()) {
                     // Acquire python GIL before accessing python objects
                     py::gil_scoped_acquire acquire;
-                    return to_table(reader, *buffers);
+                    return to_table(*buffers);
                 }
 
                 // No data was read, the query is complete, return nullopt

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -147,7 +147,7 @@ Rcpp::List soma_array_reader(const std::string& uri,
         auto buf = sr_data->get()->at(names[i]);
 
         // this is pair of array and schema pointer
-        auto pp = tdbs::ArrowAdapter::to_arrow(buf, true);
+        auto pp = tdbs::ArrowAdapter::to_arrow(buf);
 
         memcpy((void*) chldschemaxp, pp.second.get(), sizeof(ArrowSchema));
         memcpy((void*) chldarrayxp, pp.first.get(), sizeof(ArrowArray));

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -215,7 +215,7 @@ Rcpp::List sr_next(Rcpp::XPtr<tdbs::SOMAArray> sr) {
        auto buf = sr_data->get()->at(names[i]);
 
        // this is pair of array and schema pointer
-       auto pp = tdbs::ArrowAdapter::to_arrow(buf, true);
+       auto pp = tdbs::ArrowAdapter::to_arrow(buf);
 
        memcpy((void*) chldschemaxp, pp.second.get(), sizeof(ArrowSchema));
        memcpy((void*) chldarrayxp, pp.first.get(), sizeof(ArrowArray));

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -237,7 +237,7 @@ class ColumnBuffer {
         return is_nullable_;
     }
 
-    std::optional<Enumeration> get_enumeration() const {
+    std::optional<Enumeration> get_enumeration_info() const {
         return enumeration_;
     }
 

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -179,7 +179,7 @@ std::pair<const void*, std::size_t> ArrowAdapter::_get_data_and_length(
 }
 
 std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
-ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
+ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
     std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
 
@@ -249,7 +249,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
         column->data_to_bitmap();
     }
 
-    if (column->has_enumeration() && use_enum) {
+    if (column->has_enumeration()) {
         ArrowSchema* dict_sch = new ArrowSchema;
         ArrowArray* dict_arr = new ArrowArray;
 

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -41,6 +41,19 @@ using namespace tiledb;
 void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
     schema->release = nullptr;
 
+    for (int i = 0; i < schema->n_children; ++i) {
+        struct ArrowSchema* child = schema->children[i];
+        if (schema->name != nullptr) {
+            free((void*)schema->name);
+            schema->name = nullptr;
+        }
+        if (child->release != NULL) {
+            child->release(child);
+        }
+        free(child);
+    }
+    free(schema->children);
+
     struct ArrowSchema* dict = schema->dictionary;
     if (dict != nullptr) {
         if (dict->format != nullptr) {
@@ -88,20 +101,97 @@ void ArrowAdapter::release_array(struct ArrowArray* array) {
     array->release = nullptr;
 }
 
+std::pair<const void*, std::size_t> ArrowAdapter::_get_data_and_length(
+    Enumeration& enmr, const void* dst) {
+    switch (enmr.type()) {
+        case TILEDB_BOOL: {
+            // We must handle this specially because vector<bool> does
+            // not store elements contiguously in memory
+            auto data = enmr.as_vector<bool>();
+
+            // Represent the Boolean vector with, at most, the last two
+            // bits. In Arrow, Boolean values are LSB packed
+            uint8_t src = 0;
+            for (size_t i = 0; i < data.size(); ++i)
+                src |= (data[i] << i);
+
+            // Allocate a single byte to copy the bits into
+            size_t sz = 1;
+            dst = (const void*)malloc(sz);
+            std::memcpy((void*)dst, &src, sz);
+
+            return std::pair(dst, data.size());
+        }
+        case TILEDB_INT8: {
+            auto data = enmr.as_vector<int8_t>();
+            return std::pair(_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_UINT8: {
+            auto data = enmr.as_vector<uint8_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_INT16: {
+            auto data = enmr.as_vector<int16_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_UINT16: {
+            auto data = enmr.as_vector<uint16_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_INT32: {
+            auto data = enmr.as_vector<int32_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_UINT32: {
+            auto data = enmr.as_vector<uint32_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_INT64: {
+            auto data = enmr.as_vector<int64_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_UINT64: {
+            auto data = enmr.as_vector<uint64_t>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_FLOAT32: {
+            auto data = enmr.as_vector<float>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        case TILEDB_FLOAT64: {
+            auto data = enmr.as_vector<double>();
+            return std::pair(
+                ArrowAdapter::_fill_data_buffer(data, dst), data.size());
+        }
+        default:
+            throw TileDBSOMAError(fmt::format(
+                "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
+                tiledb::impl::type_to_str(enmr.type())));
+    }
+}
+
 std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
 ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
     std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
     std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
 
-    schema->format = to_arrow_format(column->type()).data();  // mandatory
-    schema->name = column->name().data();                     // optional
-    schema->metadata = nullptr;                               // optional
-    schema->flags = 0;                                        // optional
-    schema->n_children = 0;                                   // mandatory
-    schema->children = nullptr;                               // optional
-    schema->dictionary = nullptr;                             // optional
-    schema->release = &release_schema;                        // mandatory
-    schema->private_data = nullptr;                           // optional
+    schema->format = to_arrow_format(column->type()).data();
+    schema->name = column->name().data();
+    schema->metadata = nullptr;
+    schema->flags = 0;
+    schema->n_children = 0;
+    schema->children = nullptr;
+    schema->dictionary = nullptr;
+    schema->release = &release_schema;
+    schema->private_data = nullptr;
 
     int n_buffers = column->is_var() ? 3 : 2;
 
@@ -114,16 +204,16 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
     //   reaches 0, the ColumnBuffer data will be deleted.
     auto arrow_buffer = new ArrowBuffer(column);
 
-    array->length = column->size();             // mandatory
-    array->null_count = 0;                      // mandatory
-    array->offset = 0;                          // mandatory
-    array->n_buffers = n_buffers;               // mandatory
-    array->n_children = 0;                      // mandatory
-    array->buffers = nullptr;                   // mandatory
-    array->children = nullptr;                  // optional
-    array->dictionary = nullptr;                // optional
-    array->release = &release_array;            // mandatory
-    array->private_data = (void*)arrow_buffer;  // mandatory
+    array->length = column->size();
+    array->null_count = 0;
+    array->offset = 0;
+    array->n_buffers = n_buffers;
+    array->n_children = 0;
+    array->buffers = nullptr;
+    array->children = nullptr;
+    array->dictionary = nullptr;
+    array->release = &release_array;
+    array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(fmt::format(
         "[ArrowAdapter] create array name='{}' use_count={}",
@@ -159,46 +249,56 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
         column->data_to_bitmap();
     }
 
-    // If we have an enumeration, fill a dictionary.
-    // The Python callpath handles this separately. The R callpath needs us
-    // to do this. TODO: uniformize this at the callsites.
     if (column->has_enumeration() && use_enum) {
-        auto enumvec = column->get_enumeration();
-
         ArrowSchema* dict_sch = new ArrowSchema;
         ArrowArray* dict_arr = new ArrowArray;
 
-        dict_sch->format = (const char*)malloc(
-            sizeof(char) * 2);  // mandatory, 'u' as 32bit indexing
-        strcpy((char*)dict_sch->format, "u");
-        dict_sch->name = nullptr;             // optional in dictionary
-        dict_sch->metadata = nullptr;         // optional
-        dict_sch->flags = 0;                  // optional
-        dict_sch->n_children = 0;             // mandatory
-        dict_sch->children = nullptr;         // optional
-        dict_sch->dictionary = nullptr;       // optional
-        dict_sch->release = &release_schema;  // mandatory
-        dict_sch->private_data = nullptr;     // optional
+        auto enmr = column->get_enumeration_info();
+        dict_sch->format = strdup(to_arrow_format(enmr->type(), false).data());
+        dict_sch->name = strdup(enmr->name().c_str());
+        dict_sch->metadata = nullptr;
+        dict_sch->flags = 0;
+        dict_sch->n_children = 0;
+        dict_sch->children = nullptr;
+        dict_sch->dictionary = nullptr;
+        dict_sch->release = &release_schema;
+        dict_sch->private_data = nullptr;
 
-        const int n_buf = 3;  // always variable here
+        const int n_buf = strcmp(dict_sch->format, "u") == 0 ? 3 : 2;
+        dict_arr->null_count = 0;
+        dict_arr->offset = 0;
+        dict_arr->n_buffers = n_buf;
+        dict_arr->n_children = 0;
+        dict_arr->buffers = nullptr;
+        dict_arr->children = nullptr;
+        dict_arr->dictionary = nullptr;
+        dict_arr->release = &release_array;
+        dict_arr->private_data = nullptr;
 
-        const int64_t n_vec = enumvec.size();
-        dict_arr->length = n_vec;            // mandatory
-        dict_arr->null_count = 0;            // mandatory
-        dict_arr->offset = 0;                // mandatory
-        dict_arr->n_buffers = n_buf;         // mandatory
-        dict_arr->n_children = 0;            // mandatory
-        dict_arr->buffers = nullptr;         // mandatory
-        dict_arr->children = nullptr;        // optional
-        dict_arr->dictionary = nullptr;      // optional
-        dict_arr->release = &release_array;  // release from parent
-        dict_arr->private_data = nullptr;    // optional here
-
-        column->convert_enumeration();
         dict_arr->buffers = (const void**)malloc(sizeof(void*) * n_buf);
         dict_arr->buffers[0] = nullptr;  // validity: none here
-        dict_arr->buffers[1] = column->enum_offsets().data();
-        dict_arr->buffers[2] = column->enum_string().data();
+
+        // TODO string types currently get the data and offset buffers from
+        // ColumnBuffer::enum_offsets and ColumnBuffer::enum_string which is
+        // retrieved via ColumnBuffer::convert_enumeration. This may be
+        // refactored to all use ColumnBuffer::get_enumeration_info. Note
+        // that ColumnBuffer::has_enumeration may also be removed in a
+        // future refactor as ColumnBuffer::get_enumeration_info returns
+        // std::optional where std::nullopt indicates the column does not
+        // contain enumerated values.
+        if (enmr->type() == TILEDB_STRING_ASCII or
+            enmr->type() == TILEDB_STRING_UTF8) {
+            auto dict_vec = enmr->as_vector<std::string>();
+            column->convert_enumeration();
+            dict_arr->buffers[1] = column->enum_offsets().data();
+            dict_arr->buffers[2] = column->enum_string().data();
+            dict_arr->length = dict_vec.size();
+        } else {
+            auto [dict_data, dict_length] = ArrowAdapter::_get_data_and_length(
+                *enmr, dict_arr->buffers[1]);
+            dict_arr->buffers[1] = dict_data;
+            dict_arr->length = dict_length;
+        }
 
         schema->dictionary = dict_sch;
         array->dictionary = dict_arr;
@@ -207,14 +307,17 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum) {
     return std::pair(std::move(array), std::move(schema));
 }
 
-std::string_view ArrowAdapter::to_arrow_format(tiledb_datatype_t datatype) {
+std::string_view ArrowAdapter::to_arrow_format(
+    tiledb_datatype_t datatype, bool use_large) {
     switch (datatype) {
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
-            return "U";  // large because TileDB uses 64bit offsets
+            return use_large ? "U" :
+                               "u";  // large because TileDB uses 64bit offsets
         case TILEDB_CHAR:
         case TILEDB_BLOB:
-            return "Z";  // large because TileDB uses 64bit offsets
+            return use_large ? "Z" :
+                               "z";  // large because TileDB uses 64bit offsets
         case TILEDB_BOOL:
             return "b";
         case TILEDB_INT32:

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -40,10 +40,11 @@ class ArrowAdapter {
     /**
      * @brief Convert ColumnBuffer to an Arrow array.
      *
-     * @return auto [Arrow array, Arrow schema]
+     * @return std::pair<std::unique_ptr<ArrowArray>,
+     * std::unique_ptr<ArrowSchema>>
      */
     static std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
-    to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum = true);
+    to_arrow(std::shared_ptr<ColumnBuffer> column);
 
     /**
      * @brief Get Arrow format string from TileDB datatype.

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -2,6 +2,7 @@
 #define ARROW_ADAPTER_H
 
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
 
 // https://arrow.apache.org/docs/format/CDataInterface.html
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-listing-for-each-layout
@@ -11,6 +12,8 @@
 #include "carrow.h"
 #endif
 namespace tiledbsoma {
+
+using namespace tiledb;
 
 class ColumnBuffer;
 
@@ -40,7 +43,7 @@ class ArrowAdapter {
      * @return auto [Arrow array, Arrow schema]
      */
     static std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
-    to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum = false);
+    to_arrow(std::shared_ptr<ColumnBuffer> column, bool use_enum = true);
 
     /**
      * @brief Get Arrow format string from TileDB datatype.
@@ -48,9 +51,21 @@ class ArrowAdapter {
      * @param datatype TileDB datatype.
      * @return std::string_view Arrow format string.
      */
-    static std::string_view to_arrow_format(tiledb_datatype_t datatype);
-};
+    static std::string_view to_arrow_format(
+        tiledb_datatype_t datatype, bool use_large = true);
 
+   private:
+    static std::pair<const void*, std::size_t> _get_data_and_length(
+        Enumeration& enmr, const void* dst);
+
+    template <typename T>
+    static const void* _fill_data_buffer(std::vector<T> src, const void* dst) {
+        auto sz = src.size() * sizeof(T);
+        dst = (const void*)malloc(sz);
+        std::memcpy((void*)dst, src.data(), sz);
+        return dst;
+    }
+};
 };  // namespace tiledbsoma
 
 #endif


### PR DESCRIPTION
**Issue and/or context:**

Updates in Pandas 2.0 has introduced changes to `DictionaryArray.from_arrays` that required refactoring in `pytiledbsoma.cc`. This bug motivated a change in the C++ `ArrowAdapter::to_arrow` method to further handle all supported enumerated types.

**Changes:**

- Several pre-existing C++ and Pybind11 modifications have pulled from https://github.com/single-cell-data/TileDB-SOMA/pull/1793
- Previously in the Python API the `ArrowTable` was converted from `Table.from_arrays` and then enumerations were added in an additional step with `DictionaryArray.from_arrays`. `DictionaryArray.from_arrays` has now been completely removed and now only uses `Table.from_arrays`
- The required changes for the above to work required refactoring of the C++ `ArrowAdapter::to_arrow` method. Previous work has been done to support enumerated string values. The changes in this PR have expanded this now handle all supported enumerated types including all integral numeric types, floating point numbers, and Boolean
- `to_arrow_format` now takes a `use_large` Boolean argument. For enumerations, we need to use `string` or `binary` rather than `large_string` or `large_binary`

**Notes for Reviewer:**

- Pre-existing changes to the `ColumnBuffer` class to handle string enumerations, and the steps used in `ArrowAdapter::to_arrow` to populate the data and offet buffers remain untouched. However, I have written a TODO note on how this can be cleaned up in a future refactor
- Boolean enumerations require special handling from other numeric types as `std::vector<bool>` is a specialized vector that does not store values contigously in memory. We must iterate through the container and then use bit masking to set each bit in least significant bit ordering
- Awaiting TileDB-Py 0.23.4 release