### PR TITLE
[r] Let `get_tarball.R` interop with `update-tiledb-version.py`

### DIFF
--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -13,7 +13,13 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
+    if (arch == "x86_64") {
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
+    } else if (arch == "arm64") {
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-arm64-x86_64-2.19.1-29ceb3e7.tar.gz"
+    } else {
+      stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
+    }
 } else if (isLinux) {
     url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz"
 } else {

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -1,16 +1,11 @@
 #!/usr/bin/env Rscript
 
-## version pinning info
-tiledb_core_version <- "2.19.1"
-# 8-nybble hash for 2.19.0 and 2.19.1 only. Please see https://github.com/TileDB-Inc/TileDB/pull/4599.
-tiledb_core_sha1 <- "29ceb3e7"
+# Please use scripts/update-tiledb-version.py in this repo's base directory to
+# update URLs in this file as well as the FindTileDB_EP.cmake file within the
+# libtiledbsoma directory.
 
 if ( ! dir.exists("inst/") ) {
     stop("No 'inst/' directory. Exiting.", call. = FALSE)
-}
-
-makeUrl <- function(arch, ver=tiledb_core_version, sha1=tiledb_core_sha1) {
-    sprintf("https://github.com/TileDB-Inc/TileDB/releases/download/%s/tiledb-%s-%s-%s.tar.gz", ver, arch, ver, sha1)
 }
 
 isMac <- Sys.info()["sysname"] == "Darwin"
@@ -18,9 +13,9 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
-    url <- makeUrl(paste0("macos-", arch))
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
 } else if (isLinux) {
-    url <- makeUrl("linux-x86_64")
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -16,7 +16,7 @@ if (isMac) {
     if (arch == "x86_64") {
       url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-arm64-x86_64-2.19.1-29ceb3e7.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-arm64-2.19.1-29ceb3e7.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }


### PR DESCRIPTION
## Issue

When we do releases and depedency bumps following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases), `apis/r/tools/get_tarball.R` has always required a manual-edit step.

This PR lets `apis/r/tools/get_tarball.R` be updated hands-off, automatically, along with `libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake`.

This PR centralizes the hash-computation and file-update logic in a way that no longer requires the operator to be familiar with C++/Python/R build internals.

## To give this a test drive

* Check out today's `main`
* `./scripts/update-tiledb-version.py 2.19.0`
* `git diff`

## Before this PR

`scripts/update-tiledb-version.py 2.19.0`

```
diff --git a/apis/r/tools/get_tarball.R b/apis/r/tools/get_tarball.R
index 34d435d6..52b87072 100644
--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -10,7 +10,7 @@ if ( ! dir.exists("inst/") ) {
 }

 makeUrl <- function(arch, ver=tiledb_core_version, sha1=tiledb_core_sha1) {
-    sprintf("https://github.com/TileDB-Inc/TileDB/releases/download/%s/tiledb-%s-%s-%s.tar.gz", ver, arch, ver, sha1)
+    sprintf("https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-2.19.0-2.19.0-2.19.0.tar.gz", ver, arch, ver, sha1)
 }

 isMac <- Sys.info()["sysname"] == "Darwin"
```

which then requires manual edits to restore the line that had `%s`, as well as doing manual edits here:

https://github.com/single-cell-data/TileDB-SOMA/blob/b3e802de05e220ae1d9f6e8a27f8059d4cf0eb24/apis/r/tools/get_tarball.R#L4-L5

## With this PR

`scripts/update-tiledb-version.py 2.19.0`

```
diff --git a/apis/r/tools/get_tarball.R b/apis/r/tools/get_tarball.R
index d2b79600..ff8f3a38 100644
--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -13,9 +13,9 @@ isLinux <- Sys.info()["sysname"] == "Linux"

 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-x86_64-2.19.0-fa30a88a.tar.gz"
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-linux-x86_64-2.19.0-fa30a88a.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }
```

No manual edits are required.