### PR TITLE
[r] Add `drop_levels` to `SOMAExperimentAxisQuery` -> ecosystem outgestors

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.12.99.1
+Version: 1.12.99.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 * Change `$reopen(mode = )` default to not flip modes; require explicit `mode` parameter to be passed
+* Add `drop_levels` to `SOMAExperimentAxisQuery` -> ecosystem outgestors to drop unused factor levels
 
 # tiledbsoma 1.11.4
 

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -337,7 +337,8 @@ Loads the query as a \code{\link[SeuratObject]{Seurat}} object
   var_column_names = NULL,
   obsm_layers = NULL,
   varm_layers = NULL,
-  obsp_layers = NULL
+  obsp_layers = NULL,
+  drop_levels = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -359,6 +360,8 @@ Loads the query as a \code{\link[SeuratObject]{Seurat}} object
 \item{\code{varm_layers}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_mlayers(axis = 'varm')}}
 
 \item{\code{obsp_layers}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_players()}}
+
+\item{\code{drop_levels}}{Drop unused levels from \code{obs} and \code{var} factor columns}
 }
 \if{html}{\out{</div>}}
 }
@@ -376,7 +379,8 @@ Loads the query as a Seurat \code{\link[SeuratObject]{Assay}}
   X_layers = c(counts = "counts", data = "logcounts"),
   obs_index = NULL,
   var_index = NULL,
-  var_column_names = NULL
+  var_column_names = NULL,
+  drop_levels = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -390,6 +394,8 @@ Loads the query as a Seurat \code{\link[SeuratObject]{Assay}}
 \item{\code{var_index}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_index(axis = 'var')}}
 
 \item{\code{var_column_names}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_metadata_names(axis = 'var')}}
+
+\item{\code{drop_levels}}{Drop unused levels from \code{var} factor columns}
 }
 \if{html}{\out{</div>}}
 }
@@ -469,7 +475,8 @@ Loads the query as a
   var_column_names = NULL,
   obsm_layers = NULL,
   obsp_layers = NULL,
-  varp_layers = NULL
+  varp_layers = NULL,
+  drop_levels = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -491,6 +498,8 @@ Loads the query as a
 \item{\code{obsp_layers}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_players('sce')}}
 
 \item{\code{varp_layers}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_players('sce', 'varp')}}
+
+\item{\code{drop_levels}}{Drop unused levels from \code{obs} and \code{var} factor columns}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -57,12 +57,24 @@ create_arrow_schema <- function(foo_first = TRUE) {
   }
 }
 
-create_arrow_table <- function(nrows = 10L) {
-  arrow::arrow_table(
+create_arrow_table <- function(nrows = 10L, factors = FALSE) {
+  if (isTRUE(factors)) {
+    return(arrow::arrow_table(
       foo = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
       bar = seq(nrows) + 0.1,
       baz = as.character(seq.int(nrows) + 1000L),
-      schema = create_arrow_schema()
+      grp = factor(c(
+        rep_len("lvl1", length.out = floor(nrows / 2)),
+        rep_len("lvl2", length.out = ceiling(nrows / 2))
+      ))
+    ))
+  }
+  arrow::arrow_table(
+      foo = seq.int(nrows) + 1000L,
+      soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
+      bar = seq(nrows) + 0.1,
+      baz = as.character(seq.int(nrows) + 1000L)
+      # schema = create_arrow_schema()
     )
 }


### PR DESCRIPTION
R analog of #2811 and single-cell-data/SOMA#204; add a `drop_levels` paramter to the ecosystem outgestors to drop unused factor levels from resulting data frames

Modified SOMA methods:
 - `SOMAExperimentAxisQuery$to_seurat()`: add `drop_levels` to drop drop unused levels from `obs` and `var` data frames
 - `SOMAExperimentAxisQuery$to_seurat_assay()`: add `drop_levels` to drop unused levels from `var` data frame
 - `SOMAExperimentAxisQuery$to_single_cell_experiment()`: add `drop_levels` to drop unused levels from `obs` and `var` data frames

Also shifts `SOMAExperimentAxisQuery$to_seurat()` and `SOMAExperimentAxisQuery$to_seurat_assay()` to use `SOMAExperimentAxisQuery$private$.load_df()` for loading `obs` and `var`; removing standalone code and increase sharing with the SCE outgestor

resolves #2765

[SC-51945](https://app.shortcut.com/tiledb-inc/story/51945)