### PR TITLE
[python] Fix many `typeguard` warnings

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -101,7 +101,7 @@ jobs:
 #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools sparse
+      run: python -m pip -v install -U pip pytest-cov 'typeguard>=4.0' types-setuptools sparse
 
     - name: Install tiledbsoma
       run: python -m pip -v install -e apis/python

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -101,7 +101,7 @@ jobs:
 #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov 'typeguard>=4.0' types-setuptools sparse
+      run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools sparse
 
     - name: Install tiledbsoma
       run: python -m pip -v install -e apis/python

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-path: ./apis/python/setup.py
 
       - name: Install testing prereqs
-        run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools
+        run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools
 
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -1,5 +1,5 @@
 cmake >= 3.21
 pybind11-global >= 2.10.0
-typeguard < 3.0
+typeguard>=4
 pytest
 sparse

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -13,7 +13,6 @@
 # Based on ideas from https://github.com/pybind/cmake_example
 # The `bld` script here is reused for pip install, CI, and local builds.
 
-# type: ignore
 import ctypes
 import os
 import pathlib

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 from typing import Optional
 
-import setuptools
 import setuptools.command.build_ext
 import wheel.bdist_wheel
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -338,7 +338,7 @@ setuptools.setup(
             "black",
             "ruff",
             "pytest",
-            "typeguard<3.0",
+            "typeguard>=4.0",
         ]
     },
     python_requires=">=3.8",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -338,7 +338,7 @@ setuptools.setup(
             "black",
             "ruff",
             "pytest",
-            "typeguard>=4.0",
+            "typeguard>=4",
         ]
     },
     python_requires=">=3.8",

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -30,7 +30,6 @@ import somacore
 import somacore.collection
 import tiledb
 from somacore import options
-from typeguard import typeguard_ignore
 from typing_extensions import Self
 
 from . import _funcs, _tdb_handles
@@ -38,6 +37,7 @@ from ._common_nd_array import NDArray
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
 from ._exception import SOMAError, is_does_not_exist_error
+from ._funcs import typeguard_ignore
 from ._sparse_nd_array import SparseNDArray
 from ._tiledb_object import AnyTileDBObject, TileDBObject
 from ._types import OpenTimestamp
@@ -231,7 +231,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             Experimental.
         """
         child_cls = kind or Collection
-        return self._add_new_element(  # type: ignore[no-any-return]
+        return self._add_new_element(
             key,
             child_cls,
             lambda create_uri: child_cls.create(
@@ -276,7 +276,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
-        return self._add_new_element(  # type: ignore[no-any-return]
+        return self._add_new_element(
             key,
             DataFrame,
             lambda create_uri: DataFrame.create(
@@ -293,7 +293,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         self, cls: Type[_NDArr], key: str, *, uri: Optional[str] = None, **kwargs: Any
     ) -> _NDArr:
         """Internal implementation of common NDArray-adding operations."""
-        return self._add_new_element(  # type: ignore[no-any-return]
+        return self._add_new_element(
             key,
             cls,
             lambda create_uri: cls.create(
@@ -377,7 +377,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._add_new_ndarray(SparseNDArray, key, **kwargs)
 
-    @typeguard_ignore  # type: ignore[misc]
+    @typeguard_ignore
     def _add_new_element(
         self,
         key: str,
@@ -685,7 +685,7 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
     __slots__ = ()
 
 
-@typeguard_ignore  # type: ignore[misc]
+@typeguard_ignore
 def _real_class(cls: Type[Any]) -> type:
     """Extracts the real class from a generic alias.
 

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -51,7 +51,7 @@ from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
 # A collection can hold any sub-type of TileDBObject
 CollectionElementType = TypeVar("CollectionElementType", bound=AnyTileDBObject)
-_TDBO = TypeVar("_TDBO", bound=AnyTileDBObject)
+_TDBO = TypeVar("_TDBO", bound=TileDBObject)  # type: ignore[type-arg]
 _Coll = TypeVar("_Coll", bound="CollectionBase[AnyTileDBObject]")
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -442,7 +442,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
                     entry.entry.wrapper_type.open, uri, mode, context, timestamp
                 )
             # Since we just opened this object, we own it and should close it.
-            self._close_stack.enter_context(entry.soma)
+            self._close_stack.enter_context(entry.soma)  # type: ignore[arg-type]
         return cast(CollectionElementType, entry.soma)
 
     def set(

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -30,6 +30,7 @@ import somacore
 import somacore.collection
 import tiledb
 from somacore import options
+from typeguard import typeguard_ignore
 from typing_extensions import Self
 
 from . import _funcs, _tdb_handles
@@ -188,7 +189,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         *,
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
-    ) -> "AnyTileDBCollection":
+    ) -> AnyTileDBCollection:
         """Adds a new sub-collection to this collection.
 
         Args:
@@ -229,8 +230,8 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
-        child_cls: Type[AnyTileDBCollection] = kind or Collection
-        return self._add_new_element(
+        child_cls = kind or Collection
+        return self._add_new_element(  # type: ignore[no-any-return]
             key,
             child_cls,
             lambda create_uri: child_cls.create(
@@ -275,7 +276,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
-        return self._add_new_element(
+        return self._add_new_element(  # type: ignore[no-any-return]
             key,
             DataFrame,
             lambda create_uri: DataFrame.create(
@@ -292,7 +293,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         self, cls: Type[_NDArr], key: str, *, uri: Optional[str] = None, **kwargs: Any
     ) -> _NDArr:
         """Internal implementation of common NDArray-adding operations."""
-        return self._add_new_element(
+        return self._add_new_element(  # type: ignore[no-any-return]
             key,
             cls,
             lambda create_uri: cls.create(
@@ -376,6 +377,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._add_new_ndarray(SparseNDArray, key, **kwargs)
 
+    @typeguard_ignore  # type: ignore[misc]
     def _add_new_element(
         self,
         key: str,
@@ -683,6 +685,7 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
     __slots__ = ()
 
 
+@typeguard_ignore  # type: ignore[misc]
 def _real_class(cls: Type[Any]) -> type:
     """Extracts the real class from a generic alias.
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -496,7 +496,11 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         return self
 
     def _set_reader_coord(
-        self, sr: clib.SOMAArray, dim_idx: int, dim: tiledb.Dim, coord: object
+        self,
+        sr: clib.SOMAArray,
+        dim_idx: int,
+        dim: Union[pa.Field, tiledb.Dim],
+        coord: object,
     ) -> bool:
         if coord is None:
             return True  # No constraint; select all in this dimension
@@ -570,7 +574,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self,
         sr: clib.SOMAArray,
         dim_idx: int,
-        dim: tiledb.Dim,
+        dim: Union[pa.Field, tiledb.Dim],
         coord: object,
     ) -> bool:
         if isinstance(coord, np.ndarray):

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -6,7 +6,7 @@
 """
 Implementation of a SOMA DataFrame
 """
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,8 @@ from .options._soma_tiledb_context import _validate_soma_tiledb_context
 from .options._tiledb_create_options import TileDBCreateOptions
 
 _UNBATCHED = options.BatchSize()
-Domain = Sequence[Optional[Tuple[Any, Any] | List[Any]]]
+# TODO: in Python ≥3.10, this can be `Tuple[Any, Any] | List[Any]`. In Python <3.10 it raises `TypeError: unsupported operand type(s) for |: '_GenericAlias' and '_GenericAlias'`
+Domain = Sequence[Optional[Sequence[Any]]]
 
 
 class DataFrame(TileDBArray, somacore.DataFrame):
@@ -720,18 +721,22 @@ def _build_tiledb_schema(
             )
 
     dims = []
-    for index_column_name, slot_domain in zip(index_column_names, domain):
+    for index_column_name, _slot_domain in zip(index_column_names, domain):
+        # TODO: this can be cleaned up a bit in Python ≥3.10 (see note on ``Domain`` type above)
+        if _slot_domain is not None:
+            if not isinstance(_slot_domain, tuple):
+                if len(_slot_domain) != 2:
+                    raise ValueError(
+                        f"Domain slots must be tuples or lists of length 2; received {len(_slot_domain)}-list {_slot_domain}"
+                    )
+            slot_domain = _slot_domain[0], _slot_domain[1]
+        else:
+            slot_domain = None
+
         pa_type = schema.field(index_column_name).type
         dtype = _arrow_types.tiledb_type_from_arrow_type(
             pa_type, is_indexed_column=True
         )
-
-        if isinstance(slot_domain, list):
-            if len(slot_domain) != 2:
-                raise ValueError(
-                    f"Domain slots must be tuples or lists of length 2; received {len(slot_domain)}-list {slot_domain}"
-                )
-            slot_domain = slot_domain[0], slot_domain[1]
 
         slot_domain = _fill_out_slot_domain(
             slot_domain, index_column_name, pa_type, dtype
@@ -772,7 +777,8 @@ def _build_tiledb_schema(
         has_enum = pa.types.is_dictionary(pa_attr.type)
 
         if has_enum:
-            enmr_dtype: np.dtype[Any]
+            # TODO; make this `np.dtype[Any]` in Python ≥3.9
+            enmr_dtype: np.dtype  # type: ignore[type-arg]
             vtype = pa_attr.type.value_type
             if pa.types.is_large_string(vtype) or pa.types.is_string(vtype):
                 enmr_dtype = np.dtype("U")

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -401,7 +401,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         dim_names_set = self.index_column_names
         n = None
 
-        se: tiledb.schema_evolution.ArraySchemaEvolution = None
+        se: Optional[tiledb.schema_evolution.ArraySchemaEvolution] = None
 
         for col_info in values.schema:
             name = col_info.name

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -120,7 +120,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         # 1,000,000x1,000,000 but only 100x200 cells were written -- then we need the non-empty
         # domain.
         #
-        # The non-empty domain is the corret choice in either case.
+        # The non-empty domain is the correct choice in either case.
         #
         # The only exception is if the array has been created but no data have been written at
         # all, in which case the best we can do is use the schema shape.

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -124,7 +124,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         #
         # The only exception is if the array has been created but no data have been written at
         # all, in which case the best we can do is use the schema shape.
-        handle: clib.DenseNDArrayWrapper = self._handle._handle
+        handle: clib.SOMADenseNDArray = self._handle._handle
 
         data_shape = handle.shape
         ned = self.non_empty_domain()

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -7,7 +7,17 @@
 Collection.
 """
 
-from typing import Callable, Dict, Optional, Type, TypeVar, Union, cast, overload
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    no_type_check,
+    overload,
+)
 
 import somacore
 from somacore import options
@@ -29,6 +39,7 @@ from ._constants import (
 )
 from ._exception import SOMAError
 from ._funcs import typeguard_ignore
+from ._tiledb_object import TileDBObject
 from ._types import OpenTimestamp
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
@@ -66,7 +77,7 @@ def open(
     uri: str,
     mode: options.OpenMode = "r",
     *,
-    soma_type: Union[Type["_tiledb_object.AnyTileDBObject"], str, None] = None,
+    soma_type: Union[Type[TileDBObject], str, None] = None,
     context: Optional[SOMATileDBContext] = None,
     tiledb_timestamp: Optional[OpenTimestamp] = None,
 ) -> "_tiledb_object.AnyTileDBObject":
@@ -130,6 +141,7 @@ def open(
         raise
 
 
+@no_type_check
 def _open_internal(
     opener: Callable[
         [str, options.OpenMode, SOMATileDBContext, Optional[OpenTimestamp]], _Wrapper
@@ -195,7 +207,7 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
     return obj_type
 
 
-@typeguard_ignore
+@no_type_check
 def _type_name_to_cls(type_name: str) -> Type["_tiledb_object.AnyTileDBObject"]:
     type_map: Dict[str, Type["_tiledb_object.AnyTileDBObject"]] = {
         t.soma_type.lower(): t  # type: ignore[attr-defined, misc]  # spurious

--- a/apis/python/src/tiledbsoma/_funcs.py
+++ b/apis/python/src/tiledbsoma/_funcs.py
@@ -21,19 +21,18 @@ _T = TypeVar("_T")
 _CT = TypeVar("_CT", bound=Callable[..., Any])
 
 
-# Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
-# decorator without having to depend upon typeguard at runtime.
-def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
-    """No-op. Returns the argument unchanged."""
-    return f
-
-
 try:
     import typeguard
 
-    typeguard_ignore = typeguard.typeguard_ignore  # noqa: F811
+    def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
+        return typeguard.typeguard_ignore(f)  # type: ignore[no-any-return]
+
 except ImportError:
-    pass
+    # Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
+    # decorator without having to depend upon typeguard at runtime.
+    def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
+        """No-op. Returns the argument unchanged."""
+        return f
 
 
 def forwards_kwargs_to(

--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -4,9 +4,10 @@ SOMATileDBContext which would otherwise ensue.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
+import pyarrow as pa
 from somacore.query.types import IndexLike
 
 from tiledbsoma import pytiledbsoma as clib
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def tiledbsoma_build_index(
-    keys: np.typing.NDArray[np.int64],
+    keys: Union[np.typing.NDArray[np.int64], pa.Array],
     *,
     context: Optional["SOMATileDBContext"] = None,
     thread_count: int = 4,

--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 from somacore.query.types import IndexLike
 
@@ -17,7 +18,15 @@ if TYPE_CHECKING:
 
 
 def tiledbsoma_build_index(
-    keys: Union[np.typing.NDArray[np.int64], pa.Array],
+    keys: Union[  # type: ignore[type-arg]
+        np.typing.NDArray[np.int64],
+        pa.Array,
+        pa.IntegerArray,
+        pd.Series,
+        pd.arrays.IntegerArray,
+        pa.ChunkedArray,
+        list[int],
+    ],
     *,
     context: Optional["SOMATileDBContext"] = None,
     thread_count: int = 4,

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -365,8 +365,8 @@ class QueryConditionTree(ast.NodeVisitor):
         return val
 
     def cast_val_to_dtype(
-        self, val: Union[str, int, float, bytes, np.int32], dtype: str
-    ) -> Union[str, int, float, bytes, np.int32]:
+        self, val: Union[str, int, float, bytes, np.int32, np.int64], dtype: str
+    ) -> Union[str, int, float, bytes, np.int32, np.int64]:
         if dtype != "string":
             try:
                 # this prevents numeric strings ("1", '123.32') from getting

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -365,8 +365,10 @@ class QueryConditionTree(ast.NodeVisitor):
         return val
 
     def cast_val_to_dtype(
-        self, val: Union[str, int, float, bytes, np.int32, np.int64], dtype: str
-    ) -> Union[str, int, float, bytes, np.int32, np.int64]:
+        self,
+        val: Union[str, int, float, bytes, np.int32, np.int64, np.float32],
+        dtype: str,
+    ) -> Union[str, int, float, bytes, np.int32, np.int64, np.float32]:
         if dtype != "string":
             try:
                 # this prevents numeric strings ("1", '123.32') from getting

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -152,7 +152,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
     @classmethod
     def _validate_args(
         cls,
-        shape: Union[NTuple, list[int]],
+        shape: Union[NTuple, Sequence[int]],
         axis: Union[int, Sequence[int]],
         size: Optional[Union[int, Sequence[int]]] = None,
         reindex_disable_on_axis: Optional[Union[int, Sequence[int]]] = None,
@@ -229,7 +229,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         """Private"""
         return EagerIterator(x, pool=_pool) if self.eager else x
 
-    def _table_reader(self) -> Generator[BlockwiseTableReadIterResult, None, None]:
+    def _table_reader(self) -> Iterator[BlockwiseTableReadIterResult]:
         """Private. Blockwise table reader. Helper function for sub-class use"""
         kwargs: Dict[str, object] = {"result_order": self.sr.result_order}
         for coord_chunk in _coords_strider(

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import (
     TYPE_CHECKING,
     Dict,
+    Generator,
     Iterator,
     List,
     Optional,
@@ -72,6 +73,9 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
     def concat(self) -> pa.Table:
         """Concatenate remainder of iterator, and return as a single `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_"""
         return pa.concat_tables(self)
+
+
+_EagerRT = TypeVar("_EagerRT")
 
 
 class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
@@ -148,7 +152,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
     @classmethod
     def _validate_args(
         cls,
-        shape: NTuple,
+        shape: Union[NTuple, list[int]],
         axis: Union[int, Sequence[int]],
         size: Optional[Union[int, Sequence[int]]] = None,
         reindex_disable_on_axis: Optional[Union[int, Sequence[int]]] = None,
@@ -219,15 +223,13 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("Blockwise iterators do not support concat operation")
 
-    _EagerRT = TypeVar("_EagerRT")
-
     def _maybe_eager_iterator(
         self, x: Iterator[_EagerRT], _pool: Optional[ThreadPoolExecutor] = None
     ) -> Iterator[_EagerRT]:
         """Private"""
         return EagerIterator(x, pool=_pool) if self.eager else x
 
-    def _table_reader(self) -> BlockwiseSingleAxisTableIter:
+    def _table_reader(self) -> Generator[BlockwiseTableReadIterResult, None, None]:
         """Private. Blockwise table reader. Helper function for sub-class use"""
         kwargs: Dict[str, object] = {"result_order": self.sr.result_order}
         for coord_chunk in _coords_strider(
@@ -247,7 +249,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
     def _reindexed_table_reader(
         self,
         _pool: Optional[ThreadPoolExecutor] = None,
-    ) -> BlockwiseSingleAxisTableIter:
+    ) -> Generator[BlockwiseTableReadIterResult, None, None]:
         """Private. Blockwise table reader w/ reindexing. Helper function for sub-class use"""
         for tbl, coords in self._maybe_eager_iterator(self._table_reader(), _pool):
             pytbl = {}

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -38,7 +38,13 @@ from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import OpenTimestamp
 from .options._soma_tiledb_context import SOMATileDBContext
 
-RawHandle = Union[tiledb.Array, tiledb.Group, clib.SOMADataFrame]
+RawHandle = Union[
+    tiledb.Array,
+    tiledb.Group,
+    clib.SOMADataFrame,
+    clib.SOMASparseNDArray,
+    clib.SOMADenseNDArray,
+]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 """A raw TileDB object. Covariant because Handles are immutable enough."""
 
@@ -350,7 +356,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
 
     # Covariant types should normally not be in parameters, but this is for
     # internal use only so it's OK.
-    def _do_initial_reads(self, reader: _RawHdl_co) -> None:  # type: ignore[misc]
+    def _do_initial_reads(self, reader: _RawHdl_co) -> None:
         """Final setup step before returning the Handle.
 
         This is passed a raw TileDB object opened in read mode, since writers

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -356,7 +356,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
 
     # Covariant types should normally not be in parameters, but this is for
     # internal use only so it's OK.
-    def _do_initial_reads(self, reader: _RawHdl_co) -> None:
+    def _do_initial_reads(self, reader: RawHandle) -> None:
         """Final setup step before returning the Handle.
 
         This is passed a raw TileDB object opened in read mode, since writers

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -354,8 +354,6 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
             timestamp=(0, timestamp),
         )
 
-    # Covariant types should normally not be in parameters, but this is for
-    # internal use only so it's OK.
     def _do_initial_reads(self, reader: RawHandle) -> None:
         """Final setup step before returning the Handle.
 

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the MIT License.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, no_type_check
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import pyarrow as pa
 import tiledb
@@ -40,7 +40,10 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         Lifecycle:
             Experimental.
         """
-        if isinstance(self._tiledb_array_schema(), tiledb.ArraySchema):
+        if isinstance(
+            self._tiledb_array_schema(),
+            tiledb.ArraySchema,
+        ):
             return tiledb_schema_to_arrow(
                 self._tiledb_array_schema(), self.uri, self._ctx
             )
@@ -57,8 +60,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         """
         return self._handle.non_empty_domain()
 
-    @no_type_check  # TODO: sometimes returns pyarrow.lib.Schema
-    def _tiledb_array_schema(self) -> tiledb.ArraySchema:
+    def _tiledb_array_schema(self) -> Union[pa.Schema, tiledb.ArraySchema]:
         """Returns the TileDB array schema, for internal use."""
         return self._handle.schema
 

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the MIT License.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple, no_type_check
 
 import pyarrow as pa
 import tiledb
@@ -57,6 +57,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         """
         return self._handle.non_empty_domain()
 
+    @no_type_check  # TODO: sometimes returns pyarrow.lib.Schema
     def _tiledb_array_schema(self) -> tiledb.ArraySchema:
         """Returns the TileDB array schema, for internal use."""
         return self._handle.schema

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -96,7 +96,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         if not isinstance(handle, cls._reader_wrapper_type):
             handle = cls._wrapper_type.open(uri, mode, context, tiledb_timestamp)
         return cls(
-            handle,  # type: ignore
+            handle,  # type: ignore[arg-type]
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -292,7 +292,7 @@ def anndata_dataframe_unmodified(old: pd.DataFrame, new: pd.DataFrame) -> bool:
     Checks that we didn't mutate the object while ingesting. Intended for unit tests.
     """
     try:
-        return (old == new).all().all()
+        return bool((old == new).all().all())
     except ValueError:
         # Can be thrown when columns don't match -- which is what we check for
         return False

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -7,6 +7,7 @@ from typing import (
     ContextManager,
     Optional,
     Tuple,
+    Union,
 )
 from unittest import mock
 
@@ -71,7 +72,9 @@ def _hack_patch_anndata() -> ContextManager[object]:
     """Part Two of the ``_FSPathWrapper`` trick."""
 
     @file_backing.AnnDataFileManager.filename.setter  # type: ignore
-    def filename(self: file_backing.AnnDataFileManager, filename: Path) -> None:
+    def filename(
+        self: file_backing.AnnDataFileManager, filename: Union[Path, _FSPathWrapper]
+    ) -> None:
         self._filename = filename
 
     return mock.patch.object(file_backing.AnnDataFileManager, "filename", filename)

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -52,10 +52,6 @@ class _FSPathWrapper:
     so here we just proxy all attributes except ``__fspath__``.
     """
 
-    # Needed to make typeguard happy
-    # def __call__(self) -> None:
-    #     pass
-
     def __init__(self, obj: object, path: Path) -> None:
         self._obj = obj
         self._path = path
@@ -71,7 +67,7 @@ class _FSPathWrapper:
 def _hack_patch_anndata() -> ContextManager[object]:
     """Part Two of the ``_FSPathWrapper`` trick."""
 
-    @file_backing.AnnDataFileManager.filename.setter  # type: ignore
+    @file_backing.AnnDataFileManager.filename.setter  # type: ignore[misc]
     def filename(
         self: file_backing.AnnDataFileManager, filename: Union[Path, _FSPathWrapper]
     ) -> None:

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -38,6 +38,7 @@ def read_h5ad(
 # This trick lets us ingest H5AD with "r" (backed mode) from S3 URIs.  While h5ad
 # supports any file-like object, AnnData specifically wants only an `os.PathLike`
 # object. The only thing it does with the PathLike is to use it to get the filename.
+# @typeguard_ignore
 class _FSPathWrapper:
     """Tricks anndata into thinking a file-like object is an ``os.PathLike``.
 
@@ -50,6 +51,10 @@ class _FSPathWrapper:
     so here we just proxy all attributes except ``__fspath__``.
     """
 
+    # Needed to make typeguard happy
+    # def __call__(self) -> None:
+    #     pass
+
     def __init__(self, obj: object, path: Path) -> None:
         self._obj = obj
         self._path = path
@@ -61,6 +66,7 @@ class _FSPathWrapper:
         return getattr(self._obj, name)
 
 
+# @typeguard_ignore
 def _hack_patch_anndata() -> ContextManager[object]:
     """Part Two of the ``_FSPathWrapper`` trick."""
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -24,6 +24,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    no_type_check,
     overload,
 )
 
@@ -1042,7 +1043,7 @@ def _create_or_open_collection(
     ...
 
 
-@typeguard_ignore
+@no_type_check
 def _create_or_open_collection(
     cls: Type[Any],
     uri: str,

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -15,6 +15,7 @@ from typing import (
 import attrs as attrs_  # We use the name `attrs` later.
 import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
+from attr import Attribute
 from somacore import options
 from typing_extensions import Self, TypedDict
 
@@ -168,7 +169,7 @@ class TileDBCreateOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "create"))
         if isinstance(create_entry, dict):
-            attrs: Tuple["attrs_.Attribute", ...] = cls.__attrs_attrs__
+            attrs: Tuple[Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filered_create_entry: Dict[str, Any] = {

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -15,7 +15,6 @@ from typing import (
 import attrs as attrs_  # We use the name `attrs` later.
 import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
-from attr import Attribute
 from somacore import options
 from typing_extensions import Self, TypedDict
 
@@ -173,7 +172,7 @@ class TileDBCreateOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "create"))
         if isinstance(create_entry, dict):
-            attrs: Tuple[Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
+            attrs: Tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filered_create_entry: Dict[str, Any] = {

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -17,6 +17,7 @@ import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
 from attr import Attribute
 from somacore import options
+from typeguard import typeguard_ignore
 from typing_extensions import Self, TypedDict
 
 # Most defaults are configured directly as default attribute values
@@ -81,10 +82,12 @@ class _ColumnConfig:
     tile: Optional[int] = attrs_.field(validator=vld.optional(vld.instance_of(int)))
 
     @classmethod
+    @typeguard_ignore  # type: ignore[misc]
     def from_dict(cls, input: _DictColumnSpec) -> Self:
         return cls(filters=input.get("filters"), tile=input.get("tile"))
 
 
+@typeguard_ignore  # type: ignore[misc]
 def _normalize_columns(
     input: Mapping[str, _DictColumnSpec]
 ) -> Mapping[str, _ColumnConfig]:
@@ -145,10 +148,10 @@ class TileDBCreateOptions:
         validator=vld.optional(vld.instance_of(str)), default=None
     )
     dims: Mapping[str, _ColumnConfig] = attrs_.field(
-        factory=dict, converter=_normalize_columns
+        factory=dict, converter=_normalize_columns  # type: ignore[misc]
     )
     attrs: Mapping[str, _ColumnConfig] = attrs_.field(
-        factory=dict, converter=_normalize_columns
+        factory=dict, converter=_normalize_columns  # type: ignore[misc]
     )
     consolidate_and_vacuum: bool = attrs_.field(
         validator=vld.instance_of(bool), default=False

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -168,7 +168,7 @@ class TileDBCreateOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "create"))
         if isinstance(create_entry, dict):
-            attrs: Tuple["attrs_.Attribute[Any]", ...] = cls.__attrs_attrs__
+            attrs: Tuple["attrs_.Attribute", ...] = cls.__attrs_attrs__
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filered_create_entry: Dict[str, Any] = {

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -7,6 +7,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -16,9 +17,7 @@ import attrs as attrs_  # We use the name `attrs` later.
 import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
 from somacore import options
-from typing_extensions import Self, TypedDict
-
-from .._funcs import typeguard_ignore
+from typing_extensions import Self
 
 # Most defaults are configured directly as default attribute values
 # within TileDBCreateOptions.
@@ -82,12 +81,10 @@ class _ColumnConfig:
     tile: Optional[int] = attrs_.field(validator=vld.optional(vld.instance_of(int)))
 
     @classmethod
-    @typeguard_ignore
     def from_dict(cls, input: _DictColumnSpec) -> Self:
         return cls(filters=input.get("filters"), tile=input.get("tile"))
 
 
-@typeguard_ignore
 def _normalize_columns(
     input: Mapping[str, _DictColumnSpec]
 ) -> Mapping[str, _ColumnConfig]:
@@ -148,10 +145,10 @@ class TileDBCreateOptions:
         validator=vld.optional(vld.instance_of(str)), default=None
     )
     dims: Mapping[str, _ColumnConfig] = attrs_.field(
-        factory=dict, converter=_normalize_columns  # type: ignore[misc]
+        factory=dict, converter=_normalize_columns
     )
     attrs: Mapping[str, _ColumnConfig] = attrs_.field(
-        factory=dict, converter=_normalize_columns  # type: ignore[misc]
+        factory=dict, converter=_normalize_columns
     )
     consolidate_and_vacuum: bool = attrs_.field(
         validator=vld.instance_of(bool), default=False

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -17,8 +17,9 @@ import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
 from attr import Attribute
 from somacore import options
-from typeguard import typeguard_ignore
 from typing_extensions import Self, TypedDict
+
+from .._funcs import typeguard_ignore
 
 # Most defaults are configured directly as default attribute values
 # within TileDBCreateOptions.
@@ -82,12 +83,12 @@ class _ColumnConfig:
     tile: Optional[int] = attrs_.field(validator=vld.optional(vld.instance_of(int)))
 
     @classmethod
-    @typeguard_ignore  # type: ignore[misc]
+    @typeguard_ignore
     def from_dict(cls, input: _DictColumnSpec) -> Self:
         return cls(filters=input.get("filters"), tile=input.get("tile"))
 
 
-@typeguard_ignore  # type: ignore[misc]
+@typeguard_ignore
 def _normalize_columns(
     input: Mapping[str, _DictColumnSpec]
 ) -> Mapping[str, _ColumnConfig]:

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -1,5 +1,5 @@
 import pyarrow as pa
-from typeguard.importhook import install_import_hook
+from typeguard import install_import_hook
 
 # avoid typeguard by importing before calling install_import_hook
 from tiledbsoma import _query_condition  # noqa: F401

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -1,10 +1,10 @@
 import pyarrow as pa
 from typeguard import install_import_hook
 
-# avoid typeguard by importing before calling install_import_hook
-from tiledbsoma import _query_condition  # noqa: F401
-
 install_import_hook("tiledbsoma")
+
+# TODO: `pytest tests/test_basic_anndata_io.py` segfaults without this here (likely other things as well)
+from tiledbsoma import _query_condition  # noqa: F401, E402
 
 """Types supported in a SOMA*NDArray """
 NDARRAY_ARROW_TYPES_SUPPORTED = [

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -1,17 +1,17 @@
 from contextlib import contextmanager
-from typing import Type
+from typing import Any, Type
 
 import pytest
 from typeguard import suppress_type_checks
 
 
 @contextmanager
-def raises(exc: Type[Exception]):
+def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
     """Temporarily suppress typeguard checks in order to verify a runtime exception is raised.
 
     Otherwise, most errors end up manifesting as ``TypeCheckError``s, during tests (thanks to
     ``typeguard``'s import hook).
     """
     with suppress_type_checks():
-        with pytest.raises(exc):
+        with pytest.raises(exc, *args, **kwargs):
             yield

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager
+from typing import Type
+
+import pytest
+from typeguard import suppress_type_checks
+
+
+@contextmanager
+def raises(exc: Type[Exception]):
+    """Temporarily suppress typeguard checks in order to verify a runtime exception is raised.
+
+    Otherwise, most errors end up manifesting as ``TypeCheckError``s, during tests (thanks to
+    ``typeguard``'s import hook).
+    """
+    with suppress_type_checks():
+        with pytest.raises(exc):
+            yield

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -7,9 +7,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from typeguard import suppress_type_checks
 from typing_extensions import Literal
 
 import tiledbsoma as soma
+from tests._util import raises_no_typeguard
 from tiledbsoma import _collection, _factory, _tiledb_object
 from tiledbsoma._exception import DoesNotExistError
 from tiledbsoma.options import SOMATileDBContext
@@ -385,14 +387,15 @@ def test_cascading_close(tmp_path: pathlib.Path):
     ],
 )
 def test_real_class(in_type, want):
-    assert _collection._real_class(in_type) is want
+    with suppress_type_checks():
+        assert _collection._real_class(in_type) is want
 
 
 @pytest.mark.parametrize(
     "in_type", (Union[int, str], Literal["bacon"], TypeVar("_T", bound=List))
 )
 def test_real_class_fail(in_type):
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         _collection._real_class(in_type)
 
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -10,7 +10,7 @@ import tiledb
 from pandas.api.types import union_categoricals
 
 import tiledbsoma as soma
-from tests._util import raises
+from tests._util import raises_no_typeguard
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def test_dataframe(tmp_path, arrow_schema):
     with pytest.raises(ValueError):
         # requires one or more index columns
         soma.DataFrame.create(uri, schema=asch, index_column_names=[])
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # invalid schema type
         soma.DataFrame.create(uri, schema=asch.to_string(), index_column_names=[])
     with pytest.raises(ValueError):
@@ -79,7 +79,7 @@ def test_dataframe(tmp_path, arrow_schema):
 
             sdf.write(rb)
 
-            with raises(TypeError):
+            with raises_no_typeguard(TypeError):
                 # non-arrow write
                 sdf.write(rb.to_pandas)
 
@@ -947,7 +947,7 @@ def test_result_order(tmp_path):
             15,
         ]
 
-        with raises(ValueError):
+        with raises_no_typeguard(ValueError):
             next(sdf.read(result_order="bogus"))
 
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -10,6 +10,7 @@ import tiledb
 from pandas.api.types import union_categoricals
 
 import tiledbsoma as soma
+from tests._util import raises
 
 
 @pytest.fixture
@@ -44,7 +45,7 @@ def test_dataframe(tmp_path, arrow_schema):
     with pytest.raises(ValueError):
         # requires one or more index columns
         soma.DataFrame.create(uri, schema=asch, index_column_names=[])
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         # invalid schema type
         soma.DataFrame.create(uri, schema=asch.to_string(), index_column_names=[])
     with pytest.raises(ValueError):
@@ -78,7 +79,7 @@ def test_dataframe(tmp_path, arrow_schema):
 
             sdf.write(rb)
 
-            with pytest.raises(TypeError):
+            with raises(TypeError):
                 # non-arrow write
                 sdf.write(rb.to_pandas)
 
@@ -946,7 +947,7 @@ def test_result_order(tmp_path):
             15,
         ]
 
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             next(sdf.read(result_order="bogus"))
 
 

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -10,6 +10,7 @@ import tiledbsoma as soma
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+from ._util import raises
 
 
 @pytest.mark.parametrize(
@@ -24,7 +25,7 @@ def test_dense_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         soma.DenseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
         )
@@ -75,7 +76,7 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
     # random sample -- written to entire array
     data = np.random.default_rng().standard_normal(np.prod(shape)).reshape(shape)
     coords = tuple(slice(0, dim_len) for dim_len in shape)
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         a.write(coords, data)
     a.write(coords, pa.Tensor.from_numpy(data))
     del a
@@ -343,7 +344,7 @@ def test_dense_nd_array_indexing_errors(tmp_path, io):
         a.write(coords=write_coords, values=pa.Tensor.from_numpy(npa))
 
     with soma.DenseNDArray.open(tmp_path.as_posix()) as a:
-        with pytest.raises(io["throws"]):
+        with raises(io["throws"]):
             a.read(coords=read_coords).to_numpy()
 
 

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -10,7 +10,7 @@ import tiledbsoma as soma
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
-from ._util import raises
+from ._util import raises_no_typeguard
 
 
 @pytest.mark.parametrize(
@@ -25,7 +25,7 @@ def test_dense_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         soma.DenseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
         )
@@ -76,7 +76,7 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
     # random sample -- written to entire array
     data = np.random.default_rng().standard_normal(np.prod(shape)).reshape(shape)
     coords = tuple(slice(0, dim_len) for dim_len in shape)
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         a.write(coords, data)
     a.write(coords, pa.Tensor.from_numpy(data))
     del a
@@ -344,7 +344,7 @@ def test_dense_nd_array_indexing_errors(tmp_path, io):
         a.write(coords=write_coords, values=pa.Tensor.from_numpy(npa))
 
     with soma.DenseNDArray.open(tmp_path.as_posix()) as a:
-        with raises(io["throws"]):
+        with raises_no_typeguard(io["throws"]):
             a.read(coords=read_coords).to_numpy()
 
 

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -10,7 +10,7 @@ from scipy import sparse
 from somacore import options
 
 import tiledbsoma as soma
-from tests._util import raises
+from tests._util import raises_no_typeguard
 from tiledbsoma import SOMATileDBContext, _factory
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma.experiment_query import X_as_series
@@ -511,7 +511,7 @@ def test_error_corners(soma_experiment: soma.Experiment):
     # Illegal layer name type
     for lyr_name in [True, 3, 99.3]:
         with soma_experiment.axis_query("RNA") as query:
-            with raises(KeyError):
+            with raises_no_typeguard(KeyError):
                 next(query.X(lyr_name))
             with pytest.raises(ValueError):
                 next(query.obsp(lyr_name))

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import numpy as np
 import pyarrow as pa
 import pytest
+from typeguard import suppress_type_checks
 
 import tiledbsoma as soma
 from tiledbsoma import _factory
@@ -107,7 +108,8 @@ def test_metadata(soma_object):
         assert "'foobar': " in meta_repr
         assert "'my': 'enemies'" in meta_repr
     # ...but closed metadata does not.
-    meta_repr_closed = repr(second_read.metadata)
+    with suppress_type_checks():  # type checking eagerly evaluates properties including `len`, which fails on a closed object
+        meta_repr_closed = repr(second_read.metadata)
     assert "foobar" not in meta_repr_closed
 
 

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -508,13 +508,13 @@ def test_multiples_without_experiment(
         h5ad_file_names[permutation[2]],
         h5ad_file_names[permutation[3]],
     ]:
-        tiledbsoma.io.from_h5ad(  # typeguard: ignore
+        tiledbsoma.io.from_h5ad(
             experiment_uri,
             h5ad_file_name,
             measurement_name="measname",
             ingest_mode="write",
             registration_mapping=rd,
-        )  # typeguard: ignore
+        )
 
     expect_obs_soma_joinids = list(range(12))
     expect_var_soma_joinids = list(range(7))

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -508,13 +508,13 @@ def test_multiples_without_experiment(
         h5ad_file_names[permutation[2]],
         h5ad_file_names[permutation[3]],
     ]:
-        tiledbsoma.io.from_h5ad(
+        tiledbsoma.io.from_h5ad(  # typeguard: ignore
             experiment_uri,
             h5ad_file_name,
             measurement_name="measname",
             ingest_mode="write",
             registration_mapping=rd,
-        )
+        )  # typeguard: ignore
 
     expect_obs_soma_joinids = list(range(12))
     expect_var_soma_joinids = list(range(7))

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -19,7 +19,7 @@ from tiledbsoma import _factory
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
-from ._util import raises
+from ._util import raises_no_typeguard
 
 AnySparseTensor = Union[pa.SparseCOOTensor, pa.SparseCSRMatrix, pa.SparseCSCMatrix]
 
@@ -36,7 +36,7 @@ def test_sparse_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # non-arrow write
         soma.SparseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
@@ -249,7 +249,7 @@ def test_sparse_nd_array_read_write_sparse_tensor(
     # so we must be prepared for StopIteration on reading them. It simplifies unit-test logic to use
     # occupation density of 1.0 for this test.
     data = create_random_tensor(format, shape, np.float64, 1.0)
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # non-arrow write
         a.write(data.to_numpy())
     a.write(data)
@@ -964,9 +964,9 @@ def test_sparse_nd_array_error_corners(tmp_path):
         )
 
         # Write should reject unknown types
-        with raises(TypeError):
+        with raises_no_typeguard(TypeError):
             a.write(pa.array(np.zeros((99,), dtype=np.uint32)))
-        with raises(TypeError):
+        with raises_no_typeguard(TypeError):
             a.write(pa.chunked_array([np.zeros((99,), dtype=np.uint32)]))
 
         # Write should reject wrong dimensionality

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -19,6 +19,7 @@ from tiledbsoma import _factory
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+from ._util import raises
 
 AnySparseTensor = Union[pa.SparseCOOTensor, pa.SparseCSRMatrix, pa.SparseCSCMatrix]
 
@@ -35,7 +36,7 @@ def test_sparse_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         # non-arrow write
         soma.SparseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
@@ -248,7 +249,7 @@ def test_sparse_nd_array_read_write_sparse_tensor(
     # so we must be prepared for StopIteration on reading them. It simplifies unit-test logic to use
     # occupation density of 1.0 for this test.
     data = create_random_tensor(format, shape, np.float64, 1.0)
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         # non-arrow write
         a.write(data.to_numpy())
     a.write(data)
@@ -963,9 +964,9 @@ def test_sparse_nd_array_error_corners(tmp_path):
         )
 
         # Write should reject unknown types
-        with pytest.raises(TypeError):
+        with raises(TypeError):
             a.write(pa.array(np.zeros((99,), dtype=np.uint32)))
-        with pytest.raises(TypeError):
+        with raises(TypeError):
             a.write(pa.chunked_array([np.zeros((99,), dtype=np.uint32)]))
 
         # Write should reject wrong dimensionality

--- a/apis/python/tests/test_tiledbobject.py
+++ b/apis/python/tests/test_tiledbobject.py
@@ -2,7 +2,7 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
-from tests._util import raises
+from tests._util import raises_no_typeguard
 
 # Checking that objects _do_ exist is already done (thoroughly) in other tests. Here
 # we primarily focus on the negative cases.
@@ -42,7 +42,7 @@ def test_tiledbobject_exists_nonexistent_path(uri, somaclass):
     ],
 )
 def test_tiledbobject_exists_invalid_uri_type(uri, somaclass):
-    with raises(TypeError):
+    with raises_no_typeguard(TypeError):
         somaclass.exists(uri)
 
 

--- a/apis/python/tests/test_tiledbobject.py
+++ b/apis/python/tests/test_tiledbobject.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
+from tests._util import raises
 
 # Checking that objects _do_ exist is already done (thoroughly) in other tests. Here
 # we primarily focus on the negative cases.
@@ -41,7 +42,7 @@ def test_tiledbobject_exists_nonexistent_path(uri, somaclass):
     ],
 )
 def test_tiledbobject_exists_invalid_uri_type(uri, somaclass):
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         somaclass.exists(uri)
 
 


### PR DESCRIPTION
Some post-1.6.0 housekeeping.

We've been seeing literally hundreds of `pytest` warnings per CI run, which is frictional to sort through on CI fails.

Regarding the dominant error which is `no type annotations present -- not typechecking {}'.format(function_name(func))` I could not easily find any _where_ location. (Maddening.) But by comment-out bisection on `tiledbsoma.io` I found `_create_and_open_coll` and `_create_and_open_collection` (and `@overload` variants), the _existence_ of which on a typeguarded import results in these warnings.

I found https://github.com/agronholm/typeguard/issues/108 and in particular https://github.com/agronholm/typeguard/issues/108#issuecomment-1379547357 indicating that this is a fault of older typeguard versions.

Meanwhile thanks to yours truly on https://github.com/single-cell-data/TileDB-SOMA/pull/1115 we're currently pinned to `typeguard<3` which deprives us of the fix for the above.

On the other hand, typeguard 4 has a couple syntax changes to accommodate -- which this PR dutifully implements.

----
### @ryan-williams updates ca. Mar '24

- Fixes #1116
- Fixes #2238: restores typeguard to running on most of the `tiledbsoma` module (which was previously being skipped inadvertently)
- Fixes/Ignores many type errors that had crept in due to missing typeguard coverage