### PR TITLE
[r] Set default create options during `TileDBCreateOptions$new()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.1
+Version: 1.10.99.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -8,6 +8,7 @@
 * Add support for blockwise iteration
 * Make `reopen()` a public method for all `TileDBObjects`
 * Add support for resume-mode in `write_soma()`
+* Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
 
 # 1.7.0
 

--- a/apis/r/R/TileDBCreateOptions.R
+++ b/apis/r/R/TileDBCreateOptions.R
@@ -21,22 +21,22 @@
 #     }
 # }
 
-# Non-filter-related schema parameters
-.default_tile_order        <- function() { "ROW_MAJOR" }
-.default_cell_order        <- function() { "ROW_MAJOR" }
-.default_tile_extent       <- function() { 2048        }
-.default_capacity          <- function() { 100000      }
-.default_allows_duplicates <- function() { FALSE      }
-
-# Filter-related schema parameters
-.default_dataframe_dim_zstd_level       <- function() { 3 }
-.default_sparse_nd_array_dim_zstd_level <- function() { 3 }
-.default_offsets_filters  <- function() { list("DOUBLE_DELTA", "BIT_WIDTH_REDUCTION", "ZSTD")}
-.default_validity_filters <- function() { list() }
-
-# Used for chunked data ingestion
-.default_write_x_chunked  <- function() { TRUE }
-.default_goal_chunk_nnz   <- function() { 200000000 }
+.CREATE_DEFAULTS <- list(
+  # Non-filter-related schema parameters
+  tile_order = 'ROW_MAJOR',
+  cell_order = 'ROW_MAJOR',
+  # tile_extent = 2048,
+  capacity = 100000,
+  allows_duplicates = FALSE,
+  # Filter-related schema parameters
+  dataframe_dim_zstd_level = 3,
+  sparse_nd_array_dim_zstd_level = 3,
+  offsets_filters = list('DOUBLE_DELTA', 'BIT_WIDTH_REDUCTION', 'ZSTD'),
+  validity_filters = list(),
+  # Used for chunked data ingestion
+  write_X_chunked = TRUE,
+  goal_chunk_nnz = 200000000
+)
 
 #' TileDBCreateOptions
 #'
@@ -57,17 +57,16 @@ TileDBCreateOptions <- R6::R6Class(
   inherit = MappingBase,
   public = list(
 
-    # Initializes from a PlatformConfig object.
     #' @description Create a \code{TileDBCreateOptions} object
     #'
     #' @template param-platform-config
     #'
-    initialize = function(platform_config) {
+    initialize = function(platform_config = NULL) {
       if (!is.null(platform_config)) {
-        stopifnot(
-          "'platform_config' must be null, or a PlatformConfig type" = inherits(x = platform_config, what = 'PlatformConfig')
-        )
-
+        stopifnot("'platform_config' must be a PlatformConfig" = inherits(
+          x = platform_config,
+          what = 'PlatformConfig'
+        ))
         if ("tiledb" %in% platform_config$platforms() && "create" %in% platform_config$params()) {
           map <- platform_config$get('tiledb', 'create')
           for (key in map$keys()) {
@@ -75,151 +74,187 @@ TileDBCreateOptions <- R6::R6Class(
           }
         }
       }
+
+      for (key in setdiff(names(.CREATE_DEFAULTS), self$keys())) {
+        self$set(key = key, value = .CREATE_DEFAULTS[[key]])
+      }
     },
 
     #' @description Returns the cell and tile orders that should be used.
     #' If neither \code{cell_order} nor \code{tile_order} is present, only in this
     #' case will we use the default values provided.
     #
-    #' @return a list keyed by \dQuote{\code{cell_order}} and
-    #' \dQuote{\code{tile_order}}, where either value or both may be \code{NULL}.
+    #' @return A two-length character vector with names of
+    #' \dQuote{\code{cell_order}} and \dQuote{\code{tile_order}}
+    #'
+    cell_tile_orders = function() c(
+      cell_order = self$get('cell_order'),
+      tile_order = self$get('tile_order')
+    ),
 
-    cell_tile_orders = function() {
-        if ("cell_order" %in% super$keys() || "tile_order" %in% super$keys()) {
-            c(cell_order = super$get("cell_order", default=NULL), tile_order = super$get("tile_order", default=NULL))
-        } else {
-          c(cell_order = .default_cell_order(), tile_order = .default_tile_order())
-        }
-    },
-
-    # This allows a user to specify TileDB extents on a per-dimension basis.
-    #
-    # Example:
-    # * cfg <- PlatformConfig$new()
-    # * cfg$set('tiledb', 'create', 'dims', list(soma_dim_0 = list(tile = 999)))
-    # * tdco <- TileDBCreateOptions$new(cfg)
-    #
-    # Then tdco$dim_tile("soma_dim_0") will be 999
-    #
     #' @param dim_name Name of dimension to get tiling for
     #' @param default Default tiling if \code{dim_name} is not set
     #'
     #' @return int
     #'
-    dim_tile = function(dim_name, default=.default_tile_extent()) {
-      stopifnot(!is.null(dim_name))
-      o <- self$.dim(dim_name)
-      if (is.null(o)) {
-        return(default)
-      }
-      o <- o[['tile']]
-      if (is.null(o)) {
-        return(default)
-      }
-      return(o)
+    #' @examples
+    #' cfg <- PlatformConfig$new()
+    #' cfg$set(
+    #'   platform = 'tiledb',
+    #'   param = 'create',
+    #'   key = 'dims',
+    #'   value = list(soma_dim_0 = list(tile = 999))
+    #' )
+    #' (tdco <- TileDBCreateOptions$new(cfg))
+    #' tdco$dim_tile("soma_dim_0")
+    #' tdco$dim_tile("soma_dim_1")
+    #'
+    dim_tile = function(dim_name, default = 2048) {
+      stopifnot(
+        "'dim_name' must be a single character value" = is.character(dim_name) &&
+          length(dim_name) == 1L &&
+          nzchar(dim_name),
+        "'default' must be a single integerish value" = rlang::is_scalar_integerish(
+          default,
+          finite = TRUE
+        )
+      )
+      return(private$.dim(dim_name)[['tile']] %||% default)
     },
 
     #' @return int
-    capacity = function() {
-      super$get("capacity", default=.default_capacity())
-    },
+    #'
+    capacity = function() self$get('capacity'),
 
     #' @return bool
-    allows_duplicates = function() {
-      super$get("allows_duplicates", default=.default_allows_duplicates())
-    },
+    #'
+    allows_duplicates = function() self$get('allows_duplicates'),
 
     #' @return int
-    dataframe_dim_zstd_level = function() {
-      super$get("dataframe_dim_zstd_level", default=.default_dataframe_dim_zstd_level())
-    },
+    #'
+    dataframe_dim_zstd_level = function() self$get('dataframe_dim_zstd_level'),
 
     #' @return int
-    sparse_nd_array_dim_zstd_level = function() {
-        super$get("sparse_nd_array_dim_zstd_level", default=.default_sparse_nd_array_dim_zstd_level())
-    },
+    #'
+    sparse_nd_array_dim_zstd_level = function() self$get('sparse_nd_array_dim_zstd_level'),
 
     #' @param default Default offset filters to use if not currently set
     #'
-    #' @return list of tiledb.Filter
-    offsets_filters = function(default=.default_offsets_filters()) {
-      self$.build_filters(super$get("offsets_filters", default))
+    #' @return A list of
+    #' \code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
+    #'
+    offsets_filters = function(default = list()) {
+      stopifnot(
+        "'default' must be an unnamed list" = is.list(default) && !is_named(default)
+      )
+      return(private$.build_filters(self$get('offsets_filters', default = default)))
     },
 
     #' @param default Default validity filters to use if not currently set
     #'
-    #' @return list of tiledb.Filter
-    validity_filters = function(default=.default_validity_filters()) {
-      self$.build_filters(super$get("validity_filters", default))
+    #' @return A list of
+    #' \code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
+    #'
+    validity_filters = function(default = list()) {
+      stopifnot(
+        "'default' must be an unnamed list" = is.list(default) && !is_named(default)
+      )
+      return(private$.build_filters(self$get('validity_filters', default = default)))
     },
 
-    # Example input:
-    #
-    #   cfg <- PlatformConfig$new()
-    #   cfg$set('tiledb', 'create', 'attrs', list(
-    #     soma_dim_0 = list(tile = 100, filters = list("RLE")),
-    #     soma_dim_1 = list(tile = 200, filters = list("RLE", list(name="ZSTD", COMPRESSION_LEVEL=9)))
-    #   ))
-    #   tdco <- TileDBCreateOptions$new(cfg)
-    #
     #' @param dim_name Name of dimension to get filters for
     #' @param default Default filters to use for if not currently set
     #'
-    #' @return list of tiledb.Filter
-    dim_filters = function(dim_name, default=list()) {
-      stopifnot(!is.null(dim_name))
-      stopifnot(!is.null(default))
-      o <- self$.dim(dim_name)
-      if (is.null(o)) {
-        return(self$.build_filters(default))
-      }
-      o <- o[['filters']]
-      if (is.null(o)) {
-        return(self$.build_filters(default))
-      }
-      return(self$.build_filters(o))
+    #' @return A list of
+    #' \code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
+    #'
+    #' @examples
+    #' filters <- list(
+    #'   soma_dim_0 = list(tile = 100, filters = list("RLE")),
+    #'   soma_dim_1 = list(tile = 200, filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+    #' )
+    #' cfg <- PlatformConfig$new()
+    #' cfg$set(platform = 'tiledb', param = 'create', key = 'dims', value = filters)
+    #' (tdco <- TileDBCreateOptions$new(cfg))
+    #' tdco$dim_filters("soma_dim_0")
+    #' tdco$dim_filters("non-existant")
+    #'
+    dim_filters = function(dim_name, default = list()) {
+      stopifnot(
+        "'dim_name' must be a single character value" = is.character(dim_name) &&
+          length(dim_name) == 1L &&
+          nzchar(dim_name),
+        "'default' must be an unnamed list" = is.list(default) && !is_named(default)
+      )
+      filters <- private$.dim(dim_name)[['filters']] %||% default
+      return(private$.build_filters(filters))
     },
 
-    # Example input:
-    #
-    #   cfg <- PlatformConfig$new()
-    #   cfg$set('tiledb', 'create', 'attrs', list(
-    #     soma_data_a = list(filters = list("RLE")),
-    #     soma_data_b = list(filters = list("RLE", list(name="ZSTD", COMPRESSION_LEVEL=9)))
-    #   ))
-    #   tdco <- TileDBCreateOptions$new(cfg)
-    #
     #' @param attr_name Name of attribute
     #' @param default Default filters to use if not currently set
     #'
-    #' @return list of tiledb.Filter
+    #' @return A list of
+    #' \code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
     #'
-    attr_filters = function(attr_name, default=list()) {
-      stopifnot(!is.null(attr_name))
-      stopifnot(!is.null(default))
-      o <- self$.attr(attr_name)
-      if (is.null(o)) {
-        return(self$.build_filters(default))
-      }
-      o <- o[['filters']]
-      if (is.null(o)) {
-        return(self$.build_filters(default))
-      }
-      return(self$.build_filters(o))
+    #' @examples
+    #' filters <- list(
+    #'   soma_data_a = list(filters = list("RLE")),
+    #'   soma_data_b = list(filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+    #' )
+    #' cfg <- PlatformConfig$new()
+    #' cfg$set(platform = 'tiledb', param = 'create', key = 'attrs', value = filters)
+    #' (tdco <- TileDBCreateOptions$new(cfg))
+    #' tdco$attr_filters("soma_data_b")
+    #' tdco$attr_filters("non-existant")
+    #'
+    attr_filters = function(attr_name, default = list()) {
+      stopifnot(
+        "'attr_name' must be a single character value" = is.character(attr_name) &&
+          length(attr_name) == 1L &&
+          nzchar(attr_name),
+        "'default' must be an unnamed list" = is.list(default) && !is_named(default)
+      )
+      filters <- private$.attr(attr_name)[['filters']] %||% default
+      return(private$.build_filters(filters))
     },
 
     #' @return bool
     #'
-    write_X_chunked = function() {
-        super$get("write_X_chunked", default=.default_write_x_chunked())
-    },
+    write_X_chunked = function() self$get('write_X_chunked'),
 
     #' @return int
     #'
-    goal_chunk_nnz = function() {
-        super$get("goal_chunk_nnz", default=.default_goal_chunk_nnz())
-    },
+    goal_chunk_nnz = function() self$get('goal_chunk_nnz'),
 
+    #' @description ...
+    #'
+    #' @param build_filters Build filters into
+    #' \code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
+    #'
+    #' @return The create options as a list
+    #'
+    to_list = function(build_filters = TRUE) {
+      stopifnot("'build_filters' must be TRUE or FALSE" = is_scalar_logical(build_filters))
+      opts <- super$to_list()
+      if (isTRUE(build_filters)) {
+        for (key in grep('_filters$', names(x = opts), value = TRUE)) {
+          opts[[key]] <- private$.build_filters(opts[[key]])
+        }
+        for (key in c('dims', 'attrs')) {
+          for (i in seq_along(opts[[key]])) {
+            if ('filters' %in% names(opts[[key]][[i]])) {
+              opts[[key]][[i]][['filters']] <- private$.build_filters(
+                opts[[key]][[i]][['filters']]
+              )
+            }
+          }
+        }
+      }
+      return(opts)
+    }
+  ),
+
+  private = list(
     # This is an accessor for nested things like
     #
     #   cfg <- PlatformConfig$new()
@@ -228,17 +263,11 @@ TileDBCreateOptions <- R6::R6Class(
     #
     # -- given "soma_dim_0", this pulls out the `list(tile = 6)` part.
     #
-    #' @param dim_name Name of dimensions
-    #'
-    #' @return Named list of character
-    #'
-    .dim = function(dim_name) {
-        o <- super$get("dims", NULL)
-        if (is.null(o)) {
-          return(NULL)
-        }
-        o[[dim_name]]
-    },
+    # @param dim_name Name of dimensions
+    #
+    # @return Named list of character
+    #
+    .dim = function(dim_name) self$get('dims', NULL)[[dim_name]],
 
     # This is an accessor for nested things like
     #
@@ -248,17 +277,11 @@ TileDBCreateOptions <- R6::R6Class(
     #
     # -- this pulls out the `attrs` -> `myattr` part.
     #
-    #' @param attr_name Name of attribute
+    # @param attr_name Name of attribute
+    #
+    # @return Named list of character
     #'
-    #' @return Named list of character
-    #'
-    .attr = function(attr_name) {
-        o <- super$get("attrs", NULL)
-        if (is.null(o)) {
-          return(NULL)
-        }
-        o[[attr_name]]
-    },
+    .attr = function(attr_name) self$get("attrs", NULL)[[attr_name]],
 
     # The `items` argument is a list of arguments acceptable to `.build_filter`.
     # Example argument:
@@ -266,39 +289,39 @@ TileDBCreateOptions <- R6::R6Class(
     #     "RLE",
     #     list(name = "ZSTD", COMPRESSION_LEVEL = 9)
     #   )
-    #' @param items A list of filters; see \code{$.build_filter()} for details
-    #' about entries in \code{items}
-    #'
-    #' @return A list of tiledb filters.
-    #'
-    .build_filters = function(items) {
-      lapply(items, self$.build_filter)
-    },
+    # @param items A list of filters; see \code{$.build_filter()} for details
+    # about entries in \code{items}
+    #
+    # @return A list of tiledb filters.
+    #
+    .build_filters = function(items) lapply(items, private$.build_filter),
 
     # The `item` argument can be a string, like "RLE".
     # Or, a named list with filter name and remaining arguments, like
     # list(name="ZSTD", COMPRESSION_LEVEL=-1).
     #
-    #' @param item THe name of a filter or a list with the name and arguments
-    #' for a filter (eg. \code{list(name = "ZSTD", COMPRESSION_LEVEL = -1)})
-    #'
-    #' @return A tiledb filter.
-    #'
+    # @param item THe name of a filter or a list with the name and arguments
+    # for a filter (eg. \code{list(name = "ZSTD", COMPRESSION_LEVEL = -1)})
+    #
+    # @return A tiledb filter.
+    #
     .build_filter = function(item) {
       # See also:
       # https://tiledb-inc.github.io/TileDB-R/reference/tiledb_filter.html
-      if (is.character(item) && length(item) == 1) {
-        return(tiledb::tiledb_filter(item[[1]]))
+      if (rlang::is_scalar_character(item)) {
+        # return(tiledb::tiledb_filter(item[[1]]))
+        item <- list(name = item)
       }
-
-      stopifnot(!is.na(item['name']))
+      stopifnot(
+        "'item' must be a named list" = is.list(item) &&
+          is_named(item, allow_empty = FALSE),
+        "'name' must be one of the names in 'item'" = 'name' %in% names(item)
+      )
       filter <- tiledb::tiledb_filter(item[['name']])
-      for (key in names(item)) {
-        if (key != "name") {
-          tiledb::tiledb_filter_set_option(filter, key, item[[key]])
-        }
+      for (key in setdiff(x = names(item), y = 'name')) {
+        tiledb::tiledb_filter_set_option(filter, option = key, value = item[[key]])
       }
-      filter
+      return(filter)
     }
   )
 )

--- a/apis/r/man/TileDBCreateOptions.Rd
+++ b/apis/r/man/TileDBCreateOptions.Rd
@@ -10,6 +10,54 @@ Provides strongly-typed access and default values for
 
 Intended for internal use only.
 }
+\examples{
+
+## ------------------------------------------------
+## Method `TileDBCreateOptions$dim_tile`
+## ------------------------------------------------
+
+cfg <- PlatformConfig$new()
+cfg$set(
+  platform = 'tiledb',
+  param = 'create',
+  key = 'dims',
+  value = list(soma_dim_0 = list(tile = 999))
+)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$dim_tile("soma_dim_0")
+tdco$dim_tile("soma_dim_1")
+
+
+## ------------------------------------------------
+## Method `TileDBCreateOptions$dim_filters`
+## ------------------------------------------------
+
+filters <- list(
+  soma_dim_0 = list(tile = 100, filters = list("RLE")),
+  soma_dim_1 = list(tile = 200, filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+)
+cfg <- PlatformConfig$new()
+cfg$set(platform = 'tiledb', param = 'create', key = 'dims', value = filters)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$dim_filters("soma_dim_0")
+tdco$dim_filters("non-existant")
+
+
+## ------------------------------------------------
+## Method `TileDBCreateOptions$attr_filters`
+## ------------------------------------------------
+
+filters <- list(
+  soma_data_a = list(filters = list("RLE")),
+  soma_data_b = list(filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+)
+cfg <- PlatformConfig$new()
+cfg$set(platform = 'tiledb', param = 'create', key = 'attrs', value = filters)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$attr_filters("soma_data_b")
+tdco$attr_filters("non-existant")
+
+}
 \keyword{internal}
 \section{Super class}{
 \code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{TileDBCreateOptions}
@@ -30,10 +78,7 @@ Intended for internal use only.
 \item \href{#method-TileDBCreateOptions-attr_filters}{\code{TileDBCreateOptions$attr_filters()}}
 \item \href{#method-TileDBCreateOptions-write_X_chunked}{\code{TileDBCreateOptions$write_X_chunked()}}
 \item \href{#method-TileDBCreateOptions-goal_chunk_nnz}{\code{TileDBCreateOptions$goal_chunk_nnz()}}
-\item \href{#method-TileDBCreateOptions-.dim}{\code{TileDBCreateOptions$.dim()}}
-\item \href{#method-TileDBCreateOptions-.attr}{\code{TileDBCreateOptions$.attr()}}
-\item \href{#method-TileDBCreateOptions-.build_filters}{\code{TileDBCreateOptions$.build_filters()}}
-\item \href{#method-TileDBCreateOptions-.build_filter}{\code{TileDBCreateOptions$.build_filter()}}
+\item \href{#method-TileDBCreateOptions-to_list}{\code{TileDBCreateOptions$to_list()}}
 \item \href{#method-TileDBCreateOptions-clone}{\code{TileDBCreateOptions$clone()}}
 }
 }
@@ -48,7 +93,6 @@ Intended for internal use only.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="remove"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-remove'><code>tiledbsoma::MappingBase$remove()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="set"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-set'><code>tiledbsoma::MappingBase$set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="setv"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-setv'><code>tiledbsoma::MappingBase$setv()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="to_list"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-to_list'><code>tiledbsoma::MappingBase$to_list()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="update"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-update'><code>tiledbsoma::MappingBase$update()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="MappingBase" data-id="values"><a href='../../tiledbsoma/html/MappingBase.html#method-MappingBase-values'><code>tiledbsoma::MappingBase$values()</code></a></span></li>
 </ul>
@@ -60,7 +104,7 @@ Intended for internal use only.
 \subsection{Method \code{new()}}{
 Create a \code{TileDBCreateOptions} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$new(platform_config)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$new(platform_config = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -84,8 +128,8 @@ case will we use the default values provided.
 }
 
 \subsection{Returns}{
-a list keyed by \dQuote{\code{cell_order}} and
-\dQuote{\code{tile_order}}, where either value or both may be \code{NULL}.
+A two-length character vector with names of
+\dQuote{\code{cell_order}} and \dQuote{\code{tile_order}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -93,7 +137,7 @@ a list keyed by \dQuote{\code{cell_order}} and
 \if{latex}{\out{\hypertarget{method-TileDBCreateOptions-dim_tile}{}}}
 \subsection{Method \code{dim_tile()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$dim_tile(dim_name, default = .default_tile_extent())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$dim_tile(dim_name, default = 2048)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -108,6 +152,24 @@ a list keyed by \dQuote{\code{cell_order}} and
 \subsection{Returns}{
 int
 }
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{cfg <- PlatformConfig$new()
+cfg$set(
+  platform = 'tiledb',
+  param = 'create',
+  key = 'dims',
+  value = list(soma_dim_0 = list(tile = 999))
+)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$dim_tile("soma_dim_0")
+tdco$dim_tile("soma_dim_1")
+
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TileDBCreateOptions-capacity"></a>}}
@@ -162,7 +224,7 @@ int
 \if{latex}{\out{\hypertarget{method-TileDBCreateOptions-offsets_filters}{}}}
 \subsection{Method \code{offsets_filters()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$offsets_filters(default = .default_offsets_filters())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$offsets_filters(default = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -173,7 +235,8 @@ int
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-list of tiledb.Filter
+A list of
+\code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
 }
 }
 \if{html}{\out{<hr>}}
@@ -181,7 +244,7 @@ list of tiledb.Filter
 \if{latex}{\out{\hypertarget{method-TileDBCreateOptions-validity_filters}{}}}
 \subsection{Method \code{validity_filters()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$validity_filters(default = .default_validity_filters())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$validity_filters(default = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -192,7 +255,8 @@ list of tiledb.Filter
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-list of tiledb.Filter
+A list of
+\code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
 }
 }
 \if{html}{\out{<hr>}}
@@ -213,8 +277,26 @@ list of tiledb.Filter
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-list of tiledb.Filter
+A list of
+\code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
 }
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{filters <- list(
+  soma_dim_0 = list(tile = 100, filters = list("RLE")),
+  soma_dim_1 = list(tile = 200, filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+)
+cfg <- PlatformConfig$new()
+cfg$set(platform = 'tiledb', param = 'create', key = 'dims', value = filters)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$dim_filters("soma_dim_0")
+tdco$dim_filters("non-existant")
+
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TileDBCreateOptions-attr_filters"></a>}}
@@ -234,8 +316,26 @@ list of tiledb.Filter
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-list of tiledb.Filter
+A list of
+\code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects
 }
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{filters <- list(
+  soma_data_a = list(filters = list("RLE")),
+  soma_data_b = list(filters = list("RLE", list(name = "ZSTD", COMPRESSION_LEVEL = 9)))
+)
+cfg <- PlatformConfig$new()
+cfg$set(platform = 'tiledb', param = 'create', key = 'attrs', value = filters)
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$attr_filters("soma_data_b")
+tdco$attr_filters("non-existant")
+
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TileDBCreateOptions-write_X_chunked"></a>}}
@@ -262,81 +362,24 @@ int
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TileDBCreateOptions-.dim"></a>}}
-\if{latex}{\out{\hypertarget{method-TileDBCreateOptions-.dim}{}}}
-\subsection{Method \code{.dim()}}{
+\if{html}{\out{<a id="method-TileDBCreateOptions-to_list"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBCreateOptions-to_list}{}}}
+\subsection{Method \code{to_list()}}{
+...
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$.dim(dim_name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$to_list(build_filters = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{dim_name}}{Name of dimensions}
+\item{\code{build_filters}}{Build filters into
+\code{\link[tiledb:tiledb_filter-class]{tiledb_filter}} objects}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Named list of character
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TileDBCreateOptions-.attr"></a>}}
-\if{latex}{\out{\hypertarget{method-TileDBCreateOptions-.attr}{}}}
-\subsection{Method \code{.attr()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$.attr(attr_name)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{attr_name}}{Name of attribute}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Named list of character
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TileDBCreateOptions-.build_filters"></a>}}
-\if{latex}{\out{\hypertarget{method-TileDBCreateOptions-.build_filters}{}}}
-\subsection{Method \code{.build_filters()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$.build_filters(items)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{items}}{A list of filters; see \code{$.build_filter()} for details
-about entries in \code{items}}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A list of tiledb filters.
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TileDBCreateOptions-.build_filter"></a>}}
-\if{latex}{\out{\hypertarget{method-TileDBCreateOptions-.build_filter}{}}}
-\subsection{Method \code{.build_filter()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$.build_filter(item)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{item}}{THe name of a filter or a list with the name and arguments
-for a filter (eg. \code{list(name = "ZSTD", COMPRESSION_LEVEL = -1)})}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A tiledb filter.
+The create options as a list
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/tests/testthat/test-TileDBCreateOptions.R
+++ b/apis/r/tests/testthat/test-TileDBCreateOptions.R
@@ -12,27 +12,27 @@ test_that("TileDBCreateOptions construction", {
 test_that("TileDBCreateOptions access from PlatformConfig", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('not_tiledb', 'not_create', 'not_dataframe_dim_zstd_level', 999)
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'not_create', 'not_dataframe_dim_zstd_level', 999)
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('not_tiledb', 'create', 'not_dataframe_dim_zstd_level', 999)
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'not_dataframe_dim_zstd_level', 999)
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'dataframe_dim_zstd_level', 999)
@@ -45,7 +45,7 @@ test_that("TileDBCreateOptions access from PlatformConfig", {
 test_that("TileDBCreateOptions dataframe_dim_zstd_level", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dataframe_dim_zstd_level(), .default_dataframe_dim_zstd_level())
+  expect_equal(tdco$dataframe_dim_zstd_level(), .CREATE_DEFAULTS$dataframe_dim_zstd_level)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'dataframe_dim_zstd_level', 999)
@@ -56,7 +56,10 @@ test_that("TileDBCreateOptions dataframe_dim_zstd_level", {
 test_that("TileDBCreateOptions sparse_nd_array_dim_zstd_level", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$sparse_nd_array_dim_zstd_level(), .default_sparse_nd_array_dim_zstd_level())
+  expect_equal(
+    tdco$sparse_nd_array_dim_zstd_level(),
+    .CREATE_DEFAULTS$sparse_nd_array_dim_zstd_level
+  )
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'sparse_nd_array_dim_zstd_level', 999)
@@ -67,7 +70,7 @@ test_that("TileDBCreateOptions sparse_nd_array_dim_zstd_level", {
 test_that("TileDBCreateOptions write_X_chunked", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$write_X_chunked(), .default_write_x_chunked())
+  expect_equal(tdco$write_X_chunked(), .CREATE_DEFAULTS$write_X_chunked)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'write_X_chunked', FALSE)
@@ -83,7 +86,7 @@ test_that("TileDBCreateOptions write_X_chunked", {
 test_that("TileDBCreateOptions goal_chunk_nnz", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$goal_chunk_nnz(), .default_goal_chunk_nnz())
+  expect_equal(tdco$goal_chunk_nnz(), .CREATE_DEFAULTS$goal_chunk_nnz)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'goal_chunk_nnz', 999)
@@ -94,17 +97,28 @@ test_that("TileDBCreateOptions goal_chunk_nnz", {
 test_that("TileDBCreateOptions cell_tile_orders", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$cell_tile_orders(), c(cell_order = .default_cell_order(), tile_order = .default_tile_order()))
+  expect_equal(
+    tdco$cell_tile_orders(),
+    c(cell_order = .CREATE_DEFAULTS$cell_order, tile_order = .CREATE_DEFAULTS$tile_order)
+  )
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'cell_order', 'foo')
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$cell_tile_orders(), c(cell_order = 'foo', tile_order = NULL))
+  expect_equal(
+    tdco$cell_tile_orders(),
+    c(cell_order = 'foo', tile_order = .CREATE_DEFAULTS$tile_order)
+  )
+  # expect_equal(tdco$cell_tile_orders(), c(cell_order = 'foo', tile_order = NULL))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'tile_order', 'bar')
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$cell_tile_orders(), c(cell_order = NULL, tile_order = 'bar'))
+  expect_equal(
+    tdco$cell_tile_orders(),
+    c(cell_order = .CREATE_DEFAULTS$cell_order, tile_order = 'bar')
+  )
+  # expect_equal(tdco$cell_tile_orders(), c(cell_order = NULL, tile_order = 'bar'))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'cell_order', 'foo')
@@ -116,7 +130,7 @@ test_that("TileDBCreateOptions cell_tile_orders", {
 test_that("TileDBCreateOptions dim_tile", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$dim_tile("soma_dim_0"), .default_tile_extent())
+  expect_equal(tdco$dim_tile("soma_dim_0"), 2048)
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'dims', list(soma_dim_0 = list(tile = 999)))
@@ -164,7 +178,7 @@ test_that("TileDBCreateOptions attr_filters", {
 test_that("TileDBCreateOptions offsets_filters", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(length(tdco$offsets_filters()), length(.default_offsets_filters()))
+  expect_length(tdco$offsets_filters(), length(.CREATE_DEFAULTS$offsets_filters))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'offsets_filters',
@@ -187,7 +201,7 @@ test_that("TileDBCreateOptions offsets_filters", {
 test_that("TileDBCreateOptions validity_filters", {
   cfg <- PlatformConfig$new()
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(length(tdco$validity_filters()), length(.default_validity_filters()))
+  expect_length(tdco$validity_filters(), length(.CREATE_DEFAULTS$validity_filters))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'validity_filters',
@@ -226,7 +240,7 @@ test_that("TileDBCreateOptions overrides", {
 
   expect_error(tdco$dim_tile())
   expect_equal(tdco$dim_tile('soma_dim_0'), 6)
-  expect_equal(tdco$dim_tile('soma_dim_1'), .default_tile_extent())
+  expect_equal(tdco$dim_tile('soma_dim_1'), 2048)
 
   expect_error(tdco$dim_filters())
   expect_equal(length(tdco$dim_filters("soma_dim_0")), 0)


### PR DESCRIPTION
Set default creation options during `TileDBCreateOptions$initialize()` instead of on-the-fly in the accessors. This allows easy serialization of `TileDBCreateOptions` with `TileDBCreateOptions$to_list()`

Also add a new `build_filters` parameter to `TileDBCreateOptions$to_list()`; if `TRUE`, builds filters with `tiledb::tiledb_filter()`, otherwise leaves as characters/lists of characters describing the filters

Also simplify a lot of the accessors/filter building methods, and move `$.dim()`, `$.attr()`, `$.build_filters()`, and `$.build_filter()` to be private methods instead of public ones