### PR TITLE
[r] Determine the R version dynamically in r-ci

### DIFF
--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -17,7 +17,7 @@ set -e
 
 CRAN=${CRAN:-"https://cloud.r-project.org"}
 OS=$(uname -s)
-RVER=${RVER:-"4.3.1"}
+RVER=${RVER:-$(Rscript -e 'cat(format(getRversion()))')}
 
 ## Optional drat repos, unset by default
 DRAT_REPOS=${DRAT_REPOS:-""}

--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -17,7 +17,7 @@ set -e
 
 CRAN=${CRAN:-"https://cloud.r-project.org"}
 OS=$(uname -s)
-RVER=${RVER:-$(Rscript -e 'cat(format(getRversion()))')}
+RVER=${RVER:-"4.3.2"}
 
 ## Optional drat repos, unset by default
 DRAT_REPOS=${DRAT_REPOS:-""}
@@ -203,9 +203,10 @@ BootstrapLinuxOptions() {
 
 BootstrapMac() {
     # Install from latest CRAN binary build for OS X
+    echo "Downloading ${RVER} for macOS"
     wget ${CRAN}/bin/macosx/big-sur-x86_64/base/R-${RVER}-x86_64.pkg -O /tmp/R-latest.pkg
 
-    echo "Installing OS X binary package for R"
+    echo "Installing macOS binary package for R"
     sudo installer -pkg "/tmp/R-latest.pkg" -target /
     rm "/tmp/R-latest.pkg"
 


### PR DESCRIPTION
**Issue and/or context:**

CI on macOS can currently warns 'package xyz built under R 4.3.2' because the version installed is still hard-wired to 4.3.1 -- and because the [default version of R at GitHub Actions on macOS](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md) is still 4.3.1.

**Changes:**

The script is changed to use a fall-back default of 4.3.2.

**Notes for Reviewer:**

[SC 36713](https://app.shortcut.com/tiledb-inc/story/36713/r-determine-r-version-at-run-time-in-r-ci-for-macos)