### PR TITLE
[python] Release GIL where necessary in pybind11 code

### DIFF
--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -60,7 +60,8 @@ void load_soma_collection(py::module& m) {
             py::kw_only(),
             "mode"_a,
             "context"_a,
-            "timestamp"_a = py::none())
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>())
         .def(
             "__iter__",
             [](SOMACollection& collection) {

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -131,11 +131,18 @@ void load_soma_dataframe(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none())
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>())
 
-        .def_static("exists", &SOMADataFrame::exists)
+        .def_static(
+            "exists",
+            &SOMADataFrame::exists,
+            py::call_guard<py::gil_scoped_release>())
         .def_property_readonly(
             "index_column_names", &SOMADataFrame::index_column_names)
-        .def_property_readonly("count", &SOMADataFrame::count);
+        .def_property_readonly(
+            "count",
+            &SOMADataFrame::count,
+            py::call_guard<py::gil_scoped_release>());
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -120,9 +120,13 @@ void load_soma_dense_ndarray(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none())
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>())
 
-        .def_static("exists", &SOMADenseNDArray::exists)
+        .def_static(
+            "exists",
+            &SOMADenseNDArray::exists,
+            py::call_guard<py::gil_scoped_release>())
 
         .def("write", write);
 }

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -98,7 +98,8 @@ void load_soma_object(py::module& m) {
             "context"_a,
             py::kw_only(),
             "timestamp"_a = py::none(),
-            "clib_type"_a = py::none())
+            "clib_type"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>())
         .def_property_readonly("type", &SOMAObject::type);
 };
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -108,8 +108,12 @@ void load_soma_sparse_ndarray(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none())
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>())
 
-        .def_static("exists", &SOMASparseNDArray::exists);
+        .def_static(
+            "exists",
+            &SOMASparseNDArray::exists,
+            py::call_guard<py::gil_scoped_release>());
 }
 }  // namespace libtiledbsomacpp


### PR DESCRIPTION
**Issue and/or context:**

This issue was internally reported by @bkmartinjr:
> I am using the latest Python SOMA, and seeing some really weird serialization of my API requests that "feel" like the GIL is not being released for some I/O operations.
>
> For example:  soma.DataFrame.count.  If I'm reading the code right, it calls the underlying nnz method without releasing it.

**Changes:**

- Just as we do for `clib.SOMAArray.nnz`, we need to release the GIL for `clib.SOMADataFrame.count`
- Also release for all `create` and `open` operations