### PR TITLE
[r] Ensure factors are releveled before appending w/ expanded levels

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: linux

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -180,6 +180,7 @@ SOMADataFrame <- R6::R6Class(
                       ase <- tiledb::tiledb_array_schema_evolution()
                       ase <- tiledb::tiledb_array_schema_evolution_extend_enumeration(ase, arr, attr_name, added_enum)
                       tiledb::tiledb_array_schema_evolution_array_evolve(ase, self$uri)
+                      df[, attr_name] <- factor(df[, attr_name], levels = unique(c(old_enum,new_enum)))
                   }
               }
           }

--- a/apis/r/tests/testthat.R
+++ b/apis/r/tests/testthat.R
@@ -1,9 +1,3 @@
-if (Sys.info()[["sysname"]] == "Linux") {
-    Sys.setenv("TILEDB_SM_COMPUTE_CONCURRENCY_LEVEL"=1,
-               "TILEDB_SM_IO_CONCURRENCY_LEVEL"=1,
-               "OMP_THREAD_LIMIT"=1)
-}
-
 library(testthat)
 library(tiledbsoma)
 

--- a/apis/r/tests/testthat.R
+++ b/apis/r/tests/testthat.R
@@ -1,3 +1,9 @@
+if (Sys.info()[["sysname"]] == "Linux") {
+    Sys.setenv("TILEDB_SM_COMPUTE_CONCURRENCY_LEVEL"=1,
+               "TILEDB_SM_IO_CONCURRENCY_LEVEL"=1,
+               "OMP_THREAD_LIMIT"=1)
+}
+
 library(testthat)
 library(tiledbsoma)
 

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -152,7 +152,6 @@ test_that("Iterated Interface from SOMA Classes", {
 
 test_that("Iterated Interface from SOMA Sparse Matrix", {
     skip_if(!extended_tests() || covr_tests())
-    skip_on_ci()
     skip_if_not_installed("pbmc3k.tiledb")      # a Suggests: pre-package 3k PBMC data
 
     tdir <- tempfile()

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -153,6 +153,7 @@ test_that("Iterated Interface from SOMA Classes", {
 test_that("Iterated Interface from SOMA Sparse Matrix", {
     skip_if(!extended_tests() || covr_tests())
     skip_if_not_installed("pbmc3k.tiledb")      # a Suggests: pre-package 3k PBMC data
+    skip_if(Sys.getenv("CI", "") != "")         # breaks only in CI so skipping
 
     tdir <- tempfile()
     tgzfile <- system.file("raw-data", "soco-pbmc3k.tar.gz", package="pbmc3k.tiledb")


### PR DESCRIPTION
**Issue and/or context:**

When a `factor` variable `factor(c("A", "B", "A"))` is written, we write vector `c(1,2,1)` and labels `c("A", "B")`.  So far, so good.  As @bkmartinjr demonstrated if we then append a `factor(c("B", "C", "B"))` that is constructed without knowledge of the prior factor we also see `c(1,2,1)` and labels `c("B", "C"))`.   We were already correctly augmenting the stored enumeration labels to be `c("A", "B", "C")` but we still wrote `c(1,2,1)` -- when it should be `c(2, 3, 2)`.   

**Changes:**

The missing step of 're-levelling' the factor variable that is appended is now added.  

New tests have been added.

**Notes for Reviewer:**

[SC 38305](https://app.shortcut.com/tiledb-inc/story/38305/diagnose-multiple-categorical-write-issue-for-tiledb-soma-py-and-tiledb-soma-r)
