### PR TITLE
[Backport release-1.11] [c++] Also map "NONE" to `TILEDB_FILTER_NONE` (#2599)

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -325,6 +325,7 @@ void ArrowAdapter::_append_to_filter_list(
         {"XOR", TILEDB_FILTER_XOR},
         {"WEBP", TILEDB_FILTER_WEBP},
         {"NOOP", TILEDB_FILTER_NONE},
+        {"NONE", TILEDB_FILTER_NONE},
     };
 
     try {


### PR DESCRIPTION
Manually backport #2599 to `release-1.11`

https://github.com/single-cell-data/TileDB-SOMA/pull/2599#issuecomment-2122703348