### PR TITLE
[r] Use `.Deprecated` for `used_shape` in R

### DIFF
--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -161,7 +161,7 @@ TileDBArray <- R6::R6Class(
         isTRUE(simplify) || isFALSE(simplify),
         isTRUE(index1) || isFALSE(index1)
       )
-      .Deprecated(new="shape", msg="used_shape will be removed in TileDB-SOMA 1.14")
+      .Deprecated(new="shape", msg="The 'used_shape' function will be removed in TileDB-SOMA 1.14.")
       dims <- self$dimnames()
       utilized <- vector(mode = 'list', length = length(dims))
       names(utilized) <- dims

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -161,6 +161,7 @@ TileDBArray <- R6::R6Class(
         isTRUE(simplify) || isFALSE(simplify),
         isTRUE(index1) || isFALSE(index1)
       )
+      .Deprecated(new="shape", msg="used_shape will be removed in TileDB-SOMA 1.14")
       dims <- self$dimnames()
       utilized <- vector(mode = 'list', length = length(dims))
       names(utilized) <- dims

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -416,7 +416,10 @@ test_that("SOMASparseNDArray bounding box", {
     }
   }
 
-  expect_type(bbox <- ndarray$used_shape(index1 = TRUE), 'list')
+  expect_type(
+    bbox <- suppressWarnings(ndarray$used_shape(index1 = TRUE), classes = "deprecatedWarning"),
+    'list'
+  )
   expect_length(bbox, length(dim(mat)))
   expect_equal(names(bbox), dnames)
   expect_true(all(vapply(bbox, length, integer(1L)) == 2L))
@@ -424,7 +427,10 @@ test_that("SOMASparseNDArray bounding box", {
     expect_equal(bbox[[i]], bit64::as.integer64(c(1L, dim(mat)[i])))
   }
 
-  expect_type(bbox0 <- ndarray$used_shape(index1 = FALSE), 'list')
+  expect_type(
+    bbox0 <- suppressWarnings(ndarray$used_shape(index1 = FALSE), classes = "deprecatedWarning"),
+    'list'
+  )
   expect_length(bbox0, length(dim(mat)))
   expect_equal(names(bbox0), dnames)
   expect_true(all(vapply(bbox0, length, integer(1L)) == 2L))
@@ -432,7 +438,10 @@ test_that("SOMASparseNDArray bounding box", {
     expect_equal(bbox0[[i]], bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
   }
 
-  expect_s3_class(bboxS <- ndarray$used_shape(simplify = TRUE), 'integer64')
+  expect_s3_class(
+    bboxS <- suppressWarnings(ndarray$used_shape(simplify = TRUE), classes = "deprecatedWarning"),
+    'integer64'
+  )
   expect_length(bboxS, length(dim(mat)))
   expect_equal(names(bboxS), dnames)
   for (i in seq_along(bboxS)) {
@@ -459,7 +468,7 @@ test_that("SOMASparseNDArray without bounding box", {
 
   expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
-  expect_error(ndarray$used_shape())
+  expect_error(suppressWarnings(ndarray$used_shape(), classes = "deprecatedWarning"))
 })
 
 test_that("SOMASparseNDArray with failed bounding box", {
@@ -489,7 +498,7 @@ test_that("SOMASparseNDArray with failed bounding box", {
 
   expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
-  expect_error(ndarray$used_shape())
+  expect_error(suppressWarnings(ndarray$used_shape(), classes = "deprecatedWarning"))
 })
 
 test_that("SOMASparseNDArray bounding box implicitly-stored values", {
@@ -521,7 +530,10 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
     }
   }
 
-  expect_type(bbox <- ndarray$used_shape(index1 = TRUE), 'list')
+  expect_type(
+    bbox <- suppressWarnings(ndarray$used_shape(index1 = TRUE), classes = "deprecatedWarning"),
+    'list'
+  )
   expect_length(bbox, length(dim(mat)))
   expect_equal(names(bbox), dnames)
   expect_true(all(vapply(bbox, length, integer(1L)) == 2L))
@@ -529,7 +541,10 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
     expect_equal(bbox[[i]], bit64::as.integer64(c(1L, dim(mat)[i])))
   }
 
-  expect_type(bbox0 <- ndarray$used_shape(index1 = FALSE), 'list')
+  expect_type(
+    bbox0 <- suppressWarnings(ndarray$used_shape(index1 = FALSE), classes = "deprecatedWarning"),
+    'list'
+  )
   expect_length(bbox0, length(dim(mat)))
   expect_equal(names(bbox0), dnames)
   expect_true(all(vapply(bbox0, length, integer(1L)) == 2L))
@@ -537,7 +552,10 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
     expect_equal(bbox0[[i]], bit64::as.integer64(c(0L, dim(mat)[i] - 1L)))
   }
 
-  expect_s3_class(bboxS <- ndarray$used_shape(simplify = TRUE), 'integer64')
+  expect_s3_class(
+    bboxS <- suppressWarnings(ndarray$used_shape(simplify = TRUE), classes = "deprecatedWarning"),
+    'integer64'
+  )
   expect_length(bboxS, length(dim(mat)))
   expect_equal(names(bboxS), dnames)
   for (i in seq_along(bboxS)) {
@@ -551,7 +569,12 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
     ranges[i] <- bit64::as.integer64(max(range(slot(mat, s))))
   }
   expect_equal(ndarray$non_empty_domain(), ranges)
-  expect_true(all(ndarray$non_empty_domain() < ndarray$used_shape(simplify = TRUE)))
+  expect_true(all(
+    ndarray$non_empty_domain() < suppressWarnings(
+      ndarray$used_shape(simplify = TRUE),
+      classes = "deprecatedWarning"
+    )
+  ))
 })
 
 test_that("Bounding box assertions", {

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -286,7 +286,10 @@ test_that("Resume-mode sparse arrays", {
     expected.label = "knex"
   )
   bbox <- tryCatch(
-    as.integer(ssac$used_shape(simplify = TRUE, index1 = TRUE)),
+    as.integer(suppressWarnings(
+      ssac$used_shape(simplify = TRUE, index1 = TRUE),
+      classes = "deprecatedWarning"
+    )),
     error = function(...) NULL
   )
   if (!is.null(bbox)) {


### PR DESCRIPTION
Follow-on from https://github.com/single-cell-data/TileDB-SOMA/pull/2834#issuecomment-2269958874 for issue 2407

Example interactive use:

```
> exp <- SOMAExperimentOpen('/var/p')

> exp$ms$get("RNA")$X$get("data")$used_shape()
$soma_dim_0
integer64
[1] 0    2637

$soma_dim_1
integer64
[1] 0    1837

Warning message:
used_shape will be removed in TileDB-SOMA 1.14
```