### PR TITLE
[python] Extend unit-test coverage for enumeration value-types [WIP]

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -429,6 +429,11 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     # only extend if there are new values
                     if update_vals:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
+                        if not (
+                            np.issubdtype(enmr.dtype.type, np.str_)
+                            or np.issubdtype(enmr.dtype.type, np.bytes_)
+                        ):
+                            update_vals = np.array(update_vals, enmr.dtype)
                         new_enmr = enmr.extend(update_vals)
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -420,7 +420,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
                     enmr = self._handle.enum(attr.name)
 
-                    # get new enumeration values
+                    # get new enumeration values, maintain original ordering
                     update_vals = []
                     for new_val in col.chunk(0).dictionary.tolist():
                         if new_val not in enmr.values():
@@ -429,12 +429,13 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     # only extend if there are new values
                     if update_vals:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
-                        if not (
-                            np.issubdtype(enmr.dtype.type, np.str_)
-                            or np.issubdtype(enmr.dtype.type, np.bytes_)
-                        ):
-                            update_vals = np.array(update_vals, enmr.dtype)
-                        new_enmr = enmr.extend(update_vals)
+                        if np.issubdtype(enmr.dtype.type, np.str_):
+                            extend_vals = np.array(update_vals, "U")
+                        elif np.issubdtype(enmr.dtype.type, np.bytes_):
+                            extend_vals = np.array(update_vals, "S")
+                        else:
+                            extend_vals = np.array(update_vals, enmr.dtype)
+                        new_enmr = enmr.extend(extend_vals)
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -183,51 +183,41 @@ bool get_enum_is_ordered(SOMAArray& sr, std::string attr_name){
 }
 
 /**
- * @brief Convert ColumnBuffer to Arrow array.
- *
- * @param column_buffer ColumnBuffer
- * @return py::object Arrow array
- */
-py::object to_array(std::shared_ptr<ColumnBuffer> column_buffer) {
-    auto pa = py::module::import("pyarrow");
-    auto pa_array_import = pa.attr("Array").attr("_import_from_c");
-
-    auto [array, schema] = ArrowAdapter::to_arrow(column_buffer);
-    return pa_array_import(py::capsule(array.get()), py::capsule(schema.get()));
-}
-
-/**
  * @brief Convert ArrayBuffers to Arrow table.
  *
  * @param cbs ArrayBuffers
  * @return py::object
  */
-py::object to_table(SOMAArray& sr, std::shared_ptr<ArrayBuffers> array_buffers) {
+py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {
     auto pa = py::module::import("pyarrow");
     auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
-    auto pa_dict_from_arrays = pa.attr("DictionaryArray").attr("from_arrays");
+    auto pa_array_import = pa.attr("Array").attr("_import_from_c");
+    auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");
 
+    py::list array_list;
     py::list names;
-    py::list arrays;
 
-    for (auto& name : array_buffers->names()) {
-        auto column = array_buffers->at(name);
+    for (auto& name : buffers->names()) {
+        auto column = buffers->at(name);
+        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(column, true);
+        auto array = pa_array_import(py::capsule(pa_array.get()), 
+                                     py::capsule(pa_schema.get()));
+        array_list.append(array);
         names.append(name);
-
-        if(sr.get_attr_to_enum_mapping().count(name) == 0){
-            arrays.append(to_array(column));
-        }else{
-            arrays.append(pa_dict_from_arrays(
-                to_array(column),
-                get_enum(sr, name),
-                py::none(),
-                get_enum_is_ordered(sr, name)));
-        }
     }
 
-    auto pa_table = pa_table_from_arrays(arrays, names);
+    return pa_table_from_arrays(array_list, names);
+}
 
-    return pa_table;
+std::optional<py::object> to_table(
+    std::optional<std::shared_ptr<ArrayBuffers>> buffers){
+    // If more data was read, convert it to an arrow table and return
+    if (buffers.has_value()) {
+        return _buffer_to_table(*buffers);
+    }
+
+    // No data was read, the query is complete, return nullopt
+    return std::nullopt;
 }
 
 /**
@@ -682,7 +672,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                 if (buffers.has_value()) {
                     // Acquire python GIL before accessing python objects
                     py::gil_scoped_acquire acquire;
-                    return to_table(reader, *buffers);
+                    return to_table(*buffers);
                 }
 
                 // No data was read, the query is complete, return nullopt

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -74,7 +74,7 @@ SOMADataFrame <- R6::R6Class(
           name = field_name,
           # Numeric index types must be positive values for indexing
           domain = arrow_type_unsigned_range(field$type), tile = tile_extent,
-          type = tiledb_type_from_arrow_type(field$type),
+          type = tiledb_type_from_arrow_type(field$type, is_dim=TRUE),
           filter_list = tiledb::tiledb_filter_list(tdb_opts)
         )
       }
@@ -87,7 +87,7 @@ SOMADataFrame <- R6::R6Class(
 
       for (field_name in attr_column_names) {
         field <- schema$GetFieldByName(field_name)
-        field_type <- tiledb_type_from_arrow_type(field$type)
+        field_type <- tiledb_type_from_arrow_type(field$type, is_dim=FALSE)
 
         ## # Check if the field is ordered and mark it as such
         ## if (!is.null(x = levels[[field_name]]) && isTRUE(field$type$ordered)) {
@@ -98,7 +98,7 @@ SOMADataFrame <- R6::R6Class(
           name = field_name,
           type = field_type,
           nullable = field$nullable,
-          ncells = if (field_type == "ASCII") NA_integer_ else 1L,
+          ncells = if (field_type == "ASCII" || field_type == "UTF8" ) NA_integer_ else 1L,
           filter_list = tiledb::tiledb_filter_list(tiledb_create_options$attr_filters(field_name))
         )
       }

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -105,7 +105,7 @@ SOMANDArrayBase <- R6::R6Class(
       # create array attribute
       tdb_attr <- tiledb::tiledb_attr(
         name = "soma_data",
-        type = tiledb_type_from_arrow_type(type),
+        type = tiledb_type_from_arrow_type(type, is_dim=FALSE),
         filter_list = tdb_attr_filters
       )
 

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -36,13 +36,14 @@ is_arrow_dictionary <- function(x) {
 
 #' Convert Arrow types to supported TileDB type
 #' List of TileDB types supported in R: https://github.com/TileDB-Inc/TileDB-R/blob/8014da156b5fee5b4cc221d57b4aa7d388abc968/inst/tinytest/test_dim.R#L97-L121
+#' Note: TileDB attrs may be UTF-8; TileDB dims may not.
 #'
 #' List of all arrow types: https://github.com/apache/arrow/blob/90aac16761b7dbf5fe931bc8837cad5116939270/r/R/type.R#L700
 #' @noRd
 
-tiledb_type_from_arrow_type <- function(x) {
+tiledb_type_from_arrow_type <- function(x, is_dim) {
   stopifnot(is_arrow_data_type(x))
-  switch(x$name,
+  retval <- switch(x$name,
     int8 = "INT8",
     int16 = "INT16",
     int32 = "INT32",
@@ -62,11 +63,9 @@ tiledb_type_from_arrow_type <- function(x) {
     # binary = "binary",
     # large_binary = "large_binary",
     # fixed_size_binary = "fixed_size_binary",
-    # tiledb::r_to_tiledb_type() returns UTF8 for characters but they are
-    # not yet queryable so we use ASCII for now
-    utf8 = "ASCII",
-    string = "ASCII",
-    large_utf8 = "ASCII",
+    utf8 = "UTF8",
+    string = "UTF8",
+    large_utf8 = "UTF8",
     # date32 = "date32",
     # date64 = "date64",
     # time32 = "time32",
@@ -84,9 +83,13 @@ tiledb_type_from_arrow_type <- function(x) {
     # fixed_size_list = "fixed_size_list",
     # map_of = "map",
     # duration = "duration",
-    dictionary = tiledb_type_from_arrow_type(x$index_type),
+    dictionary = tiledb_type_from_arrow_type(x$index_type, is_dim=is_dim),
     stop("Unsupported Arrow data type: ", x$name, call. = FALSE)
   )
+  if (is_dim && retval == "UTF8") {
+    retval <- "ASCII"
+  }
+  retval
 }
 
 arrow_type_from_tiledb_type <- function(x) {
@@ -209,12 +212,12 @@ tiledb_attr_from_arrow_field <- function(field, tiledb_create_options) {
     COMPRESSION_LEVEL = tiledb_create_options$dataframe_dim_zstd_level()
   )
 
-  field_type <- tiledb_type_from_arrow_type(field$type)
+  field_type <- tiledb_type_from_arrow_type(field$type, is_dim=FALSE)
   tiledb::tiledb_attr(
     name = field$name,
     type = field_type,
     nullable = field$nullable,
-    ncells = if (field_type == "ASCII") NA_integer_ else 1L,
+    ncells = if (field_type == "ASCII" || field_type == "UTF8") NA_integer_ else 1L,
     filter_list = tiledb::tiledb_filter_list(
       tiledb_create_options$attr_filters(
         attr_name = field$name,

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -23,7 +23,7 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   expect_true(is_arrow_field(dim0_field))
   expect_equal(dim0_field$name, tiledb::name(dim0))
   expect_equal(
-    tiledb_type_from_arrow_type(dim0_field$type),
+    tiledb_type_from_arrow_type(dim0_field$type, is_dim=TRUE),
     tiledb::datatype(dim0)
   )
 
@@ -32,14 +32,14 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   expect_true(is_arrow_field(dim1_field))
   expect_equal(dim1_field$name, tiledb::name(dim1))
   expect_equal(
-    tiledb_type_from_arrow_type(dim1_field$type),
+    tiledb_type_from_arrow_type(dim1_field$type, is_dim=TRUE),
     tiledb::datatype(dim1)
   )
 
   # Attribute to Arrow field
   attr0 <- tiledb::tiledb_attr(
     name = "attr0",
-    type = "ASCII"
+    type = "UTF8"
   )
 
   attr1 <- tiledb::tiledb_attr(
@@ -55,7 +55,7 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   expect_true(is_arrow_field(attr0_field))
   expect_equal(attr0_field$name, tiledb::name(attr0))
   expect_equal(
-    tiledb_type_from_arrow_type(attr0_field$type),
+    tiledb_type_from_arrow_type(attr0_field$type, is_dim=FALSE),
     tiledb::datatype(attr0)
   )
 
@@ -64,7 +64,7 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   expect_true(is_arrow_field(attr1_field))
   expect_equal(attr1_field$name, tiledb::name(attr1))
   expect_equal(
-    tiledb_type_from_arrow_type(attr1_field$type),
+    tiledb_type_from_arrow_type(attr1_field$type, is_dim=FALSE),
     tiledb::datatype(attr1)
   )
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -240,7 +240,7 @@ class ColumnBuffer {
         return is_nullable_;
     }
 
-    std::optional<Enumeration> get_enumeration() const {
+    std::optional<Enumeration> get_enumeration_info() const {
         return enumeration_;
     }
 


### PR DESCRIPTION
**Issue and/or context:** #1746

**Changes:** Automated manual-testing feedback from @bkmartinjr 

**Notes for Reviewer:**

This PR is not ready for review.

It depends on TileDB-Py PRs https://github.com/TileDB-Inc/TileDB-Py/pull/1853, https://github.com/TileDB-Inc/TileDB-Py/pull/1854, and https://github.com/TileDB-Inc/TileDB-Py/pull/1858 which will be in an as-yet-uncreated TileDB-Py 0.23.4. It also depends on #1848 in this repository.

For now, this PR can only have red CI.