### PR TITLE
[python/ci] Leave 3.12 support provisional

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -23,6 +23,8 @@ jobs:
         # TODO: decide on Windows CI coverage
         os: [ubuntu-22.04, macos-12]
         # os: [ubuntu-22.04, macos-12, windows-2019]
+        # TODO: add 3.12
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - runs-on: ubuntu-22.04

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -22,8 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, macos-12]
-        # Just testing this out for https://github.com/single-cell-data/TileDB-SOMA/issues/1849
-        python-version: ['3.7, '3.12']
+        python-version: ['3.7', '3.11']
         include:
           - os: ubuntu-22.04
             cc: gcc-11


### PR DESCRIPTION
**Issue and/or context:**

* Issue #1849 
* I put up PR #2108 and it was green so I merged it
* Now PRs #2119 #2136 and anything else new is failing MacPS Python 3.12 CI fails
  * Unable to install wheel for `pyarrow`
  * https://github.com/single-cell-data/TileDB-SOMA/actions/runs/7896650237/job/21550972931?pr=2138 for example
* Another issue: TileDB-Py doesn't have wheels for 3.12
  * https://pypi.org/project/tiledb/#files

**Changes:**

* Leave 3.12 support in place -- don't entirely revert #1849 
* Don't fail CI for 3.12 until the above is resolved
* Leave #1849 open for tracking

**Notes for Reviewer:**

