### PR TITLE
Update to use somacore==1.0.7.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: mypy
       additional_dependencies:
         - "pandas-stubs==1.5.3.230214"
-        - "somacore==1.0.6"
+        - "somacore==1.0.7"
         - "types-setuptools==67.4.0.3"
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -293,7 +293,7 @@ setuptools.setup(
         "pyarrow>=9.0.0; platform_system!='Darwin'",
         "scanpy>=1.9.2",
         "scipy",
-        "somacore==1.0.6",
+        "somacore==1.0.7",
         "tiledb~=0.24.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],


### PR DESCRIPTION
somacore v1.0.7 is fully compatible with v1.0.6 and does not introduce any behavior changes. It does *prepare* us for the reindexer change: https://github.com/single-cell-data/TileDB-SOMA/pull/1728

Note: This can be folded into #1728 if we want, and I have no objections to doing so.