### PR TITLE
[r] Remove default mode-flipping in `$reopen()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.12.99.0
+Version: 1.12.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changes
+
+* Change `$reopen(mode = )` default to not flip modes; require explicit `mode` parameter to be passed
+
 # tiledbsoma 1.11.4
 
 ## Changes

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -82,15 +82,11 @@ TileDBObject <- R6::R6Class(
     #'  \item \dQuote{\code{READ}}
     #'  \item \dQuote{\code{WRITE}}
     #' }
-    #' By default, reopens in the opposite mode of the current mode
     #'
-    #' @return Invisibly returns \code{self}
+    #' @return Invisibly returns \code{self} opened in \code{mode}
     #'
-    reopen = function(mode = NULL) {
-      modes <- c(READ = 'WRITE', WRITE = 'READ')
-      oldmode <- self$mode()
-      mode <- mode %||% modes[oldmode]
-      mode <- match.arg(mode, choices = modes)
+    reopen = function(mode) {
+      mode <- match.arg(mode, choices = c('READ', 'WRITE'))
       self$close()
       private$tiledb_timestamp <- NULL
       self$open(mode, internal_use_only = 'allowed_use')

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -106,7 +106,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -116,13 +116,12 @@ Close and reopen the TileDB object in a new mode
 \itemize{
 \item \dQuote{\code{READ}}
 \item \dQuote{\code{WRITE}}
-}
-By default, reopens in the opposite mode of the current mode}
+}}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Invisibly returns \code{self}
+Invisibly returns \code{self} opened in \code{mode}
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/tests/testthat/test-reopen.R
+++ b/apis/r/tests/testthat/test-reopen.R
@@ -36,21 +36,21 @@ test_that("`reopen()` works on arrays", {
     lab <- sprintf("%s$reopen()", cls)
     is_open <- sprintf("%s$reopen() returns an object object", cls)
 
-    # Test implicit WRITE -> READ
-    expect_invisible(arr$reopen(), label = lab)
+    # Test reopen("READ")
+    expect_invisible(arr$reopen("READ"), label = lab)
     expect_identical(
       arr$mode(),
       "READ",
-      info = sprintf("%s$reopen() when mode is 'WRITE' reopens as 'READ'", cls)
+      info = sprintf("%s$reopen('READ') reopens as 'READ'", cls)
     )
     expect_true(arr$is_open(), info = is_open)
 
-    # Test implicit READ -> WRITE
-    expect_invisible(arr$reopen(), label = lab)
+    # Test reopen("WRITE")
+    expect_invisible(arr$reopen("WRITE"), label = lab)
     expect_identical(
       arr$mode(),
       "WRITE",
-      info = sprintf("%s$reopen() when mode is 'READ' reopens as 'WRITE'", cls)
+      info = sprintf("%s$reopen('WRITE') reopens as 'WRITE'", cls)
     )
     expect_true(arr$is_open(), info = is_open)
 
@@ -87,9 +87,21 @@ test_that("`reopen()` works on arrays", {
     }
 
     arr$close()
-    expect_error(arr$reopen())
 
     # Test assertions
+    expect_error(arr$reopen())
+    for (mode in c("READ", "WRITE")) {
+      arr$reopen(mode)
+      expect_error(
+        arr$reopen(),
+        label = sprintf(
+          "'%s$reopen()' with no arguments fails when array mode is %s",
+          cls,
+          mode
+        )
+      )
+    }
+    expect_error(arr$reopen("CLOSED"))
     expect_error(arr$reopen("tomato"))
     expect_error(arr$reopen(TRUE))
     expect_error(arr$reopen(1L))
@@ -106,13 +118,13 @@ test_that("`reopen()` works on collections", {
   expect_identical(col$mode(), "WRITE")
   expect_true(col$is_open())
 
-  # Test implicit WRITE -> READ
-  expect_invisible(col$reopen())
+  # Test reopen("READ")
+  expect_invisible(col$reopen("READ"))
   expect_identical(col$mode(), "READ")
   expect_true(col$is_open())
 
-  # Test implicit READ -> WRITE
-  expect_invisible(col$reopen())
+  # Test reopen("WRITE")
+  expect_invisible(col$reopen("WRITE"))
   expect_identical(col$mode(), "WRITE")
   expect_true(col$is_open())
 
@@ -175,8 +187,8 @@ test_that("`reopen()` works on nested collections", {
     )
   }
 
-  # Test implicit WRITE -> READ
-  expect_invisible(col$reopen())
+  # Test reopen("READ")
+  expect_invisible(col$reopen("READ"))
   expect_identical(col$mode(), "READ")
   expect_true(col$is_open())
 
@@ -192,8 +204,8 @@ test_that("`reopen()` works on nested collections", {
     )
   }
 
-  # Test implicit READ -> WRITE
-  expect_invisible(col$reopen())
+  # Test reopen("WRITE")
+  expect_invisible(col$reopen("WRITE"))
   expect_identical(col$mode(), "WRITE")
   expect_true(col$is_open())
 
@@ -285,8 +297,8 @@ test_that("`reopen()` works on SOMAMeasurements", {
     name = "RNA"
   )
 
-  # Test implicit WRITE -> READ
-  expect_invisible(ms$reopen())
+  # Test reopen("READ")
+  expect_invisible(ms$reopen("READ"))
   expect_identical(ms$mode(), "READ")
   expect_true(ms$is_open())
 
@@ -296,8 +308,8 @@ test_that("`reopen()` works on SOMAMeasurements", {
   expect_identical(ms$X$mode(), "READ")
   expect_true(ms$X$is_open())
 
-  # Test implicit READ -> WRITE
-  expect_invisible(ms$reopen())
+  # Test reopen("WRITE")
+  expect_invisible(ms$reopen("WRITE"))
   expect_identical(ms$mode(), "WRITE")
   expect_true(ms$is_open())
 
@@ -360,8 +372,8 @@ test_that("`reopen()` works on SOMAExperiments", {
   expect_identical(exp$mode(), "WRITE")
   expect_true(exp$is_open())
 
-  # Test implicit WRITE -> READ
-  expect_invisible(exp$reopen())
+  # Test reopen("READ")
+  expect_invisible(exp$reopen("READ"))
   expect_identical(exp$mode(), "READ")
   expect_true(exp$is_open())
 
@@ -371,8 +383,8 @@ test_that("`reopen()` works on SOMAExperiments", {
   expect_identical(exp$ms$mode(), "READ")
   expect_true(exp$ms$is_open())
 
-  # Test implicit READ -> WRITE
-  expect_invisible(exp$reopen())
+  # Test reopen("WRITE")
+  expect_invisible(exp$reopen("WRITE"))
   expect_identical(exp$mode(), "WRITE")
   expect_true(exp$is_open())
 


### PR DESCRIPTION
As discussed on Slack, `$reopen()` should not default to switching open mode; instead `mode` should always be passed in by the user

Modified SOMA methods:
 - `TileDBObject$reopen()`: `mode` no longer has a default; instead, the user must supply a mode to reopen the object as

[SC-51935](https://app.shortcut.com/tiledb-inc/story/51935)