### PR TITLE
[python] Deprecate `tiledb_ctx` usage in `TileDBSOMAContext`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -19,7 +19,7 @@ from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_JOINID
 from ._exception import SOMAError, map_exception_for_create
-from ._general_utilities import get_implementation_version
+from ._general_utilities import assert_version_before
 from ._query_condition import QueryCondition
 from ._read_iters import TableReadIter
 from ._soma_array import SOMAArray
@@ -453,8 +453,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
-            version = get_implementation_version().split(".")
-            assert (int(version[0]), int(version[1])) < (1, 13)
+            assert_version_before(1, 13)
             warnings.warn(
                 "The write parameter now takes in TileDBWriteOptions "
                 "instead of TileDBCreateOptions. This warning will be removed "

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -8,8 +8,8 @@
 import os
 import platform
 import sys
+import warnings
 from re import fullmatch
-from typing import Tuple
 
 import tiledb
 
@@ -53,9 +53,17 @@ def get_implementation_version() -> str:
             return "unknown"
 
 
-def get_release_version() -> Tuple[int, int]:
-    version = get_implementation_version().split(".")
-    return (int(version[0]), int(version[1]))
+def assert_version_before(major: int, minor: int) -> None:
+    version_string = get_implementation_version()
+    if version_string == "unknown":
+        warnings.warn(
+            "`assert_version_before` could not retrieve the current "
+            "implementation version"
+        )
+        return
+
+    version = version_string.split(".")
+    assert (int(version[0]), int(version[1])) < (major, minor)
 
 
 def get_storage_engine() -> str:

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -9,6 +9,7 @@ import os
 import platform
 import sys
 from re import fullmatch
+from typing import Tuple
 
 import tiledb
 
@@ -50,6 +51,11 @@ def get_implementation_version() -> str:
             return importlib.metadata.version("tiledbsoma")
         except importlib.metadata.PackageNotFoundError:
             return "unknown"
+
+
+def get_release_version() -> Tuple[int, int]:
+    version = get_implementation_version().split(".")
+    return (int(version[0]), int(version[1]))
 
 
 def get_storage_engine() -> str:

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -17,13 +17,13 @@ from typing_extensions import Self
 import tiledb
 
 from .. import pytiledbsoma as clib
-from .._general_utilities import get_release_version
+from .._general_utilities import assert_version_before
 from .._types import OpenTimestamp
 from .._util import ms_to_datetime, to_timestamp_ms
 
 
 def _warn_ctx_deprecation() -> None:
-    assert get_release_version() < (1, 14)
+    assert_version_before(1, 14)
     warnings.warn(
         "tiledb_ctx is now deprecated for removal in 1.14. "
         "Use tiledb_config instead by passing "

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -17,9 +17,19 @@ from typing_extensions import Self
 import tiledb
 
 from .. import pytiledbsoma as clib
-from .._general_utilities import get_implementation_version
+from .._general_utilities import get_release_version
 from .._types import OpenTimestamp
 from .._util import ms_to_datetime, to_timestamp_ms
+
+
+def _tiledb_ctx_deprecation() -> None:
+    assert get_release_version() < (1, 14)
+    warnings.warn(
+        "tiledb_ctx is now deprecated for removal in 1.14. "
+        "Use tiledb_config instead by passing "
+        "SOMATileDBContext(tiledb_config=ctx.config()).",
+        DeprecationWarning,
+    )
 
 
 def _default_config(
@@ -121,14 +131,7 @@ class SOMATileDBContext(ContextBase):
                 default settings.
         """
         if tiledb_ctx is not None:
-            version = get_implementation_version().split(".")
-            assert (int(version[0]), int(version[1])) < (1, 14)
-            warnings.warn(
-                "The tiledb_ctx parameter will be deprecated in 1.14. "
-                "Use tiledb_config instead by passing "
-                "SOMATileDBContext(tiledb_config=ctx.config()).",
-                DeprecationWarning,
-            )
+            _tiledb_ctx_deprecation()
 
         if tiledb_ctx is not None and tiledb_config is not None:
             raise ValueError(
@@ -187,13 +190,7 @@ class SOMATileDBContext(ContextBase):
     @property
     def tiledb_ctx(self) -> tiledb.Ctx:
         """The TileDB-Py Context for this SOMA context."""
-        version = get_implementation_version().split(".")
-        assert (int(version[0]), int(version[1])) < (1, 14)
-        warnings.warn(
-            "The tiledb_ctx attribute will be deprecated in 1.14. "
-            "Use tiledb_config to view configuration settings.",
-            DeprecationWarning,
-        )
+        _tiledb_ctx_deprecation()
 
         with self._lock:
             if self._tiledb_ctx is None:
@@ -272,14 +269,7 @@ class SOMATileDBContext(ContextBase):
         """
         with self._lock:
             if tiledb_ctx is not None:
-                version = get_implementation_version().split(".")
-                assert (int(version[0]), int(version[1])) < (1, 14)
-                warnings.warn(
-                    "The tiledb_ctx parameter will be deprecated in 1.14. "
-                    "Use tiledb_config instead by passing "
-                    "SOMATileDBContext(tiledb_config=ctx.config()).",
-                    DeprecationWarning,
-                )
+                _tiledb_ctx_deprecation()
 
             if tiledb_config is not None:
                 if tiledb_ctx:

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -27,7 +27,7 @@ def _tiledb_ctx_deprecation() -> None:
     warnings.warn(
         "tiledb_ctx is now deprecated for removal in 1.14. "
         "Use tiledb_config instead by passing "
-        "SOMATileDBContext(tiledb_config=ctx.config()).",
+        "SOMATileDBContext(tiledb_config=ctx.config().dict()).",
         DeprecationWarning,
     )
 

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -22,7 +22,7 @@ from .._types import OpenTimestamp
 from .._util import ms_to_datetime, to_timestamp_ms
 
 
-def _tiledb_ctx_deprecation() -> None:
+def _warn_ctx_deprecation() -> None:
     assert get_release_version() < (1, 14)
     warnings.warn(
         "tiledb_ctx is now deprecated for removal in 1.14. "
@@ -131,7 +131,7 @@ class SOMATileDBContext(ContextBase):
                 default settings.
         """
         if tiledb_ctx is not None:
-            _tiledb_ctx_deprecation()
+            _warn_ctx_deprecation()
 
         if tiledb_ctx is not None and tiledb_config is not None:
             raise ValueError(
@@ -190,7 +190,7 @@ class SOMATileDBContext(ContextBase):
     @property
     def tiledb_ctx(self) -> tiledb.Ctx:
         """The TileDB-Py Context for this SOMA context."""
-        _tiledb_ctx_deprecation()
+        _warn_ctx_deprecation()
 
         with self._lock:
             if self._tiledb_ctx is None:
@@ -269,7 +269,7 @@ class SOMATileDBContext(ContextBase):
         """
         with self._lock:
             if tiledb_ctx is not None:
-                _tiledb_ctx_deprecation()
+                _warn_ctx_deprecation()
 
             if tiledb_config is not None:
                 if tiledb_ctx:

--- a/apis/python/src/tiledbsoma/soma_context.cc
+++ b/apis/python/src/tiledbsoma/soma_context.cc
@@ -49,6 +49,8 @@ using namespace tiledbsoma;
 
 void load_soma_context(py::module& m) {
     py::class_<SOMAContext, std::shared_ptr<SOMAContext>>(m, "SOMAContext")
-        .def(py::init<std::map<std::string, std::string>>());
+        .def(py::init<>())
+        .def(py::init<std::map<std::string, std::string>>())
+        .def("config", &SOMAContext::tiledb_config);
 };
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -24,7 +24,8 @@ def test_lazy_init():
         mock_ctx.assert_not_called()
         assert context._tiledb_ctx is None
         # Invoke the @property twice to ensure we only build one Ctx.
-        assert context.tiledb_ctx is context.tiledb_ctx
+        with pytest.deprecated_call():
+            assert context.tiledb_ctx is context.tiledb_ctx
         mock_ctx.assert_called_once()
 
 
@@ -57,7 +58,8 @@ def test_shared_ctx():
     """Verifies that one global context is shared by default."""
     ctx = stc.SOMATileDBContext()
     ctx_2 = stc.SOMATileDBContext()
-    assert ctx.tiledb_ctx is ctx_2.tiledb_ctx
+    with pytest.deprecated_call():
+        assert ctx.tiledb_ctx is ctx_2.tiledb_ctx
 
 
 def test_unshared_ctx():
@@ -65,8 +67,9 @@ def test_unshared_ctx():
     ctx = stc.SOMATileDBContext()
     ctx_2 = stc.SOMATileDBContext(tiledb_config={})
     ctx_3 = stc.SOMATileDBContext(tiledb_config={})
-    assert ctx.tiledb_ctx is not ctx_2.tiledb_ctx
-    assert ctx_2.tiledb_ctx is not ctx_3.tiledb_ctx
+    with pytest.deprecated_call():
+        assert ctx.tiledb_ctx is not ctx_2.tiledb_ctx
+        assert ctx_2.tiledb_ctx is not ctx_3.tiledb_ctx
 
 
 def test_replace_timestamp():
@@ -85,10 +88,13 @@ def test_replace_timestamp():
 
 
 def test_replace_context():
-    orig_ctx = stc.SOMATileDBContext()
+    with pytest.deprecated_call():
+        orig_ctx = stc.SOMATileDBContext(tiledb_ctx=tiledb.Ctx())
     new_tdb_ctx = tiledb.Ctx({"vfs.s3.region": "hy-central-1"})
-    new_ctx = orig_ctx.replace(tiledb_ctx=new_tdb_ctx)
-    assert new_ctx.tiledb_ctx is new_tdb_ctx
+    with pytest.deprecated_call():
+        new_ctx = orig_ctx.replace(tiledb_ctx=new_tdb_ctx)
+    with pytest.deprecated_call():
+        assert new_ctx.tiledb_ctx is new_tdb_ctx
 
 
 def test_replace_config_after_construction():
@@ -96,7 +102,7 @@ def test_replace_config_after_construction():
 
     # verify defaults expected by subsequent tests
     assert context.timestamp_ms is None
-    assert context.tiledb_ctx.config()["vfs.s3.region"] == "us-east-1"
+    assert context.native_context.config()["vfs.s3.region"] == "us-east-1"
 
     now = int(time.time() * 1000)
     open_ts = context._open_timestamp_ms(None)
@@ -114,6 +120,7 @@ def test_replace_config_after_construction():
         new_soma_ctx = context.replace(tiledb_config={"vfs.s3.region": "us-west-2"})
         assert new_soma_ctx.tiledb_config["vfs.s3.region"] == "us-west-2"
         mock_ctx.assert_not_called()
-        new_tdb_ctx = new_soma_ctx.tiledb_ctx
+        with pytest.deprecated_call():
+            new_tdb_ctx = new_soma_ctx.tiledb_ctx
         mock_ctx.assert_called_once()
         assert new_tdb_ctx.config()["vfs.s3.region"] == "us-west-2"


### PR DESCRIPTION
**Issue and/or context:**

[sc-49124]

Deprecating usage of `tiledb.Ctx` for users is necessary for the complete removal of tiledb-py. Internally, the codebase now passes around a `TileDBSOMAContext.native_context` which is a C++ `SOMAContext` binding. We no longer use `tiledb.Ctx` anywhere.

**Changes:**

* Deprecate `tiledb_ctx` as an argument into the constructor and `replace`
* Deprecate `tiledb_ctx` as an attribute getter
* Use `tiledb_config` as an alternative 

**Notes for Reviewer:**

I have set the deprecation for 1.14.