### PR TITLE
Add minor typo related bug fixes

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -329,7 +329,7 @@ setuptools.setup(
         "pyarrow>=9.0.0; platform_system!='Darwin'",
         "scanpy>=1.9.2",
         "scipy",
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@dark/query-part1",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@dark/query-part-1",  # DO NOT MERGE TO MAIN
         "tiledb~=0.29.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
     from .._types import Path
     from ..io._registration import ExperimentAmbientLabelMapping
-    from ..io.ingeset import AdditionalMetadata
+    from ..io.ingest import AdditionalMetadata
     from ..options import SOMATileDBContext
 
 


### PR DESCRIPTION
**Issue and/or context:**

- Fix `setup.py` to reference `somacare` from `dark/query-part-1` branch
- Fix typo in the import section of `experimental/ingest.py`

**Changes:**

**Notes for Reviewer:**

