### PR TITLE
[python/ci] Add CI job to test building wheel from sdist

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -142,6 +142,9 @@ jobs:
           find . -name '*tile*.so*'
           ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
 
+  # Confirm shared object copying when building the Python package
+  # https://github.com/single-cell-data/TileDB-SOMA/pull/1937
+  # Same as job above, but running on macOS instead of in a Docker container
   macos:
     runs-on: macos-13
     name: "SO copying (macos) TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
@@ -318,7 +321,24 @@ jobs:
         run: ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
 
   # Build a wheel from a source tarball (confirms all required files are
-  # distributed in the sdist)
+  # distributed in the sdist). This is in preparation for the official building of
+  # the PyPI wheels in python-packaging.yml.
+  # https://github.com/single-cell-data/TileDB-SOMA/pull/2506
+  #
+  #
+  #  Differences to python-packaging.yml:
+  #
+  #  * Uses transparent python commands instead of the opaque action
+  #    `pypa/cibuildwheel`, and therefore easier to debug
+  #  * Only builds two wheels total (python 3.11 on Ubuntu and macOS), so it is
+  #    much faster. It's not creating the wheels for distribution, but instead just
+  #    providing a quick check that all the required files are distributed in the
+  #    source tarball
+  #  * Runs whenever an installation-related file is modified instead of only
+  #    after a release
+  #
+  # In summary, the goal is to identify any potential problems with building
+  # the PyPI wheels when a PR is submitted, and not at release time.
   sdist:
     runs-on: ${{ matrix.os }}
     name: "Wheel from sdist (${{ matrix.os }})"

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/python-ci-packaging.yml'
       - 'apis/python/MANIFEST.in'
+      - 'apis/python/pyproject.toml'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
@@ -20,6 +21,7 @@ on:
     paths:
       - '.github/workflows/python-ci-packaging.yml'
       - 'apis/python/MANIFEST.in'
+      - 'apis/python/pyproject.toml'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -1,12 +1,12 @@
-# Confirm shared object copying when building the Python package
-# https://github.com/single-cell-data/TileDB-SOMA/pull/1937
+# This CI confirms the Python package continues to install properly in the many
+# different required contexts
 
-name: Python SO copying
+name: TileDB-SOMA Python CI (Packaging)
 
 on:
   push:
     paths:
-      - '.github/workflows/python-so-copying.yml'
+      - '.github/workflows/python-ci-packaging.yml'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
@@ -17,7 +17,7 @@ on:
       - 'libtiledbsoma/CMakeLists.txt'
   pull_request:
     paths:
-      - '.github/workflows/python-so-copying.yml'
+      - '.github/workflows/python-ci-packaging.yml'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
@@ -30,9 +30,11 @@ on:
 
 jobs:
 
+  # Confirm shared object copying when building the Python package
+  # https://github.com/single-cell-data/TileDB-SOMA/pull/1937
   docker:
     runs-on: ubuntu-latest
-    name: "docker TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
+    name: "SO copying (docker) TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +142,7 @@ jobs:
 
   macos:
     runs-on: macos-13
-    name: "macos TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
+    name: "SO copying (macos) TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false
       matrix:
@@ -236,7 +238,7 @@ jobs:
   # Tests that the --libtiledbsoma flag to setup.py continues working
   setuptools:
     runs-on: ${{ matrix.os }}
-    name: "${{ matrix.os }} setuptools"
+    name: "setuptools (${{ matrix.os }})"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - '.github/workflows/python-ci-packaging.yml'
+      - 'apis/python/MANIFEST.in'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/python-ci-packaging.yml'
+      - 'apis/python/MANIFEST.in'
       - 'apis/python/setup.py'
       - 'apis/python/src/tiledbsoma/__init__.py'
       - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
@@ -314,3 +316,39 @@ jobs:
         run: ./venv-soma/bin/python -m pip install --prefer-binary `grep -v '^\[' apis/python/src/tiledbsoma.egg-info/requires.txt`
       - name: Runtime test
         run: ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
+
+  # Build a wheel from a source tarball (confirms all required files are
+  # distributed in the sdist)
+  sdist:
+    runs-on: ${{ matrix.os }}
+    name: "Wheel from sdist (${{ matrix.os }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04", "macos-12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for setuptools-scm
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install --prefer-binary pybind11 wheel
+      - name: Build source tarball (sdist)
+        run: |
+          cd apis/python
+          python setup.py sdist
+      - name: Extract source tarball
+        run: |
+          tar --list -f apis/python/dist/tiledbsoma-*.tar.gz
+          tar -xzf apis/python/dist/tiledbsoma-*.tar.gz
+      - name: Build wheel
+        run: |
+          cd tiledbsoma-*/
+          python setup.py bdist_wheel
+      - name: Install wheel
+        run: |
+          python -m pip install --prefer-binary tiledbsoma-*/dist/tiledbsoma-*.whl
+          python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,12 @@ Thanks for your interest in TileDB-SOMA. The notes below give some pointers for 
 - Make changes locally, then rebuild as appropriate for the level of changes (e.g.: `make` for `libtilebsc` or `python setup.py develop` for `apis/python`).
 - Make sure to run `make check`, or `pytest` to verify changes against tests (add new tests where applicable).
 - Please submit [pull requests](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) against the default [`main` branch of TileDB-SOMA](https://github.com/TileDB-Inc/TileDB-SOMA/tree/master).
+- If you edit the Python files, please run the pre-commit hooks
+
+  ```sh
+  python -m venv ./pre-commit
+  source ./pre-commit/bin/activate
+  python -m pip -v install pre-commit
+  pre-commit run -a -v
+  deactivate
+  ```

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -104,7 +104,9 @@ def main(args):
     update_version(filepath, new_version, new_hash, update_sha=False)
 
     # update CI version
-    filepath = f"{os.path.dirname(__file__)}/../.github/workflows/python-ci-packaging.yml"
+    filepath = (
+        f"{os.path.dirname(__file__)}/../.github/workflows/python-ci-packaging.yml"
+    )
     update_version(filepath, new_version, new_hash)
 
 

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -104,7 +104,7 @@ def main(args):
     update_version(filepath, new_version, new_hash, update_sha=False)
 
     # update CI version
-    filepath = f"{os.path.dirname(__file__)}/../.github/workflows/python-so-copying.yml"
+    filepath = f"{os.path.dirname(__file__)}/../.github/workflows/python-ci-packaging.yml"
     update_version(filepath, new_version, new_hash)
 
 


### PR DESCRIPTION
**Issue and/or context:**

TileDB-SOMA-Py is built and distributed in many different ways (from source, PyPI wheels, conda binaries). We want to identify any packaging-related problems immediately in the PR that generates them instead of in a nightly build or worse after the release has been made.

**Changes:**

This PR includes 2 main changes:

* The first is rebranding my existing CI pipeline to `python-ci-packaging.yml`. The original name was from my initial PR to test the shared object copying behavior (#1937, #2220). However, I had already previously expanded the pipeline to test the pure setuptools installation setup (which we use in tiledbsoma-feedstock) (#2221). With the addition of a 3rd job (below), I wanted to update the CI to better match its purpose

* The 1.9.0 release was delayed because the PyPI wheels could not be built (#2337, #2339). While we build wheels in many of the existing CI pipelines, none build the wheel from a source tarball (sdist) as is done in [`python-packaging.yml`](https://github.com/single-cell-data/TileDB-SOMA/blob/36d5b6e7e9657ba9d41e9f71c0b19d0468dc1f79/.github/workflows/python-packaging.yml#L31), so this error wasn't caught until post release. With this new CI job, we will immediately detect if a crucial file is absent from the source tarball 

**Notes for Reviewer:**

See the wiki page [Debugging wheel‐build issues](https://github.com/single-cell-data/TileDB-SOMA/wiki/Debugging-wheel%E2%80%90build-issues) for more details