### PR TITLE
[c++] Methodize timestamped-schema-evolution factory

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -471,6 +471,18 @@ uint64_t SOMAArray::_get_max_capacity(tiledb_datatype_t index_type) {
     }
 }
 
+ArraySchemaEvolution SOMAArray::_make_se() {
+    ArraySchemaEvolution se(*ctx_->tiledb_ctx());
+    if (timestamp_.has_value()) {
+        // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
+        // is (t1, t2).
+        auto v = timestamp_.value();
+        TimestampRange tr(v.second, v.second);
+        se.set_timestamp_range(tr);
+    }
+    return se;
+}
+
 void SOMAArray::set_column_data(
     std::string_view name,
     uint64_t num_elems,
@@ -738,14 +750,7 @@ ArrowTable SOMAArray::_cast_table(
 
     // Go through all columns in the ArrowTable and cast the values to what is
     // in the ArraySchema on disk
-    ArraySchemaEvolution se(*ctx_->tiledb_ctx());
-    if (timestamp_.has_value()) {
-        // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
-        // is (t1, t2).
-        auto v = timestamp_.value();
-        TimestampRange tr(v.second, v.second);
-        se.set_timestamp_range(tr);
-    }
+    ArraySchemaEvolution se = _make_se();
     bool evolve_schema = false;
     for (auto i = 0; i < arrow_schema->n_children; ++i) {
         auto orig_arrow_sch_ = arrow_schema->children[i];

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -762,6 +762,13 @@ class SOMAArray : public SOMAObject {
 
     uint64_t _get_max_capacity(tiledb_datatype_t index_type);
 
+    /**
+     * Convenience function for creating an ArraySchemaEvolution object
+     * referencing this array's context pointer, along with its open-at
+     * timestamp (if any).
+     */
+    ArraySchemaEvolution _make_se();
+
     bool _extend_enumeration(
         ArrowSchema* value_schema,
         ArrowArray* value_array,


### PR DESCRIPTION
**Issue and/or context:** This is a line-count-reducing under-diff split out from #2785 for issue #2407; [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

On #2895 I made an inline code block for instantiating an `ArraySchemaEvolution` object pointed at the current array's context and open-at timestamp (if any). That was after I did a call-graph analysis that showed that this was the sole spot in `main` -- at that point in time -- where we needed to do this.

However, on #2785 we'll be making more use of schema evolution, from more than one callsite. It makes even more sense now to encapsulate this logic in a single place.

**Notes for Reviewer:**

#2785 is unreviewable as-is: besides being a WIP, it's an all-in-one experimental area. Smaller PRs such as this one are being offered for manageable review.