### PR TITLE
[c++/python] Enable optional global-order writes for sparse arrays

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -166,7 +166,7 @@ from ._general_utilities import (
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
 from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead
-from .options import SOMATileDBContext, TileDBCreateOptions
+from .options import SOMATileDBContext, TileDBCreateOptions, TileDBWriteOptions
 from .pytiledbsoma import (
     tiledbsoma_stats_disable,
     tiledbsoma_stats_dump,
@@ -207,6 +207,7 @@ __all__ = [
     "SparseNDArray",
     "SparseNDArrayRead",
     "TileDBCreateOptions",
+    "TileDBWriteOptions",
     "tiledbsoma_build_index",
     "tiledbsoma_stats_disable",
     "tiledbsoma_stats_dump",

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -19,6 +19,7 @@ from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_JOINID
 from ._exception import SOMAError, map_exception_for_create
+from ._general_utilities import get_implementation_version
 from ._query_condition import QueryCondition
 from ._read_iters import TableReadIter
 from ._soma_array import SOMAArray
@@ -27,7 +28,6 @@ from ._types import NPFloating, NPInteger, OpenTimestamp, Slice, is_slice_of
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
 from .options._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
-from ._general_utilities import get_implementation_version
 
 _UNBATCHED = options.BatchSize()
 AxisDomain = Union[None, Tuple[Any, Any], List[Any]]

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -27,6 +27,7 @@ from ._types import NPFloating, NPInteger, OpenTimestamp, Slice, is_slice_of
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
 from .options._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
+from ._general_utilities import get_implementation_version
 
 _UNBATCHED = options.BatchSize()
 AxisDomain = Union[None, Tuple[Any, Any], List[Any]]
@@ -452,8 +453,12 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
+            version = get_implementation_version().split(".")
+            assert (int(version[0]), int(version[1])) < (1, 13)
             warnings.warn(
-                "The write parameter now takes in TileDBWriteOptions instead of TileDBCreateOptions",
+                "The write parameter now takes in TileDBWriteOptions "
+                "instead of TileDBCreateOptions. This warning will be removed "
+                "and error out when passing TileDBCreateOptions in 1.13.",
                 DeprecationWarning,
             )
             write_options = TileDBCreateOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -443,16 +443,17 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         _util.check_type("values", values, (pa.Table,))
 
+        tiledb_create_options = TileDBCreateOptions.from_platform_config(
+            platform_config
+        )
+
         clib_dataframe = self._handle._handle
 
         values = _util.cast_values_to_target_schema(clib_dataframe, values, self.schema)
 
         for batch in values.to_batches():
-            clib_dataframe.write(batch)
+            clib_dataframe.write(batch, tiledb_create_options.sort_coords)
 
-        tiledb_create_options = TileDBCreateOptions.from_platform_config(
-            platform_config
-        )
         if tiledb_create_options.consolidate_and_vacuum:
             clib_dataframe.consolidate_and_vacuum()
         return self

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -9,6 +9,7 @@ Implementation of SOMA SparseNDArray.
 from __future__ import annotations
 
 import itertools
+import warnings
 from typing import (
     Dict,
     Optional,
@@ -45,7 +46,7 @@ from .options._soma_tiledb_context import (
     SOMATileDBContext,
     _validate_soma_tiledb_context,
 )
-from .options._tiledb_create_options import TileDBCreateOptions
+from .options._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
 
 _UNBATCHED = options.BatchSize()
 
@@ -269,9 +270,17 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             Experimental.
         """
 
-        tiledb_create_options = TileDBCreateOptions.from_platform_config(
-            platform_config
-        )
+        write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
+        sort_coords = None
+        if isinstance(platform_config, TileDBCreateOptions):
+            warnings.warn(
+                "The write parameter now takes in TileDBWriteOptions instead of TileDBCreateOptions",
+                DeprecationWarning,
+            )
+            write_options = TileDBCreateOptions.from_platform_config(platform_config)
+        else:
+            write_options = TileDBWriteOptions.from_platform_config(platform_config)
+            sort_coords = write_options.sort_coords
 
         clib_sparse_array = self._handle._handle
 
@@ -289,7 +298,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 np.array(
                     data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
-                tiledb_create_options.sort_coords,
+                sort_coords or True,
             )
 
             # Write bounding-box metadata. Note COO can be N-dimensional.
@@ -297,7 +306,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             bounding_box = self._compute_bounding_box_metadata(maxes)
             self._set_bounding_box_metadata(bounding_box)
 
-            if tiledb_create_options.consolidate_and_vacuum:
+            if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
                 clib_sparse_array.consolidate_and_vacuum()
             return self
@@ -321,7 +330,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 np.array(
                     sp.data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
-                tiledb_create_options.sort_coords,
+                sort_coords or True,
             )
 
             # Write bounding-box metadata. Note CSR and CSC are necessarily 2-dimensional.
@@ -329,7 +338,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             bounding_box = self._compute_bounding_box_metadata([nr - 1, nc - 1])
             self._set_bounding_box_metadata(bounding_box)
 
-            if tiledb_create_options.consolidate_and_vacuum:
+            if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
                 clib_sparse_array.consolidate_and_vacuum()
             return self
@@ -340,7 +349,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 clib_sparse_array, values, self.schema
             )
             for batch in values.to_batches():
-                clib_sparse_array.write(batch, tiledb_create_options.sort_coords)
+                clib_sparse_array.write(batch, sort_coords or False)
 
             # Write bounding-box metadata
             maxes = []
@@ -354,7 +363,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             bounding_box = self._compute_bounding_box_metadata(maxes)
             self._set_bounding_box_metadata(bounding_box)
 
-            if tiledb_create_options.consolidate_and_vacuum:
+            if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
                 clib_sparse_array.consolidate_and_vacuum()
             return self

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -289,6 +289,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 np.array(
                     data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
+                tiledb_create_options.sort_coords,
             )
 
             # Write bounding-box metadata. Note COO can be N-dimensional.
@@ -320,6 +321,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 np.array(
                     sp.data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
+                tiledb_create_options.sort_coords,
             )
 
             # Write bounding-box metadata. Note CSR and CSC are necessarily 2-dimensional.
@@ -338,7 +340,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 clib_sparse_array, values, self.schema
             )
             for batch in values.to_batches():
-                clib_sparse_array.write(batch)
+                clib_sparse_array.write(batch, tiledb_create_options.sort_coords)
 
             # Write bounding-box metadata
             maxes = []

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -47,6 +47,7 @@ from .options._soma_tiledb_context import (
     _validate_soma_tiledb_context,
 )
 from .options._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
+from ._general_utilities import get_implementation_version
 
 _UNBATCHED = options.BatchSize()
 
@@ -273,8 +274,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
+            version = get_implementation_version().split(".")
+            assert (int(version[0]), int(version[1])) < (1, 13)
             warnings.warn(
-                "The write parameter now takes in TileDBWriteOptions instead of TileDBCreateOptions",
+                "The write parameter now takes in TileDBWriteOptions "
+                "instead of TileDBCreateOptions. This warning will be removed "
+                "and error out when passing TileDBCreateOptions in 1.13.",
                 DeprecationWarning,
             )
             write_options = TileDBCreateOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -34,6 +34,7 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
+from ._general_utilities import get_implementation_version
 from ._read_iters import (
     BlockwiseScipyReadIter,
     BlockwiseTableReadIter,
@@ -47,7 +48,6 @@ from .options._soma_tiledb_context import (
     _validate_soma_tiledb_context,
 )
 from .options._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
-from ._general_utilities import get_implementation_version
 
 _UNBATCHED = options.BatchSize()
 

--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -1,7 +1,8 @@
 from ._soma_tiledb_context import SOMATileDBContext
-from ._tiledb_create_options import TileDBCreateOptions
+from ._tiledb_create_options import TileDBCreateOptions, TileDBWriteOptions
 
 __all__ = [
     "SOMATileDBContext",
     "TileDBCreateOptions",
+    "TileDBWriteOptions",
 ]

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -98,7 +98,7 @@ def _normalize_columns(
 
 @attrs_.define(frozen=True, kw_only=True, slots=True)
 class TileDBCreateOptions:
-    """Tuning options used when creating new TileDB arrays for SOMA data.
+    """Tuning options used when creating new SOMA arrays.
 
     The attribute names of this object are identical to the keys expected in the
     cross-platform ``platform_config`` dict under the ``tiledb.create`` subkey,
@@ -154,7 +154,6 @@ class TileDBCreateOptions:
     consolidate_and_vacuum: bool = attrs_.field(
         validator=vld.instance_of(bool), default=False
     )
-    sort_coords: bool = attrs_.field(validator=vld.instance_of(bool), default=True)
 
     @classmethod
     def from_platform_config(
@@ -219,6 +218,40 @@ class TileDBCreateOptions:
     ) -> Tuple[tiledb.Filter, ...]:
         """Constructs the real TileDB Filters to use for the named attribute."""
         return _filters_from(self.attrs, name, default)
+
+
+@attrs_.define(frozen=True, kw_only=True, slots=True)
+class TileDBWriteOptions:
+    """Tuning options used when writing to SOMA arrays."""
+
+    sort_coords: bool = attrs_.field(validator=vld.instance_of(bool), default=True)
+    consolidate_and_vacuum: Optional[bool] = attrs_.field(
+        validator=vld.instance_of(bool), default=False
+    )
+
+    @classmethod
+    def from_platform_config(
+        cls,
+        platform_config: Union[
+            options.PlatformConfig, "TileDBWriteOptions", None
+        ] = None,
+    ) -> Self:
+        """Creates the object from a value passed in ``platform_config``.
+
+        The value passed in should be the exact value passed into a public API
+        method as the ``platform_config`` parameter. This function will extract
+        the ``tiledb.write`` entry from a dict as needed.
+        """
+        create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "write"))
+        if isinstance(create_entry, dict):
+            attrs: Tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
+            attr_names = frozenset(a.name for a in attrs)
+            # Explicitly opt out of type-checking for these kwargs.
+            filered_create_entry: Dict[str, Any] = {
+                key: value for (key, value) in create_entry.items() if key in attr_names
+            }
+            return cls(**filered_create_entry)
+        return create_entry
 
 
 _T = TypeVar("_T")

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_options.py
@@ -154,6 +154,7 @@ class TileDBCreateOptions:
     consolidate_and_vacuum: bool = attrs_.field(
         validator=vld.instance_of(bool), default=False
     )
+    sort_coords: bool = attrs_.field(validator=vld.instance_of(bool), default=True)
 
     @classmethod
     def from_platform_config(

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -39,7 +39,7 @@ namespace py = pybind11;
 using namespace py::literals;
 using namespace tiledbsoma;
 
-void write(SOMAArray& array, py::handle py_batch) {
+void write(SOMAArray& array, py::handle py_batch, bool sort_coords = true) {
     ArrowSchema arrow_schema;
     ArrowArray arrow_array;
     uintptr_t arrow_schema_ptr = (uintptr_t)(&arrow_schema);
@@ -51,14 +51,17 @@ void write(SOMAArray& array, py::handle py_batch) {
         std::make_unique<ArrowArray>(arrow_array));
 
     try {
-        array.write();
+        array.write(sort_coords);
     } catch (const std::exception& e) {
         TPY_ERROR_LOC(e.what());
     }
 }
 
 void write_coords(
-    SOMAArray& array, std::vector<py::array> coords, py::array data) {
+    SOMAArray& array,
+    std::vector<py::array> coords,
+    py::array data,
+    bool sort_coords = true) {
     for (uint64_t i = 0; i < coords.size(); ++i) {
         py::buffer_info coords_info = coords[i].request();
         array.set_column_data(
@@ -71,7 +74,7 @@ void write_coords(
     array.set_column_data("soma_data", data.size(), (const void*)data_info.ptr);
 
     try {
-        array.write();
+        array.write(sort_coords);
     } catch (const std::exception& e) {
         TPY_ERROR_LOC(e.what());
     }

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1786,3 +1786,40 @@ def test_blockwise_iterator_uses_thread_pool_from_context(
         pool.submit.assert_called()
 
     pool.shutdown()
+
+
+def test_global_writes(tmp_path):
+    global_write_setting = soma.TileDBCreateOptions(**{"sort_coords": False})
+
+    soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.uint8(), shape=(3,))
+
+    with pytest.raises(
+        soma.SOMAError,
+        match=r"Write failed; Coordinates (.*) succeed (.*) in the global order",
+    ):
+        with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A:
+            A.write(
+                pa.Table.from_pydict(
+                    {
+                        "soma_dim_0": pa.array([2, 1, 0], type=pa.int64()),
+                        "soma_data": pa.array([1, 2, 3], type=pa.uint8()),
+                    }
+                ),
+                platform_config=global_write_setting,
+            )
+
+    data = pa.Table.from_pydict(
+        {
+            "soma_dim_0": pa.array([0, 1, 2], type=pa.int64()),
+            "soma_data": pa.array([1, 2, 3], type=pa.uint8()),
+        }
+    )
+
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A:
+        A.write(
+            data,
+            platform_config=global_write_setting,
+        )
+
+    with soma.SparseNDArray.open(tmp_path.as_posix()) as A:
+        assert A.read().tables().concat() == data

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -279,8 +279,7 @@ void ManagedQuery::submit_write(bool sort_coords) {
         query_->set_layout(
             sort_coords ? TILEDB_UNORDERED : TILEDB_GLOBAL_ORDER);
     }
-    query_->submit();
-    query_->finalize();
+    query_->submit_and_finalize();
 }
 
 void ManagedQuery::submit_read() {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -279,7 +279,13 @@ void ManagedQuery::submit_write(bool sort_coords) {
         query_->set_layout(
             sort_coords ? TILEDB_UNORDERED : TILEDB_GLOBAL_ORDER);
     }
-    query_->submit_and_finalize();
+
+    if (query_->query_layout() == TILEDB_GLOBAL_ORDER) {
+        query_->submit_and_finalize();
+    } else {
+        query_->submit();
+        query_->finalize();
+    }
 }
 
 void ManagedQuery::submit_read() {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -272,9 +272,12 @@ void ManagedQuery::setup_read() {
     }
 }
 
-void ManagedQuery::submit_write() {
+void ManagedQuery::submit_write(bool sort_coords) {
     if (array_->schema().array_type() == TILEDB_DENSE) {
         query_->set_subarray(*subarray_);
+    } else {
+        query_->set_layout(
+            sort_coords ? TILEDB_UNORDERED : TILEDB_GLOBAL_ORDER);
     }
     query_->submit();
     query_->finalize();

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -323,7 +323,7 @@ class ManagedQuery {
      * @brief Submit the write query.
      *
      */
-    void submit_write();
+    void submit_write(bool sort_coords = true);
 
     /**
      * @brief Get the schema of the array.

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -503,11 +503,11 @@ void SOMAArray::set_array_data(
     }
 };
 
-void SOMAArray::write() {
+void SOMAArray::write(bool sort_coords) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError("[SOMAArray] array must be opened in write mode");
     }
-    mq_->submit_write();
+    mq_->submit_write(sort_coords);
 
     mq_->reset();
     array_buffer_ = nullptr;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -457,7 +457,7 @@ class SOMAArray : public SOMAObject {
      *   array.write();
      *   array.close();
      */
-    void write();
+    void write(bool sort_coords = true);
 
     /**
      * @brief Consolidates and vacuums fragment metadata and commit files.


### PR DESCRIPTION
**Issue and/or context:** #2054

The C++-ification of the SOMA API now allows us to utilize global writes when writing to sparse arrays, thus saving time by skipping the coordinate sorting step when the coordinates are already known to be ordered.

**Changes:**

- Add `sort_coords` setting in the `PlatformConfig`, where by default, it is set to `False` and thus still uses `TILEDB_UNORDERED`
- Add `sort_coords` parameter to `SOMAArray::write` and `ManagedQuery::submit_write`
