### PR TITLE
[r,ci] Run coverage only on workflow_dispatch events

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: cd apis/r && tools/r-ci.sh run_tests
 
       - name: Coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}
         run: apis/r/tools/r-ci.sh coverage
 
       - name: View Logs


### PR DESCRIPTION
**Issue and/or context:**

Running code coverage under GitHub Actions periodically descends into instability that is both non-reproducible outside of GitHub Actions and has there (despite concerted best efforts) not been avoided. 

**Changes:**

Coverage will now run in workflow_dispatch events, i.e. when manually triggered.

**Notes for Reviewer:**

[SC 46218](https://app.shortcut.com/tiledb-inc/story/46218/r-run-coverage-in-workflow-dispatch-mode-only)