### PR TITLE
Remove arbitrary dimension limit in `used_shape`.

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -8,6 +8,7 @@ Implementation of SOMA SparseNDArray.
 """
 from __future__ import annotations
 
+import itertools
 from typing import (
     Dict,
     Optional,
@@ -349,7 +350,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         """
         retval = []
         with tiledb.open(self.uri, ctx=self.context.tiledb_ctx):
-            for i in range(20):
+            for i in itertools.count():
                 lower_key = f"soma_dim_{i}_domain_lower"
                 lower_val = self.metadata.get(lower_key)
                 upper_key = f"soma_dim_{i}_domain_upper"
@@ -360,7 +361,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         if not retval:
             raise SOMAError(
                 f"Array {self.uri} was not written with bounding box support. "
-                + "For an approximation, please use `non_empty_domain()` instead",
+                "For an approximation, please use `non_empty_domain()` instead"
             )
 
         # In the unlikely event that a previous data update succeeded but the


### PR DESCRIPTION
We were previously using `range(20)` as an arbitrarily high number of dimensions that people were unlikely to use. Instead, `itertools.count` provides a range-like counter that goes on forever. The function is still guaranteed to exit because there will always be a finite number of `soma_dim_{i}_domain_{endpoint}` metadata values.

---

I'm going to wait until #2446 is in to submit this, to avoid stepping on that change, but am putting it out now so that when that is in, I can just rebase and be done.