### PR TITLE
[r] tiledbsoma 1.6.2

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.6.1
+Version: 1.6.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,10 @@
+# tiledbsoma 1.6.2
+
+## Changes
+
+1.6.2 delivers a Python-only bugfix on the `release-1.5` branch. R is not affected, other than our
+commitment to keep Python and R API versions synchronized.
+
 # tiledbsoma 1.6.1
 
 ## Changes


### PR DESCRIPTION
This is a direct analog of #2004.

* 1.5.3 is a Python-only bugfix on the `release-1.5` branch, delivering #1995 . #2004 R-tags 1.5.3.
* 1.6.2 is a Python-only bugfix on the `release-1.6` branch, delivering #1996 . This PR R-tags 1.6.2.
* Both #1995 and #1996 are backports to their respective branches of the same bugfix #1993