### PR TITLE
[r] tiledbsoma-r 1.9.1

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.9.0
+Version: 1.9.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,7 @@
+# 1.9.1
+
+* This release contains a single Python-only mod
+
 # 1.9.0
 
 ## Changes

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,6 +1,6 @@
 # 1.9.1
 
-* This release contains a single Python-only mod
+* This release contains a single Python-only modification for its build process
 
 # 1.9.0
 


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

We need a 1.9.1 for our upcoming Python-only 1.9.1

#2311
[sc-43673]