### PR TITLE
[c++/python] Add `reopen` for `SOMAArray` and `SOMAGroup`

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -143,7 +143,18 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     def reopen(self, mode: options.OpenMode) -> Self:
         """
-        Return a new copy of the SOMAObject with the given mode.
+        Return a new copy of the SOMAObject with the given mode at the current
+        Unix timestamp.
+
+        Args:
+            mode:
+                The mode to open the object in.
+                - ``r``: Open for reading only (cannot write).
+                - ``w``: Open for writing only (cannot read).
+
+        Raises:
+            ValueError:
+                If the user-provided ``mode`` is invalid.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -141,6 +141,21 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         self._handle = handle
         self._close_stack.enter_context(self._handle)
 
+    def reopen(self, mode: Optional[options.OpenMode] = None) -> Self:
+        """
+        Use the passed-in mode if provided; otherwise, if the mode was originally opened in read mode, flip to opening in write mode, and vice-versa
+
+        Lifecycle:
+            Experimental.
+        """
+        handle = self._wrapper_type._from_soma_object(
+            self._handle.reopen(mode), self.context
+        )
+        return self.__class__(
+            handle,  # type: ignore[arg-type]
+            _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
+        )
+
     @property
     def context(self) -> SOMATileDBContext:
         return self._handle.context

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -141,9 +141,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         self._handle = handle
         self._close_stack.enter_context(self._handle)
 
-    def reopen(self, mode: Optional[options.OpenMode] = None) -> Self:
+    def reopen(self, mode: options.OpenMode) -> Self:
         """
-        Use the passed-in mode if provided; otherwise, if the mode was originally opened in read mode, flip to opening in write mode, and vice-versa
+        Return a new copy of the SOMAObject with the given mode.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -139,7 +139,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
     ) -> Self:
         uri = soma_object.uri
         mode = soma_object.mode
-        timestamp = soma_object.timestamp
+        timestamp = context._open_timestamp_ms(soma_object.timestamp)
         try:
             handle = cls(uri, mode, context, timestamp, soma_object)
             if handle.mode == "w":
@@ -167,6 +167,11 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def reopen(self, mode: options.OpenMode) -> clib.SOMAObject:
+        if mode not in ("r", "w"):
+            raise ValueError(
+                f"Invalid mode '{mode}' passed. " "Valid modes are 'r' and 'w'."
+            )
+
         return self._handle.reopen(
             clib.OpenMode.read if mode == "r" else clib.OpenMode.write
         )
@@ -327,6 +332,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         timestamp: int,
     ) -> clib.SOMAArray:
         open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+
         return cls._ARRAY_WRAPPED_TYPE.open(
             uri,
             mode=open_mode,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -166,6 +166,12 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
 
+    def reopen(self, mode: Optional[options.OpenMode] = None) -> clib.SOMAObject:
+        new_mode = mode or ("w" if self._handle.mode == "r" else "r")
+        return self._handle.reopen(
+            clib.OpenMode.read if new_mode == "r" else clib.OpenMode.write
+        )
+
     # Covariant types should normally not be in parameters, but this is for
     # internal use only so it's OK.
     def _do_initial_reads(self, reader: _RawHdl_co) -> None:  # type: ignore[misc]

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -166,10 +166,9 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
 
-    def reopen(self, mode: Optional[options.OpenMode] = None) -> clib.SOMAObject:
-        new_mode = mode or ("w" if self._handle.mode == "r" else "r")
+    def reopen(self, mode: options.OpenMode) -> clib.SOMAObject:
         return self._handle.reopen(
-            clib.OpenMode.read if new_mode == "r" else clib.OpenMode.write
+            clib.OpenMode.read if mode == "r" else clib.OpenMode.write
         )
 
     # Covariant types should normally not be in parameters, but this is for

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -80,6 +80,7 @@ class SOMATileDBContext(ContextBase):
     def __init__(
         self,
         tiledb_ctx: Optional[tiledb.Ctx] = None,
+        native_ctx: Optional[clib.SOMAContext] = None,
         tiledb_config: Optional[Dict[str, Union[str, float]]] = None,
         timestamp: Optional[OpenTimestamp] = None,
         threadpool: Optional[ThreadPoolExecutor] = None,
@@ -157,7 +158,7 @@ class SOMATileDBContext(ContextBase):
 
         self.threadpool = threadpool or ThreadPoolExecutor()
         """User specified threadpool. If None, we'll instantiate one ourselves."""
-        self._native_context: Optional[clib.SOMAContext] = None
+        self._native_context: Optional[clib.SOMAContext] = native_ctx
         """Lazily construct clib.SOMAContext."""
 
     @property

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -80,7 +80,6 @@ class SOMATileDBContext(ContextBase):
     def __init__(
         self,
         tiledb_ctx: Optional[tiledb.Ctx] = None,
-        native_ctx: Optional[clib.SOMAContext] = None,
         tiledb_config: Optional[Dict[str, Union[str, float]]] = None,
         timestamp: Optional[OpenTimestamp] = None,
         threadpool: Optional[ThreadPoolExecutor] = None,
@@ -158,7 +157,7 @@ class SOMATileDBContext(ContextBase):
 
         self.threadpool = threadpool or ThreadPoolExecutor()
         """User specified threadpool. If None, we'll instantiate one ourselves."""
-        self._native_context: Optional[clib.SOMAContext] = native_ctx
+        self._native_context: Optional[clib.SOMAContext] = None
         """Lazily construct clib.SOMAContext."""
 
     @property

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -83,7 +83,7 @@ void write_coords(
 }
 
 void load_soma_array(py::module& m) {
-    py::class_<SOMAArray>(m, "SOMAArray", "SOMAObject")
+    py::class_<SOMAArray, SOMAObject>(m, "SOMAArray")
         .def(
             py::init(
                 [](std::string_view uri,
@@ -191,11 +191,7 @@ void load_soma_array(py::module& m) {
             "batch_size"_a = "auto",
             "result_order"_a = ResultOrder::automatic)
 
-        .def(
-            "reopen",
-            py::overload_cast<
-                OpenMode,
-                std::optional<std::pair<uint64_t, uint64_t>>>(&SOMAArray::open))
+        .def("reopen", &SOMAArray::reopen)
         .def("close", &SOMAArray::close)
         .def_property_readonly(
             "closed",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -69,6 +69,7 @@ void load_soma_group(py::module& m) {
             [](SOMAGroup& group) {
                 return group.mode() == OpenMode::read ? "r" : "w";
             })
+        .def("reopen", &SOMAGroup::reopen)
         .def("close", &SOMAGroup::close)
         .def_property_readonly(
             "closed",

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -530,8 +530,8 @@ def test_collection_reopen(tmp_path):
     soma.Collection.create(tmp_path.as_uri())
 
     with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
-        with col1.reopen() as col2:
-            with col2.reopen() as col3:
+        with col1.reopen("w") as col2:
+            with col2.reopen("r") as col3:
                 assert col1.mode == "r"
                 assert col2.mode == "w"
                 assert col3.mode == "r"

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -530,6 +530,9 @@ def test_collection_reopen(tmp_path):
     soma.Collection.create(tmp_path.as_uri())
 
     with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
+        with raises_no_typeguard(ValueError):
+            col1.reopen("invalid")
+
         with col1.reopen("w") as col2:
             with col2.reopen("r") as col3:
                 assert col1.mode == "r"
@@ -545,3 +548,7 @@ def test_collection_reopen(tmp_path):
         with col1.reopen("w") as col2:
             assert col1.mode == "w"
             assert col2.mode == "w"
+
+    with soma.Collection.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as col1:
+        with col1.reopen("r") as col2:
+            assert col1.tiledb_timestamp < col2.tiledb_timestamp

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -538,16 +538,20 @@ def test_collection_reopen(tmp_path):
                 assert col1.mode == "r"
                 assert col2.mode == "w"
                 assert col3.mode == "r"
+                assert col1.tiledb_timestamp < col2.tiledb_timestamp
+                assert col2.tiledb_timestamp < col3.tiledb_timestamp
 
     with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
         with col1.reopen("r") as col2:
             assert col1.mode == "r"
             assert col2.mode == "r"
+            assert col1.tiledb_timestamp < col2.tiledb_timestamp
 
     with soma.Collection.open(tmp_path.as_posix(), "w") as col1:
         with col1.reopen("w") as col2:
             assert col1.mode == "w"
             assert col2.mode == "w"
+            assert col1.tiledb_timestamp < col2.tiledb_timestamp
 
     with soma.Collection.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as col1:
         with col1.reopen("r") as col2:

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -523,3 +523,25 @@ def test_context_timestamp(tmp_path: pathlib.Path):
         sub_1 = coll["sub_1"]
         assert sub_1.tiledb_timestamp_ms == 234
         assert sub_1["sub_sub"].tiledb_timestamp_ms == 234
+
+
+def test_collection_reopen(tmp_path):
+    # Ensure that reopen uses the correct mode
+    soma.Collection.create(tmp_path.as_uri())
+
+    with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
+        with col1.reopen() as col2:
+            with col2.reopen() as col3:
+                assert col1.mode == "r"
+                assert col2.mode == "w"
+                assert col3.mode == "r"
+
+    with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
+        with col1.reopen("r") as col2:
+            assert col1.mode == "r"
+            assert col2.mode == "r"
+
+    with soma.Collection.open(tmp_path.as_posix(), "w") as col1:
+        with col1.reopen("w") as col2:
+            assert col1.mode == "w"
+            assert col2.mode == "w"

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -148,9 +148,14 @@ def test_dataframe(tmp_path, arrow_schema):
 
 
 def test_dataframe_reopen(tmp_path, arrow_schema):
-    soma.DataFrame.create(tmp_path.as_posix(), schema=arrow_schema())
+    soma.DataFrame.create(
+        tmp_path.as_posix(), schema=arrow_schema(), tiledb_timestamp=1
+    )
 
     with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
+        with raises_no_typeguard(ValueError):
+            sdf1.reopen("invalid")
+
         with sdf1.reopen("w") as sdf2:
             with sdf2.reopen("r") as sdf3:
                 assert sdf1.mode == "r"
@@ -166,6 +171,10 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
         with sdf1.reopen("w") as sdf2:
             assert sdf1.mode == "w"
             assert sdf2.mode == "w"
+
+    with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
+        with sdf1.reopen("r") as sdf2:
+            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
 
 
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -155,22 +155,25 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
     with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
         with raises_no_typeguard(ValueError):
             sdf1.reopen("invalid")
-
         with sdf1.reopen("w") as sdf2:
             with sdf2.reopen("r") as sdf3:
                 assert sdf1.mode == "r"
                 assert sdf2.mode == "w"
                 assert sdf3.mode == "r"
+                assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
+                assert sdf2.tiledb_timestamp < sdf3.tiledb_timestamp
 
     with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
         with sdf1.reopen("r") as sdf2:
             assert sdf1.mode == "r"
             assert sdf2.mode == "r"
+            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
 
     with soma.DataFrame.open(tmp_path.as_posix(), "w") as sdf1:
         with sdf1.reopen("w") as sdf2:
             assert sdf1.mode == "w"
             assert sdf2.mode == "w"
+            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
 
     with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
         with sdf1.reopen("r") as sdf2:

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -151,8 +151,8 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
     soma.DataFrame.create(tmp_path.as_posix(), schema=arrow_schema())
 
     with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
-        with sdf1.reopen() as sdf2:
-            with sdf2.reopen() as sdf3:
+        with sdf1.reopen("w") as sdf2:
+            with sdf2.reopen("r") as sdf3:
                 assert sdf1.mode == "r"
                 assert sdf2.mode == "w"
                 assert sdf3.mode == "r"

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -147,6 +147,27 @@ def test_dataframe(tmp_path, arrow_schema):
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADataFrame)
 
 
+def test_dataframe_reopen(tmp_path, arrow_schema):
+    soma.DataFrame.create(tmp_path.as_posix(), schema=arrow_schema())
+
+    with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
+        with sdf1.reopen() as sdf2:
+            with sdf2.reopen() as sdf3:
+                assert sdf1.mode == "r"
+                assert sdf2.mode == "w"
+                assert sdf3.mode == "r"
+
+    with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
+        with sdf1.reopen("r") as sdf2:
+            assert sdf1.mode == "r"
+            assert sdf2.mode == "r"
+
+    with soma.DataFrame.open(tmp_path.as_posix(), "w") as sdf1:
+        with sdf1.reopen("w") as sdf2:
+            assert sdf1.mode == "w"
+            assert sdf2.mode == "w"
+
+
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame.create(
         tmp_path.as_posix(), schema=arrow_schema(), index_column_names=("bar",)

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -62,7 +62,9 @@ def test_dense_nd_array_create_ok(
 
 
 def test_dense_nd_array_reopen(tmp_path):
-    soma.DenseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
+    soma.DenseNDArray.create(
+        tmp_path.as_posix(), type=pa.float64(), shape=(1,), tiledb_timestamp=1
+    )
 
     # Ensure that reopen uses the correct mode
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
@@ -74,16 +76,20 @@ def test_dense_nd_array_reopen(tmp_path):
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"
+                assert A1.tiledb_timestamp < A2.tiledb_timestamp
+                assert A2.tiledb_timestamp < A3.tiledb_timestamp
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
         with A1.reopen("r") as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A1:
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
         with A1.reopen("r") as A2:

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -66,8 +66,8 @@ def test_dense_nd_array_reopen(tmp_path):
 
     # Ensure that reopen uses the correct mode
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
-        with A1.reopen() as A2:
-            with A2.reopen() as A3:
+        with A1.reopen("w") as A2:
+            with A2.reopen("r") as A3:
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -61,6 +61,28 @@ def test_dense_nd_array_create_ok(
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADenseNDArray)
 
 
+def test_dense_nd_array_reopen(tmp_path):
+    soma.DenseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
+
+    # Ensure that reopen uses the correct mode
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with A1.reopen() as A2:
+            with A2.reopen() as A3:
+                assert A1.mode == "r"
+                assert A2.mode == "w"
+                assert A3.mode == "r"
+
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with A1.reopen("r") as A2:
+            assert A1.mode == "r"
+            assert A2.mode == "r"
+
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A1:
+        with A1.reopen("w") as A2:
+            assert A1.mode == "w"
+            assert A2.mode == "w"
+
+
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
 def test_dense_nd_array_create_fail(

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -66,6 +66,9 @@ def test_dense_nd_array_reopen(tmp_path):
 
     # Ensure that reopen uses the correct mode
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with raises_no_typeguard(ValueError):
+            A1.reopen("invalid")
+
         with A1.reopen("w") as A2:
             with A2.reopen("r") as A3:
                 assert A1.mode == "r"
@@ -81,6 +84,10 @@ def test_dense_nd_array_reopen(tmp_path):
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"
+
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
+        with A1.reopen("r") as A2:
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -212,8 +212,8 @@ def test_experiment_reopen(tmp_path):
     soma.Experiment.create(tmp_path.as_uri())
 
     with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
-        with exp1.reopen() as exp2:
-            with exp2.reopen() as exp3:
+        with exp1.reopen("w") as exp2:
+            with exp2.reopen("r") as exp3:
                 assert exp1.mode == "r"
                 assert exp2.mode == "w"
                 assert exp3.mode == "r"

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -7,6 +7,8 @@ import pytest
 import tiledbsoma as soma
 from tiledbsoma import _factory
 
+from tests._util import raises_no_typeguard
+
 
 # ----------------------------------------------------------------
 def create_and_populate_obs(uri: str) -> soma.DataFrame:
@@ -212,6 +214,9 @@ def test_experiment_reopen(tmp_path):
     soma.Experiment.create(tmp_path.as_uri())
 
     with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
+        with raises_no_typeguard(ValueError):
+            exp1.reopen("invalid")
+
         with exp1.reopen("w") as exp2:
             with exp2.reopen("r") as exp3:
                 assert exp1.mode == "r"
@@ -227,3 +232,7 @@ def test_experiment_reopen(tmp_path):
         with exp1.reopen("w") as exp2:
             assert exp1.mode == "w"
             assert exp2.mode == "w"
+
+    with soma.Experiment.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as exp1:
+        with exp1.reopen("r") as exp2:
+            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -222,16 +222,20 @@ def test_experiment_reopen(tmp_path):
                 assert exp1.mode == "r"
                 assert exp2.mode == "w"
                 assert exp3.mode == "r"
+                assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
+                assert exp2.tiledb_timestamp < exp3.tiledb_timestamp
 
     with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
         with exp1.reopen("r") as exp2:
             assert exp1.mode == "r"
             assert exp2.mode == "r"
+            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
 
     with soma.Experiment.open(tmp_path.as_posix(), "w") as exp1:
         with exp1.reopen("w") as exp2:
             assert exp1.mode == "w"
             assert exp2.mode == "w"
+            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
 
     with soma.Experiment.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as exp1:
         with exp1.reopen("r") as exp2:

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -205,3 +205,25 @@ def test_experiment_ms_type_constraint(tmp_path):
             schema=pa.schema([("A", pa.int32())]),
             index_column_names=["A"],
         )
+
+
+def test_experiment_reopen(tmp_path):
+    # Ensure that reopen uses the correct mode
+    soma.Experiment.create(tmp_path.as_uri())
+
+    with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
+        with exp1.reopen() as exp2:
+            with exp2.reopen() as exp3:
+                assert exp1.mode == "r"
+                assert exp2.mode == "w"
+                assert exp3.mode == "r"
+
+    with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
+        with exp1.reopen("r") as exp2:
+            assert exp1.mode == "r"
+            assert exp2.mode == "r"
+
+    with soma.Experiment.open(tmp_path.as_posix(), "w") as exp1:
+        with exp1.reopen("w") as exp2:
+            assert exp1.mode == "w"
+            assert exp2.mode == "w"

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -83,6 +83,9 @@ def test_sparse_nd_array_reopen(tmp_path):
     soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with raises_no_typeguard(ValueError):
+            A1.reopen("invalid")
+
         with A1.reopen("w") as A2:
             with A2.reopen("r") as A3:
                 assert A1.mode == "r"
@@ -98,6 +101,10 @@ def test_sparse_nd_array_reopen(tmp_path):
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"
+
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
+        with A1.reopen("r") as A2:
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -79,6 +79,27 @@ def test_sparse_nd_array_create_ok(
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMASparseNDArray)
 
 
+def test_sparse_nd_array_reopen(tmp_path):
+    soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
+
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with A1.reopen() as A2:
+            with A2.reopen() as A3:
+                assert A1.mode == "r"
+                assert A2.mode == "w"
+                assert A3.mode == "r"
+
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
+        with A1.reopen("r") as A2:
+            assert A1.mode == "r"
+            assert A2.mode == "r"
+
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
+        with A1.reopen("w") as A2:
+            assert A1.mode == "w"
+            assert A2.mode == "w"
+
+
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
 def test_sparse_nd_array_create_fail(

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -80,7 +80,9 @@ def test_sparse_nd_array_create_ok(
 
 
 def test_sparse_nd_array_reopen(tmp_path):
-    soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
+    soma.SparseNDArray.create(
+        tmp_path.as_posix(), type=pa.float64(), shape=(1,), tiledb_timestamp=1
+    )
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
         with raises_no_typeguard(ValueError):
@@ -91,16 +93,20 @@ def test_sparse_nd_array_reopen(tmp_path):
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"
+                assert A1.tiledb_timestamp < A2.tiledb_timestamp
+                assert A2.tiledb_timestamp < A3.tiledb_timestamp
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
         with A1.reopen("r") as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"
+            assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
         with A1.reopen("r") as A2:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -83,8 +83,8 @@ def test_sparse_nd_array_reopen(tmp_path):
     soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,))
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
-        with A1.reopen() as A2:
-            with A2.reopen() as A3:
+        with A1.reopen("w") as A2:
+            with A2.reopen("r") as A3:
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -219,6 +219,18 @@ void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     fill_metadata_cache();
 }
 
+std::unique_ptr<SOMAArray> SOMAArray::reopen(OpenMode mode) {
+    return std::make_unique<SOMAArray>(
+        mode,
+        uri_,
+        ctx_,
+        name_,
+        column_names(),
+        batch_size_,
+        result_order_,
+        timestamp_);
+}
+
 void SOMAArray::close() {
     if (arr_->query_type() == TILEDB_WRITE)
         meta_cache_arr_->close();

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -221,14 +221,7 @@ void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
 
 std::unique_ptr<SOMAArray> SOMAArray::reopen(OpenMode mode) {
     return std::make_unique<SOMAArray>(
-        mode,
-        uri_,
-        ctx_,
-        name_,
-        column_names(),
-        batch_size_,
-        result_order_,
-        timestamp_);
+        mode, uri_, ctx_, name_, column_names(), batch_size_, result_order_);
 }
 
 void SOMAArray::close() {

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -223,6 +223,14 @@ class SOMAArray : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
+     * Return a new SOMAArray with the given mode.
+     *
+     * @param mode if the OpenMode is not given, If the SOMAObject was opened in
+     * READ mode, reopen it in WRITE mode and vice versa
+     */
+    std::unique_ptr<SOMAArray> reopen(OpenMode mode);
+
+    /**
      * Close the SOMAArray object.
      */
     void close();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -223,7 +223,7 @@ class SOMAArray : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * Return a new SOMAArray with the given mode.
+     * Return a new SOMAArray with the given mode at the current Unix timestamp.
      *
      * @param mode if the OpenMode is not given, If the SOMAObject was opened in
      * READ mode, reopen it in WRITE mode and vice versa

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -165,7 +165,7 @@ void SOMAGroup::open(
 }
 
 std::unique_ptr<SOMAGroup> SOMAGroup::reopen(OpenMode mode) {
-    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_, timestamp_);
+    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_);
 }
 
 void SOMAGroup::close() {

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -164,6 +164,10 @@ void SOMAGroup::open(
     fill_caches();
 }
 
+std::unique_ptr<SOMAGroup> SOMAGroup::reopen(OpenMode mode) {
+    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_, timestamp_);
+}
+
 void SOMAGroup::close() {
     if (group_->query_type() == TILEDB_WRITE)
         cache_group_->close();

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -126,6 +126,14 @@ class SOMAGroup : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
+     * Return a new SOMAGroup with the given mode.
+     *
+     * @param mode if the OpenMode is not given, If the SOMAObject was opened in
+     * READ mode, reopen it in WRITE mode and vice versa
+     */
+    std::unique_ptr<SOMAGroup> reopen(OpenMode mode);
+
+    /**
      * Close the SOMAGroup object.
      */
     void close();

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -126,7 +126,7 @@ class SOMAGroup : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * Return a new SOMAGroup with the given mode.
+     * Return a new SOMAGroup with the given mode at the current Unix timestamp.
      *
      * @param mode if the OpenMode is not given, If the SOMAObject was opened in
      * READ mode, reopen it in WRITE mode and vice versa


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/921

**Changes:**

- Addition of `SOMA{Array,Group}::reopen` in C++ and bindings in pybind11
- Addition of `SOMAObject.reopen` in Python
- Correct `SOMAArray` pybind11 inheritance 