### PR TITLE
[r] Add missing documentation for set_data_type

### DIFF
--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -66,7 +66,9 @@ SOMANDArrayBase <- R6::R6Class(
       self
     },
 
-    ## needed eg after open() to set (Arrow) tyoe
+    ## needed eg after open() to set (Arrow) type
+    #' @description Sets a cache value for the datatype (lifecycle: experimental)
+    #' @param type A character value describing the TileDB data type
     set_data_type = function(type) {
       spdl::debug("[SOMANDArrayBase::set_data_type] caching type {}", type$ToString())
       private$.type <- type

--- a/apis/r/man/SOMANDArrayBase.Rd
+++ b/apis/r/man/SOMANDArrayBase.Rd
@@ -87,10 +87,18 @@ directly.}
 \if{html}{\out{<a id="method-SOMANDArrayBase-set_data_type"></a>}}
 \if{latex}{\out{\hypertarget{method-SOMANDArrayBase-set_data_type}{}}}
 \subsection{Method \code{set_data_type()}}{
+Sets a cache value for the datatype (lifecycle: experimental)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMANDArrayBase$set_data_type(type)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{type}}{A character value describing the TileDB data type}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMANDArrayBase-clone"></a>}}


### PR DESCRIPTION
**Issue and/or context:**

The `roxygenize()` helper function would no longer run unless the R6 class method `set_data_type()` was also documented.

**Changes:**

This PR adds a simple short documentation entry.

**Notes for Reviewer:**

[SC 51948](https://app.shortcut.com/tiledb-inc/story/51948/r-complete-rd-content)