### PR TITLE
[python] Fix data loss for multiple writes with `Enumeration` extend

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -422,9 +422,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
                     # get new enumeration values by taking the set difference
                     # while maintaining ordering
-                    update_vals = pd.Series(
-                        np.concatenate([enmr.values(), enmr.values(), col.dictionary])
-                    ).drop_duplicates(keep=False)
+                    update_vals = np.setdiff1d(
+                        col.dictionary, enmr.values(), assume_unique=True
+                    )
 
                     # only extend if there are new values
                     if len(update_vals) != 0:

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -436,6 +436,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                         else:
                             extend_vals = np.array(update_vals, enmr.dtype)
                         new_enmr = enmr.extend(extend_vals)
+                        df = pd.Categorical(col.chunk(0).to_pandas(), new_enmr.values())
+                        col = pa.chunked_array(pa.DictionaryArray.from_pandas(df))
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -420,14 +420,14 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
                     enmr = self._handle.enum(attr.name)
 
-                    # get new enumeration values, maintain original ordering
-                    update_vals = []
-                    for new_val in col.dictionary.tolist():
-                        if new_val not in enmr.values():
-                            update_vals.append(new_val)
+                    # get new enumeration values by taking the set difference
+                    # while maintaining ordering
+                    update_vals = pd.Series(
+                        np.concatenate([enmr.values(), enmr.values(), col.dictionary])
+                    ).drop_duplicates(keep=False)
 
                     # only extend if there are new values
-                    if update_vals:
+                    if len(update_vals) != 0:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
                         if np.issubdtype(enmr.dtype.type, np.str_):
                             extend_vals = np.array(update_vals, "U")

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -427,7 +427,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     )
 
                     # only extend if there are new values
-                    if len(update_vals) != 0:
+                    if update_vals:
                         se = tiledb.ArraySchemaEvolution(self.context.tiledb_ctx)
                         if np.issubdtype(enmr.dtype.type, np.str_):
                             extend_vals = np.array(update_vals, "U")

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -404,14 +404,14 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         for col_info in values.schema:
             name = col_info.name
-            col = values.column(name)
+            col = values.column(name).combine_chunks()
             n = len(col)
 
             if self._handle.schema.has_attr(name):
                 attr = self._handle.schema.attr(name)
 
                 # Add the enumeration values to the TileDB Array from ArrowArray
-                if attr.enum_label is not None and col.num_chunks != 0:
+                if attr.enum_label is not None:
                     if not pa.types.is_dictionary(col_info.type):
                         raise ValueError(
                             "Expected dictionary type for enumerated attribute "
@@ -422,7 +422,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
                     # get new enumeration values, maintain original ordering
                     update_vals = []
-                    for new_val in col.chunk(0).dictionary.tolist():
+                    for new_val in col.dictionary.tolist():
                         if new_val not in enmr.values():
                             update_vals.append(new_val)
 
@@ -436,37 +436,25 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                         else:
                             extend_vals = np.array(update_vals, enmr.dtype)
                         new_enmr = enmr.extend(extend_vals)
-                        df = pd.Categorical(col.chunk(0).to_pandas(), new_enmr.values())
-                        col = pa.chunked_array(pa.DictionaryArray.from_pandas(df))
+                        df = pd.Categorical(col.to_pandas(), new_enmr.values())
+                        col = pa.DictionaryArray.from_pandas(df)
                         se.extend_enumeration(new_enmr)
                         se.array_evolve(uri=self.uri)
 
             cols_map = dim_cols_map if name in dim_names_set else attr_cols_map
+            schema = self._handle.schema
             if pa.types.is_dictionary(col.type):
-                if col.num_chunks != 0:
-                    if name in dim_names_set:
-                        # Dims are never categorical. Decategoricalize for them.
-                        cols_map[name] = pa.chunked_array(
-                            [chunk.dictionary_decode() for chunk in col.chunks]
-                        )
-                    else:
-                        attr = self._handle.schema.attr(name)
-                        if attr.enum_label is not None:
-                            # Normal case: writing categorical data to categorical schema.
-                            cols_map[name] = col.chunk(0).indices.to_pandas()
-                        else:
-                            # Schema is non-categorical but the user is writing categorical.
-                            # Simply decategoricalize for them.
-                            cols_map[name] = pa.chunked_array(
-                                [chunk.dictionary_decode() for chunk in col.chunks]
-                            )
+                if (
+                    name not in dim_names_set
+                    and schema.attr(name).enum_label is not None
+                ):
+                    cols_map[name] = col.indices.to_pandas()
                 else:
-                    cols_map[name] = col.to_pandas()
+                    cols_map[name] = col
 
             else:
                 if name not in dim_names_set:
-                    attr = self._handle.schema.attr(name)
-                    if attr.enum_label is not None:
+                    if schema.attr(name).enum_label is not None:
                         raise ValueError(
                             f"Categorical column {name} must be presented with categorical data"
                         )

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1203,6 +1203,7 @@ def test_multiple_writes_with_enums(tmp_path):
 
     assert df.equals(expected_df)
 
+
 def test_multichunk(tmp_path):
     uri = tmp_path.as_posix()
 
@@ -1248,7 +1249,7 @@ def test_multichunk(tmp_path):
 
     with soma.open(uri) as A:
         df = A.read().concat().to_pandas()
-        
+
     assert df.equals(expected_df)
 
 


### PR DESCRIPTION
**Issue and/or context:**

#1973

When not all the categorical values are present in the column to be written, the index values are incorrect and results in data loss.

**Changes:**

Update the column with the extended enumerations so that the index values are mapped correctly.