### PR TITLE
[python] Use original error message when re-raising with `DoesNotExistError`

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -634,7 +634,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             self._handle.writer.remove(key)
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
-                raise KeyError(f"{key!r} does not exist in {self}") from tdbe
+                raise KeyError(tdbe) from tdbe
             raise
         self._contents.pop(key, None)
         self._mutated_keys.add(key)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -130,7 +130,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
 
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
-                raise DoesNotExistError(f"{uri!r} does not exist") from tdbe
+                raise DoesNotExistError(tdbe) from tdbe
             raise
         return handle
 
@@ -151,7 +151,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
 
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
-                raise DoesNotExistError(f"{handle.uri!r} does not exist") from tdbe
+                raise DoesNotExistError(tdbe) from tdbe
             raise
         return handle
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2812

**Changes:**

Use original error message when re-raising with `DoesNotExistError`