### PR TITLE
[python] Retain GIL for `exist`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -60,8 +60,7 @@ void load_soma_collection(py::module& m) {
             py::kw_only(),
             "mode"_a,
             "context"_a,
-            "timestamp"_a = py::none(),
-            py::call_guard<py::gil_scoped_release>())
+            "timestamp"_a = py::none())
         .def(
             "__iter__",
             [](SOMACollection& collection) {

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -133,10 +133,7 @@ void load_soma_dataframe(py::module& m) {
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 
-        .def_static(
-            "exists",
-            &SOMADataFrame::exists,
-            py::call_guard<py::gil_scoped_release>())
+        .def_static("exists", &SOMADataFrame::exists)
         .def_property_readonly(
             "index_column_names", &SOMADataFrame::index_column_names)
         .def_property_readonly(

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -122,10 +122,7 @@ void load_soma_dense_ndarray(py::module& m) {
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 
-        .def_static(
-            "exists",
-            &SOMADenseNDArray::exists,
-            py::call_guard<py::gil_scoped_release>())
+        .def_static("exists", &SOMADenseNDArray::exists)
 
         .def("write", write);
 }

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -98,8 +98,7 @@ void load_soma_object(py::module& m) {
             "context"_a,
             py::kw_only(),
             "timestamp"_a = py::none(),
-            "clib_type"_a = py::none(),
-            py::call_guard<py::gil_scoped_release>())
+            "clib_type"_a = py::none())
         .def_property_readonly("type", &SOMAObject::type);
 };
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -110,9 +110,6 @@ void load_soma_sparse_ndarray(py::module& m) {
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 
-        .def_static(
-            "exists",
-            &SOMASparseNDArray::exists,
-            py::call_guard<py::gil_scoped_release>());
+        .def_static("exists", &SOMASparseNDArray::exists);
 }
 }  // namespace libtiledbsomacpp


### PR DESCRIPTION
This continues to partially revert commit 72a4e203f878c53da098a684c49a72179b68265f in conjuction with https://github.com/single-cell-data/TileDB-SOMA/pull/2800. We are now only retaining releasing the GIL for `SOMADataFrame::count`.

Due to multiple reports of intermittent segfaults internally and externally, `SOMAArray::exists` should also be reverted until we have a better way to identify and test releasing the GIL in the pybind11 code. I tested this revert fixed my itermittent segfaults locally by running `make test` 6 times. Previously, I could get a segfault to occur with 3 `make test` runs.