### PR TITLE
[r] Restore `expect_no_condition()` tests in `Seurat` object outgestion

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -53,6 +53,16 @@ jobs:
         if: ${{ matrix.os != 'macOS-latest' }}
         run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
+      - name: Install r-universe build of SeuratObject (macOS)
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: install.packages("SeuratObject", repos = c("https://mojaveazure.r-universe.dev", "https://cloud.r-project.org"))
+        shell: Rscript {0}
+
+      - name: Install r-universe build of SeuratObject (linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: install.packages("SeuratObject", repos = c("https://mojaveazure.r-universe.dev/bin/linux/jammy/4.3", "https://cloud.r-project.org"))
+        shell: Rscript {0}
+
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
 
@@ -71,11 +81,6 @@ jobs:
       #
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
-
-      - name: Install SeuratObject from source
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: install.packages("SeuratObject", type = "source", repos = "https://cloud.r-project.org")
-        shell: Rscript {0}
 
       - name: Test
         if: ${{ matrix.covr == 'no' }}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -55,13 +55,11 @@ jobs:
 
       - name: Install r-universe build of SeuratObject (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
-        run: install.packages("SeuratObject", repos = c("https://mojaveazure.r-universe.dev", "https://cloud.r-project.org"))
-        shell: Rscript {0}
+        run: cd apis/r && Rscript -e "install.packages('SeuratObject', repos = c('https://mojaveazure.r-universe.dev', 'https://cloud.r-project.org'))"
 
       - name: Install r-universe build of SeuratObject (linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: install.packages("SeuratObject", repos = c("https://mojaveazure.r-universe.dev/bin/linux/jammy/4.3", "https://cloud.r-project.org"))
-        shell: Rscript {0}
+        run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('SeuratObject', repos = c('https://mojaveazure.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all


### PR DESCRIPTION
PR #1809 disabled some tests due to SeuratObject v5 bugs. These bugs have been patched on development versions of SeuratObject;as such, this PR restores those tests. It also pulls the development versions of SeuratObject from r-universe (replacing source builds for macOS) and only runs `Seurat` object outgestion tests for Seurat v4 or patched versions of Seurat v5

resolves #1839 