### PR TITLE
[r] Ensure addition of factor levels does not overflow capacity of index type

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -177,6 +177,12 @@ SOMADataFrame <- R6::R6Class(
                   new_enum <- levels(values[[attr_name]]$as_vector())
                   added_enum <- setdiff(new_enum, old_enum)
                   if (length(added_enum) > 0) {
+                      datatype <- tiledb::datatype(attrs[[attr_name]])
+                      maxval <- tiledb:::tiledb_datatype_max_value(datatype) + 1 # R is one-based
+                      if (length(old_enum) + length(added_enum) > maxval) {
+                          stop(sprintf("For column '%s' cannot add %d factor levels to existing %d for type '%s' with maximum value %d",
+                                       attr_name, length(added_enum), length(old_enum), datatype, maxval), call. = FALSE)
+                      }
                       ase <- tiledb::tiledb_array_schema_evolution()
                       ase <- tiledb::tiledb_array_schema_evolution_extend_enumeration(ase, arr, attr_name, added_enum)
                       tiledb::tiledb_array_schema_evolution_array_evolve(ase, self$uri)

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -821,7 +821,7 @@ test_that("factor levels can grow without overlap", {
     expect_equal(tbl, ref)
 })
 
-test_that("factor levels cannot beyond index limit", {
+test_that("factor levels cannot extend beyond index limit", {
     for (tp in c("INT8", "UINT8")) {
         uri <- tempfile()
         idx_type <- if (tp == "INT8") arrow::int8() else arrow::uint8()


### PR DESCRIPTION
**Issue and/or context:**

As discussed in #1975, index type can overflow when factor levels are added.

**Changes:**

When factor levels are added, the sum of 'before plus added' is compared to the capacity of the index type, and an error is signalled if the latter is exceeded.  An unit test has been where writing 130 levels exceeds the possible 128 on `int8_t` leading to error and passes on `uint8_t` indexing.

**Notes for Reviewer:**

[SC 39079](https://app.shortcut.com/tiledb-inc/story/39079/r-ensure-factor-levels-do-not-overflow)
[SC 38448](https://app.shortcut.com/tiledb-inc/story/38448/dataframe-categorical-handling-does-not-handle-extension-past-index-type-limit)
#1975
