### PR TITLE
[python] More `nan_append` checks: not-all-NaN, non-dupe IDs

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1258,13 +1258,11 @@ def test_outgest_X_layers(tmp_path):
         assert sorted(list(bdata.layers.keys())) == ["data2", "data3"]
 
 
-@pytest.mark.parametrize("dtype", ["float64", "string"])  # new column dtype
-@pytest.mark.parametrize(
-    "nans", ["all", "none", "some"]
-)  # how many `nan`s in new column?
-@pytest.mark.parametrize(
-    "new_obs_ids", ["all", "none", "half"]
-)  # how many new obs IDs?
+# fmt: off
+@pytest.mark.parametrize("dtype", ["float64", "string"])          # new column dtype
+@pytest.mark.parametrize("nans", ["all", "none", "some"])         # how many `nan`s in new column?
+@pytest.mark.parametrize("new_obs_ids", ["all", "none", "half"])  # how many new obs IDs?
+# fmt: on
 def test_nan_append(adata, dtype, nans, new_obs_ids):
     """Test append-ingesting an AnnData object, including a new `obs` column with various properties:
 

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1258,10 +1258,25 @@ def test_outgest_X_layers(tmp_path):
         assert sorted(list(bdata.layers.keys())) == ["data2", "data3"]
 
 
-@pytest.mark.parametrize("dtype", ["float64", "string"])
-@pytest.mark.parametrize("all_nans", [False, True])
-@pytest.mark.parametrize("new_obs_ids", [False, True])
-def test_nan_append(adata, dtype, all_nans, new_obs_ids):
+@pytest.mark.parametrize("dtype", ["float64", "string"])  # new column dtype
+@pytest.mark.parametrize(
+    "nans", ["all", "none", "some"]
+)  # how many `nan`s in new column?
+@pytest.mark.parametrize(
+    "new_obs_ids", ["all", "none", "half"]
+)  # how many new obs IDs?
+def test_nan_append(adata, dtype, nans, new_obs_ids):
+    """Test append-ingesting an AnnData object, including a new `obs` column with various properties:
+
+    - {all,some,none} of its values are `nan`
+    - dtype string or float
+    - {all,none,half} of its obs IDs already present in the 1st AnnData.
+
+    Prompted by observing a failure when all obs IDs are already present, and a new column has string dtype and contains
+    at least one `nan`. See also:
+    - https://github.com/single-cell-data/TileDB-SOMA/pull/2357
+    - https://github.com/single-cell-data/TileDB-SOMA/pull/2364
+    """
     adata.obsm = None
     adata.varm = None
     adata.obsp = None
@@ -1270,16 +1285,26 @@ def test_nan_append(adata, dtype, all_nans, new_obs_ids):
 
     # Add empty column to obs
     obs = adata.obs
-    obs["batch_id"] = np.nan
-    if not all_nans:
-        elem = "batch_id" if dtype == "string" else 1.0
-        obs.loc[obs.index.tolist()[0], "batch_id"] = elem
+    if nans == "all":
+        obs["batch_id"] = np.nan
+    else:
+        elem = "batch_id" if dtype == "string" else 1.23
+        if nans == "some":
+            obs["batch_id"] = np.nan
+            obs.loc[obs.index.tolist()[0], "batch_id"] = elem
+        else:
+            obs["batch_id"] = elem
+
     obs["batch_id"] = obs["batch_id"].astype(dtype)
 
     # Create a copy of the anndata object
     adata2 = adata.copy()
-    if new_obs_ids:
-        adata2.obs.index = adata2.obs.index + "_2"
+    obs2 = adata2.obs
+    if new_obs_ids == "all":
+        obs2.index = obs2.index + "_2"
+    elif new_obs_ids == "half":
+        half = len(obs2) // 2
+        obs2.index = obs2.index[:half].tolist() + (obs2.index[half:] + "_2").tolist()
 
     # Initial ingest
     SOMA_URI = tempfile.mkdtemp(prefix="soma-exp-")


### PR DESCRIPTION
**Issue and/or context:** [sc-43541](https://app.shortcut.com/tiledb-inc/story/43541/failed-to-convert-buffer-for-attribute-on-ingest), extends #2357

**Changes:** sweep over more configurations when testing AnnData appends with empty columns:
- not all values `nan`
- not all `obs` IDs duplicated between initial and appended AnnData

Per offline discussion with @aaronwolen and @johnkerl.
