### PR TITLE
[python] Append-mode tutorial: "atlas model"

### DIFF
--- a/apis/python/notebooks/tutorial_soma_append_mode.ipynb
+++ b/apis/python/notebooks/tutorial_soma_append_mode.ipynb
@@ -702,12 +702,12 @@
         "tags": []
       },
       "source": [
-        "Finally, we'll demonstrate combining multiple new AnnDatas into one experiment.\n",
+        "Finally, we'll demonstrate combining multiple AnnDatas into one new experiment.\n",
         "\n",
         "The flow is pretty similar to the above:\n",
         "\n",
-        "1. One call to `register_anndatas` or `register_h5ads` (passing all new AnnDatas/h5ads)\n",
-        "2. One call to `from_anndata`/`from_h5ad` *for each new AnnData*\n",
+        "1. One call to `register_anndatas` or `register_h5ads` (passing all input AnnDatas/h5ads)\n",
+        "2. One call to `from_anndata`/`from_h5ad` *for each input AnnData*\n",
         "\n",
         "Here's a helper function to simulate multiple lab runs. As above, where we used `pbmc3k` to simulate Monday and Tuesday data, here we use `pbmc3k` to simulate multiple AnnData objects."
       ]
@@ -720,7 +720,7 @@
       },
       "outputs": [],
       "source": [
-        "def make_new_ad(when, scale, obs_id_suffix):\n",
+        "def make_ad(when, scale, obs_id_suffix):\n",
         "    ad = ad1.copy()\n",
         "    ad.obs.index = [e.replace(\"-1\", obs_id_suffix) for e in ad.obs.index]\n",
         "    ad.obs[\"when\"] = [when] * len(ad.obs)\n",
@@ -728,7 +728,7 @@
         "    return ad\n",
         "\n",
         "new_ads = [\n",
-        "    make_new_ad(when, scale, f\"-{idx + 3}\")\n",
+        "    make_ad(when, scale, f\"-{idx + 3}\")\n",
         "    for idx, (when, scale)\n",
         "    in enumerate({\n",
         "        \"Wednesday\": 20,\n",
@@ -991,7 +991,7 @@
         "tags": []
       },
       "source": [
-        "Reading back the appended data, we see 2700 rows for each of {`-3`, `-4`, `-5`}:"
+        "Reading back the concatenated data, we see 2700 rows for each of {`-3`, `-4`, `-5`}:"
       ]
     },
     {
@@ -1037,7 +1037,7 @@
         "tags": []
       },
       "source": [
-        "`var` is the same as in the single original Anndata (since we added more cells with all the same genes):"
+        "`var` is the same as in the single original Anndata objects (since we added more cells with all the same genes):"
       ]
     },
     {

--- a/apis/python/notebooks/tutorial_soma_append_mode.ipynb
+++ b/apis/python/notebooks/tutorial_soma_append_mode.ipynb
@@ -64,7 +64,7 @@
         "tags": []
       },
       "source": [
-        "Next we'll set up where our data are going. Note that to change the storage backend, everything in this notebook below this URI-selection cell is completely unchanged -- whether you store your data on TileDB Cloud, cloud storage such as S3, instance-local NVME, or what have you."
+        "Next we'll set up where our data are going:"
       ]
     },
     {
@@ -77,7 +77,7 @@
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240516-203638'"
+              "'/tmp/append-example-20240517-204938'"
             ]
           },
           "execution_count": 2,
@@ -89,10 +89,23 @@
         "import datetime\n",
         "\n",
         "stamp = datetime.datetime.today().strftime(\"%Y%m%d-%H%M%S\")\n",
-        "# experiment_uri = f\"tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch/append-example-{stamp}\"\n",
-        "# Self-contained demo\n",
         "experiment_uri = f\"/tmp/append-example-{stamp}\"\n",
         "experiment_uri"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "For this demo, we're writing to `/tmp`, but URIs like the following allow storing data on TileDB Cloud, cloud storage such as S3, or instance-local NVME:\n",
+        "\n",
+        "- `/var/data/mysoma1`\n",
+        "- `s3://mybucket/mysoma2`\n",
+        "- `tiledb://mynamespace/s3://mybucket/mysoma3`\n",
+        "\n",
+        "Everything in this notebook below this URI-selection cell is agnostic to the storage backend."
       ]
     },
     {
@@ -164,21 +177,21 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/obs\n"
+            "Wrote   /tmp/append-example-20240517-204938/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240516-203638/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
           ]
         },
         {
@@ -197,20 +210,20 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638\n"
+            "Wrote   /tmp/append-example-20240517-204938\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240516-203638'"
+              "'/tmp/append-example-20240517-204938'"
             ]
           },
           "execution_count": 5,
@@ -398,7 +411,7 @@
       },
       "outputs": [],
       "source": [
-        "ad2 = ad1\n",
+        "ad2 = ad1.copy()\n",
         "ad2.obs.index = [e.replace(\"-1\", \"-2\") for e in ad1.obs.index]\n",
         "ad2.obs[\"when\"] = [\"Tuesday\"] * len(ad2.obs)"
       ]
@@ -436,7 +449,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Registration: starting with experiment /tmp/append-example-20240516-203638\n"
+            "Registration: starting with experiment /tmp/append-example-20240517-204938\n"
           ]
         },
         {
@@ -471,41 +484,41 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/obs\n"
+            "Wrote   /tmp/append-example-20240517-204938/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240516-203638/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240516-203638\n"
+            "Wrote   /tmp/append-example-20240517-204938\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240516-203638'"
+              "'/tmp/append-example-20240517-204938'"
             ]
           },
           "execution_count": 11,
@@ -633,7 +646,7 @@
         "tags": []
       },
       "source": [
-        "And lastly, the expression matrix which has grown downward with the new cells, while keeping the same width as we didn't introduce new genes:"
+        "And lastly, the `X` expression matrix which has grown downward with the new cells, while keeping the same width as we didn't introduce new genes:"
       ]
     },
     {
@@ -663,6 +676,408 @@
             "[4573768 rows x 3 columns]\n",
             "\n",
             "((0, 5399), (0, 32732))\n"
+          ]
+        }
+      ],
+      "source": [
+        "with tiledbsoma.Experiment.open(experiment_uri) as exp:\n",
+        "    X = exp.ms[\"RNA\"].X[\"data\"]\n",
+        "    print(X.read().tables().concat().to_pandas())\n",
+        "    print()\n",
+        "    print(X.used_shape())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "## Ingesting multiple datasets to a SOMA Experiment"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Finally, we'll demonstrate combining multiple new AnnDatas into one experiment.\n",
+        "\n",
+        "The flow is pretty similar to the above:\n",
+        "\n",
+        "1. One call to `register_anndatas` or `register_h5ads` (passing all new AnnDatas/h5ads)\n",
+        "2. One call to `from_anndata`/`from_h5ad` *for each new AnnData*"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [],
+      "source": [
+        "def make_new_ad(when, scale, obs_id_suffix):\n",
+        "    ad = ad1.copy()\n",
+        "    ad.obs.index = [e.replace(\"-1\", obs_id_suffix) for e in ad.obs.index]\n",
+        "    ad.obs[\"when\"] = [when] * len(ad.obs)\n",
+        "    ad.X *= scale\n",
+        "    return ad\n",
+        "\n",
+        "new_ads = [\n",
+        "    make_new_ad(when, scale, f\"-{idx + 3}\")\n",
+        "    for idx, (when, scale)\n",
+        "    in enumerate({\n",
+        "        \"Wednesday\": 20,\n",
+        "        \"Thursday\": 30,\n",
+        "        \"Friday\": 40,\n",
+        "    }.items())\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Ingesting the new AnnDatas, as before (but this time to a fresh/empty `/tmp` location):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'/tmp/append-example-20240517-204944'"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "stamp = datetime.datetime.today().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "experiment_uri = f\"/tmp/append-example-{stamp}\"\n",
+        "experiment_uri"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: registering AnnData object.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: accumulated to nobs=2700 nvar=32738.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: registering AnnData object.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: accumulated to nobs=5400 nvar=32738.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: registering AnnData object.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: accumulated to nobs=8100 nvar=32738.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Registration: complete.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240517-204944\n"
+          ]
+        }
+      ],
+      "source": [
+        "rd2 = tiledbsoma.io.register_anndatas(\n",
+        "    experiment_uri=None,  # new Experiment, from scratch\n",
+        "    adatas=new_ads,\n",
+        "    measurement_name=measurement_name,\n",
+        "    obs_field_name=\"obs_id\",\n",
+        "    var_field_name=\"var_id\",\n",
+        ")\n",
+        "\n",
+        "for new_ad in new_ads:\n",
+        "    tiledbsoma.io.from_anndata(\n",
+        "        experiment_uri,\n",
+        "        new_ad,\n",
+        "        measurement_name=measurement_name,\n",
+        "        registration_mapping=rd2,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Reading back the appended data, we see 2700 rows for each of {`-3`, `-4`, `-5`}:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "                obs_id  n_genes_by_counts       when\n",
+            "0     AAACATACAACCAC-3                781  Wednesday\n",
+            "1     AAACATTGAGCTAC-3               1352  Wednesday\n",
+            "2     AAACATTGATCAGC-3               1131  Wednesday\n",
+            "3     AAACCGTGCTTCCG-3                960  Wednesday\n",
+            "4     AAACCGTGTATGCG-3                522  Wednesday\n",
+            "...                ...                ...        ...\n",
+            "8095  TTTCGAACTCTCAT-5               1155     Friday\n",
+            "8096  TTTCTACTGAGGCA-5               1227     Friday\n",
+            "8097  TTTCTACTTCCTCG-5                622     Friday\n",
+            "8098  TTTGCATGAGAGGC-5                454     Friday\n",
+            "8099  TTTGCATGCCTCAC-5                724     Friday\n",
+            "\n",
+            "[8100 rows x 3 columns]\n"
+          ]
+        }
+      ],
+      "source": [
+        "with tiledbsoma.Experiment.open(experiment_uri) as exp:\n",
+        "    print(\n",
+        "        exp.obs.read(column_names=[\"obs_id\", \"n_genes_by_counts\", \"when\"])\n",
+        "        .concat()\n",
+        "        .to_pandas()\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "`var` is the same as in the single original Anndata (since we added more cells with all the same genes):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "       soma_joinid        var_id         gene_ids\n",
+            "0                0    MIR1302-10  ENSG00000243485\n",
+            "1                1       FAM138A  ENSG00000237613\n",
+            "2                2         OR4F5  ENSG00000186092\n",
+            "3                3  RP11-34P13.7  ENSG00000238009\n",
+            "4                4  RP11-34P13.8  ENSG00000239945\n",
+            "...            ...           ...              ...\n",
+            "32733        32733    AC145205.1  ENSG00000215635\n",
+            "32734        32734         BAGE5  ENSG00000268590\n",
+            "32735        32735    CU459201.1  ENSG00000251180\n",
+            "32736        32736    AC002321.2  ENSG00000215616\n",
+            "32737        32737    AC002321.1  ENSG00000215611\n",
+            "\n",
+            "[32738 rows x 3 columns]\n"
+          ]
+        }
+      ],
+      "source": [
+        "with tiledbsoma.Experiment.open(experiment_uri) as exp:\n",
+        "    print(\n",
+        "        exp.ms[\"RNA\"]\n",
+        "        .var.read(column_names=[\"soma_joinid\", \"var_id\", \"gene_ids\"])\n",
+        "        .concat()\n",
+        "        .to_pandas()\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Finally, the `X` expression matrix contains 3x the entries as the original, but is also the same width (since we didn't introduce new genes):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "         soma_dim_0  soma_dim_1  soma_data\n",
+            "0                 0          70       20.0\n",
+            "1                 0         166       20.0\n",
+            "2                 0         178       40.0\n",
+            "3                 0         326       20.0\n",
+            "4                 0         363       20.0\n",
+            "...             ...         ...        ...\n",
+            "6860647        8099       32697       40.0\n",
+            "6860648        8099       32698      280.0\n",
+            "6860649        8099       32702       40.0\n",
+            "6860650        8099       32705       40.0\n",
+            "6860651        8099       32708      120.0\n",
+            "\n",
+            "[6860652 rows x 3 columns]\n",
+            "\n",
+            "((0, 8099), (0, 32732))\n"
           ]
         }
       ],

--- a/apis/python/notebooks/tutorial_soma_append_mode.ipynb
+++ b/apis/python/notebooks/tutorial_soma_append_mode.ipynb
@@ -45,7 +45,7 @@
             "TileDB core version (tiledb)        2.23.0\n",
             "TileDB core version (libtiledbsoma) 2.23.0\n",
             "python version                      3.11.8.final.0\n",
-            "OS version                          Linux 4.14.336-257.568.amzn2.x86_64\n"
+            "OS version                          Linux 4.14.343-261.564.amzn2.x86_64\n"
           ]
         }
       ],
@@ -77,7 +77,7 @@
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240517-204938'"
+              "'/tmp/append-example-20240521-131732'"
             ]
           },
           "execution_count": 2,
@@ -177,21 +177,21 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/obs\n"
+            "Wrote   /tmp/append-example-20240521-131732/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
           ]
         },
         {
@@ -210,20 +210,20 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938\n"
+            "Wrote   /tmp/append-example-20240521-131732\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240517-204938'"
+              "'/tmp/append-example-20240521-131732'"
             ]
           },
           "execution_count": 5,
@@ -449,7 +449,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Registration: starting with experiment /tmp/append-example-20240517-204938\n"
+            "Registration: starting with experiment /tmp/append-example-20240521-131732\n"
           ]
         },
         {
@@ -484,41 +484,41 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/obs\n"
+            "Wrote   /tmp/append-example-20240521-131732/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240517-204938\n"
+            "Wrote   /tmp/append-example-20240521-131732\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240517-204938'"
+              "'/tmp/append-example-20240521-131732'"
             ]
           },
           "execution_count": 11,
@@ -707,7 +707,9 @@
         "The flow is pretty similar to the above:\n",
         "\n",
         "1. One call to `register_anndatas` or `register_h5ads` (passing all new AnnDatas/h5ads)\n",
-        "2. One call to `from_anndata`/`from_h5ad` *for each new AnnData*"
+        "2. One call to `from_anndata`/`from_h5ad` *for each new AnnData*\n",
+        "\n",
+        "Here's a helper function to simulate multiple lab runs. As above, where we used `pbmc3k` to simulate Monday and Tuesday data, here we use `pbmc3k` to simulate multiple AnnData objects."
       ]
     },
     {
@@ -742,7 +744,7 @@
         "tags": []
       },
       "source": [
-        "Ingesting the new AnnDatas, as before (but this time to a fresh/empty `/tmp` location):"
+        "We'll ingest these AnnData objects, as before, but this time to a fresh/empty `/tmp` location:"
       ]
     },
     {
@@ -755,7 +757,7 @@
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240517-204944'"
+              "'/tmp/append-example-20240521-131738'"
             ]
           },
           "execution_count": 16,
@@ -767,6 +769,15 @@
         "stamp = datetime.datetime.today().strftime(\"%Y%m%d-%H%M%S\")\n",
         "experiment_uri = f\"/tmp/append-example-{stamp}\"\n",
         "experiment_uri"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Here we'll register all the AnnData objects. Note that the SOMA Experiment doesn't exist yet, so we pass `experiment_uri=None` to signify that."
       ]
     },
     {
@@ -824,111 +835,6 @@
           "text": [
             "Registration: complete.\n"
           ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/obs\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/obs\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/obs\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/var\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Writing /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944/ms/RNA/X/data\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Wrote   /tmp/append-example-20240517-204944\n"
-          ]
         }
       ],
       "source": [
@@ -938,8 +844,138 @@
         "    measurement_name=measurement_name,\n",
         "    obs_field_name=\"obs_id\",\n",
         "    var_field_name=\"var_id\",\n",
-        ")\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "Now that we've gotten the registrations for all the input AnnData objects, we can ingest them.\n",
         "\n",
+        "Note:\n",
+        "\n",
+        "- Here we ingest them sequentially, in the same order as above.\n",
+        "- But we could also ingest them in any shuffled order.\n",
+        "- Or we could have multiple workers in ingest them in parallel, one worker per AnnData object, as long as the registration data are passed to each worker."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Wrote   /tmp/append-example-20240521-131738\n"
+          ]
+        }
+      ],
+      "source": [
         "for new_ad in new_ads:\n",
         "    tiledbsoma.io.from_anndata(\n",
         "        experiment_uri,\n",
@@ -960,7 +996,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 19,
       "metadata": {
         "tags": []
       },
@@ -1006,7 +1042,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 20,
       "metadata": {
         "tags": []
       },
@@ -1053,7 +1089,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 21,
       "metadata": {
         "tags": []
       },

--- a/apis/python/notebooks/tutorial_soma_append_mode.ipynb
+++ b/apis/python/notebooks/tutorial_soma_append_mode.ipynb
@@ -77,7 +77,7 @@
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240521-131732'"
+              "'/tmp/append-example-20240521-145833'"
             ]
           },
           "execution_count": 2,
@@ -177,21 +177,21 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/obs\n"
+            "Wrote   /tmp/append-example-20240521-145833/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-145833/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-145833/ms/RNA/X/data\n"
           ]
         },
         {
@@ -210,20 +210,20 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-145833/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732\n"
+            "Wrote   /tmp/append-example-20240521-145833\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240521-131732'"
+              "'/tmp/append-example-20240521-145833'"
             ]
           },
           "execution_count": 5,
@@ -449,7 +449,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Registration: starting with experiment /tmp/append-example-20240521-131732\n"
+            "Registration: starting with experiment /tmp/append-example-20240521-145833\n"
           ]
         },
         {
@@ -484,41 +484,41 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/obs\n"
+            "Wrote   /tmp/append-example-20240521-145833/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-145833/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-145833/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-145833/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131732\n"
+            "Wrote   /tmp/append-example-20240521-145833\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240521-131732'"
+              "'/tmp/append-example-20240521-145833'"
             ]
           },
           "execution_count": 11,
@@ -727,7 +727,7 @@
         "    ad.X *= scale\n",
         "    return ad\n",
         "\n",
-        "new_ads = [\n",
+        "ads = [\n",
         "    make_ad(when, scale, f\"-{idx + 3}\")\n",
         "    for idx, (when, scale)\n",
         "    in enumerate({\n",
@@ -757,7 +757,7 @@
         {
           "data": {
             "text/plain": [
-              "'/tmp/append-example-20240521-131738'"
+              "'/tmp/append-example-20240521-145839'"
             ]
           },
           "execution_count": 16,
@@ -840,7 +840,7 @@
       "source": [
         "rd2 = tiledbsoma.io.register_anndatas(\n",
         "    experiment_uri=None,  # new Experiment, from scratch\n",
-        "    adatas=new_ads,\n",
+        "    adatas=ads,\n",
         "    measurement_name=measurement_name,\n",
         "    obs_field_name=\"obs_id\",\n",
         "    var_field_name=\"var_id\",\n",
@@ -873,113 +873,113 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+            "Wrote   /tmp/append-example-20240521-145839/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738\n"
+            "Wrote   /tmp/append-example-20240521-145839\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+            "Wrote   /tmp/append-example-20240521-145839/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738\n"
+            "Wrote   /tmp/append-example-20240521-145839\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/obs\n"
+            "Wrote   /tmp/append-example-20240521-145839/obs\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/var\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/var\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Writing /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Writing /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738/ms/RNA/X/data\n"
+            "Wrote   /tmp/append-example-20240521-145839/ms/RNA/X/data\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Wrote   /tmp/append-example-20240521-131738\n"
+            "Wrote   /tmp/append-example-20240521-145839\n"
           ]
         }
       ],
       "source": [
-        "for new_ad in new_ads:\n",
+        "for ad in ads:\n",
         "    tiledbsoma.io.from_anndata(\n",
         "        experiment_uri,\n",
-        "        new_ad,\n",
+        "        ad,\n",
         "        measurement_name=measurement_name,\n",
         "        registration_mapping=rd2,\n",
         "    )"


### PR DESCRIPTION
**Issue and/or context:** #2569 / https://github.com/chanzuckerberg/cellxgene-census/issues/1132, builds on #2571

**Changes:**
Extend notebook to demonstrate "atlas"-model ingestion (no prior `Experiment`, one "register" call, multiple "from"s)

**Notes for Reviewer:**
- [RTD preview](https://tiledbsoma.readthedocs.io/en/rw-apptut/notebooks/tutorial_soma_append_mode.html#Ingesting-multiple-datasets-to-a-SOMA-Experiment)
- [Direct link](https://github.com/single-cell-data/TileDB-SOMA/blob/6a878db910b3d0601475bbff88ee231ad8360c15/apis/python/notebooks/tutorial_soma_append_mode.ipynb) to .ipynb on this branch (rendered more nicely than in PR view here)
- [nbviewer.org link to new section](https://nbviewer.org/github/single-cell-data/TileDB-SOMA/blob/6a878db910b3d0601475bbff88ee231ad8360c15/apis/python/notebooks/tutorial_soma_append_mode.ipynb#Appending-multiple-new-datasets-to-a-SOMA-Experiment)
