### PR TITLE
[python] Prototype: better version numbers during development

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,5 @@ build:
   tools:
     python: "3.11"
   commands:
-    - git fetch --unshallow || true
     - pip install --upgrade pip
     - doc/build.sh -r -V  # install deps, don't make a venv

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -339,5 +339,5 @@ setuptools.setup(
     },
     python_requires=">=3.8",
     cmdclass={"build_ext": build_ext, "bdist_wheel": bdist_wheel},
-    version=version.getVersion(),
+    version=version.get_version(),
 )

--- a/apis/python/version.py
+++ b/apis/python/version.py
@@ -138,6 +138,13 @@ def readReleaseVersion():
         return None
 
 
+def generateCalVersion():
+    today = date.today().strftime("%Y.%m.%d")
+    sha = check_output(["git", "log", "-1", "--format=%h"]).decode().rstrip("\n")
+    sha_dec = int(sha, 16)
+    return f"{today}.dev{sha_dec}"
+
+
 def writeReleaseVersion(version):
     with open(RELEASE_VERSION_FILE, "w") as fd:
         print(version, file=fd)
@@ -147,7 +154,10 @@ def getVersion():
     release_version = readReleaseVersion()
     version = readGitVersion() or release_version
     if not version:
-        raise ValueError("Cannot find the version number")
+        version = generateCalVersion()
+        err(
+            f"No {basename(RELEASE_VERSION_FILE)} or Git version found, using calver {version}"
+        )
     if version != release_version:
         writeReleaseVersion(version)
     return version


### PR DESCRIPTION
## Issue and/or context: #2547, extends #2560

[`1.5.0`](https://github.com/single-cell-data/TileDB-SOMA/tree/1.5.0) (Nov '23) is typically the most recent tag that's an ancestor of `main`, because subsequent release tags all exist on release branches.

This means local installs get versions like `1.5.0rc0.post332.dev6296020074`, adapted from `git describe` (the `dev` number is the Git short SHA, `git log -1 --format=%h`, converted to base 10, for [PEP440](https://peps.python.org/pep-0440/)-compliance).

It's a little weird to see `1.5.0*` on dev installs, and it crashes in shallow clones (which GHA / RTD use by default).

## Changes

### 1. Fallback version number based on most recent release tag (e.g. `1.11.1.post0.dev67466703006`)

If `git describe` returns `1.5.0` as the nearest tagged ancestor, synthesize a more meaningful version number:

1. Find the latest release tag in the local repo (or tracked remote, if there are no local tags, e.g. in case of a shallow clone).
2. Return a version like `A.B.C.post0.devN`:
    - `A.B.C` is the most recent release tag in the repo, and
    - `post0` is intended to signal that we are "ahead" of `A.B.C`, though the number of commits is not computed/specified.
      - We are also "behind" by an unknown number of commits, but it's not important to specify either number in the version number.
      - Something that roughly tracks what the "next" SemVer will be, and encodes the Git SHA, seems better than the status quo.
    - `N` is the current short Git SHA, converted to base 10 (as above).

### 2. "[CalVer](https://calver.org/)" fallback (e.g. `2024.05.14.dev67466703006`)

The first commit in this PR adds an additional "CalVer"  fallback (suggested by @jp-dark 🙏):

```python
def generate_cal_version():
    today = date.today().strftime("%Y.%m.%d")
    return f"{today}.dev{get_sha_base10()}"
```

#### CalVer currently unused
Fallback **1.** above should always find the most recent release tag (in the upstream remote, worst case) so this CalVer is never expected to be used, as written, but I've left it in for discussion.

We could merge it, to keep the option available, or "stash" it for later.

### 3. Preview/Check version number: `python apis/python/version.py`
I added an `__name__ == '__main__'` hook to make it easy to interact with this code without running a full `pip install -e .`.

I also cleaned up a few things (e.g. use `open` as a ContextManager, convert camelCase names to snake_case).