### PR TITLE
[c++] Pass Boolean to indicate sparse or dense in ArraySchema

### DIFF
--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -51,7 +51,7 @@ void SOMADataFrame::create(
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)),
-        TILEDB_SPARSE,
+        true,
         platform_config);
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMADataFrame", timestamp);
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -225,12 +225,12 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
     std::shared_ptr<Context> ctx,
     std::unique_ptr<ArrowSchema> arrow_schema,
     ArrowTable index_column_info,
-    tiledb_array_type_t array_type,
+    bool issparse,
     std::optional<PlatformConfig> platform_config) {
     auto index_column_array = std::move(index_column_info.first);
     auto index_column_schema = std::move(index_column_info.second);
 
-    ArraySchema schema(*ctx, array_type);
+    ArraySchema schema(*ctx, issparse ? TILEDB_SPARSE : TILEDB_DENSE);
     Domain domain(*ctx);
 
     if (platform_config) {

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -230,7 +230,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
     auto index_column_array = std::move(index_column_info.first);
     auto index_column_schema = std::move(index_column_info.second);
 
-    ArraySchema schema(*ctx, issparse ? TILEDB_SPARSE : TILEDB_DENSE);
+    ArraySchema schema(*ctx, is_sparse ? TILEDB_SPARSE : TILEDB_DENSE);
     Domain domain(*ctx);
 
     if (platform_config) {

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -225,7 +225,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
     std::shared_ptr<Context> ctx,
     std::unique_ptr<ArrowSchema> arrow_schema,
     ArrowTable index_column_info,
-    bool issparse,
+    bool is_sparse,
     std::optional<PlatformConfig> platform_config) {
     auto index_column_array = std::move(index_column_info.first);
     auto index_column_schema = std::move(index_column_info.second);

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -116,7 +116,7 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx,
         std::unique_ptr<ArrowSchema> arrow_schema,
         ArrowTable index_column_info,
-        bool issparse = true,
+        bool is_sparse = true,
         std::optional<PlatformConfig> platform_config = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -116,7 +116,7 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx,
         std::unique_ptr<ArrowSchema> arrow_schema,
         ArrowTable index_column_info,
-        tiledb_array_type_t array_type = TILEDB_SPARSE,
+        bool issparse = true,
         std::optional<PlatformConfig> platform_config = std::nullopt);
 
     /**


### PR DESCRIPTION
**Issue and/or context:**

This is a follow up PR to #2481.

**Changes:**

Use `bool` instead of `tiledb_array_type_t` to indicate whether the ArraySchema should be sparse or dense.
