### PR TITLE
[python] Hold onto GIL for open methods

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -131,8 +131,7 @@ void load_soma_dataframe(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none(),
-            py::call_guard<py::gil_scoped_release>())
+            "timestamp"_a = py::none())
 
         .def_static(
             "exists",

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -120,8 +120,7 @@ void load_soma_dense_ndarray(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none(),
-            py::call_guard<py::gil_scoped_release>())
+            "timestamp"_a = py::none())
 
         .def_static(
             "exists",

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -108,8 +108,7 @@ void load_soma_sparse_ndarray(py::module& m) {
             py::kw_only(),
             "column_names"_a = py::none(),
             "result_order"_a = ResultOrder::automatic,
-            "timestamp"_a = py::none(),
-            py::call_guard<py::gil_scoped_release>())
+            "timestamp"_a = py::none())
 
         .def_static(
             "exists",


### PR DESCRIPTION
We have observed CI randomly segfaulting since the merger of https://github.com/single-cell-data/TileDB-SOMA/pull/2733. Consistent in all these stacktraces is `open`. This PR reverts the addition of `gil_scoped_release` from the `SOMAArray::open` bindings.