### PR TITLE
[ci] Update autocut rule for current ownership

### DIFF
--- a/.github/workflows/daily-test-build-issue-template.md
+++ b/.github/workflows/daily-test-build-issue-template.md
@@ -1,6 +1,6 @@
 ---
 title: Daily GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: nguyenv, mlin, johnkerl
+assignees: nguyenv, ryan-williams, johnkerl
 labels: bug
 ---
 


### PR DESCRIPTION
Follow-up from #2890. At the time that rule was created, @mlin was actively involved in TileDB-SOMA CI.

At the current point in time, @ryan-williams is actively involved in this particular area; @mlin less so; @nguyenv and @johnkerl still involved.