### PR TITLE
[doc] Update README.md badge for Python CI (closes #2694) [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
-[![TileDB-SOMA CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/ci.yml)
+[![TileDB-SOMA Python CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml)
 [![TileDB-SOMA R CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml)
 [![PyPI version](https://badge.fury.io/py/tiledbsoma.svg)](https://badge.fury.io/py/tiledbsoma)
 [![tiledbsoma status badge](https://tiledb-inc.r-universe.dev/badges/tiledbsoma)](https://tiledb-inc.r-universe.dev)


### PR DESCRIPTION
**Issue and/or context:**

As noted in #2694 the README.md points to a stale ci yaml file for Python.

**Changes:**

The link has been updated to show the status of the 'Python CI (Full)' job

**Notes for Reviewer:**

[SC 49175](https://app.shortcut.com/tiledb-inc/story/49175/doc-ci-readme-md-has-stale-link-to-old-python-ci-yaml-results-state)