### PR TITLE
[c++] Explicitly set `ArrowSchema` flag to 0

### DIFF
--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -45,6 +45,7 @@ def test_dense_nd_array_create_ok(
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
+    assert a.schema.field("soma_data").nullable == False
 
     # Validate TileDB array schema
     with tiledb.open(tmp_path.as_posix()) as A:

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -45,7 +45,7 @@ def test_dense_nd_array_create_ok(
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
-    assert a.schema.field("soma_data").nullable == False
+    assert not a.schema.field("soma_data").nullable
 
     # Validate TileDB array schema
     with tiledb.open(tmp_path.as_posix()) as A:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -57,7 +57,7 @@ def test_sparse_nd_array_create_ok(
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
-    assert a.schema.field("soma_data").nullable == False
+    assert not a.schema.field("soma_data").nullable
 
     # Ensure read mode uses clib object
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -57,6 +57,7 @@ def test_sparse_nd_array_create_ok(
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
+    assert a.schema.field("soma_data").nullable == False
 
     # Ensure read mode uses clib object
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A:

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -53,6 +53,7 @@ void SOMADenseNDArray::create(
     schema->format = strdup("+s");
     schema->n_children = index_column_size + 1;
     schema->dictionary = nullptr;
+    schema->flags = 0;
     schema->release = &ArrowAdapter::release_schema;
     schema->children = new ArrowSchema*[schema->n_children];
 
@@ -72,6 +73,7 @@ void SOMADenseNDArray::create(
     attr->format = strdup(std::string(format).c_str());
     attr->name = strdup("soma_data");
     attr->n_children = 0;
+    attr->flags = 0;
     attr->dictionary = nullptr;
     attr->release = &ArrowAdapter::release_schema;
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -54,6 +54,7 @@ void SOMASparseNDArray::create(
     schema->format = strdup("+s");
     schema->n_children = index_column_size + 1;
     schema->dictionary = nullptr;
+    schema->flags = 0;
     schema->release = &ArrowAdapter::release_schema;
     schema->children = new ArrowSchema*[schema->n_children];
 
@@ -73,6 +74,7 @@ void SOMASparseNDArray::create(
     attr->format = strdup(std::string(format).c_str());
     attr->name = strdup("soma_data");
     attr->n_children = 0;
+    attr->flags = 0;
     attr->dictionary = nullptr;
     attr->release = &ArrowAdapter::release_schema;
 


### PR DESCRIPTION
**Issue and/or context:**

As reported in slack, `SOMADenseNDArray`s were erroneously creating nullable columns by default.

**Changes:**

Explicitly set `ArrowSchema` flag to 0 in the `NDArray` create methods.