### PR TITLE
[c++] More `SOMAGroup` refinements

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -236,6 +236,11 @@ class SOMAArray : public SOMAObject {
         return arr_->is_open();
     }
 
+    /**
+     * Get whether the SOMAArray was open in read or write mode.
+     *
+     * @return OpenMode
+     */
     OpenMode mode() const {
         return mq_->query_type() == TILEDB_READ ? OpenMode::read :
                                                   OpenMode::write;

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -116,6 +116,15 @@ class SOMACollection : public SOMAGroup {
     SOMACollection(SOMACollection&&) = default;
     ~SOMACollection() = default;
 
+    using iterator =
+        typename std::map<std::string, std::shared_ptr<SOMAObject>>::iterator;
+    iterator begin() {
+        return children_.begin();
+    }
+    iterator end() {
+        return children_.end();
+    }
+
     using SOMAGroup::open;
 
     /**
@@ -180,7 +189,7 @@ class SOMACollection : public SOMAGroup {
         URIType uri_type,
         std::shared_ptr<SOMAContext> ctx,
         std::unique_ptr<ArrowSchema> schema,
-        ArrowTable indext_columns,
+        ArrowTable index_columns,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);
 

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -65,8 +65,16 @@ void SOMAExperiment::create(
     auto name = std::string(std::filesystem::path(uri).filename());
     auto group = SOMAGroup::open(
         OpenMode::write, experiment_uri.string(), ctx, name, timestamp);
-    group->set((experiment_uri / "obs").string(), URIType::absolute, "obs");
-    group->set((experiment_uri / "ms").string(), URIType::absolute, "ms");
+    group->set(
+        (experiment_uri / "obs").string(),
+        URIType::absolute,
+        "obs",
+        "SOMADataFrame");
+    group->set(
+        (experiment_uri / "ms").string(),
+        URIType::absolute,
+        "ms",
+        "SOMACollection");
     group->close();
 }
 

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -95,8 +95,8 @@ class SOMAExperiment : public SOMACollection {
     }
 
     SOMAExperiment() = delete;
-    SOMAExperiment(const SOMAExperiment&) = delete;
-    SOMAExperiment(SOMAExperiment&&) = delete;
+    SOMAExperiment(const SOMAExperiment&) = default;
+    SOMAExperiment(SOMAExperiment&&) = default;
     ~SOMAExperiment() = default;
 
     /**

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -213,7 +213,7 @@ void SOMAGroup::del(const std::string& name) {
     group_->remove_member(name);
 }
 
-std::map<std::string, SOMAGroupEntry> SOMAGroup::members() const {
+std::map<std::string, SOMAGroupEntry> SOMAGroup::members_map() const {
     return members_map_;
 }
 

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -148,7 +148,7 @@ void SOMAGroup::fill_caches() {
             default:
                 throw TileDBSOMAError("Saw invalid TileDB type");
         }
-        members_[mem.name().value()] = SOMAGroupEntry(mem.uri(), soma_type);
+        members_map_[mem.name().value()] = SOMAGroupEntry(mem.uri(), soma_type);
     }
 }
 
@@ -202,7 +202,7 @@ void SOMAGroup::set(
         relative = uri.find("://") != std::string::npos;
     }
     group_->add_member(uri, relative, name);
-    members_[name] = SOMAGroupEntry(uri, soma_type);
+    members_map_[name] = SOMAGroupEntry(uri, soma_type);
 }
 
 uint64_t SOMAGroup::count() const {
@@ -214,7 +214,7 @@ void SOMAGroup::del(const std::string& name) {
 }
 
 std::map<std::string, SOMAGroupEntry> SOMAGroup::members() const {
-    return members_;
+    return members_map_;
 }
 
 std::optional<TimestampRange> SOMAGroup::timestamp() {

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -45,6 +45,9 @@
 namespace tiledbsoma {
 using namespace tiledb;
 
+// Pair storing uri and soma type
+using SOMAGroupEntry = std::pair<std::string, std::string>;
+
 class SOMAGroup : public SOMAObject {
    public:
     //===================================================================
@@ -137,6 +140,16 @@ class SOMAGroup : public SOMAObject {
     }
 
     /**
+     * Get whether the SOMAGroup was open in read or write mode.
+     *
+     * @return OpenMode
+     */
+    OpenMode mode() const {
+        return group_->query_type() == TILEDB_READ ? OpenMode::read :
+                                                     OpenMode::write;
+    }
+
+    /**
      * Get the SOMAGroup URI.
      */
     const std::string uri() const;
@@ -177,7 +190,11 @@ class SOMAGroup : public SOMAObject {
      * or relative
      * @param name of member
      */
-    void set(const std::string& uri, URIType uri_type, const std::string& name);
+    void set(
+        const std::string& uri,
+        URIType uri_type,
+        const std::string& name,
+        const std::string& soma_type);
 
     /**
      * Get the number of members in the SOMAGroup.
@@ -192,11 +209,11 @@ class SOMAGroup : public SOMAObject {
     void del(const std::string& name);
 
     /**
-     * Return a SOMAGroup member to URI mapping.
+     * Return a mapping of all members in the group with its uri and type.
      *
      * @return std::optional<TimestampRange>
      */
-    std::map<std::string, std::string> member_to_uri_mapping() const;
+    std::map<std::string, SOMAGroupEntry> members() const;
 
     /**
      * Return optional timestamp pair SOMAArray was opened with.
@@ -327,7 +344,7 @@ class SOMAGroup : public SOMAObject {
     std::optional<TimestampRange> timestamp_;
 
     // Member-to-URI cache
-    std::map<std::string, std::string> member_to_uri_;
+    std::map<std::string, SOMAGroupEntry> members_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -213,7 +213,7 @@ class SOMAGroup : public SOMAObject {
      *
      * @return std::optional<TimestampRange>
      */
-    std::map<std::string, SOMAGroupEntry> members() const;
+    std::map<std::string, SOMAGroupEntry> members_map() const;
 
     /**
      * Return optional timestamp pair SOMAArray was opened with.
@@ -344,7 +344,7 @@ class SOMAGroup : public SOMAObject {
     std::optional<TimestampRange> timestamp_;
 
     // Member-to-URI cache
-    std::map<std::string, SOMAGroupEntry> members_;
+    std::map<std::string, SOMAGroupEntry> members_map_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -68,12 +68,36 @@ void SOMAMeasurement::create(
 
     auto name = std::string(std::filesystem::path(uri).filename());
     auto group = SOMAGroup::open(OpenMode::write, uri, ctx, name, timestamp);
-    group->set((measurement_uri / "var").string(), URIType::absolute, "var");
-    group->set((measurement_uri / "X").string(), URIType::absolute, "X");
-    group->set((measurement_uri / "obsm").string(), URIType::absolute, "obsm");
-    group->set((measurement_uri / "obsp").string(), URIType::absolute, "obsp");
-    group->set((measurement_uri / "varm").string(), URIType::absolute, "varm");
-    group->set((measurement_uri / "varp").string(), URIType::absolute, "varp");
+    group->set(
+        (measurement_uri / "var").string(),
+        URIType::absolute,
+        "var",
+        "SOMADataFrame");
+    group->set(
+        (measurement_uri / "X").string(),
+        URIType::absolute,
+        "X",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "obsm").string(),
+        URIType::absolute,
+        "obsm",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "obsp").string(),
+        URIType::absolute,
+        "obsp",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "varm").string(),
+        URIType::absolute,
+        "varm",
+        "SOMACollection");
+    group->set(
+        (measurement_uri / "varp").string(),
+        URIType::absolute,
+        "varp",
+        "SOMACollection");
     group->close();
 }
 

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -95,8 +95,8 @@ class SOMAMeasurement : public SOMACollection {
     }
 
     SOMAMeasurement() = delete;
-    SOMAMeasurement(const SOMAMeasurement&) = delete;
-    SOMAMeasurement(SOMAMeasurement&&) = delete;
+    SOMAMeasurement(const SOMAMeasurement&) = default;
+    SOMAMeasurement(SOMAMeasurement&&) = default;
     ~SOMAMeasurement() = default;
 
     /**

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -79,6 +79,13 @@ class SOMAObject {
     virtual std::shared_ptr<SOMAContext> ctx() = 0;
 
     /**
+     * Get whether the SOMAObject was open in read or write mode.
+     *
+     * @return OpenMode
+     */
+    virtual OpenMode mode() const = 0;
+
+    /**
      * @brief Close the SOMAObject.
      */
     virtual void close() = 0;

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -71,7 +71,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_sparse->uri() == sub_uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -83,7 +83,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
 
@@ -112,7 +112,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -123,7 +123,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
 
@@ -151,7 +151,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -162,7 +162,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
 }
@@ -181,14 +181,14 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
 
@@ -212,7 +212,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -220,7 +220,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
 
@@ -244,7 +244,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -252,7 +252,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members() == expected_map);
+    REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
 

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -56,8 +56,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     auto index_columns = helper::create_column_index_info();
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
 
-    std::map<std::string, std::string> expected_map{
-        {"sparse_ndarray", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -71,7 +71,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_sparse->uri() == sub_uri);
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
@@ -83,7 +83,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -97,7 +97,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     auto index_columns = helper::create_column_index_info();
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
 
-    std::map<std::string, std::string> expected_map{{"dense_ndarray", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -111,7 +112,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -122,7 +123,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -135,7 +136,8 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     SOMACollection::create(base_uri, ctx, ts);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"dataframe", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -149,7 +151,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -160,7 +162,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
 }
@@ -173,19 +175,20 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     SOMACollection::create(base_uri, ctx);
     auto schema = helper::create_schema(*ctx->tiledb_ctx(), false);
 
-    std::map<std::string, std::string> expected_map{{"subcollection", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -197,7 +200,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     SOMACollection::create(base_uri, ctx);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"experiment", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
@@ -208,7 +212,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -216,7 +220,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 
@@ -228,7 +232,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     SOMACollection::create(base_uri, ctx);
     auto [schema, index_columns] = helper::create_arrow_schema();
 
-    std::map<std::string, std::string> expected_map{{"measurement", sub_uri}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
@@ -239,7 +244,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -247,7 +252,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->member_to_uri_mapping() == expected_map);
+    REQUIRE(soma_collection->members() == expected_map);
     soma_collection->close();
 }
 

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -169,13 +169,13 @@ TEST_CASE("SOMAGroup: basic") {
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->count() == 2);
-    REQUIRE(expected_map == soma_group->members());
+    REQUIRE(expected_map == soma_group->members_map());
     REQUIRE(soma_group->get("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get("subarray").type() == Object::Type::Array);
     soma_group->close();
 
     soma_group->open(OpenMode::write, TimestampRange(0, 3));
-    REQUIRE(expected_map == soma_group->members());
+    REQUIRE(expected_map == soma_group->members_map());
     soma_group->del("subgroup");
     soma_group->close();
 

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -157,24 +157,25 @@ TEST_CASE("SOMAGroup: basic") {
 
     auto soma_group = SOMAGroup::open(
         OpenMode::write, uri_main_group, ctx, "metadata", TimestampRange(0, 1));
-    soma_group->set(uri_sub_group, URIType::absolute, "subgroup");
-    soma_group->set(uri_sub_array, URIType::absolute, "subarray");
+    soma_group->set(uri_sub_group, URIType::absolute, "subgroup", "SOMAGroup");
+    soma_group->set(uri_sub_array, URIType::absolute, "subarray", "SOMAArray");
     soma_group->close();
 
-    std::map<std::string, std::string> expected_map{
-        {"subgroup", uri_sub_group}, {"subarray", uri_sub_array}};
+    std::map<std::string, SOMAGroupEntry> expected_map{
+        {"subgroup", SOMAGroupEntry(uri_sub_group, "SOMAGroup")},
+        {"subarray", SOMAGroupEntry(uri_sub_array, "SOMAArray")}};
 
     soma_group->open(OpenMode::read, TimestampRange(0, 2));
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->count() == 2);
-    REQUIRE(expected_map == soma_group->member_to_uri_mapping());
+    REQUIRE(expected_map == soma_group->members());
     REQUIRE(soma_group->get("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get("subarray").type() == Object::Type::Array);
     soma_group->close();
 
     soma_group->open(OpenMode::write, TimestampRange(0, 3));
-    REQUIRE(expected_map == soma_group->member_to_uri_mapping());
+    REQUIRE(expected_map == soma_group->members());
     soma_group->del("subgroup");
     soma_group->close();
 


### PR DESCRIPTION
**Issue and/or context:**

This work is originally a part of https://github.com/single-cell-data/TileDB-SOMA/pull/2675

**Changes:**

- Replace contents of `SOMACollection::get` with a call to `SOMAObject::open`
- Rename `SOMAGroup::member_to_uri_mapping` to `SOMAGroup::members` (this is a getter that returns a map of the child member's name and its associated `SOMAGroupEntry`)
- Refactor `SOMAGroup::members` mapping to store `SOMAGroupEntry` values. `SOMAGroupEntry` stores the URI of the child member and the type of `SOMAObject` it is. This type info gets passed into `SOMAObject::open` (via `SOMACollection::get`) to reduce the number of unnecessary `tiledb::open` calls
- Add an iterator for `SOMACollection`
- Add missing documentation
- Rethrow `TileDBError` as `TileDBSOMAError` where relevant