### PR TITLE
[python] Fix an ingestion corner case with empty chunks

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2192,6 +2192,10 @@ def _find_sparse_chunk_size_backed(
     if start_index + chunk_size >= extent:
         return chunk_size
 
+    # The entire chunk is unoccupied sparse; the caller can skip over it
+    if chunk_nnz == 0:
+        return chunk_size
+
     # Compare initial estimate chunk nnz against the goal
     ratio = chunk_nnz / goal_chunk_nnz
 


### PR DESCRIPTION
**Issue and/or context:** This is from a non-GitHub bug report.

**Changes:** Avoid division by zero on entirely empty chunks.

**Notes for Reviewer:** I tried to create synthetic data that would trigger the corner case, but failed to repro. Had I succeeded, I'd have created a new unit-test case on this PR. As is, I was only able to repro with some larger data I'm not willing to check in. Regardless, the change has been tested successfully against that dataset, and furthermore, it's a clear and solid code mod.
