### PR TITLE
[python] Replace `py::none` with `py::list` for `column_names` default arg

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -129,7 +129,7 @@ void load_soma_dataframe(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::none(),
+            "column_names"_a = py::list(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -129,7 +129,7 @@ void load_soma_dataframe(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::list(),
+            "column_names"_a = py::tuple(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -118,7 +118,7 @@ void load_soma_dense_ndarray(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::list(),
+            "column_names"_a = py::tuple(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -118,7 +118,7 @@ void load_soma_dense_ndarray(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::none(),
+            "column_names"_a = py::list(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -106,7 +106,7 @@ void load_soma_sparse_ndarray(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::list(),
+            "column_names"_a = py::tuple(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -106,7 +106,7 @@ void load_soma_sparse_ndarray(py::module& m) {
             "mode"_a,
             "context"_a,
             py::kw_only(),
-            "column_names"_a = py::none(),
+            "column_names"_a = py::list(),
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -111,6 +111,20 @@ def test_dataframe(tmp_path, arrow_schema):
         assert sorted([e.as_py() for e in list(table["baz"])]) == ["apple", "cat"]
         assert [e.as_py() for e in list(table["quux"])] == [True, False]
 
+    # Open and read with bindings
+    sdf = soma.pytiledbsoma.SOMADataFrame.open(
+        uri, soma.pytiledbsoma.OpenMode.read, soma.pytiledbsoma.SOMAContext()
+    )
+    table = sdf.read_next()
+    assert table.num_rows == 5
+    assert table.num_columns == 5
+    assert [e.as_py() for e in list(table["soma_joinid"])] == pydict["soma_joinid"]
+    assert [e.as_py() for e in list(table["foo"])] == pydict["foo"]
+    assert [e.as_py() for e in list(table["bar"])] == pydict["bar"]
+    assert [e.as_py() for e in list(table["baz"])] == pydict["baz"]
+    assert [e.as_py() for e in list(table["quux"])] == pydict["quux"]
+    sdf.close()
+
     # Validate TileDB array schema
     with tiledb.open(uri) as A:
         assert A.schema.sparse

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 from typing import Dict, List
 
@@ -95,35 +96,36 @@ def test_dataframe(tmp_path, arrow_schema):
         table = sdf.read().concat()
         assert table.num_rows == 5
         assert table.num_columns == 5
-        assert [e.as_py() for e in list(table["soma_joinid"])] == pydict["soma_joinid"]
-        assert [e.as_py() for e in list(table["foo"])] == pydict["foo"]
-        assert [e.as_py() for e in list(table["bar"])] == pydict["bar"]
-        assert [e.as_py() for e in list(table["baz"])] == pydict["baz"]
-        assert [e.as_py() for e in list(table["quux"])] == pydict["quux"]
+        assert [e.as_py() for e in table["soma_joinid"]] == pydict["soma_joinid"]
+        assert [e.as_py() for e in table["foo"]] == pydict["foo"]
+        assert [e.as_py() for e in table["bar"]] == pydict["bar"]
+        assert [e.as_py() for e in table["baz"]] == pydict["baz"]
+        assert [e.as_py() for e in table["quux"]] == pydict["quux"]
 
         # Read ids
         table = sdf.read(coords=[[30, 10]]).concat()
         assert table.num_rows == 2
         assert table.num_columns == 5
-        assert sorted([e.as_py() for e in list(table["soma_joinid"])]) == [0, 2]
-        assert sorted([e.as_py() for e in list(table["foo"])]) == [10, 30]
-        assert sorted([e.as_py() for e in list(table["bar"])]) == [4.1, 6.3]
-        assert sorted([e.as_py() for e in list(table["baz"])]) == ["apple", "cat"]
-        assert [e.as_py() for e in list(table["quux"])] == [True, False]
+        assert sorted([e.as_py() for e in table["soma_joinid"]]) == [0, 2]
+        assert sorted([e.as_py() for e in table["foo"]]) == [10, 30]
+        assert sorted([e.as_py() for e in table["bar"]]) == [4.1, 6.3]
+        assert sorted([e.as_py() for e in table["baz"]]) == ["apple", "cat"]
+        assert [e.as_py() for e in table["quux"]] == [True, False]
 
     # Open and read with bindings
-    sdf = soma.pytiledbsoma.SOMADataFrame.open(
-        uri, soma.pytiledbsoma.OpenMode.read, soma.pytiledbsoma.SOMAContext()
-    )
-    table = sdf.read_next()
-    assert table.num_rows == 5
-    assert table.num_columns == 5
-    assert [e.as_py() for e in list(table["soma_joinid"])] == pydict["soma_joinid"]
-    assert [e.as_py() for e in list(table["foo"])] == pydict["foo"]
-    assert [e.as_py() for e in list(table["bar"])] == pydict["bar"]
-    assert [e.as_py() for e in list(table["baz"])] == pydict["baz"]
-    assert [e.as_py() for e in list(table["quux"])] == pydict["quux"]
-    sdf.close()
+    with contextlib.closing(
+        soma.pytiledbsoma.SOMADataFrame.open(
+            uri, soma.pytiledbsoma.OpenMode.read, soma.pytiledbsoma.SOMAContext()
+        )
+    ) as sdf:
+        table = sdf.read_next()
+        assert table.num_rows == 5
+        assert table.num_columns == 5
+        assert [e.as_py() for e in table["soma_joinid"]] == pydict["soma_joinid"]
+        assert [e.as_py() for e in table["foo"]] == pydict["foo"]
+        assert [e.as_py() for e in table["bar"]] == pydict["bar"]
+        assert [e.as_py() for e in table["baz"]] == pydict["baz"]
+        assert [e.as_py() for e in table["quux"]] == pydict["quux"]
 
     # Validate TileDB array schema
     with tiledb.open(uri) as A:

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -90,6 +90,16 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
         t = b.read((slice(None),) * ndim, result_order="column-major")
         assert t.equals(pa.Tensor.from_numpy(data.transpose()))
 
+    # Open and read with bindings
+    a = soma.pytiledbsoma.SOMADenseNDArray.open(
+        tmp_path.as_posix(),
+        soma.pytiledbsoma.OpenMode.read,
+        soma.pytiledbsoma.SOMAContext(),
+    )
+    table = a.read_next()["soma_data"]
+    assert np.array_equal(data, table.combine_chunks().to_numpy().reshape(shape))
+    a.close()
+
     # Validate TileDB array schema
     with tiledb.open(tmp_path.as_posix()) as A:
         assert not A.schema.sparse

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,3 +1,4 @@
+import contextlib
 import pathlib
 from typing import Tuple
 
@@ -91,14 +92,15 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
         assert t.equals(pa.Tensor.from_numpy(data.transpose()))
 
     # Open and read with bindings
-    a = soma.pytiledbsoma.SOMADenseNDArray.open(
-        tmp_path.as_posix(),
-        soma.pytiledbsoma.OpenMode.read,
-        soma.pytiledbsoma.SOMAContext(),
-    )
-    table = a.read_next()["soma_data"]
-    assert np.array_equal(data, table.combine_chunks().to_numpy().reshape(shape))
-    a.close()
+    with contextlib.closing(
+        soma.pytiledbsoma.SOMADenseNDArray.open(
+            tmp_path.as_posix(),
+            soma.pytiledbsoma.OpenMode.read,
+            soma.pytiledbsoma.SOMAContext(),
+        )
+    ) as a:
+        table = a.read_next()["soma_data"]
+        assert np.array_equal(data, table.combine_chunks().to_numpy().reshape(shape))
 
     # Validate TileDB array schema
     with tiledb.open(tmp_path.as_posix()) as A:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import itertools
 import operator
 import pathlib
@@ -60,13 +61,14 @@ def test_sparse_nd_array_create_ok(
     assert not a.schema.field("soma_data").nullable
 
     # Check with open binding
-    b = soma.pytiledbsoma.SOMASparseNDArray.open(
-        tmp_path.as_posix(),
-        soma.pytiledbsoma.OpenMode.read,
-        soma.pytiledbsoma.SOMAContext(),
-    )
-    assert a.schema == b.schema
-    b.close()
+    with contextlib.closing(
+        soma.pytiledbsoma.SOMASparseNDArray.open(
+            tmp_path.as_posix(),
+            soma.pytiledbsoma.OpenMode.read,
+            soma.pytiledbsoma.SOMAContext(),
+        )
+    ) as b:
+        assert a.schema == b.schema
 
     # Ensure read mode uses clib object
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -59,6 +59,15 @@ def test_sparse_nd_array_create_ok(
     assert a.schema.field("soma_data").type == element_type
     assert not a.schema.field("soma_data").nullable
 
+    # Check with open binding
+    b = soma.pytiledbsoma.SOMASparseNDArray.open(
+        tmp_path.as_posix(),
+        soma.pytiledbsoma.OpenMode.read,
+        soma.pytiledbsoma.SOMAContext(),
+    )
+    assert a.schema == b.schema
+    b.close()
+
     # Ensure read mode uses clib object
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A:
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMASparseNDArray)


### PR DESCRIPTION
**Issue and/or context:**

As internally reported, the `open` bindings error out when `column_names` uses the default argument `py::none` because the C++ argument is a `std::vector<std::string>` and not `optional<...>`.

```
In [10]: clib.SOMAObject.open("tiledb://TileDB-Inc/4b53d109-27aa-4e17-b02a-d61710719b7b", mode=clib.OpenMode.read, context=native_context)
Out[10]: <tiledbsoma.pytiledbsoma.SOMADataFrame at 0x7bc8d4304eb0>

In [11]: clib.SOMADataFrame.open("tiledb://TileDB-Inc/4b53d109-27aa-4e17-b02a-d61710719b7b", mode=clib.OpenMode.read, context=native_context)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[11], line 1
----> 1 clib.SOMADataFrame.open("tiledb://TileDB-Inc/4b53d109-27aa-4e17-b02a-d61710719b7b", mode=clib.OpenMode.read, context=native_context)

TypeError: open(): incompatible function arguments. The following argument types are supported:
    1. (uri: str, mode: tiledbsoma.pytiledbsoma.OpenMode, context: tiledbsoma.pytiledbsoma.SOMAContext, *, column_names: list[str] = None, result_order: tiledbsoma.pytiledbsoma.ResultOrder = <ResultOrder.automatic: 0>, timestamp: Optional[tuple[int, int]] = None) -> tiledbsoma.pytiledbsoma.SOMADataFrame

Invoked with: 'tiledb://TileDB-Inc/4b53d109-27aa-4e17-b02a-d61710719b7b'; kwargs: mode=<OpenMode.read: 0>, context=<tiledbsoma.pytiledbsoma.SOMAContext object at 0x7bc8d431c4f0>
```

**Changes:**

- Use an empty tuple rather than `None`
- Add tests using bindings directly