### PR TITLE
[python] Enforce if-not-exists semantics for append/registration

### DIFF
--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -349,7 +349,10 @@ class ExperimentAmbientLabelMapping:
     ) -> Self:
         """Acquires label-to-ID mappings from the baseline, already-written SOMA experiment."""
 
-        if experiment_uri is not None and tiledbsoma.Experiment.exists(experiment_uri):
+        if experiment_uri is not None:
+            if not tiledbsoma.Experiment.exists(experiment_uri):
+                raise ValueError("cannot find experiment at URI {experiment_uri}")
+
             # Pre-check
             with tiledbsoma.Experiment.open(experiment_uri, context=context) as exp:
                 if measurement_name not in exp.ms:
@@ -387,7 +390,10 @@ class ExperimentAmbientLabelMapping:
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
         """Extends registration data from the baseline, already-written SOMA
-        experiment to include multiple H5AD input files."""
+        experiment to include multiple H5AD input files. If ``experiment_uri``
+        is ``None`` then you will be computing registrations only for the input
+        ``AnnData`` objects. If ``experiment_uri`` is not ``None`` then it is
+        an error if the experiment is not accessible."""
 
         registration_data = cls._acquire_experiment_mappings(
             experiment_uri,

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1130,3 +1130,20 @@ def test_ealm_expose():
     # However, the pre-commit hook will strip out this import statement as "unused".
     # So, assert something.
     assert tiledbsoma.io.ExperimentAmbientLabelMapping is not None
+
+
+def test_append_registration_with_nonexistent_storage(tmp_path):
+    anndata1 = create_anndata_canned(1, "obs_id", "var_id")
+    anndata2 = create_anndata_canned(2, "obs_id", "var_id")
+    soma_uri = tmp_path.as_posix()
+
+    tiledbsoma.io.from_anndata(soma_uri, anndata1, measurement_name="RNA")
+
+    with pytest.raises(ValueError):
+        tiledbsoma.io.register_anndatas(
+            soma_uri + "-nonesuch",
+            [anndata2],
+            measurement_name="RNA",
+            obs_field_name="obs_id",
+            var_field_name="var_id",
+        )


### PR DESCRIPTION
**Issue and/or context:**

There are two use-cases for registration:

* The SOMA Experiment does not exist, and there are one or more `AnnData` objects to be registered and then ingested.
  * This user intent is signaled by passing `experiment_uri=None` to the registrar
* The SOMA Experiment does exist, and there are one or more `AnnData` objects to be co-registered with the existing experiment, and then the `AnnData` objects are to be ingested
  * This user intent is signaled by passing a non-empty `experiment_uri` to the registrar

Due to an unforunate implementation bug (in the code touched by this PR) these two use-cases were getting conflated.

**Changes:**

* Raise an exception if the `experiment_uri` passed to the registrar is not `None`. This is a non-breaking change, since the existing docstrings already make it sound like what this PR is doing was already the case.
* Make the docstrings even clearer
* Unit-test the behavior

**Notes for Reviewer:**

[sc-44602]