### PR TITLE
[r] Always return filters in `TileDBCreateOptions`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.2
+Version: 1.10.99.3
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/R/TileDBCreateOptions.R
+++ b/apis/r/R/TileDBCreateOptions.R
@@ -236,6 +236,11 @@ TileDBCreateOptions <- R6::R6Class(
     to_list = function(build_filters = TRUE) {
       stopifnot("'build_filters' must be TRUE or FALSE" = is_scalar_logical(build_filters))
       opts <- super$to_list()
+      for (key in grep('_filters$', names(.CREATE_DEFAULTS), value = TRUE)) {
+        if (is.null(opts[[key]])) {
+          opts[[key]] <- .CREATE_DEFAULTS[[key]]
+        }
+      }
       if (isTRUE(build_filters)) {
         for (key in grep('_filters$', names(x = opts), value = TRUE)) {
           opts[[key]] <- private$.build_filters(opts[[key]])


### PR DESCRIPTION
Ensure filters are always returned in `TileDBCreateOptions$to_list()`