### PR TITLE
[c++] Pass `ColumnIndexInfo` as `ArrowTable`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -230,16 +230,17 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                     f"if domain is specified, it must have the same length as index_column_names; got {ndom} != {nidx}"
                 )
 
-        domains = []
-        extents = []
+        index_column_schema = []
+        index_column_data = {}
+
         for index_column_name, slot_domain in zip(index_column_names, domain):
-            pa_type = schema.field(index_column_name).type
+            pa_field = schema.field(index_column_name)
             dtype = _arrow_types.tiledb_type_from_arrow_type(
-                pa_type, is_indexed_column=True
+                pa_field.type, is_indexed_column=True
             )
 
             slot_domain = _fill_out_slot_domain(
-                slot_domain, index_column_name, pa_type, dtype
+                slot_domain, index_column_name, pa_field.type, dtype
             )
 
             extent = _find_extent_for_domain(
@@ -249,12 +250,13 @@ class DataFrame(TileDBArray, somacore.DataFrame):
                 slot_domain,
             )
 
-            domains.append(pa.array(slot_domain, type=pa_type))
-            extents.append(pa.array([extent], type=pa_type))
+            index_column_schema.append(pa_field)
+            index_column_data[pa_field.name] = [*slot_domain, extent]
 
-        domains = pa.StructArray.from_arrays(domains, names=index_column_names)
-        extents = pa.StructArray.from_arrays(extents, names=index_column_names)
-
+        index_column_info = pa.RecordBatch.from_pydict(
+            index_column_data, schema=pa.schema(index_column_schema)
+        )
+        
         plt_cfg = None
         if platform_config:
             ops = TileDBCreateOptions.from_platform_config(platform_config)
@@ -282,9 +284,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
             clib.SOMADataFrame.create(
                 uri,
                 schema=schema,
-                index_column_names=index_column_names,
-                domains=domains,
-                extents=extents,
+                index_column_info=index_column_info,
                 ctx=context.native_context,
                 platform_config=plt_cfg,
                 timestamp=(0, timestamp_ms),

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -256,7 +256,7 @@ class DataFrame(TileDBArray, somacore.DataFrame):
         index_column_info = pa.RecordBatch.from_pydict(
             index_column_data, schema=pa.schema(index_column_schema)
         )
-        
+
         plt_cfg = None
         if platform_config:
             ops = TileDBCreateOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -96,7 +96,7 @@ class NotCreateableError(SOMAError):
     pass
 
 
-def is_not_createable_error(e: tiledb.TileDBError) -> bool:
+def is_not_createable_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
     """Given a TileDBError, return true if it indicates the object cannot be created
 
     Lifecycle: experimental
@@ -132,7 +132,7 @@ def is_not_createable_error(e: tiledb.TileDBError) -> bool:
     return False
 
 
-def is_duplicate_group_key_error(e: tiledb.TileDBError) -> bool:
+def is_duplicate_group_key_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
     """Given a TileDBError, return try if it indicates a duplicate member
     add request in a tiledb.Group.
 

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -111,10 +111,15 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns,
+    ArrowTable index_columns,
     std::optional<PlatformConfig> platform_config) {
     SOMAExperiment::create(
-        uri, std::move(schema), index_columns, ctx, platform_config);
+        uri,
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx,
+        platform_config);
     std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
         uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -128,8 +133,13 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns) {
-    SOMAMeasurement::create(uri, std::move(schema), index_columns, ctx);
+    ArrowTable index_columns) {
+    SOMAMeasurement::create(
+        uri,
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx);
     std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
         uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -143,10 +153,15 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     URIType uri_type,
     std::shared_ptr<SOMAContext> ctx,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns,
+    ArrowTable index_columns,
     std::optional<PlatformConfig> platform_config) {
     SOMADataFrame::create(
-        uri, std::move(schema), index_columns, ctx, platform_config);
+        uri,
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx,
+        platform_config);
     std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
         uri, OpenMode::read, ctx);
     this->set(std::string(uri), uri_type, std::string(key));

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -158,7 +158,7 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns,
+        ArrowTable index_columns,
         std::optional<PlatformConfig> platform_config = std::nullopt);
 
     /**
@@ -175,7 +175,7 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns);
+        ArrowTable index_columns);
 
     /**
      * Create and add a SOMADataFrame to the SOMACollection.
@@ -191,7 +191,7 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns,
+        ArrowTable index_columns,
         std::optional<PlatformConfig> platform_config = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -42,12 +42,16 @@ using namespace tiledb;
 void SOMADataFrame::create(
     std::string_view uri,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns,
+    ArrowTable index_columns,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<PlatformConfig> platform_config,
     std::optional<TimestampRange> timestamp) {
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
-        ctx->tiledb_ctx(), std::move(schema), index_columns, platform_config);
+        ctx->tiledb_ctx(),
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        platform_config);
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMADataFrame", timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -63,7 +63,7 @@ class SOMADataFrame : public SOMAArray {
     static void create(
         std::string_view uri,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns,
+        ArrowTable index_columns,
         std::shared_ptr<SOMAContext> ctx,
         std::optional<PlatformConfig> platform_config = std::nullopt,
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -44,7 +44,7 @@ using namespace tiledb;
 void SOMAExperiment::create(
     std::string_view uri,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns,
+    ArrowTable index_columns,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<PlatformConfig> platform_config,
     std::optional<TimestampRange> timestamp) {
@@ -54,7 +54,8 @@ void SOMAExperiment::create(
     SOMADataFrame::create(
         exp_uri + "/obs",
         std::move(schema),
-        index_columns,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         platform_config,
         timestamp);

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -57,7 +57,7 @@ class SOMAExperiment : public SOMACollection {
     static void create(
         std::string_view uri,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns,
+        ArrowTable index_columns,
         std::shared_ptr<SOMAContext> ctx,
         std::optional<PlatformConfig> platform_config = std::nullopt,
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -44,7 +44,7 @@ using namespace tiledb;
 void SOMAMeasurement::create(
     std::string_view uri,
     std::unique_ptr<ArrowSchema> schema,
-    ColumnIndexInfo index_columns,
+    ArrowTable index_columns,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<PlatformConfig> platform_config,
     std::optional<TimestampRange> timestamp) {
@@ -54,7 +54,8 @@ void SOMAMeasurement::create(
     SOMADataFrame::create(
         exp_uri + "/var",
         std::move(schema),
-        index_columns,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         platform_config,
         timestamp);

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -58,7 +58,7 @@ class SOMAMeasurement : public SOMACollection {
     static void create(
         std::string_view uri,
         std::unique_ptr<ArrowSchema> schema,
-        ColumnIndexInfo index_columns,
+        ArrowTable index_columns,
         std::shared_ptr<SOMAContext> ctx,
         std::optional<PlatformConfig> platform_config = std::nullopt,
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -313,7 +313,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                 dims.insert({dim.name(), dim});
                 isattr = false;
                 break;
-            } 
+            }
         }
         if (isattr) {
             Attribute attr(*ctx, child->name, type);

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -311,6 +311,24 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                         dims.insert({child->name, dim});
                         break;
                     }
+                    case TILEDB_TIME_SEC:
+                    case TILEDB_TIME_MS:
+                    case TILEDB_TIME_US:
+                    case TILEDB_TIME_NS:
+                    case TILEDB_DATETIME_SEC:
+                    case TILEDB_DATETIME_MS:
+                    case TILEDB_DATETIME_US:
+                    case TILEDB_DATETIME_NS: {
+                        auto datetime_buff = (uint64_t*)buff;
+                        auto dim = Dimension::create(
+                            *ctx,
+                            child->name,
+                            type,
+                            datetime_buff,
+                            datetime_buff + 2);
+                        dims.insert({child->name, dim});
+                        break;
+                    }
                     case TILEDB_INT8: {
                         auto dim = ArrowAdapter::_create_dim(
                             *ctx, child->name, (int8_t*)buff);

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -319,7 +319,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     }
                     case TILEDB_UINT8: {
                         auto dim = ArrowAdapter::_create_dim(
-                            *ctx, child->name, (int16_t*)buff);
+                            *ctx, child->name, (uint8_t*)buff);
                         dims.insert({child->name, dim});
                         break;
                     }

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -34,12 +34,6 @@ struct ArrowBuffer {
 using ArrowTable =
     std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>;
 
-using ColumnIndexInfo = std::tuple<
-    std::vector<std::string>,     // name of column
-    std::shared_ptr<ArrowArray>,  // domain
-    std::shared_ptr<ArrowArray>   // tile extent
-    >;
-
 class PlatformConfig {
    public:
     uint64_t dataframe_dim_zstd_level = 3;
@@ -89,7 +83,7 @@ class ArrowAdapter {
     static ArraySchema tiledb_schema_from_arrow_schema(
         std::shared_ptr<Context> ctx,
         std::unique_ptr<ArrowSchema> arrow_schema,
-        ColumnIndexInfo index_column_info,
+        ArrowTable index_column_info,
         std::optional<PlatformConfig> platform_config);
 
     /**

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -117,8 +117,10 @@ class ArrowAdapter {
         return dst;
     }
 
-    static std::optional<std::pair<const void*, const void*>> _get_dim_info(
-        std::string_view dim_name, ArrowTable index_columns);
+    template <typename T>
+    static Dimension _create_dim(Context ctx, std::string name, T* b) {
+        return Dimension::create<T>(ctx, name, {b[0], b[1]}, b[2]);
+    }
 
     static bool _isvar(const char* format);
 };

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -51,25 +51,21 @@ ArraySchema create_schema(Context& ctx, bool allow_duplicates) {
     return schema;
 }
 
-std::pair<std::unique_ptr<ArrowSchema>, ColumnIndexInfo> create_arrow_schema() {
-    // Create ArrowSchema
+std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema() {
+    // Create ArrowSchema for SOMAArray
     auto arrow_schema = std::make_unique<ArrowSchema>();
     arrow_schema->format = "+s";
     arrow_schema->n_children = 2;
     arrow_schema->dictionary = nullptr;
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->children = new ArrowSchema*[arrow_schema->n_children];
-
-    ArrowSchema* dim = nullptr;
-    dim = arrow_schema->children[0] = new ArrowSchema;
+    ArrowSchema* dim = arrow_schema->children[0] = new ArrowSchema;
     dim->format = "l";
     dim->name = "d0";
     dim->n_children = 0;
     dim->dictionary = nullptr;
     dim->release = &ArrowAdapter::release_schema;
-
-    ArrowSchema* attr = nullptr;
-    attr = arrow_schema->children[1] = new ArrowSchema;
+    ArrowSchema* attr = arrow_schema->children[1] = new ArrowSchema;
     attr->format = "l";
     attr->name = "a0";
     attr->n_children = 0;
@@ -77,58 +73,45 @@ std::pair<std::unique_ptr<ArrowSchema>, ColumnIndexInfo> create_arrow_schema() {
     attr->dictionary = nullptr;
     attr->release = &ArrowAdapter::release_schema;
 
-    // Create array for index columns
-    std::vector<std::string> index_column_names = {"d0"};
+    // Create ArrowSchema for IndexColumnInfo
+    auto col_info_schema = std::make_unique<ArrowSchema>();
+    col_info_schema->format = "+s";
+    col_info_schema->n_children = 1;
+    col_info_schema->dictionary = nullptr;
+    col_info_schema->release = &ArrowAdapter::release_schema;
+    col_info_schema->children = new ArrowSchema*[col_info_schema->n_children];
+    dim = col_info_schema->children[0] = new ArrowSchema;
+    dim->format = "l";
+    dim->name = "d0";
+    dim->n_children = 0;
+    dim->dictionary = nullptr;
+    dim->release = &ArrowAdapter::release_schema;
 
-    auto domains = std::make_shared<ArrowArray>();
-    domains->length = 0;
-    domains->null_count = 0;
-    domains->offset = 0;
-    domains->n_buffers = 0;
-    domains->buffers = nullptr;
-    domains->n_children = 2;
-    domains->release = &ArrowAdapter::release_array;
-    domains->children = new ArrowArray*[1];
+    // Create ArrowArray for IndexColumnInfo
+    auto col_info_array = std::make_unique<ArrowArray>();
+    col_info_array->length = 0;
+    col_info_array->null_count = 0;
+    col_info_array->offset = 0;
+    col_info_array->n_buffers = 0;
+    col_info_array->buffers = nullptr;
+    col_info_array->n_children = 2;
+    col_info_array->release = &ArrowAdapter::release_array;
+    col_info_array->children = new ArrowArray*[1];
+    auto d0_info = col_info_array->children[0] = new ArrowArray;
+    d0_info->length = 3;
+    d0_info->null_count = 0;
+    d0_info->offset = 0;
+    d0_info->n_buffers = 2;
+    d0_info->release = &ArrowAdapter::release_array;
+    d0_info->buffers = new const void*[2];
+    d0_info->buffers[0] = nullptr;
+    d0_info->buffers[1] = malloc(sizeof(int64_t) * 3);
+    d0_info->n_children = 0;
+    int64_t dom[] = {0, 1000, 1};
+    std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * 3);
 
-    auto d0_domain = domains->children[0] = new ArrowArray;
-    d0_domain->length = 2;
-    d0_domain->null_count = 0;
-    d0_domain->offset = 0;
-    d0_domain->n_buffers = 2;
-    d0_domain->release = &ArrowAdapter::release_array;
-    d0_domain->buffers = new const void*[2];
-    d0_domain->buffers[0] = nullptr;
-    d0_domain->buffers[1] = malloc(sizeof(int64_t) * 2);
-    d0_domain->n_children = 0;
-    int64_t dom[] = {0, 1000};
-    std::memcpy((void*)d0_domain->buffers[1], &dom, sizeof(int64_t) * 2);
-
-    auto tiles = std::make_shared<ArrowArray>();
-    tiles->length = 0;
-    tiles->null_count = 0;
-    tiles->offset = 0;
-    tiles->n_buffers = 0;
-    tiles->buffers = nullptr;
-    tiles->n_children = 2;
-    tiles->release = &ArrowAdapter::release_array;
-    tiles->children = new ArrowArray*[1];
-
-    ArrowArray* d0_tile = tiles->children[0] = new ArrowArray;
-    d0_tile->length = 1;
-    d0_tile->null_count = 0;
-    d0_tile->offset = 0;
-    d0_tile->n_buffers = 2;
-    d0_tile->release = &ArrowAdapter::release_array;
-    d0_tile->buffers = new const void*[2];
-    d0_tile->buffers[0] = nullptr;
-    d0_tile->buffers[1] = malloc(sizeof(int64_t));
-    d0_tile->n_children = 0;
-    int64_t tile = 1;
-    std::memcpy((void*)d0_tile->buffers[1], &tile, sizeof(int64_t));
-
-    ColumnIndexInfo index_columns_info = std::tuple(
-        index_column_names, domains, tiles);
-
-    return std::pair(std::move(arrow_schema), index_columns_info);
+    return std::pair(
+        std::move(arrow_schema),
+        ArrowTable(std::move(col_info_array), std::move(col_info_schema)));
 }
 }  // namespace helper

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -61,6 +61,6 @@ static const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
 
 namespace helper {
 ArraySchema create_schema(Context& ctx, bool allow_duplicates = false);
-std::pair<std::unique_ptr<ArrowSchema>, ColumnIndexInfo> create_arrow_schema();
+std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema();
 }  // namespace helper
 #endif

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -118,7 +118,8 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         URIType::absolute,
         ctx,
         std::move(schema),
-        index_columns);
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)));
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
@@ -175,7 +176,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         URIType::absolute,
         ctx,
         std::move(schema),
-        index_columns);
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)));
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
@@ -205,7 +207,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         URIType::absolute,
         ctx,
         std::move(schema),
-        index_columns);
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)));
     REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
@@ -279,7 +282,8 @@ TEST_CASE("SOMAExperiment: metadata") {
     SOMAExperiment::create(
         uri,
         std::move(schema),
-        index_columns,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         std::nullopt,
         TimestampRange(0, 2));
@@ -342,7 +346,8 @@ TEST_CASE("SOMAMeasurement: metadata") {
     SOMAMeasurement::create(
         uri,
         std::move(schema),
-        index_columns,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         std::nullopt,
         TimestampRange(0, 2));

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -37,7 +37,12 @@ TEST_CASE("SOMADataFrame: basic") {
     std::string uri = "mem://unit-test-dataframe-basic";
 
     auto [schema, index_columns] = helper::create_arrow_schema();
-    SOMADataFrame::create(uri, std::move(schema), index_columns, ctx);
+    SOMADataFrame::create(
+        uri,
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx);
 
     auto soma_dataframe = SOMADataFrame::open(uri, OpenMode::read, ctx);
     REQUIRE(soma_dataframe->uri() == uri);
@@ -83,7 +88,8 @@ TEST_CASE("SOMADataFrame: metadata") {
     SOMADataFrame::create(
         uri,
         std::move(schema),
-        index_columns,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         std::nullopt,
         TimestampRange(0, 2));


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2471

**Changes:**

Change the argument dtype of `ColumnIndexInfo` to `ArrowTable`