### PR TITLE
[r] Add support for registering arrays with `write_soma()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.6.99
+Version: 1.6.99.9001
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.6.99.9001
+Version: 1.6.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,9 @@
+# Develop
+
+## Changes
+
+* Add support for registering arrays with their parent collection in `write_soma()`
+
 # tiledbsoma 1.6.0
 
 ## Fixes

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -54,6 +54,9 @@ NULL
 #' \code{\link{SOMADataFrame}}
 #' @param index_column_names Names of columns in \code{x} to index in the
 #' resulting SOMA object
+#' @param key Optionally register the resulting \code{SOMADataFrame} in
+#' \code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
+#' to handle manually
 #'
 #' @rdname write_soma_objects
 #'
@@ -88,6 +91,7 @@ write_soma.data.frame <- function(
   df_index = NULL,
   index_column_names = 'soma_joinid',
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -95,8 +99,10 @@ write_soma.data.frame <- function(
   stopifnot(
     "'x' must be named" = is_named(x, allow_empty = FALSE),
     "'df_index' must be a single character value" = is.null(df_index) ||
-      is_scalar_character(df_index),
-    "'index_column_names' must be a character vector" = is.character(index_column_names)
+      (is_scalar_character(df_index) && nzchar(key)),
+    "'index_column_names' must be a character vector" = is.character(index_column_names),
+    "'key' must be a single character value" = is.null(key) ||
+      (is_scalar_character(key) && nzchar(key))
   )
   # Create a proper URI
   uri <- .check_soma_uri(
@@ -104,6 +110,9 @@ write_soma.data.frame <- function(
     soma_parent = soma_parent,
     relative = relative
   )
+  if (is.character(key) && is.null(soma_parent)) {
+    stop("'soma_parent' must be a SOMACollection if 'key' is provided")
+  }
   # Clean up data types in `x`
   remove <- vector(mode = 'logical', length = ncol(x))
   for (i in seq_len(ncol(x))) {
@@ -163,8 +172,13 @@ write_soma.data.frame <- function(
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  # Write and return
+  # Write values
   sdf$write(tbl)
+  # Add to `soma_parent`
+  if (is.character(key)) {
+    soma_parent$set(sdf, name = key, relative = relative)
+  }
+  # Return
   return(sdf)
 }
 
@@ -194,6 +208,7 @@ write_soma.matrix <- function(
   type = NULL,
   transpose = FALSE,
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -201,7 +216,9 @@ write_soma.matrix <- function(
   stopifnot(
     "'sparse' must be a single logical value" = is_scalar_logical(sparse),
     "'type' must be an Arrow type" = is.null(type) || is_arrow_data_type(type),
-    "'transpose' must be a single logical value" = is_scalar_logical(transpose)
+    "'transpose' must be a single logical value" = is_scalar_logical(transpose),
+    "'key' must be a single character value" = is.null(key) ||
+      (is_scalar_character(key) && nzchar(key))
   )
   if (!isTRUE(sparse) && inherits(x = x, what = 'sparseMatrix')) {
     stop(
@@ -218,6 +235,7 @@ write_soma.matrix <- function(
       type = type,
       transpose = transpose,
       ...,
+      key = key,
       platform_config = platform_config,
       tiledbsoma_ctx = tiledbsoma_ctx,
       relative = relative
@@ -233,6 +251,9 @@ write_soma.matrix <- function(
     soma_parent = soma_parent,
     relative = relative
   )
+  if (is.character(key) && is.null(soma_parent)) {
+    stop("'soma_parent' must be a SOMACollection if 'key' is provided")
+  }
   # Transpose the matrix
   if (isTRUE(transpose)) {
     x <- t(x)
@@ -245,8 +266,13 @@ write_soma.matrix <- function(
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  # Write and return
+  # Write values
   array$write(x)
+  # Add to `soma_parent`
+  if (is.character(key)) {
+    soma_parent$set(array, name = key, relative = relative)
+  }
+  # Return
   return(array)
 }
 
@@ -284,6 +310,7 @@ write_soma.TsparseMatrix <- function(
   type = NULL,
   transpose = FALSE,
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -293,7 +320,9 @@ write_soma.TsparseMatrix <- function(
     "'x' must not be a pattern matrix" = !inherits(x = x, what = 'nsparseMatrix'),
     "'type' must be an Arrow type" = is.null(type) ||
       (R6::is.R6(type) && inherits(x = type, what = 'DataType')),
-    "'transpose' must be a single logical value" = is_scalar_logical(transpose)
+    "'transpose' must be a single logical value" = is_scalar_logical(transpose),
+    "'key' must be a single character value" = is.null(key) ||
+      (is_scalar_character(key) && nzchar(key))
   )
   # Create a proper URI
   uri <- .check_soma_uri(
@@ -301,6 +330,9 @@ write_soma.TsparseMatrix <- function(
     soma_parent = soma_parent,
     relative = relative
   )
+  if (is.character(key) && is.null(soma_parent)) {
+    stop("'soma_parent' must be a SOMACollection if 'key' is provided")
+  }
   # Transpose the matrix
   if (isTRUE(transpose)) {
     x <- Matrix::t(x)
@@ -313,8 +345,13 @@ write_soma.TsparseMatrix <- function(
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  # Write and return
+  # Write values
   array$write(x)
+  # Add to `soma_parent`
+  if (is.character(key)) {
+    soma_parent$set(array, name = key, relative = relative)
+  }
+  # Return
   return(array)
 }
 

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -42,6 +42,7 @@
   df_index = NULL,
   index_column_names = "soma_joinid",
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -120,6 +121,10 @@ relative or aboslute}
 determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 
 \item{transpose}{Transpose \code{x} before writing}
+
+\item{key}{Optionally register the resulting \code{SOMADataFrame} in
+\code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
+to handle manually}
 }
 \value{
 The resulting SOMA \link[tiledbsoma:SOMASparseNDArray]{array} or

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -56,6 +56,7 @@
   type = NULL,
   transpose = FALSE,
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -69,6 +70,7 @@
   type = NULL,
   transpose = FALSE,
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -81,6 +83,7 @@
   type = NULL,
   transpose = FALSE,
   ...,
+  key = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -1,4 +1,3 @@
-spdl::set_level('warn')
 
 test_that("write_soma.data.frame mechanics", {
   skip_if(!extended_tests())
@@ -116,6 +115,47 @@ test_that("write_soma.data.frame no enumerations", {
   }
 })
 
+test_that("write_soma.data.frame registration", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("datasets")
+
+  uri <- withr::local_tempdir("write-soma-data-frame-registration")
+  collection <- SOMACollectionCreate(uri)
+  on.exit(collection$close(), add = TRUE)
+
+  co2 <- get_data("CO2", package = "datasets")
+
+  expect_no_condition(sdf <- write_soma(
+    co2,
+    uri = "co2",
+    soma_parent = collection,
+    key = "co2"
+  ))
+  expect_s3_class(sdf, "SOMADataFrame")
+  expect_true(sdf$exists())
+  expect_identical(sdf$uri, file.path(collection$uri, "co2"))
+
+  sdf$close()
+  collection$close()
+
+  expect_no_condition(collection <- SOMACollectionOpen(collection$uri))
+  expect_s3_class(collection, "SOMACollection")
+  expect_identical(collection$length(), 1L)
+  expect_identical(collection$names(), "co2")
+  expect_s3_class(cdf <- collection$get("co2"), "SOMADataFrame")
+  expect_s3_class(df <- as.data.frame(cdf$read()$concat()), 'data.frame')
+  for (col in names(co2)) {
+    expect_identical(df[[col]], co2[[col]])
+  }
+
+  # Registration assertions
+  expect_error(write_soma(co2, "uri", soma_parent = collection, key = TRUE))
+  expect_error(write_soma(co2, "uri", soma_parent = collection, key = 1L))
+  expect_error(write_soma(co2, "uri", soma_parent = collection, key = c("a", "b")))
+  expect_error(write_soma(co2, "uri", soma_parent = NULL, key = "co2"))
+
+})
+
 test_that("write_soma dense matrix mechanics", {
   skip_if(!extended_tests())
   skip_if_not_installed('datasets')
@@ -173,6 +213,47 @@ test_that("write_soma dense matrix mechanics", {
   collection$close()
 })
 
+test_that("write_soma dense matrix registration", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("datasets")
+
+  uri <- withr::local_tempdir("write-soma-dense-matrix-registration")
+  collection <- SOMACollectionCreate(uri)
+  on.exit(collection$close(), add = TRUE)
+
+  state77 <- get(x = 'state.x77', envir = getNamespace('datasets'))
+
+  expect_no_condition(dmat <- write_soma(
+    state77,
+    uri = "state77",
+    soma_parent = collection,
+    sparse = FALSE,
+    key = "state77"
+  ))
+  expect_s3_class(dmat, "SOMADenseNDArray")
+  expect_true(dmat$exists())
+  expect_identical(dmat$uri, file.path(collection$uri, "state77"))
+
+  dmat$close()
+  collection$close()
+
+  expect_no_condition(collection <- SOMACollectionOpen(collection$uri))
+  expect_s3_class(collection, "SOMACollection")
+  expect_identical(collection$length(), 1L)
+  expect_identical(collection$names(), "state77")
+  expect_s3_class(cmat <- collection$get("state77"), "SOMADenseNDArray")
+  expect_type(mat <- cmat$read_dense_matrix(), 'double')
+  expect_true(is.matrix(mat))
+  expect_identical(mat, unname(state77))
+
+  # Registration assertions
+  expect_error(write_soma(state77, "uri", soma_parent = collection, key = TRUE))
+  expect_error(write_soma(state77, "uri", soma_parent = collection, key = 1L))
+  expect_error(write_soma(state77, "uri", soma_parent = collection, key = c("a", "b")))
+  expect_error(write_soma(state77, "uri", soma_parent = NULL, key = "state77"))
+
+})
+
 test_that("write_soma sparse matrix mechanics", {
   skip_if(!extended_tests())
   uri <- withr::local_tempdir("write-soma-sparse-matrix")
@@ -213,4 +294,43 @@ test_that("write_soma sparse matrix mechanics", {
   expect_equal(cmat$shape(), dim(state77))
 
   collection$close()
+})
+
+test_that("write_soma sparse matrix registration", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("datasets")
+
+  uri <- withr::local_tempdir("write-sparse-dense-matrix-registration")
+  collection <- SOMACollectionCreate(uri)
+  on.exit(collection$close(), add = TRUE)
+
+  knex <- get_data('KNex', package = 'Matrix')$mm
+
+  expect_no_condition(smat <- write_soma(
+    knex,
+    uri = "knex",
+    soma_parent = collection,
+    key = "knex"
+  ))
+  expect_s3_class(smat, "SOMASparseNDArray")
+  expect_true(smat$exists())
+  expect_identical(smat$uri, file.path(collection$uri, "knex"))
+
+  smat$close()
+  collection$close()
+
+  expect_no_condition(collection <- SOMACollectionOpen(collection$uri))
+  expect_s3_class(collection, "SOMACollection")
+  expect_identical(collection$length(), 1L)
+  expect_identical(collection$names(), "knex")
+  expect_s3_class(cmat <- collection$get("knex"), "SOMASparseNDArray")
+  expect_s4_class(mat <- cmat$read()$sparse_matrix()$concat(), "dgTMatrix")
+  expect_identical(as.matrix(mat), as.matrix(unname(knex)))
+
+  # Registration assertions
+  expect_error(write_soma(knex, "uri", soma_parent = collection, key = TRUE))
+  expect_error(write_soma(knex, "uri", soma_parent = collection, key = 1L))
+  expect_error(write_soma(knex, "uri", soma_parent = collection, key = c("a", "b")))
+  expect_error(write_soma(knex, "uri", soma_parent = NULL, key = "knex"))
+
 })


### PR DESCRIPTION
This PR adds a `key` parameter to three `write_soma()` methods enabling automatic registration of an array into the parent collection. The following methods have been modified
- `write_soma.data.frame()`: for `data.frame` and derived objects (eg. `tibble`)
- `write_soma.matrix()`: for dense matrices
- `write_soma.TsparseMatrix()`: for sparse matrices

By default, `key` is set to `NULL`, which disables registration and preserves existing behavior