### PR TITLE
[c++] Use core 2.21.2 [pending TileDB-Py 0.27.2]

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-linux-x86_64-2.21.1-acd5c50.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-linux-x86_64-2.21.2-635e5e9.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -158,7 +158,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-x86_64-2.21.1-acd5c50.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-x86_64-2.21.2-635e5e9.tar.gz
           tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
           ls external/lib/
           echo "DYLD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -249,10 +249,10 @@ jobs:
           if [ `uname -s` == "Darwin" ];
           then
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-x86_64-2.21.1-acd5c50.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-x86_64-2.21.2-635e5e9.tar.gz
           else
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-linux-x86_64-2.21.1-acd5c50.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-linux-x86_64-2.21.2-635e5e9.tar.gz
           fi
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-x86_64-2.21.1-acd5c50.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-x86_64-2.21.2-635e5e9.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-arm64-2.21.1-acd5c50.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-arm64-2.21.2-635e5e9.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-linux-x86_64-2.21.1-acd5c50.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-linux-x86_64-2.21.2-635e5e9.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -58,8 +58,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-windows-x86_64-2.21.1-acd5c50.zip")
-          SET(DOWNLOAD_SHA1 "6c5e55410d6325e6826f12d8a5aec4ad0aab2f41")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-windows-x86_64-2.21.2-635e5e9.zip")
+          SET(DOWNLOAD_SHA1 "604cf475e2c2cdc1b55785d5f655883977112797")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -76,22 +76,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-x86_64-2.21.1-acd5c50.tar.gz")
-            SET(DOWNLOAD_SHA1 "3c3e362ee46b03e6ed0d9ee840cf371c2d5b0bb8")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-x86_64-2.21.2-635e5e9.tar.gz")
+            SET(DOWNLOAD_SHA1 "046581379987f662b24f2bcc1cb8c1486f790ccb")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-arm64-2.21.1-acd5c50.tar.gz")
-            SET(DOWNLOAD_SHA1 "b00e8fc9c826d7a15c6a732e60937375887b5f25")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-arm64-2.21.2-635e5e9.tar.gz")
+            SET(DOWNLOAD_SHA1 "2ddbf8142662c7ca4343dcd48d42b94e13534524")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-x86_64-2.21.1-acd5c50.tar.gz")
-            SET(DOWNLOAD_SHA1 "3c3e362ee46b03e6ed0d9ee840cf371c2d5b0bb8")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-x86_64-2.21.2-635e5e9.tar.gz")
+            SET(DOWNLOAD_SHA1 "046581379987f662b24f2bcc1cb8c1486f790ccb")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-macos-arm64-2.21.1-acd5c50.tar.gz")
-            SET(DOWNLOAD_SHA1 "b00e8fc9c826d7a15c6a732e60937375887b5f25")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-macos-arm64-2.21.2-635e5e9.tar.gz")
+            SET(DOWNLOAD_SHA1 "2ddbf8142662c7ca4343dcd48d42b94e13534524")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.1/tiledb-linux-x86_64-2.21.1-acd5c50.tar.gz")
-          SET(DOWNLOAD_SHA1 "03f03909ed9f6ea3e0bfb6124155de09dfff940e")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.21.2/tiledb-linux-x86_64-2.21.2-635e5e9.tar.gz")
+          SET(DOWNLOAD_SHA1 "11c13010ffa1da6b31256c274352b6d5e7d4ccdb")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -113,8 +113,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.21.1.zip"
-          URL_HASH SHA1=8a9a556149eda5b06ab13f6892857a4b273eaada
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.21.2.zip"
+          URL_HASH SHA1=fe7ac59006ec13db8e126f85a4b69e6b07311006
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
**Issue and/or context:** 2.21.2 is out and ready to use.

**Changes:**

**Notes for Reviewer:** 

This is part of our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/pull/2424).

As noted below in this PR: paused until TileDB-Py has a bump to depend on core 2.21.2.