### PR TITLE
[c++] Use `std::future::get()` instead of `::wait()`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -56,7 +56,7 @@ ManagedQuery::ManagedQuery(
 
 void ManagedQuery::close() {
     if (query_future_.valid()) {
-        query_future_.wait();
+        query_future_.get();
     }
     array_->close();
 }
@@ -168,7 +168,7 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
 
     if (query_future_.valid()) {
         LOG_DEBUG(fmt::format("[ManagedQuery] [{}] Waiting for query", name_));
-        query_future_.wait();
+        query_future_.get();
     } else {
         throw TileDBSOMAError(
             fmt::format("[ManagedQuery] [{}] 'query_future_' invalid", name_));


### PR DESCRIPTION
Closes #2319

**Issue and/or context:**

See #2319 for discussion

**Changes:**

The use of `std::future::wait()` is replaced by `std::future::get()`.

**Notes for Reviewer:**

[SC 43721](https://app.shortcut.com/tiledb-inc/story/43721/asynchronous-functions-should-use-get-not-wait-so-that-errors-from-core-propagate)