### PR TITLE
[python] Rename `utils.py` to `_index_util.py`

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -13,10 +13,10 @@ from typing_extensions import Self
 
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
+from ._index_util import build_index
 from ._measurement import Measurement
 from ._tdb_handles import Wrapper
 from ._tiledb_object import AnyTileDBObject
-from .utils import build_index
 
 
 class Experiment(  # type: ignore[misc]  # __eq__ false positive

--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -1,3 +1,8 @@
+"""
+This file is separate from _util.py, due to a circular-import issue with
+SOMATileDBContext which would otherwise ensue.
+"""
+
 import numpy as np
 import pandas as pd
 
@@ -5,12 +10,11 @@ from tiledbsoma import pytiledbsoma as clib
 
 from .options import SOMATileDBContext
 
-"""Builds an indexer object compatible with :meth:`pd.Index.get_indexer`."""
-
 
 def build_index(
     keys: np.typing.NDArray[np.int64], context: SOMATileDBContext
 ) -> clib.IntIndexer:
+    """Builds an indexer object compatible with :meth:`pd.Index.get_indexer`."""
     if len(np.unique(keys)) != len(keys):
         raise pd.errors.InvalidIndexError(
             "Reindexing only valid with uniquely valued Index objects"

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pandas as pd
 
+from tiledbsoma._index_util import build_index
 from tiledbsoma.options import SOMATileDBContext
 from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_context
-from tiledbsoma.utils import build_index
 
 
 def indexer_test(keys: np.array, lookups: np.array, fail: bool):


### PR DESCRIPTION
**Issue and/or context:**

Found by @bkmartinjr on read-through. (See also #915 for context.)

* We have `_util.py` and `utils.py`, which seems one too many
* We have been following the convention of putting private-ish things with leading `_` module/class/function/etc names

**Changes:**

* I couldn't move `build_index` from `utils.py` to `_util.py`, as this resulted in a circular-import error for `SOMATileDBContext`
* So I renamed `utils.py` to `_index_util`.

**Notes for Reviewer:**