### PR TITLE
[python/ci] `typeguard==4.2.1`, make `requirements_dev.txt` canonical

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -100,11 +100,8 @@ jobs:
 #          dist
 #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
-    - name: Install testing prereqs
-      run: python -m pip -v install -U pip pytest-cov 'typeguard==4.1.5' types-setuptools sparse
-
     - name: Install tiledbsoma
-      run: python -m pip -v install -e apis/python
+      run: python -m pip -v install -e apis/python[dev]
       env:
         CC: ${{ inputs.cc }}
         CXX: ${{ inputs.cxx }}

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -69,11 +69,8 @@ jobs:
           cache: pip
           cache-dependency-path: ./apis/python/setup.py
 
-      - name: Install testing prereqs
-        run: python -m pip -v install -U pip pytest-cov 'typeguard==4.1.5' types-setuptools
-
       - name: Install tiledbsoma
-        run: python -m pip -v install -e apis/python
+        run: python -m pip -v install -e apis/python[dev]
 
       - name: Show Python package versions
         run: |

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -1,5 +1,7 @@
-cmake >= 3.21
-pybind11-global >= 2.10.0
-typeguard==4.1.5
+black
+ruff
 pytest
+pytest-cov
 sparse
+typeguard==4.1.5
+types-setuptools

--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -3,5 +3,5 @@ ruff
 pytest
 pytest-cov
 sparse
-typeguard==4.1.5
+typeguard==4.2.1
 types-setuptools

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -332,12 +332,7 @@ setuptools.setup(
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={
-        "dev": [
-            "black",
-            "ruff",
-            "pytest",
-            "typeguard==4.1.5",
-        ]
+        "dev": open("requirements_dev.txt").read(),
     },
     python_requires=">=3.8",
     cmdclass={"build_ext": build_ext, "bdist_wheel": bdist_wheel},

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -185,7 +185,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     def add_new_collection(
         self,
         key: str,
-        kind: Optional[Type[AnyTileDBCollection]] = None,
+        kind: Optional[Type[CollectionBase]] = None,  # type: ignore[type-arg]
         *,
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
@@ -377,7 +377,6 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._add_new_ndarray(SparseNDArray, key, **kwargs)
 
-    @typeguard_ignore
     def _add_new_element(
         self,
         key: str,
@@ -444,7 +443,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
                     entry.entry.wrapper_type.open, uri, mode, context, timestamp
                 )
             # Since we just opened this object, we own it and should close it.
-            self._close_stack.enter_context(entry.soma)  # type: ignore[arg-type]
+            self._close_stack.enter_context(entry.soma)
         return cast(CollectionElementType, entry.soma)
 
     def set(

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -122,7 +122,7 @@ def open(
         Experimental.
     """
     context = _validate_soma_tiledb_context(context)
-    obj: TileDBObject[_Wrapper] = _open_internal(  # type: ignore[no-untyped-call,valid-type]
+    obj: TileDBObject[_Wrapper] = _open_internal(  # type: ignore[valid-type]
         _tdb_handles.open, uri, mode, context, tiledb_timestamp
     )
     try:
@@ -143,7 +143,6 @@ def open(
         raise
 
 
-@no_type_check
 def _open_internal(
     opener: Callable[
         [str, options.OpenMode, SOMATileDBContext, Optional[OpenTimestamp]], _Wrapper

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -8,7 +8,7 @@ import functools
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, Mapping, Optional, Type, Union, cast
+from typing import Any, Dict, Literal, Mapping, Optional, Union
 
 import tiledb
 from somacore import ContextBase
@@ -46,10 +46,8 @@ def _maybe_timestamp_ms(input: Optional[OpenTimestamp]) -> Optional[int]:
     return to_timestamp_ms(input)
 
 
-class _SENTINEL:
-    """Sentinel object to distinguish default parameters from None."""
-
-    pass
+_Unset = Literal["__unset__"]
+_UNSET: _Unset = "__unset__"
 
 
 class SOMATileDBContext(ContextBase):
@@ -221,8 +219,8 @@ class SOMATileDBContext(ContextBase):
         *,
         tiledb_config: Optional[Dict[str, Any]] = None,
         tiledb_ctx: Optional[tiledb.Ctx] = None,
-        timestamp: Union[None, OpenTimestamp, Type[_SENTINEL]] = _SENTINEL,
-        threadpool: Union[None, ThreadPoolExecutor, Type[_SENTINEL]] = _SENTINEL,
+        timestamp: Union[None, OpenTimestamp, _Unset] = _UNSET,
+        threadpool: Union[None, ThreadPoolExecutor, _Unset] = _UNSET,
     ) -> Self:
         """Create a copy of the context, merging changes.
 
@@ -262,18 +260,18 @@ class SOMATileDBContext(ContextBase):
                 new_config.update(tiledb_config)
                 tiledb_config = {k: v for (k, v) in new_config.items() if v is not None}
 
-            if timestamp is _SENTINEL:
+            if timestamp == _UNSET:
                 # Keep the existing timestamp if not overridden.
                 timestamp = self._timestamp_ms
-            if threadpool is _SENTINEL:
+            if threadpool == _UNSET:
                 # Keep the existing threadpool if not overridden.
                 threadpool = self.threadpool
 
         return type(self)(
             tiledb_config=tiledb_config,
             tiledb_ctx=tiledb_ctx,
-            timestamp=cast(Optional[OpenTimestamp], timestamp),
-            threadpool=cast(Optional[ThreadPoolExecutor], threadpool),
+            timestamp=timestamp,
+            threadpool=threadpool,
         )
 
     def _open_timestamp_ms(self, in_timestamp: Optional[OpenTimestamp]) -> int:


### PR DESCRIPTION
**Issue and/or context:** #2312

**Changes:**
- use requirements_dev.txt in CI, setup.py: https://github.com/single-cell-data/TileDB-SOMA/commit/c47fa2a03b97c2b1550956f114556953374c5020
- use typeguard>=4.2, fixup some type checks: https://github.com/single-cell-data/TileDB-SOMA/pull/2314/commits/74c530b77c0b630b1540b9a662ebc4b20eb83733

**Notes for Reviewer:**
`requirements_dev.txt` seemed to be unused. I:
- populated `requirements_dev.txt` with the actual `[dev]` reqs from `setup.py` (plus a few that were only listed in CIs: `pytest-cov`, `sparse`)
- made `setup.py` use the new reqs file
- made CIs install `-e apis/python[dev]` (they were previously installing sans `[dev]`, and pre-installing a few select dev reqs)

Previously the typeguard pin existed in 4 places, for no good reason (afaict).

Let me know if there were actually two distinct sets of "dev" reqs here, which I am now conflating.