### PR TITLE
[c++] Fix a nightly-build issue

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -565,9 +565,9 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     *ctx, attr, child->name);
                 LOG_DEBUG(fmt::format(
                     "[ArrowAdapter] dictionary for {} as {} {}",
-                    child->name,
-                    enmr_type,
-                    enmr_format));
+                    std::string(child->name),
+                    tiledb::impl::type_to_str(enmr_type),
+                    std::string(enmr_format)));
             }
 
             LOG_DEBUG(


### PR DESCRIPTION
* Fixes https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/170
* Basically a recurrence of https://github.com/single-cell-data/TileDB-SOMA/pull/2609
  * There, the `fmt::format` argument which was not `formattable` was of type `json`
  * Here, the `fmt::format` argument which is not `formattable` is of core type `tiledb_datatype_t` which is a C++ int-backed `enum` type
* Open question in my mind: why is that these issues compile OK in our TileDB-SOMA repo CI but fail to compile in the nightlies? I'd love to surface these errors sooner.