### PR TITLE
[python] Use `_internal_tiledb_config` in `native_context`

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -155,14 +155,9 @@ class SOMATileDBContext:
     def native_context(self) -> clib.SOMAContext:
         """The C++ SOMAContext for this SOMA context."""
         with self._lock:
-            if self._native_context is not None:
-                return self._native_context
-
-        # tiledb_config also acquires the lock so we must first release it and
-        # then reacquire it
-        cfg = self.tiledb_config
-        with self._lock:
-            self._native_context = clib.SOMAContext({k: str(cfg[k]) for k in cfg})
+            if self._native_context is None:
+                cfg = self._internal_tiledb_config()
+                self._native_context = clib.SOMAContext({k: str(cfg[k]) for k in cfg})
             return self._native_context
 
     @property

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -157,7 +157,9 @@ class SOMATileDBContext:
         with self._lock:
             if self._native_context is None:
                 cfg = self._internal_tiledb_config()
-                self._native_context = clib.SOMAContext({k: str(cfg[k]) for k in cfg})
+                self._native_context = clib.SOMAContext(
+                    {k: str(v) for k, v in cfg.items()}
+                )
             return self._native_context
 
     @property


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/pull/2158#discussion_r1500959184

This was my fault for merging this PR in before getting a follow-up review for my change.

**Changes:**

Use `_internal_tiledb_config` in `native_context`.

