### PR TITLE
[ci] Add MacOS job to test shared object copying

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -16,14 +16,11 @@ on:
       - 'libtiledbsoma/cmake/**'
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  build:
+
+  docker:
     runs-on: ubuntu-latest
-    name: "TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
+    name: "docker TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +31,9 @@ jobs:
             TILEDBSOMA_EXISTS: "yes"
     container:
       image: ubuntu:22.04
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Docker image info
         run: |
@@ -122,5 +122,99 @@ jobs:
       - name: Confirm linking to installed shared objects
         run: |
           rm -fr build/ build-libtiledbsoma/ dist/ apis/python/build apis/python/src/tiledbsoma/*tile*.so*
-          find . -name '*tile*.so*' # should only show shared objects installed in virtual env
+          # should only show shared objects installed in virtual env or in ./external/
+          find . -name '*tile*.so*'
+          ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
+
+  macos:
+    runs-on: macos-12
+    name: "macos TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        TILEDB_EXISTS: ["no", "yes"]
+        TILEDBSOMA_EXISTS: ["no", "yes"]
+        exclude:
+          - TILEDB_EXISTS: "no"
+            TILEDBSOMA_EXISTS: "yes"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for setuptools-scm
+      - name: Install pre-built libtiledb
+        if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
+        run: |
+          mkdir -p external
+          # Please do not edit manually -- let scripts/update-tiledb-version.py update this
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.20.1/tiledb-macos-x86_64-2.20.1-249c024.tar.gz
+          tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
+          ls external/lib/
+          echo "DYLD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(pwd)/external/lib/pkgconfig" >> $GITHUB_ENV
+          echo "TILEDB_PATH=$(pwd)/external" >> $GITHUB_ENV
+      - name: Build and install libtiledbsoma
+        if: ${{ matrix.TILEDBSOMA_EXISTS == 'yes' }}
+        run: |
+          cmake -S libtiledbsoma -B build-libtiledbsoma \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_PREFIX_PATH=$(pwd)/external/ \
+            -D CMAKE_INSTALL_PREFIX:PATH=$(pwd)/external/ \
+            -D OVERRIDE_INSTALL_PREFIX=OFF \
+            -D DOWNLOAD_TILEDB_PREBUILT=OFF \
+            -D FORCE_BUILD_TILEDB=OFF
+          cmake --build build-libtiledbsoma -j $(nproc)
+          cmake --build build-libtiledbsoma --target install-libtiledbsoma
+          ls external/lib/
+          echo "TILEDBSOMA_PATH=$(pwd)/external" >> $GITHUB_ENV
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Setup Python virtual env
+        run: |
+          python --version
+          python -m venv ./venv-soma
+          ./venv-soma/bin/python -m pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/python -m pip list
+      - name: Build wheel
+        run: |
+          echo env vars: $DYLD_LIBRARY_PATH $PKG_CONFIG_PATH $TILEDB_PATH $TILEDBSOMA_PATH
+          cd apis/python
+          ../../venv-soma/bin/python setup.py bdist_wheel
+      - name: Inspect wheel
+        run: unzip -l apis/python/dist/tiledbsoma-*.whl | grep -e '\.dylib' -e '\.so'
+      - name: Confirm libtiledb.dylib is copied
+        if: ${{ matrix.TILEDB_EXISTS == 'no' }}
+        run: unzip -l apis/python/dist/tiledbsoma-*.whl | grep -q libtiledb.dylib
+      - name: Confirm libtiledb.dylib is **not** copied when using external shared object
+        if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
+        run: |
+          if unzip -l apis/python/dist/tiledbsoma-*.whl | grep -q libtiledb.dylib
+          then
+            echo "libtiledb.dylib was copied into the wheel when it was built against an external shared object"
+            exit 1
+          fi
+      - name: Confirm libtiledbsoma.dylib is copied
+        if: ${{ matrix.TILEDBSOMA_EXISTS == 'no' }}
+        run: unzip -l apis/python/dist/tiledbsoma-*.whl | grep -q libtiledbsoma.dylib
+      - name: Confirm libtiledbsoma.dylib is **not** copied when using external shared object
+        if: ${{ matrix.TILEDBSOMA_EXISTS == 'yes' }}
+        run: |
+          if unzip -l apis/python/dist/tiledbsoma-*.whl | grep -q libtiledbsoma.dylib
+          then
+            echo "libtiledbsoma.dylib was copied into the wheel when it was built against an external shared object"
+            exit 1
+          fi
+      - name: Install wheel
+        run: ./venv-soma/bin/python -m pip install --prefer-binary apis/python/dist/tiledbsoma-*.whl
+      - name: Check linking and RPATH
+        run: otool -L ./venv-soma/lib/python*/site-packages/tiledbsoma/pytiledbsoma.*.so
+      - name: Runtime test
+        run: ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
+      - name: Confirm linking to installed shared objects
+        run: |
+          rm -fr build/ build-libtiledbsoma/ dist/ apis/python/build apis/python/src/tiledbsoma/*tile*.dylib*
+          # should only show shared objects installed in virtual env or in ./external/
+          find . -name '*tile*.so*'
+          find . -name '*tile*.dylib*'
           ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"


### PR DESCRIPTION
**Issue and/or context:**

* Follow up to #1937 
* Linked Issue: #2210

**Changes:**

Expands SO copying pipeline to include a macOS job

**Notes for Reviewer:**

I have good news and bad news. The good news is that I added a macOS job, and its behavior is correct! The bad news of course is that this means it doesn't explain the feedstock failures where the macOS builds fail to find the shared objects.

I suspect this is because the feedstock is still using the older `setup.py` with the flag `--libtiledbsoma` ([script](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/6e28425785020e98e088390bec528a13eeea2dc6/recipe/build-tiledbsoma-py.sh#L8)). This was required pre-#1937. However, now that #1937 has been merged, we can now upgrade to the more modern alternative:

```sh
export TILEDB_PATH=$PREFIX
export TILEDBSOMA_PATH=$PREFIX
$PYTHON -m pip install --no-deps . -vv
```

**update:** replaced jinja2 `{{ PYTHON }}` (for use in `meta.yaml`) with `$PYTHON` (for use in separate build script)