### PR TITLE
[python/ci] Pin `typeguard==4.1.5`

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -101,7 +101,7 @@ jobs:
 #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
     - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools sparse
+      run: python -m pip -v install -U pip pytest-cov 'typeguard==4.1.5' types-setuptools sparse
 
     - name: Install tiledbsoma
       run: python -m pip -v install -e apis/python

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-path: ./apis/python/setup.py
 
       - name: Install testing prereqs
-        run: python -m pip -v install -U pip pytest-cov 'typeguard>=4' types-setuptools
+        run: python -m pip -v install -U pip pytest-cov 'typeguard==4.1.5' types-setuptools
 
       - name: Install tiledbsoma
         run: python -m pip -v install -e apis/python

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -1,5 +1,5 @@
 cmake >= 3.21
 pybind11-global >= 2.10.0
-typeguard>=4
+typeguard==4.1.5
 pytest
 sparse

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -336,7 +336,7 @@ setuptools.setup(
             "black",
             "ruff",
             "pytest",
-            "typeguard>=4",
+            "typeguard==4.1.5",
         ]
     },
     python_requires=">=3.8",


### PR DESCRIPTION
typeguard 4.2.0 and 4.2.1 were just released, raise errors on main. Pin to 4.1.5 for now.

Issue: #2312 