### PR TITLE
[python] Allow platform config to set extent and filter

### DIFF
--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -383,10 +383,13 @@ def _build_column_config(col: Optional[Mapping[str, _ColumnConfig]]) -> str:
         return ""
 
     for k in col:
+        dikt: Dict[str, Union[_JSONFilterList, int]] = {}
         if col[k].filters is not None:
-            column_config[k] = {"filters": _build_filter_list(col[k].filters, False)}
+            dikt["filters"] = _build_filter_list(col[k].filters, False)
         if col[k].tile is not None:
-            column_config[k] = {"tile": cast(int, col[k].tile)}
+            dikt["tile"] = cast(int, col[k].tile)
+        if len(dikt) != 0:
+            column_config[k] = dikt
     return json.dumps(column_config)
 
 

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -41,7 +41,7 @@ def test_platform_config(conftest_pbmc_small):
                             "NoOpFilter",
                         ],
                         "dims": {
-                            "soma_dim_0": {"tile": 6},
+                            "soma_dim_0": {"tile": 6, "filters": ["RleFilter"]},
                             # Empty filters for soma_dim_1 overrides the default
                             # dimension zstd level defined below.
                             "soma_dim_1": {"filters": []},
@@ -70,7 +70,7 @@ def test_platform_config(conftest_pbmc_small):
             ]
             assert x_arr.attr("soma_data").filters == [tiledb.NoOpFilter()]
             assert x_arr.dim("soma_dim_0").tile == 6
-            assert x_arr.dim("soma_dim_0").filters == [tiledb.ZstdFilter(level=2)]
+            assert x_arr.dim("soma_dim_0").filters == [tiledb.RleFilter()]
             # As of 2.17.0 this is the default when empty filter-list, or none at all,
             # is requested. Those who want truly no filtering can request a no-op filter.
             assert list(x_arr.dim("soma_dim_1").filters) == [


### PR DESCRIPTION
Found while experimenting with write-performance tuning, including dogfooding of #2564.

It turns out if the platform-config create spec for a dim has tile extent _and_ a filter, the filter was begin ignored.

I fixed this, and improved the unit-test coverage to catch the fixed bug.