### PR TITLE
WIP / DO NOT MERGE: attempt to trigger typeguard in a SparseNDArray method

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -36,6 +36,6 @@ jobs:
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
-      report_codecov: ${{ matrix.python-version == '3.10' }}
-      run_lint: ${{ matrix.python-version == '3.10' }}
+      report_codecov: ${{ matrix.python-version == '3.11' }}
+      run_lint: ${{ matrix.python-version == '3.11' }}
     secrets: inherit

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -407,6 +407,13 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         """Writes the bounding box to metadata storage."""
         self.metadata.update(bounding_box)
 
+    @staticmethod
+    def example_method(n: int):
+        """
+        Intentionally broken type hints, for verifying typeguard coverage.
+        """
+        assert n.upper() == "ABC"
+
 
 class _SparseNDArrayReadBase(somacore.SparseRead):
     """Base class for sparse reads"""

--- a/apis/python/tests/test_typeguard.py
+++ b/apis/python/tests/test_typeguard.py
@@ -1,0 +1,23 @@
+import typeguard
+
+from tiledbsoma import SparseNDArray
+
+
+def example_fn(n: int):
+    """Intentionally broken type hints, "control" for typeguard test."""
+    assert n == "abc"
+
+
+def test_typeguard1():
+    """Verify typeguard objects when type-hints are broken, at call-site below or in called function."""
+    example_fn("abc")
+
+
+@typeguard.typechecked
+def test_typeguard2():
+    """Verify typeguard objects when type-hints are broken, at call-site below or in called function."""
+    example_fn("abc")
+
+
+def test_typeguard_method():
+    SparseNDArray.example_method("abc")


### PR DESCRIPTION
Attempt to repro #2238 (Typeguard not raising when it should).

- [`SparseNDArray.example_method`](https://github.com/single-cell-data/TileDB-SOMA/pull/2239/commits/331161ce63255a6127077c9f6c5e37c91ff94ca1#diff-abf17678b24206e18a8d6c84a7b7a714994c2df5cbf0f2c2ad16dd8796b208b4R410-R416): takes an `int`, calls `.upper()` on it (type error, non-test code, should get caught)
- `test_typeguard.py`: [calls](https://github.com/single-cell-data/TileDB-SOMA/pull/2239/commits/331161ce63255a6127077c9f6c5e37c91ff94ca1#diff-e72f72f65b010d557d22bd939358b48e5ab101a61bbe68c0bc557a5707a4d556R23) `example_method` with a `str` instead of an `int`

The test nevertheless passes, without typeguard complaining ([GHA link](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/8195822433/job/22414814785?pr=2239#step:14:1614)).