### PR TITLE
[python] Work around bug with `aws-sdk-cpp` and `pyarrow` on MacOS

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -285,7 +285,8 @@ setuptools.setup(
         "pyarrow_hotfix",
         # MacOS issue with import pyarrow before import tiledb at >= 13.0:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149
-        "pyarrow>=9.0.0,<13.0.0",
+        "pyarrow>=9.0.0,<13.0.0; platform_system=='Darwin'",
+        "pyarrow>=9.0.0; platform_system!='Darwin'",
         "scanpy>=1.9.2",
         "scipy",
         "somacore==1.0.4",


### PR DESCRIPTION
**Issue and/or context:** Following on https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149

**Changes:** The bug has been bisected to `pyarrrow==12.0` good and `pyarrow==13.0` bad, along with `aws-sdk-cpp` 1.11, on MacOS (`x86_64` or `arm64`).  The `aws-sdk-cpp` issues https://github.com/aws/aws-sdk-cpp/issues/2411
and https://github.com/aws/aws-sdk-cpp/issues/2699 are many months old, and we cannot realistically expect traction. Therefore we pin `pyarrow<13.0` on MacOS. Also note we have `import pyarrow_hotfix` for the `pyarrow` CVE. (See also #1926.)

**Notes for Reviewer:**

