### PR TITLE
[r] Use `arrow` minimum 14, not 15

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     bit64,
     tiledb (>= 0.27.0),
     tiledb (<= 0.27.99),
-    arrow (>= 15.0.1),
+    arrow (>= 14.0.0),
     utils,
     fs,
     glue,


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/168#issuecomment-2152804811