### PR TITLE
Fix inconsistency in DictFilterSpec docstring.

### DIFF
--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -32,7 +32,7 @@ _DictFilterSpec = Mapping[str, object]
 
 The key ``_type`` is used as the name of the filter. Other entries in the
 dictionary are passed as named arguments. For example,
-``{"_name": "SomeFilter", "aggression": 5, "layers": 7}`` will call
+``{"_type": "SomeFilter", "aggression": 5, "layers": 7}`` will call
 ``SomeFilter(aggression=5, layers=7)``."""
 _FilterSpec = Union[str, _DictFilterSpec]
 """A declarative format for specifying filters:


### PR DESCRIPTION
We mistakenly used `_name` in the literal rather than `_type`.