### PR TITLE
[c++] Handle 32-bit string and binary in writes

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -66,8 +66,7 @@ void load_soma_dataframe(py::module& m) {
                     for (int64_t i = 0; i < schema.n_children; ++i) {
                         auto child = schema.children[i];
                         auto val = metadata.attr("get")(
-                            py::str(child->name)
-                                .attr("encode")("utf-8"));
+                            py::str(child->name).attr("encode")("utf-8"));
 
                         if (val != py::none() &&
                             val.cast<std::string>() == "nullable") {

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -61,17 +61,17 @@ void load_soma_dataframe(py::module& m) {
                 uintptr_t schema_ptr = (uintptr_t)(&schema);
                 py_schema.attr("_export_to_c")(schema_ptr);
 
-                for (int64_t sch_idx = 0; sch_idx < schema.n_children;
-                     ++sch_idx) {
-                    auto child = schema.children[sch_idx];
-                    auto metadata = py_schema.attr("metadata");
-                    if (py::hasattr(metadata, "get")) {
+                auto metadata = py_schema.attr("metadata");
+                if (py::hasattr(metadata, "get")) {
+                    for (int64_t i = 0; i < schema.n_children; ++i) {
+                        auto child = schema.children[i];
                         auto val = metadata.attr("get")(
-                            py::str(child->name).attr("encode")("utf-8"));
+                            py::str(child->name)
+                                .attr("encode")("utf-8"));
 
                         if (val != py::none() &&
                             val.cast<std::string>() == "nullable") {
-                            child->flags &= ARROW_FLAG_NULLABLE;
+                            child->flags |= ARROW_FLAG_NULLABLE;
                         } else {
                             child->flags &= ~ARROW_FLAG_NULLABLE;
                         }

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1433,6 +1433,7 @@ def test_enum_schema_report(tmp_path):
         assert f.type.index_type == pa.int8()
         assert f.type.value_type == pa.binary()
 
+
 def test_nullable(tmp_path):
     uri = tmp_path.as_posix()
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1432,3 +1432,20 @@ def test_enum_schema_report(tmp_path):
         f = sdf.schema.field("byte_cat")
         assert f.type.index_type == pa.int8()
         assert f.type.value_type == pa.binary()
+
+def test_nullable(tmp_path):
+    uri = tmp_path.as_posix()
+
+    asch = pa.schema([pa.field("foo", pa.int32())], metadata={"foo": "nullable"})
+
+    pydict = {}
+    pydict["soma_joinid"] = [0, 1, 2, 3, 4]
+    pydict["foo"] = [10, 20, 30, None, 50]
+    data = pa.Table.from_pydict(pydict)
+
+    with soma.DataFrame.create(uri, schema=asch) as sdf:
+        sdf.write(data)
+
+    with soma.DataFrame.open(uri, "r") as sdf:
+        df = sdf.read().concat().to_pandas()
+        assert df.compare(data.to_pandas()).empty

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -172,8 +172,10 @@ class ColumnBuffer {
         auto num_offsets = num_elems + 1;
         std::vector<uint32_t> offset_holder;
         offset_holder.resize(num_offsets);
-        offset_holder.assign((uint32_t*)offsets, (uint32_t*)offsets + num_offsets);
-        offsets_ = std::vector<uint64_t>(offset_holder.begin(), offset_holder.end());
+        offset_holder.assign(
+            (uint32_t*)offsets, (uint32_t*)offsets + num_offsets);
+        offsets_ = std::vector<uint64_t>(
+            offset_holder.begin(), offset_holder.end());
 
         data_size_ = offsets_[num_offsets - 1];
         data_.resize(data_size_);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -435,6 +435,24 @@ class SOMAArray : public SOMAObject {
         uint8_t* validity = nullptr);
 
     /**
+     * @brief Set the write buffers for string or binary with 32-bit offsets
+     * (as opposed to large string or large binary with 64-bit offsets).
+     *
+     * @param name Name of the column
+     * @param num_elems Number of elements to write
+     * @param data Pointer to the beginning of the data buffer
+     * @param offsets Pointer to the beginning of the offsets buffer
+     * @param validity Optional pointer to the beginning of the validities
+     * buffer
+     */
+    void set_column_data(
+        std::string_view name,
+        uint64_t num_elems,
+        const void* data,
+        uint32_t* offsets,
+        uint8_t* validity = nullptr);
+
+    /**
      * @brief Set the write buffers for an Arrow Table or Batch as represented
      * by an ArrowSchema and ArrowArray.
      *
@@ -758,6 +776,9 @@ class SOMAArray : public SOMAObject {
 
         return enmr;
     }
+
+    // Helper function for set_column_data
+    std::shared_ptr<ColumnBuffer> _setup_column_data(std::string_view name);
 
     // Fills the metadata cache upon opening the array.
     void fill_metadata_cache();

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -722,8 +722,8 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         schema->flags |= ARROW_FLAG_NULLABLE;  // it is also set by default
 
         // Count nulls
-        for (auto v : column->validity()) {
-            array->null_count += v == 0;
+        for (size_t i = 0; i < column->size(); ++i) {
+            array->null_count += column->validity()[i] == 0;
         }
 
         // Convert validity bytemap to a bitmap in place


### PR DESCRIPTION
**Issue and/or context:**

#2511

**Changes:**

We only dealt with large string and binary before, which use 64-bit offsets. This also supports small string and binary, which use 32-bit offsets.