### PR TITLE
[python] Avoid a double log statement on debug-mode ingest

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1155,9 +1155,6 @@ def _write_dataframe(
     context: Optional[SOMATileDBContext] = None,
     axis_mapping: AxisIDMapping,
 ) -> DataFrame:
-    _util.get_start_stamp()
-    logging.log_io(None, f"START  WRITING {df_uri}")
-
     df.reset_index(inplace=True)
     if id_column_name is not None:
         if id_column_name in df:


### PR DESCRIPTION
Found during testing. This is trivial to review, and trivial to approve.

Before, with `tiledbsoma.io.from_h5ad` and `tiledbsoma.logging.debug()`:

```
START  Experiment.from_h5ad /var/s/a/pbmc-small.h5ad
START  READING /var/s/a/pbmc-small.h5ad
FINISH READING /var/s/a/pbmc-small.h5ad TIME 0.075 seconds
Registration: registering isolated AnnData object.
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 0.000 seconds
START  WRITING foo
START  WRITING foo/obs <-------------- DUPLICATE
START  WRITING foo/obs
FINISH WRITING foo/obs TIME 0.047 seconds
...
```

After:

```
START  Experiment.from_h5ad /var/s/a/pbmc-small.h5ad
START  READING /var/s/a/pbmc-small.h5ad
FINISH READING /var/s/a/pbmc-small.h5ad TIME 0.075 seconds
Registration: registering isolated AnnData object.
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 0.000 seconds
START  WRITING foo
START  WRITING foo/obs
FINISH WRITING foo/obs TIME 0.047 seconds
...
```