### PR TITLE
[r/ci] Controlled downgrade for TileDB-R 0.23

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -110,9 +110,7 @@ jobs:
         
       - name: Test
         if: ${{ matrix.covr == 'no' }}
-        run: |
-          cd apis/r && tools/r-ci.sh run_tests
-          Rscript -e 'tiledbsoma::show_package_versions()'
+        run: cd apis/r && tools/r-ci.sh run_tests
 
       - name: Coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' }}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -110,7 +110,9 @@ jobs:
         
       - name: Test
         if: ${{ matrix.covr == 'no' }}
-        run: cd apis/r && tools/r-ci.sh run_tests
+        run: |
+          cd apis/r && tools/r-ci.sh run_tests
+          Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' }}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -55,16 +55,12 @@ jobs:
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
 
-      # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
-      # which source is available but CRAN releases (and hence update r2u binaries) are not yet:
-
-      - name: Install r-universe build of tiledb-r (macOS)
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
-
-      - name: Install r-universe build of tiledb-r (linux)
-        if: ${{ matrix.os != 'macOS-latest' }}
-        run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
+      - name: Install 0.23 build of tiledb-r with core 2.19
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.23.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.23.0.tar.gz")'
+          R CMD INSTALL 0.23.0.tar.gz    # as 0.23.0 is needed by TileDB-SOMA 1.7
 
       - name: Install r-universe build of SeuratObject (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
@@ -92,6 +88,13 @@ jobs:
       #
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
+
+      - name: Re-install 0.23 build of tiledb-r with core 2.19
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.23.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.23.0.tar.gz")'
+          R CMD INSTALL 0.23.0.tar.gz    # as 0.23.0 is needed by TileDB-SOMA 1.7
 
       # - name: Build Package
       #   run: cd apis/r && R CMD build --no-build-vignettes --no-manual .

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -41,6 +41,13 @@ jobs:
       - name: MkVars
         run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
+      - name: Install 0.23 build of tiledb-r with core 2.19
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.23.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.23.0.tar.gz")'
+          R CMD INSTALL 0.23.0.tar.gz    # as 0.23.0 is needed by TileDB-SOMA 1.7
+
       - name: Install r-universe build of tiledb-r (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
         run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
@@ -75,13 +82,31 @@ jobs:
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python
 
-      - name: Show Python package versions
+      - name: Show package versions
         run: |
           python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
+          echo
           python scripts/show-versions.py
+          echo
+          Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
+
+      - name: Re-install 0.23 build of tiledb-r with core 2.19
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.23.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.23.0.tar.gz")'
+          R CMD INSTALL 0.23.0.tar.gz    # as 0.23.0 is needed by SOMA 1.7
+
+      - name: Show package versions
+        run: |
+          python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
+          echo
+          python scripts/show-versions.py
+          echo
+          Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Interop Tests
         run: python -m pytest apis/system/tests/

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-x86_64-2.19.0-fa30a88a.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-arm64-2.19.1-29ceb3e7.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-arm64-2.19.0-fa30a88a.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-linux-x86_64-2.19.0-fa30a88a.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -58,8 +58,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-windows-x86_64-2.19.1-29ceb3e7.zip")
-          SET(DOWNLOAD_SHA1 "b3c6002e8792501a8020aa71f2ea75019b6e3339")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-windows-x86_64-2.19.0-fa30a88a.zip")
+          SET(DOWNLOAD_SHA1 "ab8b61a35f0776e851c4eedcb1340df4d8cfb4b3")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -76,22 +76,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz")
-            SET(DOWNLOAD_SHA1 "c9c667689e0a8c4e5a2989f179995b0a013ca047")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-x86_64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "089b3aa8a92df0bd5a8f7515ed8e5b6bacb5ab47")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-arm64-2.19.1-29ceb3e7.tar.gz")
-            SET(DOWNLOAD_SHA1 "eb15d2d6c2920011765e1c102a43c23b8d7b1b0f")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-arm64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "83acdc7529d50dcf293dbd6bbc81263856c7c74c")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz")
-            SET(DOWNLOAD_SHA1 "c9c667689e0a8c4e5a2989f179995b0a013ca047")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-x86_64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "089b3aa8a92df0bd5a8f7515ed8e5b6bacb5ab47")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-arm64-2.19.1-29ceb3e7.tar.gz")
-            SET(DOWNLOAD_SHA1 "eb15d2d6c2920011765e1c102a43c23b8d7b1b0f")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-arm64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "83acdc7529d50dcf293dbd6bbc81263856c7c74c")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz")
-          SET(DOWNLOAD_SHA1 "84dda6d2faa3abaef9dae296f16de1979df0f9b0")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-linux-x86_64-2.19.0-fa30a88a.tar.gz")
+          SET(DOWNLOAD_SHA1 "d236688dbeff2536a8938cf8bf0d478b9f6108f6")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -113,8 +113,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.19.1.zip"
-          URL_HASH SHA1=6255616066c193ca6c595770a3ec72e316d8b280
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.19.0.zip"
+          URL_HASH SHA1=ade4c52490440f3d348e0f2d4677b322c83993df
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
**Issue and/or context:** Applies the same pattern as #1972 did for the `release-1.5` branch and `#1996` did for the `release-1.6` branch.

**Changes:** As on #1972 and #1996. This is necessary since [TileDB-R 0.24.0](https://tiledb-inc.r-universe.dev/tiledb) now exists, and the R `DESCRIPTION` file does not syntactically support `tiledb < 0.24` or `tiledb <= 0.24`. Therefore (see also this comment https://github.com/single-cell-data/TileDB-SOMA/pull/1996#issuecomment-1881702859) we do a controlled downgrade to TileDB-R 0.23 on this PR, for the `release-1.7` branch.

**Notes for Reviewer:**

Every stanza in this PR has been proved necessary via the dialog on #1972 and #1996. See in particular https://github.com/single-cell-data/TileDB-SOMA/pull/1996#pullrequestreview-1809807165.