### PR TITLE
[r/ci] Utilize pin of tiledb-r during install

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
           codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
-          repo <- sprintf("https://tiledb-inc.r-universe.dev/bin/linux/%s/%s/", codename, rversion)
-          (opt <- sprintf('options(repos = c("%s", getOption("repos")))', repo))
+          repo <- "https://tiledb-inc.r-universe.dev"
+          (opt <- sprintf('options(repos = c("%s/bin/linux/%s/%s", "%s", getOption("repos")))', repo, codename, rversion, repo))
           cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
         shell: Rscript {0}
 
@@ -140,7 +140,7 @@ jobs:
       #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
       - name: Dependencies
-        run: R_REMOTES_UPGRADE=never cd apis/r && tools/r-ci.sh install_all
+        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
 
       # - name: Install dataset packages from source (macOS)
       #   if: ${{ matrix.os == 'macOS-latest' }}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -68,47 +68,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Install tiledb-r
-        run: |
-          options(bspm.version.check = TRUE)
-          # Find tiledb-r constraints
-          deps <- read.dcf('apis/r/DESCRIPTION', fields = 'Imports')[1, ]
-          deps <- trimws(strsplit(gsub(pattern = ',', replacement = '\n', x = deps), split = '\n')[[1L]])
-          deps <- Filter(nzchar, deps)
-          deps <- Filter(function(x) grepl('^tiledb', x), deps)
-          deps <- gsub(pattern = '[[:space:]]', replacement = '', x = deps)
-          deps <- gsub(pattern = '.*\\(|\\)', replacement = '', x = deps)
-          const <- data.frame(comp = gsub(pattern = '[[:digit:]\\.]*', replacement = '', x = deps))
-          const$vers <- gsub(pattern = paste(const$comp, collapse = '|'), replacement = '', x = deps)
-          const
-          # Find correct version of tiledb-r
-          db <- utils::available.packages(filters = c("R_version", "OS_type", "subarch"))
-          idx <- which(rownames(db) == 'tiledb')
-          valid <- vapply(
-            idx,
-            FUN = function(i) {
-              v <- db[i, 'Version']
-              res <- vector(mode = 'logical', length = nrow(const))
-              for (i in seq_along(res)) {
-                res[i] <- do.call(const$comp[i], args = list(v, const$vers[i]))
-              }
-              return(all(res))
-            },
-            FUN.VALUE = logical(1L)
-          )
-          if (!any(valid)) {
-            stop("No valid versions of tiledb-r found")
-          }
-          db <- db[-idx[!valid], , drop = FALSE]
-          # Install upstream deps
-          ups <- tools::package_dependencies("tiledb", db = db, recursive = TRUE)$tiledb
-          utils::install.packages(intersect(ups, rownames(db)))
-          # Install correct version of tiledb-r
-          ctb <- contrib.url(getOption("repos"))
-          names(ctb) <- getOption("repos")
-          dbr <- db[idx[valid], 'Repository']
-          repos <- names(ctb[ctb %in% dbr])
-          utils::install.packages("tiledb", repos = repos)
-        shell: Rscript {0}
+        run: cd apis/r && Rscript tools/install-tiledb-r.R
 
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -16,6 +16,7 @@ env:
   COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   _R_CHECK_TESTS_NLINES_: 0
   CATCHSEGV: "TRUE"
+  R_REMOTES_UPGRADE: "never"
 
 jobs:
   ci:
@@ -51,6 +52,63 @@ jobs:
 
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
+
+      - name: Set additional repositories (macOS)
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        run: echo 'options(repos = c("https://tiledb-inc.r-universe.dev", getOption("repos")))' | tee -a ~/.Rprofile
+
+      - name: Set additional repositories (Linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
+          codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
+          repo <- sprintf("https://tiledb-inc.r-universe.dev/bin/linux/%s/%s/", codename, rversion)
+          opt <- sprintf('options(repos = c("%s", getOption("repos")))', repo)
+          cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Install tiledb-r
+        run: |
+          options(bspm.version.check = TRUE)
+          # Find tiledb-r constraints
+          deps <- read.dcf('apis/r/DESCRIPTION', fields = 'Imports')[1, ]
+          deps <- trimws(strsplit(gsub(pattern = ',', replacement = '\n', x = deps), split = '\n')[[1L]])
+          deps <- Filter(nzchar, deps)
+          deps <- Filter(function(x) grepl('^tiledb', x), deps)
+          deps <- gsub(pattern = '[[:space:]]', replacement = '', x = deps)
+          deps <- gsub(pattern = '.*\\(|\\)', replacement = '', x = deps)
+          const <- data.frame(comp = gsub(pattern = '[[:digit:]\\.]*', replacement = '', x = deps))
+          const$vers <- gsub(pattern = paste(const$comp, collapse = '|'), replacement = '', x = deps)
+          const
+          # Find correct version of tiledb-r
+          db <- utils::available.packages(filters = c("R_version", "OS_type", "subarch"))
+          idx <- which(rownames(db) == 'tiledb')
+          valid <- vapply(
+            idx,
+            FUN = function(i) {
+              v <- db[i, 'Version']
+              res <- vector(mode = 'logical', length = nrow(const))
+              for (i in seq_along(res)) {
+                res[i] <- do.call(const$comp[i], args = list(v, const$vers[i]))
+              }
+              return(all(res))
+            },
+            FUN.VALUE = logical(1L)
+          )
+          if (!any(valid)) {
+            stop("No valid versions of tiledb-r found")
+          }
+          db <- db[-idx[!valid], , drop = FALSE]
+          # Install upstream deps
+          ups <- tools::package_dependencies("tiledb", db = db, recursive = TRUE)$tiledb
+          utils::install.packages(intersect(ups, rownames(db)))
+          # Install correct version of tiledb-r
+          ctb <- contrib.url(getOption("repos"))
+          names(ctb) <- getOption("repos")
+          dbr <- db[idx[valid], 'Repository']
+          repos <- names(ctb[ctb %in% dbr])
+          utils::install.packages("tiledb", repos = repos)
+        shell: Rscript {0}
 
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -63,7 +63,7 @@ jobs:
           rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
           codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
           repo <- sprintf("https://tiledb-inc.r-universe.dev/bin/linux/%s/%s/", codename, rversion)
-          opt <- sprintf('options(repos = c("%s", getOption("repos")))', repo)
+          (opt <- sprintf('options(repos = c("%s", getOption("repos")))', repo))
           cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
         shell: Rscript {0}
 
@@ -140,7 +140,7 @@ jobs:
       #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
       - name: Dependencies
-        run: cd apis/r && tools/r-ci.sh install_all
+        run: R_REMOTES_UPGRADE=never cd apis/r && tools/r-ci.sh install_all
 
       # - name: Install dataset packages from source (macOS)
       #   if: ${{ matrix.os == 'macOS-latest' }}

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.10.99.5
+Version: 1.10.99.6
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -11,6 +11,7 @@
 * Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 * Have `SOMADataFrame$shape()` throw a not-yet-implemented error
+* Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
 
 # 1.7.0
 

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -570,6 +570,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         var_index = var_index,
         var_column_names = var_column_names
       )
+      op <- options(Seurat.object.assay.calcn = FALSE)
+      on.exit(options(op), add = TRUE, after = FALSE)
       object <- SeuratObject::CreateSeuratObject(
         counts = assay,
         assay = private$.measurement_name

--- a/apis/r/tools/install-tiledb-r.R
+++ b/apis/r/tools/install-tiledb-r.R
@@ -1,0 +1,45 @@
+#!/usr/bin/env Rscript
+
+options(bspm.version.check = TRUE)
+
+# Find tiledb-r constraints
+deps <- read.dcf('DESCRIPTION', fields = 'Imports')[1, ]
+deps <- trimws(strsplit(gsub(pattern = ',', replacement = '\n', x = deps), split = '\n')[[1L]])
+deps <- Filter(nzchar, deps)
+deps <- Filter(function(x) grepl('^tiledb', x), deps)
+deps <- gsub(pattern = '[[:space:]]', replacement = '', x = deps)
+deps <- gsub(pattern = '.*\\(|\\)', replacement = '', x = deps)
+const <- data.frame(comp = gsub(pattern = '[[:digit:]\\.]*', replacement = '', x = deps))
+const$vers <- gsub(pattern = paste(const$comp, collapse = '|'), replacement = '', x = deps)
+(const)
+
+# Find correct version of tiledb-r
+db <- utils::available.packages(filters = c("R_version", "OS_type", "subarch"))
+idx <- which(rownames(db) == 'tiledb')
+valid <- vapply(
+  X = idx,
+  FUN = function(i) {
+    v <- db[i, 'Version']
+    res <- vector(mode = 'logical', length = nrow(const))
+    for (i in seq_along(res)) {
+      res[i] <- do.call(const$comp[i], args = list(v, const$vers[i]))
+    }
+    return(all(res))
+  },
+  FUN.VALUE = logical(1L)
+)
+if (!any(valid)) {
+  stop("No valid versions of tiledb-r found")
+}
+db <- db[-idx[!valid], , drop = FALSE]
+
+# Install upstream deps
+(ups <- tools::package_dependencies("tiledb", db = db, recursive = TRUE)$tiledb)
+utils::install.packages(intersect(ups, rownames(db)))
+
+# Install correct version of tiledb-r
+ctb <- contrib.url(getOption("repos"))
+names(ctb) <- getOption("repos")
+dbr <- db[idx[valid], 'Repository']
+(repos <- names(ctb[ctb %in% dbr]))
+utils::install.packages("tiledb", repos = repos)


### PR DESCRIPTION
Update `r-ci.yml` to respect the doublepin of tiledb-r in `DESCRIPTION`; this is accomplished by doing the following:
- setting environment variable `R_REMOTES_UPGRADE` to `"never"` to prevent upgrading of dependencies in `tools/r-ci.sh install_all`
- setting `tiledb-inc.r-universe.dev` as an additional repo for installing dependencies
- parsing `apis/r/DESCRIPTION` to find constraints on tiledb-r
- searching through all repos to find all accessible versions of tiledb-r
- identifying the version of tiledb-r that matches our constraints
- installing upstream dependencies of tiledb-r from all accessible repos
- installing the correctly-constrained version of tiledb-r