### PR TITLE
[c++] Fix validity buffer bit unpacking

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1437,12 +1437,23 @@ def test_enum_schema_report(tmp_path):
 def test_nullable(tmp_path):
     uri = tmp_path.as_posix()
 
-    asch = pa.schema([pa.field("foo", pa.int32())], metadata={"foo": "nullable"})
+    asch = pa.schema(
+        [
+            pa.field("int", pa.int32()),
+            pa.field("bool", pa.bool_()),
+            pa.field("ord", pa.dictionary(pa.int64(), pa.string())),
+        ]
+    )
 
     pydict = {}
-    pydict["soma_joinid"] = [0, 1, 2, 3, 4]
-    pydict["foo"] = [10, 20, 30, None, 50]
+    pydict["soma_joinid"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    pydict["int"] = [1, 2, 3, 4, 5, 6, None, 8, None, None]
+    pydict["bool"] = [True, True, True, False, True, False, None, False, None, None]
+    pydict["ord"] = pd.Categorical(
+        ["g1", "g2", "g3", None, "g2", "g3", "g1", None, "g3", "g1"]
+    )
     data = pa.Table.from_pydict(pydict)
+
 
     with soma.DataFrame.create(uri, schema=asch) as sdf:
         sdf.write(data)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1454,7 +1454,6 @@ def test_nullable(tmp_path):
     )
     data = pa.Table.from_pydict(pydict)
 
-
     with soma.DataFrame.create(uri, schema=asch) as sdf:
         sdf.write(data)
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -147,7 +147,12 @@ class ColumnBuffer {
 
         if (is_nullable_) {
             if (validity != nullptr) {
-                validity_.assign(validity, validity + num_elems);
+                for (uint64_t i = 0; i * 8 < num_elems; ++i) {
+                    uint8_t byte = ((uint8_t*)validity)[i];
+                    for (int64_t j = 0; j < 8 && i * 8 + j < num_elems; ++j) {
+                        validity_.push_back((uint8_t)((byte >> j) & 0x01));
+                    }
+                }
             } else {
                 validity_.resize(num_elems);
                 std::fill(validity_.begin(), validity_.end(), 1);
@@ -182,10 +187,15 @@ class ColumnBuffer {
         data_.assign((std::byte*)data, (std::byte*)data + data_size_);
 
         if (is_nullable_) {
+            validity_.resize(num_elems);
             if (validity != nullptr) {
-                validity_.assign(validity, validity + num_elems);
+                for (uint64_t i = 0; i * 8 < num_elems; ++i) {
+                    uint8_t byte = ((uint8_t*)validity)[i];
+                    for (int64_t j = 0; j < 8; ++j) {
+                        validity_.push_back((uint8_t)((byte >> j) & 0x01));
+                    }
+                }
             } else {
-                validity_.resize(num_elems);
                 std::fill(validity_.begin(), validity_.end(), 1);
             }
         }


### PR DESCRIPTION
**Issue and/or context:**

This bug was caught when C++-ifying the SOMA R API. https://github.com/single-cell-data/TileDB-SOMA/pull/2629 originally contains the bug fix but has now separated out into this new PR.

**Changes:**

* In Arrow, the validity buffer is stored as bitpacked buffers whereas in TileDB, they are stored as uint8_t buffers. We need to properly unpack the bits and cast them to uint8_t on writes
* Although we have unit tests in the SOMA Python API for nullable attributes in several areas, they somehow happened to write and read back fine so this issue went uncaught. This PR adds a new unit test that fails currently on main but is fixed by this PR