### PR TITLE
[Backport release-1.7] [python] Add type checks to `obsm`, `obsp`, `varm` and `varp` early in ingestion

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -22,8 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, macos-12]
-        # Just testing this out for https://github.com/single-cell-data/TileDB-SOMA/issues/1849
-        python-version: ['3.7, '3.12']
+        python-version: ['3.7', '3.12']
         include:
           - os: ubuntu-22.04
             cc: gcc-11

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -39,6 +39,7 @@ import tiledb
 from anndata._core import file_backing
 from anndata._core.sparse_dataset import SparseDataset
 from somacore.options import PlatformConfig
+from typing_extensions import get_args
 
 from .. import (
     Collection,
@@ -420,6 +421,30 @@ def from_anndata(
         raise TypeError(
             "Second argument is not an AnnData object -- did you want from_h5ad?"
         )
+
+    for key in anndata.obsm.keys():
+        if not isinstance(anndata.obsm[key], get_args(Matrix)):
+            raise TypeError(
+                f"obsm value at {key} in not of type {list(cl.__name__ for cl in get_args(Matrix))}"
+            )
+
+    for key in anndata.obsp.keys():
+        if not isinstance(anndata.obsp[key], get_args(Matrix)):
+            raise TypeError(
+                f"obsp value at {key} in not of type {list(cl.__name__ for cl in get_args(Matrix))}"
+            )
+
+    for key in anndata.varm.keys():
+        if not isinstance(anndata.varm[key], get_args(Matrix)):
+            raise TypeError(
+                f"varm value at {key} in not of type {list(cl.__name__ for cl in get_args(Matrix))}"
+            )
+
+    for key in anndata.varp.keys():
+        if not isinstance(anndata.varp[key], get_args(Matrix)):
+            raise TypeError(
+                f"varp value at {key} in not of type {list(cl.__name__ for cl in get_args(Matrix))}"
+            )
 
     # For single ingest (no append):
     #

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1134,3 +1134,13 @@ def test_index_names_io(tmp_path, obs_index_name, var_index_name):
         assert bdata.var.index.name is None
     else:
         assert adata.var.index.name == bdata.var.index.name
+
+def test_obsm_data_type(adata):
+    tempdir = tempfile.TemporaryDirectory()
+    soma_path = tempdir.name
+    bdata = anndata.AnnData(X=adata.X, obs=adata.obs, var=adata.var, obsm={"testing": adata.obs})
+
+    with pytest.raises(TypeError):
+        tiledbsoma.io.from_anndata(soma_path, bdata, measurement_name="RNA")
+
+    assert not any(Path(soma_path).iterdir())


### PR DESCRIPTION
From #2131