### PR TITLE
TileDB-SOMA 1.5.3

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.5.2
+Version: 1.5.3
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,10 @@
+# tiledbsoma 1.5.3
+
+## Changes
+
+1.5.3 delivers a Python-only bugfix on the `release-1.5` branch. R is not affected, other than our
+commitment to keep Python and R API versions synchronized.
+
 # tiledbsoma 1.5.2
 
 ## Changes


### PR DESCRIPTION
Following our established procedure:

https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases

The content of 1.5.3 is #1993 and #2003 which are Python-only.