### PR TITLE
[WIP] [r] Remove `expect_no_condition()` calls for `write_soma.SingleCellExperiment()`

### DIFF
--- a/apis/r/tests/testthat/test-SingleCellExperimentIngest.R
+++ b/apis/r/tests/testthat/test-SingleCellExperimentIngest.R
@@ -8,7 +8,8 @@ test_that("Write SingleCellExperiment mechanics", {
 
   uri <- withr::local_tempdir('single-cell-experiment')
 
-  expect_no_condition(uri <- suppressMessages(write_soma(sce, uri)))
+  # expect_no_condition(uri <- suppressMessages(write_soma(sce, uri)))
+  uri <- suppressMessages(write_soma(sce, uri))
 
   expect_type(uri, 'character')
   expect_true(grepl('^single-cell-experiment', basename(uri)))
@@ -78,7 +79,8 @@ test_that("SingleCellExperiment mainExpName mechanics", {
 
   expect_error(uri <- suppressMessages(write_soma(sce, uri)))
 
-  expect_no_condition(uri <- suppressMessages(write_soma(sce, uri, ms_name)))
+  # expect_no_condition(uri <- suppressMessages(write_soma(sce, uri, ms_name)))
+  uri <- suppressMessages(write_soma(sce, uri, ms_name))
   expect_no_condition(experiment <- SOMAExperimentOpen(uri))
   expect_identical(experiment$ms$names(), ms_name)
 
@@ -88,7 +90,8 @@ test_that("SingleCellExperiment mainExpName mechanics", {
 
   expect_type(SingleCellExperiment::mainExpName(sce), 'character')
 
-  expect_no_condition(uri <- suppressMessages(write_soma(sce, uri, ms_name2)))
+  # expect_no_condition(uri <- suppressMessages(write_soma(sce, uri, ms_name2)))
+  uri <- suppressMessages(write_soma(sce, uri, ms_name2))
   expect_no_condition(experiment <- SOMAExperimentOpen(uri))
   expect_identical(experiment$ms$names(), ms_name2)
 })

--- a/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
@@ -12,7 +12,8 @@ test_that("Write SummarizedExperiment mechanics", {
 
   uri <- withr::local_tempdir('summarized-experiment')
 
-  expect_no_condition(uri <- suppressMessages(write_soma(se, uri, 'RNA')))
+  # expect_no_condition(uri <- suppressMessages(write_soma(se, uri, 'RNA')))
+  uri <- suppressMessages(write_soma(se, uri, 'RNA'))
 
   expect_type(uri, 'character')
   expect_true(grepl('^summarized-experiment', basename(uri)))


### PR DESCRIPTION
For some reason, `write_soma.SingleCellExperiment()` seems to be calling a version of `as.data.frame.numeric()` that throws a deprecation warning. I believe this is causing downstream errors where testthat kills the write, but continues through the test suite. This PR is simply to test this theory.

Tracking issue: #1875.