### PR TITLE
[python] Check for uniqueness of registration obs/var field-name inputs

### DIFF
--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -68,12 +68,22 @@ class ExperimentIDMapping:
         return cls(obs_axis=obs_mapping, var_axes=var_axes)
 
 
+def _check_dataframe_values(values: List[str], field_name: str) -> List[str]:
+    if len(values) != len(set(values)):
+        raise ValueError(
+            "non-unique registration values have been provided in field {field_name}"
+        )
+    return values
+
+
 def get_dataframe_values(df: pd.DataFrame, field_name: str) -> List[str]:
     """Extracts the label values (e.g. cell barcode, gene symbol) from an AnnData/H5AD
     ``obs`` or ``var`` dataframe."""
     if field_name in df:
-        return [str(e) for e in df[field_name]]
-    if df.index.name in (field_name, "index", None):
-        return list(df.index)
+        values = [str(e) for e in df[field_name]]
+    elif df.index.name in (field_name, "index", None):
+        values = list(df.index)
+    else:
+        raise ValueError(f"could not find field name {field_name} in dataframe")
 
-    raise ValueError(f"could not find field name {field_name} in dataframe")
+    return _check_dataframe_values(values, field_name)

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1,9 +1,9 @@
 """
 Test join-id registrations for ingesting multiple AnnData objects into a single SOMA Experiment.
 """
-
 import math
 import tempfile
+from contextlib import nullcontext
 from typing import Optional, Sequence
 
 import anndata as ad
@@ -1191,8 +1191,8 @@ def test_append_with_nonunique_field_values(
 
     tiledbsoma.io.from_anndata(soma_uri, anndataa, measurement_name=measurement_name)
 
-    if exc is None:
-        # Implicitly expect no throw
+    ctx = pytest.raises(exc) if exc else nullcontext()
+    with ctx:
         tiledbsoma.io.register_anndatas(
             soma_uri,
             [anndatab],
@@ -1200,12 +1200,3 @@ def test_append_with_nonunique_field_values(
             obs_field_name=obs_field_name,
             var_field_name=var_field_name,
         )
-    else:
-        with pytest.raises(exc):
-            tiledbsoma.io.register_anndatas(
-                soma_uri,
-                [anndatab],
-                measurement_name=measurement_name,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-            )


### PR DESCRIPTION
**Issue and/or context:** When non-unique values are present in `obs` or `var` then append-mode ingest, if it uses that non-uniquely-valued field name as registration inputs, will fail at ingestion time with

```
Error: Duplicate coordinates (1413) are not allowed
```

This problem happens during the data write.

**Changes:**

The error should be surfaced earlier, at registration time:

* Before the write has begun
* WIth a more informative error message
* 
**Notes for Reviewer:**