### PR TITLE
[r/ci] Controlled downgrade for TileDB-R 0.24

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -61,6 +61,13 @@ jobs:
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
 
 
+      - name: Install 0.24 build of tiledb-r with core 2.20
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.24.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.24.0.tar.gz")'
+          R CMD INSTALL 0.24.0.tar.gz    # as 0.24.0 is needed by TileDB-SOMA 1.8
+
       # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
       # which source is available but CRAN releases (and hence update r2u binaries) are not yet:
       #
@@ -109,6 +116,13 @@ jobs:
       #
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
+
+      - name: Re-install 0.24 build of tiledb-r with core 2.20
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.24.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.24.0.tar.gz")'
+          R CMD INSTALL 0.24.0.tar.gz    # as 0.24.0 is needed by SOMA 1.8
 
       # - name: Build Package
       #   run: cd apis/r && R CMD build --no-build-vignettes --no-manual .

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -41,6 +41,13 @@ jobs:
       - name: MkVars
         run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
 
+      - name: Install 0.24 build of tiledb-r with core 2.20
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.24.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.24.0.tar.gz")'
+          R CMD INSTALL 0.24.0.tar.gz    # as 0.24.0 is needed by TileDB-SOMA 1.8
+
       - name: Install r-universe build of tiledb-r (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
         run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
@@ -75,13 +82,31 @@ jobs:
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python
 
-      - name: Show Python package versions
+      - name: Show package versions
         run: |
           python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
+          echo
           python scripts/show-versions.py
+          echo
+          Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
+
+      - name: Re-install 0.24 build of tiledb-r with core 2.20
+        run: |
+          cd apis/r
+          wget https://github.com/TileDB-Inc/TileDB-R/archive/refs/tags/0.24.0.tar.gz
+          Rscript -e 'remotes::install_deps("0.24.0.tar.gz")'
+          R CMD INSTALL 0.24.0.tar.gz    # as 0.24.0 is needed by SOMA 1.8
+
+      - name: Show package versions
+        run: |
+          python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
+          echo
+          python scripts/show-versions.py
+          echo
+          Rscript -e 'tiledbsoma::show_package_versions()'
 
       - name: Interop Tests
         run: python -m pytest apis/system/tests/


### PR DESCRIPTION
**Issue and/or context:** Applies the same pattern on the `release-1.8` branch as #1972 did for the `release-1.5` branch, #1996 did for the `release-1.6` branch, and #2157 did for the `release-1.7` branch.

Standard procedure:
https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases#incrementing-core-versions

[sc-43172]

**Changes:** As on #1972, #1996, and #2157. This is necessary since [TileDB-R 0.25.0](https://tiledb-inc.r-universe.dev/tiledb) now exists, and the R `DESCRIPTION` file does not syntactically support `tiledb < 0.25` or `tiledb <= 0.25`. Therefore (see also this comment https://github.com/single-cell-data/TileDB-SOMA/pull/1996#issuecomment-1881702859) we do a controlled downgrade to TileDB-R 0.24 on this PR, for the `release-1.8` branch.

**Notes for Reviewer:** Every stanza in this PR has been proved necessary via the dialog on #1972, #1996, and #2157. See in particular https://github.com/single-cell-data/TileDB-SOMA/pull/1996#pullrequestreview-1809807165.
