### PR TITLE
Use core 2.24.1 on `release-1.12` branch

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-linux-x86_64-2.24.0-ff3879b.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-linux-x86_64-2.24.1-db03540.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -172,7 +172,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-x86_64-2.24.0-ff3879b.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-x86_64-2.24.1-db03540.tar.gz
           tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
           ls external/lib/
           echo "DYLD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -264,10 +264,10 @@ jobs:
           if [ `uname -s` == "Darwin" ];
           then
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-x86_64-2.24.0-ff3879b.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-x86_64-2.24.1-db03540.tar.gz
           else
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-linux-x86_64-2.24.0-ff3879b.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-linux-x86_64-2.24.1-db03540.tar.gz
           fi
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
         "somacore==1.0.11",
-        "tiledb~=0.30.0",
+        "tiledb~=0.30.1",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-x86_64-2.24.0-ff3879b.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-x86_64-2.24.1-db03540.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-arm64-2.24.0-ff3879b.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-arm64-2.24.1-db03540.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-linux-x86_64-2.24.0-ff3879b.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-linux-x86_64-2.24.1-db03540.tar.gz"
 } else {
     stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
 }

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -58,8 +58,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-windows-x86_64-2.24.0-ff3879b.zip")
-          SET(DOWNLOAD_SHA1 "9b4456a1ba7c4805ab600806c9e96920840eda55")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-windows-x86_64-2.24.1-db03540.zip")
+          SET(DOWNLOAD_SHA1 "d602c34f726affc3caad518b446d71284fadf78a")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -76,22 +76,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-x86_64-2.24.0-ff3879b.tar.gz")
-            SET(DOWNLOAD_SHA1 "d0a5f52b8fc193ac2cd4ac86dc30fcfcd9565ed6")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-x86_64-2.24.1-db03540.tar.gz")
+            SET(DOWNLOAD_SHA1 "2b3c70c363e1c7f537e71ebe59de5be6a6c46104")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-arm64-2.24.0-ff3879b.tar.gz")
-            SET(DOWNLOAD_SHA1 "7d02855bbe80fb2cae202da404088a7859f0b455")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-arm64-2.24.1-db03540.tar.gz")
+            SET(DOWNLOAD_SHA1 "1208197bbf8bed3697fd89e8d2e12c46c95484b6")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-x86_64-2.24.0-ff3879b.tar.gz")
-            SET(DOWNLOAD_SHA1 "d0a5f52b8fc193ac2cd4ac86dc30fcfcd9565ed6")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-x86_64-2.24.1-db03540.tar.gz")
+            SET(DOWNLOAD_SHA1 "2b3c70c363e1c7f537e71ebe59de5be6a6c46104")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-macos-arm64-2.24.0-ff3879b.tar.gz")
-            SET(DOWNLOAD_SHA1 "7d02855bbe80fb2cae202da404088a7859f0b455")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-macos-arm64-2.24.1-db03540.tar.gz")
+            SET(DOWNLOAD_SHA1 "1208197bbf8bed3697fd89e8d2e12c46c95484b6")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.0/tiledb-linux-x86_64-2.24.0-ff3879b.tar.gz")
-          SET(DOWNLOAD_SHA1 "f38f4ff5a8c42d327066cfd6255adaf916ee0452")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.24.1/tiledb-linux-x86_64-2.24.1-db03540.tar.gz")
+          SET(DOWNLOAD_SHA1 "712733b42d66dae5299dbff0d8f255140da5dc6f")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -113,8 +113,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.24.0.zip"
-          URL_HASH SHA1=0316a8cd4c275988f138b1613b0c6682dfe18485
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.24.1.zip"
+          URL_HASH SHA1=83254d820740ffb673a0b3685381110eaeabaef5
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
Following our [established procedure](https://www.notion.so/785d165226074071872a8b797133d36c?v=c168da78516e487eac3746d38924fa97&p=d1c7a37761b04cf699a705bb8963dea9&pm=s).

Note in particular that core artfacts are updated using the error-proof `./scripts/update-tiledb-version.py 2.24.1`.