### PR TITLE
[python] Backport #2788 to `release-1.12`

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -29,6 +29,7 @@ def _warn_ctx_deprecation() -> None:
         "Use tiledb_config instead by passing "
         "SOMATileDBContext(tiledb_config=ctx.config().dict()).",
         DeprecationWarning,
+        stacklevel=3,
     )
 
 


### PR DESCRIPTION
Five fails on backport bot: https://github.com/single-cell-data/TileDB-SOMA/actions/runs/9881520734 -- I don't know why. Manually patching. Backports #2788 to the `release-1.12` branch.