### PR TITLE
[python] Use bindings for `SOMAGroup` 3/5

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -126,7 +126,6 @@ class DataFrame(SOMAArray, somacore.DataFrame):
     """
 
     _wrapper_type = DataFrameWrapper
-    _reader_wrapper_type = DataFrameWrapper
 
     @classmethod
     def create(

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -81,7 +81,6 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
     __slots__ = ()
 
     _wrapper_type = DenseNDArrayWrapper
-    _reader_wrapper_type = DenseNDArrayWrapper
 
     @classmethod
     def create(

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from somacore import experiment, query
 from typing_extensions import Self
 
+from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._indexer import IntIndexer
@@ -64,6 +65,7 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
+    _wrapper_type = _tdb_handles.ExperimentWrapper
 
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -166,7 +166,7 @@ def reify_handle(hdl: _Wrapper) -> TileDBObject[_Wrapper]:
     """Picks out the appropriate SOMA class for a handle and wraps it."""
     typename = _read_soma_type(hdl)
     cls = _type_name_to_cls(typename)  # type: ignore[no-untyped-call]
-    if type(hdl) not in (cls._wrapper_type, cls._reader_wrapper_type):
+    if type(hdl) != cls._wrapper_type:
         raise SOMAError(
             f"cannot open {hdl.uri!r}: a {type(hdl._handle)}"
             f" cannot be converted to a {typename}"

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -10,6 +10,7 @@ from typing import Union
 
 from somacore import measurement
 
+from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
@@ -70,6 +71,7 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
     """
 
     __slots__ = ()
+    _wrapper_type = _tdb_handles.MeasurementWrapper
 
     _subclass_constrained_soma_types = {
         "var": ("SOMADataFrame",),

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -103,7 +103,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     __slots__ = ()
 
     _wrapper_type = SparseNDArrayWrapper
-    _reader_wrapper_type = SparseNDArrayWrapper
 
     # Inherited from somacore
     # * ndim accessor

--- a/apis/python/src/tiledbsoma/_tiledb_object.py
+++ b/apis/python/src/tiledbsoma/_tiledb_object.py
@@ -45,15 +45,11 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Type[_tdb_handles.DataFrameWrapper],
         Type[_tdb_handles.DenseNDArrayWrapper],
         Type[_tdb_handles.SparseNDArrayWrapper],
+        Type[_tdb_handles.CollectionWrapper],
+        Type[_tdb_handles.ExperimentWrapper],
+        Type[_tdb_handles.MeasurementWrapper],
     ]
     """Class variable of the Wrapper class used to open this object type."""
-
-    _reader_wrapper_type: Union[
-        Type[_WrapperType_co],
-        Type[_tdb_handles.DataFrameWrapper],
-        Type[_tdb_handles.DenseNDArrayWrapper],
-        Type[_tdb_handles.SparseNDArrayWrapper],
-    ]
 
     __slots__ = ("_close_stack", "_handle")
 
@@ -102,7 +98,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         handle = _tdb_handles.open(
             uri, mode, context, tiledb_timestamp, clib_type=clib_type
         )
-        if not isinstance(handle, cls._reader_wrapper_type):
+        if not isinstance(handle, cls._wrapper_type):
             handle = cls._wrapper_type.open(uri, mode, context, tiledb_timestamp)
         return cls(
             handle,  # type: ignore[arg-type]

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -48,6 +48,19 @@ using namespace tiledbsoma;
 
 void load_soma_collection(py::module& m) {
     py::class_<SOMACollection, SOMAGroup, SOMAObject>(m, "SOMACollection")
+        .def_static(
+            "open",
+            py::overload_cast<
+                std::string_view,
+                OpenMode,
+                std::shared_ptr<SOMAContext>,
+                std::optional<std::pair<uint64_t, uint64_t>>>(
+                &SOMACollection::open),
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none())
         .def(
             "__iter__",
             [](SOMACollection& collection) {

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,10 +76,14 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
-        .def("add", &SOMAGroup::set)
+        .def("add", &SOMAGroup::set,
+            "uri"_a,
+            "uri_type"_a,
+            "name"_a,
+            "soma_type"_a)
         .def("count", &SOMAGroup::count)
         .def("remove", &SOMAGroup::del)
-        .def("members_map", &SOMAGroup::members_map)
+        .def("members", &SOMAGroup::members_map)
         .def_property_readonly(
             "timestamp",
             [](SOMAGroup& group) -> py::object {

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,7 +76,9 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
-        .def("add", &SOMAGroup::set,
+        .def(
+            "add",
+            &SOMAGroup::set,
             "uri"_a,
             "uri_type"_a,
             "name"_a,

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -136,10 +136,6 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
         assert exp.ms.metadata.get(metakey) == "SOMACollection"
         assert exp.ms["RNA"].metadata.get(metakey) == "SOMAMeasurement"
 
-        # Check ms
-        assert exp.ms.metadata.get(metakey) == "SOMACollection"
-        assert exp.ms["RNA"].metadata.get(metakey) == "SOMAMeasurement"
-
         # Check var
         var = exp.ms["RNA"].var.read().concat().to_pandas()
         assert sorted(var.columns.to_list()) == sorted(


### PR DESCRIPTION
**Issue and/or context:**

This is on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2732

**Changes:**

- Replace `GroupWrapper` (`tiledb.Group`) with `SOMAGroupWrapper` (`clib.SOMAGroup`)
- Remove `_reader_wrapper_type` as we now use `clib.SOMAObject` for all classes
- Use a mapper in `_tdb_handles.open` instead of if-else statements
- Create `from_soma_group_entry` to place `clib.SOMAObject`s into `GroupEntry`
- Remove duplicated "Check ms" test

**Notes for Reviewer:**

This PR completes the move over for `SOMAArray` and `SOMAGroup` to use the C++ bindings. There will be several more PRs on top of this to remove tiledb-py completely.