### PR TITLE
[c++] Apply `ArraySchemaEvolution` to specified timestamp

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1618,3 +1618,51 @@ def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
     # subtract 1 for the __schema/__enumerations directory;
     # only looking at fragment files
     assert len(vfs.ls(os.path.join(uri, "__schema"))) - 1 == 3
+
+
+def test_timestamped_schema_evolve(tmp_path):
+    uri = tmp_path.as_posix()
+
+    asch = pa.schema([("myenum", pa.dictionary(pa.int8(), pa.large_string()))])
+
+    # Create at time 1
+    soma.DataFrame.create(uri, schema=asch, tiledb_timestamp=1).close()
+
+    # Write at time 2
+    atbl = pa.Table.from_pydict(
+        {
+            "soma_joinid": [0, 1, 2],
+            "myenum": pd.Series(["a", "b", "a"], dtype="category"),
+        }
+    )
+    with soma.DataFrame.open(uri, "w", tiledb_timestamp=2) as sdf:
+        sdf.write(atbl)
+
+    # Write at time 3
+    atbl = pa.Table.from_pydict(
+        {
+            "soma_joinid": [3, 4],
+            "myenum": pd.Series(["b", "c"], dtype="category"),
+            # TODO https://github.com/single-cell-data/TileDB-SOMA/issues/2896
+            # "myenum": pd.Series(['b', 'b'], dtype='category'),
+            # Perhaps leave this t=3 as-is, and add a write of ['c', 'c'] at t=4.
+        }
+    )
+    with soma.DataFrame.open(uri, "w", tiledb_timestamp=3) as sdf:
+        sdf.write(atbl)
+
+    with soma.DataFrame.open(uri, tiledb_timestamp=1) as sdf:
+        table = sdf.read().concat()
+        assert table["myenum"].to_pylist() == []
+
+    with soma.DataFrame.open(uri, tiledb_timestamp=2) as sdf:
+        table = sdf.read().concat()
+        assert table["myenum"].to_pylist() == ["a", "b", "a"]
+
+    with soma.DataFrame.open(uri, tiledb_timestamp=3) as sdf:
+        table = sdf.read().concat()
+        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "c"]
+
+    with soma.DataFrame.open(uri) as sdf:
+        table = sdf.read().concat()
+        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "c"]

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -728,6 +728,13 @@ ArrowTable SOMAArray::_cast_table(
     // Go through all columns in the ArrowTable and cast the values to what is
     // in the ArraySchema on disk
     ArraySchemaEvolution se(*ctx_->tiledb_ctx());
+    if (timestamp_.has_value()) {
+      // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
+      // is (t1, t2).
+      auto v = timestamp_.value();
+      TimestampRange tr(v.second, v.second);
+      se.set_timestamp_range(tr);
+    }
     bool evolve_schema = false;
     for (auto i = 0; i < arrow_schema->n_children; ++i) {
         auto orig_arrow_sch_ = arrow_schema->children[i];

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -729,11 +729,11 @@ ArrowTable SOMAArray::_cast_table(
     // in the ArraySchema on disk
     ArraySchemaEvolution se(*ctx_->tiledb_ctx());
     if (timestamp_.has_value()) {
-      // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
-      // is (t1, t2).
-      auto v = timestamp_.value();
-      TimestampRange tr(v.second, v.second);
-      se.set_timestamp_range(tr);
+        // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
+        // is (t1, t2).
+        auto v = timestamp_.value();
+        TimestampRange tr(v.second, v.second);
+        se.set_timestamp_range(tr);
     }
     bool evolve_schema = false;
     for (auto i = 0; i < arrow_schema->n_children; ++i) {


### PR DESCRIPTION
**Issue and/or context:** #2879 

**Changes:** If we've got the array open at a timestamp, and we need to evolve it, evolve from that same timestamp.

**Notes for Reviewer:**

Material from @nguyenv to be incorporated into unit-test material:

**Script:**

```
$ cat ts.py
import tiledb
import tiledbsoma as soma
import pyarrow as pa
import tempfile
import numpy as np
import pandas as pd
import time

with tempfile.TemporaryDirectory() as uri:
    asch = pa.schema([("foo", pa.dictionary(pa.int8(), pa.large_string()))])
    soma.DataFrame.create(uri, schema=asch, tiledb_timestamp=1).close()

    pydict = {}
    pydict["soma_joinid"] = [0, 1, 2]
    pydict["foo"] = pd.Series(['a', 'b', 'a'], dtype='category')
    rb = pa.Table.from_pydict(pydict)

    with soma.DataFrame.open(uri, "w", tiledb_timestamp=2) as sdf:
        sdf.write(rb)

    pydict = {}
    pydict["soma_joinid"] = [3, 4]
    pydict["foo"] = pd.Series(['b', 'b'], dtype='category')
    rb = pa.Table.from_pydict(pydict)

    with soma.DataFrame.open(uri, "w", tiledb_timestamp=3) as sdf:
        sdf.write(rb)

    with soma.DataFrame.open(uri) as sdf:
        table = sdf.read().concat()
        print(table)

    with soma.DataFrame.open(uri, tiledb_timestamp=1) as sdf:
        table = sdf.read().concat()
        print(table)

    with soma.DataFrame.open(uri, tiledb_timestamp=2) as sdf:
        table = sdf.read().concat()
        print(table)

    with soma.DataFrame.open(uri, tiledb_timestamp=3) as sdf:
        table = sdf.read().concat()
        print(table)
```

**Before:**

```
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2,3,4]]
foo: [  -- dictionary:
["a","b"]  -- indices:
[0,1,0,0,0]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[]]
foo: [  -- dictionary:
[]  -- indices:
[]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2]]
foo: [  -- dictionary:
[]  -- indices:
[0,1,0]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2,3,4]]
foo: [  -- dictionary:
[]  -- indices:
[0,1,0,0,0]]
```

**After:**

```
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2,3,4]]
foo: [  -- dictionary:
["a","b"]  -- indices:
[0,1,0,0,0]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[]]
foo: [  -- dictionary:
[]  -- indices:
[]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2]]
foo: [  -- dictionary:
["a","b"]  -- indices:
[0,1,0]]
pyarrow.Table
soma_joinid: int64
foo: dictionary<values=string, indices=int8, ordered=0>
----
soma_joinid: [[0,1,2,3,4]]
foo: [  -- dictionary:
["a","b"]  -- indices:
[0,1,0,0,0]]
```

**Difference:**

```diff
23c23
< []  -- indices:
---
> ["a","b"]  -- indices:
31c31
< []  -- indices:
---
> ["a","b"]  -- indices:
```