### PR TITLE
[python] Debug CI `mypy` failures related to `# type: ignore[misc]`

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -46,10 +46,13 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('.github/workflows/python-ci-single.yml') }}
+        key: pre-commit-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('.github/workflows/python-ci-single.yml', '.pre-commit-config.yaml') }}
+
+    - name: Install pre-commit
+      run: python -m pip -v install pre-commit
 
     - name: Run pre-commit hooks on all files
-      run: python -m pip -v install pre-commit && pre-commit run -a -v
+      run: pre-commit run -a -v
 
     # Skip files in apis/r/src which are:
     # * nanoarrow.c/h

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -51,6 +51,9 @@ jobs:
     - name: Install pre-commit
       run: python -m pip -v install pre-commit
 
+    - name: Log pip dependencies
+      run: python -m pip list
+
     - name: Run pre-commit hooks on all files
       run: pre-commit run -a -v
 


### PR DESCRIPTION
**Issue and/or context:** #2839 [[sc-52471]](https://app.shortcut.com/tiledb-inc/story/52471)

- `actions/cache` and `actions/setup-python` cache Python dependencies based on a hash of the contents of `python-ci-single.yml`.
- `python-ci-single.yml` changed on Friday ([#2827](https://github.com/single-cell-data/TileDB-SOMA/pull/2827)) for the first time since June 6 ([#2688](https://github.com/single-cell-data/TileDB-SOMA/pull/2688))
- Some lint jobs have been failing since, apparently due to loading existing `setup-python` caches, which don't like the `# type: ignore[misc]` at [_types.py:24](https://github.com/single-cell-data/TileDB-SOMA/blob/36a4fc619d25e3a481365ca2d7485f196f4372ae/apis/python/src/tiledbsoma/_types.py#L24) (added in [#2821](https://github.com/single-cell-data/TileDB-SOMA/pull/2821), tweaked in [#2834](https://github.com/single-cell-data/TileDB-SOMA/pull/2834))
  - Existing caches' `mypy` flags this as an unused annotation.
  - Fresh environments seem to require the annotation to be present.
  - It's not clear at time of writing what causes this difference in behavior.

This PR adds a `pip list` after the `setup-python` step, which serves two purposes:
- Cache-bust `setup-python`, avoiding the (apparently bad) previous cache (`setup-python-macOS-python-3.11.9-pip-0bc0ed4dc8ce9f9b48ebc42fa10052206992eb7a7705c7a75ec8fcbe15e3e65f`, seen [here][fail] in a previous failed job)
- Help us confirm dependencies being loaded from cache, in any future CI failures of this sort.

It also includes a hash of `.pre-commit-config.yaml` in the key for `~/.cache/pre-commit` (where `pre-commit` stores environments, including `mypy` installations). Previously, stale `~/.cache/pre-commit` directories may have been downloaded, though invoking `pre-commit` in that case should have installed a fresh/correct environment (based on the contents of `.pre-commit-config.yaml`); it's not clear this was causing our issue, and in fact [the failed run][fail] mentioned above [did not use](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/10265868172/job/28402965290?pr=2824#step:4:15) a cached `~/.cache/pre-commit` directory).

It's still not clear what (from older `setup-python` caches?) was causing the failures.

[fail]: https://github.com/single-cell-data/TileDB-SOMA/actions/runs/10265868172/job/28402965290?pr=2824#step:3:34
