### PR TITLE
[python] Full Windows pre-push CI matrix

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -21,8 +21,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-12]
-        python-version: ['3.10', '3.7']
+        # TODO: temporary full -- but pre-push -- Windows-only CI for this PR
+        # os: [ubuntu-22.04, macos-12]
+        # python-version: ['3.10', '3.7']
+        os: [windows-2019]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: ubuntu-22.04
             cc: gcc-11


### PR DESCRIPTION
#1811 added Windows support. Pre-push/minimal CI was green, but post-push/full CI was not -- see notes on #1959 -- hence the revert on #1959. Then #1961 restores #1811 to `main` but without Windows CI. This is the sweet spot: now we have the large Windows PR in `main`, with opt-in CI testing here on this PR.  CC @teo-tsirpanis and @nguyenv .