### PR TITLE
[python] Chunked writes for DataFrame; byte-caps for Arrow-table writes

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1171,7 +1171,7 @@ def _write_arrow_table(
     tiledb_create_options: TileDBCreateOptions,
 ) -> None:
     """Handles num-bytes capacity for remote object stores."""
-    cap = tiledb_create_options._remote_cap_nbytes
+    cap = tiledb_create_options.remote_cap_nbytes
     if arrow_table.nbytes > cap:
         n = len(arrow_table)
         if n < 2:
@@ -2060,8 +2060,6 @@ def _write_matrix_to_sparseNDArray(
 ) -> None:
     """Write a matrix to an empty DenseNDArray"""
 
-    print(f"WSNDA SHAPE {matrix.shape}")
-
     def _coo_to_table(
         mat_coo: sp.coo_matrix,
         axis_0_mapping: AxisIDMapping,
@@ -2234,7 +2232,7 @@ def _write_matrix_to_sparseNDArray(
                 # Print doubly inclusive lo..hi like 0..17 and 18..31.
                 logging.log_io(
                     "... %7.3f%% done" % chunk_percent,
-                    "SKIP   chunk rows %d..%d of %d (%.3f%%), nnz=%d, goal=%d (%.1f%%)"
+                    "SKIP   chunk rows %d..%d of %d (%.3f%%), nnz=%d, goal=%d"
                     % (
                         i,
                         i2 - 1,
@@ -2242,7 +2240,6 @@ def _write_matrix_to_sparseNDArray(
                         chunk_percent,
                         chunk_coo.nnz,
                         tiledb_create_options.goal_chunk_nnz,
-                        100 * chunk_coo.nnz / tiledb_create_options.goal_chunk_nnz,
                     ),
                 )
                 i = i2
@@ -2251,7 +2248,7 @@ def _write_matrix_to_sparseNDArray(
         # Print doubly inclusive lo..hi like 0..17 and 18..31.
         logging.log_io(
             None,
-            "START  chunk rows %d..%d of %d (%.3f%%), nnz=%d, goal=%d (%.1f%%)"
+            "START  chunk rows %d..%d of %d (%.3f%%), nnz=%d, goal=%d"
             % (
                 i,
                 i2 - 1,
@@ -2259,7 +2256,6 @@ def _write_matrix_to_sparseNDArray(
                 chunk_percent,
                 chunk_coo.nnz,
                 tiledb_create_options.goal_chunk_nnz,
-                100 * chunk_coo.nnz / tiledb_create_options.goal_chunk_nnz,
             ),
         )
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2714,12 +2714,6 @@ def _ingest_uns_ndarray(
             ingestion_params=ingestion_params,
         )
 
-    #        soma_arr.write(
-    #            (),
-    #            pa.Tensor.from_numpy(value),
-    #            platform_config=platform_config,
-    #        )
-
     msg = f"Wrote   {soma_arr.uri} (uns ndarray)"
     logging.log_io(msg, msg)
 

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -115,7 +115,10 @@ class TileDBCreateOptions:
     goal_chunk_nnz: int = attrs_.field(
         validator=vld.instance_of(int), default=100_000_000
     )
-    _remote_cap_nbytes: int = attrs_.field(
+    # We would prefer _remote_cap_nbytes as this is a server-side parameter
+    # people should not be changing. However, leading underscores are not
+    # accepted by the attrs framework.
+    remote_cap_nbytes: int = attrs_.field(
         validator=vld.instance_of(int), default=2_400_000_000
     )
     capacity: int = attrs_.field(validator=vld.instance_of(int), default=100_000)

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -115,6 +115,9 @@ class TileDBCreateOptions:
     goal_chunk_nnz: int = attrs_.field(
         validator=vld.instance_of(int), default=100_000_000
     )
+    _remote_cap_nbytes: int = attrs_.field(
+        validator=vld.instance_of(int), default=2_400_000_000
+    )
     capacity: int = attrs_.field(validator=vld.instance_of(int), default=100_000)
     offsets_filters: Tuple[_DictFilterSpec, ...] = attrs_.field(
         converter=_normalize_filters,

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -29,6 +29,7 @@ def src_matrix(request):
         TileDBCreateOptions(write_X_chunked=False, goal_chunk_nnz=100000),
         TileDBCreateOptions(write_X_chunked=True, goal_chunk_nnz=10000),
         TileDBCreateOptions(write_X_chunked=True, goal_chunk_nnz=100000),
+        TileDBCreateOptions(write_X_chunked=True, remote_cap_nbytes=100000),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue and/or context:** Implement chunked writes for `DataFrame` in addition to `NDArray`. Along the way, offer a centralized nbytes cap for remote object stores.

**Notes for Reviewer:**

* For `SparseNDArray`, even before this PR, COO cell sizes are already capped at 24 bytes: 8 each for `soma_dim_0` and `soma_dim_1`, and 1,2,4,8 for `soma_data` depending on the cell-value type (8 bytes for `float64` and `int64`). This means that before this PR, given `goal_chunk_nnz = 100_000_000` times cell cap of 24 bytes, we already had a hard cap of 2_400_000_000 bytes per chunked write. Now we do explicit byte arithmetic, which is a logging/visibility improvement.
* For `DenseNDArray` aside from `uns`, the same is true but cell sizes are capped at 8 not 24 since we don't offer IJV triples on the data writes. That means that before this PR, we already had a hard cap of 800_000_000 bytes per chunked write. Here, too, using explicit byte arithmetic, we obtain a logging/visibility improvement.
* For `DenseNDArray` within `uns`, we were not using chunked-write logic. Now we are.
* For `DataFrame`, also we were not using chunked-write logic. Now we are.
