### PR TITLE
Split nanoarrow into a separate object library

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -1,11 +1,28 @@
 message(STATUS "Starting TileDB-SOMA build.")
 
 # ###########################################################
-# Common object library
+# Nanoarrow object library
 # ###########################################################
 set_source_files_properties(
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/src/nanoarrow/nanoarrow.c PROPERTIES LANGUAGE CXX)
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/src/nanoarrow/nanoarrow.c PROPERTIES LANGUAGE CXX
+)
+add_library(TILEDBSOMA_NANOARROW_OBJECT OBJECT
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/src/nanoarrow/nanoarrow.c
+)
+target_compile_options(TILEDBSOMA_NANOARROW_OBJECT
+  PRIVATE
+    ${TILEDBSOMA_COMPILE_OPTIONS}
+    ${TILEDBSOMA_SANITIZER_OPTIONS}
+)
+target_include_directories(TILEDBSOMA_NANOARROW_OBJECT
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/external/include/nanoarrow
+)
+set_property(TARGET TILEDBSOMA_NANOARROW_OBJECT PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# ###########################################################
+# Common object library
+# ###########################################################
 add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/reindexer/reindexer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/managed_query.cc
@@ -28,7 +45,6 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/version.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/external/src/thread_pool/thread_pool.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/external/src/thread_pool/status.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/src/nanoarrow/nanoarrow.c
 )
 
 target_compile_definitions(TILEDB_SOMA_OBJECTS
@@ -44,12 +60,6 @@ target_compile_options(TILEDB_SOMA_OBJECTS
 )
 
 set_property(TARGET TILEDB_SOMA_OBJECTS PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-target_include_directories(TILEDB_SOMA_OBJECTS
-  PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/include/nanoarrow
-)
-
 target_include_directories(TILEDB_SOMA_OBJECTS
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -57,6 +67,7 @@ target_include_directories(TILEDB_SOMA_OBJECTS
   ${CMAKE_CURRENT_SOURCE_DIR}/soma
   ${CMAKE_CURRENT_SOURCE_DIR}/external/khash
   ${CMAKE_CURRENT_SOURCE_DIR}/external/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/include/nanoarrow
   $<TARGET_PROPERTY:TileDB::tiledb_shared,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
   ${pybind11_INCLUDE_DIRS}
@@ -69,6 +80,7 @@ set(TILEDBSOMA_INSTALL_TARGETS "")
 if(TILEDBSOMA_BUILD_STATIC)
   add_library(tiledbsoma_static STATIC
     $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
+    $<TARGET_OBJECTS:TILEDBSOMA_NANOARROW_OBJECT>
   )
   list(APPEND TILEDBSOMA_INSTALL_TARGETS tiledbsoma_static)
   if(WIN32)
@@ -93,6 +105,7 @@ if(TILEDBSOMA_BUILD_STATIC)
 else()
   add_library(tiledbsoma SHARED
     $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
+    $<TARGET_OBJECTS:TILEDBSOMA_NANOARROW_OBJECT>
   )
   list(APPEND TILEDBSOMA_INSTALL_TARGETS tiledbsoma)
   target_link_libraries(tiledbsoma
@@ -220,6 +233,7 @@ if(TILEDBSOMA_BUILD_CLI)
   add_executable(tiledbsoma-cli
     ${CMAKE_CURRENT_SOURCE_DIR}/cli/cli.cc
     $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
+    $<TARGET_OBJECTS:TILEDBSOMA_NANOARROW_OBJECT>
   )
 
   list(APPEND TILEDBSOMA_INSTALL_TARGETS tiledbsoma-cli)

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Catch_EP REQUIRED)
 
 add_executable(unit_soma
     $<TARGET_OBJECTS:TILEDB_SOMA_OBJECTS>
+    $<TARGET_OBJECTS:TILEDBSOMA_NANOARROW_OBJECT>
     common.cc
     common.h
     unit_column_buffer.cc


### PR DESCRIPTION
**Issue and/or context:** #2408

**Changes:**
Create a separate object library for nanoarrow without `-Werror`.
