### PR TITLE
[Backport release-1.8] [python] Fix many `typeguard` warnings

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -101,7 +101,7 @@ jobs:
 #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools sparse
+      run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools sparse
 
     - name: Install tiledbsoma
       run: python -m pip -v install -e apis/python

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -77,7 +77,7 @@ jobs:
           cache-dependency-path: ./apis/python/setup.py
 
       - name: Install testing prereqs
-        run: python -m pip -v install -U pip pytest-cov 'typeguard<3.0' types-setuptools
+        run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools
 
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -1,5 +1,5 @@
 cmake >= 3.21
 pybind11-global >= 2.10.0
-typeguard < 3.0
+typeguard>=4
 pytest
 sparse

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -13,7 +13,6 @@
 # Based on ideas from https://github.com/pybind/cmake_example
 # The `bld` script here is reused for pip install, CI, and local builds.
 
-# type: ignore
 import ctypes
 import os
 import pathlib
@@ -22,7 +21,6 @@ import subprocess
 import sys
 from typing import Optional
 
-import setuptools
 import setuptools.command.build_ext
 import wheel.bdist_wheel
 
@@ -338,7 +336,7 @@ setuptools.setup(
             "black",
             "ruff",
             "pytest",
-            "typeguard<3.0",
+            "typeguard>=4",
         ]
     },
     python_requires=">=3.8",

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -37,6 +37,7 @@ from ._common_nd_array import NDArray
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
 from ._exception import SOMAError, is_does_not_exist_error
+from ._funcs import typeguard_ignore
 from ._sparse_nd_array import SparseNDArray
 from ._tiledb_object import AnyTileDBObject, TileDBObject
 from ._types import OpenTimestamp
@@ -50,7 +51,7 @@ from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
 # A collection can hold any sub-type of TileDBObject
 CollectionElementType = TypeVar("CollectionElementType", bound=AnyTileDBObject)
-_TDBO = TypeVar("_TDBO", bound=AnyTileDBObject)
+_TDBO = TypeVar("_TDBO", bound=TileDBObject)  # type: ignore[type-arg]
 _Coll = TypeVar("_Coll", bound="CollectionBase[AnyTileDBObject]")
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 
@@ -188,7 +189,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         *,
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
-    ) -> "AnyTileDBCollection":
+    ) -> AnyTileDBCollection:
         """Adds a new sub-collection to this collection.
 
         Args:
@@ -229,7 +230,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
-        child_cls: Type[AnyTileDBCollection] = kind or Collection
+        child_cls = kind or Collection
         return self._add_new_element(
             key,
             child_cls,
@@ -376,6 +377,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._add_new_ndarray(SparseNDArray, key, **kwargs)
 
+    @typeguard_ignore
     def _add_new_element(
         self,
         key: str,
@@ -442,7 +444,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
                     entry.entry.wrapper_type.open, uri, mode, context, timestamp
                 )
             # Since we just opened this object, we own it and should close it.
-            self._close_stack.enter_context(entry.soma)
+            self._close_stack.enter_context(entry.soma)  # type: ignore[arg-type]
         return cast(CollectionElementType, entry.soma)
 
     def set(
@@ -683,6 +685,7 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
     __slots__ = ()
 
 
+@typeguard_ignore
 def _real_class(cls: Type[Any]) -> type:
     """Extracts the real class from a generic alias.
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -120,11 +120,11 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         # 1,000,000x1,000,000 but only 100x200 cells were written -- then we need the non-empty
         # domain.
         #
-        # The non-empty domain is the corret choice in either case.
+        # The non-empty domain is the correct choice in either case.
         #
         # The only exception is if the array has been created but no data have been written at
         # all, in which case the best we can do is use the schema shape.
-        handle: clib.DenseNDArrayWrapper = self._handle._handle
+        handle: clib.SOMADenseNDArray = self._handle._handle
 
         data_shape = handle.shape
         ned = self.non_empty_domain()

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -7,7 +7,17 @@
 Collection.
 """
 
-from typing import Callable, Dict, Optional, Type, TypeVar, Union, cast, overload
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    no_type_check,
+    overload,
+)
 
 import somacore
 from somacore import options
@@ -29,6 +39,7 @@ from ._constants import (
 )
 from ._exception import SOMAError
 from ._funcs import typeguard_ignore
+from ._tiledb_object import AnyTileDBObject, TileDBObject
 from ._types import OpenTimestamp
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
@@ -45,7 +56,7 @@ def open(
     soma_type: Optional[str] = None,
     context: Optional[SOMATileDBContext] = None,
     tiledb_timestamp: Optional[OpenTimestamp] = None,
-) -> "_tiledb_object.AnyTileDBObject":
+) -> AnyTileDBObject:
     ...
 
 
@@ -66,10 +77,10 @@ def open(
     uri: str,
     mode: options.OpenMode = "r",
     *,
-    soma_type: Union[Type["_tiledb_object.AnyTileDBObject"], str, None] = None,
+    soma_type: Union[Type[TileDBObject], str, None] = None,  # type: ignore[type-arg]
     context: Optional[SOMATileDBContext] = None,
     tiledb_timestamp: Optional[OpenTimestamp] = None,
-) -> "_tiledb_object.AnyTileDBObject":
+) -> AnyTileDBObject:
     """Opens a TileDB SOMA object.
 
     Args:
@@ -111,7 +122,9 @@ def open(
         Experimental.
     """
     context = _validate_soma_tiledb_context(context)
-    obj = _open_internal(_tdb_handles.open, uri, mode, context, tiledb_timestamp)
+    obj: TileDBObject[_Wrapper] = _open_internal(  # type: ignore[no-untyped-call,valid-type]
+        _tdb_handles.open, uri, mode, context, tiledb_timestamp
+    )
     try:
         if soma_type:
             if isinstance(soma_type, str):
@@ -130,6 +143,7 @@ def open(
         raise
 
 
+@no_type_check
 def _open_internal(
     opener: Callable[
         [str, options.OpenMode, SOMATileDBContext, Optional[OpenTimestamp]], _Wrapper
@@ -138,7 +152,7 @@ def _open_internal(
     mode: options.OpenMode,
     context: SOMATileDBContext,
     timestamp: Optional[OpenTimestamp],
-) -> "_tiledb_object.TileDBObject[_Wrapper]":
+) -> TileDBObject[_Wrapper]:
     """Lower-level open function for internal use only."""
     handle = opener(uri, mode, context, timestamp)
     try:
@@ -149,10 +163,10 @@ def _open_internal(
 
 
 @typeguard_ignore
-def reify_handle(hdl: _Wrapper) -> "_tiledb_object.TileDBObject[_Wrapper]":
+def reify_handle(hdl: _Wrapper) -> TileDBObject[_Wrapper]:
     """Picks out the appropriate SOMA class for a handle and wraps it."""
     typename = _read_soma_type(hdl)
-    cls = _type_name_to_cls(typename)
+    cls = _type_name_to_cls(typename)  # type: ignore[no-untyped-call]
     if type(hdl) not in (cls._wrapper_type, cls._reader_wrapper_type):
         raise SOMAError(
             f"cannot open {hdl.uri!r}: a {type(hdl._handle)}"
@@ -195,10 +209,10 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
     return obj_type
 
 
-@typeguard_ignore
-def _type_name_to_cls(type_name: str) -> Type["_tiledb_object.AnyTileDBObject"]:
-    type_map: Dict[str, Type["_tiledb_object.AnyTileDBObject"]] = {
-        t.soma_type.lower(): t  # type: ignore[attr-defined, misc]  # spurious
+@no_type_check
+def _type_name_to_cls(type_name: str) -> Type[AnyTileDBObject]:
+    type_map: Dict[str, Type[AnyTileDBObject]] = {
+        t.soma_type.lower(): t
         for t in (
             _collection.Collection,
             _dataframe.DataFrame,

--- a/apis/python/src/tiledbsoma/_funcs.py
+++ b/apis/python/src/tiledbsoma/_funcs.py
@@ -21,19 +21,18 @@ _T = TypeVar("_T")
 _CT = TypeVar("_CT", bound=Callable[..., Any])
 
 
-# Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
-# decorator without having to depend upon typeguard at runtime.
-def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
-    """No-op. Returns the argument unchanged."""
-    return f
-
-
 try:
     import typeguard
 
-    typeguard_ignore = typeguard.typeguard_ignore  # noqa: F811
+    def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
+        return typeguard.typeguard_ignore(f)  # type: ignore[no-any-return]
+
 except ImportError:
-    pass
+    # Define a typeguard_ignore function so that we can use the `@typeguard_ignore`
+    # decorator without having to depend upon typeguard at runtime.
+    def typeguard_ignore(f: Callable[_Params, _T]) -> Callable[_Params, _T]:
+        """No-op. Returns the argument unchanged."""
+        return f
 
 
 def forwards_kwargs_to(

--- a/apis/python/src/tiledbsoma/_index_util.py
+++ b/apis/python/src/tiledbsoma/_index_util.py
@@ -4,9 +4,11 @@ SOMATileDBContext which would otherwise ensue.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 from somacore.query.types import IndexLike
 
 from tiledbsoma import pytiledbsoma as clib
@@ -16,7 +18,15 @@ if TYPE_CHECKING:
 
 
 def tiledbsoma_build_index(
-    keys: np.typing.NDArray[np.int64],
+    keys: Union[  # type: ignore[type-arg]
+        np.typing.NDArray[np.int64],
+        pa.Array,
+        pa.IntegerArray,
+        pd.Series,
+        pd.arrays.IntegerArray,
+        pa.ChunkedArray,
+        list[int],
+    ],
     *,
     context: Optional["SOMATileDBContext"] = None,
     thread_count: int = 4,

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -365,8 +365,10 @@ class QueryConditionTree(ast.NodeVisitor):
         return val
 
     def cast_val_to_dtype(
-        self, val: Union[str, int, float, bytes, np.int32], dtype: str
-    ) -> Union[str, int, float, bytes, np.int32]:
+        self,
+        val: Union[str, int, float, bytes, np.int32, np.int64, np.float32],
+        dtype: str,
+    ) -> Union[str, int, float, bytes, np.int32, np.int64, np.float32]:
         if dtype != "string":
             try:
                 # this prevents numeric strings ("1", '123.32') from getting

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -38,7 +38,13 @@ from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp
 from .options._soma_tiledb_context import SOMATileDBContext
 
-RawHandle = Union[tiledb.Array, tiledb.Group, clib.SOMADataFrame]
+RawHandle = Union[
+    tiledb.Array,
+    tiledb.Group,
+    clib.SOMADataFrame,
+    clib.SOMASparseNDArray,
+    clib.SOMADenseNDArray,
+]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 """A raw TileDB object. Covariant because Handles are immutable enough."""
 
@@ -348,9 +354,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
             timestamp=(0, timestamp),
         )
 
-    # Covariant types should normally not be in parameters, but this is for
-    # internal use only so it's OK.
-    def _do_initial_reads(self, reader: _RawHdl_co) -> None:  # type: ignore[misc]
+    def _do_initial_reads(self, reader: RawHandle) -> None:
         """Final setup step before returning the Handle.
 
         This is passed a raw TileDB object opened in read mode, since writers

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the MIT License.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import pyarrow as pa
 import tiledb
@@ -40,7 +40,10 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         Lifecycle:
             Experimental.
         """
-        if isinstance(self._tiledb_array_schema(), tiledb.ArraySchema):
+        if isinstance(
+            self._tiledb_array_schema(),
+            tiledb.ArraySchema,
+        ):
             return tiledb_schema_to_arrow(
                 self._tiledb_array_schema(), self.uri, self._ctx
             )
@@ -57,7 +60,7 @@ class TileDBArray(TileDBObject[_tdb_handles.ArrayWrapper]):
         """
         return self._handle.non_empty_domain()
 
-    def _tiledb_array_schema(self) -> tiledb.ArraySchema:
+    def _tiledb_array_schema(self) -> Union[pa.Schema, tiledb.ArraySchema]:
         """Returns the TileDB array schema, for internal use."""
         return self._handle.schema
 

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -96,7 +96,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         if not isinstance(handle, cls._reader_wrapper_type):
             handle = cls._wrapper_type.open(uri, mode, context, tiledb_timestamp)
         return cls(
-            handle,  # type: ignore
+            handle,  # type: ignore[arg-type]
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -292,7 +292,7 @@ def anndata_dataframe_unmodified(old: pd.DataFrame, new: pd.DataFrame) -> bool:
     Checks that we didn't mutate the object while ingesting. Intended for unit tests.
     """
     try:
-        return (old == new).all().all()
+        return bool((old == new).all().all())
     except ValueError:
         # Can be thrown when columns don't match -- which is what we check for
         return False

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -25,6 +25,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    no_type_check,
     overload,
 )
 
@@ -1046,7 +1047,7 @@ def _create_or_open_collection(
     ...
 
 
-@typeguard_ignore
+@no_type_check
 def _create_or_open_collection(
     cls: Type[CollectionBase[_TDBO]],
     uri: str,

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -7,6 +7,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -16,7 +17,7 @@ import attrs as attrs_  # We use the name `attrs` later.
 import attrs.validators as vld  # Short name because we use this a bunch.
 import tiledb
 from somacore import options
-from typing_extensions import Self, TypedDict
+from typing_extensions import Self
 
 # Most defaults are configured directly as default attribute values
 # within TileDBCreateOptions.
@@ -168,7 +169,7 @@ class TileDBCreateOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "create"))
         if isinstance(create_entry, dict):
-            attrs: Tuple["attrs_.Attribute[Any]", ...] = cls.__attrs_attrs__
+            attrs: Tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filered_create_entry: Dict[str, Any] = {

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -1,10 +1,10 @@
 import pyarrow as pa
-from typeguard.importhook import install_import_hook
-
-# avoid typeguard by importing before calling install_import_hook
-from tiledbsoma import _query_condition  # noqa: F401
+from typeguard import install_import_hook
 
 install_import_hook("tiledbsoma")
+
+# TODO: `pytest tests/test_basic_anndata_io.py` segfaults without this here (likely other things as well)
+from tiledbsoma import _query_condition  # noqa: F401, E402
 
 """Types supported in a SOMA*NDArray """
 NDARRAY_ARROW_TYPES_SUPPORTED = [

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager
+from typing import Any, Type
+
+import pytest
+from typeguard import suppress_type_checks
+
+
+@contextmanager
+def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
+    """Temporarily suppress typeguard checks in order to verify a runtime exception is raised.
+
+    Otherwise, most errors end up manifesting as ``TypeCheckError``s, during tests (thanks to
+    ``typeguard``'s import hook).
+    """
+    with suppress_type_checks():
+        with pytest.raises(exc, *args, **kwargs):
+            yield

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -7,9 +7,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from typeguard import suppress_type_checks
 from typing_extensions import Literal
 
 import tiledbsoma as soma
+from tests._util import raises_no_typeguard
 from tiledbsoma import _collection, _factory, _tiledb_object
 from tiledbsoma._exception import DoesNotExistError
 from tiledbsoma.options import SOMATileDBContext
@@ -385,14 +387,15 @@ def test_cascading_close(tmp_path: pathlib.Path):
     ],
 )
 def test_real_class(in_type, want):
-    assert _collection._real_class(in_type) is want
+    with suppress_type_checks():
+        assert _collection._real_class(in_type) is want
 
 
 @pytest.mark.parametrize(
     "in_type", (Union[int, str], Literal["bacon"], TypeVar("_T", bound=List))
 )
 def test_real_class_fail(in_type):
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         _collection._real_class(in_type)
 
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -10,6 +10,7 @@ import tiledb
 from pandas.api.types import union_categoricals
 
 import tiledbsoma as soma
+from tests._util import raises_no_typeguard
 
 
 @pytest.fixture
@@ -44,7 +45,7 @@ def test_dataframe(tmp_path, arrow_schema):
     with pytest.raises(ValueError):
         # requires one or more index columns
         soma.DataFrame.create(uri, schema=asch, index_column_names=[])
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # invalid schema type
         soma.DataFrame.create(uri, schema=asch.to_string(), index_column_names=[])
     with pytest.raises(ValueError):
@@ -78,7 +79,7 @@ def test_dataframe(tmp_path, arrow_schema):
 
             sdf.write(rb)
 
-            with pytest.raises(TypeError):
+            with raises_no_typeguard(TypeError):
                 # non-arrow write
                 sdf.write(rb.to_pandas)
 
@@ -946,7 +947,7 @@ def test_result_order(tmp_path):
             15,
         ]
 
-        with pytest.raises(ValueError):
+        with raises_no_typeguard(ValueError):
             next(sdf.read(result_order="bogus"))
 
 

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -10,6 +10,7 @@ import tiledbsoma as soma
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+from ._util import raises_no_typeguard
 
 
 @pytest.mark.parametrize(
@@ -24,7 +25,7 @@ def test_dense_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         soma.DenseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
         )
@@ -75,7 +76,7 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
     # random sample -- written to entire array
     data = np.random.default_rng().standard_normal(np.prod(shape)).reshape(shape)
     coords = tuple(slice(0, dim_len) for dim_len in shape)
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         a.write(coords, data)
     a.write(coords, pa.Tensor.from_numpy(data))
     del a
@@ -343,7 +344,7 @@ def test_dense_nd_array_indexing_errors(tmp_path, io):
         a.write(coords=write_coords, values=pa.Tensor.from_numpy(npa))
 
     with soma.DenseNDArray.open(tmp_path.as_posix()) as a:
-        with pytest.raises(io["throws"]):
+        with raises_no_typeguard(io["throws"]):
             a.read(coords=read_coords).to_numpy()
 
 

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -10,6 +10,7 @@ from scipy import sparse
 from somacore import options
 
 import tiledbsoma as soma
+from tests._util import raises_no_typeguard
 from tiledbsoma import SOMATileDBContext, _factory
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma.experiment_query import X_as_series
@@ -118,14 +119,12 @@ def test_experiment_query_all(soma_experiment):
         assert query.X("raw").tables().concat() == pa.concat_tables(
             query.X("raw").tables()
         )
-        assert sparse.vstack(
-            [
-                sp
-                for sp, _ in query.X("raw")
-                .blockwise(axis=0, reindex_disable_on_axis=[1])
-                .scipy()
-            ]
-        ).shape == (query.n_obs, query.n_vars)
+        raw = query.X("raw")
+        blockwise = raw.blockwise(axis=0, reindex_disable_on_axis=[1])
+        assert sparse.vstack([sp for sp, _ in blockwise.scipy()]).shape == (
+            query.n_obs,
+            query.n_vars,
+        )
 
         # read as anndata
         ad = query.to_anndata("raw")
@@ -512,7 +511,7 @@ def test_error_corners(soma_experiment: soma.Experiment):
     # Illegal layer name type
     for lyr_name in [True, 3, 99.3]:
         with soma_experiment.axis_query("RNA") as query:
-            with pytest.raises(KeyError):
+            with raises_no_typeguard(KeyError):
                 next(query.X(lyr_name))
             with pytest.raises(ValueError):
                 next(query.obsp(lyr_name))

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import numpy as np
 import pyarrow as pa
 import pytest
+from typeguard import suppress_type_checks
 
 import tiledbsoma as soma
 from tests._util import raises_no_typeguard
@@ -108,7 +109,8 @@ def test_metadata(soma_object):
         assert "'foobar': " in meta_repr
         assert "'my': 'enemies'" in meta_repr
     # ...but closed metadata does not.
-    meta_repr_closed = repr(second_read.metadata)
+    with suppress_type_checks():  # type checking eagerly evaluates properties including `len`, which fails on a closed object
+        meta_repr_closed = repr(second_read.metadata)
     assert "foobar" not in meta_repr_closed
 
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -19,6 +19,7 @@ from tiledbsoma import _factory
 from tiledbsoma.options import SOMATileDBContext
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
+from ._util import raises_no_typeguard
 
 AnySparseTensor = Union[pa.SparseCOOTensor, pa.SparseCSRMatrix, pa.SparseCSCMatrix]
 
@@ -35,7 +36,7 @@ def test_sparse_nd_array_create_ok(
     """
     assert pa.types.is_primitive(element_type)  # sanity check incoming params
 
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # non-arrow write
         soma.SparseNDArray.create(
             tmp_path.as_posix(), type=element_type.to_pandas_dtype(), shape=shape
@@ -248,7 +249,7 @@ def test_sparse_nd_array_read_write_sparse_tensor(
     # so we must be prepared for StopIteration on reading them. It simplifies unit-test logic to use
     # occupation density of 1.0 for this test.
     data = create_random_tensor(format, shape, np.float64, 1.0)
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         # non-arrow write
         a.write(data.to_numpy())
     a.write(data)
@@ -963,9 +964,9 @@ def test_sparse_nd_array_error_corners(tmp_path):
         )
 
         # Write should reject unknown types
-        with pytest.raises(TypeError):
+        with raises_no_typeguard(TypeError):
             a.write(pa.array(np.zeros((99,), dtype=np.uint32)))
-        with pytest.raises(TypeError):
+        with raises_no_typeguard(TypeError):
             a.write(pa.chunked_array([np.zeros((99,), dtype=np.uint32)]))
 
         # Write should reject wrong dimensionality

--- a/apis/python/tests/test_tiledbobject.py
+++ b/apis/python/tests/test_tiledbobject.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
+from tests._util import raises_no_typeguard
 
 # Checking that objects _do_ exist is already done (thoroughly) in other tests. Here
 # we primarily focus on the negative cases.
@@ -41,7 +42,7 @@ def test_tiledbobject_exists_nonexistent_path(uri, somaclass):
     ],
 )
 def test_tiledbobject_exists_invalid_uri_type(uri, somaclass):
-    with pytest.raises(TypeError):
+    with raises_no_typeguard(TypeError):
         somaclass.exists(uri)
 
 


### PR DESCRIPTION
Backport #1960 to the `release.1.8` branch