### PR TITLE
[c++] Also map "NONE" to `TILEDB_FILTER_NONE`

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -325,6 +325,7 @@ void ArrowAdapter::_append_to_filter_list(
         {"XOR", TILEDB_FILTER_XOR},
         {"WEBP", TILEDB_FILTER_WEBP},
         {"NOOP", TILEDB_FILTER_NONE},
+        {"NONE", TILEDB_FILTER_NONE},
     };
 
     try {


### PR DESCRIPTION
**Changes:**

Allow both "NONE" and "NOOP" as acceptable strings to map to `TILEDB_FILTER_NONE`.