### PR TITLE
[r] No longer show 'libtiledb=' before core library version triplet

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -133,9 +133,11 @@ tiledbsoma_stats_dump <- function() {
 #' libtiledbsoma version
 #'
 #' Returns a string with version information for libtiledbsoma and the linked TileDB Embedded library.
+#' If argument `compact` is set to `TRUE`, shorter version of just the TileDB Embedded library
+#' version is returned,
 #' @noRd
-libtiledbsoma_version <- function() {
-    .Call(`_tiledbsoma_libtiledbsoma_version`)
+libtiledbsoma_version <- function(compact = FALSE) {
+    .Call(`_tiledbsoma_libtiledbsoma_version`, compact)
 }
 
 #' TileDB embedded version

--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -33,7 +33,7 @@ show_package_versions <- function() {
     cat("tiledbsoma:    ", toString(utils::packageVersion("tiledbsoma")), "\n",
         "tiledb-r:      ", toString(utils::packageVersion("tiledb")), "\n",
         "tiledb core:   ", as.character(tiledb::tiledb_version(compact=TRUE)), "\n",
-        "libtiledbsoma: ", libtiledbsoma_version(), "\n",
+        "libtiledbsoma: ", libtiledbsoma_version(compact=TRUE), "\n",
         "R:             ", R.version.string, "\n",
         "OS:            ", utils::osVersion, "\n",
         sep="")

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -178,12 +178,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledbsoma_version
-std::string libtiledbsoma_version();
-RcppExport SEXP _tiledbsoma_libtiledbsoma_version() {
+std::string libtiledbsoma_version(const bool compact);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_version(SEXP compactSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_version());
+    Rcpp::traits::input_parameter< const bool >::type compact(compactSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_version(compact));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -213,7 +214,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_tiledbsoma_stats_disable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_disable, 0},
     {"_tiledbsoma_tiledbsoma_stats_reset", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_reset, 0},
     {"_tiledbsoma_tiledbsoma_stats_dump", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_dump, 0},
-    {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 0},
+    {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 1},
     {"_tiledbsoma_tiledb_embedded_version", (DL_FUNC) &_tiledbsoma_tiledb_embedded_version, 0},
     {NULL, NULL, 0}
 };

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -321,7 +321,10 @@ std::string tiledbsoma_stats_dump() {
 //' @noRd
 // [[Rcpp::export]]
 std::string libtiledbsoma_version() {
-    return tiledbsoma::version::as_string();
+    auto v = tiledbsoma::version::embedded_version_triple();
+    std::ostringstream txt;
+    txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
+    return txt.str();
 }
 
 //' TileDB embedded version

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -318,13 +318,19 @@ std::string tiledbsoma_stats_dump() {
 //' libtiledbsoma version
 //'
 //' Returns a string with version information for libtiledbsoma and the linked TileDB Embedded library.
+//' If argument `compact` is set to `TRUE`, a shorter version of just the TileDB Embedded library
+//' version is returned,
 //' @noRd
 // [[Rcpp::export]]
-std::string libtiledbsoma_version() {
-    auto v = tiledbsoma::version::embedded_version_triple();
-    std::ostringstream txt;
-    txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
-    return txt.str();
+std::string libtiledbsoma_version(const bool compact = false) {
+    if (compact) {
+        auto v = tiledbsoma::version::embedded_version_triple();
+        std::ostringstream txt;
+        txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
+        return txt.str();
+    } else {
+        return tiledbsoma::version::as_string();
+    }
 }
 
 //' TileDB embedded version

--- a/apis/system/tests/test_version_match.py
+++ b/apis/system/tests/test_version_match.py
@@ -17,6 +17,6 @@ class TestVersionMatch(BasePythonRInterop):
         library("tiledb")
         version = tiledb_version()
         stopifnot(as.integer(version["major"]) == {major})
-        stopifnot(as.integer(version["minor"]) == {minor})
+        stopifnot(as.integer(version["minor"]) >= {minor})
         """
         )


### PR DESCRIPTION
**Issue and/or context:**

This is a minor 'quality of life' improvement which aligns the version number display to show, say

```r
> tiledbsoma::show_package_versions()
tiledbsoma:    1.5.1
tiledb-r:      0.21.3.3
tiledb core:   2.18.0
libtiledbsoma: 2.18.0
R:             R version 4.3.2 (2023-10-31)
OS:            Ubuntu 23.04
> 
```

instead of 

```r
> tiledbsoma::show_package_versions()
tiledbsoma:    1.5.1                                    
tiledb-r:      0.21.3.3                                   
tiledb core:   2.18.0                                   
libtiledbsoma: libtiledb=2.18.0               
R:             R version 4.3.2 (2023-10-31)   
OS:            Ubuntu 23.04  
>
```

**Changes:**

The version string is now constructed locally from the version triplet and no longer exports what `as_string()` provides.

**Notes for Reviewer:**

[SC 37189](https://app.shortcut.com/tiledb-inc/story/37189/r-small-beautification-for-show-package-versions)
