### PR TITLE
[c++/python] Add `SOMAArray::stats` to get query stats

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -307,6 +307,8 @@ PYBIND11_MODULE(pytiledbsoma, m) {
             "platform_config"_a = py::dict(),
             "timestamp"_a = py::none())
 
+        .def("stats", &SOMAArray::stats)
+
         .def(
             "set_condition", 
             [](SOMAArray& reader, 

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -67,6 +67,10 @@ void ManagedQuery::reset() {
     query_submitted_ = false;
 }
 
+std::string ManagedQuery::stats() {
+    return query_->stats();
+}
+
 void ManagedQuery::select_columns(
     const std::vector<std::string>& names, bool if_not_empty) {
     // Return if we are selecting all columns (columns_ is empty) and we want to

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -76,6 +76,13 @@ class ManagedQuery {
     void reset();
 
     /**
+     * @brief Returns a JSON-formatted string of the stats.
+     *
+     * @return std::string
+     */
+    std::string stats();
+
+    /**
      * @brief Select columns names to query (dim and attr). If the
      * `if_not_empty` parameter is `true`, the column will be selected iff the
      * list of selected columns is empty. This prevents a `select_columns` call

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -221,6 +221,10 @@ void SOMAArray::reset(
     submitted_ = false;
 }
 
+std::string SOMAArray::stats() {
+    return mq_->stats();
+}
+
 std::optional<std::shared_ptr<ArrayBuffers>> SOMAArray::read_next() {
     // If the query is complete, return `std::nullopt`
     if (mq_->is_complete(true)) {

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -223,6 +223,13 @@ class SOMAArray {
         ResultOrder result_order = ResultOrder::automatic);
 
     /**
+     * @brief Returns a JSON-formatted string of the stats.
+     *
+     * @return std::string
+     */
+    std::string stats();
+
+    /**
      * @brief Set the dimension slice using one point
      *
      * @note Partitioning is not supported

--- a/libtiledbsoma/test/test_soma_array.py
+++ b/libtiledbsoma/test/test_soma_array.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-import os
 import json
+import os
 
 import pyarrow as pa
+
 import tiledbsoma.pytiledbsoma as clib
 
 VERBOSE = False
@@ -51,18 +52,20 @@ def test_soma_array_obs():
     assert sr.results_complete()
     assert arrow_table.num_rows == 2638
 
+
 def test_soma_array_stats():
     """Get query stats from an obs array."""
-    
+
     name = "obs"
     uri = os.path.join(SOMA_URI, name)
     sr = clib.SOMAArray(uri)
     sr.read_next()
     stats = json.loads(sr.stats())
-    
+
     assert "Context.StorageManager.Query.Reader.dowork.sum" in stats["timers"]
     assert "Context.StorageManager.Query.Reader.dowork.avg" in stats["timers"]
     assert "Context.StorageManager.Query.Reader.loop_num" in stats["counters"]
+
 
 def test_soma_array_var():
     """Read all values from var array into an arrow table."""

--- a/libtiledbsoma/test/test_soma_array.py
+++ b/libtiledbsoma/test/test_soma_array.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import os
+import json
 
 import pyarrow as pa
-
 import tiledbsoma.pytiledbsoma as clib
 
 VERBOSE = False
@@ -51,6 +51,18 @@ def test_soma_array_obs():
     assert sr.results_complete()
     assert arrow_table.num_rows == 2638
 
+def test_soma_array_stats():
+    """Get query stats from an obs array."""
+    
+    name = "obs"
+    uri = os.path.join(SOMA_URI, name)
+    sr = clib.SOMAArray(uri)
+    sr.read_next()
+    stats = json.loads(sr.stats())
+    
+    assert "Context.StorageManager.Query.Reader.dowork.sum" in stats["timers"]
+    assert "Context.StorageManager.Query.Reader.dowork.avg" in stats["timers"]
+    assert "Context.StorageManager.Query.Reader.loop_num" in stats["counters"]
 
 def test_soma_array_var():
     """Read all values from var array into an arrow table."""


### PR DESCRIPTION
**Issue and/or context:**

Requested by @johnkerl. Context: #1932.

**Changes:**

- Addition of `SOMAArray:;stats` which calls `tiledb::Query::stats` to get stats of query run
- Add `SOMAArray.stats` Python binding
