### PR TITLE
[r,ci] Update `r-ci.sh`, remove unneeded entries from `r-ci.yml`

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -52,11 +52,6 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
-      - name: Set pkgType to binary (macOS)
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: cat("\noptions(pkgType = 'binary')\n", file = "~/.Rprofile", append = TRUE)
-        shell: Rscript {0}
-
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
 

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -89,12 +89,12 @@ jobs:
       - name: Dependencies
         run: cd apis/r && tools/r-ci.sh install_all
 
-      - name: Install dataset packages from source (macOS)
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: cd apis/r && _CI_PKG_TYPE_=both _CI_USE_BIOC_=true Rscript tools/install_missing_deps.R
+      # - name: Install dataset packages from source (macOS)
+      #   if: ${{ matrix.os == 'macOS-latest' }}
+      #   run: cd apis/r && _CI_PKG_TYPE_=both _CI_USE_BIOC_=true Rscript tools/install_missing_deps.R
 
-      - name: CMake
-        uses: lukka/get-cmake@latest
+      # - name: CMake
+      #   uses: lukka/get-cmake@latest
 
       #- name: MkVars
       #  run: mkdir ~/.R && echo "CXX17FLAGS=-Wno-deprecated-declarations -Wno-deprecated" > ~/.R/Makevars
@@ -106,8 +106,8 @@ jobs:
       #  if: ${{ matrix.os == 'ubuntu-latest' }}
       #  run: sudo ldconfig
       #
-      - name: Update Packages
-        run: Rscript -e 'update.packages(ask=FALSE)'
+      # - name: Update Packages
+      #   run: Rscript -e 'update.packages(ask=FALSE)'
 
       # - name: Build Package
       #   run: cd apis/r && R CMD build --no-build-vignettes --no-manual .

--- a/apis/r/tools/r-ci.sh
+++ b/apis/r/tools/r-ci.sh
@@ -15,9 +15,13 @@ set -e
 # Or ratherm set it for a lot noisier output
 # set -x
 
-CRAN=${CRAN:-"https://cloud.r-project.org"}
+# Where do we run? OS can be 'Linux' or 'Darwin', ARCH can be 'x86_64' or 'arm64'
 OS=$(uname -s)
-RVER=${RVER:-"4.3.2"}
+ARCH=$(uname -m)
+
+# Default CRAN repo (use the CDN) and R verssion
+CRAN=${CRAN:-"https://cloud.r-project.org"}
+RVER=${RVER:-"4.3.3"}
 
 ## Optional drat repos, unset by default
 DRAT_REPOS=${DRAT_REPOS:-""}
@@ -213,11 +217,10 @@ BootstrapLinuxOptions() {
 }
 
 BootstrapMac() {
-    # Install from latest CRAN binary build for OS X
-    echo "Downloading ${RVER} for macOS"
-    wget ${CRAN}/bin/macosx/big-sur-x86_64/base/R-${RVER}-x86_64.pkg -O /tmp/R-latest.pkg
+    # Install from latest CRAN binary build for OS X (given ${ARCH} from 'uname -m')
+    wget ${CRAN}/bin/macosx/big-sur-${ARCH}/base/R-${RVER}-${ARCH}.pkg  -O /tmp/R-latest.pkg
 
-    echo "Installing macOS binary package for R"
+    echo "Installing macOS binary package for R on ${ARCH}"
     sudo installer -pkg "/tmp/R-latest.pkg" -target /
     rm "/tmp/R-latest.pkg"
 


### PR DESCRIPTION
**Issue and/or context:**

CI was starting to fail as GHA apparently decided to spice things up by mixing macOS hardware platforms.

**Changes:**

The stale vendored copy of `r-ci.sh` received a small, tested and already used generarlization for 'architecture', and the main YAML has three more blocks we once needed but currently do not removed.  

These changes were tested in another repo first.

**Notes for Reviewer:**

[SC 46010](https://app.shortcut.com/tiledb-inc/story/46010/r-ci-update-ci-tooling-for-r)
