### PR TITLE
[c++] Fix for error when the key array size is smaller than thread count

### DIFF
--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -46,6 +46,7 @@ def indexer_test_pass(keys: np.array, lookups: np.array):
 
 
 test_data = [
+    {"keys": [1], "lookups": [1, 1, 1, 1], "pass": True},
     {
         "keys": [-1, -1, -1, 0, 0, 0],
         "lookups": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5],

--- a/libtiledbsoma/src/reindexer/reindexer.cc
+++ b/libtiledbsoma/src/reindexer/reindexer.cc
@@ -51,14 +51,6 @@ void IntIndexer::map_locations(const int64_t* keys, int size, int threads) {
     if (size == 0) {
         return;
     }
-    if (size < 10) {
-        threads = 1;
-    }
-    if (size < threads)
-        throw std::runtime_error(
-            "The number of keys " + std::to_string(size) +
-            " must be larger than the number of threads " +
-            std::to_string(threads) + " .");
 
     LOG_DEBUG(fmt::format(
         "End of Map locations of size {} and {} threads", size, threads));


### PR DESCRIPTION
**Issue and/or context:**
When key size is smaller than thread count, we incorrectly throw an exception

**Changes:**

**Notes for Reviewer:**

