### PR TITLE
[c++] Cast `ArrowTable` values in `SOMAArray::write` to match `ArraySchema` on-disk

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -466,7 +466,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         clib_dataframe = self._handle._handle
 
-        values = _util.cast_values_to_target_schema(values, self.schema)
+        # values = _util.cast_values_to_target_schema(values, self.schema)
 
         for batch in values.to_batches():
             clib_dataframe.write(batch, sort_coords or False)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -466,8 +466,6 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         clib_dataframe = self._handle._handle
 
-        # values = _util.cast_values_to_target_schema(values, self.schema)
-
         for batch in values.to_batches():
             clib_dataframe.write(batch, sort_coords or False)
 

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -339,21 +339,12 @@ def cast_values_to_target_schema(values: pa.Table, schema: pa.Schema) -> pa.Tabl
     match the schema on disk. Cast the values to the correct dtypes.
     """
     # Ensure fields are in the correct order
-    target_schema = []
-    for input_field in values.schema:
-        name = input_field.name
-        target_field = schema.field(name)
+    # target_schema = []
+    # for input_field in values.schema:
+    #     target_schema.append(schema.field(input_field.name))
 
-        # This check is also done in C++ but we still want to keep the
-        # ValueError exception
-        if pa.types.is_dictionary(target_field.type):
-            if not pa.types.is_dictionary(input_field.type):
-                raise ValueError(f"{name} requires dictionary entry")
-            target_schema.append(input_field)
-        else:
-            target_schema.append(target_field)
-
-    return values.cast(pa.schema(target_schema, values.schema.metadata))
+    # return values.cast(pa.schema(target_schema, values.schema.metadata))
+    return values
 
 
 def build_clib_platform_config(

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1123,6 +1123,7 @@ def _write_arrow_table(
             None,
             f"Write Arrow table num_rows={len(arrow_table)} num_bytes={arrow_table.nbytes} cap={cap}",
         )
+        print(arrow_table)
         handle.write(arrow_table)
 
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1123,7 +1123,6 @@ def _write_arrow_table(
             None,
             f"Write Arrow table num_rows={len(arrow_table)} num_bytes={arrow_table.nbytes} cap={cap}",
         )
-        print(arrow_table)
         handle.write(arrow_table)
 
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -846,7 +846,8 @@ def test_write_categorical_types(tmp_path):
         sdf.write(pa.Table.from_pandas(df))
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
-        assert (df == sdf.read().concat().to_pandas()).all().all()
+        print(sdf.read().concat())
+    #     assert (df == sdf.read().concat().to_pandas()).all().all()
 
 
 # def test_write_categorical_dims(tmp_path):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -775,106 +775,106 @@ def test_read_indexing(tmp_path, io):
             assert table["A"].to_list() == io["A"]
 
 
-# def test_write_categorical_types(tmp_path):
-#     """
-#     Verify that write path accepts categoricals
-#     """
-#     schema = pa.schema(
-#         [
-#             ("soma_joinid", pa.int64()),
-#             (
-#                 "string-ordered",
-#                 pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
-#             ),
-#             ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
-#             ("string-compat", pa.large_string()),
-#             ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
-#             ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
-#             ("int-compat", pa.int64()),
-#             ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
-#             ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
-#             ("bool-compat", pa.bool_()),
-#         ]
-#     )
-#     with soma.DataFrame.create(
-#         tmp_path.as_posix(), schema=schema, index_column_names=["soma_joinid"]
-#     ) as sdf:
-#         df = pd.DataFrame(
-#             data={
-#                 "soma_joinid": [0, 1, 2, 3],
-#                 "string-ordered": pd.Categorical(
-#                     ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
-#                 ),
-#                 "string-unordered": pd.Categorical(
-#                     ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
-#                 ),
-#                 "string-compat": pd.Categorical(
-#                     ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
-#                 ),
-#                 "int-ordered": pd.Categorical(
-#                     [777777777, 888888888, 777777777, 888888888],
-#                     ordered=True,
-#                     categories=[888888888, 777777777],
-#                 ),
-#                 "int-unordered": pd.Categorical(
-#                     [777777777, 888888888, 777777777, 888888888],
-#                     ordered=False,
-#                     categories=[888888888, 777777777],
-#                 ),
-#                 "int-compat": pd.Categorical(
-#                     [777777777, 888888888, 777777777, 888888888],
-#                     ordered=False,
-#                     categories=[777777777, 888888888],
-#                 ),
-#                 "bool-ordered": pd.Categorical(
-#                     [True, False, True, False],
-#                     ordered=True,
-#                     categories=[True, False],
-#                 ),
-#                 "bool-unordered": pd.Categorical(
-#                     [True, False, True, False],
-#                     ordered=False,
-#                     categories=[True, False],
-#                 ),
-#                 "bool-compat": pd.Categorical(
-#                     [True, False, True, False],
-#                     ordered=False,
-#                     categories=[True, False],
-#                 ),
-#             }
-#         )
-#         sdf.write(pa.Table.from_pandas(df))
-
-#     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
-#         assert (df == sdf.read().concat().to_pandas()).all().all()
-
-
-def test_write_categorical_dims(tmp_path):
+def test_write_categorical_types(tmp_path):
     """
-    Categories are not supported as dims. Here we test our handling of what we
-    do when we are given them as input.
+    Verify that write path accepts categoricals
     """
     schema = pa.schema(
         [
             ("soma_joinid", pa.int64()),
-            ("string", pa.dictionary(pa.int8(), pa.large_string())),
+            # (
+            #     "string-ordered",
+            #     pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
+            # ),
+            # ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
+            ("string-compat", pa.large_string()),
+            # ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
+            # ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
+            # ("int-compat", pa.int64()),
+            # ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
+            # ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
+            # ("bool-compat", pa.bool_()),
         ]
     )
     with soma.DataFrame.create(
-        tmp_path.as_posix(),
-        schema=schema,
-        index_column_names=["soma_joinid"],
+        tmp_path.as_posix(), schema=schema, index_column_names=["soma_joinid"]
     ) as sdf:
         df = pd.DataFrame(
             data={
-                "soma_joinid": pd.Categorical([0, 1, 2, 3], categories=[0, 1, 2, 3]),
-                "string": pd.Categorical(["a", "b", "a", "b"], categories=["b", "a"]),
+                "soma_joinid": [0, 1, 2, 3],
+                # "string-ordered": pd.Categorical(
+                #     ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
+                # ),
+                # "string-unordered": pd.Categorical(
+                #     ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
+                # ),
+                "string-compat": pd.Categorical(
+                    ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
+                ),
+                # "int-ordered": pd.Categorical(
+                #     [777777777, 888888888, 777777777, 888888888],
+                #     ordered=True,
+                #     categories=[888888888, 777777777],
+                # ),
+                # "int-unordered": pd.Categorical(
+                #     [777777777, 888888888, 777777777, 888888888],
+                #     ordered=False,
+                #     categories=[888888888, 777777777],
+                # ),
+                # "int-compat": pd.Categorical(
+                #     [777777777, 888888888, 777777777, 888888888],
+                #     ordered=False,
+                #     categories=[777777777, 888888888],
+                # ),
+                # "bool-ordered": pd.Categorical(
+                #     [True, False, True, False],
+                #     ordered=True,
+                #     categories=[True, False],
+                # ),
+                # "bool-unordered": pd.Categorical(
+                #     [True, False, True, False],
+                #     ordered=False,
+                #     categories=[True, False],
+                # ),
+                # "bool-compat": pd.Categorical(
+                #     [True, False, True, False],
+                #     ordered=False,
+                #     categories=[True, False],
+                # ),
             }
         )
         sdf.write(pa.Table.from_pandas(df))
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
         assert (df == sdf.read().concat().to_pandas()).all().all()
+
+
+# def test_write_categorical_dims(tmp_path):
+#     """
+#     Categories are not supported as dims. Here we test our handling of what we
+#     do when we are given them as input.
+#     """
+#     schema = pa.schema(
+#         [
+#             ("soma_joinid", pa.int64()),
+#             ("string", pa.dictionary(pa.int8(), pa.large_string())),
+#         ]
+#     )
+#     with soma.DataFrame.create(
+#         tmp_path.as_posix(),
+#         schema=schema,
+#         index_column_names=["soma_joinid"],
+#     ) as sdf:
+#         df = pd.DataFrame(
+#             data={
+#                 "soma_joinid": pd.Categorical([0, 1, 2, 3], categories=[0, 1, 2, 3]),
+#                 "string": pd.Categorical(["a", "b", "a", "b"], categories=["b", "a"]),
+#             }
+#         )
+#         sdf.write(pa.Table.from_pandas(df))
+
+#     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
+#         assert (df == sdf.read().concat().to_pandas()).all().all()
 
 
 @pytest.mark.parametrize("index_type", [pa.int8(), pa.int16(), pa.int32(), pa.int64()])

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -782,11 +782,11 @@ def test_write_categorical_types(tmp_path):
     schema = pa.schema(
         [
             ("soma_joinid", pa.int64()),
-            # (
-            #     "string-ordered",
-            #     pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
-            # ),
-            # ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
+            (
+                "string-ordered",
+                pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
+            ),
+            ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
             ("string-compat", pa.large_string()),
             # ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
             # ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
@@ -802,12 +802,12 @@ def test_write_categorical_types(tmp_path):
         df = pd.DataFrame(
             data={
                 "soma_joinid": [0, 1, 2, 3],
-                # "string-ordered": pd.Categorical(
-                #     ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
-                # ),
-                # "string-unordered": pd.Categorical(
-                #     ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
-                # ),
+                "string-ordered": pd.Categorical(
+                    ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
+                ),
+                "string-unordered": pd.Categorical(
+                    ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
+                ),
                 "string-compat": pd.Categorical(
                     ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
                 ),
@@ -847,7 +847,7 @@ def test_write_categorical_types(tmp_path):
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
         print(sdf.read().concat())
-    #     assert (df == sdf.read().concat().to_pandas()).all().all()
+        assert (df == sdf.read().concat().to_pandas()).all().all()
 
 
 # def test_write_categorical_dims(tmp_path):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -788,12 +788,12 @@ def test_write_categorical_types(tmp_path):
             ),
             ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
             ("string-compat", pa.large_string()),
-            # ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
-            # ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
-            # ("int-compat", pa.int64()),
-            # ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
-            # ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
-            # ("bool-compat", pa.bool_()),
+            ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
+            ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
+            ("int-compat", pa.int64()),
+            ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
+            ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
+            ("bool-compat", pa.bool_()),
         ]
     )
     with soma.DataFrame.create(
@@ -811,42 +811,41 @@ def test_write_categorical_types(tmp_path):
                 "string-compat": pd.Categorical(
                     ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
                 ),
-                # "int-ordered": pd.Categorical(
-                #     [777777777, 888888888, 777777777, 888888888],
-                #     ordered=True,
-                #     categories=[888888888, 777777777],
-                # ),
-                # "int-unordered": pd.Categorical(
-                #     [777777777, 888888888, 777777777, 888888888],
-                #     ordered=False,
-                #     categories=[888888888, 777777777],
-                # ),
-                # "int-compat": pd.Categorical(
-                #     [777777777, 888888888, 777777777, 888888888],
-                #     ordered=False,
-                #     categories=[777777777, 888888888],
-                # ),
-                # "bool-ordered": pd.Categorical(
-                #     [True, False, True, False],
-                #     ordered=True,
-                #     categories=[True, False],
-                # ),
-                # "bool-unordered": pd.Categorical(
-                #     [True, False, True, False],
-                #     ordered=False,
-                #     categories=[True, False],
-                # ),
-                # "bool-compat": pd.Categorical(
-                #     [True, False, True, False],
-                #     ordered=False,
-                #     categories=[True, False],
-                # ),
+                "int-ordered": pd.Categorical(
+                    [777777777, 888888888, 777777777, 888888888],
+                    ordered=True,
+                    categories=[888888888, 777777777],
+                ),
+                "int-unordered": pd.Categorical(
+                    [777777777, 888888888, 777777777, 888888888],
+                    ordered=False,
+                    categories=[888888888, 777777777],
+                ),
+                "int-compat": pd.Categorical(
+                    [777777777, 888888888, 777777777, 888888888],
+                    ordered=False,
+                    categories=[777777777, 888888888],
+                ),
+                "bool-ordered": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=True,
+                    categories=[True, False],
+                ),
+                "bool-unordered": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=False,
+                    categories=[True, False],
+                ),
+                "bool-compat": pd.Categorical(
+                    [True, False, True, False],
+                    ordered=False,
+                    categories=[True, False],
+                ),
             }
         )
         sdf.write(pa.Table.from_pandas(df))
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
-        print(sdf.read().concat())
         assert (df == sdf.read().concat().to_pandas()).all().all()
 
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -775,78 +775,78 @@ def test_read_indexing(tmp_path, io):
             assert table["A"].to_list() == io["A"]
 
 
-def test_write_categorical_types(tmp_path):
-    """
-    Verify that write path accepts categoricals
-    """
-    schema = pa.schema(
-        [
-            ("soma_joinid", pa.int64()),
-            (
-                "string-ordered",
-                pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
-            ),
-            ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
-            ("string-compat", pa.large_string()),
-            ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
-            ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
-            ("int-compat", pa.int64()),
-            ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
-            ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
-            ("bool-compat", pa.bool_()),
-        ]
-    )
-    with soma.DataFrame.create(
-        tmp_path.as_posix(), schema=schema, index_column_names=["soma_joinid"]
-    ) as sdf:
-        df = pd.DataFrame(
-            data={
-                "soma_joinid": [0, 1, 2, 3],
-                "string-ordered": pd.Categorical(
-                    ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
-                ),
-                "string-unordered": pd.Categorical(
-                    ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
-                ),
-                "string-compat": pd.Categorical(
-                    ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
-                ),
-                "int-ordered": pd.Categorical(
-                    [777777777, 888888888, 777777777, 888888888],
-                    ordered=True,
-                    categories=[888888888, 777777777],
-                ),
-                "int-unordered": pd.Categorical(
-                    [777777777, 888888888, 777777777, 888888888],
-                    ordered=False,
-                    categories=[888888888, 777777777],
-                ),
-                "int-compat": pd.Categorical(
-                    [777777777, 888888888, 777777777, 888888888],
-                    ordered=False,
-                    categories=[777777777, 888888888],
-                ),
-                "bool-ordered": pd.Categorical(
-                    [True, False, True, False],
-                    ordered=True,
-                    categories=[True, False],
-                ),
-                "bool-unordered": pd.Categorical(
-                    [True, False, True, False],
-                    ordered=False,
-                    categories=[True, False],
-                ),
-                "bool-compat": pd.Categorical(
-                    [True, False, True, False],
-                    ordered=False,
-                    categories=[True, False],
-                ),
-            }
-        )
-        sdf.write(pa.Table.from_pandas(df))
+# def test_write_categorical_types(tmp_path):
+#     """
+#     Verify that write path accepts categoricals
+#     """
+#     schema = pa.schema(
+#         [
+#             ("soma_joinid", pa.int64()),
+#             (
+#                 "string-ordered",
+#                 pa.dictionary(pa.int8(), pa.large_string(), ordered=True),
+#             ),
+#             ("string-unordered", pa.dictionary(pa.int8(), pa.large_string())),
+#             ("string-compat", pa.large_string()),
+#             ("int-ordered", pa.dictionary(pa.int8(), pa.int64(), ordered=True)),
+#             ("int-unordered", pa.dictionary(pa.int8(), pa.int64())),
+#             ("int-compat", pa.int64()),
+#             ("bool-ordered", pa.dictionary(pa.int8(), pa.bool_(), ordered=True)),
+#             ("bool-unordered", pa.dictionary(pa.int8(), pa.bool_())),
+#             ("bool-compat", pa.bool_()),
+#         ]
+#     )
+#     with soma.DataFrame.create(
+#         tmp_path.as_posix(), schema=schema, index_column_names=["soma_joinid"]
+#     ) as sdf:
+#         df = pd.DataFrame(
+#             data={
+#                 "soma_joinid": [0, 1, 2, 3],
+#                 "string-ordered": pd.Categorical(
+#                     ["a", "b", "a", "b"], ordered=True, categories=["b", "a"]
+#                 ),
+#                 "string-unordered": pd.Categorical(
+#                     ["a", "b", "a", "b"], ordered=False, categories=["b", "a"]
+#                 ),
+#                 "string-compat": pd.Categorical(
+#                     ["a", "b", "a", "b"], ordered=False, categories=["a", "b"]
+#                 ),
+#                 "int-ordered": pd.Categorical(
+#                     [777777777, 888888888, 777777777, 888888888],
+#                     ordered=True,
+#                     categories=[888888888, 777777777],
+#                 ),
+#                 "int-unordered": pd.Categorical(
+#                     [777777777, 888888888, 777777777, 888888888],
+#                     ordered=False,
+#                     categories=[888888888, 777777777],
+#                 ),
+#                 "int-compat": pd.Categorical(
+#                     [777777777, 888888888, 777777777, 888888888],
+#                     ordered=False,
+#                     categories=[777777777, 888888888],
+#                 ),
+#                 "bool-ordered": pd.Categorical(
+#                     [True, False, True, False],
+#                     ordered=True,
+#                     categories=[True, False],
+#                 ),
+#                 "bool-unordered": pd.Categorical(
+#                     [True, False, True, False],
+#                     ordered=False,
+#                     categories=[True, False],
+#                 ),
+#                 "bool-compat": pd.Categorical(
+#                     [True, False, True, False],
+#                     ordered=False,
+#                     categories=[True, False],
+#                 ),
+#             }
+#         )
+#         sdf.write(pa.Table.from_pandas(df))
 
-    with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
-        assert (df == sdf.read().concat().to_pandas()).all().all()
+#     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
+#         assert (df == sdf.read().concat().to_pandas()).all().all()
 
 
 def test_write_categorical_dims(tmp_path):

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -591,7 +591,7 @@ void SOMAArray::_cast_dictionary_values<std::string>(
         values.push_back(data_v.substr(beg, sz));
     }
 
-    auto indexes = SOMAArray::_get_index_vector(
+    std::vector<int64_t> indexes = SOMAArray::_get_index_vector(
         orig_column_schema, orig_column_array);
 
     uint64_t offset_sum = 0;
@@ -625,42 +625,61 @@ void SOMAArray::_promote_indexes_to_values(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
-            SOMAArray::_cast_dictionary_values<std::string>(
+            return SOMAArray::_cast_dictionary_values<std::string>(
                 orig_column_schema, orig_column_array, new_column_array);
-            break;
-        // case TILEDB_BOOL:
-        // case TILEDB_INT8:
-        // case TILEDB_UINT8:
-        // case TILEDB_INT16:
-        // case TILEDB_UINT16:
-        // case TILEDB_INT32:
-        // case TILEDB_UINT32:
-        // case TILEDB_INT64:
-        // case TILEDB_DATETIME_YEAR:
-        // case TILEDB_DATETIME_MONTH:
-        // case TILEDB_DATETIME_WEEK:
-        // case TILEDB_DATETIME_DAY:
-        // case TILEDB_DATETIME_HR:
-        // case TILEDB_DATETIME_MIN:
-        // case TILEDB_DATETIME_SEC:
-        // case TILEDB_DATETIME_MS:
-        // case TILEDB_DATETIME_US:
-        // case TILEDB_DATETIME_NS:
-        // case TILEDB_DATETIME_PS:
-        // case TILEDB_DATETIME_FS:
-        // case TILEDB_DATETIME_AS:
-        // case TILEDB_TIME_HR:
-        // case TILEDB_TIME_MIN:
-        // case TILEDB_TIME_SEC:
-        // case TILEDB_TIME_MS:
-        // case TILEDB_TIME_US:
-        // case TILEDB_TIME_NS:
-        // case TILEDB_TIME_PS:
-        // case TILEDB_TIME_FS:
-        // case TILEDB_TIME_AS:
-        // case TILEDB_UINT64:
-        // case TILEDB_FLOAT32:
-        // case TILEDB_FLOAT64:
+        case TILEDB_BOOL:
+        case TILEDB_INT8:
+            return SOMAArray::_cast_dictionary_values<int8_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_UINT8:
+            return SOMAArray::_cast_dictionary_values<uint8_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_INT16:
+            return SOMAArray::_cast_dictionary_values<int16_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_UINT16:
+            return SOMAArray::_cast_dictionary_values<uint16_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_INT32:
+            return SOMAArray::_cast_dictionary_values<int32_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_UINT32:
+            return SOMAArray::_cast_dictionary_values<uint32_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_INT64:
+            return SOMAArray::_cast_dictionary_values<int64_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_TIME_HR:
+        case TILEDB_TIME_MIN:
+        case TILEDB_TIME_SEC:
+        case TILEDB_TIME_MS:
+        case TILEDB_TIME_US:
+        case TILEDB_TIME_NS:
+        case TILEDB_TIME_PS:
+        case TILEDB_TIME_FS:
+        case TILEDB_TIME_AS:
+        case TILEDB_UINT64:
+            return SOMAArray::_cast_dictionary_values<uint64_t>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_FLOAT32:
+            return SOMAArray::_cast_dictionary_values<float>(
+                orig_column_schema, orig_column_array, new_column_array);
+        case TILEDB_FLOAT64:
+            return SOMAArray::_cast_dictionary_values<double>(
+                orig_column_schema, orig_column_array, new_column_array);
         default:
             throw TileDBSOMAError(fmt::format(
                 "Saw invalid TileDB value type when attempting to "

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -350,11 +350,6 @@ Enumeration SOMAArray::_extend_and_evolve_schema_str(
     ArrowArray* value_array,
     ArrowSchema* index_schema,
     ArrowArray* index_array) {
-    std::string column_name = index_schema->name;
-    auto disk_index_type = tiledb_schema()->attribute(column_name).type();
-    auto enmr = ArrayExperimental::get_enumeration(
-        *ctx_->tiledb_ctx(), *arr_, column_name);
-    uint64_t max_capacity = SOMAArray::_get_max_capacity(disk_index_type);
     uint64_t num_elems = value_array->length;
 
     std::vector<uint64_t> offsets_v;
@@ -382,6 +377,9 @@ Enumeration SOMAArray::_extend_and_evolve_schema_str(
         enums_in_write.push_back(data_v.substr(beg, sz));
     }
 
+    std::string column_name = index_schema->name;
+    auto enmr = ArrayExperimental::get_enumeration(
+        *ctx_->tiledb_ctx(), *arr_, column_name);
     std::vector<std::string> extend_values;
     auto enums_existing = enmr.as_vector<std::string>();
     for (auto enum_val : enums_in_write) {
@@ -394,6 +392,8 @@ Enumeration SOMAArray::_extend_and_evolve_schema_str(
     if (extend_values.size() != 0) {
         // Check that we extend the enumeration values without
         // overflowing
+        auto disk_index_type = tiledb_schema()->attribute(column_name).type();
+        uint64_t max_capacity = SOMAArray::_get_max_capacity(disk_index_type);
         auto free_capacity = max_capacity - enums_existing.size();
         if (free_capacity < extend_values.size()) {
             throw TileDBSOMAError(
@@ -505,6 +505,8 @@ void SOMAArray::set_array_data(
     auto [casted_array, casted_schema] = SOMAArray::_cast_table(
         std::move(arrow_schema), std::move(arrow_array));
 
+    std::cout << "SOMAArray::set_array_data" << std::endl;
+
     for (auto i = 0; i < casted_schema->n_children; ++i) {
         auto arrow_sch_ = casted_schema->children[i];
         auto arrow_arr_ = casted_array->children[i];
@@ -565,12 +567,216 @@ void SOMAArray::set_array_data(
 ArrowTable SOMAArray::_cast_table(
     std::unique_ptr<ArrowSchema> arrow_schema,
     std::unique_ptr<ArrowArray> arrow_array) {
+    auto casted_arrow_schema = std::make_unique<ArrowSchema>();
+    casted_arrow_schema->format = strdup("+s");
+    casted_arrow_schema->n_children = arrow_schema->n_children;
+    casted_arrow_schema->dictionary = nullptr;
+    casted_arrow_schema->release = &ArrowAdapter::release_schema;
+    casted_arrow_schema->children = (ArrowSchema**)malloc(
+        arrow_schema->n_children * sizeof(ArrowSchema*));
+
+    auto casted_arrow_array = std::make_unique<ArrowArray>();
+    casted_arrow_array->length = 0;
+    casted_arrow_array->null_count = 0;
+    casted_arrow_array->offset = 0;
+    casted_arrow_array->n_buffers = 0;
+    casted_arrow_array->buffers = nullptr;
+    casted_arrow_array->n_children = arrow_array->n_children;
+    casted_arrow_array->release = &ArrowAdapter::release_array;
+    casted_arrow_array->children = (ArrowArray**)malloc(
+        arrow_array->n_children * sizeof(ArrowArray*));
+
     // Go through all columns in the ArrowTable and cast the values to what is
     // in the ArraySchema on disk
     for (auto i = 0; i < arrow_schema->n_children; ++i) {
-        auto arrow_sch_ = arrow_schema->children[i];
-        auto arrow_arr_ = arrow_array->children[i];
-        std::string name(arrow_sch_->name);
+        auto orig_arrow_sch_ = arrow_schema->children[i];
+        auto orig_arrow_arr_ = arrow_array->children[i];
+        auto new_arrow_sch_ = casted_arrow_schema
+                                  ->children[i] = new ArrowSchema;
+        auto new_arrow_arr_ = casted_arrow_array->children[i] = new ArrowArray;
+
+        tiledb_datatype_t user_type = ArrowAdapter::to_tiledb_format(
+            orig_arrow_sch_->format);
+        std::string name(orig_arrow_sch_->name);
+
+        std::cout << name << ": " << tiledb::impl::type_to_str(user_type);
+
+        tiledb_datatype_t disk_type;
+        if (tiledb_schema()->has_attribute(name)) {
+            disk_type = tiledb_schema()->attribute(name).type();
+        } else {
+            disk_type = tiledb_schema()->domain().dimension(name).type();
+        }
+
+        new_arrow_sch_->format = strdup(
+            ArrowAdapter::to_arrow_format(disk_type).data());
+        new_arrow_sch_->name = strdup(orig_arrow_sch_->name);
+        new_arrow_sch_->n_children = orig_arrow_sch_->n_children;
+        new_arrow_sch_->release = &ArrowAdapter::release_schema;
+        new_arrow_sch_->children = (ArrowSchema**)malloc(
+            orig_arrow_sch_->n_children * sizeof(ArrowSchema*));
+        new_arrow_arr_->length = orig_arrow_arr_->length;
+        new_arrow_arr_->null_count = orig_arrow_arr_->null_count;
+        new_arrow_arr_->offset = 0;
+        new_arrow_arr_->n_buffers = orig_arrow_arr_->n_buffers;
+        new_arrow_arr_->buffers = new const void*[orig_arrow_arr_->n_buffers];
+        new_arrow_arr_->n_children = orig_arrow_arr_->n_children;
+        new_arrow_arr_->release = &ArrowAdapter::release_array;
+        new_arrow_arr_->children = (ArrowArray**)malloc(
+            orig_arrow_arr_->n_children * sizeof(ArrowArray*));
+
+        switch (user_type) {
+            case TILEDB_STRING_ASCII:
+            case TILEDB_STRING_UTF8:
+            case TILEDB_CHAR: {
+                std::vector<uint64_t> offsets_v;
+                if ((strcmp(orig_arrow_sch_->format, "U") == 0) ||
+                    (strcmp(orig_arrow_sch_->format, "Z") == 0)) {
+                    uint64_t* offsets = (uint64_t*)orig_arrow_arr_->buffers[1];
+                    offsets_v.resize(orig_arrow_arr_->length + 1);
+                    offsets_v.assign(
+                        offsets, offsets + orig_arrow_arr_->length + 1);
+                } else {
+                    uint32_t* offsets = (uint32_t*)orig_arrow_arr_->buffers[1];
+                    std::vector<uint32_t> offset_holder(
+                        offsets, offsets + orig_arrow_arr_->length + 1);
+                    for (auto offset : offset_holder) {
+                        offsets_v.push_back((uint64_t)offset);
+                    }
+                }
+
+                new_arrow_arr_->buffers[1] = malloc(
+                    sizeof(uint64_t) * offsets_v.size());
+                std::memcpy(
+                    (void*)new_arrow_arr_->buffers[1],
+                    offsets_v.data(),
+                    sizeof(uint64_t) * offsets_v.size());
+
+                new_arrow_arr_->buffers[2] = malloc(
+                    sizeof(char) * offsets_v.back());
+                std::memcpy(
+                    (void*)new_arrow_arr_->buffers[2],
+                    orig_arrow_arr_->buffers[2],
+                    sizeof(char) * offsets_v.back());
+
+                break;
+            }
+            case TILEDB_BOOL: {
+                if (orig_arrow_arr_->n_buffers == 3) {
+                    new_arrow_arr_->buffers[2] = malloc(
+                        orig_arrow_arr_->length);
+                    std::memcpy(
+                        (void*)new_arrow_arr_->buffers[2],
+                        orig_arrow_arr_->buffers[2],
+                        orig_arrow_arr_->length);
+                } else {
+                    new_arrow_arr_->buffers[1] = malloc(
+                        orig_arrow_arr_->length);
+                    std::memcpy(
+                        (void*)new_arrow_arr_->buffers[1],
+                        orig_arrow_arr_->buffers[1],
+                        orig_arrow_arr_->length);
+                }
+                break;
+            }
+            case TILEDB_INT8:
+                SOMAArray::_cast_column<int8_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_UINT8:
+                SOMAArray::_cast_column<uint8_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_INT16:
+                SOMAArray::_cast_column<int16_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_UINT16:
+                SOMAArray::_cast_column<uint16_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_INT32:
+                SOMAArray::_cast_column<int32_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_UINT32:
+                SOMAArray::_cast_column<uint32_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_INT64:
+            case TILEDB_DATETIME_YEAR:
+            case TILEDB_DATETIME_MONTH:
+            case TILEDB_DATETIME_WEEK:
+            case TILEDB_DATETIME_DAY:
+            case TILEDB_DATETIME_HR:
+            case TILEDB_DATETIME_MIN:
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+            case TILEDB_DATETIME_PS:
+            case TILEDB_DATETIME_FS:
+            case TILEDB_DATETIME_AS:
+            case TILEDB_TIME_HR:
+            case TILEDB_TIME_MIN:
+            case TILEDB_TIME_SEC:
+            case TILEDB_TIME_MS:
+            case TILEDB_TIME_US:
+            case TILEDB_TIME_NS:
+            case TILEDB_TIME_PS:
+            case TILEDB_TIME_FS:
+            case TILEDB_TIME_AS:
+                SOMAArray::_cast_column<int64_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_UINT64:
+                SOMAArray::_cast_column<uint64_t>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_FLOAT32:
+                SOMAArray::_cast_column<float>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            case TILEDB_FLOAT64:
+                SOMAArray::_cast_column<double>(
+                    orig_arrow_sch_,
+                    orig_arrow_arr_,
+                    // new_arrow_sch_,
+                    new_arrow_arr_);
+                break;
+            default:
+                throw TileDBSOMAError(fmt::format(
+                    "Saw invalid TileDB user type when attempting to "
+                    "cast table: {}",
+                    tiledb::impl::type_to_str(user_type)));
+        }
 
         // if the attribute is enumerated, ensure that the index values also
         // match is in the ArraySchema on disk
@@ -581,8 +787,8 @@ ArrowTable SOMAArray::_cast_table(
                 *ctx_->tiledb_ctx(), attr);
 
             if (enmr_name.has_value()) {
-                auto dict_sch_ = arrow_sch_->dictionary;
-                auto dict_arr_ = arrow_arr_->dictionary;
+                auto dict_sch_ = orig_arrow_sch_->dictionary;
+                auto dict_arr_ = orig_arrow_arr_->dictionary;
 
                 if (dict_arr_ == nullptr) {
                     throw std::invalid_argument(fmt::format(
@@ -595,62 +801,18 @@ ArrowTable SOMAArray::_cast_table(
                 }
 
                 auto extended_enmr = extend_enumeration(
-                    dict_sch_, dict_arr_, arrow_sch_, arrow_arr_);
-            }else{
-                        tiledb_datatype_t user_type = ArrowAdapter::to_tiledb_format(
-            arrow_sch_->format);
-        switch (user_type) {
-            case TILEDB_STRING_ASCII:
-            case TILEDB_STRING_UTF8:
-            case TILEDB_CHAR:
-            case TILEDB_BOOL:
-                break;
-            case TILEDB_INT8:
-                SOMAArray::_cast_column<int8_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_UINT8:
-                SOMAArray::_cast_column<uint8_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_INT16:
-                SOMAArray::_cast_column<int16_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_UINT16:
-                SOMAArray::_cast_column<uint16_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_INT32:
-                SOMAArray::_cast_column<int32_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_UINT32:
-                SOMAArray::_cast_column<uint32_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_INT64:
-                SOMAArray::_cast_column<int64_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_UINT64:
-                SOMAArray::_cast_column<uint64_t>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_FLOAT32:
-                SOMAArray::_cast_column<float>(arrow_sch_, arrow_arr_);
-                break;
-            case TILEDB_FLOAT64:
-                SOMAArray::_cast_column<double>(arrow_sch_, arrow_arr_);
-                break;
-            default:
-                throw TileDBSOMAError(fmt::format(
-                    "Saw invalid TileDB type when attempting to cast table: "
-                    "{} ",
-                    tiledb::impl::type_to_str(user_type)));
-        }
+                    dict_sch_, dict_arr_, orig_arrow_sch_, orig_arrow_arr_);
             }
         }
 
         // Cast column values from bit to uint8
-        if (strcmp(arrow_sch_->format, "b") == 0) {
-            _cast_bit_to_uint8(arrow_sch_, arrow_arr_);
+        if (strcmp(new_arrow_sch_->format, "b") == 0) {
+            _cast_bit_to_uint8(orig_arrow_sch_, orig_arrow_arr_);
         }
     }
 
-    return ArrowTable(std::move(arrow_array), std::move(arrow_schema));
+    return ArrowTable(
+        std::move(casted_arrow_array), std::move(casted_arrow_schema));
 }
 
 void SOMAArray::_cast_bit_to_uint8(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -667,7 +667,8 @@ ArrowTable SOMAArray::_cast_table(
             }
             case TILEDB_BOOL: {
                 new_arrow_arr_->buffers[0] = orig_arrow_arr_->buffers[0];
-                auto sz = orig_arrow_arr_->length + (orig_arrow_arr_->length % 8 == 0 ? 0 : 1);
+                auto sz = orig_arrow_arr_->length +
+                          (orig_arrow_arr_->length % 8 == 0 ? 0 : 1);
 
                 if (orig_arrow_arr_->n_buffers == 3) {
                     new_arrow_arr_->buffers[2] = malloc(sz);
@@ -688,39 +689,27 @@ ArrowTable SOMAArray::_cast_table(
             }
             case TILEDB_INT8:
                 SOMAArray::_cast_column<int8_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_UINT8:
                 SOMAArray::_cast_column<uint8_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_INT16:
                 SOMAArray::_cast_column<int16_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_UINT16:
                 SOMAArray::_cast_column<uint16_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_INT32:
                 SOMAArray::_cast_column<int32_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_UINT32:
                 SOMAArray::_cast_column<uint32_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_INT64:
             case TILEDB_DATETIME_YEAR:
@@ -746,27 +735,19 @@ ArrowTable SOMAArray::_cast_table(
             case TILEDB_TIME_FS:
             case TILEDB_TIME_AS:
                 SOMAArray::_cast_column<int64_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_UINT64:
                 SOMAArray::_cast_column<uint64_t>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_FLOAT32:
                 SOMAArray::_cast_column<float>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             case TILEDB_FLOAT64:
                 SOMAArray::_cast_column<double>(
-                    orig_arrow_sch_,
-                    orig_arrow_arr_,
-                    new_arrow_arr_);
+                    orig_arrow_sch_, orig_arrow_arr_, new_arrow_arr_);
                 break;
             default:
                 throw TileDBSOMAError(fmt::format(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -608,8 +608,7 @@ ArrowTable SOMAArray::_cast_table(
 }
 
 void SOMAArray::_cast_bit_to_uint8(
-    ArrowSchema* arrow_schema,
-    ArrowArray* arrow_array){
+    ArrowSchema* arrow_schema, ArrowArray* arrow_array) {
     const void* data;
     if (arrow_array->n_buffers == 3) {
         data = arrow_array->buffers[2];

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -819,11 +819,16 @@ class SOMAArray : public SOMAObject {
         ArrowSchema* index_schema,
         ArrowArray* index_array);
 
-    template <typename UserType>
     void _cast_column(
         ArrowSchema* orig_column_schema,
         ArrowArray* orig_column_array,
-        // ArrowSchema* new_column_schema,
+        ArrowSchema* new_column_schema,
+        ArrowArray* new_column_array);
+
+    template <typename UserType>
+    void _cast_column_aux(
+        ArrowSchema* orig_column_schema,
+        ArrowArray* orig_column_array,
         ArrowArray* new_column_array) {
         tiledb_datatype_t disk_type;
         std::string name(orig_column_schema->name);
@@ -840,41 +845,23 @@ class SOMAArray : public SOMAObject {
                 break;
             case TILEDB_BOOL:
             case TILEDB_INT8:
-                return SOMAArray::_cast_column_aux<UserType, int8_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, int8_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_UINT8:
-                return SOMAArray::_cast_column_aux<UserType, uint8_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, uint8_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_INT16:
-                return SOMAArray::_cast_column_aux<UserType, int16_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, int16_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_UINT16:
-                return SOMAArray::_cast_column_aux<UserType, uint16_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, uint16_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_INT32:
-                return SOMAArray::_cast_column_aux<UserType, int32_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, int32_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_UINT32:
-                return SOMAArray::_cast_column_aux<UserType, uint32_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, uint32_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_INT64:
             case TILEDB_DATETIME_YEAR:
             case TILEDB_DATETIME_MONTH:
@@ -898,29 +885,17 @@ class SOMAArray : public SOMAObject {
             case TILEDB_TIME_PS:
             case TILEDB_TIME_FS:
             case TILEDB_TIME_AS:
-                return SOMAArray::_cast_column_aux<UserType, int64_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, int64_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_UINT64:
-                return SOMAArray::_cast_column_aux<UserType, uint64_t>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, uint64_t>(
+                    orig_column_array, new_column_array);
             case TILEDB_FLOAT32:
-                return SOMAArray::_cast_column_aux<UserType, float>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, float>(
+                    orig_column_array, new_column_array);
             case TILEDB_FLOAT64:
-                return SOMAArray::_cast_column_aux<UserType, double>(
-                    // orig_column_schema,
-                    orig_column_array,
-                    // new_column_schema,
-                    new_column_array);
+                return SOMAArray::_copy_column<UserType, double>(
+                    orig_column_array, new_column_array);
             default:
                 throw TileDBSOMAError(
                     "Saw invalid TileDB disk type when attempting to cast "
@@ -930,11 +905,8 @@ class SOMAArray : public SOMAObject {
     }
 
     template <typename UserType, typename DiskType>
-    void _cast_column_aux(
-        // ArrowSchema* orig_column_schema,
-        ArrowArray* orig_column_array,
-        // ArrowSchema* new_column_schema,
-        ArrowArray* new_column_array) {
+    void _copy_column(
+        ArrowArray* orig_column_array, ArrowArray* new_column_array) {
         UserType* buf;
         if (orig_column_array->n_buffers == 3) {
             buf = (UserType*)orig_column_array->buffers[2] +

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -825,6 +825,12 @@ class SOMAArray : public SOMAObject {
         ArrowSchema* new_column_schema,
         ArrowArray* new_column_array);
 
+    void _create_column(
+        ArrowSchema* orig_column_schema,
+        ArrowArray* orig_column_array,
+        ArrowSchema* new_column_schema,
+        ArrowArray* new_column_array);
+
     void _cast_column(
         ArrowSchema* orig_column_schema,
         ArrowArray* orig_column_array,

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1084,6 +1084,65 @@ class SOMAArray : public SOMAObject {
         }
     }
 
+    void _promote_indexes_to_values(
+        ArrowSchema* orig_column_schema,
+        ArrowArray* orig_column_array,
+        ArrowArray* new_column_array);
+
+    template <typename T>
+    void _cast_dictionary_values(
+        ArrowSchema* orig_column_schema,
+        ArrowArray* orig_column_array,
+        ArrowArray* new_column_array) {
+        ;
+    }
+
+    std::vector<int64_t> _get_index_vector(
+        ArrowSchema* orig_column_schema, ArrowArray* orig_column_array) {
+        auto index_type = ArrowAdapter::to_tiledb_format(
+            orig_column_schema->format);
+        auto len = orig_column_array->length;
+
+        switch (index_type) {
+            case TILEDB_INT8: {
+                int8_t* idxbuf = (int8_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_UINT8: {
+                uint8_t* idxbuf = (uint8_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_INT16: {
+                int16_t* idxbuf = (int16_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_UINT16: {
+                uint16_t* idxbuf = (uint16_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_INT32: {
+                int32_t* idxbuf = (int32_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_UINT32: {
+                uint32_t* idxbuf = (uint32_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_INT64: {
+                int64_t* idxbuf = (int64_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            case TILEDB_UINT64: {
+                uint64_t* idxbuf = (uint64_t*)orig_column_array->buffers[1];
+                return std::vector<int64_t>(idxbuf, idxbuf + len);
+            }
+            default:
+                throw TileDBSOMAError(
+                    "Saw invalid index type when trying to promote indexes to "
+                    "values");
+        }
+    }
+
     // Helper function to cast Boolean of bits (Arrow) to uint8 (TileDB)
     void _cast_bit_to_uint8(ArrowSchema* arrow_schema, ArrowArray* arrow_array);
 
@@ -1125,9 +1184,10 @@ class SOMAArray : public SOMAObject {
     // Array associated with mq_
     std::shared_ptr<Array> arr_;
 
-    // Array associated with metadata_. Metadata values need to be accessible in
-    // write mode as well. We need to keep this read-mode array alive in order
-    // for the metadata value pointers in the cache to be accessible
+    // Array associated with metadata_. Metadata values need to be
+    // accessible in write mode as well. We need to keep this read-mode
+    // array alive in order for the metadata value pointers in the cache to
+    // be accessible
     std::shared_ptr<Array> meta_cache_arr_;
 
     // True if this is the first call to read_next()
@@ -1139,7 +1199,8 @@ class SOMAArray : public SOMAObject {
     // Unoptimized method for computing nnz() (issue `count_cells` query)
     uint64_t nnz_slow();
 
-    // ArrayBuffers to hold ColumnBuffers alive when submitting to write query
+    // ArrayBuffers to hold ColumnBuffers alive when submitting to write
+    // query
     std::shared_ptr<ArrayBuffers> array_buffer_ = nullptr;
 };
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -950,6 +950,9 @@ class SOMAArray : public SOMAObject {
         }
     }
 
+    // Help function to cast Boolean of bits (Arrow) to uint8 (TileDB)
+    void _cast_bit_to_uint8(ArrowSchema* arrow_schema, ArrowArray* arrow_array);
+
     // Helper function for set_column_data
     std::shared_ptr<ColumnBuffer> _setup_column_data(std::string_view name);
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -833,8 +833,6 @@ class SOMAArray : public SOMAObject {
             disk_type = tiledb_schema()->domain().dimension(name).type();
         }
 
-        std::cout << " " << tiledb::impl::type_to_str(disk_type) << std::endl;
-
         switch (disk_type) {
             case TILEDB_STRING_ASCII:
             case TILEDB_STRING_UTF8:
@@ -951,6 +949,8 @@ class SOMAArray : public SOMAObject {
         for (auto val : original_values) {
             casted_values.push_back(val);
         }
+
+        new_column_array->buffers[0] = orig_column_array->buffers[0];
 
         if (orig_column_array->n_buffers == 3) {
             new_column_array->buffers[2] = malloc(

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -819,6 +819,12 @@ class SOMAArray : public SOMAObject {
         ArrowSchema* index_schema,
         ArrowArray* index_array);
 
+    void _create_and_cast_column(
+        ArrowSchema* orig_column_schema,
+        ArrowArray* orig_column_array,
+        ArrowSchema* new_column_schema,
+        ArrowArray* new_column_array);
+
     void _cast_column(
         ArrowSchema* orig_column_schema,
         ArrowArray* orig_column_array,

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -950,7 +950,7 @@ class SOMAArray : public SOMAObject {
         }
     }
 
-    // Help function to cast Boolean of bits (Arrow) to uint8 (TileDB)
+    // Helper function to cast Boolean of bits (Arrow) to uint8 (TileDB)
     void _cast_bit_to_uint8(ArrowSchema* arrow_schema, ArrowArray* arrow_array);
 
     // Helper function for set_column_data


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2709

**Changes:**

**Notes for Reviewer:**
Still failing Python one last unit test `test_write_categorical_types` where if the attribute in the ArraySchema is not an enumeration, but the column in the ArrowTable contains a dictionary encoding then it segfaults.
