### PR TITLE
[python] Fix `pyarrow.compute` import for version 12

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -19,6 +19,7 @@ from typing import (
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pacomp
 import somacore
 import tiledb
 from somacore import options
@@ -247,7 +248,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             for i in range(coord_tbl.num_columns):
                 coords = values.column(f"soma_dim_{i}")
                 if coords:
-                    maxes.append(pa.compute.max(coords).as_py())
+                    maxes.append(pacomp.max(coords).as_py())
                 else:  # completely empty X
                     maxes.append(0)
             bounding_box = self._compute_bounding_box_metadata(maxes)


### PR DESCRIPTION
Running TileDB-SOMA-Py unit tests on a system with `pyarrow` version 12:

```
...
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/io/ingest.py", line 340, in from_h5ad
    uri = from_anndata(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/io/ingest.py", line 545, in from_anndata
    with _create_from_matrix(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/io/ingest.py", line 1336, in _create_from_matrix
    _write_matrix_to_sparseNDArray(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/io/ingest.py", line 2217, in _write_matrix_to_sparseNDArray
    soma_ndarray.write(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_sparse_nd_array.py", line 250, in write
    maxes.append(pa.compute.max(coords).as_py())
  File "/usr/local/lib/python3.10/dist-packages/pyarrow/__init__.py", line 316, in __getattr__
    raise AttributeError(
AttributeError: module 'pyarrow' has no attribute 'compute'
```

It appears that in `pyarrow` version 11, `import pyarrow` pulls in `pyarow.compute`, but in version 12, we have to explicitly do `import pyarrow.compute`.