### PR TITLE
[Backport release-1.11] [r] Better handling of timestamps in `$reopen()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.11.1
+Version: 1.11.1.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -18,6 +18,7 @@
 * Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
 * Have `SOMADataFrame$shape()` throw a not-yet-implemented error
 * Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
+* Clear timestamp when using `$reopen()` to reopen at the current time
 
 # 1.10.2
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -202,7 +202,7 @@ SOMADataFrame <- R6::R6Class(
       arr[] <- df
       # tiledb-r always closes the array after a write operation so we need to
       # manually reopen it until close-on-write is optional
-      self$open("WRITE", internal_use_only = "allowed_use")
+      self$reopen("WRITE")
       invisible(self)
     },
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -171,14 +171,17 @@ TileDBGroup <- R6::R6Class(
       # we return it. But if not (e.g. first access on read from storage)
       # then we invoke the appropriate constructor. Note: child classes
       # may override construct_member.
-      if (is.null(member$object)) {
+      obj <- if (is.null(member$object)) {
         obj <- private$construct_member(member$uri, member$type)
-        obj$open(mode = self$mode(), internal_use_only = "allowed_use")
       } else {
-        obj <- member$object
-        if (!obj$is_open()) {
-          obj$open(mode = self$mode(), internal_use_only = "allowed_use")
-        }
+        member$object
+      }
+      if (!obj$is_open()) {
+        switch(
+          EXPR = (mode <- self$mode()),
+          READ = obj$open(mode, internal_use_only = "allowed_use"),
+          WRITE = obj$reopen(mode)
+        )
       }
 
       private$add_cached_member(name, obj)

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -83,21 +83,17 @@ TileDBObject <- R6::R6Class(
     #'  \item \dQuote{\code{WRITE}}
     #' }
     #' By default, reopens in the opposite mode of the current mode
-    #' @param force Force a close/reopen cycle; by default, if \code{mode} is
-    #' \code{self$mode()}, \code{reopen()} does nothing
     #'
     #' @return Invisibly returns \code{self}
     #'
-    reopen = function(mode = NULL, force = FALSE) {
-      stopifnot("'force' must be TRUE or FALSE" = is_scalar_logical(force))
+    reopen = function(mode = NULL) {
       modes <- c(READ = 'WRITE', WRITE = 'READ')
       oldmode <- self$mode()
       mode <- mode %||% modes[oldmode]
       mode <- match.arg(mode, choices = modes)
-      if (isTRUE(force) || mode != oldmode) {
-        self$close()
-        self$open(mode, internal_use_only = 'allowed_use')
-      }
+      self$close()
+      private$tiledb_timestamp <- NULL
+      self$open(mode, internal_use_only = 'allowed_use')
       return(invisible(self))
     },
 

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -526,7 +526,7 @@ write_soma.Seurat <- function(
     stop(
       "Requested an array of shape (",
       paste(shape, collapse = ', '),
-      "), but was given a matrix with a larger shape (",
+      "), but was given a Seurat object with a larger shape (",
       paste(dim(x), collapse = ', '),
       ")",
       call. = FALSE
@@ -807,7 +807,7 @@ write_soma.SeuratCommand <- function(
     logs$reopen("WRITE")
     logs
   }
-  on.exit(logs$close(), add = TRUE)
+  on.exit(logs$close(), add = TRUE, after = FALSE)
 
   # Encode parameters
   spdl::info("Encoding parameters in the command log")

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -244,6 +244,8 @@ write_soma.data.frame <- function(
   }
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- sdf$mode()
+    on.exit(sdf$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(sdf, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -369,6 +371,8 @@ write_soma.matrix <- function(
   array$write(x)
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- array$mode()
+    on.exit(array$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(array, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -498,6 +502,8 @@ write_soma.TsparseMatrix <- function(
   }
   # Add to `soma_parent`
   if (is.character(key)) {
+    mode <- array$mode()
+    on.exit(array$reopen(mode), add = TRUE, after = FALSE)
     withCallingHandlers(
       expr = .register_soma_object(array, soma_parent, key, relative),
       existingKeyWarning = .maybe_muffle
@@ -598,12 +604,18 @@ write_soma.TsparseMatrix <- function(
     "'key' must be a single character value" = is_scalar_character(key) && nzchar(key),
     "'relative' must be a single logical value" = is_scalar_logical(relative)
   )
+  xmode <- x$mode()
+  if (xmode == 'CLOSED') {
+    x$reopen('READ')
+    xmode <- x$mode()
+  }
+  on.exit(x$reopen(mode = xmode), add = TRUE, after = FALSE)
   oldmode <- soma_parent$mode()
   if (oldmode == 'CLOSED') {
     soma_parent$reopen("READ")
     oldmode <- soma_parent$mode()
   }
-  on.exit(soma_parent$reopen(oldmode))
+  on.exit(soma_parent$reopen(oldmode), add = TRUE, after = FALSE)
   if (key %in% soma_parent$names()) {
     existing <- soma_parent$get(key)
     warning(warningCondition(

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL, force = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -118,9 +118,6 @@ Close and reopen the TileDB object in a new mode
 \item \dQuote{\code{WRITE}}
 }
 By default, reopens in the opposite mode of the current mode}
-
-\item{\code{force}}{Force a close/reopen cycle; by default, if \code{mode} is
-\code{self$mode()}, \code{reopen()} does nothing}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Manual backport of #2497. I added the `backport release-1.11` tag there and backport didn't run; I don't know why not.