### PR TITLE
[r] Port resume-mode to R

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99
+Version: 1.10.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NAMESPACE
+++ b/apis/r/NAMESPACE
@@ -2,6 +2,8 @@
 
 S3method("[[",MappingBase)
 S3method("[[<-",MappingBase)
+S3method(.read_soma_joinids,SOMADataFrame)
+S3method(.read_soma_joinids,SOMASparseNDArray)
 S3method(as.list,CoordsStrider)
 S3method(as.list,MappingBase)
 S3method(iterators::nextElem,CoordsStrider)

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,7 @@
 * Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
 * Add support for blockwise iteration
 * Make `reopen()` a public method for all `TileDBObjects`
+* Add support for resume-mode in `write_soma()`
 
 # 1.7.0
 

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -1,198 +1,402 @@
 
-#' @title Create SOMA DataFrame
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#' Create SOMA DataFrame
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
 #' @param uri URI for the TileDB object
-#' @param schema schema Arrow schema argument passed on to DataFrame$create()
-#' @param index_column_names Index column names passed on to DataFrame$create()
+#' @param schema Arrow schema argument for the \link[SOMADataFrame]{SOMA dataframe}
+#' @param index_column_names A vector of column names to use as user-defined
+#' index columns; all named columns must exist in the schema, and at least
+#' one index column name is required
+#' @param ingest_mode Ingestion mode when creating the TileDB object; choose from:
+#' \itemize{
+#'  \item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+#'  \item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+#'   if it already exists, simply open it for writing
+#' }
 #' @param platform_config Optional platform configuration
 #' @param tiledbsoma_ctx Optional SOMATileDBContext
 #' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#'
 #' @export
-SOMADataFrameCreate <- function(uri, schema, index_column_names = c("soma_joinid"),
-                                platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    sdf <- SOMADataFrame$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp, internal_use_only = "allowed_use")
-    sdf$create(schema, index_column_names=index_column_names, platform_config=platform_config, internal_use_only = "allowed_use")
-
-    sdf
+#'
+SOMADataFrameCreate <- function(
+  uri,
+  schema,
+  index_column_names = c("soma_joinid"),
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  sdf <- SOMADataFrame$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(sdf$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    sdf$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
+    sdf$create(
+      schema,
+      index_column_names = index_column_names,
+      platform_config = platform_config,
+      internal_use_only = "allowed_use"
+    )
+  }
+  return(sdf)
 }
 
-#' @title Open SOMA DataFrame
-#' @description Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
+#' Open SOMA DataFrame
+#'
+#' Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
 #' @param mode One of `"READ"` or `"WRITE"`
 #' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp.
+#' In READ mode, defaults to the current time. If non-NULL, then all members
+#' accessed through the collection object inherit the timestamp.
+#'
 #' @export
-SOMADataFrameOpen <- function(uri, mode="READ",
-                              platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    sdf <- SOMADataFrame$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                             internal_use_only = "allowed_use")
-    sdf$open(mode, internal_use_only = "allowed_use")
-    sdf
+#'
+SOMADataFrameOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  sdf <- SOMADataFrame$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  sdf$open(mode, internal_use_only = "allowed_use")
+  return(sdf)
 }
 
-#' @title Create SOMA Sparse Nd Array
-#' @description Factory function to create a SOMASparseNDArray for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
+#' Create SOMA Sparse Nd Array
+#'
+#' Factory function to create a SOMASparseNDArray for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
 #' @param type An [Arrow type][arrow::data-type] defining the type of each element in the array.
 #' @param shape A vector of integers defining the shape of the array.
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#'
 #' @export
-SOMASparseNDArrayCreate <- function(uri, type, shape,
-                                    platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    snda <- SOMASparseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                  internal_use_only = "allowed_use")
-    snda$create(type, shape, platform_config=platform_config, internal_use_only = "allowed_use")
-    snda
+#'
+SOMASparseNDArrayCreate <- function(
+  uri,
+  type,
+  shape,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  snda <- SOMASparseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(snda$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    snda$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
+    snda$create(
+      type,
+      shape,
+      platform_config = platform_config,
+      internal_use_only = "allowed_use"
+    )
+  }
+  return(snda)
 }
 
-#' @title Open SOMA Sparse Nd Array
-#' @description Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Open SOMA Sparse Nd Array
+#'
+#' Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMASparseNDArrayOpen <- function(uri, mode="READ",
-                                  platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    snda <- SOMASparseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                  internal_use_only = "allowed_use")
-    snda$open(mode, internal_use_only = "allowed_use")
-    snda
+#'
+SOMASparseNDArrayOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  snda <- SOMASparseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  snda$open(mode, internal_use_only = "allowed_use")
+  return(snda)
 }
 
-#' @title Create SOMA Dense Nd Array
-#' @description Factory function to create a SOMADenseNDArray for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param type An [Arrow type][arrow::data-type] defining the type of each element in the array.
-#' @param shape A vector of integers defining the shape of the array.
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Dense Nd Array
+#'
+#' Factory function to create a SOMADenseNDArray for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMASparseNDArrayCreate
+#'
 #' @export
-SOMADenseNDArrayCreate <- function(uri, type, shape,
-                                   platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    dnda <- SOMADenseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                 internal_use_only = "allowed_use")
-    dnda$create(type, shape, platform_config=platform_config, internal_use_only = "allowed_use")
-    dnda
+#'
+SOMADenseNDArrayCreate <- function(
+  uri,
+  type,
+  shape,
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  dnda <- SOMADenseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  dnda$create(
+    type,
+    shape,
+    platform_config = platform_config,
+    internal_use_only = "allowed_use"
+  )
+  return(dnda)
 }
 
-#' @title Open SOMA Dense Nd Array
-#' @description Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Open SOMA Dense Nd Array
+#'
+#' Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMADenseNDArrayOpen <- function(uri, mode="READ",
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    dnda <- SOMADenseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                 internal_use_only = "allowed_use")
-    dnda$open(mode, internal_use_only = "allowed_use")
-    dnda
+#'
+SOMADenseNDArrayOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  dnda <- SOMADenseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  dnda$open(mode, internal_use_only = "allowed_use")
+  return(dnda)
 }
 
-#' @title Create SOMA Collection
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Collection
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMACollectionCreate <- function(uri,
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    coll <- SOMACollection$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                               internal_use_only = "allowed_use")
+#'
+SOMACollectionCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  coll <- SOMACollection$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(coll$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    coll$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     coll$create(internal_use_only = "allowed_use")
-    coll
+  }
+  return(coll)
 }
 
-#' @title Open SOMA Collection
-#' @description Factory function to open a SOMACollection for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Collection
+#'
+#' Factory function to open a SOMACollection for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMACollectionOpen <- function(uri, mode="READ",
-                               platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    coll <- SOMACollection$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                               internal_use_only = "allowed_use")
-    coll$open(mode, internal_use_only = "allowed_use")
-    coll
+#'
+SOMACollectionOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  coll <- SOMACollection$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  coll$open(mode, internal_use_only = "allowed_use")
+  return(coll)
 }
 
-#' @title Create SOMA Measurement
-#' @description Factory function to create a SOMAMeasurement for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Measurement
+#'
+#' Factory function to create a SOMAMeasurement for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMAMeasurementCreate <- function(uri,
-                                  platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    meas <- SOMAMeasurement$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                internal_use_only = "allowed_use")
+#'
+SOMAMeasurementCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  meas <- SOMAMeasurement$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(meas$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    meas$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     meas$create(internal_use_only = "allowed_use")
-    meas
+  }
+  return(meas)
 }
 
-#' @title Open SOMA Measurement
-#' @description Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Measurement
+#'
+#' Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMAMeasurementOpen <- function(uri, mode="READ",
-                                platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    meas <- SOMAMeasurement$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                internal_use_only = "allowed_use")
-    meas$open(mode, internal_use_only = "allowed_use")
-    meas
+#'
+SOMAMeasurementOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  meas <- SOMAMeasurement$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  meas$open(mode, internal_use_only = "allowed_use")
+  return(meas)
 }
 
-#' @title Create SOMA Experiment
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Experiment
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMAExperimentCreate <- function(uri,
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    exp <- SOMAExperiment$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                              internal_use_only = "allowed_use")
+#'
+SOMAExperimentCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  exp <- SOMAExperiment$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(exp$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    exp$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     exp$create(internal_use_only = "allowed_use")
-    exp
+  }
+  return(exp)
 }
 
-#' @title Open SOMA Experiment
-#' @description Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Experiment
+#'
+#' Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMAExperimentOpen <- function(uri, mode="READ",
-                               platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    exp <- SOMAExperiment$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                              internal_use_only = "allowed_use")
-    exp$open(mode, internal_use_only = "allowed_use")
-    exp
+#'
+SOMAExperimentOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  exp <- SOMAExperiment$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  exp$open(mode, internal_use_only = "allowed_use")
+  return(exp)
 }

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -83,15 +83,18 @@ TileDBObject <- R6::R6Class(
     #'  \item \dQuote{\code{WRITE}}
     #' }
     #' By default, reopens in the opposite mode of the current mode
+    #' @param force Force a close/reopen cycle; by default, if \code{mode} is
+    #' \code{self$mode()}, \code{reopen()} does nothing
     #'
     #' @return Invisibly returns \code{self}
     #'
-    reopen = function(mode = NULL) {
+    reopen = function(mode = NULL, force = FALSE) {
+      stopifnot("'force' must be TRUE or FALSE" = is_scalar_logical(force))
       modes <- c(READ = 'WRITE', WRITE = 'READ')
       oldmode <- self$mode()
       mode <- mode %||% modes[oldmode]
       mode <- match.arg(mode, choices = modes)
-      if (mode != oldmode) {
+      if (isTRUE(force) || mode != oldmode) {
         self$close()
         self$open(mode, internal_use_only = 'allowed_use')
       }

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -94,6 +94,18 @@ uns_hint <- function(type = c('1d', '2d')) {
   })
 }
 
+.maybe_muffle <- function(w, cond = getOption('verbose', default = FALSE)) {
+  if (isTRUE(x = cond)) {
+    warning(warningCondition(
+      message = conditionMessage(w),
+      class = setdiff(class(w), c('warning', 'simpleError', 'error', 'condition')),
+      call = conditionCall(w)
+    ))
+  } else {
+    tryInvokeRestart('muffleWarning')
+  }
+}
+
 #' Read the SOMA Join IDs from an Array
 #'
 #' @param x A \code{\link{SOMASparseNDarray}} or \code{\link{SOMADataFrame}}

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -138,7 +138,7 @@ uns_hint <- function(type = c('1d', '2d')) {
 .read_soma_joinids.SOMASparseNDArray <- function(x, axis = 0L, ...) {
   stopifnot(
     "'axis' must be a single positive integer" = is.integer(axis) &&
-      length(axis) == 1L,
+      length(axis) == 1L
   )
   if (axis < 0L || axis >= length(x$dimnames())) {
     stop("'axis' must be between 0 and ", length(x$dimnames()), call. = FALSE)

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -94,6 +94,66 @@ uns_hint <- function(type = c('1d', '2d')) {
   })
 }
 
+#' Read the SOMA Join IDs from an Array
+#'
+#' @param x A \code{\link{SOMASparseNDarray}} or \code{\link{SOMADataFrame}}
+#'
+#' @return An \code{\link[bit64]{integer64}} vector with the SOMA join IDs
+#'
+#' @keywords internal
+#'
+#' @noRd
+#'
+.read_soma_joinids <- function(x, ...) {
+  stopifnot(inherits(x = x, what = 'TileDBArray'))
+  oldmode <- x$mode()
+  on.exit(x$reopen(oldmode), add = TRUE, after = FALSE)
+  op <- options(arrow.int64_downcast = FALSE)
+  on.exit(options(op), add = TRUE, after = FALSE)
+  ids <- UseMethod(generic = '.read_soma_joinids', object = x)
+  return(ids)
+}
+
+#' @rdname dot-read_soma_joinids
+#'
+#' @noRd
+#'
+#' @method .read_soma_joinids SOMADataFrame
+#' @export
+#'
+.read_soma_joinids.SOMADataFrame <- function(x, ...) {
+  x$reopen("READ")
+  return(x$read(column_names = "soma_joinid")$concat()$GetColumnByName("soma_joinid")$as_vector())
+}
+
+#' @param axis Which dimension to read (zero-based)
+#'
+#' @rdname dot-read_soma_joinids
+#'
+#' @noRd
+#'
+#' @method .read_soma_joinids SOMASparseNDArray
+#' @export
+#'
+.read_soma_joinids.SOMASparseNDArray <- function(x, axis = 0L, ...) {
+  stopifnot(
+    "'axis' must be a single positive integer" = is.integer(axis) &&
+      length(axis) == 1L,
+  )
+  if (axis < 0L || axis >= length(x$dimnames())) {
+    stop("'axis' must be between 0 and ", length(x$dimnames()), call. = FALSE)
+  }
+  x$reopen("READ")
+  dimname <- x$dimnames()[axis + 1L]
+  rl <- sr_setup(
+    uri = x$uri,
+    config = as.character(tiledb::config(x$tiledbsoma_ctx$context())),
+    colnames = dimname,
+    timestamp_end = x$.__enclos_env__$private$tiledb_timestamp
+  )
+  return(TableReadIter$new(rl$sr)$concat()$GetColumnByName(dimname)$as_vector())
+}
+
 #' Pad Names of a Character Vector
 #'
 #' Fill in missing names of a vector using missing values of said vector

--- a/apis/r/R/write_bioc.R
+++ b/apis/r/R/write_bioc.R
@@ -10,6 +10,7 @@ write_soma.DataFrame <- function(
   df_index = NULL,
   index_column_names = 'soma_joinid',
   ...,
+  ingest_mode = 'write',
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -30,6 +31,7 @@ write_soma.DataFrame <- function(
     df_index = df_index,
     index_column_names = index_column_names,
     ...,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx,
     relative = relative
@@ -49,6 +51,7 @@ write_soma.Hits <- function(
   type = NULL,
   transpose = FALSE,
   ...,
+  ingest_mode = 'write',
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -61,6 +64,7 @@ write_soma.Hits <- function(
     type = type,
     transpose = transpose,
     ...,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx,
     relative = relative
@@ -71,6 +75,7 @@ write_soma.Hits <- function(
 #' object to a SOMA
 #'
 #' @inheritParams write_soma
+#' @inheritParams write_soma_objects
 #' @param ms_name Name for resulting measurement; defaults to
 #' \code{\link[SingleCellExperiment]{mainExpName}(x)}
 #'
@@ -99,17 +104,30 @@ write_soma.SingleCellExperiment <- function(
   uri,
   ms_name = NULL,
   ...,
+  ingest_mode = 'write',
   platform_config = NULL,
   tiledbsoma_ctx = NULL
 ) {
   check_package('SingleCellExperiment', version = .MINIMUM_SCE_VERSION())
+  ingest_mode <- match.arg(arg = ingest_mode, choices = c('write', 'resume'))
+  if ('shape' %in% names(args <- rlang::dots_list(...))) {
+    shape <- args$shape
+    stopifnot(
+      "'shape' must be a vector of two postiive integers" = is.null(shape) ||
+        (rlang::is_integerish(shape, n = 2L, finite = TRUE) && all(shape > 0L))
+    )
+  } else {
+    shape <- NULL
+  }
   ms_name <- ms_name %||% SingleCellExperiment::mainExpName(x)
+
   uri <- NextMethod(
     'write_soma',
     x,
     uri = uri,
     ms_name = ms_name,
     ...,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
@@ -119,97 +137,99 @@ write_soma.SingleCellExperiment <- function(
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  on.exit(expr = experiment$close(), add = TRUE)
+  on.exit(expr = experiment$close(), add = TRUE, after = FALSE)
+
   ms <- experiment$ms$get(ms_name)
+  on.exit(ms$close(), add = TRUE, after = FALSE)
 
   # Write reduced dimensions
   spdl::info("Adding reduced dimensions")
-  obsm <- tryCatch(
-    expr = ms$obsm,
-    error = function(...) {
-      return(NULL)
-    }
-  )
-  if (is.null(obsm)) {
+  if (!'obsm' %in% ms$names()) {
     ms$obsm <- SOMACollectionCreate(
       uri = file.path(ms$uri, 'obsm'),
+      ingest_mode = ingest_mode,
       platform_config = platform_config,
       tiledbsoma_ctx = tiledbsoma_ctx
     )
-    obsm <- ms$obsm
+  } else {
+    ms$obsm$reopen("WRITE")
   }
   for (rd in SingleCellExperiment::reducedDimNames(x)) {
     spdl::info("Adding reduced dimension {}", rd)
-    obsm$set(
-      object = write_soma(
-        x = SingleCellExperiment::reducedDim(x, rd),
-        uri = rd,
-        soma_parent = obsm,
-        sparse = TRUE,
-        platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx
-      ),
-      name = rd
+    write_soma(
+      x = SingleCellExperiment::reducedDim(x, rd),
+      uri = rd,
+      soma_parent = ms$obsm,
+      sparse = TRUE,
+      key = rd,
+      ingest_mode = ingest_mode,
+      shape = if (is.null(shape)) {
+        NULL
+      } else {
+        c(shape[2L], ncol(SingleCellExperiment::reducedDim(x, rd)))
+      },
+      platform_config = platform_config,
+      tiledbsoma_ctx = tiledbsoma_ctx
     )
   }
 
   # Write nearest-neighbor graphs
-  obsp <- tryCatch(
-    expr = ms$obsp,
-    error = function(...) {
-      return(NULL)
-    }
-  )
-  if (is.null(obsp)) {
+  if (!'obsp' %in% ms$names()) {
     ms$obsp <- SOMACollectionCreate(
       uri = file.path(ms$uri, 'obsp'),
+      ingest_mode = ingest_mode,
       platform_config = platform_config,
       tiledbsoma_ctx = tiledbsoma_ctx
     )
-    obsp <- ms$obsp
+  } else {
+    ms$obsp$reopen("WRITE")
   }
   for (cp in SingleCellExperiment::colPairNames(x)) {
     spdl::info("Adding colPair {}", cp)
-    obsp$set(
-      object = write_soma(
-        x = SingleCellExperiment::colPair(x, cp),
-        uri = cp,
-        soma_parent = obsp,
-        sparse = TRUE,
-        platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx
-      ),
-      name = cp
+    write_soma(
+      x = SingleCellExperiment::colPair(x, cp),
+      uri = cp,
+      soma_parent = obsp,
+      sparse = TRUE,
+      key = cp,
+      ingest_mode = ingest_mode,
+      shape = if (is.null(shape)) {
+        NULL
+      } else {
+        rep_len(shape[2L], length.out = 2L)
+      },
+      platform_config = platform_config,
+      tiledbsoma_ctx = tiledbsoma_ctx
     )
   }
 
   # Write coexpression networks
-  varp <- tryCatch(
-    expr = ms$varp,
-    error = function(...) {
-      return(NULL)
-    }
-  )
-  if (is.null(varp)) {
+  if (!'varp' %in% ms$names()) {
     ms$varp <- SOMACollectionCreate(
       uri = file.path(ms$uri, 'varp'),
+      ingest_mode = ingest_mode,
       platform_config = platform_config,
       tiledbsoma_ctx = tiledbsoma_ctx
     )
-    varp <- ms$varp
+  } else {
+    ms$varp$reopen("WRITE")
   }
   for (rp in SingleCellExperiment::rowPairNames(x)) {
     spdl::info("Adding rowPair {}", rp)
-    varp$set(
-      object = write_soma(
-        x = SingleCellExperiment::rowPair(x, rp),
-        uri = rp,
-        soma_parent = varp,
-        sparse = TRUE,
-        platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx
-      ),
-      name = rp
+    write_soma(
+      x = SingleCellExperiment::rowPair(x, rp),
+      uri = rp,
+      soma_parent = varp,
+      sparse = TRUE,
+      key = rp,
+      ingest_mode = ingest_mode,
+      shape = if (is.null(shape)) {
+        NULL
+      } else {
+        rep_len(shape[1L], length.out = 2L)
+      },
+      platform_config = platform_config,
+      tiledbsoma_ctx = tiledbsoma_ctx
     )
   }
 
@@ -221,6 +241,7 @@ write_soma.SingleCellExperiment <- function(
 #' object to a SOMA
 #'
 #' @inheritParams write_soma
+#' @inheritParams write_soma_objects
 #' @param ms_name Name for resulting measurement
 #'
 #' @inherit write_soma return
@@ -251,6 +272,7 @@ write_soma.SummarizedExperiment <- function(
   uri,
   ms_name,
   ...,
+  ingest_mode = 'write',
   platform_config = NULL,
   tiledbsoma_ctx = NULL
 ) {
@@ -262,12 +284,24 @@ write_soma.SummarizedExperiment <- function(
       nzchar(ms_name) &&
       !is.na(ms_name)
   )
+  ingest_mode <- match.arg(arg = ingest_mode, choices = c('write', 'resume'))
+  if ('shape' %in% names(args <- rlang::dots_list(...))) {
+    shape <- args$shape
+    stopifnot(
+      "'shape' must be a vector of two postiive integers" = is.null(shape) ||
+        (rlang::is_integerish(shape, n = 2L, finite = TRUE) && all(shape > 0L))
+    )
+  } else {
+    shape <- NULL
+  }
+
   experiment <- SOMAExperimentCreate(
     uri = uri,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  on.exit(experiment$close(), add = TRUE)
+  on.exit(experiment$close(), add = TRUE, after = FALSE)
 
   # Write cell-level meta data (obs)
   spdl::info("Adding colData")
@@ -277,6 +311,7 @@ write_soma.SummarizedExperiment <- function(
     x = obs_df,
     uri = 'obs',
     soma_parent = experiment,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
@@ -286,6 +321,7 @@ write_soma.SummarizedExperiment <- function(
   experiment$add_new_collection(
     object = SOMACollectionCreate(
       file_path(experiment$uri, 'ms'),
+      ingest_mode = ingest_mode,
       platform_config = platform_config,
       tiledbsoma_ctx = tiledbsoma_ctx
     ),
@@ -294,30 +330,39 @@ write_soma.SummarizedExperiment <- function(
   ms_uri <- .check_soma_uri(uri = ms_name, soma_parent = experiment$ms)
   ms <- SOMAMeasurementCreate(
     uri = ms_uri,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
-  ms$X <- SOMACollectionCreate(
-    uri = file.path(ms$uri, 'X'),
-    platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx
-  )
+  on.exit(ms$close(), add = TRUE, after = FALSE)
+
+  if (!'X' %in% ms$names()) {
+    ms$X <- SOMACollectionCreate(
+      uri = file.path(ms$uri, 'X'),
+      ingest_mode = ingest_mode,
+      platform_config = platform_config,
+      tiledbsoma_ctx = tiledbsoma_ctx
+    )
+  } else {
+    ms$X$reopen("WRITE")
+  }
+  on.exit(ms$X$close(), add = TRUE, after = FALSE)
+
   for (assay in SummarizedExperiment::assayNames(x)) {
     spdl::info("Adding {} assay", assay)
-    ms$X$set(
-      object = write_soma(
-        x = SummarizedExperiment::assay(x, assay),
-        uri = assay,
-        soma_parent = ms$X,
-        sparse = TRUE,
-        transpose = TRUE,
-        platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx
-      ),
-      name = assay
+    write_soma(
+      x = SummarizedExperiment::assay(x, assay),
+      uri = assay,
+      soma_parent = ms$X,
+      sparse = TRUE,
+      transpose = TRUE,
+      key = assay,
+      ingest_mode = ingest_mode,
+      shape = rev(shape),
+      platform_config = platform_config,
+      tiledbsoma_ctx = tiledbsoma_ctx
     )
   }
-  ms$X$close()
 
   # Write feature-level meta data
   spdl::info("Adding rowData")
@@ -329,11 +374,11 @@ write_soma.SummarizedExperiment <- function(
     x = var_df,
     uri = 'var',
     soma_parent = ms,
+    ingest_mode = ingest_mode,
     platform_config = platform_config,
     tiledbsoma_ctx = tiledbsoma_ctx
   )
 
-  ms$close()
   experiment$ms$set(object = ms, name = ms_name)
 
   return(experiment$uri)

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -35,6 +35,12 @@ write_soma <- function(x, uri, ..., platform_config = NULL, tiledbsoma_ctx = NUL
 #' @param soma_parent The parent \link[tiledbsoma:SOMACollection]{collection}
 #' (eg. a \code{\link{SOMACollection}}, \code{\link{SOMAExperiment}}, or
 #' \code{\link{SOMAMeasurement}})
+#' @param ingest_mode Ingestion mode when creating the SOMA; choose from:
+#' \itemize{
+#'  \item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+#'  \item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+#'   exists, simply open it for writing
+#' }
 #' @param relative \strong{\[Internal use only\]} Is \code{uri}
 #' relative or aboslute
 #'

--- a/apis/r/man/SOMACollectionCreate.Rd
+++ b/apis/r/man/SOMACollectionCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMACollectionCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMACollectionCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMACollectionOpen.Rd
+++ b/apis/r/man/SOMACollectionOpen.Rd
@@ -19,11 +19,11 @@ SOMACollectionOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMACollection for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMADataFrameCreate.Rd
+++ b/apis/r/man/SOMADataFrameCreate.Rd
@@ -8,6 +8,7 @@ SOMADataFrameCreate(
   uri,
   schema,
   index_column_names = c("soma_joinid"),
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -16,9 +17,18 @@ SOMADataFrameCreate(
 \arguments{
 \item{uri}{URI for the TileDB object}
 
-\item{schema}{schema Arrow schema argument passed on to DataFrame$create()}
+\item{schema}{Arrow schema argument for the \link[SOMADataFrame]{SOMA dataframe}}
 
-\item{index_column_names}{Index column names passed on to DataFrame$create()}
+\item{index_column_names}{A vector of column names to use as user-defined
+index columns; all named columns must exist in the schema, and at least
+one index column name is required}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMADataFrameOpen.Rd
+++ b/apis/r/man/SOMADataFrameOpen.Rd
@@ -21,7 +21,9 @@ SOMADataFrameOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMADenseNDArrayOpen.Rd
+++ b/apis/r/man/SOMADenseNDArrayOpen.Rd
@@ -21,7 +21,9 @@ SOMADenseNDArrayOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMAExperimentCreate.Rd
+++ b/apis/r/man/SOMAExperimentCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMAExperimentCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMAExperimentCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMAExperimentOpen.Rd
+++ b/apis/r/man/SOMAExperimentOpen.Rd
@@ -19,11 +19,11 @@ SOMAExperimentOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMAMeasurementCreate.Rd
+++ b/apis/r/man/SOMAMeasurementCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMAMeasurementCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMAMeasurementCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMAMeasurementOpen.Rd
+++ b/apis/r/man/SOMAMeasurementOpen.Rd
@@ -19,11 +19,11 @@ SOMAMeasurementOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMASparseNDArrayCreate.Rd
+++ b/apis/r/man/SOMASparseNDArrayCreate.Rd
@@ -8,6 +8,7 @@ SOMASparseNDArrayCreate(
   uri,
   type,
   shape,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -19,6 +20,13 @@ SOMASparseNDArrayCreate(
 \item{type}{An \link[arrow:data-type]{Arrow type} defining the type of each element in the array.}
 
 \item{shape}{A vector of integers defining the shape of the array.}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMASparseNDArrayOpen.Rd
+++ b/apis/r/man/SOMASparseNDArrayOpen.Rd
@@ -21,7 +21,9 @@ SOMASparseNDArrayOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -118,6 +118,9 @@ Close and reopen the TileDB object in a new mode
 \item \dQuote{\code{WRITE}}
 }
 By default, reopens in the opposite mode of the current mode}
+
+\item{\code{force}}{Force a close/reopen cycle; by default, if \code{mode} is
+\code{self$mode()}, \code{reopen()} does nothing}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -4,7 +4,14 @@
 \alias{write_soma.Seurat}
 \title{Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA}
 \usage{
-\method{write_soma}{Seurat}(x, uri, ..., platform_config = NULL, tiledbsoma_ctx = NULL)
+\method{write_soma}{Seurat}(
+  x,
+  uri,
+  ...,
+  ingest_mode = "write",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL
+)
 }
 \arguments{
 \item{x}{A \code{\link[SeuratObject]{Seurat}} object}
@@ -12,6 +19,13 @@
 \item{uri}{URI for resulting SOMA object}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma.SingleCellExperiment.Rd
+++ b/apis/r/man/write_soma.SingleCellExperiment.Rd
@@ -10,6 +10,7 @@ object to a SOMA}
   uri,
   ms_name = NULL,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL
 )
@@ -23,6 +24,13 @@ object to a SOMA}
 \code{\link[SingleCellExperiment]{mainExpName}(x)}}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma.SummarizedExperiment.Rd
+++ b/apis/r/man/write_soma.SummarizedExperiment.Rd
@@ -5,7 +5,15 @@
 \title{Write a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 object to a SOMA}
 \usage{
-\method{write_soma}{SummarizedExperiment}(x, uri, ms_name, ..., platform_config = NULL, tiledbsoma_ctx = NULL)
+\method{write_soma}{SummarizedExperiment}(
+  x,
+  uri,
+  ms_name,
+  ...,
+  ingest_mode = "write",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL
+)
 }
 \arguments{
 \item{x}{An object}
@@ -15,6 +23,13 @@ object to a SOMA}
 \item{ms_name}{Name for resulting measurement}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -72,6 +72,7 @@
   ...,
   key = NULL,
   ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -87,6 +88,7 @@
   ...,
   key = NULL,
   ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -101,6 +103,7 @@
   ...,
   key = NULL,
   ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -145,6 +148,9 @@ determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 \item{key}{Optionally register the resulting \code{SOMADataFrame} in
 \code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
 to handle manually}
+
+\item{shape}{A vector of two positive integers giving the on-disk shape of
+the array; defaults to \code{dim(x)}}
 }
 \value{
 The resulting SOMA \link[tiledbsoma:SOMASparseNDArray]{array} or

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -149,6 +149,13 @@ determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 \code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
 to handle manually}
 
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
+
 \item{shape}{A vector of two positive integers giving the on-disk shape of
 the array; defaults to \code{dim(x)}}
 }

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -42,6 +42,7 @@
   soma_parent,
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -55,6 +56,7 @@
   index_column_names = "soma_joinid",
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -69,6 +71,7 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -83,6 +86,7 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -96,6 +100,7 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -18,6 +18,7 @@
   df_index = NULL,
   index_column_names = "soma_joinid",
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -31,6 +32,7 @@
   type = NULL,
   transpose = FALSE,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -128,6 +130,13 @@ resulting SOMA object}
 
 \item{...}{Arguments passed to other methods}
 
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
+
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}
 
@@ -148,13 +157,6 @@ determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 \item{key}{Optionally register the resulting \code{SOMADataFrame} in
 \code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
 to handle manually}
-
-\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
-\itemize{
-\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
-\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
-exists, simply open it for writing
-}}
 
 \item{shape}{A vector of two positive integers giving the on-disk shape of
 the array; defaults to \code{dim(x)}}

--- a/apis/r/man/write_soma_seurat_sub.Rd
+++ b/apis/r/man/write_soma_seurat_sub.Rd
@@ -13,6 +13,7 @@
   uri = NULL,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -25,6 +26,7 @@
   fidx = NULL,
   nfeatures = NULL,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -35,6 +37,7 @@
   uri,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -45,6 +48,7 @@
   uri = NULL,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -63,6 +67,13 @@ for the \code{DimReduc} and \code{Graph} methods, this \strong{must} be a
 was generated from}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -160,6 +160,7 @@ test_that("Write DimReduc mechanics", {
   ))
   on.exit(ms_pca2$close(), add = TRUE, after = FALSE)
   expect_no_condition(write_soma(pbmc_small_tsne, soma_parent = ms))
+  ms$reopen(ms$mode(), force = TRUE)
   expect_identical(sort(ms$names()), sort(c('X', 'var', 'obsm', 'varm')))
   expect_identical(sort(ms$obsm$names()), sort(paste0('X_', c('pca', 'tsne'))))
   expect_identical(ms$varm$names(), 'PCs')

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -1,7 +1,6 @@
 
 test_that("write_soma.data.frame mechanics", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame")
@@ -28,7 +27,6 @@ test_that("write_soma.data.frame mechanics", {
 
 test_that("write_soma.data.frame enumerations", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame-enumerations")
@@ -69,7 +67,6 @@ test_that("write_soma.data.frame enumerations", {
 
 test_that("write_soma.data.frame no enumerations", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame-factorless")

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -195,7 +195,36 @@ test_that("Resume-mode dense arrays", {
   skip_if(!extended_tests())
   skip_if_not_installed('datasets')
 
+  collection <- SOMACollectionCreate(withr::local_tempdir("dense-array-resume"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
   mat <- get(x = 'state.x77', envir = getNamespace('datasets'))
+
+  # Resume mode should always fail for dense arrays
+  expect_s3_class(
+    sda <- write_soma(
+      mat,
+      uri = "state-x77",
+      soma_parent = collection,
+      sparse = FALSE
+    ),
+    "SOMADenseNDArray"
+  )
+  on.exit(sda$close(), add = TRUE, after = FALSE)
+
+  expect_error(write_soma(
+    mat,
+    uri = "state-x77",
+    soma_parent = collection,
+    sparse = FALSE
+  ))
+  expect_error(write_soma(
+    mat,
+    uri = "state-x77",
+    soma_parent = collection,
+    sparse = FALSE,
+    ingest_mode = "resume"
+  ))
 })
 
 test_that("Resume-mode Seurat", {

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -29,6 +29,8 @@ test_that("Factory re-creation", {
     expect_error(fxn(uri))
     obj$close()
   }
+
+  gc()
 })
 
 test_that("Resume-mode factories", {
@@ -71,6 +73,8 @@ test_that("Resume-mode factories", {
     expect_identical(obj$mode(), "WRITE", label = label)
     obj$close()
   }
+
+  gc()
 })
 
 test_that("Resume-mode data frames", {
@@ -182,6 +186,8 @@ test_that("Resume-mode data frames", {
       )
     }
   }
+
+  gc()
 })
 
 test_that("Resume-mode sparse arrays", {
@@ -284,6 +290,8 @@ test_that("Resume-mode sparse arrays", {
   if (!is.null(bbox)) {
     expect_identical(bbox, dim(knex))
   }
+
+  gc()
 })
 
 test_that("Resume-mode dense arrays", {
@@ -320,6 +328,8 @@ test_that("Resume-mode dense arrays", {
     sparse = FALSE,
     ingest_mode = "resume"
   ))
+
+  gc()
 })
 
 test_that("Resume-mode Seurat", {
@@ -368,6 +378,9 @@ test_that("Resume-mode Seurat", {
       expected.label = sprintf("pbmc_small[['%s']]", i)
     )
   }
+
+  exp$close()
+  gc()
 
   # Expect error when writing to existing array
   expect_error(write_soma(pbmc_small, uri = uri))
@@ -493,6 +506,9 @@ test_that("Resume-mode Seurat", {
       expected.label = sprintf("pbmc_small[['%s']]", i)
     )
   }
+
+  expc$close()
+  gc()
 })
 
 test_that("Resume-mode SingleCellExperiment", {
@@ -894,4 +910,7 @@ test_that("Resume-mode SingleCellExperiment", {
       expected.label = sprintf("rowData(sce)[['%s']]", i)
     )
   }
+
+  expc$close()
+  gc()
 })

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -409,6 +409,9 @@ test_that("Resume-mode Seurat", {
     )
   }
 
+  expr$close()
+  gc()
+
   # Test resume-mode with partial writes
   idx <- seq.int(1L, floor(ncol(pbmc_small) / 3))
   pbmc_partial <- subset(pbmc_small, cells = idx)
@@ -416,8 +419,8 @@ test_that("Resume-mode Seurat", {
     if (inherits(i, "Assay")) {
       next
     }
-    DefaultAssay(pbmc_partial[[i]]) <- DefaultAssay(pbmc_partial[[i]]) %||%
-      DefaultAssay(pbmc_partial)
+    SeuratObject::DefaultAssay(pbmc_partial[[i]]) <- SeuratObject::DefaultAssay(pbmc_partial[[i]]) %||%
+      SeuratObject::DefaultAssay(pbmc_partial)
   }
 
   expect_type(
@@ -457,12 +460,11 @@ test_that("Resume-mode Seurat", {
     )
   }
 
+  expp$close()
+  gc()
+
   expect_type(
-    uric <- write_soma(
-      pbmc_small,
-      uri = urip,
-      ingest_mode = "resume"
-    ),
+    uric <- write_soma(pbmc_small, uri = urip, ingest_mode = "resume"),
     "character"
   )
   expect_identical(uric, urip)

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -1,0 +1,116 @@
+
+factories <- list(
+  substitute(SOMADataFrameCreate),
+  substitute(SOMASparseNDArrayCreate),
+  substitute(SOMADenseNDArrayCreate),
+  substitute(SOMACollectionCreate),
+  substitute(SOMAMeasurementCreate),
+  substitute(SOMAExperimentCreate)
+)
+
+schema <- arrow::infer_schema(data.frame(
+  soma_joinid = bit64::integer64(),
+  int = integer()
+))
+
+test_that("Factory re-creation", {
+  skip_if(!extended_tests())
+  for (i in seq_along(factories)) {
+    fname <- as.character(factories[[i]])
+    fxn <- eval(factories[[i]])
+    uri <- withr::local_tempdir(fname)
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(uri, type = arrow::int32(), shape = c(20L, 10L)),
+      fxn(uri)
+    ))
+    expect_error(fxn(uri))
+    obj$close()
+  }
+})
+
+test_that("Resume-mode factories", {
+  skip_if(!extended_tests())
+  for (i in seq_along(factories)) {
+    fname <- as.character(factories[[i]])
+    if (fname == 'SOMADenseNDArrayCreate') {
+      next
+    }
+    fxn <- eval(factories[[i]])
+    label <- paste0(fname, "-resume")
+    uri <- withr::local_tempdir(label)
+    # Do an initial create
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(uri, type = arrow::int32(), shape = c(20L, 10L)),
+      fxn(uri)
+    ))
+    expect_true(obj$is_open(), label = fname)
+    expect_identical(obj$mode(), "WRITE", label = fname)
+    expect_true(obj$exists(), label = fname)
+    obj$close()
+
+    # Test that re-creating in "resume" mode simply re-opens the object
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema, ingest_mode = "resume"),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(
+        uri,
+        type = arrow::int32(),
+        shape = c(20L, 10L),
+        ingest_mode = "resume"
+      ),
+      fxn(uri, ingest_mode = "resume")
+    ))
+    expect_true(obj$is_open(), label = label)
+    expect_identical(obj$mode(), "WRITE", label = label)
+    obj$close()
+  }
+})
+
+test_that("Resume-mode data frames", {
+  skip_if(!extended_tests())
+  skip_if_not_installed('datasets')
+
+  co2 <- get_data('CO2', package = 'datasets')
+})
+
+test_that("Resume-mode sparse arrays", {
+  skip_if(!extended_tests())
+
+  mat <- get_data('KNex', package = 'Matrix')$mm
+})
+
+test_that("Resume-mode dense arrays", {
+  skip_if(!extended_tests())
+  skip_if_not_installed('datasets')
+
+  mat <- get(x = 'state.x77', envir = getNamespace('datasets'))
+})
+
+test_that("Resume-mode Seurat", {
+  skip_if(TRUE)
+  skip_if(!extended_tests())
+  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
+
+  pbmc_small <- get_data('pbmc_small', package = 'SeuratObject')
+
+  uri <- withr::local_tempdir(SeuratObject::Project(pbmc_small))
+})
+
+test_that("Resume-mode SingleCellExperiment", {
+  skip_if(TRUE)
+  skip_if(!extended_tests())
+  skip_if_not_installed('pbmc3k.sce')
+  suppressMessages(skip_if_not_installed('SingleCellExperiment', .MINIMUM_SCE_VERSION('c')))
+
+  sce <- get_data('pbmc3k.final', package = 'pbmc3k.sce')
+  SingleCellExperiment::mainExpName(sce) <- 'RNA'
+
+  uri <- withr::local_tempdir('single-cell-experiment')
+})

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -411,10 +411,14 @@ test_that("Resume-mode Seurat", {
 
   # Test resume-mode with partial writes
   idx <- seq.int(1L, floor(ncol(pbmc_small) / 3))
-  pbmc_partial <- suppressWarnings(SeuratObject::UpdateSeuratObject(subset(
-    pbmc_small,
-    cells = idx
-  )))
+  pbmc_partial <- subset(pbmc_small, cells = idx)
+  for (i in names(pbmc_partial)) {
+    if (inherits(i, "Assay")) {
+      next
+    }
+    DefaultAssay(pbmc_partial[[i]]) <- DefaultAssay(pbmc_partial[[i]]) %||%
+      DefaultAssay(pbmc_partial)
+  }
 
   expect_type(
     urip <- write_soma(


### PR DESCRIPTION
Implement resume-mode ingestion in the R API

This PR parallels #664; it adds support for resume-mode in factory functions, which allows `SOMA*Create()` to check for an already existing TileDB object at `uri` and if so, simply connect to it rather than try to re-create

It also adds support for resume-mode in `write_soma()` methods; these methods check the `soma_joinids` that are present in the input data and that already exist on disk, and only writes data for `soma_joinids` that are missing from disk

The following SOMA functions have been modified to with an `ingest_mode` parameter:
 - `SOMADataFrameCreate()`
 - `SOMASparseNDarrayCreate()`
 - `SOMACollectionCreate()`
 - `SOMAMeasurementCreate()`
 - `SOMAExperimentCreate()`

The following methods of `write_soma()` have been modified with an `ingest_mode` parameter:
 - `write_soma.character()`/`write_soma.data.frame()`/`write_soma.Dataframe()`
 - `write_soma.matrix()`/`write_soma.TsparseMatrix()`
 - `write_soma.Seurat()` and other Seurat-subobject methods
 - `write_soma.SummarizedExperiment()`/`write_soma.SingleCellExperiment()`

resolves #1399