### PR TITLE
[c++] Fix typos in unit-test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAKEFLAGS += --no-print-directory
 # print help by default
 help:
 
-# install 
+# install
 # -------------------------------------------------------------------
 
 # Set default variable values, if non-null
@@ -33,9 +33,13 @@ update:
 # test
 # -------------------------------------------------------------------
 .PHONY: test
-test: data
+
+test: ctest
+	pytest apis/python/tests
+
+.PHONY: ctest
+ctest: data
 	ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
-	pytest apis/python/tests 
 
 .PHONY: data
 data:
@@ -91,7 +95,7 @@ Rules:
 Options:
   build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
   prefix=PREFIX       Install location [${PWD}/dist]
-  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
+  tiledb=TILEDB_DIST  Absolute path to custom TileDB build
 
 Examples:
   Install Release build
@@ -111,7 +115,7 @@ Examples:
     make update
 
 
-endef 
+endef
 export HELP
 
 .PHONY: help

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -70,12 +70,13 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
         // Root SOMA objects include a `dataset_type` entry to allow the
         // TileDB Cloud UI to detect that they are SOMA datasets.
         if (soma_type == "SOMAExperiment") {
+            std::string key = "dataset_type";
             std::string dataset_type = "soma";
             group->put_metadata(
-              "dataset_type",
-              TILEDB_STRING_UTF8,
-              static_cast<uint32_t>(dataset_type.length()),
-              dataset_type.c_str());
+                key,
+                TILEDB_STRING_UTF8,
+                static_cast<uint32_t>(dataset_type.length()),
+                dataset_type.c_str());
         }
 
         return std::make_unique<SOMAGroup>(ctx, group, timestamp);

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -70,7 +70,12 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
         // Root SOMA objects include a `dataset_type` entry to allow the
         // TileDB Cloud UI to detect that they are SOMA datasets.
         if (soma_type == "SOMAExperiment") {
-            group->put_metadata("dataset_type", TILEDB_STRING_UTF8, 4, "soma");
+            std::string dataset_type = "soma";
+            group->put_metadata(
+              "dataset_type",
+              TILEDB_STRING_UTF8,
+              static_cast<uint32_t>(dataset_type.length()),
+              dataset_type.c_str());
         }
 
         return std::make_unique<SOMAGroup>(ctx, group, timestamp);

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -254,6 +254,6 @@ TEST_CASE("SOMAGroup: dataset_type") {
 
     REQUIRE(experiment->has_metadata("dataset_type"));
     auto dataset_type = experiment->get_metadata("dataset_type");
-    REQUIRE(std::strcmp(
+    REQUIRE(!std::strcmp(
         ((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
 }

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -238,7 +238,11 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(soma_group->metadata_num() == 2);
 }
 
+static void breakme() {
+}
+
 TEST_CASE("SOMAGroup: dataset_type") {
+    breakme();
     auto ctx = std::make_shared<SOMAContext>();
     SOMAGroup::create(ctx, "mem://experiment", "SOMAExperiment");
     SOMAGroup::create(ctx, "mem://collection", "SOMACollection");
@@ -254,19 +258,13 @@ TEST_CASE("SOMAGroup: dataset_type") {
 
     REQUIRE(experiment->has_metadata("dataset_type"));
 
-    auto dataset_type = experiment->get_metadata("dataset_type");
     std::string expect = "soma";
-    auto actual = (const char*)std::get<MetadataInfo::value>(*dataset_type);
 
-    // debug CI-only fail
-    std::cout << "\n";
-    std::cout << "ACTUAL  <<" << actual << ">>\n";
-    std::cout << "STRCMP <<" << std::strcmp(actual, expect.c_str()) << ">>\n";
-    auto cmp = std::strcmp(actual, expect.c_str());
-    std::cout << "CMP <<" << cmp << "\n";
-    // debug CI-only fail
+    // tuple of dtype, count, void*:
+    auto dataset_type = experiment->get_metadata("dataset_type");
+    auto bytes = (const char*)std::get<MetadataInfo::value>(*dataset_type);
+    auto count = std::get<MetadataInfo::num>(*dataset_type);
+    auto actual = std::string(bytes, count);
 
-    // REQUIRE(!std::strcmp(
-    //((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
-    REQUIRE(!cmp);
+    REQUIRE(actual == expect);
 }

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -255,14 +255,18 @@ TEST_CASE("SOMAGroup: dataset_type") {
     REQUIRE(experiment->has_metadata("dataset_type"));
 
     auto dataset_type = experiment->get_metadata("dataset_type");
+    std::string expect = "soma";
+    auto actual = (const char*)std::get<MetadataInfo::value>(*dataset_type);
 
     // debug CI-only fail
     std::cout << "\n";
-    auto foo = (const char*)std::get<MetadataInfo::value>(*dataset_type);
-    std::cout << "VALUE  <<" << foo << ">>\n";
-    std::cout << "STRCMP <<" << std::strcmp(foo, "soma") << ">>\n";
+    std::cout << "ACTUAL  <<" << actual << ">>\n";
+    std::cout << "STRCMP <<" << std::strcmp(actual, expect.c_str()) << ">>\n";
+    auto cmp = std::strcmp(actual, expect.c_str());
+    std::cout << "CMP <<" << cmp << "\n";
     // debug CI-only fail
 
-    REQUIRE(!std::strcmp(
-        ((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
+    // REQUIRE(!std::strcmp(
+    //((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
+    REQUIRE(!cmp);
 }

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -260,7 +260,7 @@ TEST_CASE("SOMAGroup: dataset_type") {
     std::cout << "\n";
     auto foo = (const char*)std::get<MetadataInfo::value>(*dataset_type);
     std::cout << "VALUE  <<" << foo << ">>\n";
-    std::cout << "STRCMP <<" << std::strcmp(foo, "soma") << "\n";
+    std::cout << "STRCMP <<" << std::strcmp(foo, "soma") << ">>\n";
     // debug CI-only fail
 
     REQUIRE(!std::strcmp(

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -253,7 +253,16 @@ TEST_CASE("SOMAGroup: dataset_type") {
     REQUIRE(!measurement->has_metadata("dataset_type"));
 
     REQUIRE(experiment->has_metadata("dataset_type"));
+
     auto dataset_type = experiment->get_metadata("dataset_type");
+
+    // debug CI-only fail
+    std::cout << "\n";
+    auto foo = (const char*)std::get<MetadataInfo::value>(*dataset_type);
+    std::cout << "VALUE  <<" << foo << ">>\n";
+    std::cout << "STRCMP <<" << std::strcmp(foo, "soma") << "\n";
+    // debug CI-only fail
+
     REQUIRE(!std::strcmp(
         ((const char*)std::get<MetadataInfo::value>(*dataset_type)), "soma"));
 }


### PR DESCRIPTION
CI fail introduced on #2884.

`std::strcmp` returns 0 on match so the intended use is `!std::strcmp("foo", "foo")` to get a truthy value.