### PR TITLE
[python] Add `pybind11` bindings for `SOMAGroup` 2/5

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -208,7 +208,8 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
     return results;
 }
 
-void set_metadata(SOMAObject& soma_object, const std::string& key, py::array value) {
+void set_metadata(
+    SOMAObject& soma_object, const std::string& key, py::array value) {
     tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
 
     if (is_tdb_str(value_type) && value.size() > 1)

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -42,7 +42,8 @@ std::optional<py::object> to_table(
     std::optional<std::shared_ptr<ArrayBuffers>> buffers);
 
 py::dict meta(std::map<std::string, MetadataValue> metadata_mapping);
-void set_metadata(SOMAObject& soma_object, const std::string& key, py::array value);
+void set_metadata(
+    SOMAObject& soma_object, const std::string& key, py::array value);
 
 class PyQueryCondition {
    private:

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -33,10 +33,16 @@ class TileDBSOMAPyError : std::runtime_error {
 namespace tiledbsoma {
 
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
+
 tiledb_datatype_t np_to_tdb_dtype(py::dtype type);
+
 bool is_tdb_str(tiledb_datatype_t type);
+
 std::optional<py::object> to_table(
     std::optional<std::shared_ptr<ArrayBuffers>> buffers);
+
+py::dict meta(std::map<std::string, MetadataValue> metadata_mapping);
+void set_metadata(SOMAObject& soma_object, const std::string& key, py::array value);
 
 class PyQueryCondition {
    private:

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -58,6 +58,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .value("rowmajor", ResultOrder::rowmajor)
         .value("colmajor", ResultOrder::colmajor);
 
+    py::enum_<URIType>(m, "URIType")
+        .value("automatic", URIType::automatic)
+        .value("absolute", URIType::absolute)
+        .value("relative", URIType::relative);
+
     m.doc() = "SOMA acceleration library";
 
     m.def("version", []() { return tiledbsoma::version::as_string(); });

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -101,52 +101,6 @@ py::dict meta(SOMAArray& array) {
     return results;
 }
 
-py::tuple get_enum(SOMAArray& sr, std::string attr_name) {
-    auto attr_to_enmrs = sr.get_attr_to_enum_mapping();
-    if (attr_to_enmrs.count(attr_name) == 0)
-        TPY_ERROR_LOC("Given attribute does not have enumeration");
-
-    Enumeration enmr(attr_to_enmrs.at(attr_name));
-
-    switch (enmr.type()) {
-        case TILEDB_UINT8:
-            return py::tuple(py::cast(enmr.as_vector<uint8_t>()));
-        case TILEDB_INT8:
-            return py::tuple(py::cast(enmr.as_vector<int8_t>()));
-        case TILEDB_UINT16:
-            return py::tuple(py::cast(enmr.as_vector<uint16_t>()));
-        case TILEDB_INT16:
-            return py::tuple(py::cast(enmr.as_vector<int16_t>()));
-        case TILEDB_UINT32:
-            return py::tuple(py::cast(enmr.as_vector<uint32_t>()));
-        case TILEDB_INT32:
-            return py::tuple(py::cast(enmr.as_vector<int32_t>()));
-        case TILEDB_UINT64:
-            return py::tuple(py::cast(enmr.as_vector<uint64_t>()));
-        case TILEDB_INT64:
-            return py::tuple(py::cast(enmr.as_vector<int64_t>()));
-        case TILEDB_FLOAT32:
-            return py::tuple(py::cast(enmr.as_vector<float>()));
-        case TILEDB_FLOAT64:
-            return py::tuple(py::cast(enmr.as_vector<double>()));
-        case TILEDB_STRING_ASCII:
-        case TILEDB_STRING_UTF8:
-        case TILEDB_CHAR:
-            return py::tuple(py::cast(enmr.as_vector<std::string>()));
-        case TILEDB_BOOL:
-            return py::tuple(py::cast(enmr.as_vector<bool>()));
-        default:
-            TPY_ERROR_LOC("Unsupported enumeration type.");
-    }
-}
-
-bool get_enum_is_ordered(SOMAArray& sr, std::string attr_name) {
-    auto attr_to_enmrs = sr.get_attr_to_enum_mapping();
-    if (attr_to_enmrs.count(attr_name) == 0)
-        TPY_ERROR_LOC("Given attribute does not have enumeration");
-    return attr_to_enmrs.at(attr_name).ordered();
-}
-
 void load_soma_array(py::module& m) {
     py::class_<SOMAArray>(m, "SOMAArray", "SOMAObject")
         .def(
@@ -183,20 +137,20 @@ void load_soma_array(py::module& m) {
             "platform_config"_a = py::dict(),
             "timestamp"_a = py::none())
 
-        .def("__enter__", [](SOMAArray& reader) { return reader; })
+        .def("__enter__", [](SOMAArray& array) { return array; })
         .def(
             "__exit__",
-            [](SOMAArray& reader,
+            [](SOMAArray& array,
                py::object exc_type,
                py::object exc_value,
-               py::object traceback) { reader.close(); })
+               py::object traceback) { array.close(); })
 
         .def(
             "set_condition",
-            [](SOMAArray& reader,
+            [](SOMAArray& array,
                py::object py_query_condition,
                py::object py_schema) {
-                auto column_names = reader.column_names();
+                auto column_names = array.column_names();
                 // Handle query condition based on
                 // TileDB-Py::PyQuery::set_attr_cond()
                 QueryCondition* qc = nullptr;
@@ -223,14 +177,14 @@ void load_soma_array(py::module& m) {
                              .ptr()
                              .get();
                 }
-                reader.reset(column_names);
+                array.reset(column_names);
 
                 // Release python GIL after we're done accessing python
                 // objects
                 py::gil_scoped_release release;
                 // Set query condition if present
                 if (qc) {
-                    reader.set_condition(*qc);
+                    array.set_condition(*qc);
                 }
             },
             "py_query_condition"_a,
@@ -238,7 +192,7 @@ void load_soma_array(py::module& m) {
 
         .def(
             "reset",
-            [](SOMAArray& reader,
+            [](SOMAArray& array,
                std::optional<std::vector<std::string>> column_names_in,
                std::string_view batch_size,
                ResultOrder result_order) {
@@ -249,7 +203,7 @@ void load_soma_array(py::module& m) {
                 }
 
                 // Reset state of the existing SOMAArray object
-                reader.reset(column_names, batch_size, result_order);
+                array.reset(column_names, batch_size, result_order);
             },
             py::kw_only(),
             "column_names"_a = py::none(),
@@ -264,20 +218,20 @@ void load_soma_array(py::module& m) {
         .def("close", &SOMAArray::close)
         .def_property_readonly(
             "closed",
-            [](SOMAArray& reader) -> bool { return not reader.is_open(); })
+            [](SOMAArray& array) -> bool { return not array.is_open(); })
         .def_property_readonly(
             "mode",
-            [](SOMAArray& reader) {
-                return reader.mode() == OpenMode::read ? "r" : "w";
+            [](SOMAArray& array) {
+                return array.mode() == OpenMode::read ? "r" : "w";
             })
         .def_property_readonly(
             "schema",
-            [](SOMAArray& reader) -> py::object {
+            [](SOMAArray& array) -> py::object {
                 auto pa = py::module::import("pyarrow");
                 auto pa_schema_import = pa.attr("Schema").attr(
                     "_import_from_c");
                 return pa_schema_import(
-                    py::capsule(reader.arrow_schema().get()));
+                    py::capsule(array.arrow_schema().get()));
             })
         .def("context", &SOMAArray::ctx)
 
@@ -286,7 +240,7 @@ void load_soma_array(py::module& m) {
         // long if-else-if function.
         .def(
             "set_dim_points_arrow",
-            [](SOMAArray& reader,
+            [](SOMAArray& array,
                const std::string& dim,
                py::object py_arrow_array,
                int partition_index,
@@ -300,56 +254,56 @@ void load_soma_array(py::module& m) {
                     array_chunks.append(py_arrow_array);
                 }
 
-                for (const pybind11::handle array : array_chunks) {
+                for (const pybind11::handle handle : array_chunks) {
                     ArrowSchema arrow_schema;
                     ArrowArray arrow_array;
                     uintptr_t arrow_schema_ptr = (uintptr_t)(&arrow_schema);
                     uintptr_t arrow_array_ptr = (uintptr_t)(&arrow_array);
 
-                    // Call array._export_to_c to get arrow array and schema
+                    // Call handle._export_to_c to get arrow array and schema
                     //
                     // If ever a NumPy array gets in here, there will be an
                     // exception like "AttributeError: 'numpy.ndarray' object
                     // has no attribute '_export_to_c'".
-                    array.attr("_export_to_c")(
+                    handle.attr("_export_to_c")(
                         arrow_array_ptr, arrow_schema_ptr);
 
-                    auto coords = array.attr("tolist")();
+                    auto coords = handle.attr("tolist")();
 
                     if (!strcmp(arrow_schema.format, "l")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<int64_t>>());
                     } else if (!strcmp(arrow_schema.format, "i")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<int32_t>>());
                     } else if (!strcmp(arrow_schema.format, "s")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<int16_t>>());
                     } else if (!strcmp(arrow_schema.format, "c")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<int8_t>>());
                     } else if (!strcmp(arrow_schema.format, "L")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<uint64_t>>());
                     } else if (!strcmp(arrow_schema.format, "I")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<uint32_t>>());
                     } else if (!strcmp(arrow_schema.format, "S")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<uint16_t>>());
                     } else if (!strcmp(arrow_schema.format, "C")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<uint8_t>>());
                     } else if (!strcmp(arrow_schema.format, "f")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<float>>());
                     } else if (!strcmp(arrow_schema.format, "g")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<double>>());
                     } else if (
                         !strcmp(arrow_schema.format, "u") ||
                         !strcmp(arrow_schema.format, "z")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<std::string>>());
                     } else if (
                         !strcmp(arrow_schema.format, "tss:") ||
@@ -358,14 +312,14 @@ void load_soma_array(py::module& m) {
                         !strcmp(arrow_schema.format, "tsn:")) {
                         // convert the Arrow Array to int64
                         auto pa = py::module::import("pyarrow");
-                        coords = array.attr("cast")(pa.attr("int64")())
+                        coords = handle.attr("cast")(pa.attr("int64")())
                                      .attr("tolist")();
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<int64_t>>());
                     } else if (
                         !strcmp(arrow_schema.format, "U") ||
                         !strcmp(arrow_schema.format, "Z")) {
-                        reader.set_dim_points(
+                        array.set_dim_points(
                             dim, coords.cast<std::vector<std::string>>());
                     } else {
                         TPY_ERROR_LOC(
@@ -564,12 +518,12 @@ void load_soma_array(py::module& m) {
 
         .def(
             "read_next",
-            [](SOMAArray& reader) -> std::optional<py::object> {
+            [](SOMAArray& array) -> std::optional<py::object> {
                 // Release python GIL before reading data
                 py::gil_scoped_release release;
 
                 // Try to read more data
-                auto buffers = reader.read_next();
+                auto buffers = array.read_next();
 
                 // If more data was read, convert it to an arrow table and
                 // return
@@ -597,27 +551,21 @@ void load_soma_array(py::module& m) {
 
         .def_property_readonly("result_order", &SOMAArray::result_order)
 
-        .def("get_enum", get_enum)
-
-        .def("get_enum_is_ordered", get_enum_is_ordered)
-
-        .def("get_enum_label_on_attr", &SOMAArray::get_enum_label_on_attr)
-
         .def_property_readonly(
             "timestamp",
-            [](SOMAArray& reader) -> py::object {
-                if (!reader.timestamp().has_value())
+            [](SOMAArray& array) -> py::object {
+                if (!array.timestamp().has_value())
                     return py::none();
-                return py::cast(reader.timestamp()->second);
+                return py::cast(array.timestamp()->second);
             })
 
         .def(
             "non_empty_domain",
-            [](SOMAArray& reader, std::string name, py::dtype dtype) {
+            [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
                         return py::cast(
-                            reader.non_empty_domain<uint64_t>(name));
+                            array.non_empty_domain<uint64_t>(name));
                     case TILEDB_DATETIME_YEAR:
                     case TILEDB_DATETIME_MONTH:
                     case TILEDB_DATETIME_WEEK:
@@ -632,28 +580,28 @@ void load_soma_array(py::module& m) {
                     case TILEDB_DATETIME_FS:
                     case TILEDB_DATETIME_AS:
                     case TILEDB_INT64:
-                        return py::cast(reader.non_empty_domain<int64_t>(name));
+                        return py::cast(array.non_empty_domain<int64_t>(name));
                     case TILEDB_UINT32:
                         return py::cast(
-                            reader.non_empty_domain<uint32_t>(name));
+                            array.non_empty_domain<uint32_t>(name));
                     case TILEDB_INT32:
-                        return py::cast(reader.non_empty_domain<int32_t>(name));
+                        return py::cast(array.non_empty_domain<int32_t>(name));
                     case TILEDB_UINT16:
                         return py::cast(
-                            reader.non_empty_domain<uint16_t>(name));
+                            array.non_empty_domain<uint16_t>(name));
                     case TILEDB_INT16:
-                        return py::cast(reader.non_empty_domain<int16_t>(name));
+                        return py::cast(array.non_empty_domain<int16_t>(name));
                     case TILEDB_UINT8:
-                        return py::cast(reader.non_empty_domain<uint8_t>(name));
+                        return py::cast(array.non_empty_domain<uint8_t>(name));
                     case TILEDB_INT8:
-                        return py::cast(reader.non_empty_domain<int8_t>(name));
+                        return py::cast(array.non_empty_domain<int8_t>(name));
                     case TILEDB_FLOAT64:
-                        return py::cast(reader.non_empty_domain<double>(name));
+                        return py::cast(array.non_empty_domain<double>(name));
                     case TILEDB_FLOAT32:
-                        return py::cast(reader.non_empty_domain<float>(name));
+                        return py::cast(array.non_empty_domain<float>(name));
                     case TILEDB_STRING_UTF8:
                     case TILEDB_STRING_ASCII:
-                        return py::cast(reader.non_empty_domain_var(name));
+                        return py::cast(array.non_empty_domain_var(name));
                     default:
                         throw TileDBSOMAError(
                             "Unsupported dtype for nonempty domain.");
@@ -662,10 +610,10 @@ void load_soma_array(py::module& m) {
 
         .def(
             "domain",
-            [](SOMAArray& reader, std::string name, py::dtype dtype) {
+            [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
-                        return py::cast(reader.domain<uint64_t>(name));
+                        return py::cast(array.domain<uint64_t>(name));
                     case TILEDB_DATETIME_YEAR:
                     case TILEDB_DATETIME_MONTH:
                     case TILEDB_DATETIME_WEEK:
@@ -680,23 +628,23 @@ void load_soma_array(py::module& m) {
                     case TILEDB_DATETIME_FS:
                     case TILEDB_DATETIME_AS:
                     case TILEDB_INT64:
-                        return py::cast(reader.domain<int64_t>(name));
+                        return py::cast(array.domain<int64_t>(name));
                     case TILEDB_UINT32:
-                        return py::cast(reader.domain<uint32_t>(name));
+                        return py::cast(array.domain<uint32_t>(name));
                     case TILEDB_INT32:
-                        return py::cast(reader.domain<int32_t>(name));
+                        return py::cast(array.domain<int32_t>(name));
                     case TILEDB_UINT16:
-                        return py::cast(reader.domain<uint16_t>(name));
+                        return py::cast(array.domain<uint16_t>(name));
                     case TILEDB_INT16:
-                        return py::cast(reader.domain<int16_t>(name));
+                        return py::cast(array.domain<int16_t>(name));
                     case TILEDB_UINT8:
-                        return py::cast(reader.domain<uint8_t>(name));
+                        return py::cast(array.domain<uint8_t>(name));
                     case TILEDB_INT8:
-                        return py::cast(reader.domain<int8_t>(name));
+                        return py::cast(array.domain<int8_t>(name));
                     case TILEDB_FLOAT64:
-                        return py::cast(reader.domain<double>(name));
+                        return py::cast(array.domain<double>(name));
                     case TILEDB_FLOAT32:
-                        return py::cast(reader.domain<float>(name));
+                        return py::cast(array.domain<float>(name));
                     case TILEDB_STRING_UTF8:
                     case TILEDB_STRING_ASCII: {
                         std::pair<std::string, std::string> str_domain;

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -564,8 +564,7 @@ void load_soma_array(py::module& m) {
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
-                        return py::cast(
-                            array.non_empty_domain<uint64_t>(name));
+                        return py::cast(array.non_empty_domain<uint64_t>(name));
                     case TILEDB_DATETIME_YEAR:
                     case TILEDB_DATETIME_MONTH:
                     case TILEDB_DATETIME_WEEK:
@@ -582,13 +581,11 @@ void load_soma_array(py::module& m) {
                     case TILEDB_INT64:
                         return py::cast(array.non_empty_domain<int64_t>(name));
                     case TILEDB_UINT32:
-                        return py::cast(
-                            array.non_empty_domain<uint32_t>(name));
+                        return py::cast(array.non_empty_domain<uint32_t>(name));
                     case TILEDB_INT32:
                         return py::cast(array.non_empty_domain<int32_t>(name));
                     case TILEDB_UINT16:
-                        return py::cast(
-                            array.non_empty_domain<uint16_t>(name));
+                        return py::cast(array.non_empty_domain<uint16_t>(name));
                     case TILEDB_INT16:
                         return py::cast(array.non_empty_domain<int16_t>(name));
                     case TILEDB_UINT8:
@@ -661,8 +658,8 @@ void load_soma_array(py::module& m) {
         .def("consolidate_and_vacuum", &SOMAArray::consolidate_and_vacuum)
 
         .def(
-            "set_metadata", 
-            [](SOMAArray& array, const std::string& key, py::array value){
+            "set_metadata",
+            [](SOMAArray& array, const std::string& key, py::array value) {
                 set_metadata(array, key, value);
             })
         .def("delete_metadata", &SOMAArray::delete_metadata)

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -101,21 +101,6 @@ py::dict meta(SOMAArray& array) {
     return results;
 }
 
-void set_metadata(SOMAArray& sr, const std::string& key, py::array value) {
-    tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
-
-    if (is_tdb_str(value_type) && value.size() > 1)
-        throw py::type_error("array/list of strings not supported");
-
-    py::buffer_info value_buffer = value.request();
-    if (value_buffer.ndim != 1)
-        throw py::type_error("Only 1D Numpy arrays can be stored as metadata");
-
-    auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
-    sr.set_metadata(
-        key, value_type, value_num, value_num > 0 ? value.data() : nullptr);
-}
-
 py::tuple get_enum(SOMAArray& sr, std::string attr_name) {
     auto attr_to_enmrs = sr.get_attr_to_enum_mapping();
     if (attr_to_enmrs.count(attr_name) == 0)
@@ -727,8 +712,11 @@ void load_soma_array(py::module& m) {
 
         .def("consolidate_and_vacuum", &SOMAArray::consolidate_and_vacuum)
 
-        .def("set_metadata", set_metadata)
-
+        .def(
+            "set_metadata", 
+            [](SOMAArray& array, const std::string& key, py::array value){
+                set_metadata(array, key, value);
+            })
         .def("delete_metadata", &SOMAArray::delete_metadata)
 
         .def(

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -47,8 +47,19 @@ using namespace py::literals;
 using namespace tiledbsoma;
 
 void load_soma_collection(py::module& m) {
-    py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection");
-    py::class_<SOMAExperiment, SOMAGroup, SOMAObject>(m, "SOMAExperiment");
-    py::class_<SOMAMeasurement, SOMAGroup, SOMAObject>(m, "SOMAMeasurement");
+    py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
+        .def(
+            "__iter__",
+            [](SOMACollection& collection) {
+                return py::make_iterator(collection.begin(), collection.end());
+            },
+            py::keep_alive<0, 1>())
+        .def("get", &SOMACollection::get);
+
+    py::class_<SOMAExperiment, SOMACollection, SOMAGroup, SOMAObject>(
+        m, "SOMAExperiment");
+
+    py::class_<SOMAMeasurement, SOMACollection, SOMAGroup, SOMAObject>(
+        m, "SOMAMeasurement");
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -93,8 +93,8 @@ void load_soma_group(py::module& m) {
                 return meta(group.get_metadata());
             })
         .def(
-            "set_metadata", 
-            [](SOMAGroup& group, const std::string& key, py::array value){
+            "set_metadata",
+            [](SOMAGroup& group, const std::string& key, py::array value) {
                 set_metadata(group, key, value);
             })
         .def("delete_metadata", &SOMAGroup::delete_metadata)

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -40,6 +40,65 @@ using namespace tiledbsoma;
 
 void load_soma_group(py::module& m) {
     py::class_<SOMAGroup, SOMAObject>(m, "SOMAGroup")
-        .def_property_readonly("type", &SOMAGroup::type);
+        .def_static(
+            "create",
+            [](std::shared_ptr<SOMAContext> ctx,
+               std::string_view uri,
+               std::string soma_type,
+               std::optional<TimestampRange> timestamp) {
+                try {
+                    SOMAGroup::create(ctx, uri, soma_type, timestamp);
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
+            py::kw_only(),
+            "ctx"_a,
+            "uri"_a,
+            "soma_type"_a,
+            "timestamp"_a = py::none())
+        .def("__enter__", [](SOMAGroup& group) { return group; })
+        .def(
+            "__exit__",
+            [](SOMAGroup& group,
+               py::object exc_type,
+               py::object exc_value,
+               py::object traceback) { group.close(); })
+        .def_property_readonly(
+            "mode",
+            [](SOMAGroup& group) {
+                return group.mode() == OpenMode::read ? "r" : "w";
+            })
+        .def("close", &SOMAGroup::close)
+        .def_property_readonly(
+            "closed",
+            [](SOMAGroup& group) -> bool { return not group.is_open(); })
+        .def_property_readonly("uri", &SOMAGroup::uri)
+        .def("context", &SOMAGroup::ctx)
+        .def("has", &SOMAGroup::has)
+        .def("add", &SOMAGroup::set)
+        .def("count", &SOMAGroup::count)
+        .def("remove", &SOMAGroup::del)
+        .def("members", &SOMAGroup::members)
+        .def_property_readonly(
+            "timestamp",
+            [](SOMAGroup& group) -> py::object {
+                if (!group.timestamp().has_value())
+                    return py::none();
+                return py::cast(group.timestamp()->second);
+            })
+        .def_property_readonly(
+            "meta",
+            [](SOMAGroup& group) -> py::dict {
+                return meta(group.get_metadata());
+            })
+        .def(
+            "set_metadata", 
+            [](SOMAGroup& group, const std::string& key, py::array value){
+                set_metadata(group, key, value);
+            })
+        .def("delete_metadata", &SOMAGroup::delete_metadata)
+        .def("has_metadata", &SOMAGroup::has_metadata)
+        .def("metadata_num", &SOMAGroup::metadata_num);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -79,7 +79,7 @@ void load_soma_group(py::module& m) {
         .def("add", &SOMAGroup::set)
         .def("count", &SOMAGroup::count)
         .def("remove", &SOMAGroup::del)
-        .def("members", &SOMAGroup::members)
+        .def("members_map", &SOMAGroup::members_map)
         .def_property_readonly(
             "timestamp",
             [](SOMAGroup& group) -> py::object {

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -344,11 +344,7 @@ class SOMAGroup : public SOMAObject {
     std::optional<TimestampRange> timestamp_;
 
     // Member-to-URI cache
-<<<<<<< HEAD
     std::map<std::string, SOMAGroupEntry> members_map_;
-=======
-    std::map<std::string, SOMAGroupEntry> members_;
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -344,7 +344,11 @@ class SOMAGroup : public SOMAObject {
     std::optional<TimestampRange> timestamp_;
 
     // Member-to-URI cache
+<<<<<<< HEAD
     std::map<std::string, SOMAGroupEntry> members_map_;
+=======
+    std::map<std::string, SOMAGroupEntry> members_;
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -112,11 +112,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -127,11 +123,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -159,11 +151,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -174,11 +162,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
 }
@@ -197,22 +181,14 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -236,11 +212,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -248,11 +220,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -276,11 +244,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -288,11 +252,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
-=======
-    REQUIRE(soma_collection->members() == expected_map);
->>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -112,7 +112,11 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         "l",
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dense->uri() == sub_uri);
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
@@ -123,7 +127,11 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -151,7 +159,11 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dataframe->uri() == sub_uri);
     REQUIRE(soma_dataframe->ctx() == ctx);
     REQUIRE(soma_dataframe->type() == "SOMADataFrame");
@@ -162,7 +174,11 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
 }
@@ -181,14 +197,22 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_subcollection->uri() == sub_uri);
     REQUIRE(soma_subcollection->ctx() == ctx);
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -212,7 +236,11 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_experiment->uri() == sub_uri);
     REQUIRE(soma_experiment->ctx() == ctx);
     REQUIRE(soma_experiment->type() == "SOMAExperiment");
@@ -220,7 +248,11 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 
@@ -244,7 +276,11 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)));
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     REQUIRE(soma_measurement->uri() == sub_uri);
     REQUIRE(soma_measurement->ctx() == ctx);
     REQUIRE(soma_measurement->type() == "SOMAMeasurement");
@@ -252,7 +288,11 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_collection->close();
 
     soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+<<<<<<< HEAD
     REQUIRE(soma_collection->members_map() == expected_map);
+=======
+    REQUIRE(soma_collection->members() == expected_map);
+>>>>>>> 46adfa3e ([c++] More `SOMAGroup` refinements)
     soma_collection->close();
 }
 


### PR DESCRIPTION
**Issue and/or context:**

These changes are on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2731

**Changes:**

- Add bindings for `SOMAGroup` which gets inherited by `SOMACollection`, `SOMAMeasurement`, and `SOMAExperiment`
- Add bindings for `URIType` enumeration
- Move shared metadata functions used by both `SOMAArray` and `SOMAGroup` into `common.{cc,h}`
- Rename `reader` to `array` in `SOMAArray`
