### PR TITLE
[r] Backport resume-mode for R to the `release-1.10` branch, and R 1.10.2

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.1
+Version: 1.10.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NAMESPACE
+++ b/apis/r/NAMESPACE
@@ -2,6 +2,8 @@
 
 S3method("[[",MappingBase)
 S3method("[[<-",MappingBase)
+S3method(.read_soma_joinids,SOMADataFrame)
+S3method(.read_soma_joinids,SOMASparseNDArray)
 S3method(as.list,CoordsStrider)
 S3method(as.list,MappingBase)
 S3method(iterators::nextElem,CoordsStrider)

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -11,6 +11,7 @@
 * Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
 * Add support for blockwise iteration
 * Make `reopen()` a public method for all `TileDBObjects`
+* Add support for resume-mode in `write_soma()`
 
 # 1.7.0
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,7 @@
+# 1.10.2
+
+* Port resume-ingest mode from Python to R
+
 # 1.10.1
 
 * This release contains a single Python-only bug fix

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -1,198 +1,402 @@
 
-#' @title Create SOMA DataFrame
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#' Create SOMA DataFrame
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
 #' @param uri URI for the TileDB object
-#' @param schema schema Arrow schema argument passed on to DataFrame$create()
-#' @param index_column_names Index column names passed on to DataFrame$create()
+#' @param schema Arrow schema argument for the \link[SOMADataFrame]{SOMA dataframe}
+#' @param index_column_names A vector of column names to use as user-defined
+#' index columns; all named columns must exist in the schema, and at least
+#' one index column name is required
+#' @param ingest_mode Ingestion mode when creating the TileDB object; choose from:
+#' \itemize{
+#'  \item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+#'  \item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+#'   if it already exists, simply open it for writing
+#' }
 #' @param platform_config Optional platform configuration
 #' @param tiledbsoma_ctx Optional SOMATileDBContext
 #' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#'
 #' @export
-SOMADataFrameCreate <- function(uri, schema, index_column_names = c("soma_joinid"),
-                                platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    sdf <- SOMADataFrame$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp, internal_use_only = "allowed_use")
-    sdf$create(schema, index_column_names=index_column_names, platform_config=platform_config, internal_use_only = "allowed_use")
-
-    sdf
+#'
+SOMADataFrameCreate <- function(
+  uri,
+  schema,
+  index_column_names = c("soma_joinid"),
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  sdf <- SOMADataFrame$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(sdf$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    sdf$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
+    sdf$create(
+      schema,
+      index_column_names = index_column_names,
+      platform_config = platform_config,
+      internal_use_only = "allowed_use"
+    )
+  }
+  return(sdf)
 }
 
-#' @title Open SOMA DataFrame
-#' @description Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
+#' Open SOMA DataFrame
+#'
+#' Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
 #' @param mode One of `"READ"` or `"WRITE"`
 #' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp.
+#' In READ mode, defaults to the current time. If non-NULL, then all members
+#' accessed through the collection object inherit the timestamp.
+#'
 #' @export
-SOMADataFrameOpen <- function(uri, mode="READ",
-                              platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    sdf <- SOMADataFrame$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                             internal_use_only = "allowed_use")
-    sdf$open(mode, internal_use_only = "allowed_use")
-    sdf
+#'
+SOMADataFrameOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  sdf <- SOMADataFrame$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  sdf$open(mode, internal_use_only = "allowed_use")
+  return(sdf)
 }
 
-#' @title Create SOMA Sparse Nd Array
-#' @description Factory function to create a SOMASparseNDArray for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
+#' Create SOMA Sparse Nd Array
+#'
+#' Factory function to create a SOMASparseNDArray for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
 #' @param type An [Arrow type][arrow::data-type] defining the type of each element in the array.
 #' @param shape A vector of integers defining the shape of the array.
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#'
 #' @export
-SOMASparseNDArrayCreate <- function(uri, type, shape,
-                                    platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    snda <- SOMASparseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                  internal_use_only = "allowed_use")
-    snda$create(type, shape, platform_config=platform_config, internal_use_only = "allowed_use")
-    snda
+#'
+SOMASparseNDArrayCreate <- function(
+  uri,
+  type,
+  shape,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  snda <- SOMASparseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(snda$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    snda$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
+    snda$create(
+      type,
+      shape,
+      platform_config = platform_config,
+      internal_use_only = "allowed_use"
+    )
+  }
+  return(snda)
 }
 
-#' @title Open SOMA Sparse Nd Array
-#' @description Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Open SOMA Sparse Nd Array
+#'
+#' Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMASparseNDArrayOpen <- function(uri, mode="READ",
-                                  platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    snda <- SOMASparseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                  internal_use_only = "allowed_use")
-    snda$open(mode, internal_use_only = "allowed_use")
-    snda
+#'
+SOMASparseNDArrayOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  snda <- SOMASparseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  snda$open(mode, internal_use_only = "allowed_use")
+  return(snda)
 }
 
-#' @title Create SOMA Dense Nd Array
-#' @description Factory function to create a SOMADenseNDArray for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param type An [Arrow type][arrow::data-type] defining the type of each element in the array.
-#' @param shape A vector of integers defining the shape of the array.
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Dense Nd Array
+#'
+#' Factory function to create a SOMADenseNDArray for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMASparseNDArrayCreate
+#'
 #' @export
-SOMADenseNDArrayCreate <- function(uri, type, shape,
-                                   platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    dnda <- SOMADenseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                 internal_use_only = "allowed_use")
-    dnda$create(type, shape, platform_config=platform_config, internal_use_only = "allowed_use")
-    dnda
+#'
+SOMADenseNDArrayCreate <- function(
+  uri,
+  type,
+  shape,
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  dnda <- SOMADenseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  dnda$create(
+    type,
+    shape,
+    platform_config = platform_config,
+    internal_use_only = "allowed_use"
+  )
+  return(dnda)
 }
 
-#' @title Open SOMA Dense Nd Array
-#' @description Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Open SOMA Dense Nd Array
+#'
+#' Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMADenseNDArrayOpen <- function(uri, mode="READ",
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    dnda <- SOMADenseNDArray$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                 internal_use_only = "allowed_use")
-    dnda$open(mode, internal_use_only = "allowed_use")
-    dnda
+#'
+SOMADenseNDArrayOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  dnda <- SOMADenseNDArray$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  dnda$open(mode, internal_use_only = "allowed_use")
+  return(dnda)
 }
 
-#' @title Create SOMA Collection
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Collection
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMACollectionCreate <- function(uri,
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    coll <- SOMACollection$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                               internal_use_only = "allowed_use")
+#'
+SOMACollectionCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  coll <- SOMACollection$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(coll$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    coll$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     coll$create(internal_use_only = "allowed_use")
-    coll
+  }
+  return(coll)
 }
 
-#' @title Open SOMA Collection
-#' @description Factory function to open a SOMACollection for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Collection
+#'
+#' Factory function to open a SOMACollection for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMACollectionOpen <- function(uri, mode="READ",
-                               platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    coll <- SOMACollection$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                               internal_use_only = "allowed_use")
-    coll$open(mode, internal_use_only = "allowed_use")
-    coll
+#'
+SOMACollectionOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  coll <- SOMACollection$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  coll$open(mode, internal_use_only = "allowed_use")
+  return(coll)
 }
 
-#' @title Create SOMA Measurement
-#' @description Factory function to create a SOMAMeasurement for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Measurement
+#'
+#' Factory function to create a SOMAMeasurement for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMAMeasurementCreate <- function(uri,
-                                  platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    meas <- SOMAMeasurement$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                internal_use_only = "allowed_use")
+#'
+SOMAMeasurementCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  meas <- SOMAMeasurement$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(meas$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    meas$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     meas$create(internal_use_only = "allowed_use")
-    meas
+  }
+  return(meas)
 }
 
-#' @title Open SOMA Measurement
-#' @description Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Measurement
+#'
+#' Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMAMeasurementOpen <- function(uri, mode="READ",
-                                platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    meas <- SOMAMeasurement$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                                internal_use_only = "allowed_use")
-    meas$open(mode, internal_use_only = "allowed_use")
-    meas
+#'
+SOMAMeasurementOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  meas <- SOMAMeasurement$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  meas$open(mode, internal_use_only = "allowed_use")
+  return(meas)
 }
 
-#' @title Create SOMA Experiment
-#' @description Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp
+#' Create SOMA Experiment
+#'
+#' Factory function to create a SOMADataFrame for writing, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameCreate
+#'
 #' @export
-SOMAExperimentCreate <- function(uri,
-                                 platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    exp <- SOMAExperiment$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                              internal_use_only = "allowed_use")
+#'
+SOMAExperimentCreate <- function(
+  uri,
+  ingest_mode = c("write", "resume"),
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  ingest_mode <- match.arg(ingest_mode)
+  exp <- SOMAExperiment$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  ingest_mode <- switch(
+    EXPR = ingest_mode,
+    resume = ifelse(exp$exists(), yes = ingest_mode, no = "write"),
+    ingest_mode
+  )
+  if (ingest_mode %in% c("resume")) {
+    exp$open(mode = "WRITE", internal_use_only = "allowed_use")
+  } else {
     exp$create(internal_use_only = "allowed_use")
-    exp
+  }
+  return(exp)
 }
 
-#' @title Open SOMA Experiment
-#' @description Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)
-#' @param uri URI for the TileDB object
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-#'        to the current time. If non-NULL, then all members accessed through the collection object
-#'        inherit the timestamp.
+#' Open SOMA Experiment
+#'
+#' Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)
+#'
+#' @inheritParams SOMADataFrameOpen
+#'
 #' @export
-SOMAExperimentOpen <- function(uri, mode="READ",
-                               platform_config = NULL, tiledbsoma_ctx = NULL, tiledb_timestamp = NULL) {
-    exp <- SOMAExperiment$new(uri, platform_config, tiledbsoma_ctx, tiledb_timestamp,
-                              internal_use_only = "allowed_use")
-    exp$open(mode, internal_use_only = "allowed_use")
-    exp
+#'
+SOMAExperimentOpen <- function(
+  uri,
+  mode = "READ",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL,
+  tiledb_timestamp = NULL
+) {
+  exp <- SOMAExperiment$new(
+    uri,
+    platform_config,
+    tiledbsoma_ctx,
+    tiledb_timestamp,
+    internal_use_only = "allowed_use"
+  )
+  exp$open(mode, internal_use_only = "allowed_use")
+  return(exp)
 }

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -83,15 +83,18 @@ TileDBObject <- R6::R6Class(
     #'  \item \dQuote{\code{WRITE}}
     #' }
     #' By default, reopens in the opposite mode of the current mode
+    #' @param force Force a close/reopen cycle; by default, if \code{mode} is
+    #' \code{self$mode()}, \code{reopen()} does nothing
     #'
     #' @return Invisibly returns \code{self}
     #'
-    reopen = function(mode = NULL) {
+    reopen = function(mode = NULL, force = FALSE) {
+      stopifnot("'force' must be TRUE or FALSE" = is_scalar_logical(force))
       modes <- c(READ = 'WRITE', WRITE = 'READ')
       oldmode <- self$mode()
       mode <- mode %||% modes[oldmode]
       mode <- match.arg(mode, choices = modes)
-      if (mode != oldmode) {
+      if (isTRUE(force) || mode != oldmode) {
         self$close()
         self$open(mode, internal_use_only = 'allowed_use')
       }

--- a/apis/r/man/SOMACollectionCreate.Rd
+++ b/apis/r/man/SOMACollectionCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMACollectionCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMACollectionCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMACollectionOpen.Rd
+++ b/apis/r/man/SOMACollectionOpen.Rd
@@ -19,11 +19,11 @@ SOMACollectionOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMACollection for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMADataFrameCreate.Rd
+++ b/apis/r/man/SOMADataFrameCreate.Rd
@@ -8,6 +8,7 @@ SOMADataFrameCreate(
   uri,
   schema,
   index_column_names = c("soma_joinid"),
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -16,9 +17,18 @@ SOMADataFrameCreate(
 \arguments{
 \item{uri}{URI for the TileDB object}
 
-\item{schema}{schema Arrow schema argument passed on to DataFrame$create()}
+\item{schema}{Arrow schema argument for the \link[SOMADataFrame]{SOMA dataframe}}
 
-\item{index_column_names}{Index column names passed on to DataFrame$create()}
+\item{index_column_names}{A vector of column names to use as user-defined
+index columns; all named columns must exist in the schema, and at least
+one index column name is required}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMADataFrameOpen.Rd
+++ b/apis/r/man/SOMADataFrameOpen.Rd
@@ -21,7 +21,9 @@ SOMADataFrameOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMADataFrame for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMADenseNDArrayOpen.Rd
+++ b/apis/r/man/SOMADenseNDArrayOpen.Rd
@@ -21,7 +21,9 @@ SOMADenseNDArrayOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMADenseNDArray for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMAExperimentCreate.Rd
+++ b/apis/r/man/SOMAExperimentCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMAExperimentCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMAExperimentCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMAExperimentOpen.Rd
+++ b/apis/r/man/SOMAExperimentOpen.Rd
@@ -19,11 +19,11 @@ SOMAExperimentOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMAExperiment for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMAMeasurementCreate.Rd
+++ b/apis/r/man/SOMAMeasurementCreate.Rd
@@ -6,6 +6,7 @@
 \usage{
 SOMAMeasurementCreate(
   uri,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -13,6 +14,13 @@ SOMAMeasurementCreate(
 }
 \arguments{
 \item{uri}{URI for the TileDB object}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMAMeasurementOpen.Rd
+++ b/apis/r/man/SOMAMeasurementOpen.Rd
@@ -19,11 +19,11 @@ SOMAMeasurementOpen(
 
 \item{platform_config}{Optional platform configuration}
 
-\item{tiledbsoma_ctx}{optional SOMATileDBContext}
+\item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp. In READ mode, defaults
-to the current time. If non-NULL, then all members accessed through the collection object
-inherit the timestamp.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMAMeasurement for reading, (lifecycle: experimental)

--- a/apis/r/man/SOMASparseNDArrayCreate.Rd
+++ b/apis/r/man/SOMASparseNDArrayCreate.Rd
@@ -8,6 +8,7 @@ SOMASparseNDArrayCreate(
   uri,
   type,
   shape,
+  ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   tiledb_timestamp = NULL
@@ -19,6 +20,13 @@ SOMASparseNDArrayCreate(
 \item{type}{An \link[arrow:data-type]{Arrow type} defining the type of each element in the array.}
 
 \item{shape}{A vector of integers defining the shape of the array.}
+
+\item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new TileDB object;
+if it already exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional platform configuration}
 

--- a/apis/r/man/SOMASparseNDArrayOpen.Rd
+++ b/apis/r/man/SOMASparseNDArrayOpen.Rd
@@ -21,7 +21,9 @@ SOMASparseNDArrayOpen(
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
 }
 \description{
 Factory function to open a SOMASparseNDArray for reading, (lifecycle: experimental)

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -118,6 +118,9 @@ Close and reopen the TileDB object in a new mode
 \item \dQuote{\code{WRITE}}
 }
 By default, reopens in the opposite mode of the current mode}
+
+\item{\code{force}}{Force a close/reopen cycle; by default, if \code{mode} is
+\code{self$mode()}, \code{reopen()} does nothing}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -4,7 +4,14 @@
 \alias{write_soma.Seurat}
 \title{Write a \code{\link[SeuratObject]{Seurat}} object to a SOMA}
 \usage{
-\method{write_soma}{Seurat}(x, uri, ..., platform_config = NULL, tiledbsoma_ctx = NULL)
+\method{write_soma}{Seurat}(
+  x,
+  uri,
+  ...,
+  ingest_mode = "write",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL
+)
 }
 \arguments{
 \item{x}{A \code{\link[SeuratObject]{Seurat}} object}
@@ -12,6 +19,13 @@
 \item{uri}{URI for resulting SOMA object}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma.SingleCellExperiment.Rd
+++ b/apis/r/man/write_soma.SingleCellExperiment.Rd
@@ -10,6 +10,7 @@ object to a SOMA}
   uri,
   ms_name = NULL,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL
 )
@@ -23,6 +24,13 @@ object to a SOMA}
 \code{\link[SingleCellExperiment]{mainExpName}(x)}}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma.SummarizedExperiment.Rd
+++ b/apis/r/man/write_soma.SummarizedExperiment.Rd
@@ -5,7 +5,15 @@
 \title{Write a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 object to a SOMA}
 \usage{
-\method{write_soma}{SummarizedExperiment}(x, uri, ms_name, ..., platform_config = NULL, tiledbsoma_ctx = NULL)
+\method{write_soma}{SummarizedExperiment}(
+  x,
+  uri,
+  ms_name,
+  ...,
+  ingest_mode = "write",
+  platform_config = NULL,
+  tiledbsoma_ctx = NULL
+)
 }
 \arguments{
 \item{x}{An object}
@@ -15,6 +23,13 @@ object to a SOMA}
 \item{ms_name}{Name for resulting measurement}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -18,6 +18,7 @@
   df_index = NULL,
   index_column_names = "soma_joinid",
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -31,6 +32,7 @@
   type = NULL,
   transpose = FALSE,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -42,6 +44,7 @@
   soma_parent,
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -55,6 +58,7 @@
   index_column_names = "soma_joinid",
   ...,
   key = NULL,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -69,6 +73,8 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -83,6 +89,8 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -96,6 +104,8 @@
   transpose = FALSE,
   ...,
   key = NULL,
+  ingest_mode = "write",
+  shape = NULL,
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -120,6 +130,13 @@ resulting SOMA object}
 
 \item{...}{Arguments passed to other methods}
 
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
+
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}
 
@@ -140,6 +157,9 @@ determine arrow type with \code{\link[arrow:infer_type]{arrow::infer_type}()}}
 \item{key}{Optionally register the resulting \code{SOMADataFrame} in
 \code{soma_parent} as \code{key}; pass \code{NULL} to prevent registration
 to handle manually}
+
+\item{shape}{A vector of two positive integers giving the on-disk shape of
+the array; defaults to \code{dim(x)}}
 }
 \value{
 The resulting SOMA \link[tiledbsoma:SOMASparseNDArray]{array} or

--- a/apis/r/man/write_soma_seurat_sub.Rd
+++ b/apis/r/man/write_soma_seurat_sub.Rd
@@ -13,6 +13,7 @@
   uri = NULL,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -25,6 +26,7 @@
   fidx = NULL,
   nfeatures = NULL,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -35,6 +37,7 @@
   uri,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -45,6 +48,7 @@
   uri = NULL,
   soma_parent,
   ...,
+  ingest_mode = "write",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
   relative = TRUE
@@ -63,6 +67,13 @@ for the \code{DimReduc} and \code{Graph} methods, this \strong{must} be a
 was generated from}
 
 \item{...}{Arguments passed to other methods}
+
+\item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
+\itemize{
+\item \dQuote{\code{write}}: create a new SOMA and error if it already exists
+\item \dQuote{\code{resume}}: attempt to create a new SOMA; if it already
+exists, simply open it for writing
+}}
 
 \item{platform_config}{Optional \link[tiledbsoma:PlatformConfig]{platform
 configuration}}

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -160,6 +160,7 @@ test_that("Write DimReduc mechanics", {
   ))
   on.exit(ms_pca2$close(), add = TRUE, after = FALSE)
   expect_no_condition(write_soma(pbmc_small_tsne, soma_parent = ms))
+  ms$reopen(ms$mode(), force = TRUE)
   expect_identical(sort(ms$names()), sort(c('X', 'var', 'obsm', 'varm')))
   expect_identical(sort(ms$obsm$names()), sort(paste0('X_', c('pca', 'tsne'))))
   expect_identical(ms$varm$names(), 'PCs')

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -1,7 +1,6 @@
 
 test_that("write_soma.data.frame mechanics", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame")
@@ -28,7 +27,6 @@ test_that("write_soma.data.frame mechanics", {
 
 test_that("write_soma.data.frame enumerations", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame-enumerations")
@@ -69,7 +67,6 @@ test_that("write_soma.data.frame enumerations", {
 
 test_that("write_soma.data.frame no enumerations", {
   skip_if(!extended_tests())
-  skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('datasets')
 
   uri <- withr::local_tempdir("write-soma-data-frame-factorless")

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -1,0 +1,916 @@
+
+factories <- list(
+  substitute(SOMADataFrameCreate),
+  substitute(SOMASparseNDArrayCreate),
+  substitute(SOMADenseNDArrayCreate),
+  substitute(SOMACollectionCreate),
+  substitute(SOMAMeasurementCreate),
+  substitute(SOMAExperimentCreate)
+)
+
+schema <- arrow::infer_schema(data.frame(
+  soma_joinid = bit64::integer64(),
+  int = integer()
+))
+
+test_that("Factory re-creation", {
+  skip_if(!extended_tests())
+  for (i in seq_along(factories)) {
+    fname <- as.character(factories[[i]])
+    fxn <- eval(factories[[i]])
+    uri <- withr::local_tempdir(fname)
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(uri, type = arrow::int32(), shape = c(20L, 10L)),
+      fxn(uri)
+    ))
+    expect_error(fxn(uri))
+    obj$close()
+  }
+
+  gc()
+})
+
+test_that("Resume-mode factories", {
+  skip_if(!extended_tests())
+  for (i in seq_along(factories)) {
+    fname <- as.character(factories[[i]])
+    if (fname == 'SOMADenseNDArrayCreate') {
+      next
+    }
+    fxn <- eval(factories[[i]])
+    label <- paste0(fname, "-resume")
+    uri <- withr::local_tempdir(label)
+    # Do an initial create
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(uri, type = arrow::int32(), shape = c(20L, 10L)),
+      fxn(uri)
+    ))
+    expect_true(obj$is_open(), label = fname)
+    expect_identical(obj$mode(), "WRITE", label = fname)
+    expect_true(obj$exists(), label = fname)
+    obj$close()
+
+    # Test that re-creating in "resume" mode simply re-opens the object
+    expect_no_condition(obj <- switch(
+      EXPR = fname,
+      SOMADataFrameCreate = fxn(uri, schema = schema, ingest_mode = "resume"),
+      SOMASparseNDArrayCreate = ,
+      SOMADenseNDArrayCreate = fxn(
+        uri,
+        type = arrow::int32(),
+        shape = c(20L, 10L),
+        ingest_mode = "resume"
+      ),
+      fxn(uri, ingest_mode = "resume")
+    ))
+    expect_true(obj$is_open(), label = label)
+    expect_identical(obj$mode(), "WRITE", label = label)
+    obj$close()
+  }
+
+  gc()
+})
+
+test_that("Resume-mode data frames", {
+  skip_if(!extended_tests())
+  skip_if_not_installed('datasets')
+
+  collection <- SOMACollectionCreate(withr::local_tempdir("dataframe-resume"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  co2 <- get_data('CO2', package = 'datasets')
+
+  # Test resume-mode when writing data.frames
+  uri <- "co2-complete"
+  expect_s3_class(
+    sdf <- write_soma(co2, uri = uri, soma_parent = collection),
+    "SOMADataFrame"
+  )
+  on.exit(sdf$close(), add = TRUE, after = FALSE)
+
+  sdf$reopen("READ")
+  df <- as.data.frame(sdf$read()$concat())
+  for (i in names(co2)) {
+    expect_identical(
+      df[[i]],
+      co2[[i]],
+      label = sprintf("df[['%s']]", i),
+      expected.label = sprintf("co2[['%s']]", i)
+    )
+  }
+
+  # Expect error when writing to existing array
+  expect_error(write_soma(co2, uri = uri, soma_parent = collection))
+
+  # Expect seamless pass when resuming writing to exisitng array
+  expect_s3_class(
+    sdfr <- write_soma(
+      co2,
+      uri = uri,
+      soma_parent = collection,
+      ingest_mode = "resume"
+    ),
+    "SOMADataFrame"
+  )
+  on.exit(sdfr$close(), add = TRUE, after = FALSE)
+  expect_identical(sdf$uri, sdfr$uri)
+
+  sdfr$reopen("READ")
+  dfr <- as.data.frame(sdfr$read()$concat())
+  for (i in names(co2)) {
+    for (i in names(co2)) {
+      expect_identical(
+        dfr[[i]],
+        co2[[i]],
+        label = sprintf("dfr[['%s']]", i),
+        expected.label = sprintf("co2[['%s']]", i)
+      )
+    }
+  }
+
+  # Test resume-mode with partial writes
+  idx <- seq.int(1L, floor(nrow(co2) / 3))
+  co2p <- co2[idx, , drop = FALSE]
+  uri <- "co2-parital"
+  expect_s3_class(
+    sdfp <- write_soma(co2p, uri = uri, soma_parent = collection),
+    "SOMADataFrame"
+  )
+  on.exit(sdfp$close(), add = TRUE, after = FALSE)
+
+  sdfp$reopen("READ")
+  dfp <- as.data.frame(sdfp$read()$concat())
+  for (i in names(co2)) {
+    for (i in names(co2)) {
+      expect_identical(
+        dfp[[i]],
+        co2[[i]][idx],
+        label = sprintf("dfp[['%s']]", i),
+        expected.label = sprintf("co2[['%s']]", i)
+      )
+      expect_false(
+        identical(dfp[[i]], co2[[i]]),
+        info = "partial write is not identical to original data",
+        label = sprintf("dfp[['%s']] != co2[['%s']]", i, i)
+      )
+    }
+  }
+
+  expect_s3_class(
+    sdfc <- write_soma(
+      co2,
+      uri = uri,
+      soma_parent = collection,
+      ingest_mode = "resume"
+    ),
+    "SOMADataFrame"
+  )
+  on.exit(sdfc$close(), add = TRUE, after = FALSE)
+  expect_identical(sdfc$uri, sdfp$uri)
+
+  sdfc$reopen("READ")
+  dfc <- as.data.frame(sdfc$read()$concat())
+  for (i in names(co2)) {
+    for (i in names(co2)) {
+      expect_identical(
+        dfc[[i]],
+        co2[[i]],
+        label = sprintf("dfc[['%s']]", i),
+        expected.label = sprintf("co2[['%s']]", i)
+      )
+    }
+  }
+
+  gc()
+})
+
+test_that("Resume-mode sparse arrays", {
+  skip_if(!extended_tests())
+
+  collection <- SOMACollectionCreate(withr::local_tempdir("sparse-array-resume"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  knex <- as(get_data('KNex', package = 'Matrix')$mm, "TsparseMatrix")
+
+  # Test resume-mode when writing sparse arrays
+  uri <- "knex-complete"
+  expect_s3_class(
+    ssa <- write_soma(knex, uri = uri, soma_parent = collection),
+    "SOMASparseNDArray"
+  )
+  on.exit(ssa$close(), add = TRUE, after = FALSE)
+
+  ssa$reopen("READ")
+  mat <- ssa$read()$sparse_matrix()$concat()
+  expect_equal(
+    as.matrix(mat),
+    as.matrix(knex),
+    label = "mat",
+    expected.label = "knex"
+  )
+
+  # Expect error when writing to existing array
+  expect_error(write_soma(knex, uri = uri, soma_parent = collection))
+
+  # Expect seamless pass when resuming writing to complete existing array
+  expect_s3_class(
+    ssar <- write_soma(
+      knex,
+      uri = uri,
+      soma_parent = collection,
+      ingest_mode = "resume"
+    ),
+    "SOMASparseNDArray"
+  )
+  on.exit(ssar$close(), add = TRUE, after = FALSE)
+  expect_identical(ssar$uri, ssa$uri)
+
+  ssar$reopen("READ")
+  matr <- ssar$read()$sparse_matrix()$concat()
+  expect_identical(
+    as.matrix(matr),
+    as.matrix(knex),
+    label = "matr",
+    expected.label = "knex"
+  )
+
+  # Test resume-mode with partial writes
+  idx <- seq.int(1L, floor(nrow(knex) / 3))
+  knexp <- knex[idx, , drop = FALSE]
+  uri <- "knex-parital"
+  expect_s3_class(
+    ssap <- write_soma(knexp, uri = uri, soma_parent = collection, shape = dim(knex)),
+    "SOMASparseNDArray"
+  )
+  on.exit(ssap$close(), add = TRUE, after = FALSE)
+
+  ssap$reopen("READ")
+  matp <- ssap$read()$sparse_matrix()$concat()
+  expect_identical(dim(matp), dim(knex))
+  expect_identical(max(matp@i) + 1L, max(idx), label = "max(matp@i)")
+  expect_equal(
+    as.matrix(matp[idx, , drop = FALSE]),
+    as.matrix(knexp),
+    label = "matp",
+    expected.label = "knexp"
+  )
+
+  expect_s3_class(
+    ssac <- write_soma(
+      knex,
+      uri = uri,
+      soma_parent = collection,
+      ingest_mode = "resume"
+    ),
+    "SOMASparseNDArray"
+  )
+  on.exit(ssac$close(), add = TRUE, after = FALSE)
+  expect_identical(ssac$uri, ssap$uri)
+
+  ssac$reopen("READ")
+  matc <- ssac$read()$sparse_matrix()$concat()
+  expect_identical(dim(matc), dim(knex))
+  expect_identical(max(matc@i) + 1L, nrow(knex))
+  expect_identical(
+    as.matrix(matc),
+    as.matrix(knex),
+    label = "matc",
+    expected.label = "knex"
+  )
+  bbox <- tryCatch(
+    as.integer(ssac$used_shape(simplify = TRUE, index1 = TRUE)),
+    error = function(...) NULL
+  )
+  if (!is.null(bbox)) {
+    expect_identical(bbox, dim(knex))
+  }
+
+  gc()
+})
+
+test_that("Resume-mode dense arrays", {
+  skip_if(!extended_tests())
+  skip_if_not_installed('datasets')
+
+  collection <- SOMACollectionCreate(withr::local_tempdir("dense-array-resume"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  mat <- get(x = 'state.x77', envir = getNamespace('datasets'))
+
+  # Resume mode should always fail for dense arrays
+  expect_s3_class(
+    sda <- write_soma(
+      mat,
+      uri = "state-x77",
+      soma_parent = collection,
+      sparse = FALSE
+    ),
+    "SOMADenseNDArray"
+  )
+  on.exit(sda$close(), add = TRUE, after = FALSE)
+
+  expect_error(write_soma(
+    mat,
+    uri = "state-x77",
+    soma_parent = collection,
+    sparse = FALSE
+  ))
+  expect_error(write_soma(
+    mat,
+    uri = "state-x77",
+    soma_parent = collection,
+    sparse = FALSE,
+    ingest_mode = "resume"
+  ))
+
+  gc()
+})
+
+test_that("Resume-mode Seurat", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
+
+  # Test resume-mode when writing Seurat object
+  expect_type(
+    uri <- write_soma(
+      pbmc_small,
+      uri = withr::local_tempdir(SeuratObject::Project(pbmc_small))
+    ),
+    "character"
+  )
+  exp <- SOMAExperimentOpen(uri)
+  on.exit(exp$close(), add = TRUE, after = FALSE)
+
+  layers <- exp$ms$get("RNA")$X$names()
+  names(layers) <- gsub("_", ".", layers)
+
+  obj <- suppressWarnings(SOMAExperimentAxisQuery$new(exp, "RNA")$to_seurat(
+    layers,
+    obs_index = "obs_id",
+    var_index = "var_id"
+  ))
+
+  expect_identical(
+    sort(names(obj)),
+    sort(names(pbmc_small)),
+    label = "names(obj)",
+    expected.label = "names(pbmc_small)"
+  )
+
+  for (i in names(obj)) {
+    expect_s4_class(obj[[i]], class(pbmc_small[[i]]))
+    expect_identical(dim(obj[[i]]), dim(pbmc_small[[i]]))
+  }
+
+  for (i in names(pbmc_small[[]])) {
+    expect_identical(
+      obj[[i]],
+      pbmc_small[[i]],
+      label = sprintf("obj[['%s']]", i),
+      expected.label = sprintf("pbmc_small[['%s']]", i)
+    )
+  }
+
+  exp$close()
+  gc()
+
+  # Expect error when writing to existing array
+  expect_error(write_soma(pbmc_small, uri = uri))
+
+  # Expect seamless pass when resuming writing to exisitng experiment
+  expect_type(
+    urir <- write_soma(pbmc_small, uri = uri, ingest_mode = "resume"),
+    "character"
+  )
+  expect_identical(urir, uri)
+
+  expr <- SOMAExperimentOpen(urir)
+  on.exit(expr$close(), add = TRUE, after = FALSE)
+
+  objr <- suppressWarnings(SOMAExperimentAxisQuery$new(expr, "RNA")$to_seurat(
+    layers,
+    obs_index = "obs_id",
+    var_index = "var_id"
+  ))
+
+  expect_identical(
+    sort(names(objr)),
+    sort(names(pbmc_small)),
+    label = "names(objr)",
+    expected.label = "names(pbmc_small)"
+  )
+
+  for (i in names(objr)) {
+    expect_s4_class(objr[[i]], class(pbmc_small[[i]]))
+    expect_identical(dim(objr[[i]]), dim(pbmc_small[[i]]))
+  }
+
+  for (i in names(pbmc_small[[]])) {
+    expect_identical(
+      objr[[i]],
+      pbmc_small[[i]],
+      label = sprintf("objr[['%s']]", i),
+      expected.label = sprintf("pbmc_small[['%s']]", i)
+    )
+  }
+
+  expr$close()
+  gc()
+
+  # Test resume-mode with partial writes
+  idx <- seq.int(1L, floor(ncol(pbmc_small) / 3))
+  pbmc_partial <- subset(pbmc_small, cells = idx)
+  for (i in names(pbmc_partial)) {
+    if (inherits(i, "Assay")) {
+      next
+    }
+    SeuratObject::DefaultAssay(pbmc_partial[[i]]) <- SeuratObject::DefaultAssay(pbmc_partial[[i]]) %||%
+      SeuratObject::DefaultAssay(pbmc_partial)
+  }
+
+  expect_type(
+    urip <- write_soma(
+      pbmc_partial,
+      uri = withr::local_tempdir("pbmc-partial"),
+      shape = dim(pbmc_small)
+    ),
+    "character"
+  )
+
+  expp <- SOMAExperimentOpen(urip)
+  on.exit(expp$close(), add = TRUE, after = FALSE)
+
+  layers <- expp$ms$get("RNA")$X$names()
+  names(layers) <- gsub("_", ".", layers)
+
+  objp <- suppressWarnings(SOMAExperimentAxisQuery$new(expp, "RNA")$to_seurat(
+    layers,
+    obs_index = "obs_id",
+    var_index = "var_id"
+  ))
+
+  expect_identical(dim(objp), dim(pbmc_partial))
+
+  for (i in names(objp)) {
+    expect_s4_class(objp[[i]], class(pbmc_partial[[i]]))
+    expect_identical(dim(objp[[i]]), dim(pbmc_partial[[i]]))
+  }
+
+  for (i in names(pbmc_partial[[]])) {
+    expect_identical(
+      objp[[i]],
+      pbmc_partial[[i]],
+      label = sprintf("objp[['%s']]", i),
+      expected.label = sprintf("pbmc_partial[['%s']]", i)
+    )
+  }
+
+  expp$close()
+  gc()
+
+  expect_type(
+    uric <- write_soma(pbmc_small, uri = urip, ingest_mode = "resume"),
+    "character"
+  )
+  expect_identical(uric, urip)
+
+  expc <- SOMAExperimentOpen(uric)
+  on.exit(expc$close(), add = TRUE, after = FALSE)
+
+  objc <- suppressWarnings(SOMAExperimentAxisQuery$new(expc, "RNA")$to_seurat(
+    layers,
+    obs_index = "obs_id",
+    var_index = "var_id"
+  ))
+
+  expect_identical(dim(objc), dim(pbmc_small))
+
+  for (i in names(objc)) {
+    expect_s4_class(objc[[i]], class(pbmc_small[[i]]))
+    expect_identical(dim(objc[[i]]), dim(pbmc_small[[i]]))
+  }
+
+  for (i in names(pbmc_small[[]])) {
+    expect_identical(
+      objc[[i]],
+      pbmc_small[[i]],
+      label = sprintf("objc[['%s']]", i),
+      expected.label = sprintf("pbmc_small[['%s']]", i)
+    )
+  }
+
+  expc$close()
+  gc()
+})
+
+test_that("Resume-mode SingleCellExperiment", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("pbmc3k.sce")
+  suppressMessages(skip_if_not_installed("SingleCellExperiment", .MINIMUM_SCE_VERSION("c")))
+
+  sce <- get_data('pbmc3k.final', package = "pbmc3k.sce")
+  SingleCellExperiment::mainExpName(sce) <- "RNA"
+
+  # Test resume-mode when writing Seurat object
+  expect_type(
+    uri <- write_soma(sce, uri = withr::local_tempdir("single-cell-experiment")),
+    "character"
+  )
+  exp <- SOMAExperimentOpen(uri)
+  on.exit(exp$close(), add = TRUE, after = FALSE)
+
+  obj <- SOMAExperimentAxisQuery$new(exp, "RNA")$to_single_cell_experiment(
+    obs_index = "obs_id",
+    var_index = "var_id"
+  )
+
+  expect_identical(dim(obj), dim(sce))
+  expect_identical(
+    sort(SummarizedExperiment::assayNames(obj)),
+    sort(SummarizedExperiment::assayNames(sce)),
+    label = 'assayNames(obj)',
+    expected.label = 'assayNames(sce)'
+  )
+  for (i in SummarizedExperiment::assayNames(sce)) {
+    expect_identical(
+      dim(SummarizedExperiment::assay(obj, i)),
+      dim(SummarizedExperiment::assay(sce, i)),
+      label = sprintf("dim(assay(obj, '%s'))", i),
+      expected.label = sprintf("dim(assay(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::reducedDimNames(obj)),
+    sort(SingleCellExperiment::reducedDimNames(sce)),
+    label = 'reducedDimNames(obj)',
+    expected.label = 'reducedDimNames(sce)'
+  )
+  for (i in SingleCellExperiment::reducedDimNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::reducedDim(obj, i)),
+      dim(SingleCellExperiment::reducedDim(sce, i)),
+      label = sprintf("dim(reducedDim(obj, '%s'))", i),
+      expected.label = sprintf("dim(reducedDim(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::colPairNames(obj)),
+    sort(SingleCellExperiment::colPairNames(sce)),
+    label = 'colPairNames(obj)',
+    expected.label = 'colPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::colPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::colPair(obj, i)),
+      dim(SingleCellExperiment::colPair(sce, i)),
+      label = sprintf("dim(colPair(obj, '%s'))", i),
+      expected.label = sprintf("dim(colPair(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::rowPairNames(obj)),
+    sort(SingleCellExperiment::rowPairNames(sce)),
+    label = 'rowPairNames(obj)',
+    expected.label = 'rowPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::rowPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::rowPair(obj, i)),
+      dim(SingleCellExperiment::rowPair(sce, i)),
+      label = sprintf("dim(rowPair(obj, '%s'))", i),
+      expected.label = sprintf("dim(rowPair(sce, '%s'))", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::colData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::colData(obj)[[i]],
+      SummarizedExperiment::colData(sce)[[i]],
+      label = sprintf("colData(obj)[['%s']]", i),
+      expected.label = sprintf("colData(sce)[['%s']]", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::rowData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::rowData(obj)[[i]],
+      SummarizedExperiment::rowData(sce)[[i]],
+      label = sprintf("rowData(obj)[['%s']]", i),
+      expected.label = sprintf("rowData(sce)[['%s']]", i)
+    )
+  }
+
+  exp$close()
+  gc()
+
+  # Expect error when writing to existing array
+  expect_error(write_soma(sce, uri = uri))
+
+  # Expect seamless pass when resuming writing to exisitng experiment
+  expect_type(
+    urir <- write_soma(sce, uri = uri, ingest_mode = "resume"),
+    "character"
+  )
+  expect_identical(urir, uri)
+
+  expr <- SOMAExperimentOpen(urir)
+  on.exit(expr$close(), add = TRUE, after = FALSE)
+
+  objr <- SOMAExperimentAxisQuery$new(expr, "RNA")$to_single_cell_experiment(
+    obs_index = "obs_id",
+    var_index = "var_id"
+  )
+
+  expect_identical(
+    sort(SummarizedExperiment::assayNames(objr)),
+    sort(SummarizedExperiment::assayNames(sce)),
+    label = 'assayNames(objr)',
+    expected.label = 'assayNames(sce)'
+  )
+  for (i in SummarizedExperiment::assayNames(sce)) {
+    expect_identical(
+      dim(SummarizedExperiment::assay(objr, i)),
+      dim(SummarizedExperiment::assay(sce, i)),
+      label = sprintf("dim(assay(objr, '%s'))", i),
+      expected.label = sprintf("dim(assay(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::reducedDimNames(objr)),
+    sort(SingleCellExperiment::reducedDimNames(sce)),
+    label = 'reducedDimNames(objr)',
+    expected.label = 'reducedDimNames(sce)'
+  )
+  for (i in SingleCellExperiment::reducedDimNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::reducedDim(objr, i)),
+      dim(SingleCellExperiment::reducedDim(sce, i)),
+      label = sprintf("dim(reducedDim(objr, '%s'))", i),
+      expected.label = sprintf("dim(reducedDim(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::colPairNames(objr)),
+    sort(SingleCellExperiment::colPairNames(sce)),
+    label = 'colPairNames(objr)',
+    expected.label = 'colPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::colPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::colPair(objr, i)),
+      dim(SingleCellExperiment::colPair(sce, i)),
+      label = sprintf("dim(colPair(objr, '%s'))", i),
+      expected.label = sprintf("dim(colPair(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::rowPairNames(objr)),
+    sort(SingleCellExperiment::rowPairNames(sce)),
+    label = 'rowPairNames(objr)',
+    expected.label = 'rowPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::rowPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::rowPair(objr, i)),
+      dim(SingleCellExperiment::rowPair(sce, i)),
+      label = sprintf("dim(rowPair(objr, '%s'))", i),
+      expected.label = sprintf("dim(rowPair(sce, '%s'))", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::colData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::colData(objr)[[i]],
+      SummarizedExperiment::colData(sce)[[i]],
+      label = sprintf("colData(objr)[['%s']]", i),
+      expected.label = sprintf("colData(sce)[['%s']]", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::rowData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::rowData(objr)[[i]],
+      SummarizedExperiment::rowData(sce)[[i]],
+      label = sprintf("rowData(objr)[['%s']]", i),
+      expected.label = sprintf("rowData(sce)[['%s']]", i)
+    )
+  }
+
+  expr$close()
+  gc()
+
+  # Test resume-mode with partial writes
+  idx <- seq.int(1L, floor(ncol(sce) / 3))
+  sce_partial <- sce[, idx]
+
+  expect_type(
+    urip <- write_soma(
+      sce_partial,
+      uri = withr::local_tempdir("single-cell-experiment-partial"),
+      shape = dim(sce)
+    ),
+    "character"
+  )
+
+  expp <- SOMAExperimentOpen(urip)
+  on.exit(expp$close(), add = TRUE, after = FALSE)
+
+  objp <- SOMAExperimentAxisQuery$new(expp, "RNA")$to_single_cell_experiment(
+    obs_index = "obs_id",
+    var_index = "var_id"
+  )
+
+  expect_identical(dim(objp), dim(sce_partial))
+
+  expect_identical(
+    sort(SummarizedExperiment::assayNames(objp)),
+    sort(SummarizedExperiment::assayNames(sce_partial)),
+    label = 'assayNames(objp)',
+    expected.label = 'assayNames(sce_partial)'
+  )
+  for (i in SummarizedExperiment::assayNames(sce_partial)) {
+    expect_identical(
+      dim(SummarizedExperiment::assay(objp, i)),
+      dim(SummarizedExperiment::assay(sce_partial, i)),
+      label = sprintf("dim(assay(objp, '%s'))", i),
+      expected.label = sprintf("dim(assay(sce_partial, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::reducedDimNames(objp)),
+    sort(SingleCellExperiment::reducedDimNames(sce_partial)),
+    label = 'reducedDimNames(objp)',
+    expected.label = 'reducedDimNames(sce_partial)'
+  )
+  for (i in SingleCellExperiment::reducedDimNames(sce_partial)) {
+    expect_identical(
+      dim(SingleCellExperiment::reducedDim(objp, i)),
+      dim(SingleCellExperiment::reducedDim(sce_partial, i)),
+      label = sprintf("dim(reducedDim(objp, '%s'))", i),
+      expected.label = sprintf("dim(reducedDim(sce_partial, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::colPairNames(objp)),
+    sort(SingleCellExperiment::colPairNames(sce_partial)),
+    label = 'colPairNames(objp)',
+    expected.label = 'colPairNames(sce_partial)'
+  )
+  for (i in SingleCellExperiment::colPairNames(sce_partial)) {
+    expect_identical(
+      dim(SingleCellExperiment::colPair(objp, i)),
+      dim(SingleCellExperiment::colPair(sce_partial, i)),
+      label = sprintf("dim(colPair(objp, '%s'))", i),
+      expected.label = sprintf("dim(colPair(sce_partial, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::rowPairNames(objp)),
+    sort(SingleCellExperiment::rowPairNames(sce_partial)),
+    label = 'rowPairNames(objp)',
+    expected.label = 'rowPairNames(sce_partial)'
+  )
+  for (i in SingleCellExperiment::rowPairNames(sce_partial)) {
+    expect_identical(
+      dim(SingleCellExperiment::rowPair(objp, i)),
+      dim(SingleCellExperiment::rowPair(sce_partial, i)),
+      label = sprintf("dim(rowPair(objp, '%s'))", i),
+      expected.label = sprintf("dim(rowPair(sce_partial, '%s'))", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::colData(sce_partial))) {
+    expect_equivalent(
+      SummarizedExperiment::colData(objp)[[i]],
+      SummarizedExperiment::colData(sce_partial)[[i]],
+      label = sprintf("colData(objp)[['%s']]", i),
+      expected.label = sprintf("colData(sce_partial)[['%s']]", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::rowData(sce_partial))) {
+    expect_equivalent(
+      SummarizedExperiment::rowData(objp)[[i]],
+      SummarizedExperiment::rowData(sce_partial)[[i]],
+      label = sprintf("rowData(objp)[['%s']]", i),
+      expected.label = sprintf("rowData(sce_partial)[['%s']]", i)
+    )
+  }
+
+  expp$close()
+  gc()
+
+  expect_type(
+    uric <- write_soma(sce, uri = urip, ingest_mode = "resume"),
+    "character"
+  )
+  expect_identical(uric, urip)
+
+  expc <- SOMAExperimentOpen(uric)
+  on.exit(expc$close(), add = TRUE, after = FALSE)
+
+  objc <- SOMAExperimentAxisQuery$new(expc, "RNA")$to_single_cell_experiment(
+    obs_index = "obs_id",
+    var_index = "var_id"
+  )
+
+  expect_identical(dim(objc), dim(sce))
+
+  expect_identical(
+    sort(SummarizedExperiment::assayNames(objc)),
+    sort(SummarizedExperiment::assayNames(sce)),
+    label = 'assayNames(objc)',
+    expected.label = 'assayNames(sce)'
+  )
+  for (i in SummarizedExperiment::assayNames(sce)) {
+    expect_identical(
+      dim(SummarizedExperiment::assay(objc, i)),
+      dim(SummarizedExperiment::assay(sce, i)),
+      label = sprintf("dim(assay(objc, '%s'))", i),
+      expected.label = sprintf("dim(assay(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::reducedDimNames(objc)),
+    sort(SingleCellExperiment::reducedDimNames(sce)),
+    label = 'reducedDimNames(objc)',
+    expected.label = 'reducedDimNames(sce)'
+  )
+  for (i in SingleCellExperiment::reducedDimNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::reducedDim(objc, i)),
+      dim(SingleCellExperiment::reducedDim(sce, i)),
+      label = sprintf("dim(reducedDim(objc, '%s'))", i),
+      expected.label = sprintf("dim(reducedDim(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::colPairNames(objc)),
+    sort(SingleCellExperiment::colPairNames(sce)),
+    label = 'colPairNames(objc)',
+    expected.label = 'colPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::colPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::colPair(objc, i)),
+      dim(SingleCellExperiment::colPair(sce, i)),
+      label = sprintf("dim(colPair(objc, '%s'))", i),
+      expected.label = sprintf("dim(colPair(sce, '%s'))", i)
+    )
+  }
+
+  expect_identical(
+    sort(SingleCellExperiment::rowPairNames(objc)),
+    sort(SingleCellExperiment::rowPairNames(sce)),
+    label = 'rowPairNames(objc)',
+    expected.label = 'rowPairNames(sce)'
+  )
+  for (i in SingleCellExperiment::rowPairNames(sce)) {
+    expect_identical(
+      dim(SingleCellExperiment::rowPair(objc, i)),
+      dim(SingleCellExperiment::rowPair(sce, i)),
+      label = sprintf("dim(rowPair(objc, '%s'))", i),
+      expected.label = sprintf("dim(rowPair(sce, '%s'))", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::colData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::colData(objc)[[i]],
+      SummarizedExperiment::colData(sce)[[i]],
+      label = sprintf("colData(objc)[['%s']]", i),
+      expected.label = sprintf("colData(sce)[['%s']]", i)
+    )
+  }
+
+  for (i in names(SummarizedExperiment::rowData(sce))) {
+    expect_equivalent(
+      SummarizedExperiment::rowData(objc)[[i]],
+      SummarizedExperiment::rowData(sce)[[i]],
+      label = sprintf("rowData(objc)[['%s']]", i),
+      expected.label = sprintf("rowData(sce)[['%s']]", i)
+    )
+  }
+
+  expc$close()
+  gc()
+})


### PR DESCRIPTION
**Issue and/or context:** Backport #2405 from `main` to the `release-1.10` branch. The backport bot didn't run; I don't know why not. So this is manual.

Also sets R 1.10.2 in `apis/r/DESCRIPTION` (per our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)) in an attempt to reduce CI load.