### PR TITLE
[c++] Append `TILEDBSOMA_COVERAGE` to cmake flags

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(TILEDBSOMA_INSTALL_TARGETS "")
 # Adding coverage flags
 # ###########################################################
 
-set(CMAKE_CXX_FLAGS "$ENV{TILEDBSOMA_COVERAGE}")
-set(CMAKE_C_FLAGS "$ENV{TILEDBSOMA_COVERAGE}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
 
 # ###########################################################
 # Find required dependencies

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -9,8 +9,8 @@ add_compile_definitions(TILEDBSOMA_SOURCE_ROOT="${TILEDBSOMA_SOURCE_ROOT}")
 # ###########################################################
 # Adding coverage flags
 # ###########################################################
-set(CMAKE_CXX_FLAGS "$ENV{TILEDBSOMA_COVERAGE}")
-set(CMAKE_C_FLAGS "$ENV{TILEDBSOMA_COVERAGE}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
 
 ############################################################
 # Dependencies


### PR DESCRIPTION
**Issue and/or context:**

This issue was reported in https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/71 by @jdblischak.

**Changes:**

Previously the `CMAKE_C{,XX}_FLAGS` variable was being replaced by `$ENV{TILEDBSOMA_COVERAGE}`, causing issues when compiling in the [tiledbsoma-feedstock](https://github.com/TileDB-Inc/tiledbsoma-feedstock) nightly builds. The change appends this variable to any existing flags instead of replacing it.