### PR TITLE
[r] Correct parenthesis in covr() call activate quiet=FALSE

### DIFF
--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -398,9 +398,9 @@ Coverage() {
     # COVERAGE_TOKEN=${COVERAGE_TOKEN:-""}
     # COVERAGE_PATH=${COVERAGE_PATH:-"apis/r"}
     if [[ "${CATCHSEGV}" != "FALSE" ]] && [[ "Linux" == "${OS}" ]]; then
-        COVR="true" catchsegv Rscript -e 'setwd("apis/r"); library(covr); res <- package_coverage(relative_path="../..", line_exclusion=list("apis/r/src/nanoarrow.c", "apis/r/src/nanoarrow.h", "apis/r/R/roxygen.R", quiet=FALSE)); print(res); codecov(coverage=res, token="", flags="r")'
+        COVR="true" catchsegv Rscript -e 'setwd("apis/r"); library(covr); res <- package_coverage(relative_path="../..", line_exclusion=list("apis/r/src/nanoarrow.c", "apis/r/src/nanoarrow.h", "apis/r/R/roxygen.R"), quiet=FALSE); print(res); codecov(coverage=res, token="", flags="r")'
     else
-        COVR="true" Rscript -e 'setwd("apis/r"); library(covr); res <- package_coverage(relative_path="../..", line_exclusion=list("apis/r/src/nanoarrow.c", "apis/r/src/nanoarrow.h", "apis/r/R/roxygen.R", quiet=FALSE)); print(res); codecov(coverage=res, token="", flags="r")'
+        COVR="true" Rscript -e 'setwd("apis/r"); library(covr); res <- package_coverage(relative_path="../..", line_exclusion=list("apis/r/src/nanoarrow.c", "apis/r/src/nanoarrow.h", "apis/r/R/roxygen.R"), quiet=FALSE); print(res); codecov(coverage=res, token="", flags="r")'
     fi
 }
 


### PR DESCRIPTION
**Issue and/or context:**

The `covr()` function of the eponymous package has an argument `quiet` defaulting to TRUE; our attempt to set it to FALSE was thwarted by the fact that we accidentally included in the other, preceding argument.

**Changes:**

Move one character a few places in both parts of the if/else call.

**Notes for Reviewer:**

[SC 42849](https://app.shortcut.com/tiledb-inc/story/42849/r-correct-misplaced-parenthesis-in-coverage-call-in-r-ci-sh)