### PR TITLE
[Backport release-1.7] [python] Fix some docstring typos

### DIFF
--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -22,16 +22,16 @@ def tiledbsoma_build_index(
     thread_count: int = 4,
 ) -> IndexLike:
     """
-    Returns a IndexLike re-indexer
-    The reindxer has an API similar to :meth:`pd.Index.get_indexer`
+    Returns an ``IndexLike`` re-indexer.
+    The reindexer has an API similar to :meth:`pd.Index.get_indexer`
 
     Args:
         keys:
-           integer keys used to build the index (hash) table.
+           Integer keys used to build the index (hash) table.
        context:
-           tiledbcontext object containing concurrecy level (exclusive with thread_count).
+           ``SOMATileDBContext`` object containing concurrecy level (exclusive with thread_count).
        thread_count:
-           concurrecy level when the user does not want to use `context`.
+           Concurrency level when the user does not want to use ``context``.
 
     Lifecycle:
         Experimental.
@@ -40,12 +40,8 @@ def tiledbsoma_build_index(
         tdb_concurrency = int(
             context.tiledb_ctx.config().get("sm.compute_concurrency_level", 10)
         )
-    tdb_concurrency = 10
-    if context is not None:
-        tdb_concurrency = int(
-            context.tiledb_ctx.config().get("sm.compute_concurrency_level", 10)
-        )
-    thread_count = tdb_concurrency // 2
+        thread_count = max(1, tdb_concurrency // 2)
+
     reindexer = clib.IntIndexer()
     reindexer.map_locations(keys, thread_count)
     return reindexer  # type: ignore[no-any-return]


### PR DESCRIPTION
Backports #2094 to the `release-1.7` branch