### PR TITLE
[python] `verify_core_versions()` during `import tiledbsoma`

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -156,6 +156,7 @@ from ._general_utilities import (
     get_SOMA_version,
     get_storage_engine,
     show_package_versions,
+    verify_core_versions,
 )
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
@@ -167,6 +168,8 @@ from .pytiledbsoma import (
     tiledbsoma_stats_enable,
     tiledbsoma_stats_reset,
 )
+
+verify_core_versions()
 
 __version__ = get_implementation_version()
 

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -169,6 +169,9 @@ from .pytiledbsoma import (
     tiledbsoma_stats_reset,
 )
 
+# Ensure TileDB-Py and libtiledbsoma have matching core versions; if they don't, undefined behavior
+# / segfaults may ensue. Once libtiledbsoma is the only "path to core" (cf. #1632), this can be
+# removed.
 verify_core_versions()
 
 __version__ = get_implementation_version()


### PR DESCRIPTION
**Issue and/or context:** #1837 

**Changes:**
- Add `verify_core_versions` helper which asserts that TileDB-Py's and `libtiledbsoma`'s core versions match
- Add `verify_core_versions()` to `tiledbsoma.__init__.py`
- Add `TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL=err` "escape hatch"; if the check above catches any users, and they *really* want to just keep running and fix it later, this allows it (but prints a relevant error message).
- Minor reformatting of `show_package_versions` output:
  ```diff
  < tiledbsoma.__version__        1.5.0rc0.post272.dev2332272127
  < TileDB-Py tiledb.version()    (0, 27, 1)
  < TileDB core version           2.21.1
  < libtiledbsoma version()       libtiledb=2.21.1
  < python version                3.11.8.final.0
  < OS version                    Darwin 23.2.0
  ---
  > tiledbsoma.__version__              1.5.0rc0.post272.dev2332272127
  > TileDB-Py version                   0.27.1
  > TileDB core version (tiledb)        2.21.1
  > TileDB core version (libtiledbsoma) 2.21.1
  > python version                      3.11.8.final.0
  > OS version                          Darwin 23.2.0
  ```

**Notes for Reviewer:**
- We could probably put together a test for this in a Docker image where we intentionally install mismatched versions… not sure it's worth it.
- I am fetching libtiledbsoma's "core" version via [`pytiledbsoma.version`](https://github.com/single-cell-data/TileDB-SOMA/blob/1.9.5/apis/python/src/tiledbsoma/pytiledbsoma.cc#L63), which [calls `tiledbsoma::version::as_string()`](https://github.com/single-cell-data/TileDB-SOMA/blob/main/libtiledbsoma/src/utils/version.cc#L38-L42), which calls `tiledb_version`.
  - The naming feels a bit off, the former two seem like they'd return a version of `libtiledbsoma`, not `libtiledb`.
  - Don't need to change it here, just want to make sure I'm understanding.
