### PR TITLE
[c++] Final update for Python/R metadata typing

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -212,7 +212,9 @@ void set_metadata(
     SOMAObject& soma_object, const std::string& key, py::array value) {
     tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
 
-    // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900
+    // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900:
+    // Ensure that all Python and R write paths use UTF-8 for string
+    // metadata values.
     if (value_type == TILEDB_STRING_ASCII) {
         value_type = TILEDB_STRING_UTF8;
     }

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -212,6 +212,11 @@ void set_metadata(
     SOMAObject& soma_object, const std::string& key, py::array value) {
     tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
 
+    // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900
+    if (value_type == TILEDB_STRING_ASCII) {
+        value_type = TILEDB_STRING_UTF8;
+    }
+
     if (is_tdb_str(value_type) && value.size() > 1)
         throw py::type_error("array/list of strings not supported");
 


### PR DESCRIPTION
**Issue and/or context:** For #2698

I ran an audit here: https://gist.github.com/johnkerl/a9eb64de62f881e80cd8e7ee54aa1c5c

Findings:

* Python: At initial group-creation and array-creation time we have these:
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/libtiledbsoma/src/soma/soma_group.cc#L58-L68
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/libtiledbsoma/src/soma/soma_array.cc#L65-L75
  * These explicitly, and correctly, specifies type `TILEDB_STRING_UTF8`
* Python: For subsequent post-create metadata updates we have this:
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/apis/python/src/tiledbsoma/_tdb_handles.py#L531-L536
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/apis/python/src/tiledbsoma/soma_group.cc#L102-L106
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/apis/python/src/tiledbsoma/soma_array.cc#L643
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/libtiledbsoma/src/soma/soma_group.cc#L233-L248
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/libtiledbsoma/src/soma/soma_array.cc#L1272-L1288
  * https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/apis/python/src/tiledbsoma/common.cc#L211-L225
  * Here the value type is supplied from the `np.array` at https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.0/apis/python/src/tiledbsoma/_tdb_handles.py#L531-L536 and I was unable to find a dtype that did the right thing
  * Instead I have the mod on this PR, which says, string-valued metadata keys must use type `TILEDB_STRING_UTF8`
* R: At initial group-creation and array-creation times we have these:
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/R/SOMACollectionBase.R#L174-L179
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/R/SOMAArrayBase.R#L32-L40
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/R/TileDBGroup.R#L270-L293
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/R/TileDBArray.R#L105-L116
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/R/RcppExports.R#L73-L75
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ab0a5b59e3d54c03d27d60a6b3b049ebbf783b31/apis/r/src/metadata.cpp#L164-L168
* R: subsequentpost-create metadata updates: same path

As a result:

* On initial object creation, string metadata values are correctly UTF-8 from Python or R
* Subsequent post-create metadata update, they were incorrectly non-UTF-8 from Python

Confounding circumstances:

* How these print from TileDB-SOMA-Py
* How these print from TileDB-SOMA-R
* How these print from TileDB-Py
* I found it easiest, as in the gist https://gist.github.com/johnkerl/a9eb64de62f881e80cd8e7ee54aa1c5c, to use TileDB-Py for readback:
  * Initial object-creation-time metadata reads back as `"foo"`
  * Post-create updated metadata reads back as `b"foo"` ...
  * ... until this PR

**Changes:**

Write post-create metadata updates from Python correctly using UTF-8 types.

**Notes for Reviewer:**

After this PR is merged I'll do cross-language tests in `apis/system/tests` to automate the kinds of things shown at gist https://gist.github.com/johnkerl/a9eb64de62f881e80cd8e7ee54aa1c5c
