### PR TITLE
[c++/ci] Fix a `pkgdown` CI error about unnecessary semicolons

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -531,7 +531,7 @@ class SOMAArray {
     template <typename T>
     std::pair<T, T> non_empty_domain(const std::string& name) {
         return arr_->non_empty_domain<T>(name);
-    };
+    }
 
     /**
      * Retrieves the non-empty domain from the array on the given dimension.
@@ -541,7 +541,7 @@ class SOMAArray {
     std::pair<std::string, std::string> non_empty_domain_var(
         const std::string& name) {
         return arr_->non_empty_domain_var(name);
-    };
+    }
 
     /**
      * Returns the domain of the given dimension.

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -257,7 +257,7 @@ class SOMADataFrame : public SOMAObject {
     template <typename T>
     std::pair<T, T> non_empty_domain(const std::string& column_index_name) {
         return array_->non_empty_domain<T>(column_index_name);
-    };
+    }
 
     /**
      * Retrieves the non-empty domain of the column index.
@@ -266,7 +266,7 @@ class SOMADataFrame : public SOMAObject {
     std::pair<std::string, std::string> non_empty_domain_var(
         const std::string& column_index_name) {
         return array_->non_empty_domain_var(column_index_name);
-    };
+    }
 
     /**
      * Returns the domain of the given column index.

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -189,7 +189,7 @@ class SOMADenseNDArray : public SOMAObject {
      */
     bool is_sparse() {
         return false;
-    };
+    }
 
     /**
      * @brief Get URI of the SOMADenseNDArray.

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -189,7 +189,7 @@ class SOMASparseNDArray : public SOMAObject {
      */
     bool is_sparse() {
         return true;
-    };
+    }
 
     /**
      * @brief Get URI of the SOMASparseNDArray.

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -52,7 +52,7 @@ class TileDBSOMAError : public std::runtime_error {
    public:
     virtual const char* what() const noexcept override {
         return std::runtime_error::what();
-    };
+    }
 };
 
 };  // namespace tiledbsoma


### PR DESCRIPTION
**Issue and/or context:**
From https://github.com/single-cell-data/TileDB-SOMA/actions/runs/7618476508/job/20749733125#step:5:916

**Changes:**

**Notes for Reviewer:**
The odd thing is this fires only on `pkgdown` CI, which in turn only runs on releases ... 🤔 