### PR TITLE
[c++] Add `NDArray::soma_data_type`

### DIFF
--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -110,6 +110,11 @@ bool SOMADenseNDArray::exists(
     }
 }
 
+std::string_view SOMADenseNDArray::soma_data_type() {
+    return ArrowAdapter::to_arrow_format(
+        tiledb_schema()->attribute("soma_data").type());
+}
+
 //===================================================================
 //= public non-static
 //===================================================================

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -158,6 +158,14 @@ class SOMADenseNDArray : public SOMAArray {
      * @return std::unique_ptr<ArrowSchema>
      */
     std::unique_ptr<ArrowSchema> schema() const;
+
+    /**
+     * @brief Get the soma_data's dtype in the form of an Arrow
+     * format string.
+     *
+     * @return std::string_view Arrow format string.
+     */
+    std::string_view soma_data_type();
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -111,6 +111,11 @@ bool SOMASparseNDArray::exists(
     }
 }
 
+std::string_view SOMASparseNDArray::soma_data_type() {
+    return ArrowAdapter::to_arrow_format(
+        tiledb_schema()->attribute("soma_data").type());
+}
+
 //===================================================================
 //= public non-static
 //===================================================================

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -157,6 +157,14 @@ class SOMASparseNDArray : public SOMAArray {
      * @return std::unique_ptr<ArrowSchema>
      */
     std::unique_ptr<ArrowSchema> schema() const;
+
+    /**
+     * @brief Get the soma_data's dtype in the form of an Arrow
+     * format string.
+     *
+     * @return std::string_view Arrow format string.
+     */
+    std::string_view soma_data_type();
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -57,6 +57,7 @@ TEST_CASE("SOMADenseNDArray: basic") {
     REQUIRE(soma_dense->ctx() == ctx);
     REQUIRE(soma_dense->type() == "SOMADenseNDArray");
     REQUIRE(soma_dense->is_sparse() == false);
+    REQUIRE(soma_dense->soma_data_type() == "l");
     auto schema = soma_dense->tiledb_schema();
     REQUIRE(schema->has_attribute("soma_data"));
     REQUIRE(schema->array_type() == TILEDB_DENSE);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -57,6 +57,7 @@ TEST_CASE("SOMASparseNDArray: basic") {
     REQUIRE(soma_sparse->ctx() == ctx);
     REQUIRE(soma_sparse->type() == "SOMASparseNDArray");
     REQUIRE(soma_sparse->is_sparse() == true);
+    REQUIRE(soma_sparse->soma_data_type() == "l");
     auto schema = soma_sparse->tiledb_schema();
     REQUIRE(schema->has_attribute("soma_data"));
     REQUIRE(schema->array_type() == TILEDB_SPARSE);


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2797

**Changes:**

As requested for the SOMA R API, add `soma_data_type` for `SOMADenseNDArray` and `SOMASparseNDArray`.