### PR TITLE
[python] Verify `pa.{Chunked,Integer}Array` args to `SparseNDArray.read`

### DIFF
--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -829,6 +829,19 @@ def test_csr_csc_2d_read(tmp_path, shape):
             },
             "throws": None,
         },
+        {
+            "name": "2D coords=(pa_chunked[1, 2], pa64[3, 4])",
+            "shape": (9, 11),
+            "coords": (
+                pa.chunked_array([[1], [2]]),
+                pa.array([3, 4]),
+            ),
+            "dims": {
+                "soma_dim_0": [1, 1, 2, 2],
+                "soma_dim_1": [3, 4, 3, 4],
+            },
+            "throws": None,
+        },
     ],
     ids=lambda io: io.get("name"),
 )


### PR DESCRIPTION
### Issue and/or context
#1791 

### Changes
Add a test case to `test_sparse_nd_array_table_slicing`, verifying that `pa.ChunkedArray` (of integers) and `pa.IntegerArray` work as `SparseNDCoord`s.

### Notes for Reviewer
Ideally we'd have a repro where:
- Type checker fails when `pa.ChunkedArray` passed to `SparseNDArray.read` (before any changes to `SparseNDCoord` [in somacore](https://github.com/single-cell-data/SOMA/blob/76b2d2bbca7c8baf543b5cc9cf71fc5c9138a39a/python-spec/src/somacore/options.py#L172-L179); see https://github.com/single-cell-data/SOMA/pull/187).
- Same checks succeed when `pa.ChunkedArray` is added to `SparseNDCoord`.

The existing test I've modified here apparently isn't subjected to such runtime type-checking. A more explicit version in https://github.com/single-cell-data/TileDB-SOMA/commit/0d93315e34d86549524959ba5fec98f7818779cd also doesn't exhibit a type-check failure. I'll keep looking into how to accomplish that.

