### PR TITLE
[r] Expose timestamps publicly and plumb through for resume-mode

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -165,7 +165,7 @@ SOMADataFrame <- R6::R6Class(
                      colnames = column_names,
                      qc = value_filter,
                      dim_points = coords,
-                     timestamprange = private$tiledb_timestamp,  # NULL or two-elem vector
+                     timestamprange = self$tiledb_timestamp,  # NULL or two-elem vector
                      loglevel = log_level)
       private$ctx_ptr <- rl$ctx
       TableReadIter$new(rl$sr)

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -51,8 +51,8 @@ SOMASparseNDArray <- R6::R6Class(
                      config = cfg,
                      dim_points = coords,
                      result_order = result_order,
-                     timestamprange = if (is.null(private$tiledb_timestamp)) private$tiledb_timestamp
-                                      else c(0, private$tiledb_timestamp),
+                     timestamprange = if (is.null(self$tiledb_timestamp)) self$tiledb_timestamp
+                                      else c(0, self$tiledb_timestamp),
                      loglevel = log_level)
       private$ctx_ptr <- rl$ctx
       SOMASparseNDArrayRead$new(rl$sr, self, coords)
@@ -222,8 +222,9 @@ SOMASparseNDArray <- R6::R6Class(
       stopifnot(is.data.frame(values))
       # private$log_array_ingestion()
       arr <- self$object
-      if (!is.null(private$tiledb_timestamp)) {
-          arr@timestamp <- private$tiledb_timestamp
+      if (!is.null(self$tiledb_timestamp)) {
+          # arr@timestamp <- self$tiledb_timestamp
+        arr@timestamp_end <- self$tiledb_timestamp
       }
       nms <- colnames(values)
 

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -26,16 +26,16 @@ TileDBArray <- R6::R6Class(
       }
 
       private$.mode <- mode
-      if (is.null(private$tiledb_timestamp)) {
+      if (is.null(self$tiledb_timestamp)) {
         spdl::debug("[TileDBArray$open] Opening {} '{}' in {} mode", self$class(), self$uri, mode)
         private$.tiledb_array <- tiledb::tiledb_array_open(self$object, type = mode)
       } else {
         if (is.null(internal_use_only)) stopifnot("tiledb_timestamp not yet supported for WRITE mode" = mode == "READ")
         spdl::debug("[TileDBArray$open] Opening {} '{}' in {} mode at ({},{})",
-                    self$class(), self$uri, mode, private$tiledb_timestamp[1],
-                    private$tiledb_timestamp[2])
+                    self$class(), self$uri, mode, self$tiledb_timestamp[1],
+                    self$tiledb_timestamp[2])
         #private$.tiledb_array <- tiledb::tiledb_array_open_at(self$object, type = mode,
-        #                                                      timestamp = private$tiledb_timestamp)
+        #                                                      timestamp = self$tiledb_timestamp)
       }
 
       ## TODO -- cannot do here while needed for array case does not work for data frame case

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -52,12 +52,12 @@ TileDBGroup <- R6::R6Class(
                    "factory method as e.g. 'SOMACollectionOpen()'."), call. = FALSE)
       }
       private$.mode = mode
-      private$.group_open_timestamp <- if (mode == "READ" && is.null(private$tiledb_timestamp)) {
+      private$.group_open_timestamp <- if (mode == "READ" && is.null(self$tiledb_timestamp)) {
         # In READ mode, if the opener supplied no timestamp then we default to the time of
         # opening, providing a temporal snapshot of all group members.
         Sys.time()
       } else {
-        private$tiledb_timestamp
+        self$tiledb_timestamp
       }
       if (is.null(private$.group_open_timestamp)) {
         spdl::debug("Opening {} '{}' in {} mode", self$class(), self$uri, mode)
@@ -312,7 +312,7 @@ TileDBGroup <- R6::R6Class(
     .tiledb_group = NULL,
 
     # This field stores the timestamp with which we opened the group, whether we used the
-    # opener-supplied private$tiledb_timestamp, or defaulted to the time of opening, or neither
+    # opener-supplied self$tiledb_timestamp, or defaulted to the time of opening, or neither
     # (NULL). This is the timestamp to propagate to accessed members.
     .group_open_timestamp = NULL,
 

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -40,7 +40,7 @@ TileDBObject <- R6::R6Class(
 
       if (!is.null(tiledb_timestamp)) {
         stopifnot("'tiledb_timestamp' must be a POSIXct datetime object" = inherits(tiledb_timestamp, "POSIXct"))
-        private$tiledb_timestamp <- tiledb_timestamp
+        private$.tiledb_timestamp <- tiledb_timestamp
       }
 
       spdl::debug("[TileDBObject] initialize {} with '{}' at ({},{})", self$class(), self$uri,
@@ -94,7 +94,7 @@ TileDBObject <- R6::R6Class(
           inherits(tiledb_timestamp, what = "POSIXct")
       )
       self$close()
-      private$tiledb_timestamp <- tiledb_timestamp
+      private$.tiledb_timestamp <- tiledb_timestamp
       self$open(mode, internal_use_only = 'allowed_use')
       return(invisible(self))
     },
@@ -136,6 +136,14 @@ TileDBObject <- R6::R6Class(
       }
       return(private$.tiledbsoma_ctx)
     },
+    #' @field tiledb_timestamp Time that object was opened at
+    #'
+    tiledb_timestamp = function(value) {
+      if (!missing(value)) {
+        private$.read_only_error("tiledb_timestamp")
+      }
+      return(private$.tiledb_timestamp)
+    },
     #' @field uri
     #' The URI of the TileDB object.
     uri = function(value) {
@@ -168,7 +176,7 @@ TileDBObject <- R6::R6Class(
 
     # Opener-supplied POSIXct timestamp, if any. TileDBArray and TileDBGroup are each responsible
     # for making this effective, since the methods differ slightly.
-    tiledb_timestamp = NULL,
+    .tiledb_timestamp = NULL,
 
     # Internal context
     .tiledbsoma_ctx = NULL,

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -123,7 +123,11 @@ uns_hint <- function(type = c('1d', '2d')) {
 .read_soma_joinids <- function(x, ...) {
   stopifnot(inherits(x = x, what = 'TileDBArray'))
   oldmode <- x$mode()
-  on.exit(x$reopen(oldmode), add = TRUE, after = FALSE)
+  on.exit(
+    x$reopen(oldmode, tiledb_timestamp = x$tiledb_timestamp),
+    add = TRUE,
+    after = FALSE
+  )
   op <- options(arrow.int64_downcast = FALSE)
   on.exit(options(op), add = TRUE, after = FALSE)
   ids <- UseMethod(generic = '.read_soma_joinids', object = x)
@@ -138,7 +142,7 @@ uns_hint <- function(type = c('1d', '2d')) {
 #' @export
 #'
 .read_soma_joinids.SOMADataFrame <- function(x, ...) {
-  x$reopen("READ")
+  x$reopen("READ", tiledb_timestamp = x$tiledb_timestamp)
   return(x$read(column_names = "soma_joinid")$concat()$GetColumnByName("soma_joinid")$as_vector())
 }
 
@@ -159,13 +163,13 @@ uns_hint <- function(type = c('1d', '2d')) {
   if (axis < 0L || axis >= length(x$dimnames())) {
     stop("'axis' must be between 0 and ", length(x$dimnames()), call. = FALSE)
   }
-  x$reopen("READ")
+  x$reopen("READ", tiledb_timestamp = x$tiledb_timestamp)
   dimname <- x$dimnames()[axis + 1L]
   rl <- sr_setup(
     uri = x$uri,
     config = as.character(tiledb::config(x$tiledbsoma_ctx$context())),
     colnames = dimname,
-    timestamprange = c(0, x$.__enclos_env__$private$tiledb_timestamp)
+    timestamprange = c(0, x$tiledb_timestamp)
   )
   return(TableReadIter$new(rl$sr)$concat()$GetColumnByName(dimname)$as_vector())
 }

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -466,7 +466,8 @@ write_soma.TsparseMatrix <- function(
     shape = shape %||% dim(x),
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx
+    tiledbsoma_ctx = tiledbsoma_ctx,
+    tiledb_timestamp = Sys.time()
   )
   # Write values
   if (ingest_mode %in% c('resume')) {
@@ -606,13 +607,13 @@ write_soma.TsparseMatrix <- function(
   )
   xmode <- x$mode()
   if (xmode == 'CLOSED') {
-    x$reopen('READ')
+    x$reopen('READ', tiledb_timestamp = x$tiledb_timestamp)
     xmode <- x$mode()
   }
   on.exit(x$reopen(mode = xmode), add = TRUE, after = FALSE)
   oldmode <- soma_parent$mode()
   if (oldmode == 'CLOSED') {
-    soma_parent$reopen("READ")
+    soma_parent$reopen("READ", tiledb_timestamp = soma_parent$tiledb_timestamp)
     oldmode <- soma_parent$mode()
   }
   on.exit(soma_parent$reopen(oldmode), add = TRUE, after = FALSE)

--- a/apis/r/man/TileDBObject.Rd
+++ b/apis/r/man/TileDBObject.Rd
@@ -14,6 +14,8 @@ TileDBGroup classes. (lifecycle: maturing)
 
 \item{\code{tiledbsoma_ctx}}{SOMATileDBContext}
 
+\item{\code{tiledb_timestamp}}{Time that object was opened at}
+
 \item{\code{uri}}{The URI of the TileDB object.}
 }
 \if{html}{\out{</div>}}
@@ -106,7 +108,7 @@ otherwise returns the mode (eg. \dQuote{\code{READ}}) of the object
 \subsection{Method \code{reopen()}}{
 Close and reopen the TileDB object in a new mode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBObject$reopen(mode, tiledb_timestamp = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -117,6 +119,8 @@ Close and reopen the TileDB object in a new mode
 \item \dQuote{\code{READ}}
 \item \dQuote{\code{WRITE}}
 }}
+
+\item{\code{tiledb_timestamp}}{Optional Datetime (POSIXct) with TileDB timestamp}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Expose timestamps publicly through a new active binding; replace calls to `private$tiledb_timestamp` with `self$tiledb_timestamp`

Also plumb timestamps through for `write_soma()` in resume-mode