### PR TITLE
[python] Remove tiledb-py from top-level src (sans `io` and `options`) 5/5

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -161,7 +161,6 @@ from ._general_utilities import (
     get_SOMA_version,
     get_storage_engine,
     show_package_versions,
-    verify_core_versions,
 )
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
@@ -173,11 +172,6 @@ from .pytiledbsoma import (
     tiledbsoma_stats_enable,
     tiledbsoma_stats_reset,
 )
-
-# Ensure TileDB-Py and libtiledbsoma have matching core versions; if they don't, undefined behavior
-# / segfaults may ensue. Once libtiledbsoma is the only "path to core" (cf. #1632), this can be
-# removed.
-verify_core_versions()
 
 __version__ = get_implementation_version()
 

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -5,13 +5,10 @@
 
 """General utility functions.
 """
-import os
 import platform
 import sys
 import warnings
 from re import fullmatch
-
-import tiledb
 
 from .pytiledbsoma import version as libtiledbsoma_core_version_str
 
@@ -74,14 +71,6 @@ def get_storage_engine() -> str:
     return "tiledb"
 
 
-def get_tiledb_py_core_version() -> str:
-    """Returns the version of libtiledb ("core") used by the `tiledb` Python library.
-
-    Lifecycle: maturing
-    """
-    return ".".join(str(ijk) for ijk in list(tiledb.libtiledb.version()))
-
-
 def get_libtiledbsoma_core_version() -> str:
     """Returns the version of libtiledb ("core") used by libtiledbsoma.
 
@@ -101,35 +90,6 @@ TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL_VAR = (
 )
 
 
-def verify_core_versions() -> None:
-    """Verify that the versions of libtiledb used by the `tiledb` Python library and
-    libtiledbsoma are the same.
-
-    See discussion on https://github.com/single-cell-data/TileDB-SOMA/issues/1837; this
-    will be unnecessary when libtiledbsoma is the only "path to core" (cf.
-    https://github.com/single-cell-data/TileDB-SOMA/issues/1632).
-
-    Lifecycle: maturing
-    """
-    tiledb_py_core_version = get_tiledb_py_core_version()
-    libtiledbsoma_core_version = get_libtiledbsoma_core_version()
-    if tiledb_py_core_version != libtiledbsoma_core_version:
-        msg = "libtiledb versions used by tiledb and libtiledbsoma differ: %s != %s" % (
-            tiledb_py_core_version,
-            libtiledbsoma_core_version,
-        )
-        if os.environ.get(TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL_VAR) == "err":
-            print(msg, file=sys.stderr)
-            print(
-                f"Continuing, since ${TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL_VAR} is set, but it is highly recommended you fix the core version mismatch, as undefined behavior and segfaults can result.",
-                file=sys.stderr,
-            )
-        else:
-            raise AssertionError(
-                f"libtiledb versions used by tiledb and libtiledbsoma differ: {tiledb_py_core_version} != {libtiledbsoma_core_version}"
-            )
-
-
 def show_package_versions() -> None:
     """Nominal use is for bug reports, so issue filers and issue fixers can be on
     the same page.
@@ -139,10 +99,7 @@ def show_package_versions() -> None:
     u = platform.uname()
     # fmt: off
     print("tiledbsoma.__version__             ", get_implementation_version())
-    print("TileDB-Py version                  ", ".".join(str(v) for v in tiledb.version()))
-    print("TileDB core version (tiledb)       ", get_tiledb_py_core_version())
     print("TileDB core version (libtiledbsoma)", get_libtiledbsoma_core_version())
     print("python version                     ", ".".join(str(v) for v in sys.version_info))
     print("OS version                         ", u.system, u.release)
     # fmt: on
-    verify_core_versions()

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -5,10 +5,8 @@ import os
 import pytest
 
 import tiledbsoma.pytiledbsoma as clib
-from tiledbsoma._arrow_types import tiledb_schema_to_arrow
 from tiledbsoma._exception import SOMAError
 from tiledbsoma._query_condition import QueryCondition
-import tiledb
 
 VERBOSE = False
 
@@ -30,8 +28,7 @@ def pandas_query(uri, condition):
 def soma_query(uri, condition):
     qc = QueryCondition(condition)
     sr = clib.SOMAArray(uri)
-    schema = tiledb_schema_to_arrow(tiledb.open(uri).schema, uri, tiledb.default_ctx())
-    sr.set_condition(qc, schema)
+    sr.set_condition(qc, sr.schema)
     arrow_table = sr.read_next()
     assert sr.results_complete()
 
@@ -110,8 +107,7 @@ def test_query_condition_select_columns():
 
     sr = clib.SOMAArray(uri, column_names=["n_genes"])
     qc = QueryCondition(condition)
-    schema = tiledb_schema_to_arrow(tiledb.open(uri).schema, uri, tiledb.default_ctx())
-    sr.set_condition(qc, schema)
+    sr.set_condition(qc, sr.schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -124,10 +120,9 @@ def test_query_condition_all_columns():
     condition = "percent_mito > 0.02"
 
     qc = QueryCondition(condition)
-    schema = tiledb_schema_to_arrow(tiledb.open(uri).schema, uri, tiledb.default_ctx())
 
     sr = clib.SOMAArray(uri)
-    sr.set_condition(qc, schema)
+    sr.set_condition(qc, sr.schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -140,10 +135,9 @@ def test_query_condition_reset():
     condition = "percent_mito > 0.02"
 
     qc = QueryCondition(condition)
-    schema = tiledb_schema_to_arrow(tiledb.open(uri).schema, uri, tiledb.default_ctx())
 
     sr = clib.SOMAArray(uri)
-    sr.set_condition(qc, schema)
+    sr.set_condition(qc, sr.schema)
     arrow_table = sr.read_next()
 
     assert sr.results_complete()
@@ -155,7 +149,7 @@ def test_query_condition_reset():
     condition = "percent_mito < 0.02"
     qc = QueryCondition(condition)
     sr.reset(column_names=["percent_mito"])
-    sr.set_condition(qc, schema)
+    sr.set_condition(qc, sr.schema)
 
     arrow_table = sr.read_next()
 
@@ -218,17 +212,16 @@ def test_parsing_error_conditions(malformed_condition):
 def test_eval_error_conditions(malformed_condition):
     """Conditions which should not evaluate (but WILL parse)"""
     uri = os.path.join(SOMA_URI, "obs")
-    schema = tiledb_schema_to_arrow(tiledb.open(uri).schema, uri, tiledb.default_ctx())
     qc = QueryCondition(malformed_condition)
 
     with pytest.raises(SOMAError):
         sr = clib.SOMAArray(uri)
-        sr.set_condition(qc, schema)
+        sr.set_condition(qc, sr.schema)
 
     with pytest.raises(SOMAError):
         # test function directly for codecov
-        qc.init_query_condition(schema, [])
-        qc.init_query_condition(schema, ["bad_query_attr"])
+        qc.init_query_condition(sr.schema, [])
+        qc.init_query_condition(sr.schema, ["bad_query_attr"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Issue and/or context:**

This is on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2736

This removes `import tiledb` from `apis/python/src` but not in `io` or `options` which will be done in subsequent PRs.

**Changes:**

- Remove `tiledb_schema_to_arrow` as we no longer use TileDB `ArraySchema`
- Remove `get_tiledb_py_core_version` and `verify_core_versions`