### PR TITLE
[c++] Improve exception-handling for query futures

### DIFF
--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build libTileDB-SOMA
       run: TILEDBSOMA_COVERAGE="--coverage" ./scripts/bld --no-tiledb-deprecated=true
     - name: Run libTileDB-SOMA unittests
-      run: ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failur
+      run: ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -47,6 +47,26 @@ namespace tiledbsoma {
 
 using namespace tiledb;
 
+// Probably we should just use a std::tuple here
+class StatusAndException {
+   public:
+    StatusAndException(bool succeeded, std::string message)
+        : succeeded_(succeeded)
+        , message_(message) {
+    }
+
+    bool succeeded() {
+        return succeeded_;
+    }
+    std::string message() {
+        return message_;
+    }
+
+   private:
+    bool succeeded_;
+    std::string message_;
+};
+
 class ManagedQuery {
    public:
     //===================================================================
@@ -411,7 +431,7 @@ class ManagedQuery {
     bool query_submitted_ = false;
 
     // Future for asyncronous query
-    std::future<void> query_future_;
+    std::future<StatusAndException> query_future_;
 };
 };  // namespace tiledbsoma
 


### PR DESCRIPTION
**Issue and/or context:** Split out from PR #2785 for issue #2407. This change is makes a unit-test case pass on that PR. For this PR, it's sufficient to observe that existing unit tests all still pass.