### PR TITLE
[Backport release-1.7] [python] Using optimized reindexer in blockwise iterators

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -13,7 +13,7 @@ from typing_extensions import Self
 
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
-from ._index_util import build_index
+from ._index_util import tiledbsoma_build_index
 from ._measurement import Measurement
 from ._tdb_handles import Wrapper
 from ._tiledb_object import AnyTileDBObject
@@ -94,5 +94,7 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
             measurement_name,
             obs_query=obs_query or query.AxisQuery(),
             var_query=var_query or query.AxisQuery(),
-            index_factory=functools.partial(build_index, context=self.context),
+            index_factory=functools.partial(
+                tiledbsoma_build_index, context=self.context
+            ),
         )

--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -3,6 +3,8 @@ This file is separate from _util.py, due to a circular-import issue with
 SOMATileDBContext which would otherwise ensue.
 """
 
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 
@@ -11,17 +13,20 @@ from tiledbsoma import pytiledbsoma as clib
 from .options import SOMATileDBContext
 
 
-def build_index(
-    keys: np.typing.NDArray[np.int64], context: SOMATileDBContext
+def tiledbsoma_build_index(
+    keys: np.typing.NDArray[np.int64],
+    context: Optional[SOMATileDBContext],
 ) -> clib.IntIndexer:
     """Builds an indexer object compatible with :meth:`pd.Index.get_indexer`."""
     if len(np.unique(keys)) != len(keys):
         raise pd.errors.InvalidIndexError(
             "Reindexing only valid with uniquely valued Index objects"
         )
-    tdb_concurrency = int(
-        context.tiledb_ctx.config().get("sm.compute_concurrency_level", 10)
-    )
+    tdb_concurrency = 10
+    if context is not None:
+        tdb_concurrency = int(
+            context.tiledb_ctx.config().get("sm.compute_concurrency_level", 10)
+        )
     thread_count = tdb_concurrency // 2
     reindexer = clib.IntIndexer()
     reindexer.map_locations(keys, thread_count)

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -24,7 +24,6 @@ from typing import (
 
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
 import pyarrow as pa
 import somacore
 from scipy import sparse
@@ -36,7 +35,9 @@ import tiledbsoma.pytiledbsoma as clib
 
 from . import _util
 from ._exception import SOMAError
+from ._index_util import tiledbsoma_build_index
 from ._types import NTuple
+from .options import SOMATileDBContext
 
 if TYPE_CHECKING:
     from . import SparseNDArray
@@ -88,6 +89,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         reindex_disable_on_axis: Optional[Union[int, Sequence[int]]] = None,
         eager: bool = True,
         eager_iterator_pool: Optional[ThreadPoolExecutor] = None,
+        context: Optional[SOMATileDBContext] = None,
     ):
         super().__init__()
 
@@ -96,6 +98,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         self.sr = sr
         self.eager = eager
         self.eager_iterator_pool = eager_iterator_pool
+        self.context = context
 
         # raises on various error checks, AND normalizes args
         self.axis, self.size, self.reindex_disable_on_axis = self._validate_args(
@@ -124,7 +127,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         # build indexers, as needed
         self.axes_to_reindex = set(range(self.ndim)) - set(self.reindex_disable_on_axis)
         self.minor_axes_indexer = {
-            d: pd.Index(self.joinids[d].to_numpy())
+            d: tiledbsoma_build_index(self.joinids[d].to_numpy(), context=context)
             for d in (self.axes_to_reindex - set((self.major_axis,)))
         }
 
@@ -231,7 +234,8 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
             yield pa.concat_tables(_arrow_table_reader(self.sr)), tuple(joinids)
 
     def _reindexed_table_reader(
-        self, _pool: Optional[ThreadPoolExecutor] = None
+        self,
+        _pool: Optional[ThreadPoolExecutor] = None,
     ) -> BlockwiseSingleAxisTableIter:
         """Private. Blockwise table reader w/ reindexing. Helper function for sub-class use"""
         for tbl, coords in self._maybe_eager_iterator(self._table_reader(), _pool):
@@ -240,9 +244,13 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
                 col = tbl.column(f"soma_dim_{d}")
                 if d in self.axes_to_reindex:
                     if d == self.major_axis:
-                        col = pd.Index(coords[self.major_axis]).get_indexer(col.to_numpy())  # type: ignore[no-untyped-call]
+                        col = tiledbsoma_build_index(
+                            coords[self.major_axis], context=self.context
+                        ).get_indexer(
+                            col.to_numpy(),
+                        )
                     else:
-                        col = self.minor_axes_indexer[d].get_indexer(col.to_numpy())  # type: ignore[no-untyped-call]
+                        col = self.minor_axes_indexer[d].get_indexer(col.to_numpy())
                 pytbl[f"soma_dim_{d}"] = col
             pytbl["soma_data"] = tbl.column("soma_data")
             yield pa.Table.from_pydict(pytbl), coords
@@ -282,8 +290,10 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
         reindex_disable_on_axis: Optional[Union[int, Sequence[int]]] = None,
         eager: bool = True,
         compress: bool = True,
+        context: Optional[SOMATileDBContext] = None,
     ):
         self.compress = compress
+        self.context = context
         super().__init__(
             array,
             sr,
@@ -292,6 +302,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
             size=size,
             reindex_disable_on_axis=reindex_disable_on_axis,
             eager=eager,
+            context=context,
         )
 
         if (

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -573,6 +573,7 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
             size=self.size,
             reindex_disable_on_axis=self.reindex_disable_on_axis,
             eager=self.eager,
+            context=self.array.context,
         )
 
     def coos(self) -> somacore.ReadIter[None]:
@@ -618,4 +619,5 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
             compress=compress,
             reindex_disable_on_axis=self.reindex_disable_on_axis,
             eager=self.eager,
+            context=self.array.context,
         )

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from tiledbsoma._index_util import build_index
+from tiledbsoma._index_util import tiledbsoma_build_index
 from tiledbsoma.options import SOMATileDBContext
 from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_context
 
@@ -16,7 +16,7 @@ def indexer_test(keys: np.array, lookups: np.array, fail: bool):
 def indexer_test_fail(keys: np.array, lookups: np.array):
     try:
         context = _validate_soma_tiledb_context(SOMATileDBContext())
-        index = build_index(keys, context)
+        index = tiledbsoma_build_index(keys, context)
         index.get_indexer(lookups)
         raise AssertionError("should have failed")
     except pd.errors.InvalidIndexError:
@@ -32,7 +32,7 @@ def indexer_test_fail(keys: np.array, lookups: np.array):
 
 def indexer_test_pass(keys: np.array, lookups: np.array):
     context = _validate_soma_tiledb_context(SOMATileDBContext())
-    indexer = build_index(keys, context)
+    indexer = tiledbsoma_build_index(keys, context)
     results = indexer.get_indexer(lookups)
     panda_indexer = pd.Index(keys)
     panda_results = panda_indexer.get_indexer(lookups)


### PR DESCRIPTION
Backports #2081 to the `release-1.7` branch