### PR TITLE
[python] Raise `NotImplementedError` for `DataFrame.shape`

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -465,6 +465,11 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def write(self, values: pa.RecordBatch) -> None:
         self._handle.write(values)
 
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        # Shape is not implemented for DataFrames
+        raise NotImplementedError
+
 
 class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     """Wrapper around a Pybind11 DenseNDArrayWrapper handle."""

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -87,6 +87,7 @@ def test_dataframe(tmp_path, arrow_schema):
     with soma.DataFrame.open(uri) as sdf:
         assert sdf.count == 5
         assert len(sdf) == 5
+        assert sdf.shape is None
 
         # Read all
         table = sdf.read().concat()

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -87,7 +87,9 @@ def test_dataframe(tmp_path, arrow_schema):
     with soma.DataFrame.open(uri) as sdf:
         assert sdf.count == 5
         assert len(sdf) == 5
-        assert sdf.shape is None
+
+        with pytest.raises(AttributeError):
+            assert sdf.shape is None
 
         # Read all
         table = sdf.read().concat()


### PR DESCRIPTION
**Issue and/or context:**

As per the SOMA spec, `DataFrame`s do not have `shape` implemented.

This parallels the R API's https://github.com/single-cell-data/TileDB-SOMA/pull/2531.

**Changes:**

Raise `NotImplementedError` for `DataFrame.shape`.
