### PR TITLE
fix `scripts/bld` typo (`aarch64` opts)

### DIFF
--- a/scripts/bld
+++ b/scripts/bld
@@ -39,7 +39,7 @@ fi
 
 if [ "$(uname -m)" == "aarch64" ]; then
   # build TileDB from source on arm
-  extra_opts=+" -DDOWNLOAD_TILEDB_PREBUILT=OFF"
+  extra_opts+=" -DDOWNLOAD_TILEDB_PREBUILT=OFF"
 fi
 
 # NOTE: set to true to debug the cmake build


### PR DESCRIPTION
When building TileDB-SOMA in Docker on Mac, this was manifesting as an error like:

```
Building Release build
CMake Error: The source directory "/TileDB-SOMA/+" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
```

when `scripts/bld` called `cmake`, because `extra_opts` had a stray `+` sign.

I was working around it with:

```bash
export DOCKER_DEFAULT_PLATFORM=linux/amd64
```

which is generally useful, but then I noticed this typo/bug.