### PR TITLE
[r] Add `obsm`, `varm`, `obsp`, and `varp` to `SOMAExperimentAxisQuery`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -52,7 +52,7 @@ LinkingTo:
     RcppInt64
 Additional_repositories: https://ghrr.github.io/drat
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Suggests:
     rmarkdown,
     knitr,

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.9.99
+Version: 1.9.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -4,6 +4,7 @@
 
 * Add support for ingestion of `SeuratCommand` logs
 * Add support for outgestion of `SeuratCommand` logs
+* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
 
 # 1.7.0
 

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -115,6 +115,139 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       ))
     },
 
+    #' @description Retrieves an `obsm` layer as a \code{\link{SOMASparseNDArrayRead}}
+    #' @param layer_name The name of the layer to retrieve
+    #'
+    obsm = function(layer_name) {
+      layers <- tryCatch(
+        self$ms$obsm$names(),
+        error = function(...) character()
+      )
+      if (!length(layers)) {
+        stop(errorCondition(
+          "No obsm layers present",
+          class = c("noObsmLayersError", "noLayersError"),
+          call = FALSE
+        ))
+      }
+      stopifnot(
+        "Must specify an obsm layer name" = !missing(layer_name),
+        "Must specify a single obsm layer name" = is_scalar_character(layer_name),
+        assert_subset(layer_name, layers, "layer")
+      )
+
+      obsm_layer <- self$ms$obsm$get(layer_name)
+      stopifnot(
+        "obsm layer must be a SOMASparseNDArray" =
+          inherits(obsm_layer, "SOMASparseNDArray")
+      )
+
+      # TODO: Stop converting to vectors when SOMAArrayReader supports arrow arrays
+      return(obsm_layer$read(coords = list(
+        self$obs_joinids()$as_vector(),
+        seq.int(0L, as.integer(obsm_layer$shape()[2L]) - 1L)
+      )))
+    },
+
+    #' @description Retrieves a `varm` layer as a \code{\link{SOMASparseNDArrayRead}}
+    #' @param layer_name The name of the layer to retrieve
+    #'
+    varm = function(layer_name) {
+      layers <- tryCatch(
+        self$ms$varm$names(),
+        error = function(...) character()
+      )
+      if (!length(layers)) {
+        stop(errorCondition(
+          "No varm layers present",
+          class = c("noVarmLayersError", "noLayersError"),
+          call = FALSE
+        ))
+      }
+      stopifnot(
+        "Must specify an varm layer name" = !missing(layer_name),
+        "Must specify a single varm layer name" = is_scalar_character(layer_name),
+        assert_subset(layer_name, layers, "layer")
+      )
+
+      varm_layer <- self$ms$varm$get(layer_name)
+      stopifnot(
+        "varm layer must be a SOMASparseNDArray" =
+          inherits(varm_layer, "SOMASparseNDArray")
+      )
+
+      # TODO: Stop converting to vectors when SOMAArrayReader supports arrow arrays
+      return(varm_layer$read(coords = list(
+        self$var_joinids()$as_vector(),
+        seq.int(0L, as.integer(varm_layer$shape()[2L]) - 1L)
+      )))
+    },
+
+    #' @description Retrieves an `obsp` layer as a \code{\link{SOMASparseNDArrayRead}}
+    #' @param layer_name The name of the layer to retrieve
+    #'
+    obsp = function(layer_name) {
+      layers <- tryCatch(
+        self$ms$obsp$names(),
+        error = function(...) character()
+      )
+      if (!length(layers)) {
+        stop(errorCondition(
+          "No obsp layers present",
+          class = c("noObspLayersError", "noLayersError"),
+          call = FALSE
+        ))
+      }
+      stopifnot(
+        "Must specify an obsp layer name" = !missing(layer_name),
+        "Must specify a single obsp layer name" = is_scalar_character(layer_name),
+        assert_subset(layer_name, layers, "layer")
+      )
+
+      obsp_layer <- self$ms$obsp$get(layer_name)
+      stopifnot(
+        "obsp layer must be a SOMASparseNDArray" =
+          inherits(obsp_layer, "SOMASparseNDArray")
+      )
+
+      # TODO: Stop converting to vectors when SOMAArrayReader supports arrow arrays
+      obs_ids <- self$obs_joinids()$as_vector()
+      return(obsp_layer$read(coords = list(obs_ids, obs_ids)))
+    },
+
+    #' @description Retrieves a `varp` layer as a \code{\link{SOMASparseNDArrayRead}}
+    #' @param layer_name The name of the layer to retrieve
+    #'
+    varp = function(layer_name) {
+      layers <- tryCatch(
+        self$ms$varp$names(),
+        error = function(...) character()
+      )
+      if (!length(layers)) {
+        stop(errorCondition(
+          "No varp layers present",
+          class = c("noVarpLayersError", "noLayersError"),
+          call = FALSE
+        ))
+      }
+      stopifnot(
+        "Must specify an varp layer name" = !missing(layer_name),
+        "Must specify a single varp layer name" = is_scalar_character(layer_name),
+        assert_subset(layer_name, layers, "layer")
+      )
+
+      varp_layer <- self$ms$varp$get(layer_name)
+      stopifnot(
+        "varp layer must be a SOMASparseNDArray" =
+          inherits(varp_layer, "SOMASparseNDArray")
+      )
+
+      # TODO: Stop converting to vectors when SOMAArrayReader supports arrow arrays
+      var_ids <- self$var_joinids()$as_vector()
+      return(varp_layer$read(coords = list(var_ids, var_ids)))
+    },
+
+
     #' @description Reads the entire query result as a list of
     #' [`arrow::Table`]s. This is a low-level routine intended to be used by
     #' loaders for other in-core formats, such as `Seurat`, which can be created

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -59,6 +59,10 @@ this in the class.
 \item \href{#method-SOMAExperimentAxisQuery-obs_joinids}{\code{SOMAExperimentAxisQuery$obs_joinids()}}
 \item \href{#method-SOMAExperimentAxisQuery-var_joinids}{\code{SOMAExperimentAxisQuery$var_joinids()}}
 \item \href{#method-SOMAExperimentAxisQuery-X}{\code{SOMAExperimentAxisQuery$X()}}
+\item \href{#method-SOMAExperimentAxisQuery-obsm}{\code{SOMAExperimentAxisQuery$obsm()}}
+\item \href{#method-SOMAExperimentAxisQuery-varm}{\code{SOMAExperimentAxisQuery$varm()}}
+\item \href{#method-SOMAExperimentAxisQuery-obsp}{\code{SOMAExperimentAxisQuery$obsp()}}
+\item \href{#method-SOMAExperimentAxisQuery-varp}{\code{SOMAExperimentAxisQuery$varp()}}
 \item \href{#method-SOMAExperimentAxisQuery-read}{\code{SOMAExperimentAxisQuery$read()}}
 \item \href{#method-SOMAExperimentAxisQuery-to_sparse_matrix}{\code{SOMAExperimentAxisQuery$to_sparse_matrix()}}
 \item \href{#method-SOMAExperimentAxisQuery-to_seurat}{\code{SOMAExperimentAxisQuery$to_seurat()}}
@@ -163,6 +167,74 @@ Retrieves an \code{X} layer as a link{SOMASparseNDArrayRead}
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{layer_name}}{The name of the layer to retrieve.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperimentAxisQuery-obsm"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-obsm}{}}}
+\subsection{Method \code{obsm()}}{
+Retrieves an \code{obsm} layer as a \code{\link{SOMASparseNDArrayRead}}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$obsm(layer_name)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{layer_name}}{The name of the layer to retrieve}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperimentAxisQuery-varm"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-varm}{}}}
+\subsection{Method \code{varm()}}{
+Retrieves a \code{varm} layer as a \code{\link{SOMASparseNDArrayRead}}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$varm(layer_name)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{layer_name}}{The name of the layer to retrieve}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperimentAxisQuery-obsp"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-obsp}{}}}
+\subsection{Method \code{obsp()}}{
+Retrieves an \code{obsp} layer as a \code{\link{SOMASparseNDArrayRead}}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$obsp(layer_name)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{layer_name}}{The name of the layer to retrieve}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAExperimentAxisQuery-varp"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-varp}{}}}
+\subsection{Method \code{varp()}}{
+Retrieves a \code{varp} layer as a \code{\link{SOMASparseNDArrayRead}}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$varp(layer_name)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{layer_name}}{The name of the layer to retrieve}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-m-p.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-m-p.R
@@ -1,0 +1,292 @@
+test_that("Load *m and *p layers from SOMAExperimentAxisQuery mechanics", {
+  skip_if(!extended_tests())
+  uri <- withr::local_tempdir("m-p-experiment-query-mechanics")
+
+  n_obs <- 20L
+  n_var <- 10L
+  n_pcs <- 50L
+  n_ics <- 30L
+  n_umaps <- 2L
+
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = "counts",
+    obsm_layers = c(X_pca = n_pcs, 'dense:X_ica' = n_ics, X_umap = n_umaps),
+    varm_layers = c(PCs = n_pcs, "dense:ICs" = n_ics),
+    obsp_layer_names = 'connectivities',
+    varp_layer_names = 'network',
+    mode = 'READ'
+  )
+  on.exit(experiment$close(), add = TRUE)
+
+  # Create the query
+  query <- SOMAExperimentAxisQuery$new(experiment, measurement_name = "RNA")
+
+  # Read `obsm` layers
+  expect_s3_class(pc_qry <- query$obsm("X_pca"), "SOMASparseNDArrayRead")
+  pc_mat <- pc_qry$sparse_matrix()$concat()
+  expect_s4_class(pc_mat, "dgTMatrix")
+  expect_identical(dim(pc_mat), c(n_obs, n_pcs))
+
+  expect_s3_class(umap_qry <- query$obsm("X_umap"), "SOMASparseNDArrayRead")
+  umap_mat <- umap_qry$sparse_matrix()$concat()
+  expect_s4_class(umap_mat, "dgTMatrix")
+  expect_identical(dim(umap_mat), c(n_obs, n_umaps))
+
+  expect_error(query$obsm("X_ica"), regexp = "obsm layer must be a SOMASparseNDArray")
+
+  # Read `varm` layers
+  expect_s3_class(pc_qry <- query$varm("PCs"), "SOMASparseNDArrayRead")
+  pc_mat <- pc_qry$sparse_matrix()$concat()
+  expect_s4_class(pc_mat, "dgTMatrix")
+  expect_identical(dim(pc_mat), c(n_var, n_pcs))
+
+  expect_error(query$varm("ICs"), regexp = "varm layer must be a SOMASparseNDArray")
+
+  # Read `obsp` layers
+  expect_s3_class(con_qry <- query$obsp("connectivities"), "SOMASparseNDArrayRead")
+  con_mat <- con_qry$sparse_matrix()$concat()
+  expect_s4_class(con_mat, "dgTMatrix")
+  expect_identical(dim(con_mat), c(n_obs, n_obs))
+
+  # Read `varp` layers
+  expect_s3_class(net_qry <- query$varp("network"), "SOMASparseNDArrayRead")
+  net_mat <- net_qry$sparse_matrix()$concat()
+  expect_s4_class(net_mat, "dgTMatrix")
+  expect_identical(dim(net_mat), c(n_var, n_var))
+
+  # Test assertions
+  expect_error(query$obsm())
+  expect_error(query$obsm(1L))
+  expect_error(query$obsm(c("X_pca", "X_umap")))
+  expect_error(query$obsm("missing-layer"))
+
+  expect_error(query$varm())
+  expect_error(query$varm(1L))
+  expect_error(query$varm(c("X_pca", "X_umap")))
+  expect_error(query$varm("missing-layer"))
+
+  expect_error(query$obsp())
+  expect_error(query$obsp(1L))
+  expect_error(query$obsp(c("X_pca", "X_umap")))
+  expect_error(query$obsp("missing-layer"))
+
+  expect_error(query$varp())
+  expect_error(query$varp(1L))
+  expect_error(query$varp(c("X_pca", "X_umap")))
+  expect_error(query$varp("missing-layer"))
+})
+
+test_that("SOMAExperimentAxisQuery without *m and *p layers mechanics", {
+  skip_if(!extended_tests())
+  uri <- withr::local_tempdir("m-p-missing-experiment-query-mechanics")
+
+  n_obs <- 1001L
+  n_var <- 99L
+
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = "counts",
+    mode = 'READ'
+  )
+  on.exit(experiment$close(), add = TRUE)
+
+  # Create the query
+  query <- SOMAExperimentAxisQuery$new(experiment, measurement_name = "RNA")
+
+  expect_error(query$obsm(), class = "noLayersError")
+  expect_error(query$varm(), class = "noLayersError")
+  expect_error(query$obsp(), class = "noLayersError")
+  expect_error(query$varp(), class = "noLayersError")
+})
+
+test_that("Load *m and *p layers from sliced SOMAExperimentAxisQuery", {
+  skip_if(!extended_tests())
+  uri <- withr::local_tempdir("m-p-experiment-query-sliced")
+
+  n_obs <- 1001L
+  n_var <- 99L
+  n_pcs <- 50L
+  n_umaps <- 2L
+
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = "counts",
+    obsm_layers = c(X_pca = n_pcs, X_umap = n_umaps),
+    varm_layers = c(PCs = n_pcs),
+    obsp_layer_names = 'connectivities',
+    varp_layer_names = 'network',
+    mode = 'READ'
+  )
+  on.exit(experiment$close(), add = TRUE)
+
+  # Create the query
+  obs_slice <- bit64::as.integer64(seq(3, 72))
+  var_slice <- bit64::as.integer64(seq(7, 21))
+  n_var_slice <- length(var_slice)
+  n_obs_slice <- length(obs_slice)
+  query <- SOMAExperimentAxisQuery$new(
+    experiment = experiment,
+    measurement_name = "RNA",
+    obs_query = SOMAAxisQuery$new(coords = list(soma_joinid = obs_slice)),
+    var_query = SOMAAxisQuery$new(coords = list(soma_joinid = var_slice))
+  )
+
+  # Read `obsm` layers
+  expect_s3_class(pc_qry <- query$obsm("X_pca"), "SOMASparseNDArrayRead")
+  pc_tbl <- pc_qry$tables()$concat()
+  expect_s3_class(pc_tbl, "Table")
+  pc_obs <- pc_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_gte(min(pc_obs), min(obs_slice))
+  expect_lte(max(pc_obs), max(obs_slice))
+
+  expect_s3_class(umap_qry <- query$obsm("X_umap"), "SOMASparseNDArrayRead")
+  umap_tbl <- umap_qry$tables()$concat()
+  expect_s3_class(umap_tbl, "Table")
+  umap_obs <- umap_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_gte(min(umap_obs), min(obs_slice))
+  expect_lte(max(umap_obs), max(obs_slice))
+
+  # Read `varm` layers
+  expect_s3_class(pc_qry <- query$varm("PCs"), "SOMASparseNDArrayRead")
+  pc_tbl <- pc_qry$tables()$concat()
+  expect_s3_class(pc_tbl, "Table")
+  pc_var <- pc_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_gte(min(pc_var), min(var_slice))
+  expect_lte(max(pc_var), max(var_slice))
+
+  # Read `obsp` layers
+  expect_s3_class(con_qry <- query$obsp("connectivities"), "SOMASparseNDArrayRead")
+  con_tbl <- con_qry$tables()$concat()
+  expect_s3_class(con_tbl, "Table")
+  for (axis in paste0("soma_dim_", 0:1)) {
+    con_dim <- con_tbl$GetColumnByName(axis)$as_vector()
+    expect_gte(
+      min(con_dim),
+      min(obs_slice),
+      label = axis,
+      expected.label = 'lower obsp range'
+    )
+    expect_lte(
+      max(con_dim),
+      max(obs_slice),
+      label = axis,
+      expected.label = 'upper obsp range'
+    )
+  }
+
+  # Read `varp` layers
+  expect_s3_class(net_qry <- query$varp("network"), "SOMASparseNDArrayRead")
+  net_tbl <- net_qry$tables()$concat()
+  expect_s3_class(net_tbl, "Table")
+  for (axis in paste0("soma_dim_", 0:1)) {
+    net_dim <- net_tbl$GetColumnByName(axis)$as_vector()
+    expect_gte(
+      min(net_dim),
+      min(var_slice),
+      label = axis,
+      expected.label = 'lower varp range'
+    )
+    expect_lte(
+      max(net_dim),
+      max(var_slice),
+      label = axis,
+      expected.label = 'upper varp range'
+    )
+  }
+
+})
+
+test_that("Load *m and *p layers from indexed SOMAExperimentAxisQuery", {
+  skip_if(!extended_tests())
+  uri <- withr::local_tempdir("m-p-experiment-query-indexed")
+
+  n_obs <- 1001L
+  n_var <- 99L
+  n_pcs <- 50L
+  n_umaps <- 2L
+  obs_label_values <- c("1003", "1007", "1038", "1099")
+  var_label_values <- c("1018", "1034", "1067")
+
+  experiment <- create_and_populate_experiment(
+    uri = uri,
+    n_obs = n_obs,
+    n_var = n_var,
+    X_layer_names = "counts",
+    obsm_layers = c(X_pca = n_pcs, X_umap = n_umaps),
+    varm_layers = c(PCs = n_pcs),
+    obsp_layer_names = 'connectivities',
+    varp_layer_names = 'network',
+    mode = 'READ'
+  )
+  on.exit(experiment$close(), add = TRUE)
+
+  # Create the query
+  obs_value_filter <- paste0(
+    sprintf("baz == '%s'", obs_label_values),
+    collapse = "||"
+  )
+  var_value_filter <- paste0(
+    sprintf("quux == '%s'", var_label_values),
+    collapse = "||"
+  )
+  n_obs_select <- length(obs_label_values)
+  n_var_select <- length(var_label_values)
+  query <- SOMAExperimentAxisQuery$new(
+    experiment = experiment,
+    measurement_name = "RNA",
+    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter),
+    var_query = SOMAAxisQuery$new(value_filter = var_value_filter)
+  )
+
+
+  obs_ids <- query$obs("soma_joinid")$concat()$GetColumnByName("soma_joinid")$as_vector()
+  var_ids <- query$var("soma_joinid")$concat()$GetColumnByName("soma_joinid")$as_vector()
+  expect_length(obs_ids, n_obs_select)
+  expect_length(var_ids, n_var_select)
+
+  # Read `obsm` layers
+  expect_s3_class(pc_qry <- query$obsm("X_pca"), "SOMASparseNDArrayRead")
+  pc_tbl <- pc_qry$tables()$concat()
+  expect_s3_class(pc_tbl, "Table")
+  pc_obs <- pc_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_in(pc_obs, obs_ids)
+
+  expect_s3_class(umap_qry <- query$obsm("X_umap"), "SOMASparseNDArrayRead")
+  umap_tbl <- umap_qry$tables()$concat()
+  expect_s3_class(umap_tbl, "Table")
+  umap_obs <- umap_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_in(umap_obs, obs_ids)
+
+  # Read `varm` layers
+  expect_s3_class(pc_qry <- query$varm("PCs"), "SOMASparseNDArrayRead")
+  pc_tbl <- pc_qry$tables()$concat()
+  expect_s3_class(pc_tbl, "Table")
+  pc_var <- pc_tbl$GetColumnByName("soma_dim_0")$as_vector()
+  expect_in(pc_var, var_ids)
+
+  # Read `obsp` layers
+  expect_s3_class(con_qry <- query$obsp("connectivities"), "SOMASparseNDArrayRead")
+  con_tbl <- con_qry$tables()$concat()
+  expect_s3_class(con_tbl, "Table")
+  for (axis in paste0("soma_dim_", 0:1)) {
+    con_dim <- con_tbl$GetColumnByName(axis)$as_vector()
+    expect_in(con_dim, obs_ids)
+  }
+
+  # Read `varp` layers
+  expect_s3_class(net_qry <- query$varp("network"), "SOMASparseNDArrayRead")
+  net_tbl <- net_qry$tables()$concat()
+  expect_s3_class(net_tbl, "Table")
+  for (axis in paste0("soma_dim_", 0:1)) {
+    net_dim <- net_tbl$GetColumnByName(axis)$as_vector()
+    expect_in(net_dim, var_ids)
+  }
+
+})


### PR DESCRIPTION
Add support for querying `*m` and `*p` layers from `SOMAExperimentAxisQuery`; note, just like `$X()`, these methods only support layers stored as `SOMASparseNDArrays`

Implemented SOMA methods:
 - `SOMAExperimentAxisQuery$obsm()`: read an `obsm` layer for only the coordinates in the query
 - `SOMAExperimentAxisQuery$varm()`: read a `varm` layer for only the coordinates in the query
 - `SOMAExperimentAxisQuery$obsp()`: read an `obsp` layer for only the coordinates in the query
 - `SOMAExperimentAxisQuery$varp()`: read a `varp` layer for only the coordinates in the query

resolves #1997