### PR TITLE
Compare core to tiledb-py/tiledb-r major+minor, `release-1.12` branch

### DIFF
--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -113,7 +113,8 @@ def verify_core_versions() -> None:
     """
     tiledb_py_core_version = get_tiledb_py_core_version()
     libtiledbsoma_core_version = get_libtiledbsoma_core_version()
-    if tiledb_py_core_version != libtiledbsoma_core_version:
+    # Check major and minor but not micro: sc-50464
+    if tiledb_py_core_version[:2] != libtiledbsoma_core_version[:2]:
         msg = "libtiledb versions used by tiledb and libtiledbsoma differ: %s != %s" % (
             tiledb_py_core_version,
             libtiledbsoma_core_version,

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -5,6 +5,9 @@
 .onLoad <- function(libname, pkgname) {
     rpkg_lib_version <- tiledb::tiledb_version(compact=TRUE)
     soma_lib_version <- libtiledbsoma_version(compact=TRUE)
+    # Check major and minor but not micro: sc-50464
+    rpkg_lib_version <- strsplit(rpkg_lib_version, "\\.")[[1]][1:2]
+    soma_lib_version <- strsplit(soma_lib_version, "\\.")[[1]][1:2]
     if (rpkg_lib_version != soma_lib_version) {
         msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",
                        sQuote(rpkg_lib_version), sQuote(soma_lib_version))

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -6,7 +6,7 @@
     rpkg_lib_version <- tiledb::tiledb_version(compact=TRUE)
     soma_lib_version <- libtiledbsoma_version(compact=TRUE)
     # Check major and minor but not micro: sc-50464
-    rpkg_lib_version <- strsplit(rpkg_lib_version, "\\.")[[1]][1:2]
+    rpkg_lib_version <- strsplit(as.character(rpkg_lib_version), "\\.")[[1]][1:2]
     soma_lib_version <- strsplit(soma_lib_version, "\\.")[[1]][1:2]
     if (rpkg_lib_version != soma_lib_version) {
         msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -6,8 +6,8 @@
     rpkg_lib_version <- tiledb::tiledb_version(compact=TRUE)
     soma_lib_version <- libtiledbsoma_version(compact=TRUE)
     # Check major and minor but not micro: sc-50464
-    rpkg_lib_version <- strsplit(as.character(rpkg_lib_version), "\\.")[[1]][1:2]
-    soma_lib_version <- strsplit(soma_lib_version, "\\.")[[1]][1:2]
+    rpkg_lib_version <- paste(strsplit(as.character(rpkg_lib_version), "\\.")[[1]][1:2], collapse = ".")
+    soma_lib_version <- paste(strsplit(soma_lib_version, "\\.")[[1]][1:2], collapse = ".")
     if (rpkg_lib_version != soma_lib_version) {
         msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",
                        sQuote(rpkg_lib_version), sQuote(soma_lib_version))


### PR DESCRIPTION
[[sc-50464]](https://app.shortcut.com/tiledb-inc/story/50464/customer-soma-version-conflicts-in-pypi-install)

See also #2784