### PR TITLE
test fixture/helper cleanup

### DIFF
--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -316,7 +316,7 @@ def anndata_dataframe_unmodified_nan_safe(old: pd.DataFrame, new: pd.DataFrame) 
     return True
 
 
-def verify_obs_and_var_same(ad0: AnnData, ad1: AnnData, nan_safe: bool = False) -> None:
+def verify_obs_and_var_eq(ad0: AnnData, ad1: AnnData, nan_safe: bool = False) -> None:
     """Verify that two ``AnnData``'s ``obs`` and ``var`` dataframes are equivalent."""
     if nan_safe:
         assert anndata_dataframe_unmodified_nan_safe(ad0.obs, ad1.obs)

--- a/apis/python/tests/conftest.py
+++ b/apis/python/tests/conftest.py
@@ -1,40 +1,45 @@
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import anndata
 import pytest
+from anndata import AnnData
 
 import tiledbsoma
 import tiledbsoma.io
+from tiledbsoma import Experiment
 
 from ._util import TESTDATA
 
 
 @pytest.fixture
-def conftest_h5ad_path(request):
-    # pbmc-small is faster for automated unit-test / CI runs.
+def pbmc0_h5ad_path(request) -> Path:
+    """Path to a tiny (80x20) h5ad, useful for unit-test / CI runs."""
     return TESTDATA / "pbmc-small.h5ad"
 
 
 @pytest.fixture
-def conftest_adata(conftest_h5ad_path):
-    return anndata.read_h5ad(conftest_h5ad_path)
+def pbmc0_adata(pbmc0_h5ad_path) -> AnnData:
+    """Tiny (80x20) AnnData, useful for unit-test / CI runs."""
+    return anndata.read_h5ad(pbmc0_h5ad_path)
 
 
 @pytest.fixture
-def conftest_h5ad_file_extended(request):
-    # This has more component arrays in it
+def pbmc0_exp(pbmc0_h5ad_path) -> Experiment:
+    """Ingest an ``AnnData``, yield a ``TestCase`` with the original and new AnnData objects."""
+    with TemporaryDirectory() as exp_path:
+        tiledbsoma.io.from_h5ad(exp_path, pbmc0_h5ad_path, measurement_name="RNA")
+        with tiledbsoma.Experiment.open(exp_path) as exp:
+            yield exp
+
+
+@pytest.fixture
+def pbmc_3k_h5ad_path(request) -> Path:
+    """Path to a larger (2638x1838) h5ad, which also includes obsm, obsp, and varm arrays."""
     return TESTDATA / "pbmc3k_processed.h5ad"
 
 
 @pytest.fixture
-def conftest_adata_extended(conftest_h5ad_file_extended):
-    return anndata.read_h5ad(conftest_h5ad_file_extended)
-
-
-@pytest.fixture
-def conftest_pbmc_small(conftest_h5ad_path):
-    """Ingest an ``AnnData``, yield a ``TestCase`` with the original and new AnnData objects."""
-    with TemporaryDirectory() as exp_path:
-        tiledbsoma.io.from_h5ad(exp_path, conftest_h5ad_path, measurement_name="RNA")
-        with tiledbsoma.Experiment.open(exp_path) as exp:
-            yield exp
+def pbmc_3k_adata(pbmc_3k_h5ad_path):
+    """Larger (2638x1838) AnnData, which also includes obsm, obsp, and varm arrays."""
+    return anndata.read_h5ad(pbmc_3k_h5ad_path)

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -926,15 +926,14 @@ def test_experiment_query_uses_threadpool_from_context(soma_experiment):
         pool.submit.assert_called()
 
 
-# Magical conftest.py fixture
-def test_empty_categorical_query(conftest_pbmc_small):
-    q = conftest_pbmc_small.axis_query(
+def test_empty_categorical_query(pbmc0_exp):
+    q = pbmc0_exp.axis_query(
         measurement_name="RNA", obs_query=AxisQuery(value_filter='groups == "g1"')
     )
     obs = q.obs().concat()
     assert len(obs) == 44
 
-    q = conftest_pbmc_small.axis_query(
+    q = pbmc0_exp.axis_query(
         measurement_name="RNA", obs_query=AxisQuery(value_filter='groups == "foo"')
     )
     # Empty query on a categorical column raised ArrowInvalid before TileDB 2.21; see https://github.com/single-cell-data/TileDB-SOMA/pull/2299

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -174,19 +174,18 @@ def test_write_arrow_table(tmp_path, num_rows, cap_nbytes):
             assert list(pdf["foo"]) == pydict["foo"]
 
 
-# Magical conftest.py fixture
-def test_add_matrices(tmp_path, conftest_h5ad_path):
+def test_add_matrices(tmp_path, pbmc0_h5ad_path):
     """Test multiple add_matrix_to_collection calls can be issued on the same soma object.
 
     See https://github.com/single-cell-data/TileDB-SOMA/issues/1565."""
     # Create a soma object from an anndata object
     soma_uri = soma.io.from_h5ad(
-        tmp_path.as_posix(), input_path=conftest_h5ad_path, measurement_name="RNA"
+        tmp_path.as_posix(), input_path=pbmc0_h5ad_path, measurement_name="RNA"
     )
 
     # Synthesize some new data to be written into two matrices within the soma object (ensuring it's different from the
     # original data, so that writes must be performed)
-    h5ad = ad.read_h5ad(conftest_h5ad_path)
+    h5ad = ad.read_h5ad(pbmc0_h5ad_path)
     new_X_pca = h5ad.obsm["X_pca"] * 2
     new_PCs = h5ad.varm["PCs"] * 2
 

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -5,13 +5,12 @@ import pytest
 import tiledbsoma
 import tiledbsoma.io
 import tiledbsoma.options._tiledb_create_options as tco
-from tiledbsoma._util import verify_obs_and_var_same
+from tiledbsoma._util import verify_obs_and_var_eq
 import tiledb
 
 
 @pytest.mark.skip(reason="No longer return ArraySchema - see note in test")
-# Magical conftest.py fixture
-def test_platform_config(conftest_adata):
+def test_platform_config(pbmc0_adata):
     # TODO as we remove usage of TileDB-Py in favor of ArrowSchema, we
     # need a new method to get which filters have applied to the column
     # rather than grabbing it from the ArraySchema. One consideration
@@ -25,12 +24,12 @@ def test_platform_config(conftest_adata):
     # platform_config by calling pa.Schema.with_metadata(platform_config).
 
     # Set up anndata input path and tiledb-group output path
-    original = conftest_adata.copy()
+    original = pbmc0_adata.copy()
     with tempfile.TemporaryDirectory() as output_path:
         # Ingest
         tiledbsoma.io.from_anndata(
             output_path,
-            conftest_adata,
+            pbmc0_adata,
             "RNA",
             platform_config={
                 "tiledb": {
@@ -52,7 +51,7 @@ def test_platform_config(conftest_adata):
                 }
             },
         )
-        verify_obs_and_var_same(original, conftest_adata)
+        verify_obs_and_var_eq(original, pbmc0_adata)
 
         with tiledbsoma.Experiment.open(output_path) as exp:
             x_data = exp.ms["RNA"].X["data"]

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -13,7 +13,7 @@ import pytest
 
 import tiledbsoma.io
 import tiledbsoma.io._registration as registration
-from tiledbsoma._util import verify_obs_and_var_same
+from tiledbsoma._util import verify_obs_and_var_eq
 
 
 def _create_anndata(
@@ -77,9 +77,8 @@ def _create_anndata(
     return adata
 
 
-# Magical conftest_adata fixture
-def create_h5ad(conftest_adata, path):
-    conftest_adata.write_h5ad(path)
+def create_h5ad(pbmc0_adata, path):
+    pbmc0_adata.write_h5ad(path)
     return path
 
 
@@ -820,7 +819,7 @@ def test_append_items_with_experiment(obs_field_name, var_field_name):
             registration_mapping=rd,
         )
 
-    verify_obs_and_var_same(original, adata2)
+    verify_obs_and_var_eq(original, adata2)
 
     expect_obs_soma_joinids = list(range(6))
     expect_var_soma_joinids = list(range(5))
@@ -926,7 +925,7 @@ def test_append_with_disjoint_measurements(
         registration_mapping=rd,
     )
 
-    verify_obs_and_var_same(original, anndata2)
+    verify_obs_and_var_eq(original, anndata2)
 
     # exp/obs, use_same_cells=True:                       exp/obs, use_same_cells=False:
     #    soma_joinid obs_id cell_type  is_primary_data       soma_joinid obs_id cell_type  is_primary_data

--- a/apis/python/tests/test_update_matrix.py
+++ b/apis/python/tests/test_update_matrix.py
@@ -4,14 +4,11 @@ import tiledbsoma
 import tiledbsoma.io
 
 
-# Magical conftest.py fixture
-def test_update_matrix_X(conftest_adata_extended):
+def test_update_matrix_X(pbmc_3k_adata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
-    tiledbsoma.io.from_anndata(
-        output_path, conftest_adata_extended, measurement_name="RNA"
-    )
+    tiledbsoma.io.from_anndata(output_path, pbmc_3k_adata, measurement_name="RNA")
 
     with tiledbsoma.Experiment.open(output_path) as exp:
         old = exp.ms["RNA"].X["data"].read().tables().concat()
@@ -23,7 +20,7 @@ def test_update_matrix_X(conftest_adata_extended):
     with tiledbsoma.Experiment.open(output_path, "w") as exp:
         tiledbsoma.io.update_matrix(
             exp.ms["RNA"].X["data"],
-            conftest_adata_extended.X + 1,
+            pbmc_3k_adata.X + 1,
         )
 
     with tiledbsoma.Experiment.open(output_path) as exp:
@@ -39,13 +36,11 @@ def test_update_matrix_X(conftest_adata_extended):
 
 
 # Magical conftest.py fixture
-def test_update_matrix_obsm(conftest_adata_extended):
+def test_update_matrix_obsm(pbmc_3k_adata):
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
-    tiledbsoma.io.from_anndata(
-        output_path, conftest_adata_extended, measurement_name="RNA"
-    )
+    tiledbsoma.io.from_anndata(output_path, pbmc_3k_adata, measurement_name="RNA")
 
     with tiledbsoma.Experiment.open(output_path) as exp:
         old = exp.ms["RNA"].obsm["X_pca"].read().tables().concat()
@@ -57,7 +52,7 @@ def test_update_matrix_obsm(conftest_adata_extended):
     with tiledbsoma.Experiment.open(output_path, "w") as exp:
         tiledbsoma.io.update_matrix(
             exp.ms["RNA"].obsm["X_pca"],
-            conftest_adata_extended.obsm["X_pca"] + 1,
+            pbmc_3k_adata.obsm["X_pca"] + 1,
         )
 
     with tiledbsoma.Experiment.open(output_path) as exp:


### PR DESCRIPTION
**Issue and/or context:** Proposed for inclusion in #2521

**Changes:**
- More descriptive `pytest.fixture` names
- "Manually" expose each `TestCase` member as a `fixture`, removing automatic fixture creation hack using `globals()` ([diff](https://github.com/single-cell-data/TileDB-SOMA/commit/98bcc9736967e3b7c228d9b867964ccc703bdbc9#diff-8656b690b8df46bf6432c6aabffe4b3b71e35fdea3dc0feda652b660224b2055L80-L101))
- Factor/Rename a couple test helpers (e.g. `maybe_raises`)

**Notes for Reviewer:**
Hopefully this strikes a reasonable balance between "discoverability of `pytest.fixture`s defined in conftest.py" vs. having to spell it out at each fixture-use site.

The "auto-generated fixtures for each `TestCase` field" bit in particular was too magical, I've unrolled it here.
