### PR TITLE
[python] More AnnData equality assertions in tests

### DIFF
--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -11,10 +11,8 @@ import urllib.parse
 from itertools import zip_longest
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
 
-import pandas as pd
 import pyarrow as pa
 import somacore
-from anndata import AnnData
 from somacore import options
 
 from . import pytiledbsoma as clib
@@ -295,42 +293,6 @@ def pa_types_is_string_or_bytes(dtype: pa.DataType) -> bool:
         or pa.types.is_string(dtype)
         or pa.types.is_binary(dtype)
     )
-
-
-def anndata_dataframe_unmodified(old: pd.DataFrame, new: pd.DataFrame) -> bool:
-    """
-    Checks that we didn't mutate the object while ingesting. Intended for unit tests.
-    """
-    try:
-        return bool((old == new).all().all())
-    except ValueError:
-        # Can be thrown when columns don't match -- which is what we check for
-        return False
-
-
-def anndata_dataframe_unmodified_nan_safe(old: pd.DataFrame, new: pd.DataFrame) -> bool:
-    """
-    Same as anndata_dataframe_unmodified, except it works with NaN data.
-    A key property of NaN is it's not equal to itself: x != x.
-    """
-
-    if old.index.name != new.index.name:
-        return False
-    if len(old) != len(new):
-        return False
-    if any(old.keys() != new.keys()):
-        return False
-    return True
-
-
-def verify_obs_and_var_eq(ad0: AnnData, ad1: AnnData, nan_safe: bool = False) -> None:
-    """Verify that two ``AnnData``'s ``obs`` and ``var`` dataframes are equivalent."""
-    if nan_safe:
-        assert anndata_dataframe_unmodified_nan_safe(ad0.obs, ad1.obs)
-        assert anndata_dataframe_unmodified_nan_safe(ad0.var, ad1.var)
-    else:
-        assert anndata_dataframe_unmodified(ad0.obs, ad1.obs)
-        assert anndata_dataframe_unmodified(ad0.var, ad1.var)
 
 
 def cast_values_to_target_schema(values: pa.Table, schema: pa.Schema) -> pa.Table:

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -2,10 +2,71 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Tuple, Type, Union
 
+import numpy as np
+import pandas as pd
 import pytest
 from _pytest._code import ExceptionInfo
 from _pytest.python_api import E, RaisesContext
+from anndata import AnnData
+from numpy import array_equal
+from pandas._testing import assert_frame_equal, assert_series_equal
+from scipy.sparse import spmatrix
 from typeguard import suppress_type_checks
+
+
+def assert_uns_equal(uns0, uns1):
+    assert uns0.keys() == uns1.keys()
+    for k, v0 in uns0.items():
+        try:
+            v1 = uns1[k]
+            if isinstance(v0, dict):
+                assert isinstance(v1, dict)
+                assert_uns_equal(v0, v1)
+            elif isinstance(v0, list):
+                assert isinstance(v1, list)
+                assert len(v0) == len(v1)
+                for e0, e1 in zip(v0, v1):
+                    assert_uns_equal(e0, e1)
+            elif isinstance(v0, pd.DataFrame):
+                assert_frame_equal(v0, v1)
+            elif isinstance(v0, pd.Series):
+                assert_series_equal(v0, v1)
+            elif isinstance(v0, np.ndarray):
+                assert array_equal(v0, v1)
+            elif isinstance(v0, (int, float, str, bool)):
+                assert v0 == v1
+            else:
+                raise ValueError(f"Unsupported type: {type(v0)}")
+        except AssertionError:
+            raise AssertionError(f"assert_uns_equal: key {k} mismatched")
+
+
+def assert_array_dicts_equal(d0, d1):
+    assert d0.keys() == d1.keys()
+    for k in d0.keys():
+        assert_array_equal(d0[k], d1[k])
+
+
+def assert_array_equal(a0, a1):
+    assert type(a0) is type(a1)
+    if isinstance(a0, np.ndarray):
+        assert array_equal(a0, a1)
+    elif isinstance(a0, spmatrix):
+        assert array_equal(a0.todense(), a1.todense())
+    else:
+        raise ValueError(f"Unsupported type: {type(a0)}")
+
+
+def assert_adata_equal(ad0: AnnData, ad1: AnnData):
+    assert_frame_equal(ad0.obs, ad1.obs)
+    assert_frame_equal(ad0.var, ad1.var)
+    assert_uns_equal(ad0.uns, ad1.uns)
+    assert_array_equal(ad0.X, ad1.X)
+    assert_array_dicts_equal(ad0.obsm, ad1.obsm)
+    assert_array_dicts_equal(ad0.varm, ad1.varm)
+    assert_array_dicts_equal(ad0.obsp, ad1.obsp)
+    assert_array_dicts_equal(ad0.varp, ad1.varp)
+
 
 HERE = Path(__file__).parent
 PY_ROOT = HERE.parent
@@ -28,7 +89,7 @@ def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
 def maybe_raises(
     expected_exception: Union[None, Type[E], Tuple[Type[E], ...]],
     *args: Any,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Union[RaisesContext[E], ExceptionInfo[E]]:
     """
     Wrapper around ``pytest.raises`` that accepts None (signifying no exception should be raised).

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1070,11 +1070,11 @@ def test_uns_io(tmp_path, outgest_uns_keys):
             .reset_index()
         )
 
-    # Outgest also fails to restore `obs` and `var` properly, in this case because the ingested
+    # Outgest also fails to restore `obs` and `var` correctly, in this case because the ingested
     # `obs`/`var` had columns named "obs_id"/"var_id", which get mistaken for "default index"
     # columns and set as `df.index` on outgest; their names are also removed. This corresponds to
     # case #2 from https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
-    # TODO: fix `to_anndata` to restore `obs` and `var` properly.
+    # TODO: fix `to_anndata` to restore `obs` and `var` as ingested.
     expected_adata.obs = expected_adata.obs.set_index("obs_id")
     expected_adata.obs.index.name = None
     expected_adata.var = expected_adata.var.set_index("var_id")

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 from typing import Optional
 
@@ -10,15 +11,16 @@ import pandas as pd
 import pytest
 import scipy
 import somacore
+from scipy.sparse import csr_matrix
 
 import tiledbsoma
 import tiledbsoma.io
-from tiledbsoma import Experiment, _constants, _factory
+from tiledbsoma import SOMA_JOINID, Experiment, _constants, _factory
 from tiledbsoma._soma_object import SOMAObject
-from tiledbsoma._util import verify_obs_and_var_eq
+from tiledbsoma.io._common import _TILEDBSOMA_TYPE
 import tiledb
 
-from ._util import TESTDATA
+from ._util import TESTDATA, assert_adata_equal
 
 
 @pytest.fixture
@@ -111,7 +113,7 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
         if ingest_mode != "schema_only":
             have_ingested = True
 
-        verify_obs_and_var_eq(original, conftest_pbmc_small)
+        assert_adata_equal(original, conftest_pbmc_small)
 
         exp = tiledbsoma.Experiment.open(uri)
 
@@ -403,12 +405,12 @@ def test_ingest_uns(
         uns_keys=ingest_uns_keys,
     )
 
-    verify_obs_and_var_eq(conftest_pbmc3k_adata, adata_extended2)
+    assert_adata_equal(conftest_pbmc3k_adata, adata_extended2)
 
     with tiledbsoma.Experiment.open(uri) as exp:
         uns = exp.ms["hello"]["uns"]
         assert isinstance(uns, tiledbsoma.Collection)
-        assert uns.metadata["soma_tiledbsoma_type"] == "uns"
+        assert uns.metadata[_TILEDBSOMA_TYPE] == "uns"
         if ingest_uns_keys is None:
             assert set(uns) == {
                 "draw_graph",
@@ -476,7 +478,7 @@ def test_add_matrix_to_collection(conftest_pbmc_small):
         output_path, conftest_pbmc_small, measurement_name="RNA"
     )
 
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     exp = tiledbsoma.Experiment.open(uri)
     with _factory.open(output_path) as exp_r:
@@ -606,7 +608,7 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
         output_path, conftest_pbmc_small, measurement_name="RNA"
     )
 
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     exp = tiledbsoma.Experiment.open(uri)
     with _factory.open(output_path) as exp_r:
@@ -670,7 +672,7 @@ def test_export_anndata(conftest_pbmc_small):
 
     tiledbsoma.io.from_anndata(output_path, conftest_pbmc_small, measurement_name="RNA")
 
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     with _factory.open(output_path) as exp:
         with pytest.raises(ValueError):
@@ -766,7 +768,7 @@ def test_null_obs(conftest_pbmc_small, tmp_path: Path):
         ingest_mode="write",
         X_kind=tiledbsoma.SparseNDArray,
     )
-    verify_obs_and_var_eq(original, conftest_pbmc_small, nan_safe=True)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     exp = tiledbsoma.Experiment.open(uri)
     with tiledb.open(exp.obs.uri, "r") as obs:
@@ -796,7 +798,7 @@ def test_export_obsm_with_holes(h5ad_file_with_obsm_holes, tmp_path):
     output_path = tmp_path.as_posix()
     tiledbsoma.io.from_anndata(output_path, adata, "RNA")
 
-    verify_obs_and_var_eq(original, adata)
+    assert_adata_equal(original, adata)
 
     exp = tiledbsoma.Experiment.open(output_path)
 
@@ -942,7 +944,7 @@ def test_id_names(tmp_path, obs_id_name, var_id_name, indexify_obs, indexify_var
         obs_id_name=obs_id_name,
         var_id_name=var_id_name,
     )
-    verify_obs_and_var_eq(original, adata)
+    assert_adata_equal(original, adata)
 
     with tiledbsoma.Experiment.open(uri) as exp:
         assert obs_id_name in exp.obs.keys()
@@ -988,7 +990,7 @@ def test_uns_io(tmp_path, outgest_uns_keys):
         data={"var_id": np.asarray(["x", "y"])},
         index=np.arange(2).astype(str),
     )
-    X = np.zeros([3, 2])
+    X = csr_matrix(np.zeros([3, 2]))
 
     uns = {
         # These are stored in SOMA as metadata
@@ -1022,44 +1024,68 @@ def test_uns_io(tmp_path, outgest_uns_keys):
         uns=uns,
         dtype=X.dtype,
     )
-    original = adata.copy()
+    adata0 = deepcopy(adata)
 
     soma_uri = tmp_path.as_posix()
 
     tiledbsoma.io.from_anndata(soma_uri, adata, measurement_name="RNA")
-    verify_obs_and_var_eq(original, adata)
+
+    # NOTE: `from_anndata` mutates user-provided DataFrames in `uns`, demoting their index to a column named "index",
+    # and installing a `soma_joinid` index. Here we patch the "expected" adata to reflect this, before comparing to
+    # the post-`froM_anndata` `adata`.
+    # TODO: fix `from_anndata` to not modify DataFrames in user-provided `uns`.
+    expected_adata = deepcopy(adata0)
+    for k in ["pd_df_indexed", "pd_df_nonindexed"]:
+        df = expected_adata.uns[k]
+        expected_adata.uns[k] = df.reset_index().set_index(
+            pd.Index(list(range(len(df))), name=SOMA_JOINID)
+        )
+
+    assert_adata_equal(expected_adata, adata)
 
     with tiledbsoma.Experiment.open(soma_uri) as exp:
-        bdata = tiledbsoma.io.to_anndata(
+        adata2 = tiledbsoma.io.to_anndata(
             exp,
             measurement_name="RNA",
             uns_keys=outgest_uns_keys,
         )
 
-    # Keystroke-savers
-    a = adata.uns
-    b = bdata.uns
+    expected_adata = deepcopy(adata0)
 
-    if outgest_uns_keys is None:
-        assert a["int_scalar"] == b["int_scalar"]
-        assert a["float_scalar"] == b["float_scalar"]
-        assert a["string_scalar"] == b["string_scalar"]
-
-        assert all(a["pd_df_indexed"]["column_1"] == b["pd_df_indexed"]["column_1"])
-        assert all(
-            a["pd_df_nonindexed"]["column_1"] == b["pd_df_nonindexed"]["column_1"]
+    # When outgesting `uns` DataFrames, `to_anndata` fails to remove the `soma_joinid` column added
+    # during ingest. It also demotes the original `df.index` to a column named "index". Here we
+    # patch the "expected" adata to reflect this, before comparing to the post-`to_anndata`
+    # `adata`.
+    # TODO: use `_read_dataframe` during `uns` DataFrame outgest (which does a better job restoring
+    #  the original pd.DataFrame, dropping `soma_joinid` and restoring the original `df.index`).
+    for k in ["pd_df_indexed", "pd_df_nonindexed"]:
+        df = expected_adata.uns[k]
+        expected_adata.uns[k] = (
+            df
+            # original index becomes column (with default name "index")
+            .reset_index()
+            # soma_joinid index added during ingest
+            .set_index(pd.Index(list(range(len(df))), name=SOMA_JOINID))
+            # soma_joinid outgested as first column
+            .reset_index()
         )
 
-        assert (a["np_ndarray_1d"] == b["np_ndarray_1d"]).all()
-        assert (a["np_ndarray_2d"] == b["np_ndarray_2d"]).all()
+    # Outgest also fails to restore `obs` and `var` properly, in this case because the ingested
+    # `obs`/`var` had columns named "obs_id"/"var_id", which get mistaken for "default index"
+    # columns and set as `df.index` on outgest; their names are also removed. This corresponds to
+    # case #2 from https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
+    # TODO: fix `to_anndata` to restore `obs` and `var` properly.
+    expected_adata.obs = expected_adata.obs.set_index("obs_id")
+    expected_adata.obs.index.name = None
+    expected_adata.var = expected_adata.var.set_index("var_id")
+    expected_adata.var.index.name = None
 
-        sa = a["strings"]
-        sb = b["strings"]
-        assert (sa["string_np_ndarray_1d"] == sb["string_np_ndarray_1d"]).all()
-        assert (sa["string_np_ndarray_2d"] == sb["string_np_ndarray_2d"]).all()
+    if outgest_uns_keys is not None:
+        expected_adata.uns = {
+            k: v for k, v in expected_adata.uns.items() if k in outgest_uns_keys
+        }
 
-    else:
-        assert set(b.keys()) == set(outgest_uns_keys)
+    assert_adata_equal(expected_adata, adata2)
 
 
 @pytest.mark.parametrize("write_index", [0, 1])
@@ -1078,7 +1104,7 @@ def test_string_nan_columns(tmp_path, conftest_pbmc_small, write_index):
     uri = tmp_path.as_posix()
     original = conftest_pbmc_small.copy()
     tiledbsoma.io.from_anndata(uri, conftest_pbmc_small, measurement_name="RNA")
-    verify_obs_and_var_eq(original, conftest_pbmc_small, nan_safe=True)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     # Step 3
     with tiledbsoma.open(uri, "r") as exp:
@@ -1136,7 +1162,7 @@ def test_index_names_io(tmp_path, obs_index_name, var_index_name):
 
     original = adata.copy()
     tiledbsoma.io.from_anndata(soma_uri, adata, measurement_name)
-    verify_obs_and_var_eq(original, adata)
+    assert_adata_equal(original, adata)
 
     with tiledbsoma.Experiment.open(soma_uri) as exp:
         bdata = tiledbsoma.io.to_anndata(exp, measurement_name)

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -209,8 +209,8 @@ def test_adata_io_roundtrips(
     assert_frame_equal(outgested_obs, outgested_df)
 
     expected = deepcopy(adata0)
-    # Patch in the expected "outgested" DataFrame (which in these test cases is known to differ
-    # from what was ingested).
+    # Patch in the expected outgested DataFrame (which in these test cases is known to differ from
+    # what was ingested).
     expected.obs = outgested_df
     # TODO: outgest same format that was ingest
     expected.X = csr_matrix(expected.X)

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -191,7 +191,7 @@ def test_adata_io_roundtrips(
     n_obs = len(original_df)
     var = pd.DataFrame({"var1": [1, 2, 3], "var2": ["a", "b", "c"]})  # unused
     n_var = len(var)
-    X = np.array([0] * n_obs * n_var).reshape(n_obs, n_var)  # unused
+    X = csr_matrix(np.array([0] * n_obs * n_var).reshape(n_obs, n_var))  # unused
     adata0 = AnnData(X=X, obs=original_df, var=var)
     ingested_uri = from_anndata(uri, adata0, "meas", obs_id_name=ingest_id_column_name)
     assert ingested_uri == uri
@@ -212,8 +212,6 @@ def test_adata_io_roundtrips(
     # Patch in the expected outgested DataFrame (which in these test cases is known to differ from
     # what was ingested).
     expected.obs = outgested_df
-    # TODO: outgest same format that was ingest
-    expected.X = csr_matrix(expected.X)
     assert_adata_equal(expected, adata1)
 
 

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from dataclasses import asdict, dataclass, fields
 from inspect import getfullargspec
 from os.path import join
@@ -11,12 +12,15 @@ import pyarrow as pa
 import pytest
 from anndata import AnnData
 from pandas._testing import assert_frame_equal
+from scipy.sparse import csr_matrix
 
 from tiledbsoma import SOMA_JOINID, DataFrame, Experiment
 from tiledbsoma.io._common import _DATAFRAME_ORIGINAL_INDEX_NAME_JSON
 from tiledbsoma.io._registration import AxisIDMapping
 from tiledbsoma.io.ingest import IngestionParams, _write_dataframe, from_anndata
 from tiledbsoma.io.outgest import _read_dataframe, to_anndata
+
+from tests._util import assert_adata_equal
 
 
 def parse_col(col_str: str) -> Tuple[Optional[str], List[str]]:
@@ -201,7 +205,16 @@ def test_adata_io_roundtrips(
     with Experiment.open(ingested_uri) as exp:
         adata1 = to_anndata(exp, "meas", obs_id_name=outgest_default_index_name)
         outgested_obs = adata1.obs
+
     assert_frame_equal(outgested_obs, outgested_df)
+
+    expected = deepcopy(adata0)
+    # Patch in the expected "outgested" DataFrame (which in these test cases is known to differ
+    # from what was ingested).
+    expected.obs = outgested_df
+    # TODO: outgest same format that was ingest
+    expected.X = csr_matrix(expected.X)
+    assert_adata_equal(expected, adata1)
 
 
 @parametrize_roundtrips(ROUND_TRIPS)

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -6,8 +6,9 @@ import pytest
 import tiledbsoma
 import tiledbsoma.io
 import tiledbsoma.options._tiledb_create_write_options as tco
-from tiledbsoma._util import verify_obs_and_var_eq
 import tiledb
+
+from ._util import assert_adata_equal
 
 
 def test_platform_config(conftest_pbmc_small):
@@ -55,7 +56,7 @@ def test_platform_config(conftest_pbmc_small):
                 }
             },
         )
-        verify_obs_and_var_eq(original, conftest_pbmc_small)
+        assert_adata_equal(original, conftest_pbmc_small)
 
         x_arr_uri = str(Path(output_path) / "ms" / "RNA" / "X" / "data")
         with tiledb.open(x_arr_uri) as x_arr:

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -14,10 +14,9 @@ import pytest
 
 import tiledbsoma.io
 import tiledbsoma.io._registration as registration
-from tiledbsoma._util import verify_obs_and_var_eq
-from tiledbsoma.io._registration import (
-    signatures,
-)
+from tiledbsoma.io._registration import signatures
+
+from ._util import assert_adata_equal
 
 
 def _create_anndata(
@@ -720,7 +719,7 @@ def test_append_items_with_experiment(obs_field_name, var_field_name):
             registration_mapping=rd,
         )
 
-    verify_obs_and_var_eq(original, adata2)
+    assert_adata_equal(original, adata2)
 
     expect_obs_soma_joinids = list(range(6))
     expect_var_soma_joinids = list(range(5))
@@ -826,7 +825,7 @@ def test_append_with_disjoint_measurements(
         registration_mapping=rd,
     )
 
-    verify_obs_and_var_eq(original, anndata2)
+    assert_adata_equal(original, anndata2)
 
     # exp/obs, use_same_cells=True:                       exp/obs, use_same_cells=False:
     #    soma_joinid obs_id cell_type  is_primary_data       soma_joinid obs_id cell_type  is_primary_data

--- a/apis/python/tests/test_registration_signatures.py
+++ b/apis/python/tests/test_registration_signatures.py
@@ -4,7 +4,8 @@ import pytest
 
 import tiledbsoma.io
 import tiledbsoma.io._registration.signatures as signatures
-from tiledbsoma._util import verify_obs_and_var_eq
+
+from ._util import assert_adata_equal
 
 
 def test_signature_serdes(conftest_pbmc_small_h5ad_path, conftest_pbmc_small):
@@ -16,7 +17,7 @@ def test_signature_serdes(conftest_pbmc_small_h5ad_path, conftest_pbmc_small):
 
     original = conftest_pbmc_small.copy()
     sig = signatures.Signature.from_anndata(conftest_pbmc_small)
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     text2 = sig.to_json()
     assert sig == signatures.Signature.from_json(text2)
@@ -27,7 +28,7 @@ def test_signature_serdes(conftest_pbmc_small_h5ad_path, conftest_pbmc_small):
     output_path = tempdir.name
 
     uri = tiledbsoma.io.from_anndata(output_path, conftest_pbmc_small, "RNA")
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     sig = signatures.Signature.from_soma_experiment(uri)
     text3 = sig.to_json()
@@ -43,12 +44,12 @@ def test_compatible(conftest_pbmc_small):
 
     original = conftest_pbmc_small.copy()
     sig1 = signatures.Signature.from_anndata(conftest_pbmc_small)
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
 
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
     uri = tiledbsoma.io.from_anndata(output_path, conftest_pbmc_small, "RNA")
-    verify_obs_and_var_eq(original, conftest_pbmc_small)
+    assert_adata_equal(original, conftest_pbmc_small)
     sig2 = signatures.Signature.from_soma_experiment(uri)
 
     # Check that single inputs result in zero incompatibility
@@ -72,7 +73,7 @@ def test_compatible(conftest_pbmc_small):
 
     original = adata3.copy()
     sig3 = signatures.Signature.from_anndata(adata3)
-    verify_obs_and_var_eq(original, adata3)
+    assert_adata_equal(original, adata3)
 
     with pytest.raises(ValueError):
         signatures.Signature.check_compatible({"orig": sig1, "anndata3": sig3})

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -7,17 +7,16 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from anndata import AnnData
+from pandas._testing import assert_frame_equal
 from pyarrow import Schema
 
 import tiledbsoma
 import tiledbsoma.io
-from tiledbsoma._util import (
-    anndata_dataframe_unmodified,
-    anndata_dataframe_unmodified_nan_safe,
-    verify_obs_and_var_eq,
-)
 
-from tests._util import maybe_raises
+from ._util import (
+    assert_adata_equal,
+    maybe_raises,
+)
 
 
 @dataclass
@@ -54,7 +53,7 @@ def multiple_fixtures_with_readback(request, conftest_pbmc_small) -> TestCase:
 
         # Check that the anndata-to-soma ingestion didn't modify the old_anndata object (which is
         # passed by reference to the ingestor) while it was doing the ingest
-        verify_obs_and_var_eq(old_anndata, conftest_pbmc_small)
+        assert_adata_equal(old_anndata, conftest_pbmc_small)
 
         use_readback = request.param
 
@@ -129,7 +128,6 @@ def verify_updates(
     obs,
     var,
     exc: Optional[Type[ValueError]] = None,
-    nan_safe: bool = False,
 ):
     """
     Calls `update_obs` and `update_var` on the experiment. Also verifies that the
@@ -146,13 +144,8 @@ def verify_updates(
         with maybe_raises(exc):
             tiledbsoma.io.update_var(exp, var, "RNA")
 
-    checker = (
-        anndata_dataframe_unmodified_nan_safe
-        if nan_safe
-        else anndata_dataframe_unmodified
-    )
-    assert checker(obs0, obs)
-    assert checker(var0, var)
+    assert_frame_equal(obs0, obs)
+    assert_frame_equal(var0, var)
 
 
 # `pytest.mark.parametrize` wrapper for running a test twice:
@@ -169,7 +162,7 @@ def test_no_change(
 ):
     verify_updates(experiment_path, new_obs, new_var)
     verify_schemas(experiment_path, obs_schema, var_schema)
-    verify_obs_and_var_eq(old_anndata, new_anndata)
+    assert_adata_equal(old_anndata, new_anndata)
 
 
 @with_and_without_soma_roundtrip
@@ -265,7 +258,7 @@ def test_change_counts(
         verify_updates(experiment_path, new_obs2, new_var2)
     else:
         verify_updates(experiment_path, new_obs2, new_var2, exc=ValueError)
-        verify_obs_and_var_eq(old_anndata, new_anndata)
+        assert_adata_equal(old_anndata, new_anndata)
         verify_schemas(experiment_path, obs_schema, var_schema)
 
 
@@ -311,6 +304,4 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
     conftest_pbmc3k_adata.obs["batch_id"] = pd.NA
     conftest_pbmc3k_adata.obs["myfloat"] = np.nan
     # We need nan_safe since pd.NA != pd.NA
-    verify_updates(
-        uri, conftest_pbmc3k_adata.obs, conftest_pbmc3k_adata.var, nan_safe=True
-    )
+    verify_updates(uri, conftest_pbmc3k_adata.obs, conftest_pbmc3k_adata.var)


### PR DESCRIPTION
**Changes:**
- Introduce `assert_adata_equal` utilitiy
  - Replaces `verify_obs_and_var_eq`, `anndata_dataframe_unmodified`, `anndata_dataframe_unmodified_nan_safe`
- Use `assert_adata_equal` in tests
  - This surfaces I/O round-trip misbehavior in `test_basic_anndata_io.py::test_uns_io` (some covered by [#2829](https://github.com/single-cell-data/TileDB-SOMA/issues/2829), some specific to `uns` / not previously documented)
  - That test is updated here, to verify and document current behavior.
  - https://github.com/single-cell-data/TileDB-SOMA/compare/rw/eq...rw/uns includes follow-on work improving/fixing the issues.

#2874 builds on this, fixes some of the `uns` issues, and removes code added to `test_uns_io` here.
