### PR TITLE
[c++] Refactor `metadata` and `create` to respect timestamps

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -41,19 +41,40 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-void SOMAArray::create(
+std::unique_ptr<SOMAArray> SOMAArray::create(
     std::shared_ptr<SOMAContext> ctx,
     std::string_view uri,
     ArraySchema schema,
-    std::string soma_type) {
+    std::string soma_type,
+    std::optional<TimestampRange> timestamp) {
     Array::create(std::string(uri), schema);
-    auto array = Array(*ctx->tiledb_ctx(), std::string(uri), TILEDB_WRITE);
-    array.put_metadata(
-        "soma_object_type",
+
+    std::shared_ptr<Array> array;
+    if (timestamp) {
+        array = std::make_shared<Array>(
+            *ctx->tiledb_ctx(),
+            std::string(uri),
+            TILEDB_WRITE,
+            TemporalPolicy(
+                TimestampStartEnd, timestamp->first, timestamp->second));
+    } else {
+        array = std::make_shared<Array>(
+            *ctx->tiledb_ctx(), std::string(uri), TILEDB_WRITE);
+    }
+
+    array->put_metadata(
+        SOMA_OBJECT_TYPE_KEY,
         TILEDB_STRING_UTF8,
         static_cast<uint32_t>(soma_type.length()),
         soma_type.c_str());
-    array.close();
+
+    array->put_metadata(
+        ENCODING_VERSION_KEY,
+        TILEDB_STRING_UTF8,
+        static_cast<uint32_t>(ENCODING_VERSION_VAL.length()),
+        ENCODING_VERSION_VAL.c_str());
+
+    return std::make_unique<SOMAArray>(ctx, array, timestamp);
 }
 
 std::unique_ptr<SOMAArray> SOMAArray::open(
@@ -64,7 +85,7 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     std::vector<std::string> column_names,
     std::string_view batch_size,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     LOG_DEBUG(
         fmt::format("[SOMAArray] static method 'cfg' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
@@ -86,7 +107,7 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     std::vector<std::string> column_names,
     std::string_view batch_size,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     LOG_DEBUG(
         fmt::format("[SOMAArray] static method 'ctx' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
@@ -112,7 +133,7 @@ SOMAArray::SOMAArray(
     std::vector<std::string> column_names,
     std::string_view batch_size,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+    std::optional<TimestampRange> timestamp)
     : uri_(util::rstrip_uri(uri))
     , result_order_(result_order)
     , timestamp_(timestamp) {
@@ -130,7 +151,7 @@ SOMAArray::SOMAArray(
     std::vector<std::string> column_names,
     std::string_view batch_size,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+    std::optional<TimestampRange> timestamp)
     : uri_(util::rstrip_uri(uri))
     , ctx_(ctx)
     , result_order_(result_order)
@@ -140,20 +161,39 @@ SOMAArray::SOMAArray(
     fill_metadata_cache();
 }
 
+SOMAArray::SOMAArray(
+    std::shared_ptr<SOMAContext> ctx,
+    std::shared_ptr<Array> arr,
+    std::optional<TimestampRange> timestamp)
+    : uri_(util::rstrip_uri(arr->uri()))
+    , ctx_(ctx)
+    , batch_size_("auto")
+    , result_order_(ResultOrder::automatic)
+    , timestamp_(timestamp)
+    , mq_(std::make_unique<ManagedQuery>(arr, ctx_->tiledb_ctx(), name_))
+    , arr_(arr) {)
+    reset({}, batch_size_, result_order_);
+    fill_metadata_cache();
+}
+
 void SOMAArray::fill_metadata_cache() {
-    std::shared_ptr<Array> array;
     if (arr_->query_type() == TILEDB_WRITE) {
-        array = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, TILEDB_READ);
+        meta_cache_arr_ = std::make_shared<Array>(
+            *ctx_->tiledb_ctx(),
+            uri_,
+            TILEDB_READ,
+            TemporalPolicy(
+                TimestampStartEnd, timestamp()->first, timestamp()->second));
     } else {
-        array = arr_;
+        meta_cache_arr_ = arr_;
     }
 
-    for (uint64_t idx = 0; idx < array->metadata_num(); ++idx) {
+    for (uint64_t idx = 0; idx < meta_cache_arr_->metadata_num(); ++idx) {
         std::string key;
         tiledb_datatype_t value_type;
         uint32_t value_num;
         const void* value;
-        array->get_metadata_from_index(
+        meta_cache_arr_->get_metadata_from_index(
             idx, &key, &value_type, &value_num, &value);
         MetadataValue mdval(value_type, value_num, value);
         std::pair<std::string, const MetadataValue> mdpair(key, mdval);
@@ -169,26 +209,22 @@ std::shared_ptr<SOMAContext> SOMAArray::ctx() {
     return ctx_;
 };
 
-void SOMAArray::open(
-    OpenMode mode, std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
-    auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
-    arr_->open(tdb_mode);
-    if (timestamp) {
-        if (timestamp->first > timestamp->second) {
-            throw std::invalid_argument("timestamp start > end");
-        }
-        arr_->set_open_timestamp_start(timestamp->first);
-        arr_->set_open_timestamp_end(timestamp->second);
-        arr_->close();
-        arr_->open(tdb_mode);
-    }
+void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
+    timestamp_ = timestamp;
+
+    validate(mode, name_, timestamp);
     reset(column_names(), batch_size_, result_order_);
+    fill_metadata_cache();
 }
 
 void SOMAArray::close() {
+    if (arr_->query_type() == TILEDB_WRITE)
+        meta_cache_arr_->close();
+
     // Close the array through the managed query to ensure any pending queries
     // are completed.
     mq_->close();
+    metadata_.clear();
 }
 
 void SOMAArray::reset(
@@ -511,33 +547,39 @@ void SOMAArray::set_metadata(
     tiledb_datatype_t value_type,
     uint32_t value_num,
     const void* value) {
-    if (key.compare("soma_object_type") == 0) {
-        throw TileDBSOMAError("soma_object_type cannot be modified.");
-    }
+    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
+        throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be modified.");
+
+    if (key.compare(ENCODING_VERSION_KEY) == 0)
+        throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be modified.");
 
     arr_->put_metadata(key, value_type, value_num, value);
+
     MetadataValue mdval(value_type, value_num, value);
     std::pair<std::string, const MetadataValue> mdpair(key, mdval);
     metadata_.insert(mdpair);
 }
 
 void SOMAArray::delete_metadata(const std::string& key) {
-    if (key.compare("soma_object_type") == 0) {
-        throw TileDBSOMAError("soma_object_type cannot be deleted.");
-    }
+    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
+        throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
+
+    if (key.compare(ENCODING_VERSION_KEY) == 0)
+        throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
+
     arr_->delete_metadata(key);
     metadata_.erase(key);
 }
 
-std::map<std::string, MetadataValue> SOMAArray::get_metadata() {
-    return metadata_;
+std::optional<MetadataValue> SOMAArray::get_metadata(const std::string& key) {
+    if (metadata_.count(key) == 0)
+        return std::nullopt;
+
+    return metadata_[key];
 }
 
-std::optional<MetadataValue> SOMAArray::get_metadata(const std::string& key) {
-    if (metadata_.count(key) == 0) {
-        return std::nullopt;
-    }
-    return metadata_[key];
+std::map<std::string, MetadataValue> SOMAArray::get_metadata() {
+    return metadata_;
 }
 
 bool SOMAArray::has_metadata(const std::string& key) {
@@ -551,26 +593,21 @@ uint64_t SOMAArray::metadata_num() const {
 void SOMAArray::validate(
     OpenMode mode,
     std::string_view name,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     // Validate parameters
     auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
 
     try {
         LOG_DEBUG(fmt::format("[SOMAArray] opening array '{}'", uri_));
-        arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, tdb_mode);
         if (timestamp) {
-            if (timestamp->first > timestamp->second) {
-                throw std::invalid_argument("timestamp start > end");
-            }
-            arr_->set_open_timestamp_start(timestamp->first);
-            arr_->set_open_timestamp_end(timestamp->second);
-            arr_->close();
-            arr_->open(tdb_mode);
-            LOG_DEBUG(fmt::format(
-                "[SOMAArray] timestamp_start = {}",
-                arr_->open_timestamp_start()));
-            LOG_DEBUG(fmt::format(
-                "[SOMAArray] timestamp_end = {}", arr_->open_timestamp_end()));
+            arr_ = std::make_shared<Array>(
+                *ctx_->tiledb_ctx(),
+                uri_,
+                tdb_mode,
+                TemporalPolicy(
+                    TimestampStartEnd, timestamp->first, timestamp->second));
+        } else {
+            arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, tdb_mode);
         }
         LOG_TRACE(fmt::format("[SOMAArray] loading enumerations"));
         ArrayExperimental::load_all_enumerations(
@@ -582,7 +619,7 @@ void SOMAArray::validate(
     }
 }
 
-std::optional<std::pair<uint64_t, uint64_t>> SOMAArray::timestamp() {
+std::optional<TimestampRange> SOMAArray::timestamp() {
     return timestamp_;
 }
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -561,19 +561,22 @@ void SOMAArray::set_metadata(
 }
 
 void SOMAArray::delete_metadata(const std::string& key) {
-    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
+    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
         throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
+    }
 
-    if (key.compare(ENCODING_VERSION_KEY) == 0)
+    if (key.compare(ENCODING_VERSION_KEY) == 0) {
         throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
+    }
 
     arr_->delete_metadata(key);
     metadata_.erase(key);
 }
 
 std::optional<MetadataValue> SOMAArray::get_metadata(const std::string& key) {
-    if (metadata_.count(key) == 0)
+    if (metadata_.count(key) == 0) {
         return std::nullopt;
+    }
 
     return metadata_[key];
 }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -171,7 +171,7 @@ SOMAArray::SOMAArray(
     , result_order_(ResultOrder::automatic)
     , timestamp_(timestamp)
     , mq_(std::make_unique<ManagedQuery>(arr, ctx_->tiledb_ctx(), name_))
-    , arr_(arr) {)
+    , arr_(arr) {
     reset({}, batch_size_, result_order_);
     fill_metadata_cache();
 }

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -42,16 +42,18 @@ using namespace tiledb;
 //===================================================================
 
 std::unique_ptr<SOMACollection> SOMACollection::create(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    SOMAGroup::create(ctx, uri, "SOMACollection");
-    return SOMACollection::open(uri, OpenMode::read, ctx);
+    std::string_view uri,
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    auto soma_group = SOMAGroup::create(ctx, uri, "SOMACollection", timestamp);
+    return std::make_unique<SOMACollection>(*soma_group);
 }
 
 std::unique_ptr<SOMACollection> SOMACollection::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<SOMAContext> ctx,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMACollection>(mode, uri, ctx, timestamp);
 }
 
@@ -96,7 +98,9 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     std::string_view uri,
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx) {
-    std::shared_ptr<SOMACollection> member = SOMACollection::create(uri, ctx);
+    SOMACollection::create(uri, ctx);
+    std::shared_ptr<SOMACollection> member = SOMAExperiment::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -108,8 +112,9 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     ArraySchema schema) {
-    std::shared_ptr<SOMAExperiment> member = SOMAExperiment::create(
-        uri, schema, ctx);
+    SOMAExperiment::create(uri, schema, ctx);
+    std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -121,8 +126,9 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     ArraySchema schema) {
-    std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::create(
-        uri, schema, ctx);
+    SOMAMeasurement::create(uri, schema, ctx);
+    std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -134,8 +140,9 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     ArraySchema schema) {
-    std::shared_ptr<SOMADataFrame> member = SOMADataFrame::create(
-        uri, schema, ctx);
+    SOMADataFrame::create(uri, schema, ctx);
+    std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -147,8 +154,9 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     ArraySchema schema) {
-    std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::create(
-        uri, schema, ctx);
+    SOMADenseNDArray::create(uri, schema, ctx);
+    std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;
@@ -160,8 +168,9 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     ArraySchema schema) {
-    std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::create(
-        uri, schema, ctx);
+    SOMASparseNDArray::create(uri, schema, ctx);
+    std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::open(
+        uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
     children_[std::string(key)] = member;
     return member;

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -62,7 +62,9 @@ class SOMACollection : public SOMAGroup {
      * @param uri URI to create the SOMACollection
      */
     static std::unique_ptr<SOMACollection> create(
-        std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+        std::string_view uri,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Open a group at the specified URI and return SOMACollection
@@ -78,7 +80,7 @@ class SOMACollection : public SOMAGroup {
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<SOMAContext> ctx,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     //===================================================================
     //= public non-static
@@ -97,7 +99,7 @@ class SOMACollection : public SOMAGroup {
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+        std::optional<TimestampRange> timestamp)
         : SOMAGroup(
               mode,
               uri,

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -42,9 +42,11 @@ using namespace tiledb;
 std::unique_ptr<SOMADataFrame> SOMADataFrame::create(
     std::string_view uri,
     ArraySchema schema,
-    std::shared_ptr<SOMAContext> ctx) {
-    SOMAArray::create(ctx, uri, schema, "SOMADataFrame");
-    return SOMADataFrame::open(uri, OpenMode::read, ctx);
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    auto soma_array = SOMAArray::create(
+        ctx, uri, schema, "SOMADataFrame", timestamp);
+    return std::make_unique<SOMADataFrame>(*soma_array);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
@@ -53,7 +55,7 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::shared_ptr<SOMAContext> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMADataFrame>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -52,15 +52,17 @@ class SOMADataFrame : public SOMAArray {
     /**
      * @brief Create a SOMADataFrame object at the given URI.
      *
-     * @param uri URI to create the SOMADataFrame
+     * @param uri URI to create the SOMAArray
      * @param schema TileDB ArraySchema
-     * @param platform_config Optional config parameter dictionary
-     * @return std::shared_ptr<SOMADataFrame> opened in read mode
+     * @param ctx SOMAContext
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::unique_ptr<SOMADataFrame>
      */
     static std::unique_ptr<SOMADataFrame> create(
         std::string_view uri,
         ArraySchema schema,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMADataFrame object at the given URI.
@@ -76,7 +78,7 @@ class SOMADataFrame : public SOMAArray {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::shared_ptr<SOMADataFrame> SOMADataFrame
+     * @return std::unique_ptr<SOMADataFrame>
      */
     static std::unique_ptr<SOMADataFrame> open(
         std::string_view uri,
@@ -84,7 +86,7 @@ class SOMADataFrame : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names = {},
         ResultOrder result_order = ResultOrder::automatic,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Check if the SOMADataFrame exists at the URI.
@@ -114,7 +116,7 @@ class SOMADataFrame : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names,
         ResultOrder result_order,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt)
+        std::optional<TimestampRange> timestamp = std::nullopt)
         : SOMAArray(
               mode,
               uri,

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -29,6 +29,7 @@
  *
  *   This file defines the SOMADenseNDArray class.
  */
+
 #include "soma_dense_ndarray.h"
 
 namespace tiledbsoma {
@@ -41,9 +42,11 @@ using namespace tiledb;
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
-    std::shared_ptr<SOMAContext> ctx) {
-    SOMAArray::create(ctx, uri, schema, "SOMADenseNDArray");
-    return SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    auto soma_array = SOMAArray::create(
+        ctx, uri, schema, "SOMADenseNDArray", timestamp);
+    return std::make_unique<SOMADenseNDArray>(*soma_array);
 }
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
@@ -52,7 +55,7 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::shared_ptr<SOMAContext> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMADenseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -52,15 +52,17 @@ class SOMADenseNDArray : public SOMAArray {
     /**
      * @brief Create a SOMADenseNDArray object at the given URI.
      *
-     * @param uri URI to create the SOMADenseNDArray
+     * @param uri URI to create the SOMAArray
      * @param schema TileDB ArraySchema
-     * @param platform_config Optional config parameter dictionary
-     * @return std::shared_ptr<SOMADenseNDArray> opened in read mode
+     * @param ctx SOMAContext
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::unique_ptr<SOMADenseNDArray>
      */
     static std::unique_ptr<SOMADenseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMADenseNDArray object at the given URI.
@@ -76,7 +78,7 @@ class SOMADenseNDArray : public SOMAArray {
      * open this object. If unset, uses the timestamp provided by the context.
      * @param result_order Read result order: automatic (default), rowmajor, or
      * colmajor
-     * @return std::shared_ptr<SOMADenseNDArray> SOMADenseNDArray
+     * @return std::shared_ptr<SOMADenseNDArray>
      */
     static std::unique_ptr<SOMADenseNDArray> open(
         std::string_view uri,
@@ -84,7 +86,7 @@ class SOMADenseNDArray : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names = {},
         ResultOrder result_order = ResultOrder::automatic,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Check if the SOMADenseNDArray exists at the URI.
@@ -113,7 +115,7 @@ class SOMADenseNDArray : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names,
         ResultOrder result_order,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+        std::optional<TimestampRange> timestamp)
         : SOMAArray(
               mode,
               uri,

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -57,7 +57,24 @@ class SOMAExperiment : public SOMACollection {
     static std::unique_ptr<SOMAExperiment> create(
         std::string_view uri,
         ArraySchema schema,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open a group at the specified URI and return SOMAExperiment
+     * object.
+     *
+     * @param uri URI of the array
+     * @param mode read or write
+     * @param ctx TileDB context
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::shared_ptr<SOMAExperiment> SOMAExperiment
+     */
+    static std::unique_ptr<SOMAExperiment> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     //===================================================================
     //= public non-static
@@ -67,7 +84,7 @@ class SOMAExperiment : public SOMACollection {
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt)
+        std::optional<TimestampRange> timestamp = std::nullopt)
         : SOMACollection(mode, uri, ctx, timestamp) {
     }
 
@@ -79,6 +96,8 @@ class SOMAExperiment : public SOMACollection {
     SOMAExperiment(const SOMAExperiment&) = default;
     SOMAExperiment(SOMAExperiment&&) = default;
     ~SOMAExperiment() = default;
+
+    using SOMACollection::open;
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -44,26 +44,33 @@ using namespace tiledb;
 std::unique_ptr<SOMAMeasurement> SOMAMeasurement::create(
     std::string_view uri,
     ArraySchema schema,
-    std::shared_ptr<SOMAContext> ctx) {
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
     std::string exp_uri(uri);
 
-    SOMAGroup::create(ctx, exp_uri, "SOMAMeasurement");
-    SOMADataFrame::create(exp_uri + "/var", schema, ctx);
-    SOMACollection::create(exp_uri + "/X", ctx);
-    SOMACollection::create(exp_uri + "/obsm", ctx);
-    SOMACollection::create(exp_uri + "/obsp", ctx);
-    SOMACollection::create(exp_uri + "/varm", ctx);
-    SOMACollection::create(exp_uri + "/varp", ctx);
+    auto soma_group = SOMAGroup::create(
+        ctx, exp_uri, "SOMAMeasurement", timestamp);
+    SOMADataFrame::create(exp_uri + "/var", schema, ctx, timestamp);
+    SOMACollection::create(exp_uri + "/X", ctx, timestamp);
+    SOMACollection::create(exp_uri + "/obsm", ctx, timestamp);
+    SOMACollection::create(exp_uri + "/obsp", ctx, timestamp);
+    SOMACollection::create(exp_uri + "/varm", ctx, timestamp);
+    SOMACollection::create(exp_uri + "/varp", ctx, timestamp);
 
-    auto group = SOMAGroup::open(OpenMode::write, uri, ctx);
-    group->set(exp_uri + "/var", URIType::absolute, "var");
-    group->set(exp_uri + "/X", URIType::absolute, "X");
-    group->set(exp_uri + "/obsm", URIType::absolute, "obsm");
-    group->set(exp_uri + "/obsp", URIType::absolute, "obsp");
-    group->set(exp_uri + "/varm", URIType::absolute, "varm");
-    group->set(exp_uri + "/varp", URIType::absolute, "varp");
-    group->close();
+    soma_group->set(exp_uri + "/var", URIType::absolute, "var");
+    soma_group->set(exp_uri + "/X", URIType::absolute, "X");
+    soma_group->set(exp_uri + "/obsm", URIType::absolute, "obsm");
+    soma_group->set(exp_uri + "/obsp", URIType::absolute, "obsp");
+    soma_group->set(exp_uri + "/varm", URIType::absolute, "varm");
+    soma_group->set(exp_uri + "/varp", URIType::absolute, "varp");
+    return std::make_unique<SOMAMeasurement>(*soma_group);
+}
 
-    return std::make_unique<SOMAMeasurement>(OpenMode::read, uri, ctx);
+std::unique_ptr<SOMAMeasurement> SOMAMeasurement::open(
+    std::string_view uri,
+    OpenMode mode,
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    return std::make_unique<SOMAMeasurement>(mode, uri, ctx, timestamp);
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -58,7 +58,24 @@ class SOMAMeasurement : public SOMACollection {
     static std::unique_ptr<SOMAMeasurement> create(
         std::string_view uri,
         ArraySchema schema,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open a group at the specified URI and return SOMAMeasurement
+     * object.
+     *
+     * @param uri URI of the array
+     * @param mode read or write
+     * @param ctx TileDB context
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::shared_ptr<SOMAMeasurement> SOMAMeasurement
+     */
+    static std::unique_ptr<SOMAMeasurement> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     //===================================================================
     //= public non-static
@@ -67,7 +84,7 @@ class SOMAMeasurement : public SOMACollection {
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt)
+        std::optional<TimestampRange> timestamp = std::nullopt)
         : SOMACollection(mode, uri, ctx, timestamp) {
     }
 
@@ -79,6 +96,8 @@ class SOMAMeasurement : public SOMACollection {
     SOMAMeasurement(const SOMAMeasurement&) = default;
     SOMAMeasurement(SOMAMeasurement&&) = default;
     ~SOMAMeasurement() = default;
+
+    using SOMACollection::open;
 
    private:
     //===================================================================

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -35,6 +35,7 @@
 #ifndef SOMA_OBJECT
 #define SOMA_OBJECT
 
+#include <filesystem>
 #include <map>
 #include <string>
 #include <tiledb/tiledb>

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -42,9 +42,11 @@ using namespace tiledb;
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::create(
     std::string_view uri,
     ArraySchema schema,
-    std::shared_ptr<SOMAContext> ctx) {
-    SOMAArray::create(ctx, uri, schema, "SOMASparseNDArray");
-    return SOMASparseNDArray::open(uri, OpenMode::read, ctx);
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    auto soma_array = SOMAArray::create(
+        ctx, uri, schema, "SOMASparseNDArray", timestamp);
+    return std::make_unique<SOMASparseNDArray>(*soma_array);
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
@@ -53,7 +55,7 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::shared_ptr<SOMAContext> ctx,
     std::vector<std::string> column_names,
     ResultOrder result_order,
-    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMASparseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -52,15 +52,17 @@ class SOMASparseNDArray : public SOMAArray {
     /**
      * @brief Create a SOMASparseNDArray object at the given URI.
      *
-     * @param uri URI to create the SOMASparseNDArray
+     * @param uri URI to create the SOMAArray
      * @param schema TileDB ArraySchema
-     * @param platform_config Optional config parameter dictionary
-     * @return std::shared_ptr<SOMASparseNDArray> opened in read mode
+     * @param ctx SOMAContext
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::unique_ptr<SOMASparseNDArray>
      */
     static std::unique_ptr<SOMASparseNDArray> create(
         std::string_view uri,
         ArraySchema schema,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Open and return a SOMASparseNDArray object at the given URI.
@@ -76,7 +78,7 @@ class SOMASparseNDArray : public SOMAArray {
      * colmajor
      * @param timestamp If specified, overrides the default timestamp used to
      * open this object. If unset, uses the timestamp provided by the context.
-     * @return std::shared_ptr<SOMASparseNDArray> SOMASparseNDArray
+     * @return std::unique_ptr<SOMASparseNDArray>
      */
     static std::unique_ptr<SOMASparseNDArray> open(
         std::string_view uri,
@@ -84,7 +86,7 @@ class SOMASparseNDArray : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names = {},
         ResultOrder result_order = ResultOrder::automatic,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp = std::nullopt);
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * @brief Check if the SOMASparseNDArray exists at the URI.
@@ -113,7 +115,7 @@ class SOMASparseNDArray : public SOMAArray {
         std::shared_ptr<SOMAContext> ctx,
         std::vector<std::string> column_names,
         ResultOrder result_order,
-        std::optional<std::pair<uint64_t, uint64_t>> timestamp)
+        std::optional<TimestampRange> timestamp)
         : SOMAArray(
               mode,
               uri,

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -39,8 +39,14 @@
 
 namespace tiledbsoma {
 
+const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
+const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
+const std::string ENCODING_VERSION_VAL = "1";
+
 using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };
+
+using TimestampRange = std::pair<uint64_t, uint64_t>;
 
 class TileDBSOMAError : public std::runtime_error {
    public:

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -80,17 +80,8 @@ TEST_CASE("SOMADataFrame: basic") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-dataframe-basic";
 
-    SOMADataFrame::create(uri, create_schema(*ctx->tiledb_ctx()), ctx);
-
-    auto soma_dataframe = SOMADataFrame::open(uri, OpenMode::read, ctx);
-    REQUIRE(soma_dataframe->uri() == uri);
-    REQUIRE(soma_dataframe->ctx() == ctx);
-    REQUIRE(soma_dataframe->type() == "SOMADataFrame");
-    std::vector<std::string> expected_index_column_names = {"d0"};
-    REQUIRE(
-        soma_dataframe->index_column_names() == expected_index_column_names);
-    REQUIRE(soma_dataframe->count() == 0);
-    soma_dataframe->close();
+    auto soma_dataframe = SOMADataFrame::create(
+        uri, create_schema(*ctx->tiledb_ctx()), ctx);
 
     std::vector<int64_t> d0(10);
     for (int j = 0; j < 10; j++)
@@ -103,11 +94,13 @@ TEST_CASE("SOMADataFrame: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(tdb_arr, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(tdb_arr, "d0", d0));
 
-    soma_dataframe = SOMADataFrame::open(uri, OpenMode::write, ctx);
     soma_dataframe->write(array_buffer);
     soma_dataframe->close();
 
-    soma_dataframe = SOMADataFrame::open(uri, OpenMode::read, ctx);
+    soma_dataframe->open(OpenMode::read);
+    REQUIRE(soma_dataframe->uri() == uri);
+    REQUIRE(soma_dataframe->ctx() == ctx);
+    REQUIRE(soma_dataframe->type() == "SOMADataFrame");
     while (auto batch = soma_dataframe->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();
@@ -125,42 +118,59 @@ TEST_CASE("SOMADataFrame: basic") {
 
 TEST_CASE("SOMADataFrame: metadata") {
     auto ctx = std::make_shared<SOMAContext>();
-
     std::string uri = "mem://unit-test-collection";
-    SOMADataFrame::create(uri, create_schema(*ctx->tiledb_ctx()), ctx);
+    SOMADataFrame::create(
+        uri, create_schema(*ctx->tiledb_ctx()), ctx, TimestampRange(0, 2));
+
     auto soma_dataframe = SOMADataFrame::open(
         uri,
         OpenMode::write,
         ctx,
         {},
         ResultOrder::automatic,
-        std::pair<uint64_t, uint64_t>(1, 1));
+        TimestampRange(1, 1));
+
     int32_t val = 100;
     soma_dataframe->set_metadata("md", TILEDB_INT32, 1, &val);
     soma_dataframe->close();
 
-    soma_dataframe->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
-    REQUIRE(soma_dataframe->metadata_num() == 2);
-    REQUIRE(soma_dataframe->has_metadata("soma_object_type") == true);
-    REQUIRE(soma_dataframe->has_metadata("md") == true);
-
+    // Read metadata
+    soma_dataframe->open(OpenMode::read, TimestampRange(0, 2));
+    REQUIRE(soma_dataframe->metadata_num() == 3);
+    REQUIRE(soma_dataframe->has_metadata("soma_object_type"));
+    REQUIRE(soma_dataframe->has_metadata("soma_encoding_version"));
+    REQUIRE(soma_dataframe->has_metadata("md"));
     auto mdval = soma_dataframe->get_metadata("md");
     REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_dataframe->close();
 
-    soma_dataframe->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // md should not be available at (2, 2)
+    soma_dataframe->open(OpenMode::read, TimestampRange(2, 2));
+    REQUIRE(soma_dataframe->metadata_num() == 2);
+    REQUIRE(soma_dataframe->has_metadata("soma_object_type"));
+    REQUIRE(soma_dataframe->has_metadata("soma_encoding_version"));
+    REQUIRE(!soma_dataframe->has_metadata("md"));
+    soma_dataframe->close();
+
     // Metadata should also be retrievable in write mode
+    soma_dataframe->open(OpenMode::write, TimestampRange(0, 2));
+    REQUIRE(soma_dataframe->metadata_num() == 3);
+    REQUIRE(soma_dataframe->has_metadata("soma_object_type"));
+    REQUIRE(soma_dataframe->has_metadata("soma_encoding_version"));
+    REQUIRE(soma_dataframe->has_metadata("md"));
     mdval = soma_dataframe->get_metadata("md");
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+
+    // Delete and have it reflected when reading metadata while in write mode
     soma_dataframe->delete_metadata("md");
     mdval = soma_dataframe->get_metadata("md");
     REQUIRE(!mdval.has_value());
     soma_dataframe->close();
 
-    soma_dataframe->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
-    REQUIRE(soma_dataframe->has_metadata("md") == false);
-    REQUIRE(soma_dataframe->metadata_num() == 1);
-    soma_dataframe->close();
+    // Confirm delete in read mode
+    soma_dataframe->open(OpenMode::read, TimestampRange(0, 2));
+    REQUIRE(!soma_dataframe->has_metadata("md"));
+    REQUIRE(soma_dataframe->metadata_num() == 2);
 }

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -80,19 +80,8 @@ TEST_CASE("SOMASparseNDArray: basic") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-sparse-ndarray-basic";
 
-    SOMASparseNDArray::create(uri, create_schema(*ctx->tiledb_ctx()), ctx);
-
-    auto soma_sparse = SOMASparseNDArray::open(uri, OpenMode::read, ctx);
-    REQUIRE(soma_sparse->uri() == uri);
-    REQUIRE(soma_sparse->ctx() == ctx);
-    REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
-    REQUIRE(soma_sparse->is_sparse() == true);
-    auto schema = soma_sparse->tiledb_schema();
-    REQUIRE(schema->has_attribute("a0"));
-    REQUIRE(schema->domain().has_dimension("d0"));
-    REQUIRE(soma_sparse->ndim() == 1);
-    REQUIRE(soma_sparse->nnz() == 0);
-    soma_sparse->close();
+    auto soma_sparse = SOMASparseNDArray::create(
+        uri, create_schema(*ctx->tiledb_ctx()), ctx);
 
     std::vector<int64_t> d0(10);
     for (int j = 0; j < 10; j++)
@@ -105,11 +94,13 @@ TEST_CASE("SOMASparseNDArray: basic") {
     array_buffer->emplace("a0", ColumnBuffer::create(tdb_arr, "a0", a0));
     array_buffer->emplace("d0", ColumnBuffer::create(tdb_arr, "d0", d0));
 
-    soma_sparse->open(OpenMode::write);
     soma_sparse->write(array_buffer);
     soma_sparse->close();
 
     soma_sparse->open(OpenMode::read);
+    REQUIRE(soma_sparse->uri() == uri);
+    REQUIRE(soma_sparse->ctx() == ctx);
+    REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
     while (auto batch = soma_sparse->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at("d0")->data<int64_t>();
@@ -124,7 +115,8 @@ TEST_CASE("SOMASparseNDArray: metadata") {
     auto ctx = std::make_shared<SOMAContext>();
 
     std::string uri = "mem://unit-test-sparse-ndarray";
-    SOMASparseNDArray::create(uri, create_schema(*ctx->tiledb_ctx()), ctx);
+    SOMASparseNDArray::create(
+        uri, create_schema(*ctx->tiledb_ctx()), ctx, TimestampRange(0, 2));
     auto soma_sparse = SOMASparseNDArray::open(
         uri,
         OpenMode::write,
@@ -132,32 +124,48 @@ TEST_CASE("SOMASparseNDArray: metadata") {
         {},
         ResultOrder::automatic,
         std::pair<uint64_t, uint64_t>(1, 1));
+
     int32_t val = 100;
     soma_sparse->set_metadata("md", TILEDB_INT32, 1, &val);
     soma_sparse->close();
 
-    soma_sparse->open(OpenMode::read, std::pair<uint64_t, uint64_t>(1, 1));
-    REQUIRE(soma_sparse->metadata_num() == 2);
-    REQUIRE(soma_sparse->has_metadata("soma_object_type") == true);
-    REQUIRE(soma_sparse->has_metadata("md") == true);
-
+    // Read metadata
+    soma_sparse->open(OpenMode::read, TimestampRange(0, 2));
+    REQUIRE(soma_sparse->metadata_num() == 3);
+    REQUIRE(soma_sparse->has_metadata("soma_object_type"));
+    REQUIRE(soma_sparse->has_metadata("soma_encoding_version"));
+    REQUIRE(soma_sparse->has_metadata("md"));
     auto mdval = soma_sparse->get_metadata("md");
     REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_sparse->close();
 
-    soma_sparse->open(OpenMode::write, std::pair<uint64_t, uint64_t>(2, 2));
+    // md should not be available at (2, 2)
+    soma_sparse->open(OpenMode::read, TimestampRange(2, 2));
+    REQUIRE(soma_sparse->metadata_num() == 2);
+    REQUIRE(soma_sparse->has_metadata("soma_object_type"));
+    REQUIRE(soma_sparse->has_metadata("soma_encoding_version"));
+    REQUIRE(!soma_sparse->has_metadata("md"));
+    soma_sparse->close();
+
     // Metadata should also be retrievable in write mode
+    soma_sparse->open(OpenMode::write, TimestampRange(0, 2));
+    REQUIRE(soma_sparse->metadata_num() == 3);
+    REQUIRE(soma_sparse->has_metadata("soma_object_type"));
+    REQUIRE(soma_sparse->has_metadata("soma_encoding_version"));
+    REQUIRE(soma_sparse->has_metadata("md"));
     mdval = soma_sparse->get_metadata("md");
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+
+    // Delete and have it reflected when reading metadata while in write mode
     soma_sparse->delete_metadata("md");
     mdval = soma_sparse->get_metadata("md");
     REQUIRE(!mdval.has_value());
     soma_sparse->close();
 
-    soma_sparse->open(OpenMode::read, std::pair<uint64_t, uint64_t>(3, 3));
-    REQUIRE(soma_sparse->has_metadata("md") == false);
-    REQUIRE(soma_sparse->metadata_num() == 1);
-    soma_sparse->close();
+    // Confirm delete in read mode
+    soma_sparse->open(OpenMode::read, TimestampRange(0, 2));
+    REQUIRE(!soma_sparse->has_metadata("md"));
+    REQUIRE(soma_sparse->metadata_num() == 2);
 }


### PR DESCRIPTION
**Issue and/or context:**

#2182 

I am refactoring the create and metadata methods in C++ after I noticed issues while working on transitioning the Python `SOMADataFrame` write path to use `clib.DataFrame`.

**Changes:**
* Store read-mode `Array` or `Group` that holds metadata values valid as a class memeber
```
    // Metadata values need to be accessible in write mode as well. When adding
    // or deleting values in the array, instead of closing to update to
    // metadata; then reopening to read the array; and again reopening to
    // restore the array back to write mode, we just store the modifications to
    // this cache
    std::map<std::string, MetadataValue> metadata_;

    // Array associated with metadata_. We need to keep this read-mode array
    // alive in order for the metadata value pointers in the cache to be
    // accessible
    std::shared_ptr<Array> meta_cache_arr_;
```
* `create` methods now take in timestamps which indicate when the metadata values for `soma_object_type` and `encoding_version` should be written (this is consistent to how it is done in the TileDB-SOMA API) and when the write-mode `SOMAObject` should be opened
* `create` methods now only open `Array` or `Group` once 
* Make `soma_object_type`, `encoding_version`, and the current encoding version (`1`) consts
* Use keystroke saver `TimestampRange` type
* Test that `SOMAObject`s are writing and reading metadata correctly with timestamps
* Test that array returned by `create` can be written to

**Notes for Reviewer:**

These changes have been pulled out of a larger branch: https://github.com/single-cell-data/TileDB-SOMA/tree/viviannguyen/array-write-path