### PR TITLE
[python] Pass config options to `DataFrame.read`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -339,6 +339,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self._check_open_read()
 
         handle = self._handle._handle
+        
+        config = handle.config()
+        config.update(platform_config or {})
 
         ts = None
         if handle.timestamp is not None:
@@ -347,7 +350,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         sr = clib.SOMADataFrame.open(
             uri=handle.uri,
             mode=clib.OpenMode.read,
-            platform_config=handle.config().update(platform_config or {}),
+            platform_config=config,
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
             timestamp=ts,

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -339,7 +339,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self._check_open_read()
 
         handle = self._handle._handle
-        
+
         ts = None
         if handle.timestamp is not None:
             ts = (0, handle.timestamp)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -339,7 +339,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self._check_open_read()
 
         handle = self._handle._handle
-
+        
         ts = None
         if handle.timestamp is not None:
             ts = (0, handle.timestamp)
@@ -347,7 +347,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         sr = clib.SOMADataFrame.open(
             uri=handle.uri,
             mode=clib.OpenMode.read,
-            platform_config=platform_config or handle.config(),
+            platform_config=handle.config().update(platform_config or {}),
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
             timestamp=ts,

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -339,7 +339,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         self._check_open_read()
 
         handle = self._handle._handle
-        
+
         config = handle.config()
         config.update(platform_config or {})
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -340,6 +340,9 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         handle = self._handle._handle
 
+        config = handle.config().copy()
+        config.update(platform_config or {})
+
         ts = None
         if handle.timestamp is not None:
             ts = (0, handle.timestamp)
@@ -347,7 +350,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         sr = clib.SOMADataFrame.open(
             uri=handle.uri,
             mode=clib.OpenMode.read,
-            platform_config={**handle.config(), **(platform_config or {})},
+            platform_config=config,
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
             timestamp=ts,

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -338,21 +338,23 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         _util.check_unpartitioned(partitions)
         self._check_open_read()
 
+        handle = self._handle._handle
+
         ts = None
-        if self._handle._handle.timestamp is not None:
-            ts = (0, self._handle._handle.timestamp)
+        if handle.timestamp is not None:
+            ts = (0, handle.timestamp)
 
         sr = clib.SOMADataFrame.open(
-            uri=self._handle._handle.uri,
+            uri=handle.uri,
             mode=clib.OpenMode.read,
-            platform_config=platform_config or {},
+            platform_config=platform_config or handle.config(),
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
             timestamp=ts,
         )
 
         if value_filter is not None:
-            sr.set_condition(QueryCondition(value_filter), self._handle.schema)
+            sr.set_condition(QueryCondition(value_filter), handle.schema)
 
         self._set_reader_coords(sr, coords)
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -340,9 +340,6 @@ class DataFrame(TileDBArray, somacore.DataFrame):
 
         handle = self._handle._handle
 
-        config = handle.config()
-        config.update(platform_config or {})
-
         ts = None
         if handle.timestamp is not None:
             ts = (0, handle.timestamp)
@@ -350,7 +347,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         sr = clib.SOMADataFrame.open(
             uri=handle.uri,
             mode=clib.OpenMode.read,
-            platform_config=config,
+            platform_config={**handle.config(), **(platform_config or {})},
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
             timestamp=ts,

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -130,7 +130,7 @@ void load_soma_dataframe(py::module &m) {
         std::map<std::string, std::string> result;
         auto cfg = soma_df.ctx()->config();
         for (auto& it : cfg)
-            result[it.first] = it.second;
+            result.emplace(it.first, it.second);
         return py::cast(result);
     })
     .def_property_readonly("timestamp", [](SOMADataFrame& soma_df) -> py::object {

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -126,6 +126,13 @@ void load_soma_dataframe(py::module &m) {
         auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");
         return pa_schema_import(py::capsule(soma_df.schema().get()));
     })
+    .def("config", [](SOMADataFrame& soma_df) -> py::object {
+        std::map<std::string, std::string> result;
+        auto cfg = soma_df.ctx()->config();
+        for (auto& it : cfg)
+            result[it.first] = it.second;
+        return py::cast(result);
+    })
     .def_property_readonly("timestamp", [](SOMADataFrame& soma_df) -> py::object {
         if(!soma_df.timestamp().has_value())
             return py::none();

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -126,7 +126,7 @@ void load_soma_dataframe(py::module &m) {
         auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");
         return pa_schema_import(py::capsule(soma_df.schema().get()));
     })
-    .def("config", [](SOMADataFrame& soma_df) -> py::object {
+    .def("config", [](SOMADataFrame& soma_df) -> py::dict {
         return py::cast(soma_df.config());
     })
     .def_property_readonly("timestamp", [](SOMADataFrame& soma_df) -> py::object {

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -127,11 +127,7 @@ void load_soma_dataframe(py::module &m) {
         return pa_schema_import(py::capsule(soma_df.schema().get()));
     })
     .def("config", [](SOMADataFrame& soma_df) -> py::object {
-        std::map<std::string, std::string> result;
-        auto cfg = soma_df.ctx()->config();
-        for (auto& it : cfg)
-            result.emplace(it.first, it.second);
-        return py::cast(result);
+        return py::cast(soma_df.config());
     })
     .def_property_readonly("timestamp", [](SOMADataFrame& soma_df) -> py::object {
         if(!soma_df.timestamp().has_value())

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -981,7 +981,6 @@ def test_create_platform_config_overrides(
         for k, v in expected_schema_fields.items():
             assert getattr(D.schema, k) == v
 
-
 @pytest.mark.parametrize("allows_duplicates", [False, True])
 @pytest.mark.parametrize("consolidate", [False, True])
 def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -981,6 +981,7 @@ def test_create_platform_config_overrides(
         for k, v in expected_schema_fields.items():
             assert getattr(D.schema, k) == v
 
+
 @pytest.mark.parametrize("allows_duplicates", [False, True])
 @pytest.mark.parametrize("consolidate", [False, True])
 def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -135,6 +135,9 @@ SOMAArray::SOMAArray(
     , uri_(util::rstrip_uri(uri))
     , result_order_(result_order)
     , timestamp_(timestamp) {
+    for (auto& it : ctx->config())
+        config_[it.first] = it.second;
+
     validate(mode, name, timestamp);
     reset(column_names, batch_size, result_order);
     fill_metadata_cache();
@@ -168,6 +171,10 @@ const std::string& SOMAArray::uri() const {
 std::shared_ptr<Context> SOMAArray::ctx() {
     return ctx_;
 };
+
+std::map<std::string, std::string> SOMAArray::config() {
+    return config_;
+}
 
 void SOMAArray::open(
     OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp) {

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -186,6 +186,13 @@ class SOMAArray {
      */
     std::shared_ptr<Context> ctx();
 
+    /**
+     * Get the Config associated with the SOMAArray.
+     *
+     * @return std::map<std::string, std::string>
+     */
+    std::map<std::string, std::string> config();
+
     std::optional<std::string> soma_object_type() {
         auto soma_object_type = this->get_metadata("soma_object_type");
 
@@ -695,6 +702,9 @@ class SOMAArray {
 
     // TileDB context
     std::shared_ptr<Context> ctx_;
+
+    // Config as a map
+    std::map<std::string, std::string> config_;
 
     // SOMAArray URI
     std::string uri_;

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -148,6 +148,10 @@ std::shared_ptr<Context> SOMADataFrame::ctx() {
     return array_->ctx();
 }
 
+std::map<std::string, std::string> SOMADataFrame::config() {
+    return array_->config();
+}
+
 std::unique_ptr<ArrowSchema> SOMADataFrame::schema() const {
     return array_->arrow_schema();
 }

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -215,6 +215,13 @@ class SOMADataFrame : public SOMAObject {
     std::shared_ptr<Context> ctx();
 
     /**
+     * Get the Config associated with the SOMADataFrame.
+     *
+     * @return std::map<std::string, std::string>
+     */
+    std::map<std::string, std::string> config();
+
+    /**
      * Return optional timestamp pair SOMADataFrame was opened with.
      */
     std::optional<std::pair<uint64_t, uint64_t>> timestamp() {


### PR DESCRIPTION
**Issue and/or context:**

As reported internally, the code below breaks as the AWS S3 settings are ignored.

```
uri = "s3://cellxgene-census-public-us-west-2/cell-census/2024-01-16/soma/"

with soma.open(
    uri,
    context=soma.SOMATileDBContext(
        tiledb_config={
            "vfs.s3.no_sign_request": "true",
            "vfs.s3.region": "us-west-2",
        }
    ),
) as census:
    census["census_data"]["homo_sapiens"].obs.read()

```

```
SOMAError: Error opening array: 's3://cellxgene-census-public-us-west-2/cell-census/2024-01-16/soma/census_data/homo_sapiens/obs'
  [TileDB::Array] Error: Caught std::exception: [TileDB::S3] Error: Error while listing with prefix 's3://cellxgene-census-public-us-west-2/cell-census/2024-01-16/soma/census_data/homo_sapiens/obs/' and delimiter '/'[Error Type: 100] [HTTP Response Code: 301] [Exception: PermanentRedirect] [Remote IP: 54.231.161.178] [Request ID: 9630132PVWN1ZHJ4] [Headers: 'content-type' = 'application/xml' 'date' = 'Mon, 22 Jan 2024 21:43:18 GMT' 'server' = 'AmazonS3' 'transfer-encoding' = 'chunked' 'x-amz-bucket-region' = 'us-west-2' 'x-amz-id-2' = '/JFJGX5VnF2DA+Y0nUuv6pjEvg/2YFKxvZjYO7eDF/XRO8VOaIP4LwbI5Bxp8tEOwlO/ym0c8ug=' 'x-amz-request-id' = '9630132PVWN1ZHJ4'] : Unable to parse ExceptionName: PermanentRedirect Message: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```

**Changes:**

Pass the already set `config_options` into `read`, not the default config.

**Notes for Reviewer:**

I am not sure how to add a unit test for this as anything I can think of uses cloud. I tested locally with the code snippet above, and it now works.