### PR TITLE
[r] Enable opt-in use of 'catchsegv', enable in CI on Linux

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -15,7 +15,8 @@ env:
   COVERAGE_FLAGS: "r"
   COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   _R_CHECK_TESTS_NLINES_: 0
-
+  CATCHSEGV: "TRUE"
+  
 jobs:
   ci:
     strategy:
@@ -92,6 +93,18 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
+      # - name: Build Package
+      #   run: cd apis/r && R CMD build --no-build-vignettes --no-manual .
+
+      # - name: Install Package
+      #   run: cd apis/r && R CMD INSTALL $(ls -1tr *.tar.gz | tail -1)
+
+      # - name: Diagnostics
+      #   run: Rscript -e 'print(Sys.info())'
+
+      # - name: Downgrade TileDB-R if needed
+      #   run: cd apis/r && Rscript tools/controlled_downgrade.R
+        
       - name: Test
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r && tools/r-ci.sh run_tests

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -153,7 +153,7 @@ test_that("Iterated Interface from SOMA Classes", {
 test_that("Iterated Interface from SOMA Sparse Matrix", {
     skip_if(!extended_tests() || covr_tests())
     skip_if_not_installed("pbmc3k.tiledb")      # a Suggests: pre-package 3k PBMC data
-    skip_if(Sys.getenv("CI", "") != "")         # breaks only in CI so skipping
+    #skip_if(Sys.getenv("CI", "") != "")         # breaks only in CI so skipping
 
     tdir <- tempfile()
     tgzfile <- system.file("raw-data", "soco-pbmc3k.tar.gz", package="pbmc3k.tiledb")
@@ -171,7 +171,9 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
     for (i in 1:2) {
         expect_false(iterator$read_complete())
         dat <- iterator$read_next()$get_one_based_matrix()
-        nnz <- Matrix::nnzero(dat)
+        ## -- nnz <- Matrix::nnzero(dat)
+        ##    use length() which is identical for this data set but does not suffer from an issue sometimes seen in CI
+        nnz <- length(dat@x)
         expect_gt(nnz, 0)
         nnzTotal <- nnzTotal + nnz
         # the shard dims always match the shape of the whole sparse matrix
@@ -181,7 +183,9 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
     expect_true(iterator$read_complete())
     expect_warning(iterator$read_next()) # returns NULL with warning
     expect_warning(iterator$read_next()) # returns NULL with warning
-    expect_equal(nnzTotal, Matrix::nnzero(sdf$read()$sparse_matrix(T)$concat()$get_one_based_matrix()))
+    ## -- expect_equal(nnzTotal, Matrix::nnzero(sdf$read()$sparse_matrix(T)$concat()$get_one_based_matrix()))
+    ##    use length() which is identical for this data set but does not suffer from an issue sometimes seen in CI
+    expect_equal(nnzTotal, length(sdf$read()$sparse_matrix(T)$concat()$get_one_based_matrix()@x))
     expect_equal(nnzTotal, 2238732)
 
     rm(sdf)

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -405,7 +405,7 @@ test_that("Write Graph mechanics", {
 })
 
 test_that("Write Seurat mechanics", {
-  skip_if(Sys.getenv("CI", "") != "")
+  skip_if(!extended_tests())
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   pbmc_small <- get_data('pbmc_small', package = 'SeuratObject')
   uri <- withr::local_tempdir(SeuratObject::Project(pbmc_small))

--- a/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-SummarizedExperimentIngest.R
@@ -1,5 +1,5 @@
 test_that("Write SummarizedExperiment mechanics", {
-  skip_if(Sys.getenv("CI", "") != "")
+  skip_if(!extended_tests() || covr_tests())
   suppressMessages(skip_if_not_installed('SummarizedExperiment', '1.28.0'))
   skip_if_not_installed('pbmc3k.sce')
 


### PR DESCRIPTION
**Issue and/or context:**

Sporadic and generally non-reproducible segmentation faults in CI have beeen an irritant. This PR enables support of a glibc feature (apparently now deprecated, but still supported by Linux distros) to wrap a script `catchsegv` around an execution leading to a stacktrace and register dump in case of segmentation fault.

**Changes:**

The `r-ci.sh` script has been altered to, if `catchsegv` is opted into and on Linux, install the `glibc-tools` package and prefix both coverage and test calls with `catchsegv`.

**Notes for Reviewer:**

[SC 39492](https://app.shortcut.com/tiledb-inc/story/39492/add-libsegfault-backtrace-dumping-to-soma-ci)
