### PR TITLE
Use Python 3.11 for single version CI runs

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -39,6 +39,6 @@ jobs:
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
-      report_codecov: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9' }}
-      run_lint: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.9' }}
+      report_codecov: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.11' }}
+      run_lint: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.11' }}
     secrets: inherit

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -124,10 +124,10 @@ jobs:
           #  cc: clang
           #  cxx: clang++
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Download artifacts
         uses: actions/download-artifact@v3
       - name: Install wheel

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -65,10 +65,10 @@ jobs:
       - name: Install testing prereqs
         run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: ./apis/python/setup.py
 


### PR DESCRIPTION
**Issue and/or context:**  #2248

**Changes:**

Update GitHub CI to use Python version 3.11 for all one-off Python workflows.

