### PR TITLE
[python] Normalize unit-test exception coverage

### DIFF
--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -1805,77 +1805,77 @@ def test_types_write_errors(
 
 
 @pytest.mark.parametrize(
-    "name,index_column_names,domain,coords,error",
+    "name,index_column_names,domain,coords",
     [
         [
             "int32-pa-array-untyped",
             ["int32"],
             None,
             [pa.array([3202, 3203])],
-            RuntimeError,  # Static type (INT64) does not match expected type (INT32)
+            # Static type (INT64) does not match expected type (INT32)
         ],
         [
             "int16-pa-array-untyped",
             ["int16"],
             None,
             [pa.array([1602, 1603])],
-            RuntimeError,  # Static type (INT64) does not match expected type (INT16)
+            # Static type (INT64) does not match expected type (INT16)
         ],
         [
             "int8-pa-array-untyped",
             ["int8"],
             None,
             [pa.array([82, 83])],
-            RuntimeError,  # Static type (INT64) does not match expected type (INT8)
+            # Static type (INT64) does not match expected type (INT8)
         ],
         [
             "uint64-pa-array-untyped",
             ["uint64"],
             None,
             [pa.array([6412, 6413])],
-            RuntimeError,  # Static type (INT64) does not match expected type (UINT64)
+            # Static type (INT64) does not match expected type (UINT64)
         ],
         [
             "uint32-pa-array-untyped",
             ["uint32"],
             None,
             [pa.array([3212, 3213])],
-            RuntimeError,  # Static type (UINT64) does not match expected type (UINT32)
+            # Static type (UINT64) does not match expected type (UINT32)
         ],
         [
             "uint16-pa-array-untyped",
             ["uint16"],
             None,
             [pa.array([1612, 1613])],
-            RuntimeError,  # Static type (UINT64) does not match expected type (UINT16)
+            # Static type (UINT64) does not match expected type (UINT16)
         ],
         [
             "uint8-pa-array-untyped",
             ["uint8"],
             None,
             [pa.array([92, 93])],
-            RuntimeError,  # Static type (UINT64) does not match expected type (UINT8)
+            # Static type (UINT64) does not match expected type (UINT8)
         ],
         [
             "float32-pa-array-untyped",
             ["float32"],
             None,
             [pa.array([322.5, 323.5])],
-            RuntimeError,  # Static type (FLOAT64) does not match expected type (FLOAT32)
+            # Static type (FLOAT64) does not match expected type (FLOAT32)
         ],
         [
             "float32-pa-array-typed-float64",
             ["float32"],
             None,
             [pa.array([322.5, 323.5], pa.float64())],
-            RuntimeError,  # Static type (FLOAT64) does not match expected type (FLOAT32)
+            # Static type (FLOAT64) does not match expected type (FLOAT32)
         ],
         [
             "float64-pa-array-typed-float32",
             ["float64"],
             None,
             [pa.array([322.5, 323.5], pa.float32())],
-            RuntimeError,  # Static type (FLOAT32) does not match expected type (FLOAT64)
+            # Static type (FLOAT32) does not match expected type (FLOAT64)
         ],
     ],
 )
@@ -1886,7 +1886,6 @@ def test_types_read_errors(
     index_column_names,
     domain,
     coords,
-    error,
 ):
     uri = tmp_path.as_posix()
 
@@ -1900,6 +1899,6 @@ def test_types_read_errors(
     with soma.DataFrame.open(uri, "w") as sdf:
         sdf.write(arrow_table)
 
-    with pytest.raises(error):
+    with pytest.raises((RuntimeError, tiledb.cc.TileDBError)):
         with soma.DataFrame.open(uri, "r") as sdf:
             sdf.read(coords=coords).concat()


### PR DESCRIPTION
As we run our unit tests on more and more environments, including on-image from `docker run`, we more often run into an old unit-test error. Namely, `apis/python/tests/test_dataframe_index_columns.py::test_types_read_errors` may either throw `RuntimeError` or `tiledb.cc.TileDBError`. Yet we only catch the former. This means, for example, when running unit tests from `docker run` we need to mentally 'subtract out' these spurious fails. (This has already bitten developers, who have become used to it.) What we should be doing is catching both. (Also note: grepping for `RuntimeError` in `apis/python/tests` show we _already_ do this in other unit-test files -- we need to do it in one more.)