### PR TITLE
[r] Suppress deprecation warnings in `write_soma.DataFrame()`

### DIFF
--- a/apis/r/R/write_bioc.R
+++ b/apis/r/R/write_bioc.R
@@ -21,7 +21,7 @@ write_soma.DataFrame <- function(
     }
   }
   index <- attr(x, which = 'index')
-  x <- as.data.frame(x)
+  x <- suppressWarnings(as.data.frame(x), classes = "deprecatedWarning")
   attr(x, which = 'index') <- index
   return(write_soma(
     x = x,


### PR DESCRIPTION
Bioc 3.18 and R 4.3.2 now throw deprecation warnings when casting from `S4Vectors::DataFrame` to `data.frame`; this PR suppresses deprecation warnings when doing that cast, but allows additional warnings to percolate through

[sc-36559]

replaces #1874
resolves #1875