### PR TITLE
[python] Add `common.h` to `MANIFEST.in`

### DIFF
--- a/apis/python/MANIFEST.in
+++ b/apis/python/MANIFEST.in
@@ -1,4 +1,5 @@
 include RELEASE-VERSION version.py py.typed
 include src/tiledbsoma/*.cc
+include src/tiledbsoma/*.h
 graft dist_links
 prune dist_links/libtiledbsoma/test/__pycache__


### PR DESCRIPTION
**Issue and/or context:**

#2032

**Changes:**

Add `common.h` to `MANIFEST.in` as C++ (source and) header files are not added by `setuptools` to the distribution by default.

**Notes for Reviewer:**

Proof of working: https://github.com/single-cell-data/TileDB-SOMA/actions/runs/7603111075

