### PR TITLE
[c++] Address final `valgrind` issue

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -298,14 +298,6 @@ std::pair<const void*, std::size_t> ArrowAdapter::_get_data_and_length(
     }
 }
 
-bool ArrowAdapter::_isstr(const char* format) {
-    if ((strcmp(format, "U") == 0) || (strcmp(format, "Z") == 0) ||
-        (strcmp(format, "u") == 0) || (strcmp(format, "z") == 0)) {
-        return true;
-    }
-    return false;
-}
-
 inline void exitIfError(const ArrowErrorCode ec, const std::string& msg) {
     if (ec != NANOARROW_OK)
         throw TileDBSOMAError(
@@ -448,10 +440,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         exitIfError(
             ArrowArrayAllocateChildren(dict_arr, 0),
             "Bad array children alloc");
-        const int n_buf = ArrowAdapter::_isstr(dict_sch->format) == true ? 3 :
-                                                                           2;
-        dict_arr->buffers = (const void**)malloc(sizeof(void*) * n_buf);
-        dict_arr->buffers[0] = nullptr;  // validity: none here
+        // hook up our custom release function
         dict_arr->release = &release_array;
 
         // TODO string types currently get the data and offset

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -358,6 +358,9 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     // After allocating and initializing via nanoarrow we
     // hook our custom release function in
     array->release = &release_array;
+    if (array->private_data != nullptr) { // as we use nanoarrow's init
+        free(array->private_data);        // free what was allocated before
+    }                                     // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(fmt::format(

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -350,9 +350,9 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     // After allocating and initializing via nanoarrow we
     // hook our custom release function in
     array->release = &release_array;
-    if (array->private_data != nullptr) { // as we use nanoarrow's init
-        free(array->private_data);        // free what was allocated before
-    }                                     // assigning our ArrowBuffer pointer
+    if (array->private_data != nullptr) {  // as we use nanoarrow's init
+        free(array->private_data);         // free what was allocated before
+    }                                      // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(fmt::format(


### PR DESCRIPTION
**Issue and/or context:**

When running under `valgrind` (by for example calling an R script or expression and starting as `R -q -d valgrind`) and with the proper `memcheck` instrumentation for chasing leaks, we were reminded that we lost a small fixed amoumt of 248 bytes per column retrieved.  This was due to allocating the (opaque) `private_data` by default and then (as we do here for buffer management) store the ArrowBuffer / ColumnBuffer container handle.  

**Changes:**

By freeing the default allocation before assigning, we no longer leak.  We also removed another small assignment (and helper function used) taken care of now by `nanoarrow` following #2188.

**Notes for Reviewer:**

[SC 44774](https://app.shortcut.com/tiledb-inc/story/44774/c-squash-final-valgrind-leak)
