### PR TITLE
[c++] Add `SOMAArray::config_options` getter

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -562,6 +562,17 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
+     * @brief Get members of the schema (capacity, allows_duplicates,
+     * tile_order, cell_order, offsets_filters, validity_filters, attr filters,
+     * and dim filters) in the form of a PlatformConfig
+     *
+     * @return PlatformConfig
+     */
+    PlatformConfig config_options() const {
+        return ArrowAdapter::platform_config_from_tiledb_schema(*mq_->schema());
+    }
+
+    /**
      * @brief Get the capacity of each dimension.
      *
      * @return A vector with length equal to the number of dimensions; each

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -147,6 +147,151 @@ void ArrowAdapter::release_array(struct ArrowArray* array) {
     LOG_TRACE(fmt::format("[ArrowAdapter] release_array done"));
 }
 
+PlatformConfig ArrowAdapter::platform_config_from_tiledb_schema(
+    ArraySchema tiledb_schema) {
+    std::map<tiledb_layout_t, std::string> layout_as_string{
+        {TILEDB_ROW_MAJOR, "row-major"},
+        {TILEDB_COL_MAJOR, "column-major"},
+        {TILEDB_HILBERT, "hilbert"},
+        {TILEDB_UNORDERED, "unordered"},
+    };
+
+    PlatformConfig platform_config;
+    platform_config.capacity = tiledb_schema.capacity();
+    platform_config.allows_duplicates = tiledb_schema.allows_dups();
+    platform_config.tile_order = layout_as_string[tiledb_schema.tile_order()];
+    platform_config.cell_order = layout_as_string[tiledb_schema.cell_order()];
+    platform_config.offsets_filters = ArrowAdapter::_get_filter_list_json(
+                                          tiledb_schema.offsets_filter_list())
+                                          .dump();
+    platform_config.validity_filters = ArrowAdapter::_get_filter_list_json(
+                                           tiledb_schema.validity_filter_list())
+                                           .dump();
+    platform_config.attrs = ArrowAdapter::_get_attrs_filter_list_json(
+                                tiledb_schema)
+                                .dump();
+    platform_config
+        .dims = ArrowAdapter::_get_dims_filter_list_json(tiledb_schema).dump();
+
+    return platform_config;
+}
+
+json ArrowAdapter::_get_attrs_filter_list_json(ArraySchema tiledb_schema) {
+    json attrs_filter_list_as_json;
+    for (auto attr : tiledb_schema.attributes()) {
+        attrs_filter_list_as_json.emplace(
+            attr.first,
+            ArrowAdapter::_get_filter_list_json(attr.second.filter_list()));
+    }
+    return attrs_filter_list_as_json;
+}
+
+json ArrowAdapter::_get_dims_filter_list_json(ArraySchema tiledb_schema) {
+    json dims_filter_list_as_json;
+    for (auto dim : tiledb_schema.domain().dimensions()) {
+        dims_filter_list_as_json.emplace(
+            dim.name(), ArrowAdapter::_get_filter_list_json(dim.filter_list()));
+    }
+    return dims_filter_list_as_json;
+}
+
+json ArrowAdapter::_get_filter_list_json(FilterList filter_list) {
+    std::map<tiledb_filter_option_t, std::string> option_as_string = {
+        {TILEDB_COMPRESSION_LEVEL, "COMPRESSION_LEVEL"},
+        {TILEDB_BIT_WIDTH_MAX_WINDOW, "BIT_WIDTH_MAX_WINDOW"},
+        {TILEDB_POSITIVE_DELTA_MAX_WINDOW, "POSITIVE_DELTA_MAX_WINDOW"},
+        {TILEDB_SCALE_FLOAT_BYTEWIDTH, "SCALE_FLOAT_BYTEWIDTH"},
+        {TILEDB_SCALE_FLOAT_FACTOR, "SCALE_FLOAT_FACTOR"},
+        {TILEDB_SCALE_FLOAT_OFFSET, "SCALE_FLOAT_OFFSET"},
+        {TILEDB_WEBP_INPUT_FORMAT, "WEBP_INPUT_FORMAT"},
+        {TILEDB_WEBP_QUALITY, "WEBP_QUALITY"},
+        {TILEDB_WEBP_LOSSLESS, "WEBP_LOSSLESS"},
+        {TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
+         "COMPRESSION_REINTERPRET_DATATYPE"},
+    };
+
+    json filter_list_as_json = {};
+    for (uint32_t i = 0; i < filter_list.nfilters(); ++i) {
+        json filter_as_json = {};
+
+        auto filter = filter_list.filter(i);
+        filter_as_json.emplace("name", Filter::to_str(filter.filter_type()));
+
+        switch (filter.filter_type()) {
+            case TILEDB_FILTER_GZIP:
+            case TILEDB_FILTER_ZSTD:
+            case TILEDB_FILTER_LZ4:
+            case TILEDB_FILTER_BZIP2:
+            case TILEDB_FILTER_RLE:
+            case TILEDB_FILTER_DICTIONARY:
+                filter_as_json.emplace(
+                    "COMPRESSION_LEVEL",
+                    filter.get_option<int32_t>(TILEDB_COMPRESSION_LEVEL));
+                break;
+
+            case TILEDB_FILTER_DELTA:
+            case TILEDB_FILTER_DOUBLE_DELTA:
+                filter_as_json.emplace(
+                    "COMPRESSION_LEVEL",
+                    filter.get_option<int32_t>(TILEDB_COMPRESSION_LEVEL));
+                filter_as_json.emplace(
+                    "COMPRESSION_REINTERPRET_DATATYPE",
+                    filter.get_option<uint8_t>(
+                        TILEDB_COMPRESSION_REINTERPRET_DATATYPE));
+                break;
+
+            case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
+                filter_as_json.emplace(
+                    "BIT_WIDTH_MAX_WINDOW",
+                    filter.get_option<uint32_t>(TILEDB_BIT_WIDTH_MAX_WINDOW));
+                break;
+
+            case TILEDB_FILTER_POSITIVE_DELTA:
+                filter_as_json.emplace(
+                    "POSITIVE_DELTA_MAX_WINDOW",
+                    filter.get_option<uint32_t>(
+                        TILEDB_POSITIVE_DELTA_MAX_WINDOW));
+                break;
+
+            case TILEDB_FILTER_SCALE_FLOAT:
+                filter_as_json.emplace(
+                    "SCALE_FLOAT_FACTOR",
+                    filter.get_option<double>(TILEDB_SCALE_FLOAT_FACTOR));
+                filter_as_json.emplace(
+                    "SCALE_FLOAT_OFFSET",
+                    filter.get_option<double>(TILEDB_SCALE_FLOAT_OFFSET));
+                filter_as_json.emplace(
+                    "SCALE_FLOAT_BYTEWIDTH",
+                    filter.get_option<uint64_t>(TILEDB_SCALE_FLOAT_BYTEWIDTH));
+                break;
+
+            case TILEDB_FILTER_WEBP:
+                filter_as_json.emplace(
+                    "WEBP_INPUT_FORMAT",
+                    filter.get_option<uint8_t>(TILEDB_WEBP_INPUT_FORMAT));
+                filter_as_json.emplace(
+                    "WEBP_QUALITY",
+                    filter.get_option<float>(TILEDB_WEBP_QUALITY));
+                filter_as_json.emplace(
+                    "WEBP_LOSSLESS",
+                    filter.get_option<uint8_t>(TILEDB_WEBP_LOSSLESS));
+                break;
+
+            case TILEDB_FILTER_CHECKSUM_MD5:
+            case TILEDB_FILTER_CHECKSUM_SHA256:
+            case TILEDB_FILTER_XOR:
+            case TILEDB_FILTER_BITSHUFFLE:
+            case TILEDB_FILTER_BYTESHUFFLE:
+            case TILEDB_FILTER_DEPRECATED:
+            case TILEDB_FILTER_NONE:
+                // These filters have no options and is left empty intentionally
+                break;
+        }
+        filter_list_as_json.emplace_back(filter_as_json);
+    }
+    return filter_list_as_json;
+}
+
 std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
     std::shared_ptr<Context> ctx, std::shared_ptr<Array> tiledb_array) {
     auto tiledb_schema = tiledb_array->schema();

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -189,6 +189,14 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx, std::shared_ptr<Array> tiledb_array);
 
     /**
+     * @brief Get members of the TileDB Schema in the form of a PlatformConfig
+     *
+     * @return PlatformConfig
+     */
+    static PlatformConfig platform_config_from_tiledb_schema(
+        ArraySchema tiledb_schema);
+
+    /**
      * @brief Create a TileDB ArraySchema from ArrowSchema
      *
      * @return tiledb::ArraySchema
@@ -275,6 +283,12 @@ class ArrowAdapter {
         Filter filter, std::string option_name, json value);
 
     static tiledb_layout_t _get_order(std::string order);
+
+    static json _get_attrs_filter_list_json(ArraySchema tiledb_schema);
+
+    static json _get_dims_filter_list_json(ArraySchema tiledb_schema);
+
+    static json _get_filter_list_json(FilterList filter_list);
 };
 };  // namespace tiledbsoma
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2700

**Changes:**

Get the `ArraySchema` options that cannot be represented in the `ArrowSchema` (such as filter lists, tile/cell order, etc) in the form of a `PlatformConfig`.