### PR TITLE
[python] `update_uns_by_uri`, `_update_uns`

### DIFF
--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -4,19 +4,20 @@
 # Licensed under the MIT License.
 
 """Common constants and types used during ingestion/outgestion."""
-
-from typing import Any, Mapping, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 import h5py
 import scipy.sparse as sp
 from anndata._core.sparse_dataset import SparseDataset
 
-from tiledbsoma._types import NPNDArray
+from tiledbsoma._types import Metadatum, NPNDArray
 
 SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 UnsMapping = Mapping[str, Any]
+
+AdditionalMetadata = Optional[Dict[str, Metadatum]]
 
 # Arrays of strings from AnnData's uns are stored in SOMA as SOMADataFrame,
 # since SOMA ND arrays are necessarily arrays *of numbers*. This is okay since

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -4,9 +4,11 @@
 # Licensed under the MIT License.
 
 """Common constants and types used during ingestion/outgestion."""
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 import h5py
+import numpy as np
+import pandas as pd
 import scipy.sparse as sp
 from anndata._core.sparse_dataset import SparseDataset
 
@@ -15,7 +17,16 @@ from tiledbsoma._types import Metadatum, NPNDArray
 SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, SparseDataset]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
-UnsMapping = Mapping[str, Any]
+
+UnsScalar = Union[str, int, float, np.generic]
+# TODO: support sparse matrices in `uns`
+UnsLeaf = Union[UnsScalar, List[UnsScalar], pd.DataFrame, NPNDArray]
+UnsNode = Union[UnsLeaf, Mapping[str, "UnsNode"]]
+UnsMapping = Mapping[str, UnsNode]
+# Specialize `UnsNode` to `Dict` instead of `Mapping`
+# `Mapping` doesn't expose `__set__`, so this is useful for building `uns` dictionaries.
+UnsDictNode = Union[UnsLeaf, Dict[str, "UnsDictNode"]]
+UnsDict = Dict[str, UnsDictNode]
 
 AdditionalMetadata = Optional[Dict[str, Metadatum]]
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1182,6 +1182,10 @@ def _write_dataframe_impl(
     platform_config: Optional[PlatformConfig] = None,
     context: Optional[SOMATileDBContext] = None,
 ) -> DataFrame:
+    """Save a Pandas DataFrame as a SOMA DataFrame.
+
+    Expects the required ``soma_joinid`` index to have already been added to the ``pd.DataFrame``.
+    """
     s = _util.get_start_stamp()
     logging.log_io(None, f"START  WRITING {df_uri}")
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -70,7 +70,6 @@ from .._types import (
     _INGEST_MODES,
     INGEST_MODES,
     IngestMode,
-    Metadatum,
     NPNDArray,
     Path,
     _IngestMode,
@@ -89,6 +88,7 @@ from ._common import (
     _UNS_OUTGEST_HINT_1D,
     _UNS_OUTGEST_HINT_2D,
     _UNS_OUTGEST_HINT_KEY,
+    AdditionalMetadata,
     Matrix,
     SparseMatrix,
     UnsMapping,
@@ -105,9 +105,6 @@ from ._util import get_arrow_str_format, read_h5ad
 
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 _TDBO = TypeVar("_TDBO", bound=SOMAObject[RawHandle])
-
-
-AdditionalMetadata = Optional[Dict[str, Metadatum]]
 
 
 def add_metadata(obj: SOMAObject[Any], additional_metadata: AdditionalMetadata) -> None:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -92,6 +92,7 @@ from ._common import (
     Matrix,
     SparseMatrix,
     UnsMapping,
+    UnsNode,
 )
 from ._registration import (
     AxisIDMapping,
@@ -2482,7 +2483,7 @@ def _maybe_ingest_uns(
 def _ingest_uns_dict(
     parent: AnyTileDBCollection,
     parent_key: str,
-    dct: Mapping[str, object],
+    dct: UnsMapping,
     *,
     platform_config: Optional[PlatformConfig],
     context: Optional[SOMATileDBContext],
@@ -2521,9 +2522,9 @@ def _ingest_uns_dict(
 
 
 def _ingest_uns_node(
-    coll: Any,
-    key: Any,
-    value: Any,
+    coll: AnyTileDBCollection,
+    key: str,
+    value: UnsNode,
     *,
     platform_config: Optional[PlatformConfig],
     context: Optional[SOMATileDBContext],

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -46,6 +46,7 @@ from ._common import (
     _UNS_OUTGEST_HINT_2D,
     _UNS_OUTGEST_HINT_KEY,
     Matrix,
+    UnsDict,
     UnsMapping,
 )
 
@@ -432,12 +433,12 @@ def _extract_uns(
     collection: Collection[Any],
     uns_keys: Optional[Sequence[str]] = None,
     level: int = 0,
-) -> UnsMapping:
+) -> UnsDict:
     """
     This is a helper function for ``to_anndata`` of ``uns`` elements.
     """
 
-    extracted: Dict[str, Any] = {}
+    extracted: UnsDict = {}
     for key, element in collection.items():
         if level == 0 and uns_keys is not None and key not in uns_keys:
             continue

--- a/apis/python/src/tiledbsoma/io/update_uns.py
+++ b/apis/python/src/tiledbsoma/io/update_uns.py
@@ -1,0 +1,225 @@
+from os.path import join
+from typing import Literal, Optional
+
+import numpy as np
+import pandas as pd
+from somacore.options import PlatformConfig
+
+from tiledbsoma import Experiment, SOMATileDBContext
+from tiledbsoma._collection import AnyTileDBCollection, Collection
+from tiledbsoma.io._common import AdditionalMetadata, UnsMapping
+from tiledbsoma.io._registration import AxisIDMapping
+from tiledbsoma.io.ingest import (
+    IngestionParams,
+    IngestPlatformCtx,
+    _ingest_uns_array,
+    _maybe_set,
+    _write_dataframe,
+)
+from tiledbsoma.logging import logger
+
+Strict = Literal[True, "raise", "warn", "info", "debug", "dry_run"]
+
+
+def update_uns_by_uri(
+    uri: str,
+    uns: UnsMapping,
+    measurement_name: str,
+    *,
+    use_relative_uri: Optional[bool] = None,
+    context: Optional[SOMATileDBContext] = None,
+    additional_metadata: AdditionalMetadata = None,
+    platform_config: Optional[PlatformConfig] = None,
+    default_index_name: Optional[str] = None,
+    strict: Strict = True,
+) -> None:
+    """Wrapper around :func:`_update_uns` that opens the experiment at the given URI.
+
+    Some "update uns" operations, that we may want to support in the future, will require opening
+    the ``Experiment`` more than once (e.g. to modify a DataFrame or array in ways that can't be
+    achieved "in-place" / at one TileDB timestamp). This function API is a sketch of what that
+    might look like, though it just calls :func:`update_uns` for now (overwriting DataFrames and
+    arrays is currently not supported, and will either ``raise`` or "INFO" log, based on the value
+    of the ``strict`` arg).
+    """
+    with Experiment.open(uri, "w") as exp:
+        _update_uns(
+            exp,
+            uns,
+            measurement_name,
+            use_relative_uri=use_relative_uri,
+            context=context,
+            additional_metadata=additional_metadata,
+            platform_config=platform_config,
+            default_index_name=default_index_name,
+            strict=strict,
+        )
+
+
+def _update_uns(
+    exp: Experiment,
+    uns: UnsMapping,
+    measurement_name: str,
+    *,
+    use_relative_uri: Optional[bool] = None,
+    context: Optional[SOMATileDBContext] = None,
+    additional_metadata: AdditionalMetadata = None,
+    platform_config: Optional[PlatformConfig] = None,
+    default_index_name: Optional[str] = None,
+    strict: Strict = True,
+) -> None:
+    """
+    Update the given experiment/measurement's ``uns`` Collection.
+
+    ``uns`` (short for unstructured data) is conceptually a dictionary; values can be scalars,
+    DataFrames, arrays (dense or sparse), or recursively-nested dictionaries.
+
+    This function makes a best effort at changing the existing ``uns`` Collection to match the
+    provided ``uns`` dictionary. It refuses to update DataFrame and array nodes, with errors
+    either raised or logged, based on the ``strict`` argument.
+
+    Args:
+        exp: The :class:`SOMAExperiment` whose ``uns`` is to be updated. Must
+        be opened for write.
+
+        measurement_name: Specifies which measurement's ``uns`` within the experiment
+        is to be updated.
+
+        uns: a Pandas dataframe with the desired contents.
+
+        use_relative_uri: If True, store the URI relative to the experiment's URI.
+
+        context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
+
+        additional_metadata: Additional metadata to be added to the collection.
+
+        platform_config: Platform-specific options used to update this array, provided
+        in the form ``{"tiledb": {"create": {"dataframe_dim_zstd_level": 7}}}``
+
+        default_index_name: Fallback name to use for columns representing ``pd.DataFrame`` indices.
+
+        strict: How to handle conflicts with existing nodes. By default (``strict=True``), a first
+        pass checks for conflicts, ``raise``ing if any are found. If none are found, a second pass
+        then performs the updates. This is equivalent to running once with ``strict="dry_run"``,
+        then again with ``dry_run="raise"`` (though the expectation is the latter will never
+        actually ``raise``). If ``strict={debug,info,warn}`` instead, conflicting nodes are logged
+        at the corresponding level, and the update is skipped.
+    """
+    if measurement_name not in exp.ms:
+        raise ValueError(
+            f"cannot find measurement name {measurement_name} within experiment at {exp.uri}"
+        )
+
+    ingest_platform_ctx = IngestPlatformCtx(
+        context=context,
+        ingestion_params=IngestionParams("write", label_mapping=None),
+        additional_metadata=additional_metadata,
+        platform_config=platform_config,
+    )
+    if strict is True:
+        # Surface any errors (e.g. unsupported SOMA object overwrites) without writing anything
+        _update_uns_dict(
+            exp.ms[measurement_name]["uns"],  # type: ignore[arg-type]
+            uns,
+            use_relative_uri=use_relative_uri,
+            ingest_platform_ctx=ingest_platform_ctx,
+            default_index_name=default_index_name,
+            strict="dry_run",
+        )
+        strict = "raise"
+    _update_uns_dict(
+        exp.ms[measurement_name]["uns"],  # type: ignore[arg-type]
+        uns,
+        use_relative_uri=use_relative_uri,
+        ingest_platform_ctx=ingest_platform_ctx,
+        default_index_name=default_index_name,
+        strict=strict,
+    )
+
+
+def _update_uns_dict(
+    coll: AnyTileDBCollection,
+    uns: UnsMapping,
+    *,
+    ingest_platform_ctx: IngestPlatformCtx,
+    use_relative_uri: Optional[bool],
+    default_index_name: Optional[str],
+    strict: Strict,
+) -> None:
+    for k, v in uns.items():
+        # Any existing scalar will be found in metadata, not as a child of the Collection.
+        cur = None
+        if k in coll:
+            cur = coll[k]
+        if k in coll.metadata:
+            if cur is not None:
+                logger.warn(f"{coll.uri}[{k}] exists as both metadata and child")
+            else:
+                cur = coll.metadata[k]
+        exists = cur is not None
+
+        def can_write() -> bool:
+            if exists:
+                msg = f"{coll.uri}[{k}]: already exists (type {type(cur).__name__}), refusing to overwrite with {v}"
+                if strict in ["dry_run", "raise"]:
+                    raise ValueError(msg)
+                else:
+                    msg = f"Skipping {msg}"
+                    if strict == "warn":
+                        logger.warn(msg)
+                    elif strict == "info":
+                        logger.info(msg)
+                    elif strict == "debug":
+                        logger.debug(msg)
+                    return False
+            else:
+                return strict != "dry_run"
+
+        if isinstance(v, (str, int, float, np.generic)):
+            if k in coll:
+                raise ValueError(
+                    f"can't overwrite {type(cur).__name__} at {coll.uri}/{k} with scalar {v}"
+                )
+            if isinstance(v, np.generic):
+                # Unwrap numpy scalar
+                v = v.item()
+            if strict != "dry_run":
+                coll.metadata[k] = v
+        elif isinstance(v, pd.DataFrame):
+            if can_write():
+                with _write_dataframe(
+                    df_uri=join(coll.uri, k),
+                    df=v.copy(),  # `_write_dataframe` modifies the `pd.DataFrame` it's passed
+                    id_column_name=default_index_name,
+                    ingestion_params=ingest_platform_ctx["ingestion_params"],
+                    additional_metadata=ingest_platform_ctx["additional_metadata"],
+                    platform_config=ingest_platform_ctx["platform_config"],
+                    context=ingest_platform_ctx["context"],
+                    axis_mapping=AxisIDMapping.identity(v.shape[0]),
+                ) as df:
+                    _maybe_set(coll, k, df, use_relative_uri=use_relative_uri)
+        elif isinstance(v, dict):
+            if exists:
+                if not isinstance(cur, Collection):
+                    raise ValueError(
+                        f"{coll.uri}/{k}: expected Collection, found {type(cur).__name__}"
+                    )
+            _update_uns_dict(
+                coll[k],
+                v,
+                use_relative_uri=use_relative_uri,
+                ingest_platform_ctx=ingest_platform_ctx,
+                default_index_name=default_index_name,
+                strict=strict,
+            )
+        elif isinstance(v, np.ndarray):
+            if can_write():
+                _ingest_uns_array(
+                    coll,
+                    k,
+                    v,
+                    use_relative_uri=use_relative_uri,
+                    ingest_platform_ctx=ingest_platform_ctx,
+                )
+        else:
+            raise ValueError(f"unsupported uns type {type(v)}")

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -17,7 +17,7 @@ import tiledbsoma
 import tiledbsoma.io
 from tiledbsoma import Experiment, _constants, _factory
 from tiledbsoma._soma_object import SOMAObject
-from tiledbsoma.io._common import _TILEDBSOMA_TYPE
+from tiledbsoma.io._common import _TILEDBSOMA_TYPE, UnsDict
 import tiledb
 
 from ._util import TESTDATA, assert_adata_equal, make_pd_df
@@ -992,7 +992,7 @@ def test_uns_io(tmp_path, outgest_uns_keys):
     )
     X = csr_matrix(np.zeros([3, 2]))
 
-    uns = {
+    uns: UnsDict = {
         # These are stored in SOMA as metadata
         "int_scalar": 7,
         "float_scalar": 8.5,

--- a/apis/python/tests/test_update_uns.py
+++ b/apis/python/tests/test_update_uns.py
@@ -1,0 +1,238 @@
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+from _pytest.logging import LogCaptureFixture
+
+import tiledbsoma
+from tiledbsoma import Experiment
+from tiledbsoma.io._common import UnsDict, UnsMapping
+from tiledbsoma.io.update_uns import Strict, _update_uns
+
+from tests._util import Err, assert_uns_equal, make_pd_df, maybe_raises, verify_logs
+from tests.parametrize_cases import parametrize_cases
+from tests.test_basic_anndata_io import TEST_UNS, make_uns_adata
+
+ValidUpdates = Union[None, str, List[str], Dict[str, "ValidUpdates"]]
+Logs = Optional[List[str]]
+
+
+@dataclass
+class Case:
+    """A test case for `update_uns`.
+
+    :param id: Human-readable identifier for the test case.
+    :param uns_updates: Updates to attempt to apply (to the default ``TEST_UNS`` dict).
+    :param strict: How to handle conflicts with existing ``uns`` keys. Default (``True``) performs
+        an initial "dry run" pass to verify all updates can be applied, then a second pass actually
+        applying the updates. Pass ``"debug"``, ``"info"``, or ``"warn"`` to instead skip
+        conflicting keys, and log a message at the corresponding level. See :func:`update_uns` for
+        more details.
+    :param err: If present, verify that :func:`update_uns` raises an ``Exception`` containing this
+        regex.
+    :param valid_updates: If present, only these updates are expected to have been applied. If
+        ``strict=True`` (the default), all updates must be applied (``valid_updates=None``), or
+        no updates (``valid_updates=[]``), based on presence or absence of an expected ``err``.
+    :param logs: If present, verify that these log messages are present in the captured logs. Used
+        only when ``strict`` is a log level (``"debug"``, ``"info"``, ``"warn"``).
+    """
+
+    id: str
+    uns_updates: UnsMapping
+    strict: Strict = True
+    err: Optional[Err] = None
+    valid_updates: ValidUpdates = None
+    logs: Logs = None
+
+
+def case(
+    id: str,
+    err: Optional[Err] = None,
+    valid_updates: ValidUpdates = None,
+    logs: Logs = None,
+    strict: Strict = True,
+    **uns_updates,
+) -> Case:
+    """Helper for construction a :class:`Case`.
+
+    ``err``s are verified to be ``ValueError``s, by default, and "kwargs" become ``uns_updates``.
+    """
+    if isinstance(err, str):
+        err = (ValueError, err)
+    return Case(
+        id=id,
+        uns_updates=uns_updates,
+        err=err,
+        strict=strict,
+        valid_updates=valid_updates,
+        logs=logs,
+    )
+
+
+# fmt: off
+@parametrize_cases([
+    case(
+        "Update one scalar",
+        int_scalar=11,
+    ),
+    case(
+        "Update scalar, change type",
+        int_scalar="aaa",
+    ),
+    case(
+        "Update multiple scalar values, add a new DataFrame",
+        int_scalar=11,
+        float_scalar=2.2,
+        string_scalar="HELLO 2",
+        new_df=make_pd_df(a="1,2,3"),
+    ),
+    case(
+        "Update multiple scalar values, including inside a Collection",
+        int_scalar=11,
+        float_scalar=2.2,
+        string_scalar="HELLO 2",
+        new_df=make_pd_df(a="1,2,3"),
+        strings=dict(
+            aaa="AAA",
+            nnn=111,
+        )
+    ),
+    case(
+        "Overwrite np.array inside collection (raise)",
+        strings=dict(
+           string_np_ndarray_1d=np.asarray(list("abc")),
+        ),
+        err=r"ms/RNA/uns/strings\[string_np_ndarray_1d]: already exists \(type DataFrame\), refusing to overwrite with \['a' 'b' 'c']"
+    ),
+    case(
+        "Overwrite np.array inside collection (skip)",
+        strings=dict(
+            string_np_ndarray_1d=np.asarray(list("abc")),
+        ),
+        strict="info",
+        valid_updates=[],
+        logs=[r"ms/RNA/uns/strings\[string_np_ndarray_1d]: already exists \(type DataFrame\), refusing to overwrite with \['a' 'b' 'c']"]
+    ),
+    case(
+        "No partial updates inside collection",
+        strings=dict(
+            foo="FOO",
+            string_np_ndarray_1d=np.asarray(list("abc")),
+        ),
+        err=r"ms/RNA/uns/strings\[string_np_ndarray_1d]: already exists \(type DataFrame\), refusing to overwrite with \['a' 'b' 'c']"
+    ),
+    case(
+        "Partial update inside collection",
+        strings=dict(
+            foo="FOO",
+            string_np_ndarray_1d=np.asarray(list("abc")),
+        ),
+        strict="info",
+        valid_updates={"strings": "foo"},
+        logs=[r"ms/RNA/uns/strings\[string_np_ndarray_1d]: already exists \(type DataFrame\), refusing to overwrite with \['a' 'b' 'c']"]
+    ),
+    case(
+        "Overwrite scalar with DataFrame",
+        int_scalar=make_pd_df(a="1,2,3"),
+        err=(
+                r"ms/RNA/uns\[int_scalar]: already exists \(type int\), refusing to overwrite with    a\n"
+                r"0  1\n"
+                r"1  2\n"
+                r"2  3"
+        ),
+    ),
+    case(
+        "Overwrite existing DataFrame (raise)",
+        int_scalar=22,
+        pd_df_indexed=TEST_UNS["pd_df_indexed"].copy(),
+        err=(
+            r"ms/RNA/uns\[pd_df_indexed]: already exists \(type DataFrame\), refusing to overwrite with   column_1\n"
+            r"0        d\n"
+            r"1        e\n"
+            r"2        f"
+        ),
+    ),
+    case(
+        "Overwrite existing DataFrame (skip)",
+        int_scalar=22,
+        pd_df_indexed=TEST_UNS["pd_df_indexed"].assign(column_1=list("ghi")),
+        strict="info",
+        valid_updates=['int_scalar'],  # `int_scalar` is updated, `pd_df_indexed` is not ("info" msg logged below)
+        logs=[
+            r"ms/RNA/uns\[pd_df_indexed]: already exists \(type DataFrame\), refusing to overwrite with   column_1\n"
+            r"0        g\n"
+            r"1        h\n"
+            r"2        i"
+        ],
+    ),
+])
+# fmt: on
+def test_update_uns(
+    caplog: LogCaptureFixture,
+    tmp_path: Path,
+    uns_updates: UnsDict,
+    strict: Strict,
+    err: Optional[Err],
+    valid_updates: ValidUpdates,
+    logs: Logs,
+):
+    caplog.set_level(logging.INFO)
+    soma_uri, adata = make_uns_adata(tmp_path)
+
+    with Experiment.open(soma_uri, "w") as exp:
+        with maybe_raises(err):
+            _update_uns(exp, uns_updates, measurement_name="RNA", strict=strict)
+
+    verify_logs(caplog, logs)
+
+    if err:
+        # In all cases, an error during `update_uns` should result in no updates being applied (nor
+        # should any non-empty `valid_updates` have been provided as part of the test-case "spec").
+        assert valid_updates is None or valid_updates == []
+        valid_updates = []
+
+    with Experiment.open(soma_uri) as exp:
+        adata2 = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
+
+    expected = deepcopy(TEST_UNS)
+    merge_updates(expected, uns_updates, valid_updates)
+    assert_uns_equal(adata2.uns, expected)
+
+
+def merge_updates(
+    uns: UnsDict,
+    updates: UnsDict,
+    valid_updates: ValidUpdates,
+) -> None:
+    """Apply a subset of ``updates`` to an ``uns`` dict, filtering based on ``valid_updates``.
+
+    - If ``valid_updates`` is ``None``, all updates are applied.
+    - If ``valid_updates`` is a ``list`` of strings, ``updates`` must be a ``dict``, and only keys
+        from the ``list`` are applied.
+    - If ``valid_updates`` is a ``dict``, its keys must be present in ``updates``, and filtering is
+        applied recursively, with ``valid_updates``' values applying to corresponding items in
+        ``updates``.
+    """
+    if isinstance(valid_updates, str):
+        valid_updates = [valid_updates]
+    for k, v in updates.items():
+        if isinstance(v, dict):
+            if valid_updates is None:
+                merge_updates(uns[k], v, None)
+            elif isinstance(valid_updates, list):
+                if k in valid_updates:
+                    merge_updates(uns[k], v, None)
+            else:
+                assert isinstance(valid_updates, dict)
+                if k in valid_updates:
+                    merge_updates(uns[k], v, valid_updates[k])
+        else:
+            if valid_updates is None:
+                uns[k] = v
+            else:
+                assert isinstance(valid_updates, list)
+                if k in valid_updates:
+                    uns[k] = v


### PR DESCRIPTION
## Issue and/or context
- Fixes #1769
- Extends #2892 

## Changes
### [`_update_uns`][update_uns] helper
- Takes an already-open-for-write `Experiment`
- Mostly only supports writing keys that don't currently exist:
  - Existing scalars can be updated with other scalars.
  - If the existing or new value is an array or dataframe, the update is not performed
    - Overwriting scalars with arrays/dataframes should be support-able, can add here or in a future PR.
  - `strict` param controls behavior in the presence of unsupported updates:
    - Default (`strict=True`):
      - Performs a "dry run," which `raise`s on unsupported updates, but does not perform any writes (corresponds to `strict="dry_run"`)
      - If dry run succeeds, a second pass (with `strict="raise"`) performs the updates.
        - The expectation is nothing will be `raise`d by this pass.
      - This ensures updates are either all applied, or none are.
    - `strict="{debug,info,warn}"` can also be provided, in which case unsupported updates will be skipped, and a message logged at the specified level.

### `update_uns_by_uri`
Some more involved changes to an existing `uns` (e.g. updating dataframes/arrays) would require `open`ing the SOMA objects more than once, at different timestamps, meaning the user must provide a `uri: str` instead of an `Experiment.open(…, "w")`. Existing `update_{obs,var}` take an `Experiment`, so @aaronwolen was concerned about having something called `update_uns` that doesn't conform to the same API.

`update_uns_by_uri` takes a `uri: str`, but at the moment just `Experiment.open`s the URI, and passes that along to `_update_uns`, since we don't support any cases yet that require URI-based handling.

A possible downside of including this wrapper now is that we may want `update_uns_by_uri` to have a different API, when we actually support operations that require it. Open to discussion about which subset of `update_uns{,_by_uri}` should be included in the "first pass" here.

### Tests
[`test_update_uns.py`]: verifies several cases that succeed as written, as well as errors+messages for some cases that don't.

## Notes for Reviewers

### Reusing "ingest" functions that may skip a write
With default params (`strict=True`), I've made a best effort to ensure all updates are applied, or none are. However, I delegate writing DataFrames and arrays (when nothing previously exists at that `uns` slot) to `ingest` functions ([`_write_soma_dataframe_impl`], [`_ingest_uns_array`]), but those functions will skip writing in some situations. Open to whether this "strictness" notion should be plumbed through general "ingest" functions as well…

### Breaking up `ingest.py`?
I've added the new "update `uns`" functionality in `io/update_uns.py`, instead of `io/ingest.py`. The latter is >2800 LOC, and may warrant factoring into more files, or perhaps an `ingest` sub-package?

I think most changes we might want to make can be done backwards-compatibly, e.g. with a `io/ingest/__init__.py` exposing symbols that previously lived in `ingest.py`, but may be moved to more specialized files in an `io/ingest/` package.

Not necessarily advocating doing this, just thinking through what options may exist, and trying not to inadvertently foreclose on things we might want to do in the future.

[`update_{obs,var}`]: https://github.com/single-cell-data/TileDB-SOMA/blob/b9ec3c5e8a89b3ed997f873772e0fb194eb0d34b/apis/python/src/tiledbsoma/io/ingest.py#L1367
[update_uns]: https://github.com/single-cell-data/TileDB-SOMA/pull/2876/files#diff-c82c57b8002263d8fc44e999a85fbd78b78eefcb6901799c368f0e9f44100472
[`test_update_uns.py`]: https://github.com/single-cell-data/TileDB-SOMA/pull/2876/files#diff-3d5d69b17928503976f475244d98ae2df94b7c62a454c36a7327b14a5643f666
[`_write_soma_dataframe_impl`]: https://github.com/single-cell-data/TileDB-SOMA/pull/2876/files#diff-dc1f1c04136350fc3134f40bd69db3715831b77579de8a425a1eacac03effcc7R1227
[`_ingest_uns_array`]: https://github.com/single-cell-data/TileDB-SOMA/pull/2876/files#diff-dc1f1c04136350fc3134f40bd69db3715831b77579de8a425a1eacac03effcc7R2622