### PR TITLE
[c++] Check index in enumeration casting before using

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1025,7 +1025,7 @@ class SOMAArray : public SOMAObject {
         std::vector<IndexType> shifted_indexes;
         for (auto i : original_indexes) {
             // For nullable columns, when the value is NULL, the associated
-            // index may be a negative integer, so do not index into 
+            // index may be a negative integer, so do not index into
             // enums_in_write or it will segfault
             if (0 > i) {
                 shifted_indexes.push_back(i);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1024,8 +1024,15 @@ class SOMAArray : public SOMAObject {
             idxbuf, idxbuf + index_array->length);
         std::vector<IndexType> shifted_indexes;
         for (auto i : original_indexes) {
-            auto it = std::find(beg, end, enums_in_write[i]);
-            shifted_indexes.push_back(it - beg);
+            // For nullable columns, when the value is NULL, the associated
+            // index may be a negative integer, so do not index into 
+            // enums_in_write or it will segfault
+            if (0 > i) {
+                shifted_indexes.push_back(i);
+            } else {
+                auto it = std::find(beg, end, enums_in_write[i]);
+                shifted_indexes.push_back(it - beg);
+            }
         }
 
         auto attr = tiledb_schema()->attribute(column_name);


### PR DESCRIPTION
**Issue and/or context:**

As reported by @ryan-williams, `pytest test_dataframe.py::test_dataframe_with_enumeration` was segfaulting on an Amazon Linux 2 EC2 instance (although not reproducible on other platforms).

**Changes:**

For nullable dictionary columns, when the value is null, the corresponding index may be a negative integer (depending on whether the index type is a signed or unsigned integer type). Using a negative integer to index into the vector `enums_in_write` causes a segfault so check the index value first.

There are no added tests as `test_dataframe.py::test_dataframe_with_enumeration` no longer segfaulting on the EC2 instance proves that it is fixed.