### PR TITLE
[python] Use bindings for `DenseNDArray` readpath

### DIFF
--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -169,7 +169,7 @@ def tiledb_schema_to_arrow(
         if attr.enum_label is not None:  # enumerated
             if A is None:
                 A = tiledb.open(uri, ctx=ctx)
-            info = A.enum(name)
+            info = A.enum(attr.enum_label)
             arrow_schema_dict[name] = pa.dictionary(
                 index_type=arrow_type_from_tiledb_dtype(attr.dtype),
                 value_type=arrow_type_from_tiledb_dtype(

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -343,12 +343,8 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         context = handle.context()
         if platform_config is not None:
             config = context.tiledb_config.copy()
-            config.update(platform_config or {})
+            config.update(platform_config)
             context = clib.SOMAContext(config)
-
-        ts = None
-        if handle.timestamp is not None:
-            ts = (0, handle.timestamp)
 
         sr = clib.SOMADataFrame.open(
             uri=handle.uri,
@@ -356,7 +352,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             context=context,
             column_names=column_names or [],
             result_order=_util.to_clib_result_order(result_order),
-            timestamp=ts,
+            timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
         if value_filter is not None:

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -135,12 +135,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         context = handle.context()
         if platform_config is not None:
             config = context.tiledb_config.copy()
-            config.update(platform_config or {})
+            config.update(platform_config)
             context = clib.SOMAContext(config)
-
-        ts = None
-        if handle.timestamp is not None:
-            ts = (0, handle.timestamp)
 
         sr = clib.SOMADenseNDArray.open(
             uri=handle.uri,
@@ -148,7 +144,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             context=context,
             column_names=[],
             result_order=_util.to_clib_result_order(result_order),
-            timestamp=ts,
+            timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
         self._set_reader_coords(sr, coords)

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -15,9 +15,10 @@ from somacore import options
 from typing_extensions import Self
 
 from . import _util
+from . import pytiledbsoma as clib
 from ._common_nd_array import NDArray
 from ._exception import SOMAError
-from ._tdb_handles import ArrayWrapper
+from ._tdb_handles import DenseNDArrayWrapper
 from ._util import dense_indices_to_shape
 from .options._tiledb_create_options import TileDBCreateOptions
 
@@ -72,7 +73,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
     __slots__ = ()
 
-    _reader_wrapper_type = ArrayWrapper
+    _reader_wrapper_type = DenseNDArrayWrapper
 
     def read(
         self,
@@ -107,7 +108,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         Lifecycle:
             Experimental.
         """
-        del partitions, platform_config  # Currently unused.
+        del partitions  # Currently unused.
         self._check_open_read()
         result_order = somacore.ResultOrder(result_order)
 
@@ -123,13 +124,31 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         #
         # The only exception is if the array has been created but no data have been written at
         # all, in which case the best we can do is use the schema shape.
-        data_shape = self._handle.schema.shape
+        handle: clib.DenseNDArrayWrapper = self._handle._handle
+
+        data_shape = handle.shape
         ned = self.non_empty_domain()
         if ned is not None:
             data_shape = tuple(slot[1] + 1 for slot in ned)
         target_shape = dense_indices_to_shape(coords, data_shape, result_order)
 
-        sr = self._soma_reader(result_order=result_order)
+        config = handle.config().copy()
+        config.update(platform_config or {})
+
+        ts = None
+        if handle.timestamp is not None:
+            ts = (0, handle.timestamp)
+
+        sr = clib.SOMADenseNDArray.open(
+            uri=handle.uri,
+            mode=clib.OpenMode.read,
+            platform_config=config,
+            column_names=[],
+            result_order=_util.to_clib_result_order(result_order),
+            timestamp=ts,
+        )
+
+        # sr = self._soma_reader(result_order=result_order)
 
         self._set_reader_coords(sr, coords)
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -332,9 +332,9 @@ class SOMAArrayWrapper(Wrapper[clib.SOMAArray]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAArray:
-        # Virtual method to implement _opener in derived classes 
-        # SOMADataFrameWrapper, SOMASparseNDArrayWrapper, and 
-        # SOMADenseNDArrayWrapper
+        # Ensure SOMADataFrameWrapper, SOMASparseNDArrayWrapper, and 
+        # SOMADenseNDArrayWrapper have _opener implemented to open the correct
+        # clib object (clib.DataFrame.open, etc)
         raise NotImplementedError
 
     # Covariant types should normally not be in parameters, but this is for

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -72,11 +72,13 @@ def open(
 
     if open_mode == clib.OpenMode.read and obj_type == "SOMADataFrame":
         return DataFrameWrapper._from_soma_object(soma_object, context)
+    elif open_mode == clib.OpenMode.read and obj_type == "SOMADenseNDArray":
+        return DenseNDArrayWrapper._from_soma_object(soma_object, context)
 
     if obj_type in (
         "SOMADataFrame",
-        "SOMASparseNDArray",
         "SOMADenseNDArray",
+        "SOMASparseNDArray",
         "array",
     ):
         return ArrayWrapper.open(uri, mode, context, timestamp)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -319,8 +319,8 @@ class GroupWrapper(Wrapper[tiledb.Group]):
         }
 
 
-class DataFrameWrapper(Wrapper[clib.SOMADataFrame]):
-    """Wrapper around a Pybind11 SOMADataFrame handle."""
+class SOMAArrayWrapper(Wrapper[clib.SOMAArray]):
+    """Base class for Pybind11 SOMAArrayWrapper handles."""
 
     @classmethod
     def _opener(
@@ -329,19 +329,8 @@ class DataFrameWrapper(Wrapper[clib.SOMADataFrame]):
         mode: options.OpenMode,
         context: SOMATileDBContext,
         timestamp: int,
-    ) -> clib.SOMADataFrame:
-        open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
-        config = {k: str(v) for k, v in context.tiledb_config.items()}
-        column_names: List[str] = []
-        result_order = clib.ResultOrder.automatic
-        return clib.SOMADataFrame.open(
-            uri,
-            open_mode,
-            config,
-            column_names,
-            result_order,
-            (0, timestamp),
-        )
+    ) -> clib.SOMAArray:
+        raise NotImplementedError
 
     # Covariant types should normally not be in parameters, but this is for
     # internal use only so it's OK.
@@ -364,17 +353,13 @@ class DataFrameWrapper(Wrapper[clib.SOMADataFrame]):
 
     @property
     def ndim(self) -> int:
-        return len(self._handle.index_column_names)
-
-    @property
-    def count(self) -> int:
-        return int(self._handle.count)
+        return len(self._handle.dimension_names)
 
     def _cast_domain(
         self, domain: Callable[[str, DTypeLike], Tuple[object, object]]
     ) -> Tuple[Tuple[object, object], ...]:
         result = []
-        for name in self._handle.index_column_names:
+        for name in self._handle.dimension_names:
             dtype = self._handle.schema.field(name).type
             if pa.types.is_timestamp(dtype):
                 np_dtype = np.dtype(dtype.to_pandas_dtype())
@@ -405,18 +390,76 @@ class DataFrameWrapper(Wrapper[clib.SOMADataFrame]):
     @property
     def attr_names(self) -> Tuple[str, ...]:
         return tuple(
-            f.name for f in self.schema if f.name not in self._handle.index_column_names
+            f.name for f in self.schema if f.name not in self._handle.dimension_names
         )
 
     @property
     def dim_names(self) -> Tuple[str, ...]:
-        return tuple(self._handle.index_column_names)
+        return tuple(self._handle.dimension_names)
 
     def enum(self, label: str) -> tiledb.Enumeration:
         # The DataFrame handle may either be ArrayWrapper or DataFrameWrapper.
         # enum is only used in the DataFrame write path and is implemented by
         # ArrayWrapper. If enum is called in the read path, it is an error.
         raise NotImplementedError
+
+
+class DataFrameWrapper(SOMAArrayWrapper, Wrapper[clib.SOMADataFrame]):
+    """Wrapper around a Pybind11 SOMADataFrame handle."""
+
+    @classmethod
+    def _opener(
+        cls,
+        uri: str,
+        mode: options.OpenMode,
+        context: SOMATileDBContext,
+        timestamp: int,
+    ) -> clib.SOMADataFrame:
+        open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+        config = {k: str(v) for k, v in context.tiledb_config.items()}
+        column_names: List[str] = []
+        result_order = clib.ResultOrder.automatic
+        return clib.SOMADataFrame.open(
+            uri,
+            open_mode,
+            config,
+            column_names,
+            result_order,
+            (0, timestamp),
+        )
+
+    @property
+    def count(self) -> int:
+        return int(self._handle.count)
+
+
+class DenseNDArrayWrapper(SOMAArrayWrapper, Wrapper[clib.SOMADenseNDArray]):
+    """Wrapper around a Pybind11 DenseNDArrayWrapper handle."""
+
+    @classmethod
+    def _opener(
+        cls,
+        uri: str,
+        mode: options.OpenMode,
+        context: SOMATileDBContext,
+        timestamp: int,
+    ) -> clib.SOMADenseNDArray:
+        open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+        config = {k: str(v) for k, v in context.tiledb_config.items()}
+        column_names: List[str] = []
+        result_order = clib.ResultOrder.automatic
+        return clib.SOMADenseNDArray.open(
+            uri,
+            open_mode,
+            config,
+            column_names,
+            result_order,
+            (0, timestamp),
+        )
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return tuple(self._handle.shape)
 
 
 class _DictMod(enum.Enum):

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -71,7 +71,7 @@ def open(
 
     if open_mode == clib.OpenMode.read and obj_type == "SOMADataFrame":
         return DataFrameWrapper._from_soma_object(soma_object, context)
-    elif open_mode == clib.OpenMode.read and obj_type == "SOMADenseNDArray":
+    if open_mode == clib.OpenMode.read and obj_type == "SOMADenseNDArray":
         return DenseNDArrayWrapper._from_soma_object(soma_object, context)
 
     if obj_type in (

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -332,6 +332,9 @@ class SOMAArrayWrapper(Wrapper[clib.SOMAArray]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAArray:
+        # Virtual method to implement _opener in derived classes 
+        # SOMADataFrameWrapper, SOMASparseNDArrayWrapper, and 
+        # SOMADenseNDArrayWrapper
         raise NotImplementedError
 
     # Covariant types should normally not be in parameters, but this is for

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -39,13 +39,13 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Experimental.
     """
 
-    """Class variable of the Wrapper class used to open this object type."""
     _wrapper_type: Type[_WrapperType_co]
     _reader_wrapper_type: Union[
         Type[_WrapperType_co],
         Type[_tdb_handles.DataFrameWrapper],
         Type[_tdb_handles.DenseNDArrayWrapper],
     ]
+    """Class variables of the Wrapper class used to open this object type."""
 
     __slots__ = ("_close_stack", "_handle")
 

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -42,7 +42,9 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     """Class variable of the Wrapper class used to open this object type."""
     _wrapper_type: Type[_WrapperType_co]
     _reader_wrapper_type: Union[
-        Type[_WrapperType_co], Type[_tdb_handles.DataFrameWrapper]
+        Type[_WrapperType_co],
+        Type[_tdb_handles.DataFrameWrapper],
+        Type[_tdb_handles.DenseNDArrayWrapper],
     ]
 
     __slots__ = ("_close_stack", "_handle")

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -40,12 +40,13 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     """
 
     _wrapper_type: Type[_WrapperType_co]
+    """Class variable of the Wrapper class used to open this object type."""
+
     _reader_wrapper_type: Union[
         Type[_WrapperType_co],
         Type[_tdb_handles.DataFrameWrapper],
         Type[_tdb_handles.DenseNDArrayWrapper],
     ]
-    """Class variables of the Wrapper class used to open this object type."""
 
     __slots__ = ("_close_stack", "_handle")
 

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -39,6 +39,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Experimental.
     """
 
+    """Class variable of the Wrapper class used to open this object type."""
     _wrapper_type: Type[_WrapperType_co]
     _reader_wrapper_type: Union[
         Type[_WrapperType_co], Type[_tdb_handles.DataFrameWrapper]
@@ -127,8 +128,6 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             )
         self._handle = handle
         self._close_stack.enter_context(self._handle)
-
-    """Class variable of the Wrapper class used to open this object type."""
 
     @property
     def context(self) -> SOMATileDBContext:

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -191,10 +191,18 @@ void load_soma_array(py::module& m) {
             py::overload_cast<
                 OpenMode,
                 std::optional<std::pair<uint64_t, uint64_t>>>(&SOMAArray::open))
+
+        .def(
+            "reopen",
+            py::overload_cast<
+                OpenMode,
+                std::optional<std::pair<uint64_t, uint64_t>>>(&SOMAArray::open))
         .def("close", &SOMAArray::close)
+
         .def_property_readonly(
             "closed",
             [](SOMAArray& reader) -> bool { return not reader.is_open(); })
+
         .def_property_readonly(
             "mode",
             [](SOMAArray& reader) {
@@ -585,6 +593,7 @@ void load_soma_array(py::module& m) {
                             "Unsupported dtype for nonempty domain.");
                 }
             })
+
         .def(
             "domain",
             [](SOMAArray& reader, std::string name, py::dtype dtype) {
@@ -631,6 +640,42 @@ void load_soma_array(py::module& m) {
                         throw TileDBSOMAError(
                             "Unsupported dtype for Dimension's domain");
                 }
+            })
+
+        .def_property_readonly("dimension_names", &SOMAArray::dimension_names)
+
+        .def("set_metadata", &SOMAArray::set_metadata)
+
+        .def("delete_metadata", &SOMAArray::delete_metadata)
+
+        .def(
+            "get_metadata",
+            py::overload_cast<const std::string&>(&SOMAArray::get_metadata))
+
+        .def_property_readonly(
+            "meta",
+            [](SOMAArray& soma_dataframe) -> py::dict {
+                py::dict results;
+
+                for (auto const& [key, val] : soma_dataframe.get_metadata()) {
+                    tiledb_datatype_t tdb_type = std::get<MetadataInfo::dtype>(
+                        val);
+                    uint32_t value_num = std::get<MetadataInfo::num>(val);
+                    const void* value = std::get<MetadataInfo::value>(val);
+
+                    if (tdb_type == TILEDB_STRING_UTF8) {
+                        results[py::str(key)] = py::str(
+                            std::string((const char*)value, value_num));
+                    } else if (tdb_type == TILEDB_STRING_ASCII) {
+                        results[py::str(key)] = py::bytes(
+                            std::string((const char*)value, value_num));
+                    } else {
+                        py::dtype value_type = tdb_to_np_dtype(tdb_type, 1);
+                        results[py::str(key)] = py::array(
+                            value_type, value_num, value);
+                    }
+                }
+                return results;
             })
 
         .def("set_metadata", &SOMAArray::set_metadata)

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -191,18 +191,10 @@ void load_soma_array(py::module& m) {
             py::overload_cast<
                 OpenMode,
                 std::optional<std::pair<uint64_t, uint64_t>>>(&SOMAArray::open))
-
-        .def(
-            "reopen",
-            py::overload_cast<
-                OpenMode,
-                std::optional<std::pair<uint64_t, uint64_t>>>(&SOMAArray::open))
         .def("close", &SOMAArray::close)
-
         .def_property_readonly(
             "closed",
             [](SOMAArray& reader) -> bool { return not reader.is_open(); })
-
         .def_property_readonly(
             "mode",
             [](SOMAArray& reader) {
@@ -679,10 +671,13 @@ void load_soma_array(py::module& m) {
             })
 
         .def("set_metadata", &SOMAArray::set_metadata)
+
         .def("delete_metadata", &SOMAArray::delete_metadata)
+
         .def(
             "get_metadata",
             py::overload_cast<const std::string&>(&SOMAArray::get_metadata))
+
         .def_property_readonly(
             "meta",
             [](SOMAArray& soma_dataframe) -> py::dict {
@@ -709,6 +704,7 @@ void load_soma_array(py::module& m) {
                 return results;
             })
         .def("has_metadata", &SOMAArray::has_metadata)
+
         .def("metadata_num", &SOMAArray::metadata_num);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -49,22 +49,23 @@ using namespace tiledbsoma;
 void load_soma_dense_ndarray(py::module& m) {
     py::class_<SOMADenseNDArray, SOMAArray, SOMAObject>(m, "SOMADenseNDArray")
 
-    .def_static(
-        "open", 
-        py::overload_cast<
-            std::string_view, 
-            OpenMode, 
-            std::shared_ptr<SOMAContext>, 
-            std::vector<std::string>, 
-            ResultOrder, 
-            std::optional<std::pair<uint64_t, uint64_t>>>(&SOMADenseNDArray::open),
-        "uri"_a,
-        "mode"_a,
-        "context"_a,
-        py::kw_only(),
-        "column_names"_a = py::none(),
-        "result_order"_a = ResultOrder::automatic,
-        "timestamp"_a = py::none())
+        .def_static(
+            "open",
+            py::overload_cast<
+                std::string_view,
+                OpenMode,
+                std::shared_ptr<SOMAContext>,
+                std::vector<std::string>,
+                ResultOrder,
+                std::optional<std::pair<uint64_t, uint64_t>>>(
+                &SOMADenseNDArray::open),
+            "uri"_a,
+            "mode"_a,
+            "context"_a,
+            py::kw_only(),
+            "column_names"_a = py::none(),
+            "result_order"_a = ResultOrder::automatic,
+            "timestamp"_a = py::none())
 
         .def_static("exists", &SOMADenseNDArray::exists);
 }

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -49,23 +49,22 @@ using namespace tiledbsoma;
 void load_soma_dense_ndarray(py::module& m) {
     py::class_<SOMADenseNDArray, SOMAArray, SOMAObject>(m, "SOMADenseNDArray")
 
-        .def_static(
-            "open",
-            py::overload_cast<
-                std::string_view,
-                OpenMode,
-                std::shared_ptr<SOMAContext>,
-                std::vector<std::string>,
-                ResultOrder,
-                std::optional<std::pair<uint64_t, uint64_t>>>(
-                &SOMADenseNDArray::open),
-            "uri"_a,
-            "mode"_a,
-            "ctx"_a,
-            py::kw_only(),
-            "column_names"_a = py::none(),
-            "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none())
+    .def_static(
+        "open", 
+        py::overload_cast<
+            std::string_view, 
+            OpenMode, 
+            std::shared_ptr<SOMAContext>, 
+            std::vector<std::string>, 
+            ResultOrder, 
+            std::optional<std::pair<uint64_t, uint64_t>>>(&SOMADenseNDArray::open),
+        "uri"_a,
+        "mode"_a,
+        "context"_a,
+        py::kw_only(),
+        "column_names"_a = py::none(),
+        "result_order"_a = ResultOrder::automatic,
+        "timestamp"_a = py::none())
 
         .def_static("exists", &SOMADenseNDArray::exists);
 }

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -50,37 +50,38 @@ using namespace tiledbsoma;
 void load_soma_object(py::module& m) {
     py::class_<SOMAObject>(m, "SOMAObject")
 
-    .def_static("open", [](std::string_view uri, 
-                           OpenMode mode, 
-                           std::shared_ptr<SOMAContext> context, 
-                           std::optional<std::pair<uint64_t, uint64_t>> timestamp) -> py::object {
-        try{
-            auto obj = SOMAObject::open(uri, mode, context, timestamp);
-            if (obj->type() == "SOMADataFrame")
-                return py::cast(dynamic_cast<SOMADataFrame&>(*obj));
-            else if (obj->type() == "SOMASparseNDArray")
-                return py::cast(dynamic_cast<SOMASparseNDArray&>(*obj));
-            else if (obj->type() == "SOMADenseNDArray")
-                return py::cast(dynamic_cast<SOMADenseNDArray&>(*obj));
-            else if (obj->type() == "SOMACollection")
-                return py::cast(dynamic_cast<SOMACollection&>(*obj));
-            else if (obj->type() == "SOMAExperiment")
-                return py::cast(dynamic_cast<SOMAExperiment&>(*obj));
-            else if (obj->type() == "SOMAMeasurement")
-                return py::cast(dynamic_cast<SOMAMeasurement&>(*obj));
-            return py::none();
-        }catch(...){
-            return py::none();
-        }
-    },
-    "uri"_a,
-    "mode"_a,
-    "context"_a,
-    py::kw_only(),
-    "timestamp"_a = py::none())
-    
-    .def_property_readonly("type", &SOMAObject::type);
-    
-    };
-}
+        .def_static(
+            "open",
+            [](std::string_view uri,
+               OpenMode mode,
+               std::shared_ptr<SOMAContext> context,
+               std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+                -> py::object {
+                try {
+                    auto obj = SOMAObject::open(uri, mode, context, timestamp);
+                    if (obj->type() == "SOMADataFrame")
+                        return py::cast(dynamic_cast<SOMADataFrame&>(*obj));
+                    else if (obj->type() == "SOMASparseNDArray")
+                        return py::cast(dynamic_cast<SOMASparseNDArray&>(*obj));
+                    else if (obj->type() == "SOMADenseNDArray")
+                        return py::cast(dynamic_cast<SOMADenseNDArray&>(*obj));
+                    else if (obj->type() == "SOMACollection")
+                        return py::cast(dynamic_cast<SOMACollection&>(*obj));
+                    else if (obj->type() == "SOMAExperiment")
+                        return py::cast(dynamic_cast<SOMAExperiment&>(*obj));
+                    else if (obj->type() == "SOMAMeasurement")
+                        return py::cast(dynamic_cast<SOMAMeasurement&>(*obj));
+                    return py::none();
+                } catch (...) {
+                    return py::none();
+                }
+            },
+            "uri"_a,
+            "mode"_a,
+            "context"_a,
+            py::kw_only(),
+            "timestamp"_a = py::none())
 
+        .def_property_readonly("type", &SOMAObject::type);
+};
+}  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -50,32 +50,37 @@ using namespace tiledbsoma;
 void load_soma_object(py::module& m) {
     py::class_<SOMAObject>(m, "SOMAObject")
 
-        .def_static(
-            "open",
-            [](std::string_view uri,
-               OpenMode mode,
-               std::shared_ptr<SOMAContext> ctx,
-               std::optional<std::pair<uint64_t, uint64_t>> timestamp)
-                -> py::object {
-                try {
-                    auto obj = SOMAObject::open(uri, mode, ctx, timestamp);
-                    if (obj->type() == "SOMADataFrame")
-                        return py::cast(dynamic_cast<SOMADataFrame&>(*obj));
-                    else if (obj->type() == "SOMASparseNDArray")
-                        return py::cast(dynamic_cast<SOMASparseNDArray&>(*obj));
-                    else if (obj->type() == "SOMADenseNDArray")
-                        return py::cast(dynamic_cast<SOMADenseNDArray&>(*obj));
-                    else if (obj->type() == "SOMACollection")
-                        return py::cast(dynamic_cast<SOMACollection&>(*obj));
-                    else if (obj->type() == "SOMAExperiment")
-                        return py::cast(dynamic_cast<SOMAExperiment&>(*obj));
-                    else if (obj->type() == "SOMAMeasurement")
-                        return py::cast(dynamic_cast<SOMAMeasurement&>(*obj));
-                    return py::none();
-                } catch (...) {
-                    return py::none();
-                }
-            })
-        .def_property_readonly("type", &SOMAObject::type);
-};
-}  // namespace libtiledbsomacpp
+    .def_static("open", [](std::string_view uri, 
+                           OpenMode mode, 
+                           std::shared_ptr<SOMAContext> context, 
+                           std::optional<std::pair<uint64_t, uint64_t>> timestamp) -> py::object {
+        try{
+            auto obj = SOMAObject::open(uri, mode, context, timestamp);
+            if (obj->type() == "SOMADataFrame")
+                return py::cast(dynamic_cast<SOMADataFrame&>(*obj));
+            else if (obj->type() == "SOMASparseNDArray")
+                return py::cast(dynamic_cast<SOMASparseNDArray&>(*obj));
+            else if (obj->type() == "SOMADenseNDArray")
+                return py::cast(dynamic_cast<SOMADenseNDArray&>(*obj));
+            else if (obj->type() == "SOMACollection")
+                return py::cast(dynamic_cast<SOMACollection&>(*obj));
+            else if (obj->type() == "SOMAExperiment")
+                return py::cast(dynamic_cast<SOMAExperiment&>(*obj));
+            else if (obj->type() == "SOMAMeasurement")
+                return py::cast(dynamic_cast<SOMAMeasurement&>(*obj));
+            return py::none();
+        }catch(...){
+            return py::none();
+        }
+    },
+    "uri"_a,
+    "mode"_a,
+    "context"_a,
+    py::kw_only(),
+    "timestamp"_a = py::none())
+    
+    .def_property_readonly("type", &SOMAObject::type);
+    
+    };
+}
+

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -115,6 +115,14 @@ def test_dataframe(tmp_path, arrow_schema):
         assert sdf.count == 5
         assert len(sdf) == 5
 
+    # Ensure read mode uses clib object
+    with soma.DataFrame.open(tmp_path.as_posix(), "r") as A:
+        assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADataFrame)
+
+    # Ensure write mode uses Python object
+    with soma.DataFrame.open(tmp_path.as_posix(), "w") as A:
+        assert isinstance(A._handle._handle, tiledb.Array)
+
 
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame.create(

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -49,6 +49,14 @@ def test_dense_nd_array_create_ok(
     with tiledb.open(tmp_path.as_posix()) as A:
         assert not A.schema.sparse
 
+    # Ensure read mode uses clib object
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A:
+        assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADenseNDArray)
+
+    # Ensure write mode uses Python object
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A:
+        assert isinstance(A._handle._handle, tiledb.Array)
+
 
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -129,6 +129,11 @@ class SOMADenseNDArray : public SOMAArray {
         : SOMAArray(other) {
     }
 
+    SOMADenseNDArray() = delete;
+    SOMADenseNDArray(const SOMADenseNDArray&) = default;
+    SOMADenseNDArray(SOMADenseNDArray&&) = delete;
+    ~SOMADenseNDArray() = default;
+
     using SOMAArray::open;
 
     /**


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2078

**Changes:**

Use `clib.DenseNDArray` for read path, replacing usage of `tiledb.Array`.

These changes were picked out of https://github.com/single-cell-data/TileDB-SOMA/pull/1817.

**Notes for Reviewer:**

These changes are on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2129.