### PR TITLE
[python] Expose `tiledbsoma.io.ExperimentAmbientLabelMapping`

### DIFF
--- a/apis/python/src/tiledbsoma/io/__init__.py
+++ b/apis/python/src/tiledbsoma/io/__init__.py
@@ -1,3 +1,6 @@
+from ._registration import (
+    ExperimentAmbientLabelMapping,
+)
 from .ingest import (
     add_matrix_to_collection,
     add_X_layer,
@@ -32,4 +35,5 @@ __all__ = (
     "update_matrix",
     "update_obs",
     "update_var",
+    "ExperimentAmbientLabelMapping",
 )

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1098,3 +1098,9 @@ def test_registration_with_batched_reads(tmp_path, soma_larger, use_small_buffer
 
 def test_ealm_expose():
     """Checks that this is exported from tiledbsoma.io._registration"""
+    # All we want to check is that the import doesn't throw. Job done. Period.
+    # However, the pre-commit hook will strip out this import statement as "unused".
+    # So, assert something.
+    from tiledbsoma.io import ExperimentAmbientLabelMapping
+
+    assert ExperimentAmbientLabelMapping.from_h5ad_appends_on_experiment is not None

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1094,3 +1094,7 @@ def test_registration_with_batched_reads(tmp_path, soma_larger, use_small_buffer
     )
 
     assert len(rd.obs_axis.data) == 1000
+
+
+def test_ealm_expose():
+    """Checks that this is exported from tiledbsoma.io._registration"""

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1101,6 +1101,4 @@ def test_ealm_expose():
     # All we want to check is that the import doesn't throw. Job done. Period.
     # However, the pre-commit hook will strip out this import statement as "unused".
     # So, assert something.
-    from tiledbsoma.io import ExperimentAmbientLabelMapping
-
-    assert ExperimentAmbientLabelMapping.from_h5ad_appends_on_experiment is not None
+    assert tiledbsoma.io.ExperimentAmbientLabelMapping is not None


### PR DESCRIPTION
**Issue and/or context:** The subpackage `tiledbsoma.io._registration` is mostly internals, and rightly so. There are `tiledbsoma.io.register_anndatas` and `tiledbsoma.io.register_h5ads` exposed at `tiledbsoma.io`, and this is _almost_ sufficient.

I noted on #2172, though, something I should have thought of -- namely, if any user wants to do Python type-checking on the _result_ of `tiledbsoma.io.register_anndatas` or `tiledbsoma.io.register_h5ads` then tney currently need to cal this `tiledbsoma.io._registration.ExperimentAmbientLabelMapping`. This is non-ideal since they have to type out something with a leading underscore.

**Changes:** Expose `tiledbsoma.io.ExperimentAmbientLabelMapping`

**Notes for Reviewer:**

