### PR TITLE
[python] Misc. ingest/outgest code-neaten improvements

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -19,8 +19,8 @@ module = "tiledbsoma._query_condition"
 ignore_errors = true
 
 [tool.ruff]
-lint.ignore = ["E501"]
-lint.extend-select = ["I001"]
+lint.ignore = ["E501"]  # line too long
+lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
 target-version = "py38"

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -5,7 +5,7 @@
 
 """Common constants and types used during ingestion/outgestion."""
 
-from typing import Union
+from typing import Any, Mapping, Union
 
 import h5py
 import scipy.sparse as sp
@@ -16,6 +16,7 @@ from tiledbsoma._types import NPNDArray
 SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
+UnsMapping = Mapping[str, Any]
 
 # Arrays of strings from AnnData's uns are stored in SOMA as SOMADataFrame,
 # since SOMA ND arrays are necessarily arrays *of numbers*. This is okay since

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -136,7 +136,7 @@ class ExperimentAmbientLabelMapping:
         obs_field_name: Optional[str] = None,
         var_field_name: Optional[str] = None,
     ) -> Self:
-        """Factory method to compute an label-to-SOMA-join-ID mappings for a single input file in
+        """Factory method to compute the label-to-SOMA-join-ID mappings for a single input file in
         isolation. This is used when a user is ingesting a single AnnData/H5AD to a single SOMA
         experiment, not in append mode, but allowing us to still have the bulk of the ingestor code
         to be non-duplicated between non-append mode and append mode.

--- a/apis/python/src/tiledbsoma/io/_registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/_registration/signatures.py
@@ -267,7 +267,12 @@ class Signature:
         See ``from_anndata``.
         """
         with read_h5ad(h5ad_file_name, mode="r") as adata:
-            return cls.from_anndata(adata, default_X_layer_name=default_X_layer_name)
+            return cls.from_anndata(
+                adata,
+                default_X_layer_name=default_X_layer_name,
+                default_obs_field_name=default_obs_field_name,
+                default_var_field_name=default_var_field_name,
+            )
 
     @classmethod
     def from_soma_experiment(

--- a/apis/python/src/tiledbsoma/io/_registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/_registration/signatures.py
@@ -56,7 +56,7 @@ def _string_dict_from_pandas_dataframe(
     default_index_name: str,
 ) -> Dict[str, str]:
     """
-    Here we provide compatiblity with the ingestor.
+    Here we provide compatibility with the ingestor.
 
     SOMA experiments are indexed by int64 soma_joinid and this is SOMA-only.
 

--- a/apis/python/src/tiledbsoma/io/_registration/signatures.py
+++ b/apis/python/src/tiledbsoma/io/_registration/signatures.py
@@ -309,7 +309,6 @@ class Signature:
                 raw_X_dtype = str(X.schema.field("soma_data").type)
 
             obsm_dtypes: Dict[str, str] = {}
-            obsm_dtypes = {}
             if "obsm" in exp.ms[measurement_name]:
                 for obsm_layer_name in exp.ms[measurement_name].obsm.keys():
                     obsm = exp.ms[measurement_name].obsm[obsm_layer_name]

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1495,10 +1495,26 @@ def _update_dataframe(
             e.as_py()
             for e in sdf_r.read(column_names=["soma_joinid"]).concat()["soma_joinid"]
         )
-        new_jids = list(range(len(new_data)))
-        if old_jids != new_jids:
+        num_old_data = len(old_jids)
+        num_new_data = len(new_data)
+        if num_old_data != num_new_data:
             raise ValueError(
-                f"{caller_name}: old and new data must have the same row count; got {len(old_jids)} != {len(new_jids)}",
+                f"{caller_name}: old and new data must have the same row count; got {num_old_data} != {num_new_data}",
+            )
+        new_jids = list(range(num_new_data))
+        if old_jids != new_jids:
+            max_jid_diffs_to_display = 10
+            jid_diffs = [
+                (old_jid, new_jid)
+                for old_jid, new_jid in zip(old_jids, new_jids)
+                if old_jid != new_jid
+            ]
+            jid_diff_strs = [
+                f"{old_jid} != {new_jid}"
+                for old_jid, new_jid in jid_diffs[:max_jid_diffs_to_display]
+            ] + (["…"] if len(jid_diffs) > max_jid_diffs_to_display else [])
+            raise ValueError(
+                f"{caller_name}: old data soma_joinid must be [0,{num_old_data}), found {len(jid_diffs)} diffs: {', '.join(jid_diff_strs)}"
             )
 
     old_keys = set(old_sig.keys())

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1059,7 +1059,6 @@ def _create_or_open_coll(
 def _extract_new_values_for_append(
     df_uri: str,
     arrow_table: pa.Table,
-    id_column_name: str,
     context: Optional[SOMATileDBContext] = None,
 ) -> pa.Table:
     """
@@ -1190,9 +1189,7 @@ def _write_dataframe_impl(
             # Nominally, nil id_column_name only happens for uns append and we do not append uns,
             # which is a concern for our caller. This is a second-level check.
             raise ValueError("internal coding error: id_column_name unspecified")
-        arrow_table = _extract_new_values_for_append(
-            df_uri, arrow_table, id_column_name, context
-        )
+        arrow_table = _extract_new_values_for_append(df_uri, arrow_table, context)
 
     try:
         soma_df = DataFrame.create(

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1559,7 +1559,7 @@ def _update_dataframe(
         #
         # Note: this must match what DataFrame.create does:
         # * DataFrame.create sets nullability for obs/var columns on initial ingest
-        # * Here, we set nullabiliity for obs/var columns on update_obs
+        # * Here, we set nullability for obs/var columns on update_obs
         # Users should get the same behavior either way.
         #
         # Note: this is specific to tiledbsoma.io.
@@ -2023,7 +2023,7 @@ def _find_mean_nnz(matrix: Matrix, axis: int) -> int:
     #   total_nnz = matrix[:, :].nnz
     # So instead we break it up. Testing over a variety of H5AD sizes
     # shows that the performance is fine here.
-    coords: List[slice] = [slice(None), slice(None)]  # type: ignore [unreachable]
+    coords: List[slice] = [slice(None), slice(None)]  # type: ignore[unreachable]
     bsz = 1000
     total_nnz = 0
     for lo in range(0, extent, bsz):
@@ -2644,7 +2644,7 @@ def _ingest_uns_string_array(
     Ingest an uns string array. In the SOMA data model, we have NDArrays _of number only_ ...
     so we need to make this a SOMADataFrame.
 
-    Ideally we don't want to an index column "soma_joinid" -- "index", maybe.
+    Ideally we don't want to add an index column "soma_joinid" -- "index", maybe.
     However, ``SOMADataFrame`` _requires_ that soma_joinid be present, either
     as an index column, or as a data column. The former is less confusing.
     """

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1705,9 +1705,10 @@ def add_X_layer(
     add_matrix_to_collection(
         exp,
         measurement_name,
-        "X",
-        X_layer_name,
-        X_layer_data,
+        collection_name="X",
+        matrix_name=X_layer_name,
+        matrix_data=X_layer_data,
+        ingest_mode=ingest_mode,
         use_relative_uri=use_relative_uri,
     )
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1408,7 +1408,6 @@ def update_obs(
         context=context,
         platform_config=platform_config,
         default_index_name=default_index_name,
-        measurement_name="N/A for obs",
     )
 
 
@@ -1463,7 +1462,6 @@ def update_var(
         exp.ms[measurement_name].var,
         new_data,
         "update_var",
-        measurement_name=measurement_name,
         context=context,
         platform_config=platform_config,
         default_index_name=default_index_name,
@@ -1475,7 +1473,6 @@ def _update_dataframe(
     new_data: pd.DataFrame,
     caller_name: str,
     *,
-    measurement_name: str,
     context: Optional[SOMATileDBContext] = None,
     platform_config: Optional[PlatformConfig],
     default_index_name: str,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -92,6 +92,7 @@ from ._common import (
     _UNS_OUTGEST_HINT_KEY,
     Matrix,
     SparseMatrix,
+    UnsMapping,
 )
 from ._registration import (
     AxisIDMapping,
@@ -2481,7 +2482,7 @@ def _chunk_is_contained_in_axis(
 
 def _maybe_ingest_uns(
     m: Measurement,
-    uns: Mapping[str, object],
+    uns: UnsMapping,
     *,
     platform_config: Optional[PlatformConfig],
     context: Optional[SOMATileDBContext],

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -324,14 +324,15 @@ def to_anndata(
     uns: UnsMapping = {}
     if "uns" in measurement:
         s = _util.get_start_stamp()
-        logging.log_io(None, f'Start  writing uns for {measurement["uns"].uri}')
+        uns_coll = cast(Collection[Any], measurement["uns"])
+        logging.log_io(None, f"Start  writing uns for {uns_coll.uri}")
         uns = _extract_uns(
-            cast(Collection[Any], measurement["uns"]),
+            uns_coll,
             uns_keys=uns_keys,
         )
         logging.log_io(
             None,
-            _util.format_elapsed(s, f'Finish writing uns for {measurement["uns"].uri}'),
+            _util.format_elapsed(s, f"Finish writing uns for {uns_coll.uri}"),
         )
 
     anndata = ad.AnnData(

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -46,6 +46,7 @@ from ._common import (
     _UNS_OUTGEST_HINT_2D,
     _UNS_OUTGEST_HINT_KEY,
     Matrix,
+    UnsMapping,
 )
 
 
@@ -320,7 +321,7 @@ def to_anndata(
             matrix = measurement.varp[key].read().tables().concat().to_pandas()
             varp[key] = conversions.csr_from_tiledb_df(matrix, nvar, nvar)
 
-    uns = {}
+    uns: UnsMapping = {}
     if "uns" in measurement:
         s = _util.get_start_stamp()
         logging.log_io(None, f'Start  writing uns for {measurement["uns"].uri}')
@@ -428,7 +429,7 @@ def _extract_uns(
     collection: Collection[Any],
     uns_keys: Optional[Sequence[str]] = None,
     level: int = 0,
-) -> Dict[str, Any]:
+) -> UnsMapping:
     """
     This is a helper function for ``to_anndata`` of ``uns`` elements.
     """

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -13,7 +13,7 @@ from typing_extensions import Literal
 
 import tiledbsoma as soma
 from tiledbsoma import _collection, _factory, _soma_object
-from tiledbsoma._exception import DoesNotExistError
+from tiledbsoma._exception import DoesNotExistError, SOMAError
 from tiledbsoma.options import SOMATileDBContext
 
 from tests._util import raises_no_typeguard
@@ -279,13 +279,13 @@ def test_collection_update_on_set(tmp_path):
     assert set(sc.keys()) == set([])
 
     sc["A"] = A
-    assert set(sc.keys()) == set(["A"])
+    assert set(sc.keys()) == {"A"}
     assert sc["A"] == A
 
-    pytest.xfail(reason="replacing entries is not supported")
-    sc["A"] = B
-    assert set(sc.keys()) == set(["A"])
-    assert sc["A"] == B
+    with pytest.raises(SOMAError):
+        sc["A"] = B
+    assert set(sc.keys()) == {"A"}
+    assert sc["A"] == A
 
 
 def test_cascading_close(tmp_path: pathlib.Path):

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -24,7 +24,6 @@ def _create_anndata(
     obs_field_name: str,
     var_field_name: str,
     X_value_base: int,
-    measurement_name: str,
     raw_var_ids: Optional[Sequence[str]] = None,
 ):
     n_obs = len(obs_ids)
@@ -160,7 +159,6 @@ def create_anndata_canned(which: int, obs_field_name: str, var_field_name: str):
         var_ids=var_ids,
         raw_var_ids=raw_var_ids,
         X_value_base=X_value_base,
-        measurement_name="measname",
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
     )
@@ -189,7 +187,6 @@ def anndata_larger():
         obs_ids=["id_%08d" % e for e in range(1000)],
         var_ids=["AKT1", "APOE", "ESR1", "TP53", "VEGFA", "ZZZ3"],
         X_value_base=0,
-        measurement_name="measname",
         obs_field_name="cell_id",
         var_field_name="gene_id",
     )
@@ -1240,7 +1237,6 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
         X_value_base=0,
-        measurement_name=measurement_name,
     )
 
     bdata = _create_anndata(
@@ -1249,7 +1245,6 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
         X_value_base=100,
-        measurement_name=measurement_name,
     )
 
     adata.obs["enum"] = pd.Categorical(obs_ids_a, categories=obs_ids_a)

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -277,7 +277,7 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
     #
     # One way:
     # * Create columns with non-nulls before from_anndata
-    # * Ingest, having those new column with non-nulls
+    # * Ingest, having those new columns with non-nulls
     # * Call update_obs to set the columns to have nulls
     #
     # Other way:


### PR DESCRIPTION
**Issue and/or context:** various cleanups/tweaks, factored out of #2804

**Changes:**
The commits should all be orthogonal / messages relatively self-explanatory:
- remove some unused function arguments
- fix some docstring typos
- improve an error msg in `_update_dataframe`
- ~`deepcopy` test-AnnDatas (to verify "originals" aren't mutated by `from_anndata`)~ punted to a future PR
- factor more commonly-reused kwargs in ingest.py

No user API is affected by this PR.