### PR TITLE
[r] Correct four \link{} references in help pages

### DIFF
--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -93,7 +93,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       arrow::concat_arrays(private$.joinids$var())
     },
 
-    #' @description Retrieves an `X` layer as a link{SOMASparseNDArrayRead}
+    #' @description Retrieves an `X` layer as a \link{SOMASparseNDArrayRead}
     #' @param layer_name The name of the layer to retrieve.
     X = function(layer_name) {
       stopifnot(

--- a/apis/r/R/utils-matrixZeroBasedView.R
+++ b/apis/r/R/utils-matrixZeroBasedView.R
@@ -66,9 +66,9 @@ matrixZeroBasedView <- R6::R6Class(
       private$one_based_matrix
     },
 
-    #' @description Perform arithmetic sum between this link{matrixZeroBasedView}
-    #' and another link{matrixZeroBasedView}.
-    #' @param x the link{matrixZeroBasedView} to sum.
+    #' @description Perform arithmetic sum between this \link{matrixZeroBasedView}
+    #' and another \link{matrixZeroBasedView}.
+    #' @param x the \link{matrixZeroBasedView} to sum.
     #' @return The result of the sum as a \link{matrixZeroBasedView}.
     sum = function(x) {
       if (!inherits(x, "matrixZeroBasedView")) {

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -158,7 +158,7 @@ Retrieve \code{soma_joinids} as an \code{\link[arrow:array-class]{arrow::Array}}
 \if{html}{\out{<a id="method-SOMAExperimentAxisQuery-X"></a>}}
 \if{latex}{\out{\hypertarget{method-SOMAExperimentAxisQuery-X}{}}}
 \subsection{Method \code{X()}}{
-Retrieves an \code{X} layer as a link{SOMASparseNDArrayRead}
+Retrieves an \code{X} layer as a \link{SOMASparseNDArrayRead}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMAExperimentAxisQuery$X(layer_name)}\if{html}{\out{</div>}}
 }

--- a/apis/r/man/matrixZeroBasedView.Rd
+++ b/apis/r/man/matrixZeroBasedView.Rd
@@ -116,8 +116,8 @@ One-based matrix
 \if{html}{\out{<a id="method-matrixZeroBasedView-sum"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-sum}{}}}
 \subsection{Method \code{sum()}}{
-Perform arithmetic sum between this link{matrixZeroBasedView}
-and another link{matrixZeroBasedView}.
+Perform arithmetic sum between this \link{matrixZeroBasedView}
+and another \link{matrixZeroBasedView}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$sum(x)}\if{html}{\out{</div>}}
 }
@@ -125,7 +125,7 @@ and another link{matrixZeroBasedView}.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{x}}{the link{matrixZeroBasedView} to sum.}
+\item{\code{x}}{the \link{matrixZeroBasedView} to sum.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
**Issue and/or context:**

Running `R CMD check --as-cran` (or its equivalent forms) was nagging over four `\link{}` entries missing the leading backslashes (as a follow-up from R now checking for stray pairs of `{ }`).

![image](https://github.com/single-cell-data/TileDB-SOMA/assets/673121/65513493-338a-4e01-9b5a-c8a9923d8d8a)

**Changes:**

Corrected in R files, and Rd files re-rerendered.

**Notes for Reviewer:**

No code changes. No test changes.

[SC 47990](https://app.shortcut.com/tiledb-inc/story/47990/r-minor-formatting-correction-got-four-rd-help-files)