### PR TITLE
[python] Remove `reshape` stub

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -95,14 +95,6 @@ class NDArray(SOMAArray, somacore.NDArray):
         """
         return cast(Tuple[int, ...], tuple(self._handle.shape))
 
-    def reshape(self, shape: Tuple[int, ...]) -> None:
-        """Unsupported operation for this object type.
-
-        Lifecycle:
-            Maturing.
-        """
-        raise NotImplementedError("reshape operation not implemented.")
-
     @classmethod
     def _dim_capacity_and_extent(
         cls,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -173,17 +173,6 @@ def test_zero_length_fail(tmp_path, shape):
         soma.DenseNDArray.create(tmp_path.as_posix(), type=pa.float32(), shape=shape)
 
 
-def test_dense_nd_array_reshape(tmp_path):
-    """
-    Reshape currently unimplemented.
-    """
-    a = soma.DenseNDArray.create(
-        tmp_path.as_posix(), type=pa.int32(), shape=(10, 10, 10)
-    )
-    with pytest.raises(NotImplementedError):
-        assert a.reshape((100, 10, 1))
-
-
 @pytest.mark.parametrize("shape_is_numeric", [True, False])
 def test_dense_nd_array_requires_shape(tmp_path, shape_is_numeric):
     uri = tmp_path.as_posix()


### PR DESCRIPTION
**Issue and/or context:** The `reshape` method is not part of [the SOMA spec](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md). And it is raising `NotImplementedError` so no one can be using it. This needs to be GC'ed. This is a split-out from PR #2785 for issue #2407. See also [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

**Notes for Reviewer:**

