### PR TITLE
[python] Fix `from_anndata()` to respect `var_id_name`

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -505,7 +505,7 @@ def from_anndata(
             with _write_dataframe(
                 _util.uri_joinpath(measurement_uri, "var"),
                 conversions.decategoricalize_obs_or_var(anndata.var),
-                id_column_name="var_id",
+                id_column_name=var_id_name,
                 platform_config=platform_config,
                 context=context,
                 ingestion_params=ingestion_params,

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -836,6 +836,18 @@ def test_id_names(tmp_path, obs_id_name, var_id_name, indexify_obs, indexify_var
         assert obs_id_name in exp.obs.keys()
         assert var_id_name in exp.ms["RNA"].var.keys()
 
+        if indexify_obs:
+            expected_obs_keys = ["soma_joinid", obs_id_name] + adata.obs_keys()
+        else:
+            expected_obs_keys = ["soma_joinid"] + adata.obs_keys()
+        assert list(exp.obs.keys()) == expected_obs_keys
+
+        if indexify_var:
+            expected_var_keys = ["soma_joinid", var_id_name] + adata.var_keys()
+        else:
+            expected_var_keys = ["soma_joinid"] + adata.var_keys()
+        assert list(exp.ms["RNA"].var.keys()) == expected_var_keys
+
         # Implicitly, a check for no-throw
         bdata = tiledbsoma.io.to_anndata(
             exp,


### PR DESCRIPTION
**Issue and/or context:** Bug report from user attempting to append an AnnData object to an existing SOMA experiment using a custom name for `var_id`.  

**Changes:** The `var_id_name` argument is no longer ignored. Relevant unit tests were updated to validate the set of columns read back from `obs` and `var` exactly match the input. 

