### PR TITLE
[python] Remove no-longer-necessary `_query_condition` import

### DIFF
--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -3,9 +3,6 @@ from typeguard import install_import_hook
 
 install_import_hook("tiledbsoma")
 
-# TODO: `clib.SOMAObject.open` segfaults if this import is removed: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
-from tiledbsoma import _query_condition  # noqa: F401, E402
-
 """Types supported in a SOMA*NDArray """
 NDARRAY_ARROW_TYPES_SUPPORTED = [
     pa.bool_(),


### PR DESCRIPTION
**Issue and/or context:** https://github.com/single-cell-data/TileDB-SOMA/pull/1960#discussion_r1528881351, #2293

**Update:**
- The underlying segfault still exists: #2293; occurs on macOS when `tiledb` is imported before `tiledbsoma`
- #2299 made it harder to trigger while unit-testing, because it made `conftest.py` import `tiledbsoma` very early during test initialization ([here](https://github.com/single-cell-data/TileDB-SOMA/pull/2299/files#diff-23e074510ec289097bb974f8ee8a2e0c94dfd3f8056d69fc83dc4739c382c4e1R6))
- It's probably safe/reasonable to remove the `_query_condition` import, as this PR does, since it is no longer helping us work around Typeguard issues or the segfault.

<details><summary>Previous description</summary>

If a `from tiledbsoma import _query_condition` is omitted at the start of `tests/__init__.py`, tests segfault during `clib.SOMAObject.open` here:

https://github.com/single-cell-data/TileDB-SOMA/blob/0b99e032dd54028227a0f4d8a3ce025e499c0254/apis/python/src/tiledbsoma/_tdb_handles.py#L56-L60

Currently this PR is just designed to repro the issue.

Update: [GHA repro line](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/8331447519/job/22798373940?pr=2286#step:14:20), appears to be macOS only.
</details> 
