### PR TITLE
[r] R versioning past `release-1.12` branch

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.11.99.2
+Version: 1.12.99.0
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,4 +1,28 @@
-# Develop
+# tiledbsoma 1.11.4
+
+## Changes
+
+* Fixes a couple bugs observed in Python
+
+# tiledbsoma 1.11.3
+
+## Changes
+
+* Fixes an intermittent segfault observed in Python
+
+# tiledbsoma 1.11.2
+
+## Changes
+
+* New `reopen` method available from R
+
+# tiledbsoma 1.11.1
+
+## Changes
+
+* No R changes; only an update for Python
+
+# tiledbsoma 1.11.0
 
 ## Changes
 
@@ -14,6 +38,68 @@
 * Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
 * Clear timestamp when using `$reopen()` to reopen at the current time
 * Add support for the re-indexer
+
+# 1.10.2
+
+* Port resume-ingest mode from Python to R
+
+# 1.10.1
+
+* This release contains a single Python-only bug fix
+
+# 1.10.0
+
+## Changes
+
+* Add support for ingestion of `SeuratCommand` logs
+* Add support for outgestion of `SeuratCommand` logs
+* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
+* Add support for blockwise iteration
+* Make `reopen()` a public method for all `TileDBObjects`
+* Add support for resume-mode in `write_soma()`
+
+# 1.9.5
+
+* This release contains a single Python-only bug fix
+
+# 1.9.4
+
+* This release contains an in-progress blockwise iterator, work on which will be completed in a subsequent release.
+* Reverted nanoarrow use to vendored versions and refactored the use throughout R and adjusted the build steps accordingly.
+
+# 1.9.3
+
+* This release contains a single Python-only performance improvement
+
+# 1.9.2
+
+* This release contains a single Python-only modification for an API backward-compatibility update
+
+# 1.9.1
+
+* This release contains a single Python-only modification for its build process
+
+# 1.9.0
+
+## Changes
+
+* Add support for ingestion of `SeuratCommand` logs
+* Add support for outgestion of `SeuratCommand` logs
+* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
+
+# 1.8.1
+
+## Changes
+
+* This is a release with Python changes only
+
+# 1.8.0
+
+## Changes
+
+* Add support for ingestion of `SeuratCommand` logs
+* Add support for outgestion of `SeuratCommand` logs
+
 
 # 1.7.0
 


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

See also #2672