### PR TITLE
[python] pin `pandas-stubs>=2` during pre-commit `mypy` hook

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**'
       - '!**.md'
-      - '!apis/python/**'
-      - '!docs/**'
       - '!.github/**'
       - '.github/workflows/r-ci.yml'
+      - '!.pre-commit-config.yaml'
+      - '!apis/python/**'
+      - '!docs/**'
+      - '!LICENSE''
   push:
     branches:
       - main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,10 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-        - pandas-stubs
+        # Pandas types changed between 1.x and 2.x. Our setup.py permits both, but for type-checking purposes we use the
+        # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
+        # for more info.
+        - "pandas-stubs>=2"
         - "somacore==1.0.13"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -10,29 +10,20 @@ from somacore.query.types import IndexLike
 
 from tiledbsoma import pytiledbsoma as clib
 
+from ._types import PDSeries
+
 if TYPE_CHECKING:
     from .options import SOMATileDBContext
 
-    IndexerDataType = Union[
-        npt.NDArray[np.int64],
-        pa.Array,
-        pa.IntegerArray,
-        pd.Series[Any],
-        pd.arrays.IntegerArray,
-        pa.ChunkedArray,
-        List[int],
-    ]
-
-else:
-    IndexerDataType = Union[
-        npt.NDArray[np.int64],
-        pa.Array,
-        pa.IntegerArray,
-        pd.Series,
-        pd.arrays.IntegerArray,
-        pa.ChunkedArray,
-        List[int],
-    ]
+IndexerDataType = Union[
+    npt.NDArray[np.int64],
+    pa.Array,
+    pa.IntegerArray,
+    PDSeries,
+    pd.arrays.IntegerArray,
+    pa.ChunkedArray,
+    List[int],
+]
 
 
 def tiledbsoma_build_index(

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -17,26 +17,35 @@ from somacore import types
 from typing_extensions import Literal
 
 if TYPE_CHECKING:
+    # `pd.{Series,Index}` require type parameters iff `pandas>=2`. Our pandas dependency (in `setup.py`) is unpinned,
+    # which generally resolves to `pandas>=2`, but may be pandas<2 if something else in the user's environment requires
+    # that. For type-checking purposes, `.pre-commit-config.yaml` specifies `pandas-stubs>=2`, and we type-check against
+    # the `pandas>=2` types here.
+    PDSeries = pd.Series[Any]
+    PDIndex = pd.Index[Any]
+
     NPInteger = np.integer[npt.NBitBase]
     NPFloating = np.floating[npt.NBitBase]
     NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
-    # A pd.Series of "Any" type will raise mypy error:
-    PDSeries = pd.Series[Any]  # type: ignore[misc]
 else:
+    # When not-type-checking, but running with `pandas>=2`, the "missing" type-params don't affect anything.
+    PDSeries = pd.Series
+    PDIndex = pd.Index
+
+    # Type subscription requires python >= 3.9, and we currently only type-check against 3.11.
+    # TODO: remove these (and unify around subscripted types above) when we drop support for 3.8.
     NPInteger = np.integer
     NPFloating = np.floating
+    # This alias likely needs to remain special-cased, even in Python ≥3.11, as tests pass the `Matrix` type alias
+    # (which includes `NPNDArray` via `DenseMatrix`) to `isinstance`, causing error "argument 2 cannot be a
+    # parameterized generic".
     NPNDArray = np.ndarray
-    PDSeries = pd.Series
-
 
 Path = Union[str, pathlib.Path]
 
 Ids = Union[List[str], List[bytes], List[int]]
 
-if TYPE_CHECKING:
-    Labels = Union[Sequence[str], pd.Index[Any]]
-else:
-    Labels = Union[Sequence[str], pd.Index]
+Labels = Union[Sequence[str], PDIndex]
 
 NTuple = Tuple[int, ...]
 


### PR DESCRIPTION
also simplify some `if TYPE_CHECKING` blocks

**Issue and/or context:** #2839, #2853

The unpinned `pandas-stubs` dep in `.pre-commit-config.yaml` allowed existing local environments (and old cached `setup-python` environments, which in some cases were being incorrectly used in our GHAs, per https://github.com/actions/setup-python/issues/919) to run the pre-commit `mypy` hook using `pandas-stubs<2`, where `pd.Series` is the type, and `pd.Series[Any]` requires a `# type: ignore[misc]` annotation.

With `pandas-stubs>=2` (which new environments have been picking up), `pd.Series[Any]` is the correct type, and the `# type: ignore[misc]` annotation was flagged as "unused" ([example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/10291856865/job/28485041039?pr=2853#step:7:43)).

Pinning `pandas-stubs>=2`, and using the corresponding `pd.{Series,Index}[Any]` annotations when `TYPE_CHECKING`, should resolve this conflict, in both new and existing environments (in existing environments, `pre-commit` will recognize the new `pandas-stubs>=2` pin, and create a new venv that incorporates it).