### PR TITLE
[python] relax numba dependency

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -281,9 +281,9 @@ setuptools.setup(
         # Tracked in https://github.com/single-cell-data/TileDB-SOMA/issues/1785
         "anndata != 0.10.0; python_version>='3.8'",
         "attrs>=22.2",
-        "numba~=0.58.0; python_version>='3.8'",
+        "numba>=0.58.0; python_version>='3.8'",
         # Older numba version needed for Python3.7.
-        # This older numba version was also incompatble with newer numpy
+        # This older numba version was also incompatible with newer numpy
         # versions, and the old pip solver (<=2020) needed us to explicate
         # that constraint here (issue #1051).
         "numba==0.56.4; python_version<'3.8'",


### PR DESCRIPTION
**Issue and/or context:**

Numba was pinned to `~=0.58.0`. With numba `0.59.0` released, there is demand for allowing more recent variants. See also #1733.

**Changes:**

Numba pin modified to `>=0.58.0`

