### PR TITLE
[python] Replace `tiledb.VFS` with `clib.VFS`

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -304,6 +304,7 @@ setuptools.setup(
                 "src/tiledbsoma/common.cc",
                 "src/tiledbsoma/reindexer.cc",
                 "src/tiledbsoma/query_condition.cc",
+                "src/tiledbsoma/vfs.cc",
                 "src/tiledbsoma/soma_context.cc",
                 "src/tiledbsoma/soma_array.cc",
                 "src/tiledbsoma/soma_object.cc",

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -355,7 +355,7 @@ def from_h5ad(
 
     logging.log_io(None, f"START  READING {input_path}")
 
-    with read_h5ad(input_path, mode="r", ctx=context.tiledb_ctx) as anndata:
+    with read_h5ad(input_path, mode="r", ctx=context) as anndata:
         logging.log_io(None, _util.format_elapsed(s, f"FINISH READING {input_path}"))
 
         uri = from_anndata(

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -26,6 +26,7 @@ void load_soma_group(py::module&);
 void load_soma_collection(py::module&);
 void load_query_condition(py::module&);
 void load_reindexer(py::module&);
+void load_vfs(py::module&);
 
 PYBIND11_MODULE(pytiledbsoma, m) {
     py::register_exception<TileDBSOMAError>(m, "SOMAError");
@@ -134,6 +135,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     load_soma_collection(m);
     load_query_condition(m);
     load_reindexer(m);
+    load_vfs(m);
 }
 
 };  // namespace libtiledbsomacpp


### PR DESCRIPTION
**Issue and/or context:**

This is on top of https://github.com/single-cell-data/TileDB-SOMA/pull/2740

**Changes:**

- Replace `tiledb.VFS` by binding `tiledb::VFS{Filebuf}` in `clib`
- Remove `import tiledb` from `io/_util.py`