### PR TITLE
[c++] Add missing `SOMACollection` getters and setters

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -285,7 +285,6 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
         clib_dense_array.reset(result_order=order)
-
         self._set_reader_coords(clib_dense_array, new_coords)
         clib_dense_array.write(input)
 

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -135,7 +135,7 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
         ctx,
         platform_config,
         timestamp);
-    
+
     // Note that we must return a shared_ptr to the member, instead of a
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
@@ -201,7 +201,7 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
         ctx,
         platform_config,
         timestamp);
-    
+
     // Note that we must return a shared_ptr to the member, instead of a
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
@@ -269,7 +269,7 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
         ctx,
         platform_config,
         timestamp);
-    
+
     // Note that we must return a shared_ptr to the member, instead of a
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -103,6 +103,10 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     }
 
     SOMACollection::create(uri, ctx, timestamp);
+
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMACollection> member = SOMACollection::open(
         uri, OpenMode::read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -131,6 +135,10 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
         ctx,
         platform_config,
         timestamp);
+    
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
         uri, OpenMode::read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -159,6 +167,10 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
         ctx,
         platform_config,
         timestamp);
+
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
         uri, OpenMode::read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -189,6 +201,10 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
         ctx,
         platform_config,
         timestamp);
+    
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -219,6 +235,10 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
         ctx,
         platform_config,
         timestamp);
+
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));
@@ -249,6 +269,10 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
         ctx,
         platform_config,
         timestamp);
+    
+    // Note that we must return a shared_ptr to the member, instead of a
+    // unique_ptr because we place the SOMA object into the `children_` cache
+    // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
     this->set(std::string(uri), uri_type, std::string(key));

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -128,7 +128,7 @@ class SOMACollection : public SOMAGroup {
      *
      * @param key of member
      */
-    std::shared_ptr<SOMAObject> get(const std::string& key);
+    std::unique_ptr<SOMAObject> get(const std::string& key);
 
     /**
      * Create and add a SOMACollection to the SOMACollection.
@@ -137,12 +137,14 @@ class SOMACollection : public SOMAGroup {
      * @param uri of SOMACollection to add
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMACollection> add_new_collection(
         std::string_view key,
         std::string_view uri,
         URIType uri_type,
-        std::shared_ptr<SOMAContext> ctx);
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * Create and add a SOMAExperiment to the SOMACollection.
@@ -151,6 +153,7 @@ class SOMACollection : public SOMAGroup {
      * @param uri of SOMAExperiment to add
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMAExperiment> add_new_experiment(
         std::string_view key,
@@ -159,7 +162,8 @@ class SOMACollection : public SOMAGroup {
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
         ArrowTable index_columns,
-        PlatformConfig platform_config = PlatformConfig());
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * Create and add a SOMAMeasurement to the SOMACollection.
@@ -168,6 +172,7 @@ class SOMACollection : public SOMAGroup {
      * @param uri of SOMAMeasurement to add
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMAMeasurement> add_new_measurement(
         std::string_view key,
@@ -175,7 +180,9 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns);
+        ArrowTable indext_columns,
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * Create and add a SOMADataFrame to the SOMACollection.
@@ -189,7 +196,7 @@ class SOMACollection : public SOMAGroup {
      * @param index_columns The index column names with associated domains
      * and tile extents per dimension
      * @param platform_config Optional config parameter dictionary
-     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMADataFrame> add_new_dataframe(
         std::string_view key,
@@ -199,6 +206,8 @@ class SOMACollection : public SOMAGroup {
         std::unique_ptr<ArrowSchema> schema,
         ArrowTable index_columns,
         PlatformConfig platform_config = PlatformConfig(),
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
@@ -213,7 +222,7 @@ class SOMACollection : public SOMAGroup {
      * @param index_columns The index column names with associated domains
      * and tile extents per dimension
      * @param platform_config Optional config parameter dictionary
-     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMADenseNDArray> add_new_dense_ndarray(
         std::string_view key,
@@ -223,6 +232,8 @@ class SOMACollection : public SOMAGroup {
         std::string_view format,
         ArrowTable index_columns,
         PlatformConfig platform_config = PlatformConfig(),
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
@@ -237,7 +248,7 @@ class SOMACollection : public SOMAGroup {
      * @param index_columns The index column names with associated domains
      * and tile extents per dimension
      * @param platform_config Optional config parameter dictionary
-     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     * @param timestamp Optional the timestamp range to open at
      */
     std::shared_ptr<SOMASparseNDArray> add_new_sparse_ndarray(
         std::string_view key,
@@ -247,6 +258,8 @@ class SOMACollection : public SOMAGroup {
         std::string_view format,
         ArrowTable index_columns,
         PlatformConfig platform_config = PlatformConfig(),
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
    protected:

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -95,9 +95,33 @@ class SOMAExperiment : public SOMACollection {
     }
 
     SOMAExperiment() = delete;
-    SOMAExperiment(const SOMAExperiment&) = default;
-    SOMAExperiment(SOMAExperiment&&) = default;
+    SOMAExperiment(const SOMAExperiment&) = delete;
+    SOMAExperiment(SOMAExperiment&&) = delete;
     ~SOMAExperiment() = default;
+
+    /**
+     * @brief Get the primary annotations on the observation axis
+     * @param column_names A list of column names to use as user-defined
+     index
+     * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns
+     must
+     * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor,
+     or
+     * colmajor
+     *
+     * @return std::shared_ptr<SOMADataFrame>
+     */
+    std::shared_ptr<SOMADataFrame> obs(
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic);
+
+    /**
+     * @brief Get the collection of named measurements
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> ms();
 
    private:
     //===================================================================
@@ -105,10 +129,10 @@ class SOMAExperiment : public SOMACollection {
     //===================================================================
 
     // Primary annotations on the observation axis
-    std::shared_ptr<SOMADataFrame> obs_;
+    std::shared_ptr<SOMADataFrame> obs_ = nullptr;
 
     // A collection of named measurements
-    std::shared_ptr<SOMACollection> ms_;
+    std::shared_ptr<SOMACollection> ms_ = nullptr;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -90,7 +90,8 @@ SOMAGroup::SOMAGroup(
     std::optional<TimestampRange> timestamp)
     : ctx_(ctx)
     , uri_(util::rstrip_uri(uri))
-    , name_(name) {
+    , name_(name)
+    , timestamp_(timestamp) {
     group_ = std::make_shared<Group>(
         *ctx_->tiledb_ctx(),
         std::string(uri),
@@ -196,6 +197,10 @@ void SOMAGroup::del(const std::string& name) {
 
 std::map<std::string, std::string> SOMAGroup::member_to_uri_mapping() const {
     return member_to_uri_;
+}
+
+std::optional<TimestampRange> SOMAGroup::timestamp() {
+    return timestamp_;
 }
 
 void SOMAGroup::set_metadata(

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -194,9 +194,14 @@ class SOMAGroup : public SOMAObject {
     /**
      * Return a SOMAGroup member to URI mapping.
      *
-     * @return std::map<std::string, std::string>
+     * @return std::optional<TimestampRange>
      */
     std::map<std::string, std::string> member_to_uri_mapping() const;
+
+    /**
+     * Return optional timestamp pair SOMAArray was opened with.
+     */
+    std::optional<TimestampRange> timestamp();
 
     /**
      * Set metadata key-value items to an open array. The array must

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -48,31 +48,32 @@ void SOMAMeasurement::create(
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    std::string exp_uri(uri);
+    std::filesystem::path measurement_uri(uri);
 
-    SOMAGroup::create(ctx, exp_uri, "SOMAMeasurement", timestamp);
+    SOMAGroup::create(
+        ctx, measurement_uri.string(), "SOMAMeasurement", timestamp);
     SOMADataFrame::create(
-        exp_uri + "/var",
+        (measurement_uri / "var").string(),
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)),
         ctx,
         platform_config,
         timestamp);
-    SOMACollection::create(exp_uri + "/X", ctx, timestamp);
-    SOMACollection::create(exp_uri + "/obsm", ctx, timestamp);
-    SOMACollection::create(exp_uri + "/obsp", ctx, timestamp);
-    SOMACollection::create(exp_uri + "/varm", ctx, timestamp);
-    SOMACollection::create(exp_uri + "/varp", ctx, timestamp);
+    SOMACollection::create((measurement_uri / "X").string(), ctx, timestamp);
+    SOMACollection::create((measurement_uri / "obsm").string(), ctx, timestamp);
+    SOMACollection::create((measurement_uri / "obsp").string(), ctx, timestamp);
+    SOMACollection::create((measurement_uri / "varm").string(), ctx, timestamp);
+    SOMACollection::create((measurement_uri / "varp").string(), ctx, timestamp);
 
     auto name = std::string(std::filesystem::path(uri).filename());
     auto group = SOMAGroup::open(OpenMode::write, uri, ctx, name, timestamp);
-    group->set(exp_uri + "/var", URIType::absolute, "var");
-    group->set(exp_uri + "/X", URIType::absolute, "X");
-    group->set(exp_uri + "/obsm", URIType::absolute, "obsm");
-    group->set(exp_uri + "/obsp", URIType::absolute, "obsp");
-    group->set(exp_uri + "/varm", URIType::absolute, "varm");
-    group->set(exp_uri + "/varp", URIType::absolute, "varp");
+    group->set((measurement_uri / "var").string(), URIType::absolute, "var");
+    group->set((measurement_uri / "X").string(), URIType::absolute, "X");
+    group->set((measurement_uri / "obsm").string(), URIType::absolute, "obsm");
+    group->set((measurement_uri / "obsp").string(), URIType::absolute, "obsp");
+    group->set((measurement_uri / "varm").string(), URIType::absolute, "varm");
+    group->set((measurement_uri / "varp").string(), URIType::absolute, "varp");
     group->close();
 }
 
@@ -82,5 +83,74 @@ std::unique_ptr<SOMAMeasurement> SOMAMeasurement::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMAMeasurement>(mode, uri, ctx, timestamp);
+}
+
+std::shared_ptr<SOMADataFrame> SOMAMeasurement::var(
+    std::vector<std::string> column_names, ResultOrder result_order) {
+    if (var_ == nullptr) {
+        var_ = SOMADataFrame::open(
+            (std::filesystem::path(uri()) / "var").string(),
+            OpenMode::read,
+            ctx(),
+            column_names,
+            result_order,
+            timestamp());
+    }
+    return var_;
+}
+
+std::shared_ptr<SOMACollection> SOMAMeasurement::X() {
+    if (X_ == nullptr) {
+        X_ = SOMACollection::open(
+            (std::filesystem::path(uri()) / "X").string(),
+            OpenMode::read,
+            ctx(),
+            timestamp());
+    }
+    return X_;
+}
+
+std::shared_ptr<SOMACollection> SOMAMeasurement::obsm() {
+    if (obsm_ == nullptr) {
+        obsm_ = SOMACollection::open(
+            (std::filesystem::path(uri()) / "obsm").string(),
+            OpenMode::read,
+            ctx(),
+            timestamp());
+    }
+    return obsm_;
+}
+
+std::shared_ptr<SOMACollection> SOMAMeasurement::obsp() {
+    if (obsp_ == nullptr) {
+        obsp_ = SOMACollection::open(
+            (std::filesystem::path(uri()) / "obsp").string(),
+            OpenMode::read,
+            ctx(),
+            timestamp());
+    }
+    return obsp_;
+}
+
+std::shared_ptr<SOMACollection> SOMAMeasurement::varm() {
+    if (varm_ == nullptr) {
+        varm_ = SOMACollection::open(
+            (std::filesystem::path(uri()) / "varm").string(),
+            OpenMode::read,
+            ctx(),
+            timestamp());
+    }
+    return varm_;
+}
+
+std::shared_ptr<SOMACollection> SOMAMeasurement::varp() {
+    if (varp_ == nullptr) {
+        varp_ = SOMACollection::open(
+            (std::filesystem::path(uri()) / "varp").string(),
+            OpenMode::read,
+            ctx(),
+            timestamp());
+    }
+    return varp_;
 }
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -95,9 +95,66 @@ class SOMAMeasurement : public SOMACollection {
     }
 
     SOMAMeasurement() = delete;
-    SOMAMeasurement(const SOMAMeasurement&) = default;
-    SOMAMeasurement(SOMAMeasurement&&) = default;
+    SOMAMeasurement(const SOMAMeasurement&) = delete;
+    SOMAMeasurement(SOMAMeasurement&&) = delete;
     ~SOMAMeasurement() = default;
+
+    /**
+     * @brief Get the primary annotations on the variable axis
+     * @param column_names A list of column names to use as user-defined
+     index
+     * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns
+     must
+     * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor,
+     or
+     * colmajor
+     *
+     * @return std::shared_ptr<SOMADataFrame>
+     */
+    std::shared_ptr<SOMADataFrame> var(
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic);
+
+    /**
+     * @brief Get collection of matrices, each containing measured
+     * feature values
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> X();
+
+    /**
+     * @brief Get collection of dense matrices containing annotations of
+     * each obs row
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> obsm();
+
+    /**
+     * @brief Get the collection of sparse matrices containing pairwise
+     * annotations of each obs row
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> obsp();
+
+    /**
+     * @brief Get the collection of dense matrices containing annotations of
+     * each var row
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> varm();
+
+    /**
+     * @brief Get the collection of sparse matrices containing pairwise
+     * annotations of each var row
+     *
+     * @return std::shared_ptr<SOMACollection>
+     */
+    std::shared_ptr<SOMACollection> varp();
 
    private:
     //===================================================================
@@ -105,24 +162,24 @@ class SOMAMeasurement : public SOMACollection {
     //===================================================================
 
     // Primary annotations on the variable axis
-    std::shared_ptr<SOMADataFrame> var_;
+    std::shared_ptr<SOMADataFrame> var_ = nullptr;
 
-    // A collection of matrices, each containing measured feature values
-    std::shared_ptr<SOMACollection> X_;
+    // A collection of matrices, each containing measured feature vaues
+    std::shared_ptr<SOMACollection> X_ = nullptr;
 
     // A collection of dense matrices containing annotations of each obs row
-    std::shared_ptr<SOMACollection> obsm_;
+    std::shared_ptr<SOMACollection> obsm_ = nullptr;
 
     // A collection of sparse matrices containing pairwise annotations of each
     // obs row
-    std::shared_ptr<SOMACollection> obsp_;
+    std::shared_ptr<SOMACollection> obsp_ = nullptr;
 
     // A collection of dense matrices containing annotations of each var row
-    std::shared_ptr<SOMACollection> varm_;
+    std::shared_ptr<SOMACollection> varm_ = nullptr;
 
     // A collection of sparse matrices containing pairwise annotations of each
     // var row
-    std::shared_ptr<SOMACollection> varp_;
+    std::shared_ptr<SOMACollection> varp_ = nullptr;
 };
 }  // namespace tiledbsoma
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2509

**Changes:**

- Add `timestamp`, `result_order`, and `platform_config` parameters to `SOMACollection::add_new_{soma_object}`
- Add `X`, `obs`, and `vars` setters