### PR TITLE
[python] Using optimized reindexer in blockwise iterators

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -573,6 +573,7 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
             size=self.size,
             reindex_disable_on_axis=self.reindex_disable_on_axis,
             eager=self.eager,
+            context=self.array.context,
         )
 
     def coos(self) -> somacore.ReadIter[None]:
@@ -618,4 +619,5 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
             compress=compress,
             reindex_disable_on_axis=self.reindex_disable_on_axis,
             eager=self.eager,
+            context=self.array.context,
         )


### PR DESCRIPTION
**Issue and/or context:** #2066
Block-wise iterators still use panda indexers and this must to switch to our new indexer.

**Changes:**

**Notes for Reviewer:**
I may add a benchmark for this change later.
