### PR TITLE
[r] Set `apis/r/DESCRIPTION` version to 1.8.99

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.7.99.3
+Version: 1.8.99
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases) in prep for upcoming 1.8.0