### PR TITLE
[r] Better handling of timestamps in `$reopen()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.11.99.0
+Version: 1.11.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,6 +12,7 @@
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 * Have `SOMADataFrame$shape()` throw a not-yet-implemented error
 * Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
+* Cache timestamp in when reopening an array in `WRITE` mode to enable modifications of said array
 
 # 1.7.0
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,7 +12,7 @@
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 * Have `SOMADataFrame$shape()` throw a not-yet-implemented error
 * Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
-* Cache timestamp in when reopening an array in `WRITE` mode to enable modifications of said array
+* Clear timestamp when using `$reopen()` to reopen at the current time
 
 # 1.7.0
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -202,7 +202,7 @@ SOMADataFrame <- R6::R6Class(
       arr[] <- df
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
-      self$reopen("WRITE", force = TRUE)
+      self$reopen("WRITE")
       invisible(self)
     },
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -202,7 +202,7 @@ SOMADataFrame <- R6::R6Class(
       arr[] <- df
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
-      self$open("WRITE", internal_use_only = "allowed_use")
+      self$reopen("WRITE", force = TRUE)
       invisible(self)
     },
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -171,14 +171,17 @@ TileDBGroup <- R6::R6Class(
       # we return it. But if not (e.g. first access on read from storage)
       # then we invoke the appropriate constructor. Note: child classes
       # may override construct_member.
-      if (is.null(member$object)) {
+      obj <- if (is.null(member$object)) {
         obj <- private$construct_member(member$uri, member$type)
-        obj$reopen(mode = self$mode())
       } else {
-        obj <- member$object
-        if (!obj$is_open()) {
-          obj$reopen(mode = self$mode())
-        }
+        member$object
+      }
+      if (!obj$is_open()) {
+        switch(
+          EXPR = (mode <- self$mode()),
+          READ = obj$open(mode, internal_use_only = "allowed_use"),
+          WRITE = obj$reopen(mode)
+        )
       }
 
       private$add_cached_member(name, obj)

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -173,11 +173,11 @@ TileDBGroup <- R6::R6Class(
       # may override construct_member.
       if (is.null(member$object)) {
         obj <- private$construct_member(member$uri, member$type)
-        obj$open(mode = self$mode(), internal_use_only = "allowed_use")
+        obj$reopen(mode = self$mode())
       } else {
         obj <- member$object
         if (!obj$is_open()) {
-          obj$open(mode = self$mode(), internal_use_only = "allowed_use")
+          obj$reopen(mode = self$mode())
         }
       }
 

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -92,7 +92,7 @@ TileDBObject <- R6::R6Class(
       mode <- mode %||% modes[oldmode]
       mode <- match.arg(mode, choices = modes)
       self$close()
-      private$tiledb_timestamp <- switch(mode, WRITE = NULL, READ = Sys.time())
+      private$tiledb_timestamp <- NULL
       self$open(mode, internal_use_only = 'allowed_use')
       return(invisible(self))
     },

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -96,7 +96,14 @@ TileDBObject <- R6::R6Class(
       mode <- match.arg(mode, choices = modes)
       if (isTRUE(force) || mode != oldmode) {
         self$close()
+        if (mode == "WRITE") {
+          ts <- private$tiledb_timestamp
+          private$tiledb_timestamp <- NULL
+        }
         self$open(mode, internal_use_only = 'allowed_use')
+        if (mode == "WRITE") {
+          private$tiledb_timestamp <- ts
+        }
       }
       return(invisible(self))
     },

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -83,41 +83,17 @@ TileDBObject <- R6::R6Class(
     #'  \item \dQuote{\code{WRITE}}
     #' }
     #' By default, reopens in the opposite mode of the current mode
-    #' @param force Force a close/reopen cycle; by default, if \code{mode} is
-    #' \code{self$mode()}, \code{reopen()} does nothing
-    #' @param timestamp Set timestamp for reopen; pass \dQuote{\code{restore}}
-    #' to restore the existing timestamp or \code{NULL} to reset to the
-    #' current time
-    #' @param ... ...
     #'
     #' @return Invisibly returns \code{self}
     #'
-    reopen = function(mode = NULL, force = FALSE, timestamp = NULL, ...) {
-      if (is.character(timestamp)) {
-        timestamp <- switch(
-          EXPR = timestamp,
-          restore = private$tiledb_timestamp,
-          as.POSIXct(timestamp, ...)
-        )
-      }
-      stopifnot(
-        "'force' must be TRUE or FALSE" = is_scalar_logical(force),
-        "'timestamp' must be a POSIXct" = is.null(timestamp) ||
-          inherits(timestamp, what = 'POSIXct')
-      )
+    reopen = function(mode = NULL) {
       modes <- c(READ = 'WRITE', WRITE = 'READ')
       oldmode <- self$mode()
       mode <- mode %||% modes[oldmode]
       mode <- match.arg(mode, choices = modes)
-      if (isTRUE(force) || mode != oldmode) {
-        self$close()
-        private$tiledb_timestamp <- switch(
-          EXPR = mode,
-          WRITE = NULL,
-          READ = timestamp %||% Sys.time()
-        )
-        self$open(mode, internal_use_only = 'allowed_use')
-      }
+      self$close()
+      private$tiledb_timestamp <- switch(mode, WRITE = NULL, READ = Sys.time())
+      self$open(mode, internal_use_only = 'allowed_use')
       return(invisible(self))
     },
 

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -526,7 +526,7 @@ write_soma.Seurat <- function(
     stop(
       "Requested an array of shape (",
       paste(shape, collapse = ', '),
-      "), but was given a matrix with a larger shape (",
+      "), but was given a Seurat object with a larger shape (",
       paste(dim(x), collapse = ', '),
       ")",
       call. = FALSE

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -807,7 +807,7 @@ write_soma.SeuratCommand <- function(
     logs$reopen("WRITE")
     logs
   }
-  on.exit(logs$close(), add = TRUE)
+  on.exit(logs$close(), add = TRUE, after = FALSE)
 
   # Encode parameters
   spdl::info("Encoding parameters in the command log")

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -244,6 +244,8 @@ write_soma.data.frame <- function(
   }
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- sdf$mode()
+    on.exit(sdf$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(sdf, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -369,6 +371,8 @@ write_soma.matrix <- function(
   array$write(x)
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- array$mode()
+    on.exit(array$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(array, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -498,6 +502,8 @@ write_soma.TsparseMatrix <- function(
   }
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- array$mode()
+    on.exit(array$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(array, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -598,12 +604,18 @@ write_soma.TsparseMatrix <- function(
     "'key' must be a single character value" = is_scalar_character(key) && nzchar(key),
     "'relative' must be a single logical value" = is_scalar_logical(relative)
   )
+  xmode <- x$mode()
+  if (xmode == 'CLOSED') {
+    x$reopen('READ')
+    xmode <- x$mode()
+  }
+  on.exit(x$reopen(mode = xmode), add = TRUE, after = FALSE)
   oldmode <- soma_parent$mode()
   if (oldmode == 'CLOSED') {
     soma_parent$reopen("READ")
     oldmode <- soma_parent$mode()
   }
-  on.exit(soma_parent$reopen(oldmode))
+  on.exit(soma_parent$reopen(oldmode), add = TRUE, after = FALSE)
   if (key %in% soma_parent$names()) {
     existing <- soma_parent$get(key)
     warning(warningCondition(

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE, timestamp = NULL, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -118,15 +118,6 @@ Close and reopen the TileDB object in a new mode
 \item \dQuote{\code{WRITE}}
 }
 By default, reopens in the opposite mode of the current mode}
-
-\item{\code{force}}{Force a close/reopen cycle; by default, if \code{mode} is
-\code{self$mode()}, \code{reopen()} does nothing}
-
-\item{\code{timestamp}}{Set timestamp for reopen; pass \dQuote{\code{restore}}
-to restore the existing timestamp or \code{NULL} to reset to the
-current time}
-
-\item{\code{...}}{...}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE, timestamp = NULL, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -121,6 +121,12 @@ By default, reopens in the opposite mode of the current mode}
 
 \item{\code{force}}{Force a close/reopen cycle; by default, if \code{mode} is
 \code{self$mode()}, \code{reopen()} does nothing}
+
+\item{\code{timestamp}}{Set timestamp for reopen; pass \dQuote{\code{restore}}
+to restore the existing timestamp or \code{NULL} to reset to the
+current time}
+
+\item{\code{...}}{...}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -160,7 +160,7 @@ test_that("Write DimReduc mechanics", {
   ))
   on.exit(ms_pca2$close(), add = TRUE, after = FALSE)
   expect_no_condition(write_soma(pbmc_small_tsne, soma_parent = ms))
-  ms$reopen(ms$mode(), force = TRUE)
+  ms$reopen(ms$mode())
   expect_identical(sort(ms$names()), sort(c('X', 'var', 'obsm', 'varm')))
   expect_identical(sort(ms$obsm$names()), sort(paste0('X_', c('pca', 'tsne'))))
   expect_identical(ms$varm$names(), 'PCs')

--- a/apis/r/tests/testthat/test-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-SeuratIngest.R
@@ -4,7 +4,7 @@ test_that("Write Assay mechanics", {
 
   uri <- withr::local_tempdir("write-assay")
   collection <- SOMACollectionCreate(uri)
-  on.exit(collection$close(), add = TRUE)
+  on.exit(collection$close(), add = TRUE, after = FALSE)
 
   rna <- get_data('pbmc_small', package = 'SeuratObject')[['RNA']]
   expect_no_condition(ms <- write_soma(rna, soma_parent = collection))
@@ -26,6 +26,10 @@ test_that("Write Assay mechanics", {
       info = layers[i]
     )
   }
+
+  ms$close()
+  gc()
+
   # Test no feature-level meta data
   rna2 <- rna
   for (i in names(rna2[[]])) {
@@ -39,6 +43,9 @@ test_that("Write Assay mechanics", {
   expect_identical(ms2$names(), c('X', 'var'))
   expect_s3_class(ms2$var, 'SOMADataFrame')
   expect_identical(ms2$var$attrnames(), 'var_id')
+
+  ms2$close()
+  gc()
 
   # Test no counts
   rna3 <- SeuratObject::SetAssayData(rna, 'counts', new('matrix'))
@@ -59,6 +66,9 @@ test_that("Write Assay mechanics", {
     )
   }
 
+  ms3$close()
+  gc()
+
   # Test no scale.data
   rna4 <- SeuratObject::SetAssayData(rna, 'scale.data', new('matrix'))
   expect_no_condition(ms4 <- write_soma(rna4, uri = 'rna-no-scale', soma_parent = collection))
@@ -78,6 +88,9 @@ test_that("Write Assay mechanics", {
     )
   }
 
+  ms4$close()
+  gc()
+
   # Test no counts or scale.data
   rna5 <- SeuratObject::SetAssayData(rna3, 'scale.data', new('matrix'))
   expect_no_condition(ms5 <- write_soma(rna5, uri = 'rna-no-counts-scale', soma_parent = collection))
@@ -91,6 +104,9 @@ test_that("Write Assay mechanics", {
   expect_identical(ms5$X$names(), 'data')
   expect_equal(ms5$X$get('data')$shape(), rev(dim(rna5)))
 
+  ms5$close()
+  gc()
+
   # Verify data slot isn't ingested when it's identical to counts
   rna6 <- SeuratObject::CreateAssayObject(
     counts = SeuratObject::GetAssayData(rna, "counts")
@@ -99,9 +115,16 @@ test_that("Write Assay mechanics", {
     SeuratObject::GetAssayData(rna6, "counts"),
     SeuratObject::GetAssayData(rna6, "data")
   )
-  expect_no_condition(ms6 <- write_soma(rna6, uri = "rna-identical-counts-data", soma_parent = collection))
+  expect_no_condition(ms6 <- write_soma(
+    rna6,
+    uri = "rna-identical-counts-data",
+    soma_parent = collection
+  ))
   on.exit(ms6$close(), add = TRUE, after = FALSE)
   expect_equal(ms6$X$names(), "counts")
+
+  ms6$close()
+  gc()
 
   # Test assertions
   expect_error(write_soma(rna, uri = TRUE, soma_parent = collection))
@@ -110,6 +133,8 @@ test_that("Write Assay mechanics", {
     rna,
     soma_parent = SOMADataFrameCreate(uri = file.path(uri, 'data-frame'))
   ))
+
+  gc()
 })
 
 test_that("Write DimReduc mechanics", {
@@ -118,7 +143,7 @@ test_that("Write DimReduc mechanics", {
 
   uri <- withr::local_tempdir("write-reduction")
   collection <- SOMACollectionCreate(uri)
-  on.exit(collection$close(), add = TRUE)
+  on.exit(collection$close(), add = TRUE, after = FALSE)
   pbmc_small <- get_data('pbmc_small', package = 'SeuratObject')
   pbmc_small_rna <- pbmc_small[['RNA']]
   pbmc_small_pca <- pbmc_small[['pca']]
@@ -171,6 +196,8 @@ test_that("Write DimReduc mechanics", {
   expect_true(ms_tsne$is_open())
   expect_warning(ms_pca3 <- write_soma(pbmc_small_pca, soma_parent = ms_tsne))
   expect_error(ms_tsne$varm)
+
+  gc()
 })
 
 test_that("Write Graph mechanics", {
@@ -179,7 +206,7 @@ test_that("Write Graph mechanics", {
 
   uri <- withr::local_tempdir("write-graph")
   collection <- SOMACollectionCreate(uri)
-  on.exit(collection$close(), add = TRUE)
+  on.exit(collection$close(), add = TRUE, after = FALSE)
 
   pbmc_small <- get_data('pbmc_small', package = 'SeuratObject')
   pbmc_small_rna <- pbmc_small[['RNA']]
@@ -195,6 +222,8 @@ test_that("Write Graph mechanics", {
 
   # Test assertions
   expect_error(write_soma(graph, collection = soma_parent))
+
+  gc()
 })
 
 test_that("Write SeuratCommand mechanics", {
@@ -216,7 +245,6 @@ test_that("Write SeuratCommand mechanics", {
 
     expect_s3_class(cmddf <- cmdgrp$get(cmd), 'SOMADataFrame')
     expect_invisible(cmddf$reopen("READ"))
-    on.exit(cmddf$close(), add = TRUE, after = FALSE)
 
     # Test qualities of the SOMADataFrame
     expect_identical(cmddf$attrnames(), 'values')
@@ -268,7 +296,14 @@ test_that("Write SeuratCommand mechanics", {
         expect_equivalent(params[[param]], cmdlist[[param]])
       }
     }
+
+    cmddf$close()
+    cmdgrp$close()
+    gc()
   }
+
+  uns$close()
+  gc()
 })
 
 test_that("Write Seurat mechanics", {
@@ -285,7 +320,7 @@ test_that("Write Seurat mechanics", {
     basename(uri)
   ))
   expect_no_condition(experiment <- SOMAExperimentOpen(uri))
-  on.exit(experiment$close())
+  on.exit(experiment$close(), add = TRUE, after = FALSE)
 
   expect_s3_class(experiment, 'SOMAExperiment')
   expect_equal(experiment$mode(), "READ")
@@ -297,6 +332,7 @@ test_that("Write Seurat mechanics", {
   expect_no_error(experiment$ms)
   expect_identical(experiment$ms$names(), 'RNA')
   expect_s3_class(ms <- experiment$ms$get('RNA'), 'SOMAMeasurement')
+  on.exit(ms$close(), add = TRUE, after = FALSE)
 
   expect_identical(sort(ms$X$names()), sort(c('counts', 'data', 'scale_data')))
   expect_identical(sort(ms$obsm$names()), sort(c('X_pca', 'X_tsne')))
@@ -308,8 +344,13 @@ test_that("Write Seurat mechanics", {
     names(pbmc_small[[]])
   )
 
+  ms$close()
+  experiment$close()
+
   # Test assertions
   expect_error(write_soma(pbmc_small, TRUE))
   expect_error(write_soma(pbmc_small, 1))
   expect_error(write_soma(pbmc_small, ''))
+
+  gc()
 })


### PR DESCRIPTION
Internal timestamps of not `NULL` cause `$reopen()` to fail when reopening in `"WRITE"` mode; this PR allows `$reopen()` to do one of the following:
- set the time to the current time (required for `$reopen("WRITE")`)
- restore the time to the previously set timestamp
- open at a custom timestamp by passing a `POSIXct` object

Currently, the existing timestamp causes an error when reopening for write and modifying an existing array (eg. schema evolution). For example
```r
library(SeuratObject)
data(pbmc_small)

uri <- "/path/to/uri"
tiledbsoma::write_soma(pbmc_small, uri = uri)
exp <- tiledbsoma::SOMAExperimentOpen(uri)

obs_df <- as.data.frame(exp$obs$read()$concat())
# Add new column
obs_df$colors <- sample(
  c("red", "blue", "green"),
  size = ncol(pbmc_small),
  replace = TRUE
)

# `as.data.frame.Table()` coerces integer64 to integer, need to cast back
obs_df$soma_joinid <- bit64::as.integer64(obs_df$soma_joinid)

# Reopen in WRITE mode for schema evolution
exp$reopen("WRITE")
exp$obs$update(obs_df) # fails here
exp$reopen("READ")
```

The checks in `TileDBArray$open()` https://github.com/single-cell-data/TileDB-SOMA/blob/65e6bafa808d06ebdb5aa79d7f5dc83e8af422a8/apis/r/R/TileDBArray.R#L29-L33 and `TileDBGroup$open()` https://github.com/single-cell-data/TileDB-SOMA/blob/65e6bafa808d06ebdb5aa79d7f5dc83e8af422a8/apis/r/R/TileDBGroup.R#L62-L70 are what's causing the error. Rather than change the checks, I chose to change `$reopen()` to handle the situation these checks are working on

~Question for reviewers: do we want to cache the timestamp when reopening in `"WRITE"` mode or reset it?~ ~Now changed to parameterize timestamp behavior in `$reopen()`~ Now changed to always reset to current time; re-opening at a custom time can be had with a close-and-open cycle. Adding custom timestamp behavior to `$reopen()` can be evaluated at a later date