### PR TITLE
[c++] Corner-case bug in extend-enumeration logic

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1642,7 +1642,7 @@ def test_timestamped_schema_evolve(tmp_path):
     atbl = pa.Table.from_pydict(
         {
             "soma_joinid": [3, 4],
-            "myenum": pd.Series(['b', 'b'], dtype='category'),
+            "myenum": pd.Series(["b", "b"], dtype="category"),
         }
     )
     with soma.DataFrame.open(uri, "w", tiledb_timestamp=3) as sdf:

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1642,10 +1642,7 @@ def test_timestamped_schema_evolve(tmp_path):
     atbl = pa.Table.from_pydict(
         {
             "soma_joinid": [3, 4],
-            "myenum": pd.Series(["b", "c"], dtype="category"),
-            # TODO https://github.com/single-cell-data/TileDB-SOMA/issues/2896
-            # "myenum": pd.Series(['b', 'b'], dtype='category'),
-            # Perhaps leave this t=3 as-is, and add a write of ['c', 'c'] at t=4.
+            "myenum": pd.Series(['b', 'b'], dtype='category'),
         }
     )
     with soma.DataFrame.open(uri, "w", tiledb_timestamp=3) as sdf:
@@ -1661,8 +1658,8 @@ def test_timestamped_schema_evolve(tmp_path):
 
     with soma.DataFrame.open(uri, tiledb_timestamp=3) as sdf:
         table = sdf.read().concat()
-        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "c"]
+        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "b"]
 
     with soma.DataFrame.open(uri) as sdf:
         table = sdf.read().concat()
-        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "c"]
+        assert table["myenum"].to_pylist() == ["a", "b", "a", "b", "b"]

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -431,6 +431,17 @@ bool SOMAArray::_extend_and_evolve_schema_str(
         index_schema->format = ArrowAdapter::to_arrow_format(disk_index_type)
                                    .data();
         return true;
+    } else {
+        // Example:
+        //
+        // * Already on storage/schema there are values a,b,c with indices
+        //   0,1,2.
+        // * User appends values b,c which, within the Arrow data coming in
+        //   from the user, have indices 0,1.
+        // * We need to remap those to 1,2.
+
+        SOMAArray::_remap_indexes(
+            column_name, enmr, enums_in_write, index_schema, index_array);
     }
     return false;
 }


### PR DESCRIPTION
**Issue and/or context:** Fixes issue #2896.

**Changes:** Remap indices whether or not the enumeration is extended, as shown in the unit-test example added here.

**Notes for Reviewer:**