### PR TITLE
[python] Offer better guidance on attribute names with `.`

### DIFF
--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -195,6 +195,13 @@ class QueryConditionTree(ast.NodeVisitor):
     def visit_List(self, node):
         return list(node.elts)
 
+    def visit_Attribute(self, node) -> clib.PyQueryCondition:
+        raise SOMAError(
+            f"Unhandled dot operator in {ast.dump(node)} -- if your attribute name "
+            'has a dot in it, e.g. `orig.ident`, please wrap it with `attr("...")`, '
+            'e.g. `attr("orig.ident")`'
+        )
+
     def visit_Compare(self, node: ast.Compare) -> clib.PyQueryCondition:
         operator = self.visit(node.ops[0])
 

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -243,6 +243,11 @@ def test_eval_error_conditions(malformed_condition):
             "louvain == leuko-cyte",
             "Unable to parse expression component.* did you mean to quote it as a string",
         ],
+        # FOO
+        [
+            'lou.vain == "leukocyte"',
+            "if your attribute name has a dot in it",
+        ],
     ],
 )
 def test_query_condition_syntax_handling(expression_and_message):


### PR DESCRIPTION
**Issue and/or context:** #2832 

@kounelisagis I suggest that we should do the same in TileDB-Py. I'll file a Shortcut task.

**Changes:** Provide a better error message.

**Notes for Reviewer:**

Script:

```
#!/usr/bin/env python
import tiledbsoma
expr = 'lou.vain == "leukocyte"'
uri = '/var/p'
with tiledbsoma.Experiment.open(uri) as exp:
    o = exp.obs.read(value_filter=expr).concat()
    print(o)
```

Before:

```
Traceback (most recent call last):
  File "/Users/johnkerl/git/johnkerl/tiledb-misc/notes/2024-08-06-qcond-syntax/x", line 6, in <module>
    o = exp.obs.read(value_filter=expr).concat()
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py", line 409, in read
    sr.set_condition(QueryCondition(value_filter), handle.schema)
tiledbsoma._exception.SOMAError: SOMAError: Incorrect type for attribute name: Constant(value='leukocyte')
```

After:

```
Traceback (most recent call last):
  File "/Users/johnkerl/git/johnkerl/tiledb-misc/notes/2024-08-06-qcond-syntax/x", line 6, in <module>
    o = exp.obs.read(value_filter=expr).concat()
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/_dataframe.py", line 409, in read
    sr.set_condition(QueryCondition(value_filter), handle.schema)
tiledbsoma._exception.SOMAError: SOMAError: Unhandled dot operator in Attribute(value=Name(id='lou', ctx=Load()), 
attr='vain', ctx=Load()) -- if your attribute name has a dot in it, e.g. `orig.ident`, please wrap it with
`attr("...")`, e.g. `attr("orig.ident")`
```