### PR TITLE
Restore/add wheel smoke-tests, parallelize wheel builds

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '310', '311' ]
+        python-version: [ '38', '39', '310', '311' ]
         build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
           - build: manylinux_x86_64

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -57,16 +57,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            cibw_build: 'cp3*-manylinux_x86_64'
+            cibw_build: 'cp31*-manylinux_x86_64'
             platform: manylinux2014
             wheel_name: manylinux2014
           - os: macos-12
-            cibw_build: 'cp3*-macosx_x86_64'
+            cibw_build: 'cp31*-macosx_x86_64'
             cibw_archs_macos: x86_64
             platform: macosx
             wheel_name: macos-x86_64
           - os: macos-12
-            cibw_build: 'cp3*-macosx_arm64'
+            cibw_build: 'cp31*-macosx_arm64'
             cibw_archs_macos: arm64
             platform: macosx
             wheel_name: macos-arm64

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -49,26 +49,25 @@ jobs:
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
-    name: Build wheel ${{ matrix.wheel_name }}
+    name: Build wheel ${{ matrix.python-version }}-${{ matrix.os.wheel-name }}
     needs: sdist
     if: inputs.run-id == ''
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runs-on }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
-        python_version: ['310', '311']
-        include:
-          - os: ubuntu-20.04
-            build_suffix: manylinux_x86_64
-            wheel_name: manylinux2014
-          - os: macos-12
-            build_suffix: macosx_x86_64
+        python-version: ['310', '311']
+        os:
+          - runs-on: ubuntu-20.04
+            build-suffix: manylinux_x86_64
+            wheel-name: manylinux2014
+          - runs-on: macos-12
+            build-suffix: macosx_x86_64
             cibw_archs_macos: x86_64
-            wheel_name: macos-x86_64
-          - os: macos-12
-            build_suffix: macosx_arm64
+            wheel-name: macos-x86_64
+          - runs-on: macos-12
+            build-suffix: macosx_arm64
             cibw_archs_macos: arm64
-            wheel_name: macos-arm64
+            wheel-name: macos-arm64
     steps:
       - name: Download sdist artifact
         uses: actions/download-artifact@v4
@@ -80,44 +79,43 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: tiledbsoma.tar.gz
-          only: cp${{ matrix.python_version }}-${{ matrix.build_suffix }}
+          only: cp${{ matrix.python-version }}-${{ matrix.os.build-suffix }}
         env:
-          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_BUILD: ${{ matrix.os.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_BUILD: bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
           # ^ Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
           #   run CMake build or not. Otherwise it'll keep reusing the library file built in the
           #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
           #   built for the wrong python version.
-          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
-          CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
-      - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
+          CMAKE_OSX_ARCHITECTURES: ${{ matrix.os.cibw_archs_macos }}
+      - name: Upload wheels-${{ matrix.os.wheel-name }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.wheel_name }}-${{ matrix.python_version }}
+          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
   # This step locally tries out the built wheels, without publishing to PyPI
   smoke-test:
-    name: "Smoke test wheels ${{ matrix.wheel_name }}"
+    name: "Smoke test wheel ${{ matrix.python-version }}-${{ matrix.os.wheel-name }}"
     needs: wheels
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runs-on }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
-        python_version: ['310', '311']
-        include:
-          - os: ubuntu-20.04
+        python-version: ['311']
+        os:
+          - runs-on: ubuntu-20.04
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-            wheel_name: manylinux2014
-          - os: macos-12
+            wheel-name: manylinux2014
+          - runs-on: macos-12
             arch: x86_64
             cc: clang
             cxx: clang++
-            wheel_name: macos-x86_64
+            wheel-name: macos-x86_64
           # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
           # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
           # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
@@ -127,11 +125,11 @@ jobs:
           # * unzip whatever.zip
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
-          # - os: macos-12
+          # - runs-on: macos-12
           #   arch: arm64
           #   cc: clang
           #   cxx: clang++
-          #   wheel_name: macos-arm64
+          #   wheel-name: macos-arm64
       fail-fast: false
     steps:
       - name: Set up Python 3.11
@@ -141,24 +139,24 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheel-${{ matrix.wheel_name }}-${{ matrix.python_version }}
+          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python-version }}
           run-id: ${{ inputs.run_id }}
       - name: Install wheel
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python_version }}-cp${{ matrix.python_version }}-*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python-version }}-cp${{ matrix.python-version }}-*_${{ matrix.os.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel
           pip install $WHL
           echo "WHL=$WHL" >> $GITHUB_ENV
-      - name: Smoke test ${{ matrix.os }}
+      - name: Smoke test ${{ matrix.os.runs-on }}
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os.runs-on == 'ubuntu-20.04' }}
         run: |
           docker run -v $(pwd):/mnt python:3.11 bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -8,7 +8,9 @@ on:
   # Specify the branch or other ref as required, allowing testing
   # of PRs/branches.
   workflow_dispatch:
-
+    inputs:
+      ref:
+        description: 'Branch or tag to build'
   # Trigger publication to PyPi via new release event.
   release:
     types: [published]
@@ -27,6 +29,7 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref || github.event.inputs.ref }}
           fetch-depth: 0 # ensure we get all tags to inform package version determination
       - name: Build sdist
         run: python setup.py sdist

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -60,38 +60,22 @@ jobs:
         include:
           - os: ubuntu-20.04
             build_suffix: manylinux_x86_64
-            platform: manylinux2014
             wheel_name: manylinux2014
           - os: macos-12
             build_suffix: macosx_x86_64
             cibw_archs_macos: x86_64
-            platform: macosx
             wheel_name: macos-x86_64
           - os: macos-12
             build_suffix: macosx_arm64
             cibw_archs_macos: arm64
-            platform: macosx
             wheel_name: macos-arm64
     steps:
       - name: Download sdist artifact
         uses: actions/download-artifact@v4
         with:
           name: sdist
-      - name: rename sdist
+      - name: Rename sdist
         run: cp tiledbsoma-*.tar.gz tiledbsoma.tar.gz && ls -lh
-      # This is crucial for ongoing debug (do not remove it) as this shows the
-      # OS version as used by `pip install` to find wheel names. Importantly,
-      # macos 12 and macos14 self-report as `macosx-10.9-universal2` via
-      # `distutil.util.get_platform()`.
-      - name: Show self-reported platform
-        run: |
-          echo "python --version"; python --version
-          echo matrix.platform: ${{ matrix.platform }}
-          echo matrix.arch: ${{ matrix.arch }}
-          # This bit is crucial since it's used to match up to a component of the wheel-file name
-          python -m pip install setuptools
-          python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
-          python -c 'import platform; print("platform.platform()", platform.platform())'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         with:
@@ -125,13 +109,11 @@ jobs:
         python_version: ['310', '311']
         include:
           - os: ubuntu-20.04
-            platform: manylinux2014
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
             wheel_name: manylinux2014
           - os: macos-12
-            platform: macosx
             arch: x86_64
             cc: clang
             cxx: clang++
@@ -146,7 +128,6 @@ jobs:
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
           # - os: macos-12
-          #   platform: macosx
           #   arch: arm64
           #   cc: clang
           #   cxx: clang++
@@ -162,21 +143,11 @@ jobs:
         with:
           name: wheel-${{ matrix.wheel_name }}-${{ matrix.python_version }}
           run-id: ${{ inputs.run_id }}
-      - name: Show self-reported platform
-        run: |
-          sw_vers || /usr/bin/true
-          echo "python --version"; python --version
-          echo matrix.platform: ${{ matrix.platform }}
-          echo matrix.arch: ${{ matrix.arch }}
-          # This bit is crucial since it's used to match up to a component of the wheel-file name
-          python -m pip install setuptools
-          python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
-          python -c 'import platform; print("platform.platform()", platform.platform())'
       - name: Install wheel
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python_version }}-cp${{ matrix.python_version }}-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python_version }}-cp${{ matrix.python_version }}-*_${{ matrix.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
@@ -187,7 +158,7 @@ jobs:
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        if: ${{ matrix.platform == 'manylinux2014' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           docker run -v $(pwd):/mnt python:3.11 bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -11,8 +11,6 @@ on:
     inputs:
       ref:
         description: 'Branch or tag to build'
-      run-id:
-        description: 'Workflow run ID to download wheel artifacts from'
   # Trigger publication to PyPi via new release event.
   release:
     types: [published]
@@ -26,7 +24,6 @@ on:
 jobs:
   sdist:
     name: Build source distribution
-    if: inputs.run-id == ''
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout TileDB-SOMA
@@ -51,7 +48,6 @@ jobs:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
     name: Build wheel ${{ matrix.python-version }}-${{ matrix.wheel-name }}
     needs: sdist
-    if: inputs.run-id == ''
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -149,7 +145,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wheel-${{ matrix.wheel-name }}-${{ matrix.python.v }}
-          run-id: ${{ inputs.run_id }}
       - name: Install wheel
         run: |
           set -x
@@ -182,8 +177,6 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
-        with:
-          run-id: ${{ inputs.run_id }}
       - name: Create dist
         run: |
           set -x
@@ -208,8 +201,6 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
-        with:
-          run-id: ${{ inputs.run_id }}
       - name: Create dist
         run: |
           set -x

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout TileDB-SOMA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # ensure we get all tags to inform package version determination
       - name: Build sdist

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -46,7 +46,7 @@ jobs:
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheel ${{ matrix.wheel_name }}
     needs: sdist
     runs-on: ${{ matrix.os }}
     strategy:
@@ -109,7 +109,7 @@ jobs:
 
   # This step locally tries out the built wheels, without publishing to PyPI
   smoke-test:
-    name: Smoke test wheels
+    name: "Smoke test wheels ${{ matrix.wheel_name }}"
     needs: wheels
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -104,7 +104,11 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       matrix:
-        python-version: ['311']
+        python:
+          - v: '310'
+            vv: '3.10'
+          - v: '311'
+            vv: '3.11'
         os:
           - runs-on: ubuntu-20.04
             arch: x86_64
@@ -132,20 +136,20 @@ jobs:
           #   wheel-name: macos-arm64
       fail-fast: false
     steps:
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python.v }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python.v }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python-version }}
+          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python.v }}
           run-id: ${{ inputs.run_id }}
       - name: Install wheel
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python-version }}-cp${{ matrix.python-version }}-*_${{ matrix.os.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python.v }}-cp${{ matrix.python.v }}-*_${{ matrix.os.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
@@ -158,7 +162,7 @@ jobs:
       - name: Smoke test in docker
         if: ${{ matrix.os.runs-on == 'ubuntu-20.04' }}
         run: |
-          docker run -v $(pwd):/mnt python:3.11 bash -ec "
+          docker run -v $(pwd):/mnt python:${{ matrix.python.vv }} bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
             pip3 install /mnt/$WHL
             python3 -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -117,11 +117,13 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
+            wheel_name: manylinux2014
           - os: macos-12
             platform: macosx
             arch: x86_64
             cc: clang
             cxx: clang++
+            wheel_name: macos-x86_64
           # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
           # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
           # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
@@ -131,11 +133,12 @@ jobs:
           # * unzip whatever.zip
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
-          #- os: macos-12
-          #  platform: macosx
-          #  arch: arm64
-          #  cc: clang
-          #  cxx: clang++
+          # - os: macos-12
+          #   platform: macosx
+          #   arch: arm64
+          #   cc: clang
+          #   cxx: clang++
+          #   wheel_name: macos-arm64
     steps:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
@@ -143,6 +146,8 @@ jobs:
           python-version: 3.11
       - name: Download artifacts
         uses: actions/download-artifact@v3
+        with:
+          name: wheels-${{ matrix.wheel_name }}
       - name: Show self-reported platform
         run: |
           sw_vers || /usr/bin/true
@@ -157,8 +162,8 @@ jobs:
         run: |
           set -x
           ls -lR
-          ls -lR wheels-*
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+          echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -48,18 +48,17 @@ jobs:
     strategy:
       matrix:
         python-version: [ '38', '39', '310', '311' ]
-        build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
+        cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
-          - build: manylinux_x86_64
+          - cibw_build: manylinux_x86_64
             os: ubuntu-20.04
             wheel-name: manylinux2014
-          - build: macosx_x86_64
+          - cibw_build: macosx_x86_64
             os: macos-12
             cibw_archs_macos: x86_64
             wheel-name: macos-x86_64
-          - build: macosx_arm64
-            os: macos-14
-            # ^ Note that macos-14 is arm64 only
+          - cibw_build: macosx_arm64
+            os: macos-14  # Note: macos-14 is arm64 only
             cibw_archs_macos: arm64
             wheel-name: macos-arm64
     steps:
@@ -69,11 +68,24 @@ jobs:
           name: sdist
       - name: Rename sdist
         run: cp tiledbsoma-*.tar.gz tiledbsoma.tar.gz && ls -lh
+      # This is crucial for ongoing debug (do not remove it) as this shows the
+      # OS version as used by `pip install` to find wheel names. Importantly,
+      # macos 12 and macos14 self-report as `macosx-10.9-universal2` via
+      # `distutil.util.get_platform()`.
+      - name: Show self-reported platform
+        run: |
+          echo "python --version"; python --version
+          echo matrix.platform: ${{ matrix.platform }}
+          echo matrix.arch: ${{ matrix.arch }}
+          # This bit is crucial since it's used to match up to a component of the wheel-file name
+          python -m pip install setuptools
+          python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
+          python -c 'import platform; print("platform.platform()", platform.platform())'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1
         with:
           package-dir: tiledbsoma.tar.gz
-          only: cp${{ matrix.python-version }}-${{ matrix.build }}
+          only: cp${{ matrix.python-version }}-${{ matrix.cibw_build }}
         env:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
@@ -94,16 +106,16 @@ jobs:
 
   # This step locally tries out the built wheels, without publishing to PyPI
   smoke-test:
-    name: "Smoke test ${{ matrix.python.v }}-${{ matrix.wheel-name }} wheel"
+    name: "Smoke test ${{ matrix.python.undotted-version }}-${{ matrix.wheel-name }} wheel"
     needs: wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python:
-          - v: '310'
-            vv: '3.10'
-          - v: '311'
-            vv: '3.11'
+          - undotted-version: '310'
+            dotted-version: '3.10'
+          - undotted-version: '311'
+            dotted-version: '3.11'
         wheel-name:
           - manylinux2014
           - macos-x86_64
@@ -126,19 +138,19 @@ jobs:
             cxx: clang++
       fail-fast: false
     steps:
-      - name: Set up Python ${{ matrix.python.vv }}
+      - name: Set up Python ${{ matrix.python.dotted-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python.vv }}
+          python-version: ${{ matrix.python.dotted-version }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheel-${{ matrix.wheel-name }}-${{ matrix.python.v }}
+          name: wheel-${{ matrix.wheel-name }}-${{ matrix.python.undotted-version }}
       - name: Install wheel
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python.v }}-cp${{ matrix.python.v }}-*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python.undotted-version }}-cp${{ matrix.python.undotted-version }}-*_${{ matrix.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
@@ -151,7 +163,7 @@ jobs:
       - name: Smoke test in docker
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
-          docker run -v $(pwd):/mnt python:${{ matrix.python.vv }} bash -ec "
+          docker run -v $(pwd):/mnt python:${{ matrix.python.dotted-version }} bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
             pip3 install /mnt/$WHL
             python3 -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
@@ -204,7 +216,7 @@ jobs:
           verbose: true
 
   # File a bug report if anything fails, but don't file tickets for manual runs
-  # -- only for scheduled ones.  create_issue_on_fail:
+  # -- only for scheduled ones.
   create_issue_on_fail:
     runs-on: ubuntu-latest
     needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -8,9 +8,6 @@ on:
   # Specify the branch or other ref as required, allowing testing
   # of PRs/branches.
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch or tag to build'
   # Trigger publication to PyPi via new release event.
   release:
     types: [published]
@@ -29,7 +26,6 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.event.inputs.ref }}
           fetch-depth: 0 # ensure we get all tags to inform package version determination
       - name: Build sdist
         run: python setup.py sdist

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -49,23 +49,24 @@ jobs:
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
-    name: Build wheel ${{ matrix.python-version }}-${{ matrix.os.wheel-name }}
+    name: Build wheel ${{ matrix.python-version }}-${{ matrix.wheel-name }}
     needs: sdist
     if: inputs.run-id == ''
-    runs-on: ${{ matrix.os.runs-on }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['310', '311']
-        os:
-          - runs-on: ubuntu-20.04
-            build-suffix: manylinux_x86_64
+        python-version: [ '310', '311' ]
+        build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
+        include:
+          - build: manylinux_x86_64
+            os: ubuntu-20.04
             wheel-name: manylinux2014
-          - runs-on: macos-12
-            build-suffix: macosx_x86_64
+          - build: macosx_x86_64
+            os: macos-12
             cibw_archs_macos: x86_64
             wheel-name: macos-x86_64
-          - runs-on: macos-12
-            build-suffix: macosx_arm64
+          - build: macosx_arm64
+            os: macos-12
             cibw_archs_macos: arm64
             wheel-name: macos-arm64
     steps:
@@ -79,29 +80,29 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: tiledbsoma.tar.gz
-          only: cp${{ matrix.python-version }}-${{ matrix.os.build-suffix }}
+          only: cp${{ matrix.python-version }}-${{ matrix.build }}
         env:
-          CIBW_BUILD: ${{ matrix.os.cibw_build }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_BUILD: bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
           # ^ Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
           #   run CMake build or not. Otherwise it'll keep reusing the library file built in the
           #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
           #   built for the wrong python version.
-          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw_archs_macos }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
-          CMAKE_OSX_ARCHITECTURES: ${{ matrix.os.cibw_archs_macos }}
-      - name: Upload wheels-${{ matrix.os.wheel-name }} to GitHub Actions storage
+          CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
+      - name: Upload wheel-${{ matrix.wheel-name }}-${{ matrix.python-version }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python-version }}
+          name: wheel-${{ matrix.wheel-name }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
   # This step locally tries out the built wheels, without publishing to PyPI
   smoke-test:
-    name: "Smoke test wheel ${{ matrix.python-version }}-${{ matrix.os.wheel-name }}"
+    name: "Smoke test wheel ${{ matrix.python.v }}-${{ matrix.wheel-name }}"
     needs: wheels
-    runs-on: ${{ matrix.os.runs-on }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python:
@@ -109,17 +110,21 @@ jobs:
             vv: '3.10'
           - v: '311'
             vv: '3.11'
-        os:
-          - runs-on: ubuntu-20.04
+        wheel-name:
+          - manylinux2014
+          - macos-x86_64
+          # - macos-arm64
+        include:
+          - wheel-name: manylinux2014
+            os: ubuntu-20.04
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-            wheel-name: manylinux2014
-          - runs-on: macos-12
+          - wheel-name: macos-x86_64
+            os: macos-12
             arch: x86_64
             cc: clang
             cxx: clang++
-            wheel-name: macos-x86_64
           # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
           # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
           # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
@@ -129,38 +134,38 @@ jobs:
           # * unzip whatever.zip
           # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
-          # - runs-on: macos-12
+          # - wheel-name: macos-arm64
+          #   os: macos-12
           #   arch: arm64
           #   cc: clang
           #   cxx: clang++
-          #   wheel-name: macos-arm64
       fail-fast: false
     steps:
-      - name: Set up Python ${{ matrix.python.v }}
+      - name: Set up Python ${{ matrix.python.vv }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python.v }}
+          python-version: ${{ matrix.python.vv }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheel-${{ matrix.os.wheel-name }}-${{ matrix.python.v }}
+          name: wheel-${{ matrix.wheel-name }}-${{ matrix.python.v }}
           run-id: ${{ inputs.run_id }}
       - name: Install wheel
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python.v }}-cp${{ matrix.python.v }}-*_${{ matrix.os.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python.v }}-cp${{ matrix.python.v }}-*_${{ matrix.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
           pip install wheel
           pip install $WHL
           echo "WHL=$WHL" >> $GITHUB_ENV
-      - name: Smoke test ${{ matrix.os.runs-on }}
+      - name: Smoke test ${{ matrix.os }}
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        if: ${{ matrix.os.runs-on == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           docker run -v $(pwd):/mnt python:${{ matrix.python.vv }} bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
@@ -183,7 +188,7 @@ jobs:
         run: |
           set -x
           mkdir dist
-          cp sdist/tiledbsoma-*.tar.gz wheels-*/*.whl dist
+          cp sdist/tiledbsoma-*.tar.gz wheel-*/*.whl dist
           ls -l dist
       - name: Publish packages to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -209,7 +214,7 @@ jobs:
         run: |
           set -x
           mkdir dist
-          cp sdist/tiledbsoma-*.tar.gz wheels-*/*.whl dist
+          cp sdist/tiledbsoma-*.tar.gz wheel-*/*.whl dist
           ls -l dist
       - name: Publish packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -58,7 +58,8 @@ jobs:
             cibw_archs_macos: x86_64
             wheel-name: macos-x86_64
           - build: macosx_arm64
-            os: macos-12
+            os: macos-14
+            # ^ Note that macos-14 is arm64 only
             cibw_archs_macos: arm64
             wheel-name: macos-arm64
     steps:
@@ -69,7 +70,7 @@ jobs:
       - name: Rename sdist
         run: cp tiledbsoma-*.tar.gz tiledbsoma.tar.gz && ls -lh
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.18.1
         with:
           package-dir: tiledbsoma.tar.gz
           only: cp${{ matrix.python-version }}-${{ matrix.build }}
@@ -84,6 +85,7 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
       - name: Upload wheel-${{ matrix.wheel-name }}-${{ matrix.python-version }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:
@@ -105,7 +107,7 @@ jobs:
         wheel-name:
           - manylinux2014
           - macos-x86_64
-          # - macos-arm64
+          - macos-arm64
         include:
           - wheel-name: manylinux2014
             os: ubuntu-20.04
@@ -117,20 +119,11 @@ jobs:
             arch: x86_64
             cc: clang
             cxx: clang++
-          # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
-          # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
-          # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
-          #   https://github.com/github/roadmap/issues/528
-          # Any smoke-testing for arm64 wheels needs to be done manually by:
-          # * Download the whatever.zip file from GitHub Actions -> our instance -> Artifacts
-          # * unzip whatever.zip
-          # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
-          #
-          # - wheel-name: macos-arm64
-          #   os: macos-12
-          #   arch: arm64
-          #   cc: clang
-          #   cxx: clang++
+          - wheel-name: macos-arm64
+            os: macos-14
+            arch: arm64
+            cc: clang
+            cxx: clang++
       fail-fast: false
     steps:
       - name: Set up Python ${{ matrix.python.vv }}

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -42,7 +42,7 @@ jobs:
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
-    name: Build wheel ${{ matrix.python-version }}-${{ matrix.wheel-name }}
+    name: Build ${{ matrix.python-version }}-${{ matrix.wheel-name }} wheel
     needs: sdist
     runs-on: ${{ matrix.os }}
     strategy:
@@ -92,7 +92,7 @@ jobs:
 
   # This step locally tries out the built wheels, without publishing to PyPI
   smoke-test:
-    name: "Smoke test wheel ${{ matrix.python.v }}-${{ matrix.wheel-name }}"
+    name: "Smoke test ${{ matrix.python.v }}-${{ matrix.wheel-name }} wheel"
     needs: wheels
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -55,18 +55,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-20.04, macos-12]
+        python_version: ['310', '311']
         include:
           - os: ubuntu-20.04
-            cibw_build: 'cp31*-manylinux_x86_64'
+            build_suffix: manylinux_x86_64
             platform: manylinux2014
             wheel_name: manylinux2014
           - os: macos-12
-            cibw_build: 'cp31*-macosx_x86_64'
+            build_suffix: macosx_x86_64
             cibw_archs_macos: x86_64
             platform: macosx
             wheel_name: macos-x86_64
           - os: macos-12
-            cibw_build: 'cp31*-macosx_arm64'
+            build_suffix: macosx_arm64
             cibw_archs_macos: arm64
             platform: macosx
             wheel_name: macos-arm64
@@ -94,6 +96,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: tiledbsoma.tar.gz
+          only: cp${{ matrix.python_version }}-${{ matrix.build_suffix }}
         env:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
@@ -108,7 +111,7 @@ jobs:
       - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.wheel_name }}
+          name: wheel-${{ matrix.wheel_name }}-${{ matrix.python_version }}
           path: ./wheelhouse/*.whl
 
   # This step locally tries out the built wheels, without publishing to PyPI
@@ -118,6 +121,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-20.04, macos-12]
+        python_version: ['310', '311']
         include:
           - os: ubuntu-20.04
             platform: manylinux2014
@@ -155,7 +160,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheels-${{ matrix.wheel_name }}
+          name: wheel-${{ matrix.wheel_name }}-${{ matrix.python_version }}
           run-id: ${{ inputs.run_id }}
       - name: Show self-reported platform
         run: |
@@ -171,7 +176,7 @@ jobs:
         run: |
           set -x
           ls -lR
-          WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
+          WHL=$(find . -name 'tiledbsoma-*-cp${{ matrix.python_version }}-cp${{ matrix.python_version }}-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           echo "WHL=$WHL"
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -142,6 +142,7 @@ jobs:
           #   cc: clang
           #   cxx: clang++
           #   wheel_name: macos-arm64
+      fail-fast: false
     steps:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -58,7 +58,7 @@ jobs:
             cibw_archs_macos: x86_64
             platform: macosx
             wheel_name: macos-x86_64
-          - os: macos-14
+          - os: macos-12
             cibw_build: 'cp3*-macosx_arm64'
             cibw_archs_macos: arm64
             platform: macosx
@@ -98,42 +98,6 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
-      # See https://github.com/single-cell-data/TileDB-SOMA/pull/2620
-      #
-      # * MacOS 12 and 14 self-report as `macosx-10.9-universal2` via
-      #   `distutil.util.get_platform()`.
-      # * Due to https://github.com/single-cell-data/TileDB-SOMA/pull/2124 we build
-      #   with `-mmacosx-version-min=11.0` which overrides any attempt at
-      #   setting `CMAKE_OSX_DEPLOYMENT_TARGET` in our env here.
-      # * This means a MacOS 12/14 system can self-report as 10.9, see
-      #   a wheel at 11.0, and refuse the install, claiming that no suitable
-      #   OS-version support can be found in the wheel.
-      # Therefore we rename the wheel's reported supported MacOS version to
-      # match the self-reported OS version of today's clients.
-      #
-      # Example file names we assume here:
-      # tiledbsoma-VERSIONHERE-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_x86_64.whl
-      # tiledbsoma-VERSIONHERE-cp311-cp311-macosx_14_0_arm64.whl
-      - name: MacOS portability step
-        run: |
-          pwd
-          ls -l
-          cd wheelhouse
-          ls -l
-          for wheel_file_name in *.whl; do
-            if expr "$wheel_file_name" : ".*macosx_11_0.*"; then
-              new_name=$(echo $wheel_file_name | sed "s/macosx_11_0/macosx_10_9/")
-              if [ "$wheel_file_name" = "$new_name" ]; then
-                echo "Failed to rename $wheel_file_name"
-                exit 1
-              fi
-              echo Renaming $wheel_file_name to $new_name
-              mv $wheel_file_name $new_name
-            fi
-          done
-          cd ..
-          echo
       - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
         uses: actions/upload-artifact@v3
         with:
@@ -153,16 +117,21 @@ jobs:
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
-          # Follow-up flagged in https://github.com/single-cell-data/TileDB-SOMA/issues/2634
-          # TL;DR direct pip-install of the wheel file fails bafflingly (see #2634 for details)
-          # but works in non-GHA environments including laptops and MacOS EC2 instances.
+          - os: macos-12
+            platform: macosx
+            arch: x86_64
+            cc: clang
+            cxx: clang++
+          # TODO: As of 2023-05-18 all we can do in GitHub Actions for MacOS arm64 is cross-compile the wheels
+          # for arm64, while actually running on x86 hardware. This means we can build the wheels but we cannot
+          # smoke-test them. This is pending MacOS arm64 runners for GitHub Actions which is tracked here:
+          #   https://github.com/github/roadmap/issues/528
+          # Any smoke-testing for arm64 wheels needs to be done manually by:
+          # * Download the whatever.zip file from GitHub Actions -> our instance -> Artifacts
+          # * unzip whatever.zip
+          # * pip install tiledbsoma-i.j.k-cp310-cp310-macosx_11_0_arm64.whl
           #
           #- os: macos-12
-          #  platform: macosx
-          #  arch: x86_64
-          #  cc: clang
-          #  cxx: clang++
-          #- os: macos-14
           #  platform: macosx
           #  arch: arm64
           #  cc: clang
@@ -192,8 +161,8 @@ jobs:
           WHL=$(find . -name 'tiledbsoma-*-cp311-cp311-*${{ matrix.platform }}*_${{ matrix.arch }}.whl')
           if [ -z "$WHL" ]; then echo "No wheel found"; exit 1; fi
           unzip -l $WHL
-          python -m pip install wheel
-          python -m pip install -vv $WHL
+          pip install wheel
+          pip install $WHL
           echo "WHL=$WHL" >> $GITHUB_ENV
       - name: Smoke test ${{ matrix.os }}
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
@@ -254,7 +223,7 @@ jobs:
           verbose: true
 
   # File a bug report if anything fails, but don't file tickets for manual runs
-  # -- only for scheduled ones.
+  # -- only for scheduled ones.  create_issue_on_fail:
   create_issue_on_fail:
     runs-on: ubuntu-latest
     needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -11,6 +11,8 @@ on:
     inputs:
       ref:
         description: 'Branch or tag to build'
+      run-id:
+        description: 'Workflow run ID to download wheel artifacts from'
   # Trigger publication to PyPi via new release event.
   release:
     types: [published]
@@ -24,6 +26,7 @@ on:
 jobs:
   sdist:
     name: Build source distribution
+    if: inputs.run-id == ''
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout TileDB-SOMA
@@ -35,7 +38,7 @@ jobs:
         run: python setup.py sdist
         working-directory: ./apis/python
       - name: Upload sdist artifact to GitHub Actions storage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: apis/python/dist/
@@ -48,6 +51,7 @@ jobs:
     # Note: tries all supported Python versions as specified in apis/python/setup.py
     name: Build wheel ${{ matrix.wheel_name }}
     needs: sdist
+    if: inputs.run-id == ''
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -68,7 +72,7 @@ jobs:
             wheel_name: macos-arm64
     steps:
       - name: Download sdist artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
       - name: rename sdist
@@ -102,7 +106,7 @@ jobs:
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
       - name: Upload wheels-${{ matrix.wheel_name }} to GitHub Actions storage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.wheel_name }}
           path: ./wheelhouse/*.whl
@@ -149,9 +153,10 @@ jobs:
         with:
           python-version: 3.11
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-${{ matrix.wheel_name }}
+          run-id: ${{ inputs.run_id }}
       - name: Show self-reported platform
         run: |
           sw_vers || /usr/bin/true
@@ -193,7 +198,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ inputs.run_id }}
       - name: Create dist
         run: |
           set -x
@@ -217,7 +224,9 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ inputs.run_id }}
       - name: Create dist
         run: |
           set -x


### PR DESCRIPTION
**Issue and/or context:** #2634

## Changes
Several improvements to `python-packaging.yml` ("sdist & wheels" GHA):
- Parallelize over Python versions (3x4 4-minute jobs instead of 3 4x4-minute jobs)
- Restore/Add wheel "smoke tests"
  - Restore macOS wheel smoke-test (x86 only; ~ARM still WIP~ now includes ARM, thanks @dudoslav / #2641)
  - Add smoke-tests for Python 3.10 (in addition to 3.11), across 3 {os,arch}'s
- Only download necessary artifacts in each job (previously each smoke-test downloaded wheels for all {os,arch,python} combos)

### [Before](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9212122517)
[![Screenshot 2024-05-24 at 12 45 28 AM](https://github.com/single-cell-data/TileDB-SOMA/assets/465045/f7ff2ba5-5c84-469c-b89c-d11b6ef99ae3)](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9212122517)

### [After](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9225202748)

[![](https://github.com/single-cell-data/TileDB-SOMA/assets/465045/cde80cfe-de96-4e18-93e2-4ec19de8ae0b)](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9225202748)
