### PR TITLE
Do not include nanoarrow files in clang-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ data:
 .PHONY: check-format
 check-format:
 	 @./scripts/run-clang-format.sh . clang-format 0 \
-		`find libtiledbsoma apis/python/src -name "*.cc" -or -name "*.cpp" -or -name "*.h"`
+		`find libtiledbsoma apis/python/src -name "*.cc" -or -name "*.cpp" -or -name "*.h" ! -name "nanoarrow.*"`
 
 .PHONY: format
 format:
 	 @./scripts/run-clang-format.sh . clang-format 1 \
-		`find libtiledbsoma apis/python/src -name "*.cc" -or -name "*.cpp" -or -name "*.h"`
+		`find libtiledbsoma apis/python/src -name "*.cc" -or -name "*.cpp" -or -name "*.h" ! -name "nanoarrow.*"`
 
 # clean
 # -------------------------------------------------------------------


### PR DESCRIPTION
**Issue and/or context:**

Running `make format` causes the nanoarrow files to be unnececessarily reformatted.

**Changes:**

Exclude nanoarrow files in make format's find.