### PR TITLE
[python] Work around pyarrow>=13 issue on MacOS, `release-1.10` branch

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -320,13 +320,7 @@ setuptools.setup(
         "attrs>=22.2",
         "numba>=0.58.0",
         "pandas",
-        # TODO: once we no longer support Python 3.7, remove this and pin to pyarrow >= 14.0.1
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
-        "pyarrow_hotfix",
-        # MacOS issue with import pyarrow before import tiledb at >= 13.0:
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149
-        "pyarrow>=9.0.0,<13.0.0; platform_system=='Darwin'",
-        "pyarrow>=9.0.0; platform_system!='Darwin'",
+        "pyarrow>=14.0.0",
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -89,6 +89,13 @@ Most errors will raise an appropriate Python error, e.g., ::class:`TypeError` or
 :class:`ValueError`.
 """
 
+# This ABSOLUTELY MUST be imported before pyarrow to avoid abort-traps on MacOS
+# with any pyarrow >= 13.  And the pre-commit hook, isort, et al. MUST NOT be
+# allowed to reorder this.  See also
+# https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+# https://github.com/single-cell-data/TileDB-SOMA/issues/1849
+import tiledb  # noqa E402
+
 # ^^ the rest is autogen whether viewed from Python on-line help, Sphinx/readthedocs, etc.  It's
 # crucial that we include a separator (e.g. "Classes and functions") to make an entry in the
 # readthedocs table of contents.
@@ -137,11 +144,6 @@ except ImportError:
 
 from somacore import AxisColumnNames, AxisQuery, ExperimentAxisQuery
 from somacore.options import ResultOrder
-
-# TODO: once we no longer support Python 3.7, remove this and pin to pyarrow >= 14.0.1
-# https://github.com/single-cell-data/TileDB-SOMA/issues/1926
-# ruff: noqa
-import pyarrow_hotfix
 
 from ._collection import Collection
 from ._constants import SOMA_JOINID

--- a/apis/python/tests/__init__.py
+++ b/apis/python/tests/__init__.py
@@ -1,3 +1,10 @@
+# This ABSOLUTELY MUST be imported before pyarrow to avoid abort-traps on MacOS
+# with any pyarrow >= 13.  And the pre-commit hook, isort, et al. MUST NOT be
+# allowed to reorder this.  See also
+# https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+# https://github.com/single-cell-data/TileDB-SOMA/issues/1849
+import tiledb  # noqa E402
+
 import pyarrow as pa
 from typeguard import install_import_hook
 


### PR DESCRIPTION
**Issue and/or context:** Apply #2734 to `release-1.10` for #2692, hoping to isolate the segfault from #2734.