### PR TITLE
Make `_util.read_h5ad` a `@contextmanager`

### DIFF
--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -188,15 +188,13 @@ class ExperimentAmbientLabelMapping:
         experiment, not in append mode, but allowing us to still have the bulk of the ingestor code
         to be non-duplicated between non-append mode and append mode.
         """
-        handle, adata = read_h5ad(h5ad_file_name, mode="r")
-        retval = cls.from_isolated_anndata(
-            adata,
-            measurement_name=measurement_name,
-            obs_field_name=obs_field_name,
-            var_field_name=var_field_name,
-        )
-        handle.close()
-        return retval
+        with read_h5ad(h5ad_file_name, mode="r") as adata:
+            return cls.from_isolated_anndata(
+                adata,
+                measurement_name=measurement_name,
+                obs_field_name=obs_field_name,
+                var_field_name=var_field_name,
+            )
 
     @classmethod
     def from_isolated_soma_experiment(
@@ -424,17 +422,15 @@ class ExperimentAmbientLabelMapping:
         """Extends registration data to one more H5AD input file."""
         tiledbsoma.logging.logger.info(f"Registration: registering {h5ad_file_name}.")
 
-        handle, adata = read_h5ad(h5ad_file_name, mode="r")
-        retval = cls.from_anndata_append_on_experiment(
-            adata,
-            previous,
-            measurement_name=measurement_name,
-            obs_field_name=obs_field_name,
-            var_field_name=var_field_name,
-            append_obsm_varm=append_obsm_varm,
-        )
-        handle.close()
-        return retval
+        with read_h5ad(h5ad_file_name, mode="r") as adata:
+            return cls.from_anndata_append_on_experiment(
+                adata,
+                previous,
+                measurement_name=measurement_name,
+                obs_field_name=obs_field_name,
+                var_field_name=var_field_name,
+                append_obsm_varm=append_obsm_varm,
+            )
 
     @classmethod
     def from_h5ad_appends_on_experiment(

--- a/apis/python/src/tiledbsoma/io/_registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/_registration/signatures.py
@@ -199,10 +199,8 @@ class Signature:
         """
         See ``from_anndata``.
         """
-        handle, adata = read_h5ad(h5ad_file_name, mode="r")
-        retval = cls.from_anndata(adata, default_X_layer_name=default_X_layer_name)
-        handle.close()
-        return retval
+        with read_h5ad(h5ad_file_name, mode="r") as adata:
+            return cls.from_anndata(adata, default_X_layer_name=default_X_layer_name)
 
     @classmethod
     def from_soma_experiment(

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021-2024 TileDB, Inc.
 #
 # Licensed under the MIT License.
+import pathlib
 from contextlib import contextmanager
 from typing import (
     ContextManager,
@@ -37,8 +38,7 @@ def read_h5ad(
 # This trick lets us ingest H5AD with "r" (backed mode) from S3 URIs.  While h5ad
 # supports any file-like object, AnnData specifically wants only an `os.PathLike`
 # object. The only thing it does with the PathLike is to use it to get the filename.
-# @typeguard_ignore
-class _FSPathWrapper:
+class _FSPathWrapper(pathlib.Path):
     """Tricks anndata into thinking a file-like object is an ``os.PathLike``.
 
     While h5ad supports any file-like object, anndata specifically wants
@@ -50,12 +50,19 @@ class _FSPathWrapper:
     so here we just proxy all attributes except ``__fspath__``.
     """
 
+    def __new__(cls, _obj: object, path: Path) -> "_FSPathWrapper":
+        return super().__new__(cls, path)
+
+    # ``pathlib.Path`` construction references this attribute (``PosixFlavour`` or ``WindowsFlavour``)
+    _flavour = pathlib.Path().__class__._flavour  # type: ignore[attr-defined]
+
     def __init__(self, obj: object, path: Path) -> None:
+        super().__init__()
         self._obj = obj
         self._path = path
 
-    def __fspath__(self) -> Path:
-        return self._path
+    def __fspath__(self) -> str:
+        return self._path if isinstance(self._path, str) else str(self._path)
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._obj, name)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -324,32 +324,26 @@ def from_h5ad(
 
     logging.log_io(None, f"START  READING {input_path}")
 
-    # The input handle needs to remain open while we process the file-backed
-    # AnnData object.
-    input_handle, anndata = read_h5ad(input_path, mode="r", ctx=context.tiledb_ctx)
-    logging.log_io(None, _util.format_elapsed(s, f"FINISH READING {input_path}"))
+    with read_h5ad(input_path, mode="r", ctx=context.tiledb_ctx) as anndata:
+        logging.log_io(None, _util.format_elapsed(s, f"FINISH READING {input_path}"))
 
-    uri = from_anndata(
-        experiment_uri,
-        anndata,
-        measurement_name,
-        context=context,
-        platform_config=platform_config,
-        obs_id_name=obs_id_name,
-        var_id_name=var_id_name,
-        X_layer_name=X_layer_name,
-        raw_X_layer_name=raw_X_layer_name,
-        ingest_mode=ingest_mode,
-        use_relative_uri=use_relative_uri,
-        X_kind=X_kind,
-        registration_mapping=registration_mapping,
-        uns_keys=uns_keys,
-        additional_metadata=additional_metadata,
-    )
-
-    # Close the input handle now that we're done processinig the file-backed
-    # AnnData object.
-    input_handle.close()
+        uri = from_anndata(
+            experiment_uri,
+            anndata,
+            measurement_name,
+            context=context,
+            platform_config=platform_config,
+            obs_id_name=obs_id_name,
+            var_id_name=var_id_name,
+            X_layer_name=X_layer_name,
+            raw_X_layer_name=raw_X_layer_name,
+            ingest_mode=ingest_mode,
+            use_relative_uri=use_relative_uri,
+            X_kind=X_kind,
+            registration_mapping=registration_mapping,
+            uns_keys=uns_keys,
+            additional_metadata=additional_metadata,
+        )
 
     logging.log_io(
         None, _util.format_elapsed(s, f"FINISH Experiment.from_h5ad {input_path} {uri}")

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -3,7 +3,7 @@ from typeguard import install_import_hook
 
 install_import_hook("tiledbsoma")
 
-# TODO: `pytest tests/test_basic_anndata_io.py` segfaults without this here (likely other things as well)
+# TODO: `clib.SOMAObject.open` segfaults if this import is removed: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
 from tiledbsoma import _query_condition  # noqa: F401, E402
 
 """Types supported in a SOMA*NDArray """


### PR DESCRIPTION
**Issue and/or context:** follow-on changes to #2290

**Changes:** simplify calling new `read_h5ad` helper by using `@contextmanager`/`yield` pattern

**Notes for Reviewer:**
- ~I could only get this to type-check using `typeguard>=3` (per https://github.com/agronholm/typeguard/issues/115#issuecomment-987188701), so this includes a minimal version of #1960 (and fixes #1116). It might make more sense to merge #1960 separately, then put this and #2290 on top of that.~ **Update:** #1960 is merged, this is rebased on it.
- I modified `_FSPathWrapper` to subclass from `pathlib.Path`, also to resolve type-checking issues; that's probably more accurate anyway, it's meant to quack like a `Path`.

