### PR TITLE
[c++] Add `dataset_type` into `SOMAExperiment` metadata

### DIFF
--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -67,6 +67,14 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
             static_cast<uint32_t>(ENCODING_VERSION_VAL.length()),
             ENCODING_VERSION_VAL.c_str());
 
+        // Root SOMA objects include a `dataset_type` entry to allow the
+        // TileDB Cloud UI to detect that they are SOMA datasets.
+        std::string cloud_scheme = "tiledb://";
+        if (soma_type == "SOMAExperiment" &&
+            uri.compare(0, cloud_scheme.length(), cloud_scheme) == 0) {
+            group->put_metadata("dataset_type", TILEDB_STRING_UTF8, 4, "soma");
+        }
+
         return std::make_unique<SOMAGroup>(ctx, group, timestamp);
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -69,9 +69,7 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
 
         // Root SOMA objects include a `dataset_type` entry to allow the
         // TileDB Cloud UI to detect that they are SOMA datasets.
-        std::string cloud_scheme = "tiledb://";
-        if (soma_type == "SOMAExperiment" &&
-            uri.compare(0, cloud_scheme.length(), cloud_scheme) == 0) {
+        if (soma_type == "SOMAExperiment") {
             group->put_metadata("dataset_type", TILEDB_STRING_UTF8, 4, "soma");
         }
 

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -332,7 +332,8 @@ TEST_CASE("SOMAExperiment: metadata") {
     // Read metadata
     soma_experiment = SOMAExperiment::open(
         uri, OpenMode::read, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_experiment->metadata_num() == 3);
+    REQUIRE(soma_experiment->metadata_num() == 4);
+    REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
     REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
     REQUIRE(soma_experiment->has_metadata("md"));
@@ -345,7 +346,8 @@ TEST_CASE("SOMAExperiment: metadata") {
     // md should not be available at (2, 2)
     soma_experiment = SOMAExperiment::open(
         uri, OpenMode::read, ctx, TimestampRange(2, 2));
-    REQUIRE(soma_experiment->metadata_num() == 2);
+    REQUIRE(soma_experiment->metadata_num() == 3);
+    REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
     REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
     REQUIRE(!soma_experiment->has_metadata("md"));
@@ -354,7 +356,8 @@ TEST_CASE("SOMAExperiment: metadata") {
     // Metadata should also be retrievable in write mode
     soma_experiment = SOMAExperiment::open(
         uri, OpenMode::write, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_experiment->metadata_num() == 3);
+    REQUIRE(soma_experiment->metadata_num() == 4);
+    REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
     REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
     REQUIRE(soma_experiment->has_metadata("md"));
@@ -371,7 +374,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     soma_experiment = SOMAExperiment::open(
         uri, OpenMode::read, ctx, TimestampRange(0, 2));
     REQUIRE(!soma_experiment->has_metadata("md"));
-    REQUIRE(soma_experiment->metadata_num() == 2);
+    REQUIRE(soma_experiment->metadata_num() == 3);
 }
 
 TEST_CASE("SOMAMeasurement: metadata") {

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -237,3 +237,23 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(!soma_group->has_metadata("md"));
     REQUIRE(soma_group->metadata_num() == 2);
 }
+
+TEST_CASE("SOMAGroup: dataset_type") {
+    auto ctx = std::make_shared<SOMAContext>();
+    SOMAGroup::create(ctx, "mem://experiment", "SOMAExperiment");
+    SOMAGroup::create(ctx, "mem://collection", "SOMACollection");
+    SOMAGroup::create(ctx, "mem://measurement", "SOMAMeasurement");
+
+    auto experiment = SOMAGroup::open(OpenMode::read, "mem://experiment", ctx);
+    auto collection = SOMAGroup::open(OpenMode::read, "mem://collection", ctx);
+    auto measurement = SOMAGroup::open(
+        OpenMode::read, "mem://measurement", ctx);
+
+    REQUIRE(!collection->has_metadata("dataset_type"));
+    REQUIRE(!measurement->has_metadata("dataset_type"));
+
+    REQUIRE(experiment->has_metadata("dataset_type"));
+    auto dataset_type = experiment->get_metadata("dataset_type");
+    REQUIRE(std::strcmp(
+        ((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
+}


### PR DESCRIPTION
Tracking: #2885 

As caught interally, the `dataset_type` needs to be set to `soma` for `SOMAExperiment` on tiledb-cloud upon creation.