### PR TITLE
[python] `isort`: `tiledbsoma` before `tiledb`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.3.5
     hooks:
     - id: ruff
       args: ["--config=apis/python/pyproject.toml"]

--- a/apis/python/devtools/desc-array-fragments
+++ b/apis/python/devtools/desc-array-fragments
@@ -7,6 +7,7 @@
 import argparse
 
 import pandas as pd
+
 import tiledb
 
 

--- a/apis/python/devtools/ingestor
+++ b/apis/python/devtools/ingestor
@@ -16,7 +16,6 @@ import os
 import sys
 from typing import Optional
 
-import tiledb
 from somacore import options
 
 import tiledbsoma
@@ -26,6 +25,7 @@ import tiledbsoma._util
 import tiledbsoma.io
 import tiledbsoma.logging
 from tiledbsoma.options import SOMATileDBContext
+import tiledb
 
 
 # ================================================================

--- a/apis/python/devtools/outgestor
+++ b/apis/python/devtools/outgestor
@@ -18,11 +18,10 @@ import logging
 import os
 import sys
 
-import tiledb
-
 import tiledbsoma
 import tiledbsoma._util
 import tiledbsoma.io
+import tiledb
 
 logger = logging.getLogger("tiledbsoma")
 

--- a/apis/python/devtools/peek-exp.py
+++ b/apis/python/devtools/peek-exp.py
@@ -8,10 +8,10 @@ import anndata
 import numpy
 import pandas
 import scipy  # noqa: F401
-import tiledb  # noqa: F401
 
 import tiledbsoma
 import tiledbsoma.io
+import tiledb  # noqa: F401
 
 # module aliases
 ad = anndata

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -23,5 +23,11 @@ extend-select = ["I001"]
 fix = true
 exclude = ["*.cc"]
 
-[tool.ruff.isort]
-known-first-party = ["tiledbsoma"]
+[tool.ruff.lint.isort]
+# HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
+section-order = ["future", "standard-library", "third-party", "tiledbsoma", "tiledb", "first-party", "local-folder"]
+no-lines-before = ["tiledb"]
+
+[tool.ruff.lint.isort.sections]
+"tiledbsoma" = ["tiledbsoma"]
+"tiledb" = ["tiledb"]

--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -32,6 +32,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
+
 import tiledb
 
 _ARROW_TO_TDB_ATTR: Dict[Any, Union[str, TypeError]] = {

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -28,9 +28,10 @@ from typing import (
 import attrs
 import somacore
 import somacore.collection
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 from . import _funcs, _tdb_handles
 from ._common_nd_array import NDArray

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -10,9 +10,10 @@ from typing import Optional, Sequence, Tuple, Union, cast
 import numpy as np
 import pyarrow as pa
 import somacore
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 from . import _arrow_types, _util
 from ._tiledb_array import TileDBArray

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -12,9 +12,10 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import somacore
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 from . import _arrow_types, _util
 from . import pytiledbsoma as clib

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -21,10 +21,11 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pacomp
 import somacore
-import tiledb
 from somacore import options
 from somacore.options import PlatformConfig
 from typing_extensions import Self
+
+import tiledb
 
 from . import _util
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -28,10 +28,11 @@ from typing import (
 import attrs
 import numpy as np
 import pyarrow as pa
-import tiledb
 from numpy.typing import DTypeLike
 from somacore import options
 from typing_extensions import Literal, Self
+
+import tiledb
 
 from . import pytiledbsoma as clib
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error

--- a/apis/python/src/tiledbsoma/_tiledb_array.py
+++ b/apis/python/src/tiledbsoma/_tiledb_array.py
@@ -6,9 +6,10 @@
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import pyarrow as pa
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 from . import _tdb_handles, _util
 

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -8,9 +8,10 @@ from contextlib import ExitStack
 from typing import Any, Generic, MutableMapping, Optional, Type, TypeVar, Union
 
 import somacore
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 from . import _constants, _tdb_handles
 from ._exception import SOMAError

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -13,8 +13,9 @@ from typing import (
 from unittest import mock
 
 import anndata as ad
-import tiledb
 from anndata._core import file_backing
+
+import tiledb
 
 from .._types import Path
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -36,10 +36,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
-import tiledb
 from anndata._core.sparse_dataset import SparseDataset
 from somacore.options import PlatformConfig
 from typing_extensions import get_args
+
+import tiledb
 
 from .. import (
     Collection,

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -10,9 +10,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Literal, Mapping, Optional, Union
 
-import tiledb
 from somacore import ContextBase
 from typing_extensions import Self
+
+import tiledb
 
 from .. import pytiledbsoma as clib
 from .._types import OpenTimestamp

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -15,9 +15,10 @@ from typing import (
 
 import attrs as attrs_  # We use the name `attrs` later.
 import attrs.validators as vld  # Short name because we use this a bunch.
-import tiledb
 from somacore import options
 from typing_extensions import Self
+
+import tiledb
 
 # Most defaults are configured directly as default attribute values
 # within TileDBCreateOptions.

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -10,13 +10,13 @@ import pandas as pd
 import pytest
 import scipy
 import somacore
-import tiledb
 
 import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import Experiment, _constants, _factory
 from tiledbsoma._tiledb_object import TileDBObject
 from tiledbsoma._util import verify_obs_var
+import tiledb
 
 from ._util import TESTDATA
 

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -11,10 +11,11 @@ from typeguard import suppress_type_checks
 from typing_extensions import Literal
 
 import tiledbsoma as soma
-from tests._util import raises_no_typeguard
 from tiledbsoma import _collection, _factory, _tiledb_object
 from tiledbsoma._exception import DoesNotExistError
 from tiledbsoma.options import SOMATileDBContext
+
+from tests._util import raises_no_typeguard
 
 
 # ----------------------------------------------------------------

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -3,9 +3,9 @@ import time
 from unittest import mock
 
 import pytest
-import tiledb
 
 import tiledbsoma.options._soma_tiledb_context as stc
+import tiledb
 
 
 @pytest.fixture(autouse=True)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -6,10 +6,11 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 import somacore
-import tiledb
 from pandas.api.types import union_categoricals
 
 import tiledbsoma as soma
+import tiledb
+
 from tests._util import raises_no_typeguard
 
 

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pyarrow as pa
 import pytest
-import tiledb
 
 import tiledbsoma as soma
+import tiledb
 
 
 @pytest.fixture

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -4,10 +4,10 @@ from typing import Tuple
 import numpy as np
 import pyarrow as pa
 import pytest
-import tiledb
 
 import tiledbsoma as soma
 from tiledbsoma.options import SOMATileDBContext
+import tiledb
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
 from ._util import raises_no_typeguard

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -7,16 +7,17 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-import tiledb
 from pyarrow import ArrowInvalid
 from scipy import sparse
 from somacore import AxisQuery, options
 
 import tiledbsoma as soma
-from tests._util import raises_no_typeguard
 from tiledbsoma import SOMATileDBContext, _factory
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma.experiment_query import X_as_series
+import tiledb
+
+from tests._util import raises_no_typeguard
 
 # Number of features for the embeddings layer
 N_FEATURES = 50

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -3,10 +3,10 @@ from typing import Type
 
 import numpy as np
 import pytest
-import tiledb
 
 import tiledbsoma as soma
 from tiledbsoma import _constants
+import tiledb
 
 UNKNOWN_ENCODING_VERSION = "3141596"
 

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -7,8 +7,9 @@ import pytest
 from typeguard import suppress_type_checks
 
 import tiledbsoma as soma
-from tests._util import raises_no_typeguard
 from tiledbsoma import _factory
+
+from tests._util import raises_no_typeguard
 
 """"
 Metadata handling tests for all SOMA foundational datatypes.

--- a/apis/python/tests/test_notebook_sparse_dense.py
+++ b/apis/python/tests/test_notebook_sparse_dense.py
@@ -2,6 +2,7 @@ import pytest
 
 import tiledbsoma
 import tiledbsoma.io
+
 from tests._util import PY_ROOT
 
 

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -1,12 +1,12 @@
 import tempfile
 
 import pytest
-import tiledb
 
 import tiledbsoma
 import tiledbsoma.io
 import tiledbsoma.options._tiledb_create_options as tco
 from tiledbsoma._util import verify_obs_var
+import tiledb
 
 
 @pytest.mark.skip(reason="No longer return ArraySchema - see note in test")

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -3,12 +3,12 @@
 import os
 
 import pytest
-import tiledb
 
 import tiledbsoma.pytiledbsoma as clib
 from tiledbsoma._arrow_types import tiledb_schema_to_arrow
 from tiledbsoma._exception import SOMAError
 from tiledbsoma._query_condition import QueryCondition
+import tiledb
 
 VERBOSE = False
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -12,11 +12,11 @@ import numpy as np
 import pyarrow as pa
 import pytest
 import scipy.sparse as sparse
-import tiledb
 
 import tiledbsoma as soma
 from tiledbsoma import _factory
 from tiledbsoma.options import SOMATileDBContext
+import tiledb
 
 from . import NDARRAY_ARROW_TYPES_NOT_SUPPORTED, NDARRAY_ARROW_TYPES_SUPPORTED
 from ._util import raises_no_typeguard

--- a/apis/python/tests/test_tiledbobject.py
+++ b/apis/python/tests/test_tiledbobject.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
+
 from tests._util import raises_no_typeguard
 
 # Checking that objects _do_ exist is already done (thoroughly) in other tests. Here

--- a/apis/python/tests/test_util_tiledb.py
+++ b/apis/python/tests/test_util_tiledb.py
@@ -1,8 +1,8 @@
 import pyarrow as pa
 import pytest
-import tiledb
 
 import tiledbsoma as soma
+import tiledb
 
 
 def test_stats(tmp_path, capsys: pytest.CaptureFixture[str]):

--- a/data/simple/ij_test1/gen.py
+++ b/data/simple/ij_test1/gen.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import tiledb
 
 # Reference/label array

--- a/scripts/show-versions.py
+++ b/scripts/show-versions.py
@@ -8,9 +8,9 @@ import pandas as pd
 import pyarrow as pa
 import scanpy as sc
 import scipy as sp
-import tiledb
 
 import tiledbsoma
+import tiledb
 
 print("tiledbsoma.__version__   ", tiledbsoma.__version__)
 print("tiledb.version()         ", ".".join(str(e) for e in tiledb.version()))


### PR DESCRIPTION
(hopefully temporary) workaround for #2293

**Changes:** make `isort` (⟹ `ruff` ⟹ `pre-commit`) sort `import tiledb` after `tiledbsoma`

**Notes for Reviewer:**
- Alternative to #2379 
- 2 substantive changes (the rest of the diff is import-sorting c/o `pre-commit`):
  - [`.pre-commit-config.yaml`](https://github.com/single-cell-data/TileDB-SOMA/pull/2381/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9): upgrade `ruff` used in `pre-commit` to [0.3.5](https://pypi.org/project/ruff/0.3.5/)
  - [`pyproject.toml`](https://github.com/single-cell-data/TileDB-SOMA/pull/2381/files#diff-7816b85cdf8888b32a92468aba0d05152ff122098795b7a76d39a4a92c046f0f) new `ruff.lint.isort` configs