### PR TITLE
[c++] Pass in a `shared_ptr<Context>` to `_create_dim_aux`

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -413,25 +413,25 @@ Dimension ArrowAdapter::_create_dim(
             return Dimension::create(
                 *ctx, name, type, (uint64_t*)buff, (uint64_t*)buff + 2);
         case TILEDB_INT8:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (int8_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (int8_t*)buff);
         case TILEDB_UINT8:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (uint8_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (uint8_t*)buff);
         case TILEDB_INT16:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (int16_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (int16_t*)buff);
         case TILEDB_UINT16:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (uint16_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (uint16_t*)buff);
         case TILEDB_INT32:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (int32_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (int32_t*)buff);
         case TILEDB_UINT32:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (uint32_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (uint32_t*)buff);
         case TILEDB_INT64:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (int64_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (int64_t*)buff);
         case TILEDB_UINT64:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (uint64_t*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (uint64_t*)buff);
         case TILEDB_FLOAT32:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (float*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (float*)buff);
         case TILEDB_FLOAT64:
-            return ArrowAdapter::_create_dim_aux(*ctx, name, (double*)buff);
+            return ArrowAdapter::_create_dim_aux(ctx, name, (double*)buff);
         default:
             throw TileDBSOMAError(fmt::format(
                 "ArrowAdapter: Unsupported TileDB dimension: {} ",

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -239,8 +239,9 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx);
 
     template <typename T>
-    static Dimension _create_dim_aux(Context ctx, std::string name, T* b) {
-        return Dimension::create<T>(ctx, name, {b[0], b[1]}, b[2]);
+    static Dimension _create_dim_aux(
+        std::shared_ptr<Context> ctx, std::string name, T* b) {
+        return Dimension::create<T>(*ctx, name, {b[0], b[1]}, b[2]);
     }
 
     static bool _isvar(const char* format);


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2644

* Derefencing and passing a `Context` object into `_create_dim_aux` prematurely decrements a reference count to the `Context` which then garbage collects the object. When we attempt to reference the `shared_ptr<Context>` again, it is invalid and segfaults
* Fixes intermittent bug in Release mode that is consistently reproducible in Debug mode
