### PR TITLE
Add back deprecated function `tiledbsoma_build_index`

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -193,6 +193,7 @@ __all__ = [
     "SOMATileDBContext",
     "SparseNDArray",
     "TileDBCreateOptions",
+    "tiledbsoma_build_index",
     "tiledbsoma_stats_disable",
     "tiledbsoma_stats_dump",
     "tiledbsoma_stats_enable",

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -157,7 +157,7 @@ from ._general_utilities import (
     get_storage_engine,
     show_package_versions,
 )
-from ._indexer import IntIndexer
+from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
 from ._sparse_nd_array import SparseNDArray
 from .options import SOMATileDBContext, TileDBCreateOptions

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
+from somacore.query.types import IndexLike
 
 from tiledbsoma import pytiledbsoma as clib
 
@@ -23,6 +24,26 @@ IndexerDataType = Union[
 ]
 
 
+def tiledbsoma_build_index(
+    data: IndexerDataType, *, context: Optional["SOMATileDBContext"] = None
+) -> IndexLike:
+    """Initialize re-indexer for provided indices.
+
+    Deprecated. Provides the same functionality as the``IntIndexer`` class.
+
+    Args:
+       data:
+           Integer keys used to build the index (hash) table.
+       context:
+           ``SOMATileDBContext`` object containing concurrecy level.
+
+    Lifecycle:
+        Deprecated.
+    """
+
+    return IntIndexer(data, context=context)
+
+
 class IntIndexer:
     """A re-indexer for unique integer indices.
 
@@ -33,7 +54,7 @@ class IntIndexer:
     def __init__(
         self, data: IndexerDataType, *, context: Optional["SOMATileDBContext"] = None
     ):
-        """Initialize re-indexer for provied indices.
+        """Initialize re-indexer for provided indices.
 
         Args:
            data:


### PR DESCRIPTION
**Issue and/or context:** #2343

**Changes:** 
Restore function `tiledbsoma_build_index`. Deprecate instead of removing.