### PR TITLE
[python] Fix and test `setup.py` flags to external shared objects

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -218,3 +218,83 @@ jobs:
           find . -name '*tile*.so*'
           find . -name '*tile*.dylib*'
           ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
+
+  # Tests that the --libtiledbsoma flag to setup.py continues working
+  setuptools:
+    runs-on: ${{ matrix.os }}
+    name: "${{ matrix.os }} setuptools"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04", "macos-12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for setuptools-scm
+      - name: Install pre-built libtiledb
+        run: |
+          mkdir -p external
+          if [ `uname -s` == "Darwin" ];
+          then
+            # Please do not edit manually -- let scripts/update-tiledb-version.py update this
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.20.1/tiledb-macos-x86_64-2.20.1-249c024.tar.gz
+          else
+            # Please do not edit manually -- let scripts/update-tiledb-version.py update this
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.20.1/tiledb-linux-x86_64-2.20.1-249c024.tar.gz
+          fi
+          tar -C external -xzf tiledb-*.tar.gz
+          ls external/lib/
+      - name: Build and install libtiledbsoma
+        run: |
+          cmake -S libtiledbsoma -B build-libtiledbsoma \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_PREFIX_PATH=$(pwd)/external/ \
+            -D CMAKE_INSTALL_PREFIX:PATH=$(pwd)/external/ \
+            -D OVERRIDE_INSTALL_PREFIX=OFF \
+            -D DOWNLOAD_TILEDB_PREBUILT=OFF \
+            -D FORCE_BUILD_TILEDB=OFF
+          cmake --build build-libtiledbsoma -j 2
+          cmake --build build-libtiledbsoma --target install-libtiledbsoma
+          ls external/lib/
+      # Delete all cmake executables from the runner. This will ensure that
+      # tiledbsoma-py has to use the cli flags to find the external
+      # libtiledbsoma.so and not build it from source by shelling out to cmake
+      - name: Delete cmake
+        run: |
+          echo before
+          which -a cmake
+          which -a cmake | xargs sudo rm -f
+          echo after
+          which -a cmake || echo cmake removed
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Setup Python virtual env
+        run: |
+          python --version
+          python -m venv ./venv-soma
+          ./venv-soma/bin/python -m pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/python -m pip list
+      - name: Install TileDB-SOMA-Py with setuptools and --libtiledbsoma
+        run: |
+          cd apis/python
+          ../../venv-soma/bin/python setup.py install \
+            --single-version-externally-managed \
+            --record record.txt \
+            --tiledb=$GITHUB_WORKSPACE/external/ \
+            --libtiledbsoma=$GITHUB_WORKSPACE/external/
+      - name: Check linking and RPATH (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          ldd ./venv-soma/lib/python*/site-packages/tiledbsoma/pytiledbsoma.*.so
+          readelf -d ./venv-soma/lib/python*/site-packages/tiledbsoma/pytiledbsoma.*.so  | grep R*PATH
+      - name: Check linking and RPATH (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          otool -L ./venv-soma/lib/python*/site-packages/tiledbsoma/pytiledbsoma.*.so
+          otool -l ./venv-soma/lib/python*/site-packages/tiledbsoma/pytiledbsoma.*.so
+      - name: Install runtime dependencies
+        run: ./venv-soma/bin/python -m pip install --prefer-binary `grep -v '^\[' apis/python/src/tiledbsoma.egg-info/requires.txt`
+      - name: Runtime test
+        run: ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -56,9 +56,9 @@ for arg in args:
         tiledbsoma_dir = pathlib.Path(last)
         sys.argv.remove(arg)
 
-tiledb_dir = os.environ.get("TILEDB_PATH", None)
+tiledb_dir = os.environ.get("TILEDB_PATH", tiledb_dir)
 tiledb_given = tiledb_dir is not None
-tiledbsoma_dir = os.environ.get("TILEDBSOMA_PATH", None)
+tiledbsoma_dir = os.environ.get("TILEDBSOMA_PATH", tiledbsoma_dir)
 
 if tiledbsoma_dir is not None and tiledb_dir is None:
     raise ValueError(


### PR DESCRIPTION
**Issue and/or context:**

* Closes #2210
* Follow-up to #2220 
* Address broken feedstock builds in https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/91 and https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/95

**Changes:**

* Restores the flags `--tiledb` and `--libtiledbsoma` that are passed to `setup.py`

**Notes for Reviewer:**

Here's what happened. PR #1937 fixed the shared object copying when an external libtiledb or libtiledbsoma is provided via the env vars `TILEDB_PATH` or `TILEDBSOMA_PATH`. Unfortunately, it broke the command-line flags `--tiledb` and `--libtiledbsoma`. It overwrites them with `None`. This is why the tiledbsoma-feedstock nightlies immediately started failing after it was merged, which is the only place where we still build tiledbsoma-py with `setup.py`.

We assumed there was a macOS-specific problem because 1) the linux-64 feedstock build continued to pass, and 2) #1937 only tested on linux and not macOS. However, after I added a macOS job in #2220, we knew it was not specific to macOS since macOS also properly copies the objects when using the env vars.

I figured it out by investigating the differences between linux and macOS in `setup.py`. It turns out that linux has a fall-back method to search for a system installation of libtiledbsoma. This is the only reason that the linux-64 feedstock build passed.

https://github.com/single-cell-data/TileDB-SOMA/blob/793818d778e75812193bcef49064d412c77ed855/apis/python/setup.py#L146-L147

In order to catch this type of regression in this repository, I added an extra job to my python-so-copying workflow that confirms the flags `--tiledb` and `--libtiledbsoma` are functional. To emulate the feedstock build, I delete `cmake` from the runner. Thus if tiledbsoma-py is unable to use the command-line flags and tries to fall back to building libtiledbsoma from source with `cmake`, it will fail (which I confirmed on a branch in my fork by temporarily reverting my fixes to `setup.py`).

