### PR TITLE
[c++] Only evolve schema when enumerations are extended

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1589,9 +1589,9 @@ def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
         data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
         sdf.write(pa.Table.from_pydict(data))
 
-    # total 4 fragment files
+    # total 3 fragment files
 
     vfs = tiledb.VFS()
     # subtract 1 for the __schema/__enumerations directory;
     # only looking at fragment files
-    assert len(vfs.ls(os.path.join(uri, "__schema"))) == 4
+    assert len(vfs.ls(os.path.join(uri, "__schema"))) - 1 == 3

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import os
 from typing import Dict, List
 
 import numpy as np
@@ -1543,3 +1544,54 @@ def test_nullable(tmp_path):
     with soma.DataFrame.open(uri, "r") as sdf:
         df = sdf.read().concat().to_pandas()
         assert df.compare(data.to_pandas()).empty
+
+
+def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
+    uri = tmp_path.as_posix()
+
+    schema = pa.schema(
+        [
+            pa.field("foo", pa.dictionary(pa.int64(), pa.large_string())),
+            pa.field("bar", pa.large_string()),
+        ]
+    )
+
+    # +1 creating the schema
+    # +1 evolving the schema
+    with soma.DataFrame.create(uri, schema=schema) as sdf:
+        data = {}
+        data["soma_joinid"] = [0, 1, 2, 3, 4]
+        data["foo"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
+        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        sdf.write(pa.Table.from_pydict(data))
+
+    # +1 evolving the schema
+    with soma.DataFrame.open(uri, "w") as sdf:
+        data = {}
+        data["soma_joinid"] = [0, 1, 2, 3, 4]
+        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
+        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        sdf.write(pa.Table.from_pydict(data))
+
+    # +0 no changes to enumeration values
+    with soma.DataFrame.open(uri, "w") as sdf:
+        data = {}
+        data["soma_joinid"] = [0, 1, 2, 3, 4]
+        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
+        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        sdf.write(pa.Table.from_pydict(data))
+
+    # +0 no changes enumeration values
+    with soma.DataFrame.open(uri, "w") as sdf:
+        data = {}
+        data["soma_joinid"] = [0, 1, 2, 3, 4]
+        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "d"])
+        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        sdf.write(pa.Table.from_pydict(data))
+
+    # total 4 fragment files
+
+    vfs = tiledb.VFS()
+    # subtract 1 for the __schema/__enumerations directory;
+    # only looking at fragment files
+    assert len(vfs.ls(os.path.join(uri, "__schema"))) == 4

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -759,7 +759,7 @@ class SOMAArray : public SOMAObject {
 
     uint64_t _get_max_capacity(tiledb_datatype_t index_type);
 
-    Enumeration _extend_enumeration(
+    bool _extend_enumeration(
         ArrowSchema* value_schema,
         ArrowArray* value_array,
         ArrowSchema* index_schema,
@@ -767,7 +767,7 @@ class SOMAArray : public SOMAObject {
         ArraySchemaEvolution se);
 
     template <typename ValueType>
-    Enumeration _extend_and_evolve_schema(
+    bool _extend_and_evolve_schema(
         ArrowArray* value_array,
         ArrowSchema* index_schema,
         ArrowArray* index_array,
@@ -816,21 +816,19 @@ class SOMAArray : public SOMAObject {
             index_schema->format = ArrowAdapter::to_arrow_format(
                                        disk_index_type)
                                        .data();
-
-            return extended_enmr;
+            return true;
         }
-
-        return enmr;
+        return false;
     }
 
-    Enumeration _extend_and_evolve_schema_str(
+    bool _extend_and_evolve_schema_str(
         ArrowSchema* value_schema,
         ArrowArray* value_array,
         ArrowSchema* index_schema,
         ArrowArray* index_array,
         ArraySchemaEvolution se);
 
-    void _create_and_cast_column(
+    bool _create_and_cast_column(
         ArrowSchema* orig_column_schema,
         ArrowArray* orig_column_array,
         ArrowSchema* new_column_schema,


### PR DESCRIPTION
**Issue and/or context:**

As caught be @eddelbuettel, the C++ write path was calling `SchemaEvolution.array_evolve` for every write. This call is only necessary if we have extended the enumerations. Otherwise, we end up bloating the `__schema` directory with unnecessary fragment files.

**Changes:**

- `SOMAArray` methods `_extend_enumeration`, `_extend_and_evolve_schema{,_str}`, and `_create_and_cast_column` return `bool` to indicate whether the column called `SchemaEvolution.extend_enumeration`
- Only call `SchemaEvolution.array_evolve` if any of the columns in the table called `SchemaEvolution.extend_enumeration`

**Notes for Reviewer:**

The test for this is written in Python as it is much more complicated to construct an `ArrowTable` with dictionary columns in C++.
