### PR TITLE
[r] Ensure `SOMADataFrame$shape()` throws a not-yet-implemented error

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.4
+Version: 1.10.99.5
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -10,7 +10,7 @@
 * Add support for resume-mode in `write_soma()`
 * Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
-* Ensure `SOMADataFrame$shape()` always returns `NA`
+* Have `SOMADataFrame$shape()` throw a not-yet-implemented error
 
 # 1.7.0
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -10,6 +10,7 @@
 * Add support for resume-mode in `write_soma()`
 * Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
+* Ensure `SOMADataFrame$shape()` always returns `NA`
 
 # 1.7.0
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -395,7 +395,14 @@ SOMADataFrame <- R6::R6Class(
       self$reopen(mode = "WRITE")
       spdl::info("[SOMADataFrame update]: Writing new data")
       self$write(values)
-    }
+    },
+
+    #' @description Retrieve the shape; as \code{SOMADataFrames} are shapeless,
+    #' simply returns \code{NA}
+    #'
+    #' @return \code{NA} classed as an \code{\link[bit64]{integer64}}
+    #'
+    shape = function() bit64::as.integer64(NA_integer_)
 
   ),
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -398,11 +398,14 @@ SOMADataFrame <- R6::R6Class(
     },
 
     #' @description Retrieve the shape; as \code{SOMADataFrames} are shapeless,
-    #' simply returns \code{NA}
+    #' simply raises an error
     #'
-    #' @return \code{NA} classed as an \code{\link[bit64]{integer64}}
+    #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
     #'
-    shape = function() bit64::as.integer64(NA_integer_)
+    shape = function() stop(errorCondition(
+      "'SOMADataFrame$shape()' is not implemented yet",
+      class = 'notYetImplementedError'
+    ))
 
   ),
 

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -194,13 +194,13 @@ Furthermore, \code{values} must contain the same number of rows as the current
 \if{latex}{\out{\hypertarget{method-SOMADataFrame-shape}{}}}
 \subsection{Method \code{shape()}}{
 Retrieve the shape; as \code{SOMADataFrames} are shapeless,
-simply returns \code{NA}
+simply raises an error
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$shape()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-\code{NA} classed as an \code{\link[bit64]{integer64}}
+None, instead a \code{\link{.NotYetImplemented}()} error is raised
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -19,6 +19,7 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-write}{\code{SOMADataFrame$write()}}
 \item \href{#method-SOMADataFrame-read}{\code{SOMADataFrame$read()}}
 \item \href{#method-SOMADataFrame-update}{\code{SOMADataFrame$update()}}
+\item \href{#method-SOMADataFrame-shape}{\code{SOMADataFrame$shape()}}
 \item \href{#method-SOMADataFrame-clone}{\code{SOMADataFrame$clone()}}
 }
 }
@@ -46,7 +47,6 @@ row and is intended to act as a join key for other objects, such as
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="set_metadata"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-set_metadata'><code>tiledbsoma::TileDBArray$set_metadata()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-shape'><code>tiledbsoma::TileDBArray$shape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsoma::TileDBArray$tiledb_array()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="tiledb_schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-tiledb_schema'><code>tiledbsoma::TileDBArray$tiledb_schema()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="used_shape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-used_shape'><code>tiledbsoma::TileDBArray$used_shape()</code></a></span></li>
@@ -188,6 +188,20 @@ Furthermore, \code{values} must contain the same number of rows as the current
 \code{SOMADataFrame}.
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-shape"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-shape}{}}}
+\subsection{Method \code{shape()}}{
+Retrieve the shape; as \code{SOMADataFrames} are shapeless,
+simply returns \code{NA}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$shape()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+\code{NA} classed as an \code{\link[bit64]{integer64}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMADataFrame-clone"></a>}}

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -12,6 +12,9 @@ test_that("Basic mechanics", {
   expect_true(sdf$exists())
   expect_true(dir.exists(uri))
 
+  expect_true(rlang::is_na(sdf$shape()))
+  expect_s3_class(sdf$shape(), "integer64")
+
   # check for missing columns
   expect_error(
     sdf$write(arrow::arrow_table(foo = 1L:10L)),

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -12,9 +12,6 @@ test_that("Basic mechanics", {
   expect_true(sdf$exists())
   expect_true(dir.exists(uri))
 
-  expect_true(rlang::is_na(sdf$shape()))
-  expect_s3_class(sdf$shape(), "integer64")
-
   # check for missing columns
   expect_error(
     sdf$write(arrow::arrow_table(foo = 1L:10L)),
@@ -45,6 +42,8 @@ test_that("Basic mechanics", {
   # Read back the data (ignore attributes)
   sdf <- SOMADataFrameOpen(uri)
   expect_match(sdf$soma_type, "SOMADataFrame")
+
+  expect_error(sdf$shape(), class = "notYetImplementedError")
 
   expect_equivalent(
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -13,7 +13,7 @@ test_that("write_soma.data.frame mechanics", {
   expect_identical(sdf$uri, file.path(collection$uri, 'co2'))
   expect_identical(sdf$dimnames(), 'soma_joinid')
   expect_identical(sdf$attrnames(), c(names(co2), 'obs_id'))
-  expect_true(rlang::is_na(sdf$shape()))
+  expect_error(sdf$shape(), class = 'notYetImplementedError')
   schema <- sdf$schema()
   expect_s3_class(schema, 'Schema')
   expect_equal(schema$num_fields - 2L, ncol(co2))


### PR DESCRIPTION
New `$shape()` method for `SOMADataFrame` that throws a not-yet-implemented error. This is implemneted as a custom error instead of `.NotYetImplmented()` because:
- `.NotYetImplemented()` does not understand R6 methods and produces a janky error message
```R
Error: `$` is not yet implmeneted`sdf` is not yet implemented`shape()` is not yet implemented
```
- `.NotYetImplemented()` throws a simple error (same as `stop()`) which is harder to catch; I'm custom-classing this error as `notYetImplementedError` so that any `tryCatch()` can catch this and only this

New SOMA methods:
 - `SOMADataFrame$shape()`: throw a `notYetImplementedError`

This parallels the Python's API #2533