### PR TITLE
[python] Update `doc/` README/deps, fix warnings, `from_h5ad` formatting

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -261,22 +261,27 @@ def from_h5ad(
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
 
         platform_config: Platform-specific options used to create this array, provided in the form
-        ``{"tiledb": {"create": {"sparse_nd_array_dim_zstd_level": 7}}}`` nested keys.
+          ``{\"tiledb\": {\"create\": {\"sparse_nd_array_dim_zstd_level\": 7}}}``.
 
-        obs_id_name and var_id_name: Which AnnData ``obs`` and ``var`` columns, respectively, to use
-        for append mode: values of this column will be used to decide which obs/var rows in appended
-        inputs are distinct from the ones already stored, for the assignment of ``soma_joinid``.  If
-        this column exists in the input data, as a named index or a non-index column name, it will
-        be used. If this column doesn't exist in the input data, and if the index is nameless or
-        named ``index``, that index will be given this name when written to the SOMA experiment's
-        ``obs`` / ``var``. NOTE: it is not necessary for this column to be the index-column
-        name in the input AnnData objects ``obs``/``var``.
+        obs_id_name/var_id_name: Which AnnData ``obs`` and ``var`` columns, respectively, to use
+          for append mode.
+
+          Values of this column will be used to decide which obs/var rows in appended
+          inputs are distinct from the ones already stored, for the assignment of ``soma_joinid``.  If
+          this column exists in the input data, as a named index or a non-index column name, it will
+          be used. If this column doesn't exist in the input data, and if the index is nameless or
+          named ``index``, that index will be given this name when written to the SOMA experiment's
+          ``obs`` / ``var``.
+
+          NOTE: it is not necessary for this column to be the index-column
+          name in the input AnnData objects ``obs``/``var``.
 
         X_layer_name: SOMA array name for the AnnData's ``X`` matrix.
 
         raw_X_layer_name: SOMA array name for the AnnData's ``raw/X`` matrix.
 
         ingest_mode: The ingestion type to perform:
+
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
             - ``resume``: Adds data to an existing SOMA, skipping writing data
               that was previously written. Useful for continuing after a partial
@@ -286,11 +291,13 @@ def from_h5ad(
               multiple H5AD files to a single SOMA.
 
         X_kind: Which type of matrix is used to store dense X data from the
-            H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
+          H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
 
         registration_mapping: Does not need to be supplied when ingesting a single
           H5AD/AnnData object into a single :class:`Experiment`. When multiple inputs
           are to be ingested into a single experiment, there are two steps. First:
+
+          .. code-block:: python
 
               import tiledbsoma.io
               rd = tiledbsoma.io.register_h5ads(
@@ -304,6 +311,8 @@ def from_h5ad(
 
           Once that's been done, the data ingests per se may be done in any order,
           or in parallel, via for each ``h5ad_file_name``:
+
+          .. code-block:: python
 
               tiledbsoma.io.from_h5ad(
                   experiment_uri,
@@ -320,6 +329,8 @@ def from_h5ad(
         additional_metadata: Optional metadata to add to the ``Experiment`` and all descendents.
           This is a coarse-grained mechanism for setting key-value pairs on all SOMA objects in an
           ``Experiment`` hierarchy. Metadata for particular objects is more commonly set like:
+
+          .. code-block:: python
 
               with soma.open(uri, 'w') as exp:
                   exp.metadata.update({"aaa": "BBB"})

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,19 +1,27 @@
 # Basic on-laptop setup
 
-```
-pip install .
-```
-
-This is very important -- _for developers_, the nominal use-mode is `python setup.py develop` as documented in our [../apis/python/README.md](../apis/python/README.md). But this local build _will not find_ `tiledbsoma-py` from this local install. You must install `pip install apis/python so it can find Python source for document autogen, _and_ you must re-run `pip install apis/python after each and every source-file edit, even if you're just doing an edit-build-preview iteration loop in a sandbox checkout.
-
-```
-#!/bin/bash
-set -euo pipefail
-sphinx-build -E -T -b html -d foo/doctrees -D language=en doc/source doc/html
+Build the docs with:
+```bash
+./local-build.sh
 ```
 
+The first time you run this, it will:
+1. Create and activate a virtualenv (`venv/`)
+2. Install [`requirements_doc.txt`](requirements_doc.txt)
+3. Install `..apis/python` (editable)
+4. Build the docs (output to `doc/html/`)
+
+Subsequent runs will only perform the 4th step (unless `-r`/`--reinstall` is passed).
+
+Once the docs are built, you can:
+
+```bash
+open source/_build/html/index.html
 ```
-#!/bin/bash
-set -euo pipefail
-open doc/html/python-api.html
+or e.g.:
+```bash
+http-server source/_build/html &
+open http://localhost:8080/
 ```
+
+and inspect them.

--- a/doc/local-build.sh
+++ b/doc/local-build.sh
@@ -17,57 +17,45 @@ die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1
 }
 
-arg() {
-  echo "$1" | sed "s/^${2-[^=]*=}//" | sed "s/:/;/g"
-}
-
 # Display bootstrap usage
 usage() {
-echo '
-Usage: '"$0"' [<options>]
-Options: [defaults in brackets after descriptions]
-Configuration:
-    --help                          print this message
-'
+    echo '
+    Usage: '"$0"' [-r/--reinstall] [--help]
+    Options: [defaults in brackets after descriptions]
+    Configuration:
+        -r, --reinstall                 reinstall dependencies
+        --help                          print this message
+    '
     exit 10
 }
 
 # Parse arguments
+reinstall=
 while test $# != 0; do
     case "$1" in
+    -r|--reinstall) reinstall=1 ;;
     --help) usage ;;
     *) die "Unknown option: $1" ;;
     esac
     shift
 done
 
-setup_venv() {
-  if [ ! -d "${venv_dir}" ]; then
-    python -m virtualenv "${venv_dir}" || die "could not create virtualenv"
-  fi
-  source "${venv_dir}/bin/activate" || die "could not activate virtualenv"
-  pip install 'Sphinx==1.6.7' \
-       'breathe' \
-       'sphinx_rtd_theme' \
-       -r requirements_doc.txt || die "could not install doc dependencies"
-}
+made_venv=
+if [ ! -d "${venv_dir}" ]; then
+  python -m virtualenv "${venv_dir}" || die "could not create virtualenv"
+  made_venv=1
+fi
 
-build_ext() {
-    pushd "${ext_dir}"
-    pip install apis/python || die "could not install tiledbsoma-py"
-    popd
-}
+source "${venv_dir}/bin/activate" || die "could not activate virtualenv"
 
-build_site() {
-  sphinx-build -E -T -b html -d ${build_dir}/doctrees -D language=en ${source_dir} ${build_dir}/html || \
-      die "could not build sphinx site"
-}
+if [ -n "${reinstall}" ] || [ -n "${made_venv}" ]; then
+  pip install -r requirements_doc.txt || die "could not install doc dependencies"
+  pushd "${ext_dir}"
+  pip install -e . || die "could not install tiledbsoma-py"
+  popd
+fi
 
-run() {
-  setup_venv
-  build_ext
-  build_site
-  echo "Build complete. Open '${build_dir}/html/index.html' in your browser."
-}
+sphinx-build -E -T -b html -d ${build_dir}/doctrees -D language=en ${source_dir} ${build_dir}/html || \
+  die "could not build sphinx site"
 
-run
+echo "Build complete. Open '${build_dir}/html/index.html' in your browser."

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -1,10 +1,13 @@
-sphinx==4.5.0
-sphinx-rtd-theme==1.0.0
-docutils < 0.18
+breathe==4.35.0
+cmake==3.29.2
+docutils==0.20.1
+ipython==8.24.0
 jinja2==3.1.4
-setuptools >= 18.0, <= 59.5.0
-setuptools_scm >= 1.5.4
-wheel >= 0.30
-cmake >= 3.21
-pybind11 >= 2.10.0
-nbsphinx
+nbsphinx==0.9.3
+pandoc==2.3
+pybind11==2.12.0
+setuptools==69.5.1
+setuptools-scm==8.1.0
+sphinx==7.3.7
+sphinx-rtd-theme==2.0.0
+wheel==0.43.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,7 +80,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -188,4 +188,4 @@ gensidebar.generate_sidebar(
 
 
 def setup(app):
-    app.add_stylesheet("custom.css")
+    app.add_css_file("custom.css")

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -1,5 +1,5 @@
 The tiledbsoma.io module
-=====================
+========================
 
 .. currentmodule:: tiledbsoma.io
 
@@ -7,7 +7,7 @@ The tiledbsoma.io module
 
 
 Functions
--------
+---------
 
 .. autosummary::
     :toctree: _autosummary/

--- a/doc/source/python-tiledbsoma-logging.rst
+++ b/doc/source/python-tiledbsoma-logging.rst
@@ -1,5 +1,5 @@
 The tiledbsoma.logging module
-=====================
+=============================
 
 .. currentmodule:: tiledbsoma.logging
 
@@ -7,7 +7,7 @@ The tiledbsoma.logging module
 
 
 Functions
--------
+---------
 
 .. autosummary::
     :toctree: _autosummary/


### PR DESCRIPTION
Also seems to fix #2474; best guess is newer sphinx allows missing newline before `Lifecycle:`?

**Issue and/or context:** #2474

**Changes:**
- Update doc deps
- Update `local-build.sh`
- Fix `from_h5ad` docstr / rtd rendering ([current version](https://tiledbsoma.readthedocs.io/en/latest/_autosummary/tiledbsoma.io.from_h5ad.html#tiledbsoma.io.from_h5ad) has broken formatting, missed args)


