### PR TITLE
[c++] Update CMake to use target-based properties

### DIFF
--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -165,48 +165,67 @@ if(MSVC)
   # C4702: unreachable code
   # C4800: warning implicit cast int to bool
   # C4996: deprecation warning about e.g. sscanf.
-  add_compile_options(/W4 /wd4101 /wd4146 /wd4244 /wd4251 /wd4456 /wd4457 /wd4702 /wd4800 /wd4996)
+  set(TILEDBSOMA_COMPILE_OPTIONS /W4 /wd4101 /wd4146 /wd4244 /wd4251 /wd4456 /wd4457 /wd4702 /wd4800 /wd4996)
 
   # Warnings as errors:
   if(TILEDBSOMA_ENABLE_WERROR)
-    add_compile_options(/WX)
+    list(APPEND TILEDBSOMA_COMPILE_OPTIONS /WX)
   endif()
 
   # Disable GDI (which we don't need, and causes some macro
   # re-definition issues if wingdi.h is included)
-  add_compile_options(/DNOGDI)
+  list(APPEND TILEDBSOMA_COMPILE_OPTIONS /DNOGDI)
 
   # Add /MPn flag from CMake invocation (if defined).
-  add_compile_options(${MSVC_MP_FLAG})
+  list(APPEND TILEDBSOMA_COMPILE_OPTIONS ${MSVC_MP_FLAG})
 
-  # Build-specific flags
-  add_compile_options(
-    "$<$<CONFIG:Debug>:/DDEBUG /Od /Zi /bigobj>"
-    "$<$<CONFIG:Release>:/DNDEBUG /Ox>"
-    "$<$<CONFIG:RelWithDebInfo>:/DNDEBUG /Ox /Zi>"
+  # Build-specific flags: Must use generator expressions to support multi-configuration
+  # build generators that set the config type at build time.
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<CONFIG:Debug>:/DDEBUG /Od /Zi /bigobj>
+  )
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<CONFIG:Release>:/DNDEBUG /Ox>
+  )
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<CONFIG:RelWithDebInfo>:/DNDEBUG /Ox /Zi>
   )
 else()
-  add_compile_options(-Wall -Wextra)
+
+  set(TILEDBSOMA_COMPILE_OPTIONS -Wall -Wextra)
 
   if(TILEDBSOMA_ENABLE_WERROR)
-    add_compile_options(-Werror)
+    list(APPEND TILEDBSOMA_COMPILE_OPTIONS -Werror)
   endif()
 
-  # Build-specific flags
-  if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3)
-  elseif(CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(-DNDEBUG -O3)
-  elseif(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
-    add_compile_options(-DNDEBUG -O3 -g3 -ggdb3 -gdwarf-3)
-  elseif(CMAKE_BUILD_TYPE MATCHES "Coverage")
-    add_compile_options(-DDEBUG -g3 -gdwarf-3 --coverage)
-    add_link_options(--coverage)
-  endif()
+  # Build-specific flags: Must use generator expressions to support multi-configuration
+  # build generators that set the config type at build time.
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>: -DDEBUG -O0 -g3 -ggdb3 -gdwarf-3>
+  )
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<STREQUAL:${CMAKE_BUILD_TYPE},Release>: -DNDEBUG -O3>
+  )
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<STREQUAL:${CMAKE_BUILD_TYPE},RelWithDebInfo>: -DNDEBUG -O3 -g3 -ggdb3 -gdwarf-3>
+  )
+  list(APPEND
+    TILEDBSOMA_COMPILE_OPTIONS
+    $<$<STREQUAL:${CMAKE_BUILD_TYPE},>: -DDEBUG -g3 -gdwarf-3 --coverage>
+  )
 
   # Use -Wno-literal-suffix on Linux with C++ sources.
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-literal-suffix>)
+    list(APPEND
+      TILEDBSOMA_COMPILE_OPTIONS
+      $<$<COMPILE_LANGUAGE:CXX>:-Wno-literal-suffix>
+    )
   endif()
 endif()
 
@@ -215,15 +234,24 @@ add_definitions(-D_FILE_OFFSET_BITS=64)
 
 # Disable incorrect availability check on conda build
 # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
-add_compile_options(-D_LIBCPP_DISABLE_AVAILABILITY)
+add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
 
 # AVX2 flag
 include(CheckAVX2Support)
 CheckAVX2Support()
 
 if(COMPILER_SUPPORTS_AVX2)
-  add_compile_options(${COMPILER_AVX2_FLAG})
+  list(APPEND TILEDBSOMA_COMPILE_OPTIONS ${COMPILER_AVX2_FLAG})
 endif()
+
+
+## Leaving this helper. Debugging generator expressions in CMake can be difficult.
+## To view compile options uncomment the below and run the target.
+## (Hint: This target is inside build/libtiledbsoma)
+add_custom_target(
+    debugflag COMMAND ${CMAKE_COMMAND} -E echo "compile options: ${TILEDBSOMA_COMPILE_OPTIONS}"
+)
+
 
 # ###########################################################
 # Regular build

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -253,6 +253,16 @@ add_custom_target(
 # ###########################################################
 # Regular build
 # ###########################################################
+
+# Adding coverage flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
+
+# Find required dependencies
+# See ../cmake/Modules/*.cmake for provenance/version info
+find_package(TileDB_EP REQUIRED)
+find_package(Spdlog_EP REQUIRED)
+
 add_subdirectory(src)
 
 if(TILEDBSOMA_ENABLE_TESTING)

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -220,12 +220,9 @@ else()
     $<$<STREQUAL:${CMAKE_BUILD_TYPE},>: -DDEBUG -g3 -gdwarf-3 --coverage>
   )
 
-  # Use -Wno-literal-suffix on Linux with C++ sources.
+  # Use -Wno-literal-suffix on Linux for C++ libtiledbsoma target.
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    list(APPEND
-      TILEDBSOMA_COMPILE_OPTIONS
-      $<$<COMPILE_LANGUAGE:CXX>:-Wno-literal-suffix>
-    )
+    list(APPEND TILEDBSOMA_COMPILE_OPTIONS -Wno-literal-suffix)
   endif()
 endif()
 

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -3,20 +3,6 @@ message(STATUS "Starting TileDB-SOMA build.")
 set(TILEDBSOMA_INSTALL_TARGETS "")
 
 # ###########################################################
-# Adding coverage flags
-# ###########################################################
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
-set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
-
-# ###########################################################
-# Find required dependencies
-# See ../cmake/Modules/*.cmake for provenance/version info
-# ###########################################################
-find_package(TileDB_EP REQUIRED)
-find_package(Spdlog_EP REQUIRED)
-
-# ###########################################################
 # Get source commit hash
 # ###########################################################
 find_package(Git REQUIRED)

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -72,20 +72,21 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/stats.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/util.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/version.cc
-
   ${CMAKE_CURRENT_SOURCE_DIR}/external/src/thread_pool/thread_pool.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/external/src/thread_pool/status.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/external/src/nanoarrow/nanoarrow.c
 )
 
 message(STATUS "Building TileDB without deprecation warnings")
-target_compile_definitions(TILEDB_SOMA_OBJECTS PRIVATE
+target_compile_definitions(TILEDB_SOMA_OBJECTS
+  PRIVATE
   -DBUILD_COMMIT_HASH="${BUILD_COMMIT_HASH}"
   -DTILEDB_DEPRECATED=
 )
 
-target_compile_options(
-  TILEDB_SOMA_OBJECTS PRIVATE
+target_compile_options(TILEDB_SOMA_OBJECTS
+  PRIVATE
+  ${TILEDBSOMA_COMPILE_OPTIONS}
 )
 
 set_property(TARGET TILEDB_SOMA_OBJECTS PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -57,7 +57,11 @@ target_include_directories(unit_soma
     $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-target_compile_definitions(unit_soma PRIVATE CATCH_CONFIG_MAIN)
+target_compile_definitions(unit_soma
+  PRIVATE
+  CATCH_CONFIG_MAIN
+)
+target_compile_options(unit_soma PRIVATE ${TILEDBSOMA_COMPILE_OPTIONS})
 
 if (NOT MSVC)
   # Allow deprecated function for writing to an array with a timestamp

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -6,18 +6,6 @@
 get_filename_component(TILEDBSOMA_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE)
 add_compile_definitions(TILEDBSOMA_SOURCE_ROOT="${TILEDBSOMA_SOURCE_ROOT}")
 
-# ###########################################################
-# Adding coverage flags
-# ###########################################################
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
-set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} $ENV{TILEDBSOMA_COVERAGE}")
-
-############################################################
-# Dependencies
-############################################################
-
-find_package(TileDB_EP REQUIRED)
-find_package(Spdlog_EP REQUIRED)
 
 ############################################################
 # SOMA unit test


### PR DESCRIPTION
**Issue and/or context:** Closes #2664

**Changes:**
* Add options explicitly to targets instead of to everything. Note: this means compile options are no longer propagated to third-party libraries included with `FetchContent` and `ExternalProject_Add`.
* Move `find_package` calls and coverage flags to base `CMakeLists.txt` instead of adding them twice.

