### PR TITLE
[python] Export `tiledbsoma.SparseNDArrayRead`, include in module doc site

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -165,7 +165,7 @@ from ._general_utilities import (
 )
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
-from ._sparse_nd_array import SparseNDArray
+from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead
 from .options import SOMATileDBContext, TileDBCreateOptions
 from .pytiledbsoma import (
     tiledbsoma_stats_disable,
@@ -205,6 +205,7 @@ __all__ = [
     "SOMAError",
     "SOMATileDBContext",
     "SparseNDArray",
+    "SparseNDArrayRead",
     "TileDBCreateOptions",
     "tiledbsoma_build_index",
     "tiledbsoma_stats_disable",

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -506,7 +506,8 @@ class _SparseNDArrayReadBase(somacore.SparseRead):
 
 
 class SparseNDArrayRead(_SparseNDArrayReadBase):
-    """Intermediate type to choose result format when reading a sparse array.
+    """:class:`SparseNDArrayRead` is an intermediate type which supports multiple eventual result formats
+     when reading a sparse array.
 
     Results returned by `coos` and `tables` iterate over COO coordinates in the user-specified result order,
     but with breaks between iterator steps at arbitrary coordinates (i.e., any given result may split a row or

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -18,9 +18,10 @@ Classes
 
     tiledbsoma.DataFrame
     tiledbsoma.SparseNDArray
+    tiledbsoma.SparseNDArrayRead
     tiledbsoma.DenseNDArray
 
-      tiledbsoma.ResultOrder
+    tiledbsoma.ResultOrder
 
     tiledbsoma.AxisColumnNames
     tiledbsoma.AxisQuery


### PR DESCRIPTION
**Issue and/or context:** #2502

**Changes:**
- Export `SparseNDArrayRead` from `tiledbsoma` module
- Include `SparseNDArrayRead` in docs ([tiledbsoma.readthedocs.io/en/latest/python-tiledbsoma.html#classes](https://tiledbsoma.readthedocs.io/en/latest/python-tiledbsoma.html#classes))

**Notes for Reviewer:**
- Are there any concerns about adding a new class to the `tiledbsoma` top-level/module API?
- This is currently based on #2538, should auto-redirect to `main` once that's merged.
