### PR TITLE
skip `test_empty_categorical_query`

### DIFF
--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -907,6 +907,7 @@ def test_experiment_query_uses_threadpool_from_context(soma_experiment):
         pool.submit.assert_called()
 
 
+@pytest.mark.skip("raises ArrowInvalid in TileDB<2.21; see #1988 / #2299")
 def test_empty_categorical_query(pbmc_small):
     q = pbmc_small.axis_query(
         measurement_name="RNA", obs_query=AxisQuery(value_filter='groups == "g1"')


### PR DESCRIPTION
Skip test added in #2299 which requires core 2.21.0, and is currently failing builds `release-1.8` builds ([example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/8392617173/job/22989959668)).

**Issue and/or context:** #1988, #2299