### PR TITLE
[python/ci] Unbreak wheel builds, `main`

### DIFF
--- a/apis/python/MANIFEST.in
+++ b/apis/python/MANIFEST.in
@@ -3,3 +3,4 @@ include src/tiledbsoma/*.cc
 include src/tiledbsoma/*.h
 graft dist_links
 prune dist_links/libtiledbsoma/test/__pycache__
+include requirements_dev.txt


### PR DESCRIPTION
Ports #2339 (which was on the `release-1.9` branch) to `main`

#2311
[sc-43673]