### PR TITLE
[python] Move `SOMAGroup` to use C++ bindings

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -469,17 +469,13 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         if entry.soma is None:
             from . import _factory  # Delayed binding to resolve circular import.
 
-            if isinstance(entry.entry, str):
-                uri = entry.entry
-            else:
-                uri = entry.entry.uri
+            uri = entry.entry.uri
             mode = self.mode
             context = self.context
             timestamp = self.tiledb_timestamp_ms
+            clib_type = entry.entry.wrapper_type.clib_type
 
-            # clib_type = entry.entry.wrapper_type.clib_type
-            # wrapper = _tdb_handles.open(uri, mode, context, timestamp, clib_type)
-            wrapper = _tdb_handles.open(uri, mode, context, timestamp)
+            wrapper = _tdb_handles.open(uri, mode, context, timestamp, clib_type)
             entry.soma = _factory.reify_handle(wrapper)
 
             # Since we just opened this object, we own it and should close it.
@@ -724,7 +720,7 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
     __slots__ = ()
 
     _wrapper_type = _tdb_handles.GroupWrapper
-    _reader_wrapper_type = _tdb_handles.SOMACollection
+    _reader_wrapper_type = _tdb_handles.CollectionWrapper
 
 
 @typeguard_ignore

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -46,7 +46,7 @@ from ._exception import (
     is_already_exists_error,
     is_does_not_exist_error,
     is_not_createable_error,
-    map_exception_for_create
+    map_exception_for_create,
 )
 from ._funcs import typeguard_ignore
 from ._sparse_nd_array import SparseNDArray
@@ -748,7 +748,6 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
                 uri=uri, ctx=context.native_context, timestamp=(0, timestamp_ms)
             )
             handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
-            cls._set_create_metadata(handle)
             return cls(
                 handle,
                 _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -126,7 +126,6 @@ class DataFrame(SOMAArray, somacore.DataFrame):
     """
 
     _wrapper_type = DataFrameWrapper
-    _reader_wrapper_type = DataFrameWrapper
 
     @classmethod
     def create(

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -81,7 +81,6 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     __slots__ = ()
 
     _wrapper_type = DenseNDArrayWrapper
-    _reader_wrapper_type = DenseNDArrayWrapper
 
     @classmethod
     def create(

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -6,10 +6,6 @@
 """Exceptions.
 """
 
-from typing import Union
-
-import tiledb
-
 
 class SOMAError(Exception):
     """Base error type for SOMA-specific exceptions.
@@ -29,16 +25,16 @@ class DoesNotExistError(SOMAError):
     pass
 
 
-def is_does_not_exist_error(e: Union[RuntimeError, tiledb.TileDBError]) -> bool:
-    """Given a TileDBError, return true if it indicates the object does not exist
+def is_does_not_exist_error(e: RuntimeError) -> bool:
+    """Given a RuntimeError, return true if it indicates the object does not exist
 
     Lifecycle: maturing
 
     Example:
         try:
-            with tiledb.open(uri):
+            with tiledbsoma.open(uri):
                 ...
-        except tiledb.TileDBError as e:
+        except RuntimeError as e:
             if is_does_not_exist_error(e):
                 ...
             raise e
@@ -66,16 +62,16 @@ class AlreadyExistsError(SOMAError):
     pass
 
 
-def is_already_exists_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
-    """Given a TileDBError, return true if it indicates the object already exists
+def is_already_exists_error(e: SOMAError) -> bool:
+    """Given a SOMAError, return true if it indicates the object already exists
 
     Lifecycle: experimental
 
     Example:
         try:
-            tiledb.Array.create(uri, schema, ctx=ctx)
+            clib.SOMASparseNDArray.create(...)
                 ...
-        except tiledb.TileDBError as e:
+        except SOMAError as e:
             if is_already_exists_error(e):
                 ...
             raise e
@@ -96,7 +92,7 @@ class NotCreateableError(SOMAError):
     pass
 
 
-def is_not_createable_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
+def is_not_createable_error(e: SOMAError) -> bool:
     """Given a TileDBError, return true if it indicates the object cannot be created
 
     Lifecycle: experimental
@@ -132,7 +128,7 @@ def is_not_createable_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
     return False
 
 
-def is_duplicate_group_key_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
+def is_duplicate_group_key_error(e: SOMAError) -> bool:
     """Given a TileDBError, return try if it indicates a duplicate member
     add request in a tiledb.Group.
 

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -66,8 +66,8 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
 
     __slots__ = ()
     _wrapper_type = _tdb_handles.GroupWrapper
-    _reader_wrapper_type = _tdb_handles.GroupWrapper
-    
+    _reader_wrapper_type = _tdb_handles.ExperimentWrapper
+
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from somacore import experiment, query
 from typing_extensions import Self
 
+from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._indexer import IntIndexer
@@ -64,7 +65,9 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
-
+    _wrapper_type = _tdb_handles.GroupWrapper
+    _reader_wrapper_type = _tdb_handles.GroupWrapper
+    
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -8,24 +8,29 @@
 import functools
 from typing import Any, Optional
 
-from somacore import experiment, query
+from somacore import experiment, options, query
 from typing_extensions import Self
 
 from . import _tdb_handles
+from . import pytiledbsoma as clib
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
+from ._exception import SOMAError, map_exception_for_create
 from ._indexer import IntIndexer
 from ._measurement import Measurement
 from ._tdb_handles import Wrapper
-from ._tiledb_object import AnyTileDBObject
+from ._soma_object import AnySOMAObject
+from ._types import OpenTimestamp
+from .options import SOMATileDBContext
+from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
 
 class Experiment(  # type: ignore[misc]  # __eq__ false positive
-    CollectionBase[AnyTileDBObject],
+    CollectionBase[AnySOMAObject],
     experiment.Experiment[  # type: ignore[type-var]
         DataFrame,
         Collection[Measurement],
-        AnyTileDBObject,
+        AnySOMAObject,
     ],
 ):
     """A collection subtype that combines observations and measurements
@@ -65,13 +70,38 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
-    _wrapper_type = _tdb_handles.GroupWrapper
-    _reader_wrapper_type = _tdb_handles.ExperimentWrapper
+    _wrapper_type = _tdb_handles.ExperimentWrapper
 
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
     }
+
+    @classmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
+    ) -> Self:
+        context = _validate_soma_tiledb_context(context)
+        try:
+            timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
+            clib.SOMAGroup.create(
+                uri=uri,
+                soma_type="SOMAExperiment",
+                ctx=context.native_context,
+                timestamp=(0, timestamp_ms),
+            )
+            handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
+            return cls(
+                handle,
+                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+            )
+        except SOMAError as e:
+            raise map_exception_for_create(e, uri) from None
 
     @classmethod
     def _set_create_metadata(cls, handle: Wrapper[Any]) -> None:

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -8,21 +8,16 @@
 import functools
 from typing import Any, Optional
 
-from somacore import experiment, options, query
+from somacore import experiment, query
 from typing_extensions import Self
 
 from . import _tdb_handles
-from . import pytiledbsoma as clib
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
-from ._exception import SOMAError, map_exception_for_create
 from ._indexer import IntIndexer
 from ._measurement import Measurement
-from ._tdb_handles import Wrapper
 from ._soma_object import AnySOMAObject
-from ._types import OpenTimestamp
-from .options import SOMATileDBContext
-from .options._soma_tiledb_context import _validate_soma_tiledb_context
+from ._tdb_handles import Wrapper
 
 
 class Experiment(  # type: ignore[misc]  # __eq__ false positive
@@ -70,38 +65,13 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
+
     _wrapper_type = _tdb_handles.ExperimentWrapper
 
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
     }
-
-    @classmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[OpenTimestamp] = None,
-    ) -> Self:
-        context = _validate_soma_tiledb_context(context)
-        try:
-            timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
-            clib.SOMAGroup.create(
-                uri=uri,
-                soma_type="SOMAExperiment",
-                ctx=context.native_context,
-                timestamp=(0, timestamp_ms),
-            )
-            handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
-            return cls(
-                handle,
-                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
-            )
-        except SOMAError as e:
-            raise map_exception_for_create(e, uri) from None
 
     @classmethod
     def _set_create_metadata(cls, handle: Wrapper[Any]) -> None:

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -28,9 +28,9 @@ from . import (
     _dense_nd_array,
     _experiment,
     _measurement,
+    _soma_object,
     _sparse_nd_array,
     _tdb_handles,
-    _soma_object,
 )
 from ._constants import (
     SOMA_ENCODING_VERSION,

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -6,20 +6,26 @@
 """Implementation of a SOMA Measurement.
 """
 
-from typing import Union
+from typing import Optional, Union
 
-from somacore import measurement
+from somacore import measurement, options
+from typing_extensions import Self
 
 from . import _tdb_handles
+from . import pytiledbsoma as clib
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
+from ._exception import SOMAError, map_exception_for_create
 from ._sparse_nd_array import SparseNDArray
-from ._tiledb_object import AnyTileDBObject
+from ._soma_object import AnySOMAObject
+from ._types import OpenTimestamp
+from .options import SOMATileDBContext
+from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
 
 class Measurement(  # type: ignore[misc]  # __eq__ false positive
-    CollectionBase[AnyTileDBObject],
+    CollectionBase[AnySOMAObject],
     measurement.Measurement[  # type: ignore[type-var]
         DataFrame,
         Collection[
@@ -27,7 +33,7 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
         ],  # not just `NDArray` since that has no common `read`
         Collection[DenseNDArray],
         Collection[SparseNDArray],
-        AnyTileDBObject,
+        AnySOMAObject,
     ],
 ):
     """A set of observations defined by a dataframe, with measurements.
@@ -71,8 +77,33 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
-    _wrapper_type = _tdb_handles.GroupWrapper
-    _reader_wrapper_type = _tdb_handles.MeasurementWrapper
+    _wrapper_type = _tdb_handles.MeasurementWrapper
+
+    @classmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
+    ) -> Self:
+        context = _validate_soma_tiledb_context(context)
+        try:
+            timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
+            clib.SOMAGroup.create(
+                uri=uri,
+                soma_type="SOMAMeasurement",
+                ctx=context.native_context,
+                timestamp=(0, timestamp_ms),
+            )
+            handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
+            return cls(
+                handle,
+                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+            )
+        except SOMAError as e:
+            raise map_exception_for_create(e, uri) from None
 
     _subclass_constrained_soma_types = {
         "var": ("SOMADataFrame",),

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -10,6 +10,7 @@ from typing import Union
 
 from somacore import measurement
 
+from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
@@ -70,7 +71,9 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
-
+    _wrapper_type = _tdb_handles.GroupWrapper
+    _reader_wrapper_type = _tdb_handles.GroupWrapper
+    
     _subclass_constrained_soma_types = {
         "var": ("SOMADataFrame",),
         "X": ("SOMACollection",),

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -6,22 +6,16 @@
 """Implementation of a SOMA Measurement.
 """
 
-from typing import Optional, Union
+from typing import Union
 
-from somacore import measurement, options
-from typing_extensions import Self
+from somacore import measurement
 
 from . import _tdb_handles
-from . import pytiledbsoma as clib
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
-from ._exception import SOMAError, map_exception_for_create
-from ._sparse_nd_array import SparseNDArray
 from ._soma_object import AnySOMAObject
-from ._types import OpenTimestamp
-from .options import SOMATileDBContext
-from .options._soma_tiledb_context import _validate_soma_tiledb_context
+from ._sparse_nd_array import SparseNDArray
 
 
 class Measurement(  # type: ignore[misc]  # __eq__ false positive
@@ -77,33 +71,8 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
-    _wrapper_type = _tdb_handles.MeasurementWrapper
 
-    @classmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[SOMATileDBContext] = None,
-        tiledb_timestamp: Optional[OpenTimestamp] = None,
-    ) -> Self:
-        context = _validate_soma_tiledb_context(context)
-        try:
-            timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
-            clib.SOMAGroup.create(
-                uri=uri,
-                soma_type="SOMAMeasurement",
-                ctx=context.native_context,
-                timestamp=(0, timestamp_ms),
-            )
-            handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
-            return cls(
-                handle,
-                _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
-            )
-        except SOMAError as e:
-            raise map_exception_for_create(e, uri) from None
+    _wrapper_type = _tdb_handles.MeasurementWrapper
 
     _subclass_constrained_soma_types = {
         "var": ("SOMADataFrame",),

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -72,8 +72,8 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
 
     __slots__ = ()
     _wrapper_type = _tdb_handles.GroupWrapper
-    _reader_wrapper_type = _tdb_handles.GroupWrapper
-    
+    _reader_wrapper_type = _tdb_handles.MeasurementWrapper
+
     _subclass_constrained_soma_types = {
         "var": ("SOMADataFrame",),
         "X": ("SOMACollection",),

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -13,12 +13,12 @@ from . import _tdb_handles, _util
 
 # This package's pybind11 code
 from . import pytiledbsoma as clib  # noqa: E402
-from ._tiledb_object import TileDBObject
+from ._soma_object import SOMAObject
 from ._types import OpenTimestamp, is_nonstringy_sequence
 from .options._soma_tiledb_context import SOMATileDBContext
 
 
-class SOMAArray(TileDBObject[_tdb_handles.SOMAArrayWrapper[Any]]):
+class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
     """Base class for all SOMAArrays: DataFrame and NDarray.
 
     Lifecycle:

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -103,7 +103,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     __slots__ = ()
 
     _wrapper_type = SparseNDArrayWrapper
-    _reader_wrapper_type = SparseNDArrayWrapper
 
     # Inherited from somacore
     # * ndim accessor

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -46,6 +46,7 @@ RawHandle = Union[
     clib.SOMADataFrame,
     clib.SOMASparseNDArray,
     clib.SOMADenseNDArray,
+    clib.SOMAGroup,
     clib.SOMACollection,
 ]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
@@ -93,7 +94,7 @@ def open(
     if soma_type == "somasparsendarray":
         return SparseNDArrayWrapper._from_soma_object(soma_object, context)
 
-    if soma_type == "somacollection" and mode == "r":
+    if soma_type == "somacollection":
         return CollectionWrapper._from_soma_object(soma_object, context)
     if soma_type == "somaexperiment" and mode == "r":
         return ExperimentWrapper._from_soma_object(soma_object, context)
@@ -384,7 +385,7 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
 
     def _do_initial_reads(self, group: clib.SOMAGroup) -> None:
         super()._do_initial_reads(group)
-        
+
         self.initial_contents = {
             name: GroupEntry.from_soma_group_entry(entry)
             for name, entry in group.members().items()
@@ -396,15 +397,18 @@ class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
 
     _WRAPPED_TYPE = clib.SOMACollection
 
+
 class ExperimentWrapper(SOMAGroupWrapper[clib.SOMAExperiment]):
     """Wrapper around a Pybind11 ExperimentWrapper handle."""
 
     _WRAPPED_TYPE = clib.SOMAExperiment
-    
+
+
 class MeasurementWrapper(SOMAGroupWrapper[clib.SOMAMeasurement]):
     """Wrapper around a Pybind11 MeasurementWrapper handle."""
 
     _WRAPPED_TYPE = clib.SOMAMeasurement
+
 
 _ArrType = TypeVar("_ArrType", bound=clib.SOMAArray)
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -396,12 +396,6 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def dim_names(self) -> Tuple[str, ...]:
         return tuple(self._handle.dimension_names)
 
-    def enum(self, label: str):
-        # The DataFrame handle may either be ArrayWrapper or DataFrameWrapper.
-        # enum is only used in the DataFrame write path and is implemented by
-        # ArrayWrapper. If enum is called in the read path, it is an error.
-        raise NotImplementedError
-
     @property
     def shape(self) -> Tuple[int, ...]:
         return tuple(self._handle.shape)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -363,7 +363,7 @@ _GrpType = TypeVar("_GrpType", bound=clib.SOMAGroup)
 class SOMAGroupWrapper(Wrapper[_GrpType]):
     """Base class for Pybind11 SOMAGroupWrapper handles."""
 
-    _WRAPPED_TYPE: Type[_GrpType]
+    _GROUP_WRAPPED_TYPE: Type[_GrpType]
 
     clib_type = "SOMAGroup"
 
@@ -376,12 +376,14 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
         timestamp: int,
     ) -> clib.SOMAGroup:
         open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
-        return cls._WRAPPED_TYPE.open(
+        obj = cls._GROUP_WRAPPED_TYPE.open(
             uri,
             open_mode,
             context=context.native_context,
             timestamp=(0, timestamp),
         )
+        
+        return obj
 
     def _do_initial_reads(self, group: clib.SOMAGroup) -> None:
         super()._do_initial_reads(group)
@@ -395,19 +397,19 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
     """Wrapper around a Pybind11 CollectionWrapper handle."""
 
-    _WRAPPED_TYPE = clib.SOMACollection
+    _GROUP_WRAPPED_TYPE = clib.SOMACollection
 
 
 class ExperimentWrapper(SOMAGroupWrapper[clib.SOMAExperiment]):
     """Wrapper around a Pybind11 ExperimentWrapper handle."""
 
-    _WRAPPED_TYPE = clib.SOMAExperiment
+    _GROUP_WRAPPED_TYPE = clib.SOMAExperiment
 
 
 class MeasurementWrapper(SOMAGroupWrapper[clib.SOMAMeasurement]):
     """Wrapper around a Pybind11 MeasurementWrapper handle."""
 
-    _WRAPPED_TYPE = clib.SOMAMeasurement
+    _GROUP_WRAPPED_TYPE = clib.SOMAMeasurement
 
 
 _ArrType = TypeVar("_ArrType", bound=clib.SOMAArray)
@@ -416,7 +418,7 @@ _ArrType = TypeVar("_ArrType", bound=clib.SOMAArray)
 class SOMAArrayWrapper(Wrapper[_ArrType]):
     """Base class for Pybind11 SOMAArrayWrapper handles."""
 
-    _WRAPPED_TYPE: Type[_ArrType]
+    _ARRAY_WRAPPED_TYPE: Type[_ArrType]
 
     clib_type = "SOMAArray"
 
@@ -429,7 +431,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         timestamp: int,
     ) -> clib.SOMAArray:
         open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
-        return cls._WRAPPED_TYPE.open(
+        return cls._ARRAY_WRAPPED_TYPE.open(
             uri,
             open_mode,
             context=context.native_context,
@@ -515,7 +517,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
 class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     """Wrapper around a Pybind11 SOMADataFrame handle."""
 
-    _WRAPPED_TYPE = clib.SOMADataFrame
+    _ARRAY_WRAPPED_TYPE = clib.SOMADataFrame
 
     @property
     def count(self) -> int:
@@ -533,13 +535,13 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
 class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     """Wrapper around a Pybind11 DenseNDArrayWrapper handle."""
 
-    _WRAPPED_TYPE = clib.SOMADenseNDArray
+    _ARRAY_WRAPPED_TYPE = clib.SOMADenseNDArray
 
 
 class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
     """Wrapper around a Pybind11 SparseNDArrayWrapper handle."""
 
-    _WRAPPED_TYPE = clib.SOMASparseNDArray
+    _ARRAY_WRAPPED_TYPE = clib.SOMASparseNDArray
 
     @property
     def nnz(self) -> int:

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -208,4 +208,19 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
     return results;
 }
 
+void set_metadata(SOMAArray& sr, const std::string& key, py::array value) {
+    tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
+
+    if (is_tdb_str(value_type) && value.size() > 1)
+        throw py::type_error("array/list of strings not supported");
+
+    py::buffer_info value_buffer = value.request();
+    if (value_buffer.ndim != 1)
+        throw py::type_error("Only 1D Numpy arrays can be stored as metadata");
+
+    auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
+    sr.set_metadata(
+        key, value_type, value_num, value_num > 0 ? value.data() : nullptr);
+}
+
 }  // namespace tiledbsoma

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -33,10 +33,15 @@ class TileDBSOMAPyError : std::runtime_error {
 namespace tiledbsoma {
 
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
+
 tiledb_datatype_t np_to_tdb_dtype(py::dtype type);
+
 bool is_tdb_str(tiledb_datatype_t type);
+
 std::optional<py::object> to_table(
     std::optional<std::shared_ptr<ArrayBuffers>> buffers);
+
+py::dict meta(std::map<std::string, MetadataValue> metadata_mapping);
 
 class PyQueryCondition {
    private:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -66,7 +66,7 @@ from .._exception import (
 )
 from .._soma_array import SOMAArray
 from .._tdb_handles import RawHandle
-from .._tiledb_object import AnyTileDBObject, TileDBObject
+from .._soma_object import AnySOMAObject, SOMAObject
 from .._types import (
     _INGEST_MODES,
     INGEST_MODES,
@@ -100,14 +100,14 @@ from ._registration import (
 from ._util import read_h5ad
 
 _NDArr = TypeVar("_NDArr", bound=NDArray)
-_TDBO = TypeVar("_TDBO", bound=TileDBObject[RawHandle])
+_TDBO = TypeVar("_TDBO", bound=SOMAObject[RawHandle])
 
 
 AdditionalMetadata = Optional[Dict[str, Metadatum]]
 
 
 def add_metadata(
-    obj: TileDBObject[Any], additional_metadata: AdditionalMetadata
+    obj: SOMAObject[Any], additional_metadata: AdditionalMetadata
 ) -> None:
     if additional_metadata:
         obj.verify_open_for_writing()
@@ -942,7 +942,7 @@ def append_X(
 def _maybe_set(
     coll: AnyTileDBCollection,
     key: str,
-    value: AnyTileDBObject,
+    value: AnySOMAObject,
     *,
     use_relative_uri: Optional[bool],
 ) -> None:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -65,8 +65,8 @@ from .._exception import (
     SOMAError,
 )
 from .._soma_array import SOMAArray
-from .._tdb_handles import RawHandle
 from .._soma_object import AnySOMAObject, SOMAObject
+from .._tdb_handles import RawHandle
 from .._types import (
     _INGEST_MODES,
     INGEST_MODES,
@@ -106,9 +106,7 @@ _TDBO = TypeVar("_TDBO", bound=SOMAObject[RawHandle])
 AdditionalMetadata = Optional[Dict[str, Metadatum]]
 
 
-def add_metadata(
-    obj: SOMAObject[Any], additional_metadata: AdditionalMetadata
-) -> None:
+def add_metadata(obj: SOMAObject[Any], additional_metadata: AdditionalMetadata) -> None:
     if additional_metadata:
         obj.verify_open_for_writing()
         obj.metadata.update(additional_metadata)

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -58,6 +58,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .value("rowmajor", ResultOrder::rowmajor)
         .value("colmajor", ResultOrder::colmajor);
 
+    py::enum_<URIType>(m, "URIType")
+        .value("automatic", URIType::automatic)
+        .value("absolute", URIType::absolute)
+        .value("relative", URIType::relative);
+
     m.doc() = "SOMA acceleration library";
 
     m.def("version", []() { return tiledbsoma::version::as_string(); });

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -49,13 +49,6 @@ using namespace tiledbsoma;
 void load_soma_collection(py::module& m) {
     py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
         .def_static(
-            "create",
-            &SOMACollection::create,
-            "uri"_a,
-            py::kw_only(),
-            "ctx"_a,
-            "timestamp"_a = py::none())
-        .def_static(
             "open",
             py::overload_cast<
                 std::string_view,
@@ -74,29 +67,12 @@ void load_soma_collection(py::module& m) {
                 return py::make_iterator(collection.begin(), collection.end());
             },
             py::keep_alive<0, 1>())
-        .def("get", &SOMACollection::get)
-        .def("add_new_collection", &SOMACollection::add_new_collection)
-        /* TODO ArrowTable needs to be passed in as py::object and converted */
-        // .def("add_new_experiment", &SOMACollection::add_new_experiment)
-        // .def("add_new_measurement", &SOMACollection::add_new_measurement)
-        // .def("add_new_dataframe", &SOMACollection::add_new_dataframe)
-        // .def("add_new_dense_ndarray", &SOMACollection::add_new_dense_ndarray)
-        // .def("add_new_sparse_ndarray",
-        // &SOMACollection::add_new_sparse_ndarray)
-        ;
+        .def("get", &SOMACollection::get);
 
     py::class_<SOMAExperiment, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAExperiment")
-        .def("obs", &SOMAExperiment::obs)
-        .def("ms", &SOMAExperiment::ms);
+        m, "SOMAExperiment");
 
     py::class_<SOMAMeasurement, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAMeasurement")
-        .def("var", &SOMAMeasurement::var)
-        .def("X", &SOMAMeasurement::X)
-        .def("obsm", &SOMAMeasurement::obsm)
-        .def("obsp", &SOMAMeasurement::obsp)
-        .def("varm", &SOMAMeasurement::varm)
-        .def("varp", &SOMAMeasurement::varp);
+        m, "SOMAMeasurement");
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -47,8 +47,30 @@ using namespace py::literals;
 using namespace tiledbsoma;
 
 void load_soma_collection(py::module& m) {
-    py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection");
-    py::class_<SOMAExperiment, SOMAGroup, SOMAObject>(m, "SOMAExperiment");
-    py::class_<SOMAMeasurement, SOMAGroup, SOMAObject>(m, "SOMAMeasurement");
+    py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
+        .def("get", &SOMACollection::get)
+        .def("add_new_collection", &SOMACollection::add_new_collection)
+        /* TODO ArrowTable needs to be passed in as py::object and converted */
+        // .def("add_new_experiment", &SOMACollection::add_new_experiment)
+        // .def("add_new_measurement", &SOMACollection::add_new_measurement)
+        // .def("add_new_dataframe", &SOMACollection::add_new_dataframe)
+        // .def("add_new_dense_ndarray", &SOMACollection::add_new_dense_ndarray)
+        // .def("add_new_sparse_ndarray",
+        // &SOMACollection::add_new_sparse_ndarray)
+        ;
+
+    py::class_<SOMAExperiment, SOMACollection, SOMAGroup, SOMAObject>(
+        m, "SOMAExperiment")
+        .def("obs", &SOMAExperiment::obs)
+        .def("ms", &SOMAExperiment::ms);
+
+    py::class_<SOMAMeasurement, SOMACollection, SOMAGroup, SOMAObject>(
+        m, "SOMAMeasurement")
+        .def("var", &SOMAMeasurement::var)
+        .def("X", &SOMAMeasurement::X)
+        .def("obsm", &SOMAMeasurement::obsm)
+        .def("obsp", &SOMAMeasurement::obsp)
+        .def("varm", &SOMAMeasurement::varm)
+        .def("varp", &SOMAMeasurement::varp);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -55,6 +55,19 @@ void load_soma_collection(py::module& m) {
             py::kw_only(),
             "ctx"_a,
             "timestamp"_a = py::none())
+        .def_static(
+            "open",
+            py::overload_cast<
+                std::string_view,
+                OpenMode,
+                std::shared_ptr<SOMAContext>,
+                std::optional<std::pair<uint64_t, uint64_t>>>(
+                &SOMACollection::open),
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none())
         .def(
             "__iter__",
             [](SOMACollection& collection) {

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -48,6 +48,13 @@ using namespace tiledbsoma;
 
 void load_soma_collection(py::module& m) {
     py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
+        .def_static(
+            "create",
+            &SOMACollection::create,
+            "uri"_a,
+            py::kw_only(),
+            "ctx"_a,
+            "timestamp"_a = py::none())
         .def(
             "__iter__",
             [](SOMACollection& collection) {

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -48,6 +48,12 @@ using namespace tiledbsoma;
 
 void load_soma_collection(py::module& m) {
     py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
+        .def(
+            "__iter__",
+            [](SOMACollection& collection) {
+                return py::make_iterator(collection.begin(), collection.end());
+            },
+            py::keep_alive<0, 1>())
         .def("get", &SOMACollection::get)
         .def("add_new_collection", &SOMACollection::add_new_collection)
         /* TODO ArrowTable needs to be passed in as py::object and converted */

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -40,6 +40,19 @@ using namespace tiledbsoma;
 
 void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
-        .def_property_readonly("type", &SOMAGroup::type);
+        .def("close", &SOMAGroup::close)
+        .def_property_readonly(
+            "closed",
+            [](SOMAGroup& group) -> bool { return not group.is_open(); })
+        .def("uri", &SOMAGroup::uri)
+        .def("context", &SOMAGroup::ctx)
+        .def("has", &SOMAGroup::has)
+        .def("count", &SOMAGroup::count)
+        .def("member_to_uri_mapping", &SOMAGroup::member_to_uri_mapping)
+        .def("timestamp", &SOMAGroup::timestamp)
+        .def("set_metadata", &SOMAGroup::set_metadata)
+        .def("delete_metadata", &SOMAGroup::delete_metadata)
+        .def("has_metadata", &SOMAGroup::has_metadata)
+        .def("metadata_num", &SOMAGroup::metadata_num);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -55,6 +55,14 @@ void set_metadata(SOMAGroup& sr, const std::string& key, py::array value) {
 
 void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
+        .def_static(
+            "create",
+            &SOMAGroup::create,
+            py::kw_only(),
+            "ctx"_a,
+            "uri"_a,
+            "soma_type"_a,
+            "timestamp"_a = py::none())
         .def("__enter__", [](SOMAGroup& group) { return group; })
         .def(
             "__exit__",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -40,16 +40,26 @@ using namespace tiledbsoma;
 
 void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
+        .def_property_readonly(
+            "mode",
+            [](SOMAGroup& group) {
+                return group.mode() == OpenMode::read ? "r" : "w";
+            })
         .def("close", &SOMAGroup::close)
         .def_property_readonly(
             "closed",
             [](SOMAGroup& group) -> bool { return not group.is_open(); })
-        .def("uri", &SOMAGroup::uri)
+        .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
         .def("count", &SOMAGroup::count)
         .def("member_to_uri_mapping", &SOMAGroup::member_to_uri_mapping)
         .def("timestamp", &SOMAGroup::timestamp)
+        .def_property_readonly(
+            "meta",
+            [](SOMAGroup& group) -> py::dict {
+                return meta(group.get_metadata());
+            })
         .def("set_metadata", &SOMAGroup::set_metadata)
         .def("delete_metadata", &SOMAGroup::delete_metadata)
         .def("has_metadata", &SOMAGroup::has_metadata)

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -57,7 +57,16 @@ void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
         .def_static(
             "create",
-            &SOMAGroup::create,
+            [](std::shared_ptr<SOMAContext> ctx,
+               std::string_view uri,
+               std::string soma_type,
+               std::optional<TimestampRange> timestamp) {
+                try {
+                    SOMAGroup::create(ctx, uri, soma_type, timestamp);
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
             py::kw_only(),
             "ctx"_a,
             "uri"_a,

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -53,8 +53,14 @@ void load_soma_group(py::module& m) {
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
         .def("count", &SOMAGroup::count)
-        .def("member_to_uri_mapping", &SOMAGroup::member_to_uri_mapping)
-        .def("timestamp", &SOMAGroup::timestamp)
+        .def("members", &SOMAGroup::members)
+        .def_property_readonly(
+            "timestamp",
+            [](SOMAGroup& group) -> py::object {
+                if (!group.timestamp().has_value())
+                    return py::none();
+                return py::cast(group.timestamp()->second);
+            })
         .def_property_readonly(
             "meta",
             [](SOMAGroup& group) -> py::dict {

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -59,7 +59,7 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
-        .def("set", &SOMAGroup::set)
+        .def("add", &SOMAGroup::set)
         .def("count", &SOMAGroup::count)
         .def("del", &SOMAGroup::del)
         .def("members", &SOMAGroup::members)

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -40,6 +40,13 @@ using namespace tiledbsoma;
 
 void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
+        .def("__enter__", [](SOMAGroup& group) { return group; })
+        .def(
+            "__exit__",
+            [](SOMAGroup& group,
+               py::object exc_type,
+               py::object exc_value,
+               py::object traceback) { group.close(); })
         .def_property_readonly(
             "mode",
             [](SOMAGroup& group) {
@@ -52,7 +59,9 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
+        .def("set", &SOMAGroup::set)
         .def("count", &SOMAGroup::count)
+        .def("del", &SOMAGroup::del)
         .def("members", &SOMAGroup::members)
         .def_property_readonly(
             "timestamp",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,7 +76,7 @@ void load_soma_group(py::module& m) {
         .def("has", &SOMAGroup::has)
         .def("add", &SOMAGroup::set)
         .def("count", &SOMAGroup::count)
-        .def("del", &SOMAGroup::del)
+        .def("remove", &SOMAGroup::del)
         .def("members", &SOMAGroup::members)
         .def_property_readonly(
             "timestamp",

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -136,10 +136,6 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
         assert exp.ms.metadata.get(metakey) == "SOMACollection"
         assert exp.ms["RNA"].metadata.get(metakey) == "SOMAMeasurement"
 
-        # Check ms
-        assert exp.ms.metadata.get(metakey) == "SOMACollection"
-        assert exp.ms["RNA"].metadata.get(metakey) == "SOMAMeasurement"
-
         # Check var
         var = exp.ms["RNA"].var.read().concat().to_pandas()
         assert sorted(var.columns.to_list()) == sorted(

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -14,7 +14,7 @@ import somacore
 import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import Experiment, _constants, _factory
-from tiledbsoma._tiledb_object import SOMAObject
+from tiledbsoma._soma_object import SOMAObject
 from tiledbsoma._util import verify_obs_and_var_eq
 import tiledb
 

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -14,7 +14,7 @@ import somacore
 import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import Experiment, _constants, _factory
-from tiledbsoma._tiledb_object import TileDBObject
+from tiledbsoma._tiledb_object import SOMAObject
 from tiledbsoma._util import verify_obs_and_var_eq
 import tiledb
 
@@ -717,7 +717,7 @@ def test_ingest_additional_metadata(conftest_pbmc_small):
         additional_metadata=additional_metadata,
     )
 
-    def check(tdbo: TileDBObject):
+    def check(tdbo: SOMAObject):
         for k, v in additional_metadata.items():
             assert tdbo.metadata[k] == v
 

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -350,9 +350,9 @@ def test_cascading_close(tmp_path: pathlib.Path):
     un_corvid.close()
     assert un_corvid.closed
 
-    all_elements: List[_tiledb_object.AnyTileDBObject] = []
+    all_elements: List[_tiledb_object.AnySOMAObject] = []
 
-    def crawl(obj: _tiledb_object.AnyTileDBObject):
+    def crawl(obj: _tiledb_object.AnySOMAObject):
         all_elements.append(obj)
         if isinstance(obj, _collection.CollectionBase):
             for val in obj.values():

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -11,7 +11,7 @@ from typeguard import suppress_type_checks
 from typing_extensions import Literal
 
 import tiledbsoma as soma
-from tiledbsoma import _collection, _factory, _tiledb_object
+from tiledbsoma import _collection, _factory, _soma_object
 from tiledbsoma._exception import DoesNotExistError
 from tiledbsoma.options import SOMATileDBContext
 
@@ -350,9 +350,9 @@ def test_cascading_close(tmp_path: pathlib.Path):
     un_corvid.close()
     assert un_corvid.closed
 
-    all_elements: List[_tiledb_object.AnySOMAObject] = []
+    all_elements: List[_soma_object.AnySOMAObject] = []
 
-    def crawl(obj: _tiledb_object.AnySOMAObject):
+    def crawl(obj: _soma_object.AnySOMAObject):
         all_elements.append(obj)
         if isinstance(obj, _collection.CollectionBase):
             for val in obj.values():

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -236,6 +236,11 @@ class SOMAArray : public SOMAObject {
         return arr_->is_open();
     }
 
+    /**
+     * Get whether the SOMAArray was open in read or write mode.
+     *
+     * @return OpenMode
+     */
     OpenMode mode() const {
         return mq_->query_type() == TILEDB_READ ? OpenMode::read :
                                                   OpenMode::write;

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -45,7 +45,11 @@ void SOMACollection::create(
     std::string_view uri,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
-    SOMAGroup::create(ctx, uri, "SOMACollection", timestamp);
+    try {
+        SOMAGroup::create(ctx, uri, "SOMACollection", timestamp);
+    } catch (TileDBError& e) {
+        throw TileDBSOMAError(e.what());
+    }
 }
 
 std::unique_ptr<SOMACollection> SOMACollection::open(
@@ -93,7 +97,7 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMACollection> member = SOMACollection::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
 }
@@ -125,7 +129,7 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
 }
@@ -157,7 +161,7 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
 }
@@ -191,7 +195,7 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;
 }
@@ -225,7 +229,7 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;
 }
@@ -259,7 +263,7 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::open(
         uri, OpenMode::read, ctx, column_names, result_order, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key));
+    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;
 }

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -70,26 +70,10 @@ void SOMACollection::close() {
 }
 
 std::unique_ptr<SOMAObject> SOMACollection::get(const std::string& key) {
-    auto obj = SOMAGroup::get(key);
-    std::optional<std::string> soma_object_type = this->type();
-
-    if (!soma_object_type)
-        throw TileDBSOMAError("Saw invalid SOMA object.");
-
-    if (soma_object_type->compare("SOMACollection") == 0)
-        return SOMACollection::open(obj.uri(), OpenMode::read, this->ctx());
-    else if (soma_object_type->compare("SOMAExperiment") == 0)
-        return SOMAExperiment::open(obj.uri(), OpenMode::read, this->ctx());
-    else if (soma_object_type->compare("SOMAMeasurement") == 0)
-        return SOMAMeasurement::open(obj.uri(), OpenMode::read, this->ctx());
-    else if (soma_object_type->compare("SOMADataFrame") == 0)
-        return SOMADataFrame::open(obj.uri(), OpenMode::read, this->ctx());
-    else if (soma_object_type->compare("SOMASparseNDArray") == 0)
-        return SOMASparseNDArray::open(obj.uri(), OpenMode::read, this->ctx());
-    else if (soma_object_type->compare("SOMADenseNDArray") == 0)
-        return SOMADenseNDArray::open(obj.uri(), OpenMode::read, this->ctx());
-
-    throw TileDBSOMAError("Saw invalid SOMA object.");
+    auto tiledb_obj = SOMAGroup::get(key);
+    auto soma_obj = SOMAObject::open(
+        tiledb_obj.uri(), OpenMode::read, this->ctx(), this->timestamp());
+    return soma_obj;
 }
 
 std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -180,7 +180,7 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ArrowTable indext_columns,
+        ArrowTable index_columns,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);
 

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -116,6 +116,15 @@ class SOMACollection : public SOMAGroup {
     SOMACollection(SOMACollection&&) = default;
     ~SOMACollection() = default;
 
+    using iterator =
+        typename std::map<std::string, std::shared_ptr<SOMAObject>>::iterator;
+    iterator begin() {
+        return children_.begin();
+    }
+    iterator end() {
+        return children_.end();
+    }
+
     using SOMAGroup::open;
 
     /**

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -65,8 +65,16 @@ void SOMAExperiment::create(
     auto name = std::string(std::filesystem::path(uri).filename());
     auto group = SOMAGroup::open(
         OpenMode::write, experiment_uri.string(), ctx, name, timestamp);
-    group->set((experiment_uri / "obs").string(), URIType::absolute, "obs");
-    group->set((experiment_uri / "ms").string(), URIType::absolute, "ms");
+    group->set(
+        (experiment_uri / "obs").string(),
+        URIType::absolute,
+        "obs",
+        "SOMADataFrame");
+    group->set(
+        (experiment_uri / "ms").string(),
+        URIType::absolute,
+        "ms",
+        "SOMACollection");
     group->close();
 }
 

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -95,8 +95,8 @@ class SOMAExperiment : public SOMACollection {
     }
 
     SOMAExperiment() = delete;
-    SOMAExperiment(const SOMAExperiment&) = delete;
-    SOMAExperiment(SOMAExperiment&&) = delete;
+    SOMAExperiment(const SOMAExperiment&) = default;
+    SOMAExperiment(SOMAExperiment&&) = default;
     ~SOMAExperiment() = default;
 
     /**

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -189,13 +189,16 @@ bool SOMAGroup::has(const std::string& name) {
 }
 
 void SOMAGroup::set(
-    const std::string& uri, URIType uri_type, const std::string& name) {
+    const std::string& uri,
+    URIType uri_type,
+    const std::string& name,
+    const std::string& soma_type) {
     bool relative = uri_type == URIType::relative;
     if (uri_type == URIType::automatic) {
         relative = uri.find("://") != std::string::npos;
     }
     group_->add_member(uri, relative, name);
-    members_[name] = SOMAGroupEntry(uri, std::nullopt);
+    members_[name] = SOMAGroupEntry(uri, soma_type);
 }
 
 uint64_t SOMAGroup::count() const {

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -46,7 +46,11 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
     std::string_view uri,
     std::string soma_type,
     std::optional<TimestampRange> timestamp) {
-    Group::create(*ctx->tiledb_ctx(), std::string(uri));
+    try {
+        Group::create(*ctx->tiledb_ctx(), std::string(uri));
+    } catch (TileDBError& e) {
+        throw TileDBSOMAError(e.what());
+    }
 
     auto group = std::make_shared<Group>(
         *ctx->tiledb_ctx(),

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -137,6 +137,16 @@ class SOMAGroup : public SOMAObject {
     }
 
     /**
+     * Get whether the SOMAGroup was open in read or write mode.
+     *
+     * @return OpenMode
+     */
+    OpenMode mode() const {
+        return group_->query_type() == TILEDB_READ ? OpenMode::read :
+                                                     OpenMode::write;
+    }
+
+    /**
      * Get the SOMAGroup URI.
      */
     const std::string uri() const;

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -46,7 +46,7 @@ namespace tiledbsoma {
 using namespace tiledb;
 
 // Pair storing uri and soma type
-using SOMAGroupEntry = std::pair<std::string, std::optional<std::string>>;
+using SOMAGroupEntry = std::pair<std::string, std::string>;
 
 class SOMAGroup : public SOMAObject {
    public:
@@ -190,7 +190,11 @@ class SOMAGroup : public SOMAObject {
      * or relative
      * @param name of member
      */
-    void set(const std::string& uri, URIType uri_type, const std::string& name);
+    void set(
+        const std::string& uri,
+        URIType uri_type,
+        const std::string& name,
+        const std::string& soma_type);
 
     /**
      * Get the number of members in the SOMAGroup.

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -45,6 +45,9 @@
 namespace tiledbsoma {
 using namespace tiledb;
 
+// Pair storing uri and soma type
+using SOMAGroupEntry = std::pair<std::string, std::optional<std::string>>;
+
 class SOMAGroup : public SOMAObject {
    public:
     //===================================================================
@@ -202,11 +205,11 @@ class SOMAGroup : public SOMAObject {
     void del(const std::string& name);
 
     /**
-     * Return a SOMAGroup member to URI mapping.
+     * Return a mapping of all members in the group with its uri and type.
      *
      * @return std::optional<TimestampRange>
      */
-    std::map<std::string, std::string> member_to_uri_mapping() const;
+    std::map<std::string, SOMAGroupEntry> members() const;
 
     /**
      * Return optional timestamp pair SOMAArray was opened with.
@@ -337,7 +340,7 @@ class SOMAGroup : public SOMAObject {
     std::optional<TimestampRange> timestamp_;
 
     // Member-to-URI cache
-    std::map<std::string, std::string> member_to_uri_;
+    std::map<std::string, SOMAGroupEntry> members_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -68,12 +68,36 @@ void SOMAMeasurement::create(
 
     auto name = std::string(std::filesystem::path(uri).filename());
     auto group = SOMAGroup::open(OpenMode::write, uri, ctx, name, timestamp);
-    group->set((measurement_uri / "var").string(), URIType::absolute, "var");
-    group->set((measurement_uri / "X").string(), URIType::absolute, "X");
-    group->set((measurement_uri / "obsm").string(), URIType::absolute, "obsm");
-    group->set((measurement_uri / "obsp").string(), URIType::absolute, "obsp");
-    group->set((measurement_uri / "varm").string(), URIType::absolute, "varm");
-    group->set((measurement_uri / "varp").string(), URIType::absolute, "varp");
+    group->set(
+        (measurement_uri / "var").string(),
+        URIType::absolute,
+        "var",
+        "SOMADataFrame");
+    group->set(
+        (measurement_uri / "X").string(),
+        URIType::absolute,
+        "X",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "obsm").string(),
+        URIType::absolute,
+        "obsm",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "obsp").string(),
+        URIType::absolute,
+        "obsp",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "varm").string(),
+        URIType::absolute,
+        "varm",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "varp").string(),
+        URIType::absolute,
+        "varp",
+        "SOMACollection");
     group->close();
 }
 

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -95,8 +95,8 @@ class SOMAMeasurement : public SOMACollection {
     }
 
     SOMAMeasurement() = delete;
-    SOMAMeasurement(const SOMAMeasurement&) = delete;
-    SOMAMeasurement(SOMAMeasurement&&) = delete;
+    SOMAMeasurement(const SOMAMeasurement&) = default;
+    SOMAMeasurement(SOMAMeasurement&&) = default;
     ~SOMAMeasurement() = default;
 
     /**

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -79,6 +79,13 @@ class SOMAObject {
     virtual std::shared_ptr<SOMAContext> ctx() = 0;
 
     /**
+     * Get whether the SOMAObject was open in read or write mode.
+     *
+     * @return OpenMode
+     */
+    virtual OpenMode mode() const = 0;
+
+    /**
      * @brief Close the SOMAObject.
      */
     virtual void close() = 0;

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -56,8 +56,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     auto index_columns = helper::create_column_index_info();
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
 
-    std::map<std::string, std::string> expected_map{
-        {"sparse_ndarray", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -71,7 +71,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_sparse->uri() == sub_uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -83,7 +83,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -97,7 +97,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     auto index_columns = helper::create_column_index_info();
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
 
-    std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -111,7 +112,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -122,7 +123,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -135,7 +136,8 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     SOMACollection::create(base_uri, ctx, ts);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -149,7 +151,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -160,7 +162,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
 }
@@ -173,19 +175,20 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     SOMACollection::create(base_uri, ctx);
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), false);
 
-    std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -197,7 +200,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     SOMACollection::create(base_uri, ctx);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
@@ -208,7 +212,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -216,7 +220,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -228,7 +232,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     SOMACollection::create(base_uri, ctx);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
@@ -239,7 +244,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -247,7 +252,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -157,8 +157,8 @@ TEST_CASE("SOMAGroup: basic") {
 
     auto soma_group = SOMAGroup::open(
         OpenMode::write, uri_main_group, ctx, "metadata", TimestampRange(0, 1));
-    soma_group->set(uri_sub_group, URIType::absolute, "subgroup");
-    soma_group->set(uri_sub_array, URIType::absolute, "subarray");
+    soma_group->set(uri_sub_group, URIType::absolute, "subgroup", "SOMAGroup");
+    soma_group->set(uri_sub_array, URIType::absolute, "subarray", "SOMAArray");
     soma_group->close();
 
     std::map<std::string, SOMAGroupEntry> expected_map{

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -161,20 +161,21 @@ TEST_CASE("SOMAGroup: basic") {
     soma_group->set(uri_sub_array, URIType::absolute, "subarray");
     soma_group->close();
 
-    std::map<std::string, std::string> expected_map{
-        {"subgroup", uri_sub_group}, {"subarray", uri_sub_array}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"subgroup", SOMAGroupEntry(uri_sub_group, "SOMAGroup")},
+        {"subarray", SOMAGroupEntry(uri_sub_array, "SOMAArray")}};
 
     soma_group->open(OpenMode::read, TimestampRange(0, 2));
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->count() == 2);
-    REQUIRE(expected_map == soma_group->member_to_uri_mapping());
+    REQUIRE(expected_map == soma_group->members());
     REQUIRE(soma_group->get("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get("subarray").type() == Object::Type::Array);
     soma_group->close();
 
     soma_group->open(OpenMode::write, TimestampRange(0, 3));
-    REQUIRE(expected_map == soma_group->member_to_uri_mapping());
+    REQUIRE(expected_map == soma_group->members());
     soma_group->del("subgroup");
     soma_group->close();
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2674

These changes are applied on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2508

**Changes:**

- Replace `tiledb.Group` usage with `clib.SOMAGroup`
- Remove references to `tiledb.TileDBError` as we no longer have exceptions coming from tiledb-py
- Remove `ArrayWrapper` and `GroupWrapper` as these were wrappers around tiledb-py objects
- Addition of `CollectionWrapper`, `ExperimentWrapper`, and `MeasurementWrapper` to wrap around new C++ bindings
- Rename `TileDBObject` to `SOMAObject` and `_tiledb_object.py` to `_soma_object.py` to reflect moveover changes

**Notes for Reviewer:**

Although `SOMAArray` and `SOMAGroup` now fully use the C++ bindings, there's still areas of the code that use tiledb-py and need to be replaced in a follow up PR. For example, we use `tiledb.VFS` in several areas.
