### PR TITLE
[r] Expose object-type getter

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -191,3 +191,7 @@ tiledb_datatype_max_value <- function(datatype) {
     .Call(`_tiledbsoma_tiledb_datatype_max_value`, datatype)
 }
 
+get_soma_object_type <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_get_soma_object_type`, uri, ctxxp)
+}
+

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -195,3 +195,7 @@ get_soma_object_type <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_get_soma_object_type`, uri, ctxxp)
 }
 
+get_tiledb_object_type <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_get_tiledb_object_type`, uri, ctxxp)
+}
+

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -111,7 +111,7 @@ TileDBObject <- R6::R6Class(
       } else {
         stop("Unknown object type", call. = FALSE)
       }
-      tiledb::tiledb_object_type(self$uri, ctx = self$tiledbsoma_ctx$context()) %in% expected_type
+      get_tiledb_object_type(self$uri, ctx = soma_context()) %in% expected_type
     }
   ),
 

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -329,6 +329,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// get_tiledb_object_type
+std::string get_tiledb_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_get_tiledb_object_type(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_tiledb_object_type(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_createSOMAContext", (DL_FUNC) &_tiledbsoma_createSOMAContext, 1},
@@ -358,6 +370,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_tiledb_embedded_version", (DL_FUNC) &_tiledbsoma_tiledb_embedded_version, 0},
     {"_tiledbsoma_tiledb_datatype_max_value", (DL_FUNC) &_tiledbsoma_tiledb_datatype_max_value, 1},
     {"_tiledbsoma_get_soma_object_type", (DL_FUNC) &_tiledbsoma_get_soma_object_type, 2},
+    {"_tiledbsoma_get_tiledb_object_type", (DL_FUNC) &_tiledbsoma_get_tiledb_object_type, 2},
     {NULL, NULL, 0}
 };
 

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -317,6 +317,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// get_soma_object_type
+std::string get_soma_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_get_soma_object_type(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_soma_object_type(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_createSOMAContext", (DL_FUNC) &_tiledbsoma_createSOMAContext, 1},
@@ -345,6 +357,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 1},
     {"_tiledbsoma_tiledb_embedded_version", (DL_FUNC) &_tiledbsoma_tiledb_embedded_version, 0},
     {"_tiledbsoma_tiledb_datatype_max_value", (DL_FUNC) &_tiledbsoma_tiledb_datatype_max_value, 1},
+    {"_tiledbsoma_get_soma_object_type", (DL_FUNC) &_tiledbsoma_get_soma_object_type, 2},
     {NULL, NULL, 0}
 };
 

--- a/apis/r/src/soma.cpp
+++ b/apis/r/src/soma.cpp
@@ -1,0 +1,33 @@
+#include <Rcpp/Lighter>                         // for R interface to C++
+#include <nanoarrow/r.h>                        // for C/C++ interface to Arrow (via header exported from the R package)
+#include <nanoarrow/nanoarrow.hpp>              // for C/C++ interface to Arrow (vendored)
+#include <RcppInt64>                            // for fromInteger64
+
+#include <tiledbsoma/tiledbsoma>
+#include <tiledbsoma/reindexer/reindexer.h>
+
+#include "rutilities.h"         				// local declarations
+#include "xptr-utils.h"         				// xptr taggging utilities
+
+namespace tdbs = tiledbsoma;
+
+// [[Rcpp::export]]
+std::string get_soma_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    // shared pointer to SOMAContext from external pointer wrapper
+    std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
+    // shared pointer to TileDB Context from SOMAContext
+    std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+
+    auto tiledb_type = tdbs::Object::object(*ctx, uri).type();
+    switch (tiledb_type) {
+        case tdbs::Object::Type::Array:
+            return std::string("SOMAArray");
+            break;
+        case tdbs::Object::Type::Group:
+            return std::string("SOMAGroup");
+            break;
+        default:
+            Rcpp::stop("Inadmissable object type for URI '%s'", uri);
+            break;
+    }
+}

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -381,7 +381,7 @@ test_that("write_soma.character scalar", {
   expect_length(unlist(strsplit(sdf.cars, ",")), nrow(mtcars))
 })
 
-test_that("get_soma_object_type", {
+test_that("get_{some,tiledb}_object_type", {
     suppressMessages({
         library(SeuratObject)
         library(tiledbsoma)
@@ -392,14 +392,28 @@ test_that("get_soma_object_type", {
     uri <- tempfile()
     expect_equal(write_soma(pbmc_small, uri = uri), uri)  # uri return is success
 
+    # SOMA
+    expect_equal(tiledbsoma:::get_soma_object_type(uri, soma_context()), "SOMAExperiment")
+    expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, "ms/RNA"), soma_context()), "SOMAMeasurement")
+    coll <- c("ms", "ms/RNA/obsm", "ms/RNA/obsp/", "ms/RNA/varm")
+    for (co in coll) {
+        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, co), soma_context()), "SOMACollection")
+    }
+    expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, "ms/RNA/var"), soma_context()), "SOMADataFrame")
+    sparr <- c("ms/RNA/obsm/X_pca", "ms/RNA/obsm/X_tsne", "ms/RNA/obsp/RNA_snn")
+    for (a in sparr) {
+        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, a), soma_context()), "SOMASparseNDArray")
+    }
+    expect_error(tiledbsoma:::get_some_object_type("doesnotexit", soma_context()))
+
+    ## TileDB
     grps <- c("", "ms", "ms/RNA", "ms/RNA/obsm", "ms/RNA/obsp/", "ms/RNA/varm")
     for (g in grps) {
-        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, g), soma_context()), "SOMAGroup")
+        expect_equal(tiledbsoma:::get_tiledb_object_type(file.path(uri, g), soma_context()), "GROUP")
     }
     arrs <- c("ms/RNA/obsm/X_pca", "ms/RNA/obsm/X_tsne", "ms/RNA/obsp/RNA_snn", "ms/RNA/var")
     for (a in arrs) {
-        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, a), soma_context()), "SOMAArray")
+        expect_equal(tiledbsoma:::get_tiledb_object_type(file.path(uri, a), soma_context()), "ARRAY")
     }
-
-    expect_error(tiledbsoma:::get_soma_object_type("doesnotexit", soma_context()))
+    expect_equal(tiledbsoma:::get_tiledb_object_type("doesnotexit", soma_context()), "INVALID")
 })

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -380,3 +380,26 @@ test_that("write_soma.character scalar", {
   expect_identical(sdf.cars <- tbl$values$as_vector(), cars)
   expect_length(unlist(strsplit(sdf.cars, ",")), nrow(mtcars))
 })
+
+test_that("get_soma_object_type", {
+    suppressMessages({
+        library(SeuratObject)
+        library(tiledbsoma)
+    })
+
+    ## write out a SOMA
+    data("pbmc_small")
+    uri <- tempfile()
+    expect_equal(write_soma(pbmc_small, uri = uri), uri)  # uri return is success
+
+    grps <- c("", "ms", "ms/RNA", "ms/RNA/obsm", "ms/RNA/obsp/", "ms/RNA/varm")
+    for (g in grps) {
+        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, g), soma_context()), "SOMAGroup")
+    }
+    arrs <- c("ms/RNA/obsm/X_pca", "ms/RNA/obsm/X_tsne", "ms/RNA/obsp/RNA_snn", "ms/RNA/var")
+    for (a in arrs) {
+        expect_equal(tiledbsoma:::get_soma_object_type(file.path(uri, a), soma_context()), "SOMAArray")
+    }
+
+    expect_error(tiledbsoma:::get_soma_object_type("doesnotexit", soma_context()))
+})


### PR DESCRIPTION
**Issue and/or context:**

Object type (i.e. Array or Group) is currently gotten via a tiledb-r function.

**Changes:**

This PR exposes the corresponding libtiledbsoma function, and adds tests.

**Notes for Reviewer:**

[SC 52390](https://app.shortcut.com/tiledb-inc/story/52390/r-expose-somaobject-type)
