### PR TITLE
[python] Avoid a warning on ingest

### DIFF
--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -9,11 +9,11 @@ from typing import Union
 
 import h5py
 import scipy.sparse as sp
-from anndata._core.sparse_dataset import SparseDataset
+from anndata._core.sparse_dataset import CSCDataset, CSRDataset
 
 from tiledbsoma._types import NPNDArray
 
-SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
+SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSRDataset, CSCDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -9,11 +9,11 @@ from typing import Union
 
 import h5py
 import scipy.sparse as sp
-from anndata._core.sparse_dataset import CSCDataset, CSRDataset
+from anndata._core.sparse_dataset import SparseDataset
 
 from tiledbsoma._types import NPNDArray
 
-SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSRDataset, CSCDataset]
+SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2301,7 +2301,7 @@ def _write_matrix_to_sparseNDArray(
     if sp.isspmatrix_csc(matrix):
         # E.g. if we used anndata.X[:]
         stride_axis = 1
-    if isinstance(matrix, SparseDataset) and matrix.format_str == "csc":
+    if isinstance(matrix, SparseDataset) and matrix.format == "csc":
         # E.g. if we used anndata.X without the [:]
         stride_axis = 1
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -37,7 +37,7 @@ import pyarrow as pa
 import scipy.sparse as sp
 import tiledb
 from anndata._core import file_backing
-from anndata._core.sparse_dataset import SparseDataset
+from anndata._core.sparse_dataset import CSCDataset
 from somacore.options import PlatformConfig
 from typing_extensions import get_args
 
@@ -1375,7 +1375,7 @@ def _create_from_matrix(
     """
     Internal helper for user-facing ``create_from_matrix``.
     """
-    # SparseDataset has no ndim but it has a shape
+    # CSRDataset and CSCDataset have no ndim but they have a shape
     if len(matrix.shape) != 2:
         raise ValueError(f"expected matrix.shape == 2; got {matrix.shape}")
 
@@ -1681,7 +1681,7 @@ def update_matrix(
         soma_ndarray: a ``SparseNDArray`` or ``DenseNDArray`` already opened for write.
 
         new_data: If the ``soma_ndarray`` is sparse, a Scipy CSR/CSC matrix or
-            AnnData ``SparseDataset``. If the ``soma_ndarray`` is dense,
+            AnnData ``CSRDataset``/``CSCDataset``. If the ``soma_ndarray`` is dense,
             a NumPy NDArray.
 
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
@@ -2103,7 +2103,8 @@ def _find_sparse_chunk_size_backed(
       these nnz values is quick.  This happens when the input is AnnData via
       anndata.read_h5ad(name_of_h5ad) without the second backing-mode argument.
 
-    * If the input matrix is anndata._core.sparse_dataset.SparseDataset -- which
+    * If the input matrix is ``anndata._core.sparse_dataset.CSRDataset``
+      or ``anndata._core.sparse_dataset.CSCDataset`` -- which
       happens with out-of-core anndata reads -- then getting all these nnz
       values is prohibitively expensive.  This happens when the input is AnnData
       via anndata.read_h5ad(name_of_h5ad, "r") with the second backing-mode
@@ -2301,7 +2302,7 @@ def _write_matrix_to_sparseNDArray(
     if sp.isspmatrix_csc(matrix):
         # E.g. if we used anndata.X[:]
         stride_axis = 1
-    if isinstance(matrix, SparseDataset) and matrix.format == "csc":
+    if isinstance(matrix, CSCDataset):
         # E.g. if we used anndata.X without the [:]
         stride_axis = 1
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -37,7 +37,7 @@ import pyarrow as pa
 import scipy.sparse as sp
 import tiledb
 from anndata._core import file_backing
-from anndata._core.sparse_dataset import CSCDataset
+from anndata._core.sparse_dataset import SparseDataset
 from somacore.options import PlatformConfig
 from typing_extensions import get_args
 
@@ -1375,7 +1375,7 @@ def _create_from_matrix(
     """
     Internal helper for user-facing ``create_from_matrix``.
     """
-    # CSRDataset and CSCDataset have no ndim but they have a shape
+    # SparseDataset has no ndim but it has a shape
     if len(matrix.shape) != 2:
         raise ValueError(f"expected matrix.shape == 2; got {matrix.shape}")
 
@@ -1681,7 +1681,7 @@ def update_matrix(
         soma_ndarray: a ``SparseNDArray`` or ``DenseNDArray`` already opened for write.
 
         new_data: If the ``soma_ndarray`` is sparse, a Scipy CSR/CSC matrix or
-            AnnData ``CSRDataset``/``CSCDataset``. If the ``soma_ndarray`` is dense,
+            AnnData ``SparseDataset``. If the ``soma_ndarray`` is dense,
             a NumPy NDArray.
 
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
@@ -2103,8 +2103,7 @@ def _find_sparse_chunk_size_backed(
       these nnz values is quick.  This happens when the input is AnnData via
       anndata.read_h5ad(name_of_h5ad) without the second backing-mode argument.
 
-    * If the input matrix is ``anndata._core.sparse_dataset.CSRDataset``
-      or ``anndata._core.sparse_dataset.CSCDataset`` -- which
+    * If the input matrix is anndata._core.sparse_dataset.SparseDataset -- which
       happens with out-of-core anndata reads -- then getting all these nnz
       values is prohibitively expensive.  This happens when the input is AnnData
       via anndata.read_h5ad(name_of_h5ad, "r") with the second backing-mode
@@ -2302,7 +2301,7 @@ def _write_matrix_to_sparseNDArray(
     if sp.isspmatrix_csc(matrix):
         # E.g. if we used anndata.X[:]
         stride_axis = 1
-    if isinstance(matrix, CSCDataset):
+    if isinstance(matrix, SparseDataset) and matrix.format == "csc":
         # E.g. if we used anndata.X without the [:]
         stride_axis = 1
 


### PR DESCRIPTION
Drive-by finding on ingest.

Repro at the AnnData level:

```
>>> import anndata as ad

>>> adata = ad.read_h5ad('/var/s/a/white-matter-astrocytes.h5ad', 'r')

>>> adata.X.format
'csr'

>>> adata.X.format_str
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/anndata/_core/sparse_dataset.py:311: FutureWarning: The attribute .format_str is deprecated and will be removed in the anndata 0.11.0. Please use .format instead.
  warnings.warn(
'csr'
```

As noted below there is another warning:
```
/usr/lib/python3.10/abc.py:119: FutureWarning: SparseDataset is deprecated and will be removed in late 2024. It has been replaced by the public classes CSRDataset and CSCDataset.
```
but we can't get rid of this in Python 3.8 which we still support (#2141)