### PR TITLE
[r] Add a helper function to determine max value per int type

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -148,3 +148,8 @@ tiledb_embedded_version <- function() {
     .Call(`_tiledbsoma_tiledb_embedded_version`)
 }
 
+#' @noRd
+tiledb_datatype_max_value <- function(datatype) {
+    .Call(`_tiledbsoma_tiledb_datatype_max_value`, datatype)
+}
+

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -178,7 +178,10 @@ SOMADataFrame <- R6::R6Class(
                   added_enum <- setdiff(new_enum, old_enum)
                   if (length(added_enum) > 0) {
                       datatype <- tiledb::datatype(attrs[[attr_name]])
-                      maxval <- tiledb:::tiledb_datatype_max_value(datatype) + 1 # R is one-based
+                      ## use with tiledb-r 0.24.0
+                      ##    maxval <- tiledb:::tiledb_datatype_max_value(datatype) + 1 # R is one-based
+                      ## til then local copy
+                      maxval <- tiledb_datatype_max_value(datatype) + 1 # R is one-based
                       if (length(old_enum) + length(added_enum) > maxval) {
                           stop(sprintf("For column '%s' cannot add %d factor levels to existing %d for type '%s' with maximum value %d",
                                        attr_name, length(added_enum), length(old_enum), datatype, maxval), call. = FALSE)

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -198,6 +198,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// tiledb_datatype_max_value
+size_t tiledb_datatype_max_value(const std::string& datatype);
+RcppExport SEXP _tiledbsoma_tiledb_datatype_max_value(SEXP datatypeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type datatype(datatypeSEXP);
+    rcpp_result_gen = Rcpp::wrap(tiledb_datatype_max_value(datatype));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_soma_array_reader", (DL_FUNC) &_tiledbsoma_soma_array_reader, 9},
@@ -216,6 +227,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_tiledbsoma_stats_dump", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_dump, 0},
     {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 1},
     {"_tiledbsoma_tiledb_embedded_version", (DL_FUNC) &_tiledbsoma_tiledb_embedded_version, 0},
+    {"_tiledbsoma_tiledb_datatype_max_value", (DL_FUNC) &_tiledbsoma_tiledb_datatype_max_value, 1},
     {NULL, NULL, 0}
 };
 

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -342,3 +342,19 @@ Rcpp::IntegerVector tiledb_embedded_version() {
     std::tuple<int, int, int> triple = tiledbsoma::version::embedded_version_triple();
     return Rcpp::IntegerVector::create(std::get<0>(triple), std::get<1>(triple), std::get<2>(triple));
 }
+
+// Also present in tiledb-r but only after 0.23.0 so this can be removed (and
+// the call to it updated) once we hit a new tiledb-r release 0.24.0 (or 0.23.1)
+//' @noRd
+// [[Rcpp::export]]
+size_t tiledb_datatype_max_value(const std::string& datatype) {
+    if      (datatype == "INT8")   return std::numeric_limits<int8_t>::max();
+    else if (datatype == "UINT8")  return std::numeric_limits<uint8_t>::max();
+    else if (datatype == "INT16")  return std::numeric_limits<int16_t>::max();
+    else if (datatype == "UINT16") return std::numeric_limits<uint16_t>::max();
+    else if (datatype == "INT32")  return std::numeric_limits<int32_t>::max();
+    else if (datatype == "UINT32") return std::numeric_limits<uint32_t>::max();
+    else if (datatype == "INT64")  return std::numeric_limits<int64_t>::max();
+    else if (datatype == "UINT64") return std::numeric_limits<uint64_t>::max();
+    else Rcpp::stop("currently unsupported datatype (%s)", datatype);
+}


### PR DESCRIPTION
**Issue and/or context:**

In #2008 we added the ability to test enum (aka `factor`) levels from overflowing when appending, and relied on a small helper in tiledb-r.  Which is only in the development version which we do not want to impose on all deployments so this PR brings over a local copy of the helper function.

**Changes:**

Provide a local `tiledb_datatype_max_value()`

**Notes for Reviewer:**

[SC 39486](https://app.shortcut.com/tiledb-inc/story/39486/ensure-overflow-detection-for-enums-does-not-require-dev-version-of-tiledb-r)

This can be removed / replaced on the next tiledb-r release is out, it can rely on the development version but we do not want to impose the development version on every (non-CI) run
