### PR TITLE
Run SO copying workflow on macos-13 to avoid SIP

### DIFF
--- a/.github/workflows/python-so-copying.yml
+++ b/.github/workflows/python-so-copying.yml
@@ -139,7 +139,7 @@ jobs:
           ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     name: "macos TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false
@@ -153,6 +153,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for setuptools-scm
+      - name: Check if System Integrity Protection (SIP) is enabled
+        run: csrutil status
       - name: Install pre-built libtiledb
         if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
         run: |


### PR DESCRIPTION
**Issue and/or context:**

Closes #2237

We have a flaky macOS job that fails too often. Sometimes the macOS System Integrity Protection (SIP) unsets `DYLD_LIBRARY_PATH`, which prevents `libtiledbsoma.dylib` from finding `libtiledb.dylib`

**Changes:**

There is no way to disable SIP during a run. Fortunately the GitHub Actions runner `macos-13` has it disabled by default, so I switched to it. If SIP is enabled in the future, then we'll have to revisit.

**Notes for Reviewer:**

I added a step to run `csrutil status`, which will help us troubleshoot in the future if SIP is enabled

So far this has passed twice on my fork

https://github.com/jdblischak/TileDB-SOMA/actions/runs/8652010719/job/23723973384
https://github.com/jdblischak/TileDB-SOMA/actions/runs/8652049846/job/23724080889
