### PR TITLE
[python] Continue to use `tiledb.Ctx`'s config until it is removed

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -221,16 +221,22 @@ class SOMATileDBContext(ContextBase):
 
         Returns a new dict with the contents. Caller must hold ``_lock``.
         """
-        if self._native_context is None:
-            # Our TileDB Context has not yet been built.
-            # We return what will be passed into `tiledb.Ctx()`.
-            return (
-                dict(self._initial_config)
-                if self._initial_config is not None
-                else _default_config({})
-            )
-        # We *do* have a TileDB Context. Return its actual config.
-        return dict(self._native_context.config())
+        # We have a clib.SOMAContext. Return its actual config.
+        if self._native_context is not None:
+            return dict(self._native_context.config())
+
+        # We have TileDB Context. Return its actual config.
+        # TODO This block will be deleted once tiledb_ctx is removed in 1.14
+        if self._tiledb_ctx is not None:
+            return dict(self._tiledb_ctx.config())
+
+        # Our context has not yet been built.
+        # We return what will be passed into the context.
+        return (
+            dict(self._initial_config)
+            if self._initial_config is not None
+            else _default_config({})
+        )
 
     def replace(
         self,

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -29,6 +29,13 @@ def test_lazy_init():
         mock_ctx.assert_called_once()
 
 
+def test_tiledb_ctx_init():
+    config = {"hither": "yon"}
+    with pytest.deprecated_call():
+        context = stc.SOMATileDBContext(tiledb_ctx=tiledb.Ctx(config))
+    assert "hither" in context.tiledb_config
+
+
 def test_lazy_replace_config():
     """Verifies we don't construct a Ctx even if we call ``.replace``."""
     with mock.patch.object(tiledb, "Ctx", wraps=tiledb.Ctx) as mock_ctx:


### PR DESCRIPTION
**Issue and/or context:**

[sc-50154]

**Changes:**

https://github.com/single-cell-data/TileDB-SOMA/pull/2693 deprecated `tiledb.Ctx` in favor of `clib.SOMAContext`. When setting `tiledb_config`, we switched over to using the config in `clib.SOMAContext`. However, if the user passed in a `tiledb_ctx`, it would ignore it and not use the correct config. Since we are still allowing `tiledb_ctx` until it is removed in 1.14, ensure that we still pull the config from `tiledb_ctx` if that is what the user passed in.

**Notes for Reviewer:**

Passing this in as a `tiledb_config` works as expected.