### PR TITLE
[c++] Improve default buffer sizes

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Run libtiledbsoma unit tests
       run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
       env:
-        CI_MEMORY_USAGE: true
+        TILEDB_SOMA_INIT_BUFFER_BYTES: 16777216 # accommodate tiny runners
 
     - name: Run pytests for Python
       shell: bash

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -122,6 +122,8 @@ jobs:
 
     - name: Run libtiledbsoma unit tests
       run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
+      env:
+        CI_MEMORY_USAGE: true
 
     - name: Run pytests for Python
       shell: bash

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -21,6 +21,7 @@ env:
   _R_CHECK_TESTS_NLINES_: 0
   CATCHSEGV: "TRUE"
   R_REMOTES_UPGRADE: "never"
+  CI_MEMORY_USAGE: true
 
 jobs:
   ci:

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -21,7 +21,7 @@ env:
   _R_CHECK_TESTS_NLINES_: 0
   CATCHSEGV: "TRUE"
   R_REMOTES_UPGRADE: "never"
-  CI_MEMORY_USAGE: true
+  TILEDB_SOMA_INIT_BUFFER_BYTES: 16777216 # accommodate tiny runners
 
 jobs:
   ci:

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -112,3 +112,5 @@ jobs:
 
       - name: Interop Tests
         run: python -m pytest apis/system/tests/
+        env:
+          CI_MEMORY_USAGE: true

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -113,4 +113,4 @@ jobs:
       - name: Interop Tests
         run: python -m pytest apis/system/tests/
         env:
-          CI_MEMORY_USAGE: true
+          TILEDB_SOMA_INIT_BUFFER_BYTES: 16777216 # accommodate tiny runners

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -30,8 +30,8 @@
  * This file defines the a ColumBuffer class.
  */
 
-#include <cstdlib>
 #include "column_buffer.h"
+#include <cstdlib>
 #include "../utils/logger.h"
 
 namespace tiledbsoma {
@@ -225,7 +225,6 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
     bool is_nullable,
     std::optional<Enumeration> enumeration,
     bool is_ordered) {
-
     // Set number of bytes for the data buffer. Override with a value from
     // the config if present.
     // Respect requested CI low-memory environment if requested.

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -31,7 +31,6 @@
  */
 
 #include "column_buffer.h"
-#include <cstdlib>
 #include "../utils/logger.h"
 
 namespace tiledbsoma {
@@ -227,12 +226,7 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
     bool is_ordered) {
     // Set number of bytes for the data buffer. Override with a value from
     // the config if present.
-    // Respect requested CI low-memory environment if requested.
-    auto num_bytes = NON_CI_DEFAULT_ALLOC_BYTES;
-    if (std::getenv(ENV_CI_MEMORY_USAGE.c_str()) != nullptr) {
-        num_bytes = CI_DEFAULT_ALLOC_BYTES;
-    }
-
+    auto num_bytes = DEFAULT_ALLOC_BYTES;
     if (config.contains(CONFIG_KEY_INIT_BYTES)) {
         auto value_str = config.get(CONFIG_KEY_INIT_BYTES);
         try {

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -30,6 +30,7 @@
  * This file defines the a ColumBuffer class.
  */
 
+#include <cstdlib>
 #include "column_buffer.h"
 #include "../utils/logger.h"
 
@@ -224,9 +225,15 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
     bool is_nullable,
     std::optional<Enumeration> enumeration,
     bool is_ordered) {
+
     // Set number of bytes for the data buffer. Override with a value from
     // the config if present.
-    auto num_bytes = DEFAULT_ALLOC_BYTES;
+    // Respect requested CI low-memory environment if requested.
+    auto num_bytes = NON_CI_DEFAULT_ALLOC_BYTES;
+    if (std::getenv(ENV_CI_MEMORY_USAGE.c_str()) != nullptr) {
+        num_bytes = CI_DEFAULT_ALLOC_BYTES;
+    }
+
     if (config.contains(CONFIG_KEY_INIT_BYTES)) {
         auto value_str = config.get(CONFIG_KEY_INIT_BYTES);
         try {

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -52,7 +52,17 @@ using namespace tiledb;
  *
  */
 class ColumnBuffer {
-    inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 24;  // 16 MiB
+    // For remote stores, too-small buffer sizes can negatively impact performance
+    // due to increased numbers of round-trip times. While users can adjust
+    // soma.init_buffer_bytes, the out-of-the-box default must offer good UX
+    // on reasonable hardware (e.g. 8GB/16GB laptops).
+    //
+    // For CI, we use smaller buffer sizes via a well-known environment variable.
+    inline static const size_t CI_DEFAULT_ALLOC_BYTES = 1 << 24;  // 16 MiB
+    inline static const size_t NON_CI_DEFAULT_ALLOC_BYTES = 1 << 30;  // 1 GiB
+
+    inline static const std::string
+        ENV_CI_MEMORY_USAGE = "CI_MEMORY_USAGE";
     inline static const std::string
         CONFIG_KEY_INIT_BYTES = "soma.init_buffer_bytes";
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -52,7 +52,12 @@ using namespace tiledb;
  *
  */
 class ColumnBuffer {
-    inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 24;  // 16 MiB
+    // This "medium size" -- 1 GiB -- is a good balance between improved remote
+    // I/O performance (bigger = better) and friendliness for smaller hardware
+    // (e.g.  tiny CI runners). This value is good for general in-between
+    // hardware including modern laptops and a broad range of EC2 instances. CI
+    // can ask for smaller; power-server users can ask for larger.
+    inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 30;
     inline static const std::string
         CONFIG_KEY_INIT_BYTES = "soma.init_buffer_bytes";
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -52,17 +52,17 @@ using namespace tiledb;
  *
  */
 class ColumnBuffer {
-    // For remote stores, too-small buffer sizes can negatively impact performance
-    // due to increased numbers of round-trip times. While users can adjust
-    // soma.init_buffer_bytes, the out-of-the-box default must offer good UX
-    // on reasonable hardware (e.g. 8GB/16GB laptops).
+    // For remote stores, too-small buffer sizes can negatively impact
+    // performance due to increased numbers of round-trip times. While users can
+    // adjust soma.init_buffer_bytes, the out-of-the-box default must offer good
+    // UX on reasonable hardware (e.g. 8GB/16GB laptops).
     //
-    // For CI, we use smaller buffer sizes via a well-known environment variable.
-    inline static const size_t CI_DEFAULT_ALLOC_BYTES = 1 << 24;  // 16 MiB
+    // For CI, we use smaller buffer sizes via a well-known environment
+    // variable.
+    inline static const size_t CI_DEFAULT_ALLOC_BYTES = 1 << 24;      // 16 MiB
     inline static const size_t NON_CI_DEFAULT_ALLOC_BYTES = 1 << 30;  // 1 GiB
 
-    inline static const std::string
-        ENV_CI_MEMORY_USAGE = "CI_MEMORY_USAGE";
+    inline static const std::string ENV_CI_MEMORY_USAGE = "CI_MEMORY_USAGE";
     inline static const std::string
         CONFIG_KEY_INIT_BYTES = "soma.init_buffer_bytes";
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -52,17 +52,7 @@ using namespace tiledb;
  *
  */
 class ColumnBuffer {
-    // For remote stores, too-small buffer sizes can negatively impact
-    // performance due to increased numbers of round-trip times. While users can
-    // adjust soma.init_buffer_bytes, the out-of-the-box default must offer good
-    // UX on reasonable hardware (e.g. 8GB/16GB laptops).
-    //
-    // For CI, we use smaller buffer sizes via a well-known environment
-    // variable.
-    inline static const size_t CI_DEFAULT_ALLOC_BYTES = 1 << 24;      // 16 MiB
-    inline static const size_t NON_CI_DEFAULT_ALLOC_BYTES = 1 << 30;  // 1 GiB
-
-    inline static const std::string ENV_CI_MEMORY_USAGE = "CI_MEMORY_USAGE";
+    inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 24;  // 16 MiB
     inline static const std::string
         CONFIG_KEY_INIT_BYTES = "soma.init_buffer_bytes";
 


### PR DESCRIPTION
**Issue and/or context:** As on #2682: switch the default from small to medium. The small/CI regime is preserved via opt-in environment variable.

See also https://github.com/single-cell-data/TileDB-SOMA/pull/531 wherein I found that even 512MB was too big for Windows CI -- which is why on this PR I have explicit CI logic.
