### PR TITLE
[python] Add `CollectionBase.members`

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -531,6 +531,11 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         )
         return self
 
+    def members(self) -> Dict[str, Tuple[str, str]]:
+        """Get a mapping of {member_name: (uri, soma_object_type)}"""
+        handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
+        return handle.members()
+
     def __setitem__(self, key: str, value: CollectionElementType) -> None:
         """Default collection __setattr__"""
         self.set(key, value, use_relative_uri=None)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -23,6 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import attrs
@@ -283,6 +284,9 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
     @property
     def meta(self) -> "MetadataWrapper":
         return self.metadata
+
+    def members(self) -> Dict[str, Tuple[str, str]]:
+        return cast(Dict[str, Tuple[str, str]], self._handle.members())
 
 
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -143,6 +143,7 @@ def test_collection_mapping(soma_object, tmp_path):
     assert list(k for k in c) == list(c.keys())
     assert len(c) == 1
     assert [k for k in c] == ["mumble"]
+    assert c.members() == {"mumble": (soma_object.uri, "SOMACollection")}
 
     # TEMPORARY: This should no longer raise an error once TileDB supports
     # replacing an existing group member.


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2787

**Changes:**

The binding from Python to C++ `SOMAGroup::members_map` already exists. We are just exposing this at the API level so that the user can call `SOMA{Collection,Experiment,Measurement}.members()` to get a dictionary of member names to a tuple of (uri, type).

https://github.com/single-cell-data/TileDB-SOMA/blob/main/libtiledbsoma/src/soma/soma_group.cc#L142-L156
When creating or opening a `SOMAGroup` in C++, we call `fill_caches` which populates the member mapping by calling `tiledb::Object::member` rather than opening each object in the collection.