### PR TITLE
[c++] Correct `platform_config` to `tiledb_config`

### DIFF
--- a/libtiledbsoma/src/soma/soma_context.h
+++ b/libtiledbsoma/src/soma/soma_context.h
@@ -52,8 +52,8 @@ class SOMAContext {
         : ctx_(std::make_shared<Context>(Config({})))
         , thread_pool_mutex_(){};
 
-    SOMAContext(std::map<std::string, std::string> platform_config)
-        : ctx_(std::make_shared<Context>(Config(platform_config)))
+    SOMAContext(std::map<std::string, std::string> tiledb_config)
+        : ctx_(std::make_shared<Context>(Config(tiledb_config)))
         , thread_pool_mutex_(){};
 
     bool operator==(const SOMAContext& other) const {

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -429,6 +429,7 @@ TEST_CASE("SOMAArray: Test buffer size") {
     std::map<std::string, std::string> cfg;
     cfg["soma.init_buffer_bytes"] = "8";
     auto ctx = std::make_shared<SOMAContext>(cfg);
+    REQUIRE(ctx->tiledb_config()["soma.init_buffer_bytes"] == "8");
 
     std::string base_uri = "mem://unit-test-array";
     auto [uri, expected_nnz] = create_array(base_uri, ctx);


### PR DESCRIPTION
**Issue and/or context:**

The argument to a `SOMAContext` is a `tiledb::Config` object (as represent by a `map<string, string>`), not a `PlatformConfig` object. `PlatformConfig` is for configuring `SOMAArray`s with settings that cannot be represented by an `ArrowSchema`.

**Changes:**

- Rename argument name `platform_config` to `tiledb_config`
- Add explicit check to ensure passed config settings are honored in `SOMAContext`

