### PR TITLE
[python/ci] Complete 3.8 -> 3.11 work

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -145,11 +145,9 @@ jobs:
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        # Repeat test in stock ubuntu 20.04 docker image. This uses an older pip
-        # version with the old dependency solver. see issue #1051
         if: ${{ matrix.platform == 'manylinux2014' }}
         run: |
-          docker run -v $(pwd):/mnt ubuntu:20.04 bash -ec "
+          docker run -v $(pwd):/mnt python:3.11 bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
             pip3 install /mnt/$WHL
             python3 -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -135,7 +135,7 @@ jobs:
           set -x
           ls -lR
           ls -lR wheels-*
-          WHL=$(find . -name 'tiledbsoma-*-cp38-cp38-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel


### PR DESCRIPTION
As surfaced in the nightly smoke test for wheel-install:
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/8294234646/job/22699837592

Follow-on/completion from #2267