### PR TITLE
[ci] Updated hard-coded core version in another file

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
         run: |
           mkdir -p external
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.20.1/tiledb-linux-x86_64-2.20.1-249c024.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV

--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -55,6 +55,7 @@ jobs:
         if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
         run: |
           mkdir -p external
+          # Please do not edit manually -- let scripts/update-tiledb-version.py update this
           wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.20.1/tiledb-linux-x86_64-2.20.1-249c024.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -103,6 +103,10 @@ def main(args):
     filepath = f"{os.path.dirname(__file__)}/../apis/r/tools/get_tarball.R"
     update_version(filepath, new_version, new_hash, update_sha=False)
 
+    # update CI version
+    filepath = f"{os.path.dirname(__file__)}/../.github/workflows/python-so-copying.yml"
+    update_version(filepath, new_version, new_hash)
+
 
 if __name__ == "__main__":
     description = (


### PR DESCRIPTION
**Issue and/or context:** Found on drive-by while debugging https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/95

**Changes:** Now that we have one more hard-coded path (#1937), have the updater not fail to update it

**Notes for Reviewer:**

