### PR TITLE
[r] Fix quoting for a particular Docker-build environment (`release-1.7`)

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -41,9 +41,9 @@ ${R_HOME}/bin/Rscript tools/get_tarball.R
 ${R_HOME}/bin/Rscript tools/check_cmake_and_git.R
 
 ## Make libtiledbsoma library using cmake (and an added git dependency)
-export CC=`${R_HOME}/bin/R CMD config CC`
-export CXX=`${R_HOME}/bin/R CMD config CXX`
-export CMAKE_OSX_ARCHITECTURES=`uname -m`
+export CC="`${R_HOME}/bin/R CMD config CC`"
+export CXX="`${R_HOME}/bin/R CMD config CXX`"
+export CMAKE_OSX_ARCHITECTURES="`uname -m`"
 tools/build_libtiledbsoma.sh
 
 pkgincl="-I../inst/tiledb/include -I../inst/tiledbsoma/include"


### PR DESCRIPTION
**Issue and/or context:** This arose while doing a Docker build within a particular TileDB-internal build environment. There exists platforms within which

```
root@1f09efc85df8:/# /bin/sh
# export CC=`${R_HOME}/bin/R CMD config CC`
# export CXX=`${R_HOME}/bin/R CMD config CXX`
/bin/sh: 2: export: -std: bad variable name
```

**Changes:** Properly double-quote variables which may contain spaces.

**Notes for Reviewer:**

As discussed in Slack.

This will also be applied to the `main` branch: #2103