### PR TITLE
[r] Fix Seurat ingestion with missing command logs collection

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.7.99.2
+Version: 1.7.99.3
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -546,10 +546,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       if (inherits(uns, 'SOMACollection')) {
         cmds <- tryCatch(
           .load_seurat_command(uns, ms_names = private$.measurement_name),
-          packageCheckError = function(err) {
-            warning(conditionMessage(err), call. = FALSE, immediate. = TRUE)
-            return(NULL)
-          }
+          packageCheckError = .err_to_warn,
+          missingCollectionError = .err_to_warn
         )
         for (i in names(cmds)) {
           object[[i]] <- cmds[[i]]

--- a/apis/r/R/utils-seurat.R
+++ b/apis/r/R/utils-seurat.R
@@ -27,11 +27,15 @@
   check_package('SeuratObject', version = .MINIMUM_SEURAT_VERSION())
   stopifnot(
     "'uns' must be a SOMACollection" = inherits(uns, what = 'SOMACollection'),
-    "Cannot find a SOMACollection with command logs in 'uns'" = key %in% uns$names() &&
-      inherits(logs <- uns$get(key), what = 'SOMACollection'),
     "'ms_names' must be a character vector with no empty strings" = is.character(ms_names) &&
       all(nzchar(ms_names))
   )
+  if (!(key %in% uns$names() && inherits(logs <- uns$get(key), what = 'SOMACollection'))) {
+    stop(errorCondition(
+      "Cannot find a SOMACollection with command logs in 'uns'",
+      class = c("noCommandLogsError", "missingCollectionError")
+    ))
+  }
   slots <- slotNames(getClassDef('SeuratCommand', package = 'SeuratObject'))
   hint <- uns_hint('1d')
   lognames <- logs$names()

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -70,6 +70,10 @@ uns_hint <- function(type = c('1d', '2d')) {
   ))
 }
 
+.err_to_warn <- function(err, immediate. = TRUE) {
+  warning(conditionMessage(err), call. = FALSE, immediate. = immediate.)
+}
+
 .decode_from_char <- function(x) {
   stopifnot(is.character(x))
   double <- paste0(

--- a/apis/r/tests/testthat/test-SeuratOutgest-command.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-command.R
@@ -117,6 +117,9 @@ test_that("Load SeuratCommand with missing commands", {
 
   expect_no_condition(exp <- SOMAExperimentOpen(uri))
   on.exit(exp$close(), add = TRUE)
+  expect_true('uns' %in% exp$names())
+  expect_s3_class(uns <- exp$get('uns'), 'SOMACollection')
+  expect_false('seurat_commands' %in% uns$names())
 
   expect_s3_class(
     query <- SOMAExperimentAxisQuery$new(exp, SeuratObject::DefaultAssay(pbmc_small)),


### PR DESCRIPTION
Fix a bug in Seurat ingestion where `exp/uns` is present but `exp/uns/seurat_commands` is not

fixes #2153 