### PR TITLE
[python/ci] Stop wheel-smoke-test failures for MacOS > 11

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -125,7 +125,7 @@ jobs:
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
               new_name=$(echo $wheel_file_name | sed "s/macosx_11_0/macosx_10_9/")
               if [ "$wheel_file_name" = "$new_name" ]; then
-                echo "Failed to rename $wheel_file_name
+                echo "Failed to rename $wheel_file_name"
                 exit 1
               fi
               echo Renaming $wheel_file_name to $new_name

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -175,10 +175,12 @@ jobs:
           echo
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
+          echo wheel_os_string: ${{ matrix.wheel_os_string }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           pip install setuptools
           python -c 'from distutils import util; print(util.get_platform())'
           echo
+          echo find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl' THEN grep ${{ matrix.wheel_os_string }}
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl' | grep ${{ matrix.wheel_os_string }} )
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -101,7 +101,9 @@ jobs:
           echo
           pwd
           echo
-          cd dist
+          ls -l
+          echo
+          cd wheelhouse
           # TO DO: COMMENT ME IF THIS WORKS
           for wheel_file_name in *.whl; do
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -211,6 +211,21 @@ jobs:
           set -x
           mkdir dist
           cp sdist/tiledbsoma-*.tar.gz wheels-*/*.whl dist
+          echo
+          cd dist
+          # TO DO: COMMENT ME IF THIS WORKS
+          for wheel_file_name in *.whl; do
+            if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
+              src="macosx_11_0"
+              for dst in "macosx_12_0" "macosx_13_0" "macosx_14_0"; do
+                new_name=$(echo $wheel_file_name | sed "s/$src/$dst/")
+                echo Copying $wheel_file_name to $new_name
+                cp $wheel_file_name $new_name
+              done
+            fi
+          done
+          cd ..
+          echo
           ls -l dist
       - name: Publish packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,7 +53,8 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
-          - os: macos-14
+          ##### XXX TEMP - os: macos-14
+          - os: macos-11
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
@@ -76,6 +77,7 @@ jobs:
       # `distutil.util.get_platform()`.
       - name: Show self-reported platform
         run: |
+          echo "python --version"; python --version
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
@@ -151,7 +153,8 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          - os: macos-14
+          #### XXX TEMP - os: macos-14
+          - os: macos-11
             platform: macosx
             arch: x86_64
             cc: clang
@@ -179,6 +182,7 @@ jobs:
         uses: actions/download-artifact@v3
       - name: Show self-reported platform
         run: |
+          echo "python --version"; python --version
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,12 +53,12 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
-          - os: macos-14
+          - os: macos-12
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
             wheel_name: macos-x86_64
-          - os: macos-12
+          - os: macos-14
             cibw_build: 'cp3*-macosx_arm64'
             cibw_archs_macos: arm64
             platform: macosx
@@ -99,7 +99,7 @@ jobs:
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
       # See https://github.com/single-cell-data/TileDB-SOMA/pull/2620
       #
-      # * MacOS 12 and 14 self-report as  `macosx-10.9-universal2` via
+      # * MacOS 12 and 14 self-report as `macosx-10.9-universal2` via
       #   `distutil.util.get_platform()`.
       # * Due to https://github.com/single-cell-data/TileDB-SOMA/pull/2124 we build
       #   with `-mmacosx-version-min=11.0` which overrides any attempt at
@@ -152,21 +152,12 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          #- os: macos-14
-          #  platform: macosx
-          #  arch: x86_64
-          #  cc: clang
-          #  cxx: clang++
-          # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
-          # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
-          # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
-          #   https://github.com/github/roadmap/issues/528
-          # Any smoke-testing for arm64 wheels needs to be done manually by:
-          # * Download the whatever.zip file from GitHub Actions -> our instance -> Artifacts
-          # * unzip whatever.zip
-          # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
-          #
           - os: macos-12
+            platform: macosx
+            arch: x86_64
+            cc: clang
+            cxx: clang++
+          - os: macos-14
             platform: macosx
             arch: arm64
             cc: clang
@@ -180,6 +171,7 @@ jobs:
         uses: actions/download-artifact@v3
       - name: Show self-reported platform
         run: |
+          sw_vers || /usr/bin/true
           echo "python --version"; python --version
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -215,17 +215,18 @@ jobs:
           packages_dir: dist
           verbose: true
 
-  # File a bug report if anything fails
-  create_issue_on_fail:
-    runs-on: ubuntu-latest
-    needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
-    if: failure() || cancelled()
-    steps:
-      - name: Checkout TileDB-SOMA `main`
-        uses: actions/checkout@v2
-      - name: Create Issue if Build Fails
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/workflows/daily-test-build-issue-template.md
+# TEMP DO NOT COMMIT -- DEBUG ONLY
+#  # File a bug report if anything fails
+#  create_issue_on_fail:
+#    runs-on: ubuntu-latest
+#    needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
+#    if: failure() || cancelled()
+#    steps:
+#      - name: Checkout TileDB-SOMA `main`
+#        uses: actions/checkout@v2
+#      - name: Create Issue if Build Fails
+#        uses: JasonEtco/create-an-issue@v2
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          filename: .github/workflows/daily-test-build-issue-template.md

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -215,18 +215,18 @@ jobs:
           packages_dir: dist
           verbose: true
 
-# TEMP DO NOT COMMIT -- DEBUG ONLY
-#  # File a bug report if anything fails
-#  create_issue_on_fail:
-#    runs-on: ubuntu-latest
-#    needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
-#    if: failure() || cancelled()
-#    steps:
-#      - name: Checkout TileDB-SOMA `main`
-#        uses: actions/checkout@v2
-#      - name: Create Issue if Build Fails
-#        uses: JasonEtco/create-an-issue@v2
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          filename: .github/workflows/daily-test-build-issue-template.md
+  # File a bug report if anything fails.
+  # Don't file tickets for manual runs -- only for scheduled ones.
+  create_issue_on_fail:
+    runs-on: ubuntu-latest
+    needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
+    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Checkout TileDB-SOMA `main`
+        uses: actions/checkout@v2
+      - name: Create Issue if Build Fails
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/workflows/daily-test-build-issue-template.md

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,16 +53,19 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
+            wheel_os_string: "."
           - os: macos-14
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
             wheel_name: macos-x86_64
+            wheel_os_string: "macosx_14_0"
           - os: macos-12
             cibw_build: 'cp3*-macosx_arm64'
             cibw_archs_macos: arm64
             platform: macosx
             wheel_name: macos-arm64
+            wheel_os_string: "macosx_12_0"
     steps:
       - name: Download sdist artifact
         uses: actions/download-artifact@v3
@@ -176,7 +179,7 @@ jobs:
           pip install setuptools
           python -c 'from distutils import util; print(util.get_platform())'
           echo
-          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl' | grep ${{ matrix.wheel_os_string }} )
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,19 +53,16 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
-            wheel_os_string: "."
           - os: macos-14
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
-            platform: macosx
+            platform: macosx_14
             wheel_name: macos-x86_64
-            wheel_os_string: "macosx_14_0"
           - os: macos-12
             cibw_build: 'cp3*-macosx_arm64'
             cibw_archs_macos: arm64
-            platform: macosx
+            platform: macosx_12
             wheel_name: macos-arm64
-            wheel_os_string: "macosx_12_0"
     steps:
       - name: Download sdist artifact
         uses: actions/download-artifact@v3
@@ -165,6 +162,10 @@ jobs:
           python-version: 3.11
       - name: Download artifacts
         uses: actions/download-artifact@v3
+    # Notes to type up:
+    # tiledbsoma-VERSIONHERE-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_x86_64.whl
+    # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_arm64.whl
       - name: Install wheel
         run: |
           set -x
@@ -175,13 +176,11 @@ jobs:
           echo
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
-          echo wheel_os_string: ${{ matrix.wheel_os_string }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           pip install setuptools
           python -c 'from distutils import util; print(util.get_platform())'
           echo
-          echo find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl' THEN grep ${{ matrix.wheel_os_string }}
-          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl' | grep ${{ matrix.wheel_os_string }} )
+          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -107,7 +107,7 @@ jobs:
           # TO DO: COMMENT ME IF THIS WORKS
           for wheel_file_name in *.whl; do
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
-              new_name=$(echo $wheel_file_name | sed "s/macos_11_0/macos_10_9/")
+              new_name=$(echo $wheel_file_name | sed "s/macosx_11_0/macosx_10_9/")
               echo Renaming $wheel_file_name to $new_name
               mv $wheel_file_name $new_name
             fi

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -56,12 +56,12 @@ jobs:
           - os: macos-14
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
-            platform: macosx_14
+            platform: macosx
             wheel_name: macos-x86_64
           - os: macos-12
             cibw_build: 'cp3*-macosx_arm64'
             cibw_archs_macos: arm64
-            platform: macosx_12
+            platform: macosx
             wheel_name: macos-arm64
     steps:
       - name: Download sdist artifact
@@ -107,12 +107,9 @@ jobs:
           # TO DO: COMMENT ME IF THIS WORKS
           for wheel_file_name in *.whl; do
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
-              src="macosx_11_0"
-              for dst in "macosx_12_0" "macosx_13_0" "macosx_14_0"; do
-                new_name=$(echo $wheel_file_name | sed "s/$src/$dst/")
-                echo Copying $wheel_file_name to $new_name
-                cp $wheel_file_name $new_name
-              done
+              new_name=$(echo $wheel_file_name | sed "s/macos_11_0/macos_10_9/")
+              echo Renaming $wheel_file_name to $new_name
+              mv $wheel_file_name $new_name
             fi
           done
           cd ..

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -70,6 +70,14 @@ jobs:
           name: sdist
       - name: rename sdist
         run: cp tiledbsoma-*.tar.gz tiledbsoma.tar.gz && ls -lh
+      - name: Show platform
+        run: |
+          echo
+          echo matrix.platform: ${{ matrix.platform }}
+          echo matrix.arch: ${{ matrix.arch }}
+          # This bit is crucial since it's used to match up to a component of the wheel-file name
+          python -c 'from distutils import util; print(util.get_platform())'
+          echo
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         with:
@@ -133,10 +141,16 @@ jobs:
       - name: Install wheel
         run: |
           set -x
+          echo
           ls -lR
+          echo
           ls -lR wheels-*
+          echo
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
+          # This bit is crucial since it's used to match up to a component of the wheel-file name
+          python -c 'from distutils import util; print(util.get_platform())'
+          echo
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -129,7 +129,8 @@ jobs:
                 exit 1
               fi
               echo Renaming $wheel_file_name to $new_name
-              mv $wheel_file_name $new_name
+              #### mv $wheel_file_name $new_name
+              echo DEBUG SKIP
             fi
           done
           cd ..

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -195,7 +195,7 @@ jobs:
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel
-          pip install $WHL
+          pip install -vv $WHL
           echo "WHL=$WHL" >> $GITHUB_ENV
       - name: Smoke test ${{ matrix.os }}
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -122,6 +122,10 @@ jobs:
           for wheel_file_name in *.whl; do
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
               new_name=$(echo $wheel_file_name | sed "s/macosx_11_0/macosx_10_9/")
+              if [ "$wheel_file_name" = "$new_name" ]; then
+                echo "Failed to rename $wheel_file_name
+                exit 1
+              fi
               echo Renaming $wheel_file_name to $new_name
               mv $wheel_file_name $new_name
             fi

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -96,6 +96,25 @@ jobs:
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
           # DEBUG ONLY DO NOT COMMIT
           CMAKE_OSX_DEPLOYMENT_TARGET: "10.9"
+      - name: Temp wildcarding step
+        run: |
+          echo
+          pwd
+          echo
+          cd dist
+          # TO DO: COMMENT ME IF THIS WORKS
+          for wheel_file_name in *.whl; do
+            if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
+              src="macosx_11_0"
+              for dst in "macosx_12_0" "macosx_13_0" "macosx_14_0"; do
+                new_name=$(echo $wheel_file_name | sed "s/$src/$dst/")
+                echo Copying $wheel_file_name to $new_name
+                cp $wheel_file_name $new_name
+              done
+            fi
+          done
+          cd ..
+          echo
       - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
         uses: actions/upload-artifact@v3
         with:
@@ -211,21 +230,6 @@ jobs:
           set -x
           mkdir dist
           cp sdist/tiledbsoma-*.tar.gz wheels-*/*.whl dist
-          echo
-          cd dist
-          # TO DO: COMMENT ME IF THIS WORKS
-          for wheel_file_name in *.whl; do
-            if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
-              src="macosx_11_0"
-              for dst in "macosx_12_0" "macosx_13_0" "macosx_14_0"; do
-                new_name=$(echo $wheel_file_name | sed "s/$src/$dst/")
-                echo Copying $wheel_file_name to $new_name
-                cp $wheel_file_name $new_name
-              done
-            fi
-          done
-          cd ..
-          echo
           ls -l dist
       - name: Publish packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -70,15 +70,17 @@ jobs:
           name: sdist
       - name: rename sdist
         run: cp tiledbsoma-*.tar.gz tiledbsoma.tar.gz && ls -lh
-      - name: Show platform
+      # This is crucial for ongoing debug (do not remove it) as this shows the
+      # OS version as used by `pip install` to find wheel names. Importantly,
+      # macos 12 and macos14 self-report as `macosx-10.9-universal2` via
+      # `distutil.util.get_platform()`.
+      - name: Show self-reported platform
         run: |
-          echo
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           pip install setuptools
-          python -c 'from distutils import util; print(util.get_platform())'
-          echo
+          python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         with:
@@ -94,17 +96,29 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
-          # DEBUG ONLY DO NOT COMMIT
-          CMAKE_OSX_DEPLOYMENT_TARGET: "10.9"
-      - name: Temp wildcarding step
+      # See https://github.com/single-cell-data/TileDB-SOMA/pull/2620
+      #
+      # * MacOS 12 and 14 self-report as  `macosx-10.9-universal2` via
+      #   `distutil.util.get_platform()`.
+      # * Due to https://github.com/single-cell-data/TileDB-SOMA/pull/2124 we build
+      #   with `-mmacosx-version-min=11.0` which overrides any attempt at
+      #   setting `CMAKE_OSX_DEPLOYMENT_TARGET` in our env here.
+      # * This means a MacOS 12/14 system can self-report as 10.9, see
+      #   a wheel at 11.0, and refuse the install, claiming that no suitable
+      #   OS-version support can be found in the wheel.
+      # Therefore we rename the wheel's reported supported MacOS version to
+      # match the self-reported OS version of today's clients.
+      #
+      # Example file names we assume here:
+      # tiledbsoma-VERSIONHERE-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_x86_64.whl
+      # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_arm64.whl
+      - name: MacOS portability step
         run: |
-          echo
           pwd
-          echo
           ls -l
-          echo
           cd wheelhouse
-          # TO DO: COMMENT ME IF THIS WORKS
+          ls -l
           for wheel_file_name in *.whl; do
             if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
               new_name=$(echo $wheel_file_name | sed "s/macosx_11_0/macosx_10_9/")
@@ -159,24 +173,18 @@ jobs:
           python-version: 3.11
       - name: Download artifacts
         uses: actions/download-artifact@v3
-    # Notes to type up:
-    # tiledbsoma-VERSIONHERE-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-    # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_x86_64.whl
-    # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_arm64.whl
-      - name: Install wheel
+      - name: Show self-reported platform
         run: |
-          set -x
-          echo
-          ls -lR
-          echo
-          ls -lR wheels-*
-          echo
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           pip install setuptools
-          python -c 'from distutils import util; print(util.get_platform())'
-          echo
+          python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
+      - name: Install wheel
+        run: |
+          set -x
+          ls -lR
+          ls -lR wheels-*
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
@@ -241,8 +249,8 @@ jobs:
           packages_dir: dist
           verbose: true
 
-  # File a bug report if anything fails.
-  # Don't file tickets for manual runs -- only for scheduled ones.
+  # File a bug report if anything fails, but don't file tickets for manual runs
+  # -- only for scheduled ones.
   create_issue_on_fail:
     runs-on: ubuntu-latest
     needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -82,6 +82,7 @@ jobs:
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           python -m pip install setuptools
           python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
+          python -c 'import platform; print("platform.platform()", platform.platform())'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         with:
@@ -178,6 +179,7 @@ jobs:
           # This bit is crucial since it's used to match up to a component of the wheel-file name
           python -m pip install setuptools
           python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
+          python -c 'import platform; print("platform.platform()", platform.platform())'
       - name: Install wheel
         run: |
           set -x

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -152,11 +152,11 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          - os: macos-14
-            platform: macosx
-            arch: x86_64
-            cc: clang
-            cxx: clang++
+          #- os: macos-14
+          #  platform: macosx
+          #  arch: x86_64
+          #  cc: clang
+          #  cxx: clang++
           # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
           # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
           # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
@@ -166,11 +166,11 @@ jobs:
           # * unzip whatever.zip
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
-          #- os: macos-12
-          #  platform: macosx
-          #  arch: arm64
-          #  cc: clang
-          #  cxx: clang++
+          - os: macos-12
+            platform: macosx
+            arch: arm64
+            cc: clang
+            cxx: clang++
     steps:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -153,16 +153,20 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          - os: macos-12
-            platform: macosx
-            arch: x86_64
-            cc: clang
-            cxx: clang++
-          - os: macos-14
-            platform: macosx
-            arch: arm64
-            cc: clang
-            cxx: clang++
+          # Follow-up flagged in https://github.com/single-cell-data/TileDB-SOMA/issues/2634
+          # TL;DR direct pip-install of the wheel file fails bafflingly (see #2634 for details)
+          # but works in non-GHA environments including laptops and MacOS EC2 instances.
+          #
+          #- os: macos-12
+          #  platform: macosx
+          #  arch: x86_64
+          #  cc: clang
+          #  cxx: clang++
+          #- os: macos-14
+          #  platform: macosx
+          #  arch: arm64
+          #  cc: clang
+          #  cxx: clang++
     steps:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -76,6 +76,7 @@ jobs:
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
+          pip install setuptools
           python -c 'from distutils import util; print(util.get_platform())'
           echo
       - name: Build wheels
@@ -149,6 +150,7 @@ jobs:
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
+          pip install setuptools
           python -c 'from distutils import util; print(util.get_platform())'
           echo
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -94,6 +94,8 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
+          # DEBUG ONLY DO NOT COMMIT
+          CMAKE_OSX_DEPLOYMENT_TARGET: "10.9"
       - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -53,8 +53,7 @@ jobs:
             cibw_build: 'cp3*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
-          ##### XXX TEMP - os: macos-14
-          - os: macos-11
+          - os: macos-14
             cibw_build: 'cp3*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
@@ -129,8 +128,7 @@ jobs:
                 exit 1
               fi
               echo Renaming $wheel_file_name to $new_name
-              #### mv $wheel_file_name $new_name
-              echo DEBUG SKIP
+              mv $wheel_file_name $new_name
             fi
           done
           cd ..
@@ -154,8 +152,7 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          #### XXX TEMP - os: macos-14
-          - os: macos-11
+          - os: macos-14
             platform: macosx
             arch: x86_64
             cc: clang

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -80,7 +80,7 @@ jobs:
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
-          pip install setuptools
+          python -m pip install setuptools
           python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
@@ -184,7 +184,7 @@ jobs:
           echo matrix.platform: ${{ matrix.platform }}
           echo matrix.arch: ${{ matrix.arch }}
           # This bit is crucial since it's used to match up to a component of the wheel-file name
-          pip install setuptools
+          python -m pip install setuptools
           python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
       - name: Install wheel
         run: |
@@ -194,8 +194,8 @@ jobs:
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
-          pip install wheel
-          pip install -vv $WHL
+          python -m pip install wheel
+          python -m pip install -vv $WHL
           echo "WHL=$WHL" >> $GITHUB_ENV
       - name: Smoke test ${{ matrix.os }}
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'


### PR DESCRIPTION
## Problem

Our current package-release CI is broken. It requires manual wheel-publish as at
https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-notes

CI failures are like
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9189052757
following the well-intentioned but fateful #2491.

Also nightly wheel-build failures such as #2630.

## Cause

Debugging reveals:

* #2491 moved Python wheel-builds from macos 11 and 12 to 14 and 12
  * Why we did that: GitHub Actions is deprecating macos 11 runners
* Printing `python -c 'from distutils import util; print(util.get_platform())'` at build-wheel time and smoke-test-wheel time
  * Build-wheel time on macos 14: this reports (!) `macosx-10.9-universal2`
    * https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9193078472/job/25283290847#step:4:20
  * Smoke-test-wheel time on macos 14: this reports (!) `macosx-10.9-universal2`
  * https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9193078472/job/25284241544#step:4:93
* However: the wheel that's created has the substring `macosx_11` in its filename :(
  * https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9193078472/job/25283290847#step:5:1005
  * `Created wheel for tiledbsoma: filename=tiledbsoma-1.11.2.post0.dev4180921687-cp38-cp38-macosx_11_0_x86_64.whl`
* As a result, at smoke-test time, `util.get_platform()` says `macosx-10.9-universal2` and yet there is no wheel for 10.9 -- only 11.0
  * On MacOS 11, `pip install` of a wheel with either `macosx_10_9` or `macosx_11_0` in its wheel-file name succeeds
  * Not so on MacOS 14
  * So this all worked fine when the smoke-test runner was macos 11; not fine now that it's macos 12 or 14

## Attempted solutions

* :x: Setting the `CMAKE_OSX_DEPLOYMENT_TARGET: "10.9"` in our CI YAML's `env` does not help since in #2124 we set `-mmacosx-version-min=11.0` to support usage of C++17 feature `std::filesystem::path`, which overrides the env
* :x: Having our CI YAML copy files like `tiledbsoma-VERSIONHERE-cp311-cp311-macosx_11_0_arm64.whl` to `tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_arm64.whl` does not work, and in fact is a step in the wrong direction: since macos14 self-reports as 10.9 within `pip install` as shown above.
* :x: Having our CI YAML rename files like `tiledbsoma-VERSIONHERE-cp311-cp311-macosx_11_0_arm64.whl` to `tiledbsoma-VERSIONHERE-cp311-cp311-macosx_10_9_arm64.whl` does work, since macos 14 self-reports as 10.9 at `pip install` time.
  * ✅ Works on my laptop with macos14 and Python 3.9
  * :x: Fails in CI with macos14 and Python 3.11
  * :x: Fails in macos-on-macos Docker on my laptop with Python 3.11 (see below)

## Laptop details

With macos 14 and Python 3.9:

```
laptop$ sw_vers
ProductName:		macOS
ProductVersion:		14.5
BuildVersion:		23F79

laptop$ python --version
Python 3.9.13

laptop$ ll | grep macos | grep x86
-rw-r--r--@ 1 johnkerl  staff  24547997 May 21 22:50 tiledbsoma-1.11.2-cp310-cp310-macosx_11_0_x86_64.whl
-rw-r--r--@ 1 johnkerl  staff  24549656 May 21 22:50 tiledbsoma-1.11.2-cp311-cp311-macosx_11_0_x86_64.whl
-rw-r--r--@ 1 johnkerl  staff  24547829 May 21 22:50 tiledbsoma-1.11.2-cp38-cp38-macosx_11_0_x86_64.whl
-rw-r--r--@ 1 johnkerl  staff  24548029 May 21 22:50 tiledbsoma-1.11.2-cp39-cp39-macosx_11_0_x86_64.whl
-rw-r--r--@ 1 johnkerl  staff  97615624 May 21 18:53 wheels-macos-x86_64.zip

laptop$ pip install tiledbsoma-1.11.2-cp39-cp39-macosx_11_0_x86_64.whl
ERROR: tiledbsoma-1.11.2-cp39-cp39-macosx_11_0_x86_64.whl is not a supported wheel on this platform.

laptop$ cp tiledbsoma-1.11.2-cp39-cp39-macosx_11_0_x86_64.whl tiledbsoma-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl

laptop$ pip install tiledbsoma-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl
Processing ./tiledbsoma-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl
```

Note this _exact_ logic -- successful on laptop -- fails as of
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9198109199/job/25300662543
for commit https://github.com/single-cell-data/TileDB-SOMA/pull/2620/commits/d7934164e11ec93accab0a7b084e9d1abc6e1ddf

Using https://hub.docker.com/r/sickcodes/docker-osx -- macos-on-macos Docker -- with Python 3.11 I found that the trick which worked on my laptop (macos 14 with Python 3.9), and which fails in CI here with macos 14 and Python 3.11, also fails in `sickcodes/docker-osx` with Python 3.11.

In short it seems that the renaming trick from https://stackoverflow.com/questions/65888506/error-wheel-whl-is-not-a-supported-wheel-on-this-platform works in Python 3.9 but not 3.11.

Also note:  supposedly-macos-on-macos `sickcodes/docker-osx:latest` isn't really:

```
[arch@041a7b1338f2 OSX-KVM]$ uname -a
Linux 041a7b1338f2 5.10.104-linuxkit #1 SMP Wed Mar 9 19:05:23 UTC 2022 x86_64 GNU/Linux
```

Also, why doesn't `pip install tiledbsoma` (from PyPI) fail on my Mac?

```
johnkerl@exade[prod][][~]$ pip install tiledbsoma
Collecting tiledbsoma
  Downloading tiledbsoma-1.11.1.tar.gz (291 kB)
...
Building wheels for collected packages: tiledbsoma
  Building wheel for tiledbsoma (pyproject.toml) ... |
...
```

-- it doesn't appear to be using the `.whl` file ...

Also note: on my `arm64` mac with `macos-14`:
```
$ python -c 'from distutils import util; print(util.get_platform())'
macosx-14-arm64
```

However even `macos12+arm64` runners in GHA misbehave:
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9198915278/job/25302688619
```
distutil.util.get_platform: macosx-10.9-universal2
```

# See also

* https://stackoverflow.com/questions/65888506/error-wheel-whl-is-not-a-supported-wheel-on-this-platform -- for the rename trick
* https://github.com/pypa/cibuildwheel/issues/952 -- nice to know, but this turns out not to help here
* Also note our CI YAML currently says `pypa/buildwheel@v2.11.3` whereas newer versions exist https://github.com/pypa/cibuildwheel/releases/tag/v2.18.1 👀 🤔 ... this turns out not to help here