### PR TITLE
[r] Suppress Warnings on SOMA -> `Seurat` Outgestion

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.5
+Version: 1.10.99.6
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -11,6 +11,7 @@
 * Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 * Have `SOMADataFrame$shape()` throw a not-yet-implemented error
+* Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
 
 # 1.7.0
 

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -570,6 +570,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         var_index = var_index,
         var_column_names = var_column_names
       )
+      op <- options(Seurat.object.assay.calcn = FALSE)
+      on.exit(options(op), add = TRUE, after = FALSE)
       object <- SeuratObject::CreateSeuratObject(
         counts = assay,
         assay = private$.measurement_name


### PR DESCRIPTION
SeuratObject v5.0.2 throws a warning when the layer requested does not exist. During SOMA -> `Seurat` outgestion, this occurs when running `SeuratObject::.CalcN` eg.
```r
> obj <- query$to_seurat(X_layers = c('data' = 'data'))
Warning: Layer counts isn't present in the assay object; returning NULL
```
Since the results of `.CalcN()` should already exist in the SOMA, we can disable this processing and suppress the warning