### PR TITLE
[ci] Only run build tests when build files are modified

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -7,13 +7,25 @@ on:
   push:
     paths:
       - '.github/workflows/python-so-copying.yml'
-      - 'apis/python/**'
-      - 'libtiledbsoma/cmake/**'
+      - 'apis/python/setup.py'
+      - 'apis/python/src/tiledbsoma/__init__.py'
+      - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
+      - 'libtiledbsoma/cmake/inputs/tiledbsoma.pc.in'
+      - 'libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake'
+      - 'libtiledbsoma/cmake/Modules/TileDBCommon.cmake'
+      - 'libtiledbsoma/cmake/Superbuild.cmake'
+      - 'libtiledbsoma/CMakeLists.txt'
   pull_request:
     paths:
       - '.github/workflows/python-so-copying.yml'
-      - 'apis/python/**'
-      - 'libtiledbsoma/cmake/**'
+      - 'apis/python/setup.py'
+      - 'apis/python/src/tiledbsoma/__init__.py'
+      - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
+      - 'libtiledbsoma/cmake/inputs/tiledbsoma.pc.in'
+      - 'libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake'
+      - 'libtiledbsoma/cmake/Modules/TileDBCommon.cmake'
+      - 'libtiledbsoma/cmake/Superbuild.cmake'
+      - 'libtiledbsoma/CMakeLists.txt'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Issue and/or context:**

* Follow up to #1937, #2220, and #2221 

**Changes:**

* Only runs this CI workflow that tests the build steps if the PR/commit modifies a file that involves finding libtiledb and/or libtiledbsoma at build/run time

**Notes for Reviewer:**

* These tests are quick, but we noticed that the recently added macOS builds are extremely flaky, often requiring a restart to succeed. It's unclear to me why the macOS builds are so less reliable than the Docker ones

* For the Python package, I included both `setup.py` (finds libtiledbsoma at build time) and `src/tiledbsoma/__init__.py` (finds libtiledbsoma at runtime)
