### PR TITLE
[c++] Fix display of Arrow schema for enum of `bytes` datatype

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -19,7 +19,10 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      # TEMP: PLEASE DO NOT COMMIT
+      # fail-fast: true
+      fail-fast: false
+
       matrix:
         os: [ubuntu-22.04, macos-12]
         python-version: ['3.8', '3.11']

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1396,6 +1396,26 @@ def test_enum_schema_report(tmp_path):
         arrow_table = pa.Table.from_pandas(pandas_df, preserve_index=False)
         sdf.write(arrow_table)
 
+    # Double-check against TileDB-Py reporting
+    with tiledb.open(uri) as A:
+        for i in range(A.schema.nattr):
+            attr = A.schema.attr(i)
+            try:
+                index_type = attr.dtype
+                value_type = A.enum(attr.name).dtype
+            except tiledb.cc.TileDBError:
+                pass  # not an enum attr
+            if attr.name == "int_cat":
+                assert index_type.name == "int8"
+                assert value_type.name == "int64"
+            elif attr.name == "str_cat":
+                assert index_type.name == "int8"
+                assert value_type.name == "str32"
+            elif attr.name == "byte_cat":
+                assert index_type.name == "int8"
+                assert value_type.name == "bytes"
+
+    # Verify SOMA Arrow schema
     with soma.open(uri) as sdf:
         f = sdf.schema.field("int_cat")
         assert f.type.index_type == pa.int8()

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -145,8 +145,13 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
             auto enmr = ArrayExperimental::get_enumeration(
                 *ctx, *tiledb_array, attr.name());
             auto dict = new ArrowSchema;
-            dict->format = strdup(
-                ArrowAdapter::to_arrow_format(enmr.type(), false).data());
+            if (enmr.type() == TILEDB_STRING_ASCII or
+                enmr.type() == TILEDB_CHAR) {
+                dict->format = strdup("z");
+            } else {
+                dict->format = strdup(
+                    ArrowAdapter::to_arrow_format(enmr.type(), false).data());
+            }
             dict->name = strdup(enmr.name().c_str());
             dict->metadata = nullptr;
             dict->flags = 0;
@@ -327,7 +332,13 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         auto dict_arr = new ArrowArray;
 
         auto enmr = column->get_enumeration_info();
-        dict_sch->format = strdup(to_arrow_format(enmr->type(), false).data());
+        if (enmr->type() == TILEDB_STRING_ASCII or
+            enmr->type() == TILEDB_CHAR) {
+            dict_sch->format = strdup("z");
+        } else {
+            dict_sch->format = strdup(
+                to_arrow_format(enmr->type(), false).data());
+        }
         dict_sch->name = nullptr;
         dict_sch->metadata = nullptr;
         dict_sch->flags = 0;

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -332,13 +332,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         auto dict_arr = new ArrowArray;
 
         auto enmr = column->get_enumeration_info();
-        if (enmr->type() == TILEDB_STRING_ASCII or
-            enmr->type() == TILEDB_CHAR) {
-            dict_sch->format = strdup("z");
-        } else {
-            dict_sch->format = strdup(
-                to_arrow_format(enmr->type(), false).data());
-        }
+        dict_sch->format = strdup(to_arrow_format(enmr->type(), false).data());
         dict_sch->name = nullptr;
         dict_sch->metadata = nullptr;
         dict_sch->flags = 0;

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -353,7 +353,9 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         // returns std::optional where std::nullopt indicates the
         // column does not contain enumerated values.
         if (enmr->type() == TILEDB_STRING_ASCII or
-            enmr->type() == TILEDB_STRING_UTF8) {
+            enmr->type() == TILEDB_STRING_UTF8 or
+            enmr->type() == TILEDB_CHAR or
+            enmr->type() == TILEDB_BLOB) {
             auto dict_vec = enmr->as_vector<std::string>();
             column->convert_enumeration();
             dict_arr->buffers[1] = column->enum_offsets().data();

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -377,6 +377,8 @@ std::string_view ArrowAdapter::to_arrow_format(
     tiledb_datatype_t datatype, bool use_large) {
     switch (datatype) {
         case TILEDB_STRING_ASCII:
+            return use_large ? "Z" : "z";  // large because TileDB
+                                           // uses 64bit offsets
         case TILEDB_STRING_UTF8:
             return use_large ? "U" : "u";  // large because TileDB
                                            // uses 64bit offsets

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -37,6 +37,8 @@ class ArrowAdapter {
     static void release_schema(struct ArrowSchema* schema);
     static void release_array(struct ArrowArray* array);
 
+    static bool _isstr(const char* format);
+
     /**
      * @brief Convert ColumnBuffer to an Arrow array.
      *


### PR DESCRIPTION
**Issue and/or context:** Details on #2306 

Checker from #2306:

```
import tiledbsoma as soma
sdf = soma.open('test_dataframe')
print(sdf.schema)
```
 
Output after this PR:

```
soma_joinid: int64 not null
int_cat: dictionary<values=int64, indices=int8, ordered=0> not null
int: int64 not null
str_cat: dictionary<values=string, indices=int8, ordered=0> not null
str: large_string not null
byte_cat: dictionary<values=binary, indices=int8, ordered=0> not null
byte: large_binary not null
```

**Changes:** Report binary appropriately

**Notes for Reviewer:** Failing CI