### PR TITLE
[r] Install SeuratObject from source on macOS, rely on update r2u binary on linux

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -73,6 +73,7 @@ jobs:
         run: Rscript -e 'update.packages(ask=FALSE)'
 
       - name: Install SeuratObject from source
+        if: ${{ matrix.os != 'macOS-latest' }}
         run: install.packages("SeuratObject", type = "source", repos = "https://cloud.r-project.org")
         shell: Rscript {0}
 

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: Rscript -e 'update.packages(ask=FALSE)'
 
       - name: Install SeuratObject from source
-        if: ${{ matrix.os != 'macOS-latest' }}
+        if: ${{ matrix.os == 'macOS-latest' }}
         run: install.packages("SeuratObject", type = "source", repos = "https://cloud.r-project.org")
         shell: Rscript {0}
 

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -27,9 +27,9 @@ jobs:
           - name: macos
             os: macOS-latest
             covr: 'no'
-          # - name: coverage
-          #   os: ubuntu-latest
-          #   covr: 'yes'
+          - name: coverage
+            os: ubuntu-latest
+            covr: 'yes'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
+      - name: Install SeuratObject from source
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: install.packages("SeuratObject", type = "source", repos = "https://cloud.r-project.org")
+        shell: Rscript {0}
+
       - name: Test
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -27,9 +27,9 @@ jobs:
           - name: macos
             os: macOS-latest
             covr: 'no'
-          - name: coverage
-            os: ubuntu-latest
-            covr: 'yes'
+          # - name: coverage
+          #   os: ubuntu-latest
+          #   covr: 'yes'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -27,9 +27,9 @@ jobs:
           - name: macos
             os: macOS-latest
             covr: 'no'
-          # - name: coverage
-          #   os: ubuntu-latest
-          #   covr: 'yes'
+          - name: coverage
+            os: ubuntu-latest
+            covr: 'yes'
 
     runs-on: ${{ matrix.os }}
 
@@ -73,7 +73,6 @@ jobs:
         run: Rscript -e 'update.packages(ask=FALSE)'
 
       - name: Install SeuratObject from source
-        if: ${{ matrix.os == 'macOS-latest' }}
         run: install.packages("SeuratObject", type = "source", repos = "https://cloud.r-project.org")
         shell: Rscript {0}
 


### PR DESCRIPTION
SeuratObject imports S4 classes from Matrix, which results in S4 method/class caches that can become out of date. If Matrix gets updated, but the binary from CRAN is not rebuilt, then the S4 cache can refer to methods/classes that no longer exist (cause of R CI failure on 2023-11-08). This forces SeuratObject to be rebuilt from source to make use of the updated S4 methods/classes in Matrix