### PR TITLE
[c++] Remove a temporary `gdb` hook from #2888

### DIFF
--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -238,11 +238,7 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(soma_group->metadata_num() == 2);
 }
 
-static void breakme() {
-}
-
 TEST_CASE("SOMAGroup: dataset_type") {
-    breakme();
     auto ctx = std::make_shared<SOMAContext>();
     SOMAGroup::create(ctx, "mem://experiment", "SOMAExperiment");
     SOMAGroup::create(ctx, "mem://collection", "SOMACollection");


### PR DESCRIPTION
Follow-up from https://github.com/single-cell-data/TileDB-SOMA/pull/2888#discussion_r1716813679

I had used this to make it easier to get a breakpoint in the right spot in `gdb` while debugging #2888. I neglected to take it back out.