### PR TITLE
[c++] Allow `row-major` and `col-major` in `SOMArray::create`

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -297,9 +297,12 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                 tile_order.begin(),
                 [](unsigned char c) { return std::tolower(c); });
 
-            if (tile_order == "row-order" or tile_order == "row") {
+            if (tile_order == "row-order" or tile_order == "row-major" or
+                tile_order == "row") {
                 schema.set_tile_order(TILEDB_ROW_MAJOR);
-            } else if (tile_order == "col-order" or tile_order == "col") {
+            } else if (
+                tile_order == "col-order" or tile_order == "col-major" or
+                tile_order == "col") {
                 schema.set_tile_order(TILEDB_COL_MAJOR);
             } else {
                 throw TileDBSOMAError(fmt::format(


### PR DESCRIPTION
Found while doing analysis on [sc-47279].

In that story we have a simple repro including

<details>

```
context = tiledbsoma.SOMATileDBContext(tiledb_config = {
    "py.init_buffer_bytes": 4 * 1024**3,
    "py.deduplicate": "true",
    "soma.init_buffer_bytes": soma_init_buffer_bytes,
    "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3,
    "sm.consolidation.total_buffer_size": 4 * 1024**3,
    "sm.compute_concurrency_level": cpu_count,
    "sm.io_concurrency_level": cpu_count,
})

platform_config =  {
    "tiledb": {
        "create": {
            "capacity": 2**16,
            "dims": {
                "soma_dim_0": {"tile": 2048, "filters": [{"_type": "ZstdFilter", "level": compression_level}]},
                "soma_dim_1": {"tile": 2048, "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": compression_level}]},
            },
            "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": compression_level}]}},
            "cell_order": "row-major",
            "tile_order": "row-major",
            "allows_duplicates": True,
        },
    }
}

input = tiledbsoma.SparseNDArray.open(input_path, context=context, platform_config=platform_config)

output = tiledbsoma.SparseNDArray.create(
    output_path,
    type = pa.float32(),
    shape = input.shape,
    platform_config=platform_config,
    context=context,
)

for batch in input.read().tables():
    _ = output.write(batch)
```

</details>

TL;DR the standard names are `row-major` and `col-major`, but, running this code we get

```
Traceback (most recent call last):
  File "/home/ubuntu/./bp.py", line 108, in <module>
    output = tiledbsoma.SparseNDArray.create(
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_sparse_nd_array.py", line 158, in create
    raise map_exception_for_create(e, uri) from None
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_sparse_nd_array.py", line 149, in create
    clib.SOMASparseNDArray.create(
tiledbsoma._exception.SOMAError: Invalid tile order row-major passed to PlatformConfig
```

Let's accept these standard names.