### PR TITLE
[python] Fix performance regression in bounding-box calculation

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -245,9 +245,9 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             # Write bounding-box metadata
             maxes = []
             for i in range(coord_tbl.num_columns):
-                coords = values.column(f"soma_dim_{i}").to_pylist()
+                coords = values.column(f"soma_dim_{i}")
                 if coords:
-                    maxes.append(max(coords))
+                    maxes.append(pa.compute.max(coords).as_py())
                 else:  # completely empty X
                     maxes.append(0)
             bounding_box = self._compute_bounding_box_metadata(maxes)


### PR DESCRIPTION
**Issue and/or context:**

The addition of bounding box calculation used Python built-in `max` to find the max coordinate for each dimension.  Using Arrow builtin is over 100X faster

In addition, this removes the extra copy (to_pylist) when the input is an Arrow ChunkedArray

Note: this does not address the extra copy operation in the write operation. That is filed as #1896 
