### PR TITLE
[r] Two-sided R pin for `release-1.10` branch; backport #2540, #2546, #2549

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -16,6 +16,7 @@ env:
   COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   _R_CHECK_TESTS_NLINES_: 0
   CATCHSEGV: "TRUE"
+  R_REMOTES_UPGRADE: "never"
 
 jobs:
   ci:
@@ -52,9 +53,25 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
+      - name: Set additional repositories (macOS)
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        run: echo 'options(repos = c("https://tiledb-inc.r-universe.dev", getOption("repos")))' | tee -a ~/.Rprofile
+
+      - name: Set additional repositories (Linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
+          codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
+          repo <- "https://tiledb-inc.r-universe.dev"
+          (opt <- sprintf('options(repos = c("%s/bin/linux/%s/%s", "%s", getOption("repos")))', repo, codename, rversion, repo))
+          cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Install tiledb-r
+        run: cd apis/r && Rscript tools/install-tiledb-r.R
+
       - name: Install BioConductor package SingleCellExperiment
         run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
-
 
       # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
       # which source is available but CRAN releases (and hence update r2u binaries) are not yet:
@@ -82,7 +99,7 @@ jobs:
       #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
       - name: Dependencies
-        run: cd apis/r && tools/r-ci.sh install_all
+        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
 
       # - name: Install dataset packages from source (macOS)
       #   if: ${{ matrix.os == 'macOS-latest' }}

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -32,8 +32,21 @@ jobs:
       - name: Bootstrap
         run: cd apis/r && tools/r-ci.sh bootstrap
 
+      - name: Set additional repositories (Linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          rversion <- paste(strsplit(as.character(getRversion()), split = '\\.')[[1L]][1:2], collapse = '.')
+          codename <-  system('. /etc/os-release; echo ${VERSION_CODENAME}', intern = TRUE)
+          repo <- "https://tiledb-inc.r-universe.dev"
+          (opt <- sprintf('options(repos = c("%s/bin/linux/%s/%s", "%s", getOption("repos")))', repo, codename, rversion, repo))
+          cat(opt, "\n", file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Install tiledb-r
+        run: cd apis/r && Rscript tools/install-tiledb-r.R
+
       - name: Dependencies
-        run: cd apis/r && tools/r-ci.sh install_all
+        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
 
       - name: CMake
         uses: lukka/get-cmake@latest

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     stats,
     bit64,
     tiledb (>= 0.26.0),
+    tiledb (<= 0.26.99),
     arrow,
     utils,
     fs,

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -570,6 +570,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         var_index = var_index,
         var_column_names = var_column_names
       )
+      op <- options(Seurat.object.assay.calcn = FALSE)
+      on.exit(options(op), add = TRUE, after = FALSE)
       object <- SeuratObject::CreateSeuratObject(
         counts = assay,
         assay = private$.measurement_name

--- a/apis/r/tools/install-tiledb-r.R
+++ b/apis/r/tools/install-tiledb-r.R
@@ -1,0 +1,54 @@
+#!/usr/bin/env Rscript
+
+options(bspm.version.check = TRUE)
+
+# Find tiledb-r constraints
+deps <- read.dcf('DESCRIPTION', fields = 'Imports')[1, ]
+deps <- trimws(strsplit(gsub(pattern = ',', replacement = '\n', x = deps), split = '\n')[[1L]])
+deps <- Filter(nzchar, deps)
+deps <- Filter(function(x) grepl('^tiledb', x), deps)
+deps <- gsub(pattern = '[[:space:]]', replacement = '', x = deps)
+deps <- gsub(pattern = '.*\\(|\\)', replacement = '', x = deps)
+const <- data.frame(comp = gsub(pattern = '[[:digit:]\\.]*', replacement = '', x = deps))
+const$vers <- gsub(pattern = paste(const$comp, collapse = '|'), replacement = '', x = deps)
+(const)
+
+# Find correct version of tiledb-r
+db <- utils::available.packages(filters = c("R_version", "OS_type", "subarch"))
+idx <- which(rownames(db) == 'tiledb')
+valid <- vapply(
+  X = idx,
+  FUN = function(i) {
+    v <- db[i, 'Version']
+    res <- vector(mode = 'logical', length = nrow(const))
+    for (i in seq_along(res)) {
+      res[i] <- do.call(const$comp[i], args = list(v, const$vers[i]))
+    }
+    return(all(res))
+  },
+  FUN.VALUE = logical(1L)
+)
+if (!any(valid)) {
+  stop("No valid versions of tiledb-r found")
+}
+db <- db[-idx[!valid], , drop = FALSE]
+
+# Install upstream deps
+(ups <- tools::package_dependencies("tiledb", db = db, recursive = TRUE)$tiledb)
+utils::install.packages(intersect(ups, rownames(db)))
+
+# Install correct version of tiledb-r
+ctb <- contrib.url(getOption("repos"))
+names(ctb) <- getOption("repos")
+dbr <- db[idx[valid], 'Repository']
+(repos <- names(ctb[ctb %in% dbr]))
+
+# BSPM doesn't respect `repos`
+# Check to see if any repo w/ valid tiledb-r is CRAN
+# If not, turn of BSPM
+cran <- getOption("repos")['CRAN']
+cran[is.na(cran)] <- ""
+if (requireNamespace("bspm", quietly = TRUE) && !any(dbr %in% cran)) {
+  bspm::disable()
+}
+utils::install.packages("tiledb", repos = repos)


### PR DESCRIPTION
**Issue and/or context:** Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases), I am working on tiledbsoma 1.11 today

[sc-46600]

**Changes:**

**Notes for Reviewer:**

@mojaveazure I am following https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases#incrementing-core-versions

However, since that was updated we do have #2540 and #2546 on `main`; I'm not sure what's the right thing to do here on the `release-1.10` branch, as I am going to create a `release-1.11` branch today -- @mojaveazure let's work together on this.