### PR TITLE
[r] Fix builds against current TileDB Embedded 

### DIFF
--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -372,7 +372,7 @@ test_that("platform_config is respected", {
   cfg$set('tiledb', 'create', 'sparse_nd_array_dim_zstd_level', 9)
   cfg$set('tiledb', 'create', 'capacity', 8000)
   cfg$set('tiledb', 'create', 'tile_order', 'COL_MAJOR')
-  cfg$set('tiledb', 'create', 'cell_order', 'UNORDERED')
+  cfg$set('tiledb', 'create', 'cell_order', 'ROW_MAJOR')
   cfg$set('tiledb', 'create', 'offsets_filters', list("RLE"))
   cfg$set('tiledb', 'create', 'validity_filters', list("RLE", "NONE"))
   cfg$set('tiledb', 'create', 'dims', list(
@@ -405,7 +405,7 @@ test_that("platform_config is respected", {
 
   expect_equal(tiledb::capacity(tsch), 8000)
   expect_equal(tiledb::tile_order(tsch), "COL_MAJOR")
-  expect_equal(tiledb::cell_order(tsch), "UNORDERED")
+  expect_equal(tiledb::cell_order(tsch), "ROW_MAJOR")
 
   offsets_filters <- tiledb::filter_list(tsch)$offsets
   expect_equal(tiledb::nfilters(offsets_filters), 1)


### PR DESCRIPTION
**Issue and/or context:** It never made sense to set row/cell order in array-schema creation. But https://github.com/TileDB-Inc/TileDB/pull/4973 recently formalized this.

We shouldn't ask for unordered at schema-create time.

See also: https://github.com/TileDB-Inc/TileDB-Py/pull/1970

Note the above core change isn't in 2.23, only in `dev` -- but https://github.com/TileDB-Inc/tiledbsoma-feedstock has nightlies which point at core dev: https://github.com/jdblischak/centralized-tiledb-nightlies/issues/6#issuecomment-2115841783

**Changes:**

**Notes for Reviewer:**

