### PR TITLE
[python] Replace `TileDBObject` with `SOMAObject`; Remove `tiledb.TileDBError` usage 4/5

### DIFF
--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -6,10 +6,6 @@
 """Exceptions.
 """
 
-from typing import Union
-
-import tiledb
-
 
 class SOMAError(Exception):
     """Base error type for SOMA-specific exceptions.
@@ -29,16 +25,16 @@ class DoesNotExistError(SOMAError):
     pass
 
 
-def is_does_not_exist_error(e: Union[RuntimeError, tiledb.TileDBError]) -> bool:
-    """Given a TileDBError, return true if it indicates the object does not exist
+def is_does_not_exist_error(e: RuntimeError) -> bool:
+    """Given a RuntimeError, return true if it indicates the object does not exist
 
     Lifecycle: maturing
 
     Example:
         try:
-            with tiledb.open(uri):
+            with tiledbsoma.open(uri):
                 ...
-        except tiledb.TileDBError as e:
+        except RuntimeError as e:
             if is_does_not_exist_error(e):
                 ...
             raise e
@@ -66,16 +62,16 @@ class AlreadyExistsError(SOMAError):
     pass
 
 
-def is_already_exists_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
-    """Given a TileDBError, return true if it indicates the object already exists
+def is_already_exists_error(e: SOMAError) -> bool:
+    """Given a SOMAError, return true if it indicates the object already exists
 
     Lifecycle: experimental
 
     Example:
         try:
-            tiledb.Array.create(uri, schema, ctx=ctx)
+            clib.SOMASparseNDArray.create(...)
                 ...
-        except tiledb.TileDBError as e:
+        except SOMAError as e:
             if is_already_exists_error(e):
                 ...
             raise e
@@ -96,7 +92,7 @@ class NotCreateableError(SOMAError):
     pass
 
 
-def is_not_createable_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
+def is_not_createable_error(e: SOMAError) -> bool:
     """Given a TileDBError, return true if it indicates the object cannot be created
 
     Lifecycle: experimental
@@ -132,7 +128,7 @@ def is_not_createable_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
     return False
 
 
-def is_duplicate_group_key_error(e: Union[SOMAError, tiledb.TileDBError]) -> bool:
+def is_duplicate_group_key_error(e: SOMAError) -> bool:
     """Given a TileDBError, return try if it indicates a duplicate member
     add request in a tiledb.Group.
 

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -16,16 +16,16 @@ from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._indexer import IntIndexer
 from ._measurement import Measurement
+from ._soma_object import AnySOMAObject
 from ._tdb_handles import Wrapper
-from ._tiledb_object import AnyTileDBObject
 
 
 class Experiment(  # type: ignore[misc]  # __eq__ false positive
-    CollectionBase[AnyTileDBObject],
+    CollectionBase[AnySOMAObject],
     experiment.Experiment[  # type: ignore[type-var]
         DataFrame,
         Collection[Measurement],
-        AnyTileDBObject,
+        AnySOMAObject,
     ],
 ):
     """A collection subtype that combines observations and measurements

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -28,9 +28,9 @@ from . import (
     _dense_nd_array,
     _experiment,
     _measurement,
+    _soma_object,
     _sparse_nd_array,
     _tdb_handles,
-    _tiledb_object,
 )
 from ._constants import (
     SOMA_ENCODING_VERSION,
@@ -39,12 +39,12 @@ from ._constants import (
 )
 from ._exception import SOMAError
 from ._funcs import typeguard_ignore
-from ._tiledb_object import AnyTileDBObject, TileDBObject
+from ._soma_object import AnySOMAObject, SOMAObject
 from ._types import OpenTimestamp
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
-_Obj = TypeVar("_Obj", bound="_tiledb_object.AnyTileDBObject")
+_Obj = TypeVar("_Obj", bound="_soma_object.AnySOMAObject")
 _Wrapper = TypeVar("_Wrapper", bound=_tdb_handles.AnyWrapper)
 
 
@@ -56,7 +56,7 @@ def open(
     soma_type: Optional[str] = None,
     context: Optional[SOMATileDBContext] = None,
     tiledb_timestamp: Optional[OpenTimestamp] = None,
-) -> AnyTileDBObject:
+) -> AnySOMAObject:
     ...
 
 
@@ -77,10 +77,10 @@ def open(
     uri: str,
     mode: options.OpenMode = "r",
     *,
-    soma_type: Union[Type[TileDBObject], str, None] = None,  # type: ignore[type-arg]
+    soma_type: Union[Type[SOMAObject], str, None] = None,  # type: ignore[type-arg]
     context: Optional[SOMATileDBContext] = None,
     tiledb_timestamp: Optional[OpenTimestamp] = None,
-) -> AnyTileDBObject:
+) -> AnySOMAObject:
     """Opens a TileDB SOMA object.
 
     Args:
@@ -122,7 +122,7 @@ def open(
         Experimental.
     """
     context = _validate_soma_tiledb_context(context)
-    obj: TileDBObject[_Wrapper] = _open_internal(  # type: ignore[valid-type]
+    obj: SOMAObject[_Wrapper] = _open_internal(  # type: ignore[valid-type]
         _tdb_handles.open, uri, mode, context, tiledb_timestamp
     )
     try:
@@ -151,7 +151,7 @@ def _open_internal(
     mode: options.OpenMode,
     context: SOMATileDBContext,
     timestamp: Optional[OpenTimestamp],
-) -> TileDBObject[_Wrapper]:
+) -> SOMAObject[_Wrapper]:
     """Lower-level open function for internal use only."""
     handle = opener(uri, mode, context, timestamp)
     try:
@@ -162,17 +162,17 @@ def _open_internal(
 
 
 @typeguard_ignore
-def reify_handle(hdl: _Wrapper) -> TileDBObject[_Wrapper]:
+def reify_handle(hdl: _Wrapper) -> SOMAObject[_Wrapper]:
     """Picks out the appropriate SOMA class for a handle and wraps it."""
     typename = _read_soma_type(hdl)
     cls = _type_name_to_cls(typename)  # type: ignore[no-untyped-call]
-    if type(hdl) != cls._wrapper_type:
+    if not isinstance(hdl, cls._wrapper_type):
         raise SOMAError(
             f"cannot open {hdl.uri!r}: a {type(hdl._handle)}"
             f" cannot be converted to a {typename}"
         )
     return cast(
-        _tiledb_object.TileDBObject[_Wrapper],
+        _soma_object.SOMAObject[_Wrapper],
         cls(hdl, _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code"),
     )
 
@@ -209,8 +209,8 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
 
 
 @no_type_check
-def _type_name_to_cls(type_name: str) -> Type[AnyTileDBObject]:
-    type_map: Dict[str, Type[AnyTileDBObject]] = {
+def _type_name_to_cls(type_name: str) -> Type[AnySOMAObject]:
+    type_map: Dict[str, Type[AnySOMAObject]] = {
         t.soma_type.lower(): t
         for t in (
             _collection.Collection,

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -14,12 +14,12 @@ from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
+from ._soma_object import AnySOMAObject
 from ._sparse_nd_array import SparseNDArray
-from ._tiledb_object import AnyTileDBObject
 
 
 class Measurement(  # type: ignore[misc]  # __eq__ false positive
-    CollectionBase[AnyTileDBObject],
+    CollectionBase[AnySOMAObject],
     measurement.Measurement[  # type: ignore[type-var]
         DataFrame,
         Collection[
@@ -27,7 +27,7 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
         ],  # not just `NDArray` since that has no common `read`
         Collection[DenseNDArray],
         Collection[SparseNDArray],
-        AnyTileDBObject,
+        AnySOMAObject,
     ],
 ):
     """A set of observations defined by a dataframe, with measurements.

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -13,12 +13,12 @@ from . import _tdb_handles, _util
 
 # This package's pybind11 code
 from . import pytiledbsoma as clib  # noqa: E402
-from ._tiledb_object import TileDBObject
+from ._soma_object import SOMAObject
 from ._types import OpenTimestamp, is_nonstringy_sequence
 from .options._soma_tiledb_context import SOMATileDBContext
 
 
-class SOMAArray(TileDBObject[_tdb_handles.SOMAArrayWrapper[Any]]):
+class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
     """Base class for all SOMAArrays: DataFrame and NDarray.
 
     Lifecycle:

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -11,8 +11,6 @@ import somacore
 from somacore import options
 from typing_extensions import Self
 
-import tiledb
-
 from . import _constants, _tdb_handles
 from ._exception import SOMAError
 from ._types import OpenTimestamp
@@ -30,7 +28,7 @@ Covariant because ``_handle`` is read-only.
 """
 
 
-class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
+class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     """Base class for all TileDB SOMA objects.
 
     Accepts a SOMATileDBContext, to enable session state to be shared
@@ -146,10 +144,6 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     @property
     def context(self) -> SOMATileDBContext:
         return self._handle.context
-
-    @property
-    def _ctx(self) -> tiledb.Ctx:
-        return self.context.tiledb_ctx
 
     @property
     def metadata(self) -> MutableMapping[str, Any]:
@@ -291,7 +285,7 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 if not isinstance(md_type, str):
                     return False
                 return md_type.lower() == cls.soma_type.lower()
-        except (RuntimeError, SOMAError, tiledb.cc.TileDBError):
+        except (RuntimeError, SOMAError):
             return False
 
     @classmethod
@@ -315,4 +309,4 @@ class TileDBObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             raise ValueError(f"{self} is open for writing, not reading")
 
 
-AnyTileDBObject = TileDBObject[_tdb_handles.AnyWrapper]
+AnySOMAObject = SOMAObject[_tdb_handles.AnyWrapper]

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -32,16 +32,12 @@ from numpy.typing import DTypeLike
 from somacore import options
 from typing_extensions import Literal, Self
 
-import tiledb
-
 from . import pytiledbsoma as clib
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp
 from .options._soma_tiledb_context import SOMATileDBContext
 
 RawHandle = Union[
-    tiledb.Array,
-    tiledb.Group,
     clib.SOMAArray,
     clib.SOMADataFrame,
     clib.SOMASparseNDArray,
@@ -67,8 +63,6 @@ def open(
 
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
-    # if there is not a valid SOMAObject at the given URI, this
-    # returns None
     soma_object = clib.SOMAObject.open(
         uri=uri,
         mode=open_mode,
@@ -133,8 +127,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
             else:
                 handle._do_initial_reads(tdb)
 
-        # TODO macOS throws RuntimeError
-        except (RuntimeError, tiledb.TileDBError) as tdbe:
+        except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise DoesNotExistError(f"{uri!r} does not exist") from tdbe
             raise
@@ -155,8 +148,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
             else:
                 handle._do_initial_reads(soma_object)
 
-        # TODO macOS throws RuntimeError
-        except (RuntimeError, tiledb.TileDBError) as tdbe:
+        except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise DoesNotExistError(f"{handle.uri!r} does not exist") from tdbe
             raise
@@ -239,71 +231,10 @@ AnyWrapper = Wrapper[RawHandle]
 """Non-instantiable type representing any Handle."""
 
 
-class ArrayWrapper(Wrapper[tiledb.Array]):
-    """Wrapper around a TileDB Array handle."""
-
-    clib_type = "SOMAArray"
-
-    @classmethod
-    def _opener(
-        cls,
-        uri: str,
-        mode: options.OpenMode,
-        context: SOMATileDBContext,
-        timestamp: int,
-    ) -> tiledb.Array:
-        return tiledb.open(
-            uri,
-            mode,
-            timestamp=timestamp,
-            ctx=context.tiledb_ctx,
-        )
-
-    @property
-    def schema(self) -> tiledb.ArraySchema:
-        return self._handle.schema
-
-    def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
-        try:
-            return self._handle.nonempty_domain() or ()
-        except tiledb.TileDBError as e:
-            raise SOMAError(e)
-
-    @property
-    def domain(self) -> Tuple[Tuple[object, object], ...]:
-        dom = self._handle.schema.domain
-        return tuple(dom.dim(i).domain for i in range(dom.ndim))
-
-    @property
-    def ndim(self) -> int:
-        return int(self._handle.schema.domain.ndim)
-
-    @property
-    def attr_names(self) -> Tuple[str, ...]:
-        schema = self._handle.schema
-        return tuple(schema.attr(i).name for i in range(schema.nattr))
-
-    @property
-    def dim_names(self) -> Tuple[str, ...]:
-        schema = self._handle.schema
-        return tuple(schema.domain.dim(i).name for i in range(schema.domain.ndim))
-
-    def enum(self, label: str) -> tiledb.Enumeration:
-        return self._handle.enum(label)
-
-
 @attrs.define(frozen=True)
 class GroupEntry:
     uri: str
     wrapper_type: Type[AnyWrapper]
-
-    @classmethod
-    def from_object(cls, obj: tiledb.Object) -> "GroupEntry":
-        if obj.type == tiledb.Array:
-            return GroupEntry(obj.uri, ArrayWrapper)
-        if obj.type == tiledb.Group:
-            return GroupEntry(obj.uri, GroupWrapper)
-        raise SOMAError(f"internal error: unknown object type {obj.type}")
 
     @classmethod
     def from_soma_group_entry(cls, obj: Tuple[str, str]) -> "GroupEntry":
@@ -313,32 +244,6 @@ class GroupEntry:
         if type == "SOMAGroup":
             return GroupEntry(uri, SOMAGroupWrapper)
         raise SOMAError(f"internal error: unknown object type {uri}")
-
-
-class GroupWrapper(Wrapper[tiledb.Group]):
-    """Wrapper around a TileDB Group handle."""
-
-    clib_type = "SOMAGroup"
-
-    @classmethod
-    def _opener(
-        cls,
-        uri: str,
-        mode: options.OpenMode,
-        context: SOMATileDBContext,
-        timestamp: int,
-    ) -> tiledb.Group:
-        # We want to do open-group-at-timestamp.
-        ctx = context.tiledb_ctx
-        cfgdict = context.tiledb_ctx.config().dict()
-        cfgdict["sm.group.timestamp_end"] = timestamp
-        return tiledb.Group(uri, mode, ctx=ctx, config=tiledb.Config(cfgdict))
-
-    def _do_initial_reads(self, reader: tiledb.Group) -> None:
-        super()._do_initial_reads(reader)
-        self.initial_contents = {
-            o.name: GroupEntry.from_object(o) for o in reader if o.name is not None
-        }
 
 
 _GrpType = TypeVar("_GrpType", bound=clib.SOMAGroup)
@@ -488,12 +393,6 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     @property
     def dim_names(self) -> Tuple[str, ...]:
         return tuple(self._handle.dimension_names)
-
-    def enum(self, label: str) -> tiledb.Enumeration:
-        # The DataFrame handle may either be ArrayWrapper or DataFrameWrapper.
-        # enum is only used in the DataFrame write path and is implemented by
-        # ArrayWrapper. If enum is called in the read path, it is an error.
-        raise NotImplementedError
 
     @property
     def shape(self) -> Tuple[int, ...]:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -65,8 +65,8 @@ from .._exception import (
     SOMAError,
 )
 from .._soma_array import SOMAArray
+from .._soma_object import AnySOMAObject, SOMAObject
 from .._tdb_handles import RawHandle
-from .._tiledb_object import AnyTileDBObject, TileDBObject
 from .._types import (
     _INGEST_MODES,
     INGEST_MODES,
@@ -100,15 +100,13 @@ from ._registration import (
 from ._util import read_h5ad
 
 _NDArr = TypeVar("_NDArr", bound=NDArray)
-_TDBO = TypeVar("_TDBO", bound=TileDBObject[RawHandle])
+_TDBO = TypeVar("_TDBO", bound=SOMAObject[RawHandle])
 
 
 AdditionalMetadata = Optional[Dict[str, Metadatum]]
 
 
-def add_metadata(
-    obj: TileDBObject[Any], additional_metadata: AdditionalMetadata
-) -> None:
+def add_metadata(obj: SOMAObject[Any], additional_metadata: AdditionalMetadata) -> None:
     if additional_metadata:
         obj.verify_open_for_writing()
         obj.metadata.update(additional_metadata)
@@ -942,7 +940,7 @@ def append_X(
 def _maybe_set(
     coll: AnyTileDBCollection,
     key: str,
-    value: AnyTileDBObject,
+    value: AnySOMAObject,
     *,
     use_relative_uri: Optional[bool],
 ) -> None:

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,7 +76,9 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
-        .def("add", &SOMAGroup::set,
+        .def(
+            "add",
+            &SOMAGroup::set,
             "uri"_a,
             "uri_type"_a,
             "name"_a,

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,9 +76,7 @@ void load_soma_group(py::module& m) {
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
         .def("has", &SOMAGroup::has)
-        .def(
-            "add",
-            &SOMAGroup::set,
+        .def("add", &SOMAGroup::set,
             "uri"_a,
             "uri_type"_a,
             "name"_a,

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -14,7 +14,7 @@ import somacore
 import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import Experiment, _constants, _factory
-from tiledbsoma._tiledb_object import TileDBObject
+from tiledbsoma._soma_object import SOMAObject
 from tiledbsoma._util import verify_obs_and_var_eq
 import tiledb
 
@@ -717,7 +717,7 @@ def test_ingest_additional_metadata(conftest_pbmc_small):
         additional_metadata=additional_metadata,
     )
 
-    def check(tdbo: TileDBObject):
+    def check(tdbo: SOMAObject):
         for k, v in additional_metadata.items():
             assert tdbo.metadata[k] == v
 

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -11,7 +11,7 @@ from typeguard import suppress_type_checks
 from typing_extensions import Literal
 
 import tiledbsoma as soma
-from tiledbsoma import _collection, _factory, _tiledb_object
+from tiledbsoma import _collection, _factory, _soma_object
 from tiledbsoma._exception import DoesNotExistError
 from tiledbsoma.options import SOMATileDBContext
 
@@ -350,9 +350,9 @@ def test_cascading_close(tmp_path: pathlib.Path):
     un_corvid.close()
     assert un_corvid.closed
 
-    all_elements: List[_tiledb_object.AnyTileDBObject] = []
+    all_elements: List[_soma_object.AnySOMAObject] = []
 
-    def crawl(obj: _tiledb_object.AnyTileDBObject):
+    def crawl(obj: _soma_object.AnySOMAObject):
         all_elements.append(obj)
         if isinstance(obj, _collection.CollectionBase):
             for val in obj.values():


### PR DESCRIPTION
**Issue and/or context:**

This is on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2735

**Changes:**

- Replace `TileDBObject` with `SOMAObject`; and `_tiledb_object` with `_soma_object`
- Remove `tiledb.TileDBError` usage