### PR TITLE
[r/ci] Add check to disable BSPM in R CI

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
 
-
       # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
       # which source is available but CRAN releases (and hence update r2u binaries) are not yet:
       #

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -32,8 +32,21 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
+      - name: Set additional repositories (Linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
+          codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
+          repo <- "https://tiledb-inc.r-universe.dev"
+          (opt <- sprintf('options(repos = c("%s/bin/linux/%s/%s", "%s", getOption("repos")))', repo, codename, rversion, repo))
+          cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Install tiledb-r
+        run: cd apis/r && Rscript tools/install-tiledb-r.R
+
       - name: Dependencies
-        run: cd apis/r && tools/r-ci.sh install_all
+        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
 
       - name: CMake
         uses: lukka/get-cmake@latest

--- a/apis/r/tools/install-tiledb-r.R
+++ b/apis/r/tools/install-tiledb-r.R
@@ -42,4 +42,13 @@ ctb <- contrib.url(getOption("repos"))
 names(ctb) <- getOption("repos")
 dbr <- db[idx[valid], 'Repository']
 (repos <- names(ctb[ctb %in% dbr]))
+
+# BSPM doesn't respect `repos`
+# Check to see if any repo w/ valid tiledb-r is CRAN
+# If not, turn of BSPM
+cran <- getOption("repos")['CRAN']
+cran[is.na(cran)] <- ""
+if (requireNamespace("bspm", quietly = TRUE) && !any(dbr %in% cran)) {
+  bspm::disable()
+}
 utils::install.packages("tiledb", repos = repos)


### PR DESCRIPTION
Follow-up to #2540 

bspm does not respect the `repos` argument in `install.packages()`; this is an issue where the valid version of tiledb-r is on R-universe, but not on CRAN. In this situation, bspm will still install from APT rather than the repository specified in `install.pacakges(repos = )`

To get around this, I've added a check that asks
 - is bspm installed
 - is the valid tiledb-r avaialble only on alternate repos

If both of those are true, disable bspm for installing tiledb-r; bspm is still used for upstream dependencies of tiledb-r

Note, this has the unfortunate side-effect of installing tiledb-r from source on Linux CI. This is because Linux CI is currently using 22.04 jammy while [R-universe is now building binaries for 24.04 noble](https://tiledb-inc.r-universe.dev/tiledb). As seen in Docker using the Dockerfile [`doublepin22.Dockerfile`](https://gist.github.com/mojaveazure/c1e08930d9ee8717e02b9cce66ab5bf0#file-doublepin22-dockerfile), we build tiledb-r from source ([`jammy.log`](https://gist.github.com/mojaveazure/c1e08930d9ee8717e02b9cce66ab5bf0#file-jammy-log)); however, whenever Linux CI gets updated to 24.04 noble ([`doublepin24.Dockerfile`](https://gist.github.com/mojaveazure/c1e08930d9ee8717e02b9cce66ab5bf0#file-doublepin24-dockerfile)), we will regain binary installation of tiledb-r thanks to R-universe ([`noble.log`](https://gist.github.com/mojaveazure/c1e08930d9ee8717e02b9cce66ab5bf0#file-noble-log))