### PR TITLE
Restrict R/Python GHAs from running on irrelevant `{.github,doc}` changes

### DIFF
--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -12,8 +12,14 @@ on:
     branches:
       - main
       - 'release-*'
-    paths-ignore:
-      - 'apis/r/**'
+    paths:
+      - '**'
+      - '!**.md'
+      - '!apis/r/**'
+      - '!docs/**'
+      - '!.github/**'
+      - '.github/workflows/python-ci-minimal.yml'
+      - '.github/workflows/python-ci-single.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -2,9 +2,13 @@ name: TileDB-SOMA R CI
 
 on:
   pull_request:
-    paths-ignore:
-      - "apis/python/**"
-      - ".pre-commit-config.yaml"
+    paths:
+      - '**'
+      - '!**.md'
+      - '!apis/python/**'
+      - '!docs/**'
+      - '!.github/**'
+      - '.github/workflows/r-ci.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
**Issue and/or context:** #2230

**Changes:**
- Convert `paths-ignore` to `paths` ([GHA docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)), in order to sequence inclusions and exclusions, e.g. (adapted from `r-ci.yml`):

  ```yml
  - '**'                          # trigger GHA on all paths, by default
  - '!.github/**'                 # override: exclude changes to .github
  - '.github/workflows/r-ci.yml'  # override²: un-exclude changes to current workflow file
  ```
- Add exclusions to Python/R PR GHAs (`docs/**`, `**.md`)

**Notes for Reviewer:**

I tested the new python-ci-minimal.yml rules at [test-paths.yml](https://github.com/ryan-williams/TileDB-SOMA/actions/workflows/test-paths.yml) (in my fork):
- https://github.com/ryan-williams/TileDB-SOMA/commit/9f942dc9d007e7796d470e6bd0f2e5c87be905d5: `.github/workflows/python-ci-minimal.yml` ⟹ [GHA](https://github.com/ryan-williams/TileDB-SOMA/actions/runs/9033188327)
- https://github.com/ryan-williams/TileDB-SOMA/commit/dfd4c5340e242f8111a5c2c61fdd459f36844189: `.github/workflows/r-ci.yml` ⟹ no GHA
- https://github.com/ryan-williams/TileDB-SOMA/commit/acb6ed450ea105f72b235ec1f5bd50872acf6ebb: `apis/python/README.md` ⟹ no GHA
- https://github.com/ryan-williams/TileDB-SOMA/commit/78b593668d08919f2f7e65b2165200e649569ee1: `apis/python/setup.py` ⟹ [GHA](https://github.com/ryan-williams/TileDB-SOMA/actions/runs/9033212155)