### PR TITLE
[c++/python] Add `tiledb_timestamp` argument for `reopen`

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -165,9 +165,8 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Lifecycle:
             Experimental.
         """
-        timestamp = self.context._open_timestamp_ms(tiledb_timestamp)
         handle = self._wrapper_type._from_soma_object(
-            self._handle.reopen(mode, timestamp), self.context
+            self._handle.reopen(mode, tiledb_timestamp), self.context
         )
         return self.__class__(
             handle,  # type: ignore[arg-type]

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -141,7 +141,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         self._handle = handle
         self._close_stack.enter_context(self._handle)
 
-    def reopen(self, mode: options.OpenMode) -> Self:
+    def reopen(
+        self, mode: options.OpenMode, tiledb_timestamp: Optional[OpenTimestamp] = None
+    ) -> Self:
         """
         Return a new copy of the SOMAObject with the given mode at the current
         Unix timestamp.
@@ -151,6 +153,10 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 The mode to open the object in.
                 - ``r``: Open for reading only (cannot write).
                 - ``w``: Open for writing only (cannot read).
+            tiledb_timestamp:
+                The TileDB timestamp to open this object at,
+                measured in milliseconds since the Unix epoch.
+                When unset (the default), the current time is used.
 
         Raises:
             ValueError:
@@ -159,8 +165,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Lifecycle:
             Experimental.
         """
+        timestamp = self.context._open_timestamp_ms(tiledb_timestamp)
         handle = self._wrapper_type._from_soma_object(
-            self._handle.reopen(mode), self.context
+            self._handle.reopen(mode, timestamp), self.context
         )
         return self.__class__(
             handle,  # type: ignore[arg-type]

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -73,8 +73,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 - ``w``: Open for writing only (cannot read).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at,
-                measured in milliseconds since the Unix epoch.
-                When unset (the default), the current time is used.
+                either an int representing milliseconds since the Unix epoch
+                or a datetime.dateime object.
+                When not provided (the default), the current time is used.
 
         Returns:
             The opened SOMA object.
@@ -155,7 +156,8 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 - ``w``: Open for writing only (cannot read).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at,
-                measured in milliseconds since the Unix epoch.
+                either an int representing milliseconds since the Unix epoch
+                or a datetime.dateime object.
                 When unset (the default), the current time is used.
 
         Raises:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -166,14 +166,14 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
 
-    def reopen(self, mode: options.OpenMode) -> clib.SOMAObject:
+    def reopen(self, mode: options.OpenMode, timestamp: int) -> clib.SOMAObject:
         if mode not in ("r", "w"):
             raise ValueError(
                 f"Invalid mode '{mode}' passed. " "Valid modes are 'r' and 'w'."
             )
 
         return self._handle.reopen(
-            clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+            clib.OpenMode.read if mode == "r" else clib.OpenMode.write, (0, timestamp)
         )
 
     # Covariant types should normally not be in parameters, but this is for

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -166,14 +166,16 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
 
-    def reopen(self, mode: options.OpenMode, timestamp: int) -> clib.SOMAObject:
+    def reopen(
+        self, mode: options.OpenMode, timestamp: Optional[OpenTimestamp]
+    ) -> clib.SOMAObject:
         if mode not in ("r", "w"):
             raise ValueError(
                 f"Invalid mode '{mode}' passed. " "Valid modes are 'r' and 'w'."
             )
-
+        ts = self.context._open_timestamp_ms(timestamp)
         return self._handle.reopen(
-            clib.OpenMode.read if mode == "r" else clib.OpenMode.write, (0, timestamp)
+            clib.OpenMode.read if mode == "r" else clib.OpenMode.write, (0, ts)
         )
 
     # Covariant types should normally not be in parameters, but this is for

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import pathlib
 import textwrap
@@ -9,7 +10,6 @@ import pyarrow as pa
 import pytest
 from typeguard import suppress_type_checks
 from typing_extensions import Literal
-import datetime
 
 import tiledbsoma as soma
 from tiledbsoma import _collection, _factory, _soma_object

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -539,9 +539,9 @@ def test_collection_reopen(tmp_path):
                 assert col1.mode == "r"
                 assert col2.mode == "w"
                 assert col3.mode == "r"
-                assert col1.tiledb_timestamp.timestamp() == 0.001
-                assert col2.tiledb_timestamp.timestamp() == 0.002
-                assert col3.tiledb_timestamp.timestamp() == 0.003
+                assert col1.tiledb_timestamp_ms == 1
+                assert col2.tiledb_timestamp_ms == 2
+                assert col3.tiledb_timestamp_ms == 3
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import textwrap
+import time
 from typing import List, TypeVar, Union
 
 import numpy as np
@@ -527,13 +528,16 @@ def test_context_timestamp(tmp_path: pathlib.Path):
 
 def test_collection_reopen(tmp_path):
     # Ensure that reopen uses the correct mode
-    soma.Collection.create(tmp_path.as_uri())
+    soma.Collection.create(tmp_path.as_uri(), tiledb_timestamp=1)
 
-    with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
+    with soma.Collection.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as col1:
         with raises_no_typeguard(ValueError):
             col1.reopen("invalid")
 
         with col1.reopen("w") as col2:
+            # TODO when reopen support setting tiledb_timestamp, replace sleep
+            # with timestamp
+            time.sleep(0.001)
             with col2.reopen("r") as col3:
                 assert col1.mode == "r"
                 assert col2.mode == "w"
@@ -541,13 +545,13 @@ def test_collection_reopen(tmp_path):
                 assert col1.tiledb_timestamp < col2.tiledb_timestamp
                 assert col2.tiledb_timestamp < col3.tiledb_timestamp
 
-    with soma.Collection.open(tmp_path.as_posix(), "r") as col1:
+    with soma.Collection.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as col1:
         with col1.reopen("r") as col2:
             assert col1.mode == "r"
             assert col2.mode == "r"
             assert col1.tiledb_timestamp < col2.tiledb_timestamp
 
-    with soma.Collection.open(tmp_path.as_posix(), "w") as col1:
+    with soma.Collection.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as col1:
         with col1.reopen("w") as col2:
             assert col1.mode == "w"
             assert col2.mode == "w"

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import time
 from typing import Dict, List
 
 import numpy as np
@@ -152,10 +153,14 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
         tmp_path.as_posix(), schema=arrow_schema(), tiledb_timestamp=1
     )
 
-    with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
+    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as sdf1:
         with raises_no_typeguard(ValueError):
             sdf1.reopen("invalid")
+
         with sdf1.reopen("w") as sdf2:
+            # TODO when reopen support setting tiledb_timestamp, replace sleep
+            # with timestamp
+            time.sleep(0.001)
             with sdf2.reopen("r") as sdf3:
                 assert sdf1.mode == "r"
                 assert sdf2.mode == "w"
@@ -163,13 +168,13 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
                 assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
                 assert sdf2.tiledb_timestamp < sdf3.tiledb_timestamp
 
-    with soma.DataFrame.open(tmp_path.as_posix(), "r") as sdf1:
+    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as sdf1:
         with sdf1.reopen("r") as sdf2:
             assert sdf1.mode == "r"
             assert sdf2.mode == "r"
             assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
 
-    with soma.DataFrame.open(tmp_path.as_posix(), "w") as sdf1:
+    with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
         with sdf1.reopen("w") as sdf2:
             assert sdf1.mode == "w"
             assert sdf2.mode == "w"

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,6 +1,5 @@
 import contextlib
 import datetime
-import time
 from typing import Dict, List
 
 import numpy as np
@@ -157,32 +156,33 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
         with raises_no_typeguard(ValueError):
             sdf1.reopen("invalid")
 
-        with sdf1.reopen("w") as sdf2:
-            # TODO when reopen support setting tiledb_timestamp, replace sleep
-            # with timestamp
-            time.sleep(0.001)
-            with sdf2.reopen("r") as sdf3:
+        with sdf1.reopen("w", tiledb_timestamp=2) as sdf2:
+            with sdf2.reopen("r", tiledb_timestamp=3) as sdf3:
                 assert sdf1.mode == "r"
                 assert sdf2.mode == "w"
                 assert sdf3.mode == "r"
-                assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
-                assert sdf2.tiledb_timestamp < sdf3.tiledb_timestamp
+                assert sdf1.tiledb_timestamp.timestamp() == 0.001
+                assert sdf2.tiledb_timestamp.timestamp() == 0.002
+                assert sdf3.tiledb_timestamp.timestamp() == 0.003
 
     with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("r") as sdf2:
+        with sdf1.reopen("r", tiledb_timestamp=2) as sdf2:
             assert sdf1.mode == "r"
             assert sdf2.mode == "r"
-            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
+            assert sdf1.tiledb_timestamp.timestamp() == 0.001
+            assert sdf2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("w") as sdf2:
+        with sdf1.reopen("w", tiledb_timestamp=2) as sdf2:
             assert sdf1.mode == "w"
             assert sdf2.mode == "w"
-            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
+            assert sdf1.tiledb_timestamp.timestamp() == 0.001
+            assert sdf2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("r") as sdf2:
-            assert sdf1.tiledb_timestamp < sdf2.tiledb_timestamp
+        with sdf1.reopen("r", tiledb_timestamp=2) as sdf2:
+            assert sdf1.tiledb_timestamp.timestamp() == 0.001
+            assert sdf2.tiledb_timestamp.timestamp() == 0.002
 
 
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -161,9 +161,9 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
                 assert sdf1.mode == "r"
                 assert sdf2.mode == "w"
                 assert sdf3.mode == "r"
-                assert sdf1.tiledb_timestamp.timestamp() == 0.001
-                assert sdf2.tiledb_timestamp.timestamp() == 0.002
-                assert sdf3.tiledb_timestamp.timestamp() == 0.003
+                assert sdf1.tiledb_timestamp_ms == 1
+                assert sdf2.tiledb_timestamp_ms == 2
+                assert sdf3.tiledb_timestamp_ms == 3
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -165,24 +165,25 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
                 assert sdf2.tiledb_timestamp.timestamp() == 0.002
                 assert sdf3.tiledb_timestamp.timestamp() == 0.003
 
-    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("r", tiledb_timestamp=2) as sdf2:
+    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as sdf1:
+        with sdf1.reopen("r", tiledb_timestamp=ts2) as sdf2:
             assert sdf1.mode == "r"
             assert sdf2.mode == "r"
-            assert sdf1.tiledb_timestamp.timestamp() == 0.001
-            assert sdf2.tiledb_timestamp.timestamp() == 0.002
+            assert sdf1.tiledb_timestamp == ts1
+            assert sdf2.tiledb_timestamp == ts2
 
-    with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("w", tiledb_timestamp=2) as sdf2:
-            assert sdf1.mode == "w"
-            assert sdf2.mode == "w"
-            assert sdf1.tiledb_timestamp.timestamp() == 0.001
-            assert sdf2.tiledb_timestamp.timestamp() == 0.002
-
-    with soma.DataFrame.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as sdf1:
-        with sdf1.reopen("r", tiledb_timestamp=2) as sdf2:
-            assert sdf1.tiledb_timestamp.timestamp() == 0.001
-            assert sdf2.tiledb_timestamp.timestamp() == 0.002
+    with soma.DataFrame.open(tmp_path.as_posix(), "w") as sdf1:
+        with sdf1.reopen("w", tiledb_timestamp=None) as sdf2:
+            with sdf1.reopen("w") as sdf3:
+                assert sdf1.mode == "w"
+                assert sdf2.mode == "w"
+                assert sdf3.mode == "w"
+                now = datetime.datetime.now(datetime.timezone.utc)
+                assert sdf1.tiledb_timestamp <= now
+                assert sdf2.tiledb_timestamp <= now
+                assert sdf3.tiledb_timestamp <= now
 
 
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import pathlib
 from typing import Tuple
 
@@ -80,12 +81,14 @@ def test_dense_nd_array_reopen(tmp_path):
                 assert A2.tiledb_timestamp.timestamp() == 0.002
                 assert A3.tiledb_timestamp.timestamp() == 0.003
 
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
-        with A1.reopen("r", tiledb_timestamp=2) as A2:
+    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as A1:
+        with A1.reopen("r", tiledb_timestamp=ts2) as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
+            assert A1.tiledb_timestamp == ts1
+            assert A2.tiledb_timestamp == ts2
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
         with A1.reopen("w", tiledb_timestamp=2) as A2:
@@ -94,10 +97,16 @@ def test_dense_nd_array_reopen(tmp_path):
             assert A1.tiledb_timestamp.timestamp() == 0.001
             assert A2.tiledb_timestamp.timestamp() == 0.002
 
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("r", tiledb_timestamp=2) as A2:
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A1:
+        with A1.reopen("w", tiledb_timestamp=None) as A2:
+            with A2.reopen("w") as A3:
+                assert A1.mode == "w"
+                assert A2.mode == "w"
+                assert A3.mode == "w"
+                now = datetime.datetime.now(datetime.timezone.utc)
+                assert A1.tiledb_timestamp <= now
+                assert A2.tiledb_timestamp <= now
+                assert A3.tiledb_timestamp <= now
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,6 +1,5 @@
 import contextlib
 import pathlib
-import time
 from typing import Tuple
 
 import numpy as np
@@ -72,32 +71,33 @@ def test_dense_nd_array_reopen(tmp_path):
         with raises_no_typeguard(ValueError):
             A1.reopen("invalid")
 
-        with A1.reopen("w") as A2:
-            # TODO when reopen support setting tiledb_timestamp, replace sleep
-            # with timestamp
-            time.sleep(0.001)
-            with A2.reopen("r") as A3:
+        with A1.reopen("w", tiledb_timestamp=2) as A2:
+            with A2.reopen("r", tiledb_timestamp=3) as A3:
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"
-                assert A1.tiledb_timestamp < A2.tiledb_timestamp
-                assert A2.tiledb_timestamp < A3.tiledb_timestamp
+                assert A1.tiledb_timestamp.timestamp() == 0.001
+                assert A2.tiledb_timestamp.timestamp() == 0.002
+                assert A3.tiledb_timestamp.timestamp() == 0.003
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
-        with A1.reopen("r") as A2:
+        with A1.reopen("r", tiledb_timestamp=2) as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
-            assert A1.tiledb_timestamp < A2.tiledb_timestamp
+            assert A1.tiledb_timestamp.timestamp() == 0.001
+            assert A2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("w") as A2:
+        with A1.reopen("w", tiledb_timestamp=2) as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"
-            assert A1.tiledb_timestamp < A2.tiledb_timestamp
+            assert A1.tiledb_timestamp.timestamp() == 0.001
+            assert A2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("r") as A2:
-            assert A1.tiledb_timestamp < A2.tiledb_timestamp
+        with A1.reopen("r", tiledb_timestamp=2) as A2:
+            assert A1.tiledb_timestamp.timestamp() == 0.001
+            assert A2.tiledb_timestamp.timestamp() == 0.002
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -77,9 +77,9 @@ def test_dense_nd_array_reopen(tmp_path):
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"
-                assert A1.tiledb_timestamp.timestamp() == 0.001
-                assert A2.tiledb_timestamp.timestamp() == 0.002
-                assert A3.tiledb_timestamp.timestamp() == 0.003
+                assert A1.tiledb_timestamp_ms == 1
+                assert A2.tiledb_timestamp_ms == 2
+                assert A3.tiledb_timestamp_ms == 3
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,5 +1,6 @@
 import contextlib
 import pathlib
+import time
 from typing import Tuple
 
 import numpy as np
@@ -67,11 +68,14 @@ def test_dense_nd_array_reopen(tmp_path):
     )
 
     # Ensure that reopen uses the correct mode
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
         with raises_no_typeguard(ValueError):
             A1.reopen("invalid")
 
         with A1.reopen("w") as A2:
+            # TODO when reopen support setting tiledb_timestamp, replace sleep
+            # with timestamp
+            time.sleep(0.001)
             with A2.reopen("r") as A3:
                 assert A1.mode == "r"
                 assert A2.mode == "w"
@@ -79,13 +83,13 @@ def test_dense_nd_array_reopen(tmp_path):
                 assert A1.tiledb_timestamp < A2.tiledb_timestamp
                 assert A2.tiledb_timestamp < A3.tiledb_timestamp
 
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A1:
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
         with A1.reopen("r") as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
             assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A1:
+    with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,9 +1,9 @@
+import datetime
 from urllib.parse import urljoin
 
 import numpy as np
 import pyarrow as pa
 import pytest
-import datetime
 
 import tiledbsoma as soma
 from tiledbsoma import _factory

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,4 +1,3 @@
-import time
 from urllib.parse import urljoin
 
 import numpy as np
@@ -218,29 +217,30 @@ def test_experiment_reopen(tmp_path):
         with raises_no_typeguard(ValueError):
             exp1.reopen("invalid")
 
-        with exp1.reopen("w") as exp2:
-            # TODO when reopen support setting tiledb_timestamp, replace sleep
-            # with timestamp
-            time.sleep(0.001)
-            with exp2.reopen("r") as exp3:
+        with exp1.reopen("w", tiledb_timestamp=2) as exp2:
+            with exp2.reopen("r", tiledb_timestamp=3) as exp3:
                 assert exp1.mode == "r"
                 assert exp2.mode == "w"
                 assert exp3.mode == "r"
-                assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
-                assert exp2.tiledb_timestamp < exp3.tiledb_timestamp
+                assert exp1.tiledb_timestamp.timestamp() == 0.001
+                assert exp2.tiledb_timestamp.timestamp() == 0.002
+                assert exp3.tiledb_timestamp.timestamp() == 0.003
 
     with soma.Experiment.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as exp1:
-        with exp1.reopen("r") as exp2:
+        with exp1.reopen("r", tiledb_timestamp=2) as exp2:
             assert exp1.mode == "r"
             assert exp2.mode == "r"
-            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
+            assert exp1.tiledb_timestamp.timestamp() == 0.001
+            assert exp2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.Experiment.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as exp1:
-        with exp1.reopen("w") as exp2:
+        with exp1.reopen("w", tiledb_timestamp=2) as exp2:
             assert exp1.mode == "w"
             assert exp2.mode == "w"
-            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
+            assert exp1.tiledb_timestamp.timestamp() == 0.001
+            assert exp2.tiledb_timestamp.timestamp() == 0.002
 
     with soma.Experiment.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as exp1:
-        with exp1.reopen("r") as exp2:
-            assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
+        with exp1.reopen("r", tiledb_timestamp=2) as exp2:
+            assert exp1.tiledb_timestamp.timestamp() == 0.001
+            assert exp2.tiledb_timestamp.timestamp() == 0.002

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,3 +1,4 @@
+import time
 from urllib.parse import urljoin
 
 import numpy as np
@@ -211,13 +212,16 @@ def test_experiment_ms_type_constraint(tmp_path):
 
 def test_experiment_reopen(tmp_path):
     # Ensure that reopen uses the correct mode
-    soma.Experiment.create(tmp_path.as_uri())
+    soma.Experiment.create(tmp_path.as_uri(), tiledb_timestamp=1)
 
-    with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
+    with soma.Experiment.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as exp1:
         with raises_no_typeguard(ValueError):
             exp1.reopen("invalid")
 
         with exp1.reopen("w") as exp2:
+            # TODO when reopen support setting tiledb_timestamp, replace sleep
+            # with timestamp
+            time.sleep(0.001)
             with exp2.reopen("r") as exp3:
                 assert exp1.mode == "r"
                 assert exp2.mode == "w"
@@ -225,13 +229,13 @@ def test_experiment_reopen(tmp_path):
                 assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
                 assert exp2.tiledb_timestamp < exp3.tiledb_timestamp
 
-    with soma.Experiment.open(tmp_path.as_posix(), "r") as exp1:
+    with soma.Experiment.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as exp1:
         with exp1.reopen("r") as exp2:
             assert exp1.mode == "r"
             assert exp2.mode == "r"
             assert exp1.tiledb_timestamp < exp2.tiledb_timestamp
 
-    with soma.Experiment.open(tmp_path.as_posix(), "w") as exp1:
+    with soma.Experiment.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as exp1:
         with exp1.reopen("w") as exp2:
             assert exp1.mode == "w"
             assert exp2.mode == "w"

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -223,9 +223,9 @@ def test_experiment_reopen(tmp_path):
                 assert exp1.mode == "r"
                 assert exp2.mode == "w"
                 assert exp3.mode == "r"
-                assert exp1.tiledb_timestamp.timestamp() == 0.001
-                assert exp2.tiledb_timestamp.timestamp() == 0.002
-                assert exp3.tiledb_timestamp.timestamp() == 0.003
+                assert exp1.tiledb_timestamp_ms == 1
+                assert exp2.tiledb_timestamp_ms == 2
+                assert exp3.tiledb_timestamp_ms == 3
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import itertools
 import operator
 import pathlib
@@ -97,24 +98,25 @@ def test_sparse_nd_array_reopen(tmp_path):
                 assert A2.tiledb_timestamp.timestamp() == 0.002
                 assert A3.tiledb_timestamp.timestamp() == 0.003
 
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
-        with A1.reopen("r", tiledb_timestamp=2) as A2:
+    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as A1:
+        with A1.reopen("r", tiledb_timestamp=ts2) as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
+            assert A1.tiledb_timestamp== ts1
+            assert A2.tiledb_timestamp== ts2
 
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("w", tiledb_timestamp=2) as A2:
-            assert A1.mode == "w"
-            assert A2.mode == "w"
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
-
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("r", tiledb_timestamp=2) as A2:
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
+        with A1.reopen("w", tiledb_timestamp=None) as A2:
+            with A2.reopen("w") as A3:
+                assert A1.mode == "w"
+                assert A2.mode == "w"
+                assert A3.mode == "w"
+                now = datetime.datetime.now(datetime.timezone.utc)
+                assert A1.tiledb_timestamp <= now
+                assert A2.tiledb_timestamp <= now
+                assert A3.tiledb_timestamp <= now
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -5,6 +5,7 @@ import itertools
 import operator
 import pathlib
 import sys
+import time
 from concurrent import futures
 from typing import Any, Dict, List, Tuple, Union
 from unittest import mock
@@ -84,11 +85,14 @@ def test_sparse_nd_array_reopen(tmp_path):
         tmp_path.as_posix(), type=pa.float64(), shape=(1,), tiledb_timestamp=1
     )
 
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
         with raises_no_typeguard(ValueError):
             A1.reopen("invalid")
 
         with A1.reopen("w") as A2:
+            # TODO when reopen support setting tiledb_timestamp, replace sleep
+            # with timestamp
+            time.sleep(0.001)
             with A2.reopen("r") as A3:
                 assert A1.mode == "r"
                 assert A2.mode == "w"
@@ -96,13 +100,13 @@ def test_sparse_nd_array_reopen(tmp_path):
                 assert A1.tiledb_timestamp < A2.tiledb_timestamp
                 assert A2.tiledb_timestamp < A3.tiledb_timestamp
 
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A1:
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
         with A1.reopen("r") as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
             assert A1.tiledb_timestamp < A2.tiledb_timestamp
 
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
+    with soma.SparseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
         with A1.reopen("w") as A2:
             assert A1.mode == "w"
             assert A2.mode == "w"

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -104,8 +104,8 @@ def test_sparse_nd_array_reopen(tmp_path):
         with A1.reopen("r", tiledb_timestamp=ts2) as A2:
             assert A1.mode == "r"
             assert A2.mode == "r"
-            assert A1.tiledb_timestamp== ts1
-            assert A2.tiledb_timestamp== ts2
+            assert A1.tiledb_timestamp == ts1
+            assert A2.tiledb_timestamp == ts2
 
     with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
         with A1.reopen("w", tiledb_timestamp=None) as A2:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -94,9 +94,9 @@ def test_sparse_nd_array_reopen(tmp_path):
                 assert A1.mode == "r"
                 assert A2.mode == "w"
                 assert A3.mode == "r"
-                assert A1.tiledb_timestamp.timestamp() == 0.001
-                assert A2.tiledb_timestamp.timestamp() == 0.002
-                assert A3.tiledb_timestamp.timestamp() == 0.003
+                assert A1.tiledb_timestamp_ms == 1
+                assert A2.tiledb_timestamp_ms == 2
+                assert A3.tiledb_timestamp_ms == 3
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -219,9 +219,17 @@ void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     fill_metadata_cache();
 }
 
-std::unique_ptr<SOMAArray> SOMAArray::reopen(OpenMode mode) {
+std::unique_ptr<SOMAArray> SOMAArray::reopen(
+    OpenMode mode, std::optional<TimestampRange> timestamp) {
     return std::make_unique<SOMAArray>(
-        mode, uri_, ctx_, name_, column_names(), batch_size_, result_order_);
+        mode,
+        uri_,
+        ctx_,
+        name_,
+        column_names(),
+        batch_size_,
+        result_order_,
+        timestamp);
 }
 
 void SOMAArray::close() {

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -227,8 +227,10 @@ class SOMAArray : public SOMAObject {
      *
      * @param mode if the OpenMode is not given, If the SOMAObject was opened in
      * READ mode, reopen it in WRITE mode and vice versa
+     * @param timestamp Timestamp
      */
-    std::unique_ptr<SOMAArray> reopen(OpenMode mode);
+    std::unique_ptr<SOMAArray> reopen(
+        OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * Close the SOMAArray object.

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -164,8 +164,9 @@ void SOMAGroup::open(
     fill_caches();
 }
 
-std::unique_ptr<SOMAGroup> SOMAGroup::reopen(OpenMode mode) {
-    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_);
+std::unique_ptr<SOMAGroup> SOMAGroup::reopen(
+    OpenMode mode, std::optional<TimestampRange> timestamp) {
+    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_, timestamp);
 }
 
 void SOMAGroup::close() {

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -130,8 +130,10 @@ class SOMAGroup : public SOMAObject {
      *
      * @param mode if the OpenMode is not given, If the SOMAObject was opened in
      * READ mode, reopen it in WRITE mode and vice versa
+     * @param timestamp Timestamp
      */
-    std::unique_ptr<SOMAGroup> reopen(OpenMode mode);
+    std::unique_ptr<SOMAGroup> reopen(
+        OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
      * Close the SOMAGroup object.


### PR DESCRIPTION
**Issue and/or context:**

As reported internally, the `reopen` unit tests intermittenly fail due to a race condition when objects are opened at the same timestamp.

**Changes:**

Add `tiledb_timestamp` for `reopen` methods and modify tests to use explicit timestamps to prevent race conditions.