### PR TITLE
[r] Future-proof one assertion for an upcoming change in R 4.4.0

### DIFF
--- a/apis/r/R/utils-assertions.R
+++ b/apis/r/R/utils-assertions.R
@@ -93,7 +93,7 @@ check_package <- function(package, version = NULL, quietly = FALSE) {
 #' informative error is thrown with the missing values.
 #' @noRd
 assert_subset <- function(x, y, type = "value") {
-  stopifnot(is.atomic(x) && is.atomic(y))
+  stopifnot((is.atomic(x) || is.null(x)) && (is.atomic(y) || is.null(y)))
   missing <- !x %in% y
   if (any(missing)) {
     stop(sprintf(


### PR DESCRIPTION
**Issue and/or context:**

R-devel aka R 4.4.0 to be changes the behavior of `is.atomic` slightly.  Quoting from the [NEWS file of R-devel](https://github.com/wch/r-source/blob/e26e3f02a5e4255c4aad0842a46e141c03eed379/doc/NEWS.Rd):

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/366f2e87-a83e-4fda-afea-c5c07a90480c)


**Changes:**

We adjust one line.  Tests behave admiringly (under r-devel, the one warning is unrelated and @mojaveazure is on it)

>  [ FAIL 0 | WARN 1 | SKIP 0 | PASS 2043 ]

**Notes for Reviewer:**

[SC 37024](https://app.shortcut.com/tiledb-inc/story/37024/future-proofing-one-assertion)