### PR TITLE
[r] Condition one more test file on 'extended mode'

### DIFF
--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -1,6 +1,7 @@
 spdl::set_level('warn')
 
 test_that("write_soma.data.frame mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
@@ -27,6 +28,7 @@ test_that("write_soma.data.frame mechanics", {
 })
 
 test_that("write_soma.data.frame enumerations", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
@@ -67,6 +69,7 @@ test_that("write_soma.data.frame enumerations", {
 })
 
 test_that("write_soma.data.frame no enumerations", {
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
@@ -114,6 +117,7 @@ test_that("write_soma.data.frame no enumerations", {
 })
 
 test_that("write_soma dense matrix mechanics", {
+  skip_if(!extended_tests())
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-dense-matrix")
@@ -170,6 +174,7 @@ test_that("write_soma dense matrix mechanics", {
 })
 
 test_that("write_soma sparse matrix mechanics", {
+  skip_if(!extended_tests())
   uri <- withr::local_tempdir("write-soma-sparse-matrix")
   collection <- SOMACollectionCreate(uri)
   knex <- get_data('KNex', package = 'Matrix')$mm


### PR DESCRIPTION
**Issue and/or context:**

Some of our tests have been conditioned on being in 'extended' runs to manage test run time and avoid some false flags.

**Changes:**

This PR extends the conditioning to one more file.

**Notes for Reviewer:**

[SC 36957](https://app.shortcut.com/tiledb-inc/story/36957/condition-one-more-test-file-on-extended-or-not)
