### PR TITLE
[python] Implement scheduled removal of `TileDBCreateOptions` being passed to `write` methods

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -6,7 +6,6 @@
 """
 Implementation of a SOMA DataFrame
 """
-import warnings
 from typing import Any, List, Optional, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
@@ -19,7 +18,6 @@ from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_JOINID
 from ._exception import SOMAError, map_exception_for_create
-from ._general_utilities import assert_version_before
 from ._query_condition import QueryCondition
 from ._read_iters import TableReadIter
 from ._soma_array import SOMAArray
@@ -455,17 +453,12 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
-            assert_version_before(1, 13)
-            warnings.warn(
-                "The write parameter now takes in TileDBWriteOptions "
-                "instead of TileDBCreateOptions. This warning will be removed "
-                "and error out when passing TileDBCreateOptions in 1.13.",
-                DeprecationWarning,
+            raise ValueError(
+                "As of TileDB-SOMA 1.13, the write method takes "
+                "TileDBWriteOptions instead of TileDBCreateOptions"
             )
-            write_options = TileDBCreateOptions.from_platform_config(platform_config)
-        else:
-            write_options = TileDBWriteOptions.from_platform_config(platform_config)
-            sort_coords = write_options.sort_coords
+        write_options = TileDBWriteOptions.from_platform_config(platform_config)
+        sort_coords = write_options.sort_coords
 
         clib_dataframe = self._handle._handle
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -9,7 +9,6 @@ Implementation of SOMA SparseNDArray.
 from __future__ import annotations
 
 import itertools
-import warnings
 from typing import (
     Dict,
     Optional,
@@ -34,7 +33,6 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
-from ._general_utilities import get_implementation_version
 from ._read_iters import (
     BlockwiseScipyReadIter,
     BlockwiseTableReadIter,
@@ -276,18 +274,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
-            version = get_implementation_version().split(".")
-            assert (int(version[0]), int(version[1])) < (1, 13)
-            warnings.warn(
-                "The write parameter now takes in TileDBWriteOptions "
-                "instead of TileDBCreateOptions. This warning will be removed "
-                "and error out when passing TileDBCreateOptions in 1.13.",
-                DeprecationWarning,
+            raise ValueError(
+                "As of TileDB-SOMA 1.13, the write method takes "
+                "TileDBWriteOptions instead of TileDBCreateOptions"
             )
-            write_options = TileDBCreateOptions.from_platform_config(platform_config)
-        else:
-            write_options = TileDBWriteOptions.from_platform_config(platform_config)
-            sort_coords = write_options.sort_coords
+        write_options = TileDBWriteOptions.from_platform_config(platform_config)
+        sort_coords = write_options.sort_coords
 
         clib_sparse_array = self._handle._handle
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1864,11 +1864,10 @@ def test_global_writes(tmp_path):
     with soma.SparseNDArray.open(tmp_path.as_posix()) as A:
         assert A.read().tables().concat() == data
 
-    with pytest.warns(DeprecationWarning) as warning:
+    with pytest.raises(ValueError):
+        # Takes TileDBWriteOptions as of TileDB-SOMA 1.13
         with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A:
             A.write(
                 data,
                 platform_config=soma.TileDBCreateOptions(),
             )
-        assert "The write parameter now takes in TileDBWriteOptions instead "
-        "of TileDBCreateOptions" == warning[0].message


### PR DESCRIPTION
Implements #2841 

See also [[sc-52470]](https://app.shortcut.com/tiledb-inc/story/52470/python-implement-scheduled-removal-of-tiledbcreateoptions-being-passed-to-write-methods)