### PR TITLE
[python/ci] Use `macos-11` -> `macos-12` for `python-packaging.yml`

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,7 +53,7 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
-          - os: macos-11
+          - os: macos-12
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
@@ -104,7 +104,7 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          - os: macos-11
+          - os: macos-12
             platform: macosx
             arch: x86_64
             cc: clang
@@ -118,7 +118,7 @@ jobs:
           # * unzip whatever.zip
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
-          #- os: macos-11
+          #- os: macos-12
           #  platform: macosx
           #  arch: arm64
           #  cc: clang


### PR DESCRIPTION
**Issue and/or context:** Just a drive-by after a mention in Slack by @jdblischak 

**Changes:**

**Notes for Reviewer:**

