### PR TITLE
Small adjustments to the spatial branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@6b93e53"   # DO NOT MERGE TO MAIN
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@e277581"   # DO NOT MERGE TO MAIN
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@05c1d7c"   # DO NOT MERGE TO MAIN
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@6b93e53"   # DO NOT MERGE TO MAIN
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -342,7 +342,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@6b93e53",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@e277581",  # DO NOT MERGE TO MAIN
         "tiledb~=0.31.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -342,7 +342,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@05c1d7c",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@6b93e53",  # DO NOT MERGE TO MAIN
         "tiledb~=0.31.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -74,7 +74,7 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
         "spatial": ("SOMACollection",),
-        "obs_scene": ("SOMADataFrame",),
+        "obs_spatial_presence": ("SOMADataFrame",),
     }
 
     def axis_query(  # type: ignore

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -80,5 +80,5 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
         "obsp": ("SOMACollection",),
         "varm": ("SOMACollection",),
         "varp": ("SOMACollection",),
-        "var_scene": ("SOMADataFrame",),
+        "var_spatial_presence": ("SOMADataFrame",),
     }

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -94,7 +94,7 @@ def from_cxg_spatial_h5ad(
     uns_keys: Optional[Sequence[str]] = None,
     additional_metadata: "AdditionalMetadata" = None,
     write_obs_spatial_presence: bool = True,
-    write_var_spatial_presence: bool = True,
+    write_var_spatial_presence: bool = False,
 ) -> str:
     """
     This function reads cellxgene schema compliant H5AD file and writes

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -336,10 +336,10 @@ def _write_visium_data_to_experiment_uri(
         )
     )
 
-    # TODO: The `obs_df` should be in dataframe with only soma_joinid and obs_id. Not
-    # currently bothering to check/enforce this.
     with Experiment.open(uri, mode="r", context=context) as exp:
-        obs_df = exp.obs.read().concat().to_pandas()
+        obs_df = (
+            exp.obs.read(column_names=["soma_joinid", "obs_id"]).concat().to_pandas()
+        )
         if write_obs_spatial_presence or write_var_spatial_presence:
             x_layer = exp.ms[measurement_name].X[X_layer_name].read().tables().concat()
             if write_obs_spatial_presence:

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -93,8 +93,8 @@ def from_cxg_spatial_h5ad(
     registration_mapping: Optional["ExperimentAmbientLabelMapping"] = None,
     uns_keys: Optional[Sequence[str]] = None,
     additional_metadata: "AdditionalMetadata" = None,
-    write_obs_scene: bool = True,
-    write_var_scene: bool = True,
+    write_obs_spatial_presence: bool = True,
+    write_var_spatial_presence: bool = True,
 ) -> str:
     """
     This function reads cellxgene schema compliant H5AD file and writes
@@ -180,8 +180,8 @@ def from_cxg_spatial_h5ad(
         input_lowres=image_paths["lowres"],
         input_fullres=image_paths["fullres"],
         input_tissue_positions=Path(tissue_positions_file_path),
-        write_obs_scene=write_obs_scene,
-        write_var_scene=write_var_scene,
+        write_obs_spatial_presence=write_obs_spatial_presence,
+        write_var_spatial_presence=write_var_spatial_presence,
     )
 
 
@@ -204,8 +204,8 @@ def from_visium(
     uns_keys: Optional[Sequence[str]] = None,
     additional_metadata: "AdditionalMetadata" = None,
     use_raw_counts: bool = True,
-    write_obs_scene: bool = False,
-    write_var_scene: bool = False,
+    write_obs_spatial_presence: bool = False,
+    write_var_spatial_presence: bool = False,
 ) -> str:
     """Reads a 10x Visium dataset and writes it to an :class:`Experiment`.
 
@@ -271,8 +271,8 @@ def from_visium(
         input_lowres=input_lowres,
         input_fullres=input_fullres,
         input_tissue_positions=input_tissue_positions,
-        write_obs_scene=write_obs_scene,
-        write_var_scene=write_var_scene,
+        write_obs_spatial_presence=write_obs_spatial_presence,
+        write_var_spatial_presence=write_var_spatial_presence,
     )
 
 
@@ -299,8 +299,8 @@ def _write_visium_data_to_experiment_uri(
     input_lowres: Union[None, str, Path],
     input_fullres: Union[None, str, Path],
     input_tissue_positions: Path,
-    write_obs_scene: bool = False,
-    write_var_scene: bool = False,
+    write_obs_spatial_presence: bool = False,
+    write_var_spatial_presence: bool = False,
 ) -> str:
     uri = from_anndata(
         experiment_uri,
@@ -340,11 +340,11 @@ def _write_visium_data_to_experiment_uri(
     # currently bothering to check/enforce this.
     with Experiment.open(uri, mode="r", context=context) as exp:
         obs_df = exp.obs.read().concat().to_pandas()
-        if write_obs_scene or write_var_scene:
+        if write_obs_spatial_presence or write_var_spatial_presence:
             x_layer = exp.ms[measurement_name].X[X_layer_name].read().tables().concat()
-            if write_obs_scene:
+            if write_obs_spatial_presence:
                 obs_id = pacomp.unique(x_layer["soma_dim_0"])
-            if write_var_scene:
+            if write_var_spatial_presence:
                 var_id = pacomp.unique(x_layer["soma_dim_1"])
 
     # Add spatial information to the experiment.
@@ -420,19 +420,31 @@ def _write_visium_data_to_experiment_uri(
                     _maybe_set(scene, "varl", varl, use_relative_uri=use_relative_uri)
 
         # Create the obs presence matrix.
-        if write_obs_scene:
-            obs_scene_uri = f"{uri}/obs_scene"
-            obs_scene = _write_scene_presence_dataframe(
-                obs_id, scene_name, obs_scene_uri, **ingest_ctx
+        if write_obs_spatial_presence:
+            obs_spatial_presence_uri = f"{uri}/obs_spatial_presence"
+            obs_spatial_presence = _write_scene_presence_dataframe(
+                obs_id, scene_name, obs_spatial_presence_uri, **ingest_ctx
             )
-            _maybe_set(exp, "obs_scene", obs_scene, use_relative_uri=use_relative_uri)
-        if write_var_scene:
-            var_scene_uri = f"{uri}/ms/{measurement_name}/var_scene"
-            var_scene = _write_scene_presence_dataframe(
-                var_id, scene_name, var_scene_uri, **ingest_ctx
+            _maybe_set(
+                exp,
+                "obs_spatial_presence",
+                obs_spatial_presence,
+                use_relative_uri=use_relative_uri,
+            )
+        if write_var_spatial_presence:
+            var_spatial_presence_uri = (
+                f"{uri}/ms/{measurement_name}/var_spatial_presence"
+            )
+            var_spatial_presence = _write_scene_presence_dataframe(
+                var_id, scene_name, var_spatial_presence_uri, **ingest_ctx
             )
             meas = exp.ms[measurement_name]
-            _maybe_set(meas, "var_scene", var_scene, use_relative_uri=use_relative_uri)
+            _maybe_set(
+                meas,
+                "var_spatial_presence",
+                var_spatial_presence,
+                use_relative_uri=use_relative_uri,
+            )
     return uri
 
 


### PR DESCRIPTION
* Rename `[obs|var]_scene` -> `[obs|var]_spatial_presence`
* Default to not creating `var_spatial_presence` dataframe when ingesting cellxgene hdf5 files
* Fix the `obsl[loc]` dataframe to only have columns for the `soma_joinid` and location data (position & spot size)
