### PR TITLE
[python] Improve error message on non-constant query-condition RHS

### DIFF
--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -425,7 +425,12 @@ class QueryConditionTree(ast.NodeVisitor):
         result = self.visit(node.left)
         rhs = node.right[1:] if isinstance(node.right, list) else [node.right]
         for value in rhs:
-            result = result.combine(self.visit(value), op)
+            visited = self.visit(value)
+            if not isinstance(result, clib.PyQueryCondition):
+                raise Exception(
+                    f"Unable to parse right-hand side {ast.dump(node)} -- did you mean to double-quote it?"
+                )
+            result = result.combine(visited, op)
 
         return result
 

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -360,7 +360,7 @@ class QueryConditionTree(ast.NodeVisitor):
         else:
             raise SOMAError(
                 f"Incorrect type for comparison value: {ast.dump(val_node)}: right-hand sides must be constant"
-                " expressions, not variables -- did you mean to double-quote the right-hand side?"
+                " expressions, not variables -- did you mean to quote the right-hand side as a string?"
             )
 
         return val
@@ -428,7 +428,7 @@ class QueryConditionTree(ast.NodeVisitor):
             visited = self.visit(value)
             if not isinstance(result, clib.PyQueryCondition):
                 raise Exception(
-                    f"Unable to parse expression component {ast.dump(node)} -- did you mean to double-quote it?"
+                    f"Unable to parse expression component {ast.dump(node)} -- did you mean to quote it as a string?"
                 )
             result = result.combine(visited, op)
 

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -359,7 +359,8 @@ class QueryConditionTree(ast.NodeVisitor):
             val = val_node.value
         else:
             raise SOMAError(
-                f"Incorrect type for comparison value: {ast.dump(val_node)}"
+                f"Incorrect type for comparison value: {ast.dump(val_node)}: right-hand sides must be constant"
+                " expressions, not variables -- did you mean to double-quote the right-hand side?"
             )
 
         return val

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -428,7 +428,7 @@ class QueryConditionTree(ast.NodeVisitor):
             visited = self.visit(value)
             if not isinstance(result, clib.PyQueryCondition):
                 raise Exception(
-                    f"Unable to parse right-hand side {ast.dump(node)} -- did you mean to double-quote it?"
+                    f"Unable to parse expression component {ast.dump(node)} -- did you mean to double-quote it?"
                 )
             result = result.combine(visited, op)
 

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 import tiledbsoma.pytiledbsoma as clib
+from tiledbsoma import DataFrame
 from tiledbsoma._exception import SOMAError
 from tiledbsoma._query_condition import QueryCondition
 
@@ -222,6 +223,21 @@ def test_eval_error_conditions(malformed_condition):
         # test function directly for codecov
         qc.init_query_condition(sr.schema, [])
         qc.init_query_condition(sr.schema, ["bad_query_attr"])
+
+
+@pytest.mark.parametrize(
+    "text_and_exception",
+    [
+        ["louvain == leukocyte", SOMAError],
+        ["louvain == leuko-cyte", SOMAError],  # minus sign looks like an operator
+    ],
+)
+def test_query_condition_syntax_handling(text_and_exception):
+    uri = os.path.join(SOMA_URI, "obs")
+    text, exception = text_and_exception
+    with DataFrame.open(uri) as obs:
+        with pytest.raises(exception):
+            obs.read(value_filter=text).concat()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Issue and/or context:** [[sc-52135]](https://app.shortcut.com/tiledb-inc/story/52135) [[sc-52172]](https://app.shortcut.com/tiledb-inc/story/52172)

**Changes:** Improve the error message.

**Notes for Reviewer:**

Example:

```
#!/usr/bin/env python
import tiledbsoma
import sys
expr = 'foo is True'
if len(sys.argv) == 2:
    expr = sys.argv[1]
with tiledbsoma.Experiment.open('/var/p') as exp: # /var/p is a copy of pbmc3k; any Experiment will do
    exp.obs.read(value_filter=expr).concat()
```

```
johnkerl@exade[prod][kerl/qc-parser-nonconstant-rhs][python]$ python q1.py 'louvain == leukocyte'
Traceback (most recent call last):
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/q1.py", line 12, in <module>
    exp.obs.read(value_filter=expr).concat()
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py", line 411, in read
    sr.set_condition(QueryCondition(value_filter), handle.schema)
tiledbsoma._exception.SOMAError: SOMAError: Incorrect type for comparison value:
Name(id='leukocyte', ctx=Load()): right-hand sides must be constant expressions, not variables --
did you mean to quote the right-hand side as a string?

At:
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_query_condition.py(137): init_query_condition
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py(411): read
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/q1.py(12): <module>
```

```
johnkerl@exade[prod][kerl/qc-parser-nonconstant-rhs][python]$ python q1.py 'louvain == leuko-cyte'
Traceback (most recent call last):
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/q1.py", line 12, in <module>
    exp.obs.read(value_filter=expr).concat()
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py", line 411, in read
    sr.set_condition(QueryCondition(value_filter), handle.schema)
tiledbsoma._exception.SOMAError: SOMAError: Unable to parse expression component BinOp(left=Name(id='leuko', ctx=Load()), op=Sub(), right=Name(id='cyte', ctx=Load())) -- did you mean to quote it as a string?

At:
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_query_condition.py(137): init_query_condition
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py(411): read
  /Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/q1.py(12): <module>
```
