### PR TITLE
[r/ci] Unbreak wheel builds

### DIFF
--- a/libtiledbsoma/src/external/src/nanoarrow/nanoarrow.c
+++ b/libtiledbsoma/src/external/src/nanoarrow/nanoarrow.c
@@ -1712,6 +1712,10 @@ int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t
     return snprintf(out, n, "[invalid: schema is released]");
   }
 
+  if (out == NULL) {
+    return 0;
+  }
+
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 


### PR DESCRIPTION
**Issue and/or context:**

#2393

**Changes:**

`nanoarrow.c` mods were passing all regular per-commit CI but were failing wheel builds which are done nightly, and at release time.

Compile error appearing in wheel builds:
```
    /project/tiledbsoma-1.5.0rc0.post284.dev1878736499/dist_links/libtiledbsoma/src/utils/nanoarrow.c:1775:28: error: null destination pointer [-Werror=format-truncation=]
     1775 |     n_chars_last = snprintf(out, n, ">");
          |                    ~~~~~~~~^~~~~~~~~~~~~
```

**Notes for Reviewer:**

This unblocks my attempt to tag 1.9.4.

Validation: I manually ran https://github.com/single-cell-data/TileDB-SOMA/actions/runs/8572181618/job/23494196523 with PR #2390 which is essentially this PR.