### PR TITLE
[r] Update changed URL in three vignette files

### DIFF
--- a/apis/r/.Rbuildignore
+++ b/apis/r/.Rbuildignore
@@ -25,6 +25,7 @@ tiledbsoma.tar.gz
 src/libtiledbsoma/build
 src/libtiledbsoma/test
 src/libtiledbsoma/docs
+src/libtiledbsoma/.editorconfig
 
 # vscode
 ^\.vscode$

--- a/apis/r/vignettes/soma-experiment-queries.Rmd
+++ b/apis/r/vignettes/soma-experiment-queries.Rmd
@@ -24,7 +24,7 @@ library(tiledbsoma)
 
 ## Example data
 
-Load the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://mojaveazure.github.io/seurat-object/reference/pbmc_small.html) provided by SeuratObject. This will return a `SOMAExperiment` object.
+Load the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://satijalab.github.io/seurat-object/reference/pbmc_small.html) provided by SeuratObject. This will return a `SOMAExperiment` object.
 
 ```{r}
 experiment <- load_dataset("soma-exp-pbmc-small")
@@ -103,7 +103,7 @@ iterator$read_next()
 iterator$read_complete()
 ```
 
-We can also access the expression via `X()`. 
+We can also access the expression via `X()`.
 
 Similarly to `obs()` and `var()`, `X()` is intended for iteration, but in this case we have access to two different iterators, and thus `X()` returns a reader that gives you access to an iterator for `arrow::Table` and one for `Matrix::sparse_matrix`.
 
@@ -168,7 +168,7 @@ As well as the X matrix in two different formats:
 ```{r}
 query$X("counts")$tables()$concat()
 ```
- 
+
 `Matrix::sparse_matrix` in `dgTMatrix` format.
 
 ```{r}

--- a/apis/r/vignettes/soma-objects.Rmd
+++ b/apis/r/vignettes/soma-objects.Rmd
@@ -22,7 +22,7 @@ library(tiledbsoma)
 
 ## Example data
 
-Extract the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://mojaveazure.github.io/seurat-object/reference/pbmc_small.html) provided by `SeuratObject`. This will return a file path for the extracted dataset.
+Extract the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://satijalab.github.io/seurat-object/reference/pbmc_small.html) provided by `SeuratObject`. This will return a file path for the extracted dataset.
 
 ```{r}
 uri <- extract_dataset("soma-exp-pbmc-small")

--- a/apis/r/vignettes/soma-reading.Rmd
+++ b/apis/r/vignettes/soma-reading.Rmd
@@ -19,7 +19,7 @@ library(tiledbsoma)
 
 ## Example data
 
-Load the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://mojaveazure.github.io/seurat-object/reference/pbmc_small.html) provided by SeuratObject. This will return a `SOMAExperiment` object. This is a small dataset that easily fits into memory, but we'll focus on operations that can easily scale to larger datasets as well.
+Load the bundled `SOMAExperiment` containing a subsetted version of the 10X genomics [PBMC dataset](https://satijalab.github.io/seurat-object/reference/pbmc_small.html) provided by SeuratObject. This will return a `SOMAExperiment` object. This is a small dataset that easily fits into memory, but we'll focus on operations that can easily scale to larger datasets as well.
 
 ```{r}
 experiment <- load_dataset("soma-exp-pbmc-small")


### PR DESCRIPTION
**Issue and/or context:**

Running R CMD check under r-devel (for an unrelated issue: our use of the dual inequality in Imports actually lead to me filing an upstream R bug ([#18735](https://bugs.r-project.org/show_bug.cgi?id=18735)) for which I wanted assert the fix) flagged that three URLs (pointing at the same spot) had change with Paul handing SeuratObject over to Rahul.

**Changes:**

A simple update of the URL in three vignettes.  No new code, no new tests.

**Notes for Reviewer:**

[SC 48040](https://app.shortcut.com/tiledb-inc/story/48040/r-minor-url-rot-in-vignette-documentation)
