### PR TITLE
[r] Silence missing command logs warning

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.3
+Version: 1.10.99.4
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -9,6 +9,7 @@
 * Make `reopen()` a public method for all `TileDBObjects`
 * Add support for resume-mode in `write_soma()`
 * Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
+* Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 
 # 1.7.0
 

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -707,10 +707,13 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       # Load in the command logs
       uns <- try(self$experiment$get("uns"), silent = TRUE)
       if (inherits(uns, 'SOMACollection')) {
-        cmds <- tryCatch(
-          .load_seurat_command(uns, ms_names = private$.measurement_name),
-          packageCheckError = .err_to_warn,
-          missingCollectionError = .err_to_warn
+        cmds <- withCallingHandlers(
+          expr = tryCatch(
+            .load_seurat_command(uns, ms_names = private$.measurement_name),
+            packageCheckError = .err_to_warn,
+            missingCollectionError = .err_to_warn
+          ),
+          missingCollectionError = .maybe_muffle
         )
         for (i in names(cmds)) {
           object[[i]] <- cmds[[i]]

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -70,8 +70,12 @@ uns_hint <- function(type = c('1d', '2d')) {
   ))
 }
 
-.err_to_warn <- function(err, immediate. = TRUE) {
-  warning(conditionMessage(err), call. = FALSE, immediate. = immediate.)
+.err_to_warn <- function(err) {
+  warning(warningCondition(
+    message = conditionMessage(err),
+    class = setdiff(class(err), c('warning', 'simpleError', 'error', 'condition')),
+    call = conditionCall(err)
+  ))
 }
 
 .decode_from_char <- function(x) {

--- a/apis/r/tests/testthat/test-SeuratOutgest-command.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-command.R
@@ -109,7 +109,6 @@ test_that("Load SeuratCommand with missing commands", {
   skip_if_not_installed('SeuratObject', .MINIMUM_SEURAT_VERSION('c'))
   skip_if_not_installed('jsonlite')
 
-
   pbmc_small <- get_data('pbmc_small', package = 'SeuratObject')
   slot(pbmc_small, "commands") <- list()
   expect_true(validObject(pbmc_small))
@@ -126,10 +125,16 @@ test_that("Load SeuratCommand with missing commands", {
     'SOMAExperimentAxisQuery'
   )
 
-  expect_warning(
-    obj <- query$to_seurat(X_layers = c('data' = 'data')),
-    regexp = "^Cannot find a SOMACollection with command logs in 'uns'$"
+  expect_no_condition(obj <- query$to_seurat(X_layers = c('data' = 'data')))
+
+  withr::with_options(
+    list(verbose = TRUE),
+    expect_warning(
+      query$to_seurat(X_layers = c('data' = 'data')),
+      regexp = "^Cannot find a SOMACollection with command logs in 'uns'$"
+    )
   )
+
   expect_s4_class(obj, 'Seurat')
   expect_true(validObject(obj))
   expect_length(SeuratObject::Command(obj), 0L)


### PR DESCRIPTION
Muffle warnings about missing command logs in `SOMAExperimentAxisQuery$to_seurat()`; warnings can be restored with `options(verbose = TRUE)`
