### PR TITLE
Typo fixes, broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TileDB-SOMA provides interoperability with existing Python or R data structures:
 channel `#cellxgene-census-users`.
 
 
-## APIs Installation and Quick Start
+## APIs Installation and Quick Start <a id="quick-start"></a>
 
 * [Python installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/Python-quick-start)
 * [R installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/R-quick-start)

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -1,4 +1,4 @@
-# This file is enables building the libtiledbsoma external package as part of the
+# This file enables building the libtiledbsoma external package as part of the
 # tiledbsoma module install process.
 #
 # Local non-editable install:
@@ -62,7 +62,7 @@ tiledbsoma_dir = os.environ.get("TILEDBSOMA_PATH", tiledbsoma_dir)
 
 if tiledbsoma_dir is not None and tiledb_dir is None:
     raise ValueError(
-        "If TILEDBSOMA_PATH is set, then TILEDB_PATH must be "
+        "If TILEDBSOMA_PATH is set, then TILEDB_PATH must "
         "also be set. TILEDB_PATH must be set to the location of "
         "the TileDB shared object library linked to the "
         "TileDB-SOMA shared object library"

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -50,7 +50,7 @@ class NDArray(TileDBArray, somacore.NDArray):
             shape:
                 The maximum capacity of each dimension, including room
                 for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-                All lengths must be in the postive int64 range, or ``None``.  It's
+                All lengths must be in the positive int64 range, or ``None``.  It's
                 necessary to say ``shape=(None, None)`` or ``shape=(None, None,
                 None)``, as the sequence length determines the number of dimensions
                 N in the N-dimensional array.

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -125,8 +125,8 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
         Args:
             coords:
-                A per-dimension tuple of scalar, slice, sequence of scalar or
-                `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>`_
+                A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
+                `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>` values
                 defining the region to read.
 
         Returns:

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -12,7 +12,6 @@ NDARRAY_ARROW_TYPES_SUPPORTED = [
     pa.int8(),
     pa.int16(),
     pa.int32(),
-    pa.int16(),
     pa.uint8(),
     pa.uint16(),
     pa.uint32(),


### PR DESCRIPTION
Re: the first commit, https://github.com/single-cell-data/TileDB-SOMA/commit/9870a3fe7baf016c192519b773edf85194478d6a:
- [3rd paragraph of README](https://github.com/single-cell-data/TileDB-SOMA?tab=readme-ov-file#tiledb-soma) ("Get started…") links to `#quick-start`, which doesn't exist.
- Relevant section appears to be [APIs Installation and Quick Start](https://github.com/single-cell-data/TileDB-SOMA?tab=readme-ov-file#apis-installation-and-quick-start) a.k.a. `#apis-installation-and-quick-start`.
- Rather than "hard-code" that, I appended an empty anchor tag with a canonical `id` (`#quick-start`) to the end of the &lt;h2&gt; line. I've used this technique in the past and found it preferable / never had problems, but can use Github's default auto-generated dash-cased version if that is preferred.