### PR TITLE
[c++] Support `cmake-verbose` flag in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,15 @@ help:
 # install 
 # -------------------------------------------------------------------
 
-# set default variable values, if non-null
+# Set default variable values, if non-null
+# * build=Debug creates binary artifacts with symbols, e.g. for gdb
+# * cmake_verbose=true creates Makefiles that produce full compile lines when executed
 build ?= Release
+cmake_verbose ?= false
 
 .PHONY: install
 install: clean
-	@./scripts/bld --prefix=${prefix} --tiledb=${tiledb} --build=${build}
+	@./scripts/bld --prefix=${prefix} --tiledb=${tiledb} --build=${build} --cmake-verbose=${cmake_verbose}
 	@TILEDB_PATH=${tiledb} pip install -v -e apis/python
 
 .PHONY: r-build

--- a/scripts/bld
+++ b/scripts/bld
@@ -11,12 +11,14 @@ arg() { echo "$1" | sed "s/^${2-[^=]*=}//" | sed "s/:/;/g"; }
 build="Release"
 prefix=""
 tiledb=""
+cmake_verbose="false"
 
 while test $# != 0; do
   case "$1" in
   --build=*) build=$(arg "$1");;
   --prefix=*) prefix=$(arg "$1");;
   --tiledb=*) tiledb=$(arg "$1");;
+  --cmake-verbose=*) cmake_verbose=$(arg "$1");;
   esac
   shift
 done
@@ -43,10 +45,10 @@ if [ "$(uname -m)" == "aarch64" ]; then
 fi
 
 # NOTE: set to true to debug the cmake build
-if false; then
-  # Debug note: this is _incredibly_ helpful in that it reveals the actual compile lines etc which
-  # make itself shows by default but which cmake-driven make hides by default. Use this for any
-  # non-trivial cmake debugging.
+if [ "$cmake_verbose" = "true" ]; then
+  # This is _incredibly_ helpful in that it reveals the actual compile lines etc which make itself
+  # shows by default but which cmake-driven make hides by default. Use this for any non-trivial
+  # cmake debugging.
   extra_opts+=" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 
   # TILEDB_WERROR=OFF is necessary to build core with XCode 14; doesn't hurt for XCode 13.


### PR DESCRIPTION
The current `build=Debug` flag to `make` controls symbols in binary artifacts. We lack a standard way to set verbosity for `cmake` so that Makefiles will show full compile lines when executed. These two things are orthogonal to one another, and they are both important.

This is crucial for customer support, e.g. on #2402 it was necessary to ask an end user to do a manual edit. This is not sustainable.

Likewise, developers doing sandbox debug often don't need full compile lines hidden from them (which is the default).

A few of us have independently modded this in sandbox. A due appreciation for use of people's time compels us to make this a resuable option in source control.

Example default output: https://gist.github.com/johnkerl/26b4ac9cdb58e17f4bc595f2c174338a

Example cmake-verbose output: https://gist.github.com/johnkerl/fea6dcca26f6b76d117a72d8cc29a7e5