### PR TITLE
[python] Bump the stack level of the `tiledb_ctx` deprecation warning

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -29,6 +29,7 @@ def _warn_ctx_deprecation() -> None:
         "Use tiledb_config instead by passing "
         "SOMATileDBContext(tiledb_config=ctx.config().dict()).",
         DeprecationWarning,
+        stacklevel=3,
     )
 
 


### PR DESCRIPTION
Currently warnings about the deprecated `tiledb_ctx` have a not-super useful traceback:

```pytb
  /home/ubuntu/miniforge3/envs/cellxgene-census-bump-tiledbsoma/lib/python3.11/site-packages/tiledbsoma/options/_soma_tiledb_context.py:27: DeprecationWarning: tiledb_ctx is now deprecated for removal in 1.14. Use tiledb_config instead by passing SOMATileDBContext(tiledb_config=ctx.config().dict()).
    warnings.warn(
```

This change makes it a little more useful by showing the relevant callsite:

```
tests/test_get_anndata.py: 81 warnings
  /home/ubuntu/miniforge3/envs/cellxgene-census-bump-tiledbsoma/lib/python3.11/site-packages/tiledbsoma/_tdb_handles.py:333: DeprecationWarning: tiledb_ctx is now deprecated for removal in 1.14. Use tiledb_config instead by passing SOMATileDBContext(tiledb_config=ctx.config().dict()).
    ctx = context.tiledb_ctx

tests/test_get_anndata.py: 81 warnings
  /home/ubuntu/miniforge3/envs/cellxgene-census-bump-tiledbsoma/lib/python3.11/site-packages/tiledbsoma/_tdb_handles.py:334: DeprecationWarning: tiledb_ctx is now deprecated for removal in 1.14. Use tiledb_config instead by passing SOMATileDBContext(tiledb_config=ctx.config().dict()).
    cfgdict = context.tiledb_ctx.config().dict()
```
