### PR TITLE
[r] Arrays should remain open after write

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.5.1
+Version: 1.5.1.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,9 @@
+# tiledbsoma (development version)
+
+## Fixes
+
+* `SOMADataFrame`, `SOMASparseNDArray`, and `SOMADenseNDArray`'s `write()` method now correctly leaves the array open in write mode
+
 # tiledbsoma 1.5.1
 
 ## Changes

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -133,7 +133,7 @@ tiledbsoma_stats_dump <- function() {
 #' libtiledbsoma version
 #'
 #' Returns a string with version information for libtiledbsoma and the linked TileDB Embedded library.
-#' If argument `compact` is set to `TRUE`, shorter version of just the TileDB Embedded library
+#' If argument `compact` is set to `TRUE`, a shorter version of just the TileDB Embedded library
 #' version is returned,
 #' @noRd
 libtiledbsoma_version <- function(compact = FALSE) {

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -168,7 +168,7 @@ SOMADataFrame <- R6::R6Class(
       arr <- self$object
 
       has_enums <- tiledb::tiledb_array_has_enumeration(arr)
-      if (any(has_enums)) { 			# if enumerations exists in array
+      if (any(has_enums)) {       # if enumerations exists in array
           attrs <- tiledb::attrs(tiledb::schema(arr))
           if (!tiledb::tiledb_array_is_open(arr)) arr <- tiledb::tiledb_array_open(arr, "READ")
           for (attr_name in names(attrs)) {
@@ -186,6 +186,9 @@ SOMADataFrame <- R6::R6Class(
       }
 
       arr[] <- df
+      # tiledb-r always closes the array after a write operation so we need to
+      # manually reopen it until close-on-write is optional
+      self$open("WRITE", internal_use_only = "allowed_use")
     },
 
     #' @description Read (lifecycle: experimental)

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -189,6 +189,7 @@ SOMADataFrame <- R6::R6Class(
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
       self$open("WRITE", internal_use_only = "allowed_use")
+      invisible(self)
     },
 
     #' @description Read (lifecycle: experimental)

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -121,6 +121,7 @@ SOMADenseNDArray <- R6::R6Class(
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
       self$open("WRITE", internal_use_only = "allowed_use")
+      invisible(self)
     }
   ),
 

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -117,6 +117,10 @@ SOMADenseNDArray <- R6::R6Class(
       arr <- self$object
       tiledb::query_layout(arr) <- "COL_MAJOR"
       arr[] <- values
+
+      # tiledb-r always closes the array after a write operation so we need to
+      # manually reopen it until close-on-write is optional
+      self$open("WRITE", internal_use_only = "allowed_use")
     }
   ),
 

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -176,6 +176,10 @@ SOMASparseNDArray <- R6::R6Class(
       }
       self$set_metadata(bbox_flat)
       private$.write_coo_dataframe(coo)
+
+      # tiledb-r always closes the array after a write operation so we need to
+      # manually reopen it until close-on-write is optional
+      self$open("WRITE", internal_use_only = "allowed_use")
     },
 
     #' @description Retrieve number of non-zero elements (lifecycle: experimental)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -180,6 +180,7 @@ SOMASparseNDArray <- R6::R6Class(
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
       self$open("WRITE", internal_use_only = "allowed_use")
+      invisible(self)
     },
 
     #' @description Retrieve number of non-zero elements (lifecycle: experimental)

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -33,6 +33,10 @@ test_that("Basic mechanics", {
                              schema = asch)
 
   sdf$write(tbl0)
+
+  # Verify the array is still open for write
+  expect_equal(sdf$mode(), "WRITE")
+  expect_true(tiledb::tiledb_array_is_open(sdf$object))
   sdf$close()
 
   # Read back the data (ignore attributes)

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -11,6 +11,10 @@ test_that("SOMADenseNDArray creation", {
 
   mat <- create_dense_matrix_with_int_dims(10, 5)
   ndarray$write(mat)
+
+  # Verify the array is still open for write
+  expect_equal(ndarray$mode(), "WRITE")
+  expect_true(tiledb::tiledb_array_is_open(ndarray$object))
   ndarray$close()
 
   # Read result in column-major order to match R matrix layout

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -13,6 +13,10 @@ test_that("SOMASparseNDArray creation", {
   vals <- as.vector(t(as.matrix(mat)))
   vals <- vals[ vals != 0 ] # needed below for comparison
   ndarray$write(mat)
+
+  # Verify the array is still open for write
+  expect_equal(ndarray$mode(), "WRITE")
+  expect_true(tiledb::tiledb_array_is_open(ndarray$object))
   ndarray$close()
 
   ndarray <- SOMASparseNDArrayOpen(uri)


### PR DESCRIPTION
**Issue and/or context:** `TileDBArray`-based classes are returned in an invalid state after calling `$write()` in which:

-  `self$private$.mode == "open"` but 
- `tiledb::tiledb_array_is_open(self$object)` is `FALSE`

This happens because [tiledb-r closes arrays](https://github.com/TileDB-Inc/TileDB-R/blob/faf3ecadc9b739760812f648774f4b21a4d70f19/R/TileDBArray.R#L1412-L1413) after performing a write via `"[<-"`,  so the handle is closed following [this step](https://github.com/single-cell-data/TileDB-SOMA/blob/8bf00f9eaf2bb9c333c16a1b78fa988667aa5db3/apis/r/R/SOMADataFrame.R#L188) but the internal `private$.mode` isn't updated to reflect this.

**Changes:** Arrays are now re-opened in write mode after performing a write to be spec compliant. 

**Notes for Reviewer:**

