### PR TITLE
[python] Docstring typo, test-assertion msgs, `maybe_raises` improvement, `verify_logs` helper

### DIFF
--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -237,7 +237,7 @@ def to_anndata(
 
     If ``uns_keys`` is provided, only the specified top-level ``uns`` keys
     are extracted.  The default is to extract them all.  Use ``uns_keys=[]``
-    to not ingest any ``uns`` keys.
+    to not outgest any ``uns`` keys.
 
     Lifecycle:
         Maturing.

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -15,7 +15,9 @@ from typeguard import suppress_type_checks
 
 
 def assert_uns_equal(uns0, uns1):
-    assert uns0.keys() == uns1.keys()
+    assert (
+        uns0.keys() == uns1.keys()
+    ), f"extra keys: {uns0.keys() - uns1.keys()}, missing keys: {uns1.keys() - uns0.keys()}"
     for k, v0 in uns0.items():
         try:
             v1 = uns1[k]
@@ -34,7 +36,7 @@ def assert_uns_equal(uns0, uns1):
             elif isinstance(v0, np.ndarray):
                 assert array_equal(v0, v1)
             elif isinstance(v0, (int, float, str, bool)):
-                assert v0 == v1
+                assert v0 == v1, f"{v0} != {v1}"
             else:
                 raise ValueError(f"Unsupported type: {type(v0)}")
         except AssertionError:

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Type, Union
@@ -6,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from _pytest._code import ExceptionInfo
+from _pytest.logging import LogCaptureFixture
 from _pytest.python_api import E, RaisesContext
 from anndata import AnnData
 from numpy import array_equal
@@ -148,3 +150,19 @@ def maybe_raises(
         return pytest.raises(exc, *args, **kwargs)
     else:
         return nullcontext()
+
+
+def verify_logs(caplog: LogCaptureFixture, expected_logs: Optional[List[str]]) -> None:
+    """Verify that expected log messages are present in a pytest "caplog" (captured logs) fixture."""
+    if not expected_logs:
+        return
+
+    for expected_log in expected_logs:
+        found = False
+        for record in caplog.records:
+            log_msg = record.getMessage()
+            if re.search(expected_log, log_msg):
+                found = True
+                break
+        if not found:
+            raise AssertionError(f"Expected log message not found: {expected_log}")

--- a/apis/python/tests/parametrize_cases.py
+++ b/apis/python/tests/parametrize_cases.py
@@ -24,6 +24,7 @@ def parametrize_cases(cases: List):
         """
         # Test-case IDs
         ids = [case.id for case in cases]
+
         # Convert each case to a "values" array; also filter and reorder to match kwargs expected
         # by the wrapped "test_*" function.
         spec = getfullargspec(fn)
@@ -33,6 +34,7 @@ def parametrize_cases(cases: List):
             {name: rt_dict[name] for name in names}.values()
             for rt_dict in [asdict(case) for case in cases]
         ]
+
         # Delegate to PyTest `parametrize`
         return pytest.mark.parametrize(
             names,  # kwarg names


### PR DESCRIPTION
**Issue and/or context:** 
- Parent: #2874
- Child: #2876 (uses the new `maybe_raises` / `verify_logs` functionality, this was factored from there)

**Changes:**
- `maybe_raises` can be passed a `str` (to match against an error message, regardless of error type) or an `(exc, msg)` tuple (to match against error type as well as message. As before, this is useful for tests where some cases expect no error, while others want to verify an error's class and/or message.
- `tests._util.verify_logs` helper, which can verify presence of expected log messages, given a pytest ["caplog"](https://docs.pytest.org/en/7.1.x/how-to/logging.html#caplog-fixture) fixture
