### PR TITLE
[python] Update comments, remove unused test params

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1145,14 +1145,17 @@ def _write_dataframe(
     axis_mapping: AxisIDMapping,
 ) -> DataFrame:
     """
-    The id_column_name is for disambiguating rows in append mode;
-    it may or may not be an index name in the input AnnData obs/var.
+    Convert and save a pd.DataFrame as a SOMA DataFrame.
 
-    The original_index_name is the index name in the AnnData obs/var.
+    This function adds a ``soma_joinid`` index to the provided ``pd.DataFrame``, as that is
+    required by libtiledbsoma; the original ``pd.DataFrame`` index is "reset" to a column, with its
+    original name stored as metadata on the SOMA ``DataFrame``.
 
-    This helper mutates the input dataframe, for parsimony of memory usage.
-    The caller should have copied anything pointing to a user-provided
-    adata.obs, adata.var, etc.
+    There are several subtleties related to naming the reset index column, and the ``id_column_name``
+     parameter; see ``_prepare_df_for_ingest`` / https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
+
+    NOTE: this function mutates the input dataframe, for parsimony of memory usage. Callers should
+    copy any user-provided ``pd.DataFrame``s (adata obs, var, uns, etc.) before passing them here.
     """
     original_index_metadata = _prepare_df_for_ingest(df, id_column_name)
     df[SOMA_JOINID] = np.asarray(axis_mapping.data, dtype=np.int64)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -811,8 +811,8 @@ def append_var(
     platform_config: Optional[PlatformConfig] = None,
 ) -> str:
     """
-    Writes new rows to an existing ``obs`` dataframe. (This is distinct from ``update_obs``
-    which mutates the entirety of the ``obs`` dataframe, e.g. to add/remove columns.)
+    Writes new rows to an existing ``var`` dataframe. (This is distinct from ``update_var``
+    which mutates the entirety of the ``var`` dataframe, e.g. to add/remove columns.)
 
     Example:
 

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Tuple, Type, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -66,6 +66,35 @@ def assert_adata_equal(ad0: AnnData, ad1: AnnData):
     assert_array_dicts_equal(ad0.varm, ad1.varm)
     assert_array_dicts_equal(ad0.obsp, ad1.obsp)
     assert_array_dicts_equal(ad0.varp, ad1.varp)
+
+
+def parse_col(col_str: str) -> Tuple[Optional[str], List[str]]:
+    """Parse a "column string" of the form ``val1,val2,...`` or ``name=val1,val2,...``."""
+    pcs = col_str.split("=")
+    if len(pcs) == 1:
+        return None, col_str.split(",")
+    elif len(pcs) == 2:
+        name, vals_str = pcs
+        vals = vals_str.split(",")
+        return name, vals
+    else:
+        raise ValueError(f"Invalid column string: {col_str}")
+
+
+def make_df(index_str: Optional[str] = None, **cols) -> pd.DataFrame:
+    """DataFrame construction helper, for tests.
+
+    - index and columns are provided as strings of the form ``name=val1,val2,...``.
+    - ``name=`` is optional for the initial (``index_str``) arg.
+    """
+    cols = dict([(col, parse_col(col_str)[1]) for col, col_str in cols.items()])
+    index = None
+    index_name = None
+    if index_str:
+        index_name, index = parse_col(index_str)
+    df = pd.DataFrame(cols, index=index)
+    df.index.name = index_name
+    return df
 
 
 HERE = Path(__file__).parent

--- a/apis/python/tests/parametrize_cases.py
+++ b/apis/python/tests/parametrize_cases.py
@@ -8,7 +8,7 @@ import pytest
 def parametrize_cases(cases: List):
     """Parametrize a test with a list of test cases (each an instance of a dataclass).
 
-    The cases are expected to have a ``name`` string, which is used as the test-case "ID".
+    The cases are expected to have an ``id: str`` field, which is used as the test-case "ID".
     """
 
     cls = cases[0].__class__
@@ -19,8 +19,11 @@ def parametrize_cases(cases: List):
             )
 
     def wrapper(fn):
+        """Parameterize a test ``fn``, converting the ``cases`` above to pytest-style "ID"s and
+        kwarg keys/values.
+        """
         # Test-case IDs
-        ids = [case.name for case in cases]
+        ids = [case.id for case in cases]
         # Convert each case to a "values" array; also filter and reorder to match kwargs expected
         # by the wrapped "test_*" function.
         spec = getfullargspec(fn)

--- a/apis/python/tests/parametrize_cases.py
+++ b/apis/python/tests/parametrize_cases.py
@@ -1,0 +1,40 @@
+from dataclasses import asdict, fields
+from inspect import getfullargspec
+from typing import List
+
+import pytest
+
+
+def parametrize_cases(cases: List):
+    """Parametrize a test with a list of test cases (each an instance of a dataclass).
+
+    The cases are expected to have a ``name`` string, which is used as the test-case "ID".
+    """
+
+    cls = cases[0].__class__
+    for case in cases:
+        if case.__class__ is not cls:
+            raise ValueError(
+                f"Expected all cases to be of type {cls}, but found {case.__class__}"
+            )
+
+    def wrapper(fn):
+        # Test-case IDs
+        ids = [case.name for case in cases]
+        # Convert each case to a "values" array; also filter and reorder to match kwargs expected
+        # by the wrapped "test_*" function.
+        spec = getfullargspec(fn)
+        field_names = [f.name for f in fields(cls)]
+        names = [arg for arg in spec.args if arg in field_names]
+        values = [
+            {name: rt_dict[name] for name in names}.values()
+            for rt_dict in [asdict(case) for case in cases]
+        ]
+        # Delegate to PyTest `parametrize`
+        return pytest.mark.parametrize(
+            names,  # kwarg names
+            values,  # arg value lists
+            ids=ids,  # test-case names
+        )(fn)
+
+    return wrapper

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -20,7 +20,7 @@ from tiledbsoma._soma_object import SOMAObject
 from tiledbsoma.io._common import _TILEDBSOMA_TYPE
 import tiledb
 
-from ._util import TESTDATA, assert_adata_equal
+from ._util import TESTDATA, assert_adata_equal, make_df
 
 
 @pytest.fixture
@@ -998,13 +998,8 @@ def test_uns_io(tmp_path, outgest_uns_keys):
         "float_scalar": 8.5,
         "string_scalar": "hello",
         # These are stored in SOMA as SOMADataFrame
-        "pd_df_indexed": pd.DataFrame(
-            data={"column_1": np.asarray(["d", "e", "f"])},
-            index=np.arange(3).astype(str),
-        ),
-        "pd_df_nonindexed": pd.DataFrame(
-            data={"column_1": np.asarray(["g", "h", "i"])},
-        ),
+        "pd_df_indexed": make_df("0,1,2", column_1="d,e,f"),
+        "pd_df_nonindexed": make_df(column_1="g,h,i"),
         # These are stored in SOMA as SOMA ND arrays
         "np_ndarray_1d": np.asarray([1, 2, 3]),
         "np_ndarray_2d": np.asarray([[1, 2, 3], [4, 5, 6]]),

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1520,9 +1520,9 @@ def test_enum_schema_report(tmp_path):
 def test_nullable(tmp_path):
     uri = tmp_path.as_posix()
 
-    # Arrow fields are nullable by default.  They can be explcitly set nullable
+    # Arrow fields are nullable by default.  They can be explicitly set nullable
     # or non-nullable via the nullable kwarg to pa.field.  Also, they can be
-    # explcitly set nullable via metadata. The latter, if present, overrides
+    # explicitly set nullable via metadata. The latter, if present, overrides
     # the former.
     asch = pa.schema(
         [

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -28,7 +28,7 @@ from tests.parametrize_cases import parametrize_cases
 @dataclass
 class RoundTrip:
     # Test-case name
-    name: str
+    id: str
     # DataFrame to ingest
     original_df: pd.DataFrame
     # Expected DataFrame after outgest

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from os.path import join
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -21,37 +21,8 @@ from tiledbsoma.io._registration import AxisIDMapping
 from tiledbsoma.io.ingest import IngestionParams, _write_dataframe, from_anndata
 from tiledbsoma.io.outgest import _read_dataframe, to_anndata
 
-from tests._util import assert_adata_equal
+from tests._util import assert_adata_equal, make_df
 from tests.parametrize_cases import parametrize_cases
-
-
-def parse_col(col_str: str) -> Tuple[Optional[str], List[str]]:
-    """Parse a "column string" of the form `val1,val2,...` or `name=val1,val2,...`."""
-    pcs = col_str.split("=")
-    if len(pcs) == 1:
-        return None, col_str.split(",")
-    elif len(pcs) == 2:
-        name, vals_str = pcs
-        vals = vals_str.split(",")
-        return name, vals
-    else:
-        raise ValueError(f"Invalid column string: {col_str}")
-
-
-def make_df(index_str: str, **cols) -> pd.DataFrame:
-    """DataFrame construction helper, for tests.
-
-    - index and columns are provided as strings of the form `name=val1,val2,...`.
-    - `name=` is optional for the initial (`index_str`) arg.
-    """
-    cols = dict([(col, parse_col(col_str)[1]) for col, col_str in cols.items()])
-    index = None
-    index_name = None
-    if index_str:
-        index_name, index = parse_col(index_str)
-    df = pd.DataFrame(cols, index=index)
-    df.index.name = index_name
-    return df
 
 
 @dataclass

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -1,3 +1,6 @@
+# The tests in this file verify issues where an ingest/outgest "round trip" modifies an AnnData's
+# "obs" or "var" DataFrames. See https://github.com/single-cell-data/TileDB-SOMA/issues/2829 for more info.
+
 import json
 from copy import deepcopy
 from dataclasses import asdict, dataclass, fields
@@ -94,6 +97,8 @@ def parametrize_roundtrips(roundtrips: List[RoundTrip]):
 
 
 # fmt: off
+# These cases verify issues with ingest/outgest where an AnnData's "obs" or "var" DataFrame is not round-tripped
+# correctly. See https://github.com/single-cell-data/TileDB-SOMA/issues/2829 for more info.
 ROUND_TRIPS = [
     RoundTrip(
         '1. `df.index` named "index"',
@@ -182,6 +187,11 @@ def test_adata_io_roundtrips(
     ingest_id_column_name: Optional[str],
     outgested_df: pd.DataFrame,
 ):
+    """Given an `original_df`, set it as the `obs` DataFrame of an AnnData, ingest it, outgest it back, and compare the
+    original and final DataFrames. Also verify the persisted column names and "original index metadata."
+
+    `ingest_id_column_name` and `outgest_default_index_name`
+    """
     uri = str(tmp_path)
     n_obs = len(original_df)
     var = pd.DataFrame({"var1": [1, 2, 3], "var2": ["a", "b", "c"]})  # unused

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -68,10 +68,6 @@ class RoundTrip:
     persisted_metadata: Optional[str] = None
     # Argument passed to `_write_dataframe` on ingest (default here matches `from_anndata`'s "obs" path)
     ingest_id_column_name: Optional[str] = "obs_id"
-    # Argument passed to `_read_dataframe` on outgest (default here matches `to_anndata`'s "obs_id" path)
-    outgest_default_index_name: Optional[str] = None
-    # Argument passed to `_read_dataframe` on outgest (default here matches `to_anndata`'s "obs_id" path)
-    outgest_fallback_index_name: Optional[str] = "obs_id"
 
 
 def parametrize_roundtrips(roundtrips: List[RoundTrip]):
@@ -184,7 +180,6 @@ def test_adata_io_roundtrips(
     persisted_column_names: List[str],
     persisted_metadata: Optional[str],
     ingest_id_column_name: Optional[str],
-    outgest_default_index_name: Optional[str],
     outgested_df: pd.DataFrame,
 ):
     uri = str(tmp_path)
@@ -203,7 +198,7 @@ def test_adata_io_roundtrips(
 
     # Verify outgested pd.DataFrame
     with Experiment.open(ingested_uri) as exp:
-        adata1 = to_anndata(exp, "meas", obs_id_name=outgest_default_index_name)
+        adata1 = to_anndata(exp, "meas")
         outgested_obs = adata1.obs
 
     assert_frame_equal(outgested_obs, outgested_df)
@@ -222,8 +217,6 @@ def test_df_io_roundtrips(
     persisted_column_names: List[str],
     persisted_metadata: Optional[str],
     ingest_id_column_name: Optional[str],
-    outgest_default_index_name: Optional[str],
-    outgest_fallback_index_name: Optional[str],
     outgested_df: pd.DataFrame,
 ):
     uri = str(tmp_path)
@@ -241,7 +234,7 @@ def test_df_io_roundtrips(
     # Verify outgested pd.DataFrame
     actual_outgested_df = _read_dataframe(
         sdf,
-        default_index_name=outgest_default_index_name,
-        fallback_index_name=outgest_fallback_index_name,
+        default_index_name=None,  # corresponds to `to_anndata`'s default `obs_id_name`
+        fallback_index_name="obs_id",  # corresponds to `to_anndata`'s default behavior for "obs"
     )
     assert_frame_equal(actual_outgested_df, outgested_df)


### PR DESCRIPTION
**Issue and/or context:** #2829, #2804, #2868

**Changes:**
- Tests introduced in #2804 included configurable `outgest_default_index_name` and `outgest_fallback_index_name` fields, that were never set to non-default values. Removing them here, to avoid confusion.
- Other comment updates / typo fixes

