### PR TITLE
[python] Fix an import statement

### DIFF
--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -26,8 +26,8 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
+import scipy.sparse as sparse
 import somacore
-from scipy import sparse
 from somacore import options
 from somacore.query._eager_iter import EagerIterator
 


### PR DESCRIPTION
Running `python -m pytest tests` from `apis/python` on my laptop I am seeing

```
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.1-shape0-coords0] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.1-shape1-coords1] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.1-shape2-coords2] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape3-coords3] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape4-coords4] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape5-coords5] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape6-coords6] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape7-coords7] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape8-coords8] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape9-coords9] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape10-coords10] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape12-coords12] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape13-coords13] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape14-coords14] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape15-coords15] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape16-coords16] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.05-shape17-coords17] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.005-shape18-coords18] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.005-shape19-coords19] - ModuleNotFoundError: No module named 'sparse'
FAILED tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.005-shape20-coords20] - ModuleNotFoundError: No module named 'sparse'
```

which makes sense given the "before" on this PR. In fact, I don't understand how this didn't fail in CI as well.