### PR TITLE
[c++] Trivial parameterizes in `test/common.cc`

### DIFF
--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -97,18 +97,19 @@ std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema() {
     col_info_array->n_children = 2;
     col_info_array->release = &ArrowAdapter::release_array;
     col_info_array->children = new ArrowArray*[1];
+    int n = 3;
     auto d0_info = col_info_array->children[0] = new ArrowArray;
-    d0_info->length = 3;
+    d0_info->length = n;
     d0_info->null_count = 0;
     d0_info->offset = 0;
     d0_info->n_buffers = 2;
     d0_info->release = &ArrowAdapter::release_array;
     d0_info->buffers = new const void*[2];
     d0_info->buffers[0] = nullptr;
-    d0_info->buffers[1] = malloc(sizeof(int64_t) * 3);
+    d0_info->buffers[1] = malloc(sizeof(int64_t) * n);
     d0_info->n_children = 0;
     int64_t dom[] = {0, 1000, 1};
-    std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * 3);
+    std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * n);
 
     return std::pair(
         std::move(arrow_schema),
@@ -140,18 +141,19 @@ ArrowTable create_column_index_info() {
     col_info_array->n_children = 2;
     col_info_array->release = &ArrowAdapter::release_array;
     col_info_array->children = new ArrowArray*[1];
+    int n = 3;
     auto d0_info = col_info_array->children[0] = new ArrowArray;
-    d0_info->length = 3;
+    d0_info->length = n;
     d0_info->null_count = 0;
     d0_info->offset = 0;
     d0_info->n_buffers = 2;
     d0_info->release = &ArrowAdapter::release_array;
     d0_info->buffers = new const void*[2];
     d0_info->buffers[0] = nullptr;
-    d0_info->buffers[1] = malloc(sizeof(int64_t) * 3);
+    d0_info->buffers[1] = malloc(sizeof(int64_t) * n);
     d0_info->n_children = 0;
-    int64_t dom[] = {0, 1000, 1};
-    std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * 3);
+    int64_t dom[] = {0, 1000, 1, 0, 2147483646};
+    std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * n);
 
     return ArrowTable(std::move(col_info_array), std::move(col_info_schema));
 }

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -33,11 +33,12 @@
 #include "common.h"
 
 namespace helper {
-ArraySchema create_schema(Context& ctx, bool allow_duplicates) {
+ArraySchema create_schema(
+    Context& ctx, int64_t dim_max, bool allow_duplicates) {
     // Create schema
     ArraySchema schema(ctx, TILEDB_SPARSE);
 
-    auto dim = Dimension::create<int64_t>(ctx, "d0", {0, 1000});
+    auto dim = Dimension::create<int64_t>(ctx, "d0", {0, dim_max});
 
     Domain domain(ctx);
     domain.add_dimension(dim);
@@ -51,7 +52,8 @@ ArraySchema create_schema(Context& ctx, bool allow_duplicates) {
     return schema;
 }
 
-std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema() {
+std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema(
+    int64_t dim_max) {
     // Create ArrowSchema for SOMAArray
     auto arrow_schema = std::make_unique<ArrowSchema>();
     arrow_schema->format = "+s";
@@ -108,7 +110,7 @@ std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema() {
     d0_info->buffers[0] = nullptr;
     d0_info->buffers[1] = malloc(sizeof(int64_t) * n);
     d0_info->n_children = 0;
-    int64_t dom[] = {0, 1000, 1};
+    int64_t dom[] = {0, dim_max, 1};
     std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * n);
 
     return std::pair(
@@ -116,7 +118,7 @@ std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema() {
         ArrowTable(std::move(col_info_array), std::move(col_info_schema)));
 }
 
-ArrowTable create_column_index_info() {
+ArrowTable create_column_index_info(int64_t dim_max) {
     // Create ArrowSchema for IndexColumnInfo
     auto col_info_schema = std::make_unique<ArrowSchema>();
     col_info_schema->format = "+s";
@@ -152,7 +154,7 @@ ArrowTable create_column_index_info() {
     d0_info->buffers[0] = nullptr;
     d0_info->buffers[1] = malloc(sizeof(int64_t) * n);
     d0_info->n_children = 0;
-    int64_t dom[] = {0, 1000, 1, 0, 2147483646};
+    int64_t dom[] = {0, dim_max, 1, 0, 2147483646};
     std::memcpy((void*)d0_info->buffers[1], &dom, sizeof(int64_t) * n);
 
     return ArrowTable(std::move(col_info_array), std::move(col_info_schema));

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -60,8 +60,10 @@ using namespace Catch::Matchers;
 static const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
 
 namespace helper {
-ArraySchema create_schema(Context& ctx, bool allow_duplicates = false);
-std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema();
-ArrowTable create_column_index_info();
+ArraySchema create_schema(
+    Context& ctx, int64_t dim_max, bool allow_duplicates = false);
+std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema(
+    int64_t dim_max);
+ArrowTable create_column_index_info(int64_t dim_max);
 }  // namespace helper
 #endif

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -32,6 +32,8 @@
 
 #include "common.h"
 
+#define DIM_MAX 1000
+
 TEST_CASE("SOMACollection: basic") {
     TimestampRange ts(0, 2);
     auto ctx = std::make_shared<SOMAContext>();
@@ -53,8 +55,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     std::string sub_uri = "mem://unit-test-add-sparse-ndarray/sub";
 
     SOMACollection::create(base_uri, ctx, ts);
-    auto index_columns = helper::create_column_index_info();
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
+    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, true);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
@@ -94,8 +96,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     std::string sub_uri = "mem://unit-test-add-dense-ndarray/sub";
 
     SOMACollection::create(base_uri, ctx, ts);
-    auto index_columns = helper::create_column_index_info();
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), true);
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
+    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, true);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
@@ -134,7 +136,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     std::string sub_uri = "mem://unit-test-add-dataframe/sub";
 
     SOMACollection::create(base_uri, ctx, ts);
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
@@ -173,7 +175,7 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     std::string sub_uri = "mem://unit-test-add-collection/sub";
 
     SOMACollection::create(base_uri, ctx);
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), false);
+    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, false);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
@@ -198,7 +200,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     std::string sub_uri = "mem://unit-test-add-experiment/sub";
 
     SOMACollection::create(base_uri, ctx);
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
@@ -230,7 +232,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     std::string sub_uri = "mem://unit-test-add-measurement/sub";
 
     SOMACollection::create(base_uri, ctx);
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
@@ -313,7 +315,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     auto ctx = std::make_shared<SOMAContext>();
 
     std::string uri = "mem://unit-test-experiment";
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
     SOMAExperiment::create(
         uri,
         std::move(schema),
@@ -380,7 +382,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 TEST_CASE("SOMAMeasurement: metadata") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-measurement";
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
     SOMAMeasurement::create(
         uri,
         std::move(schema),

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -32,13 +32,15 @@
 
 #include "common.h"
 
+#define DIM_MAX 1000
+
 TEST_CASE("SOMADataFrame: basic") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-dataframe-basic";
 
     REQUIRE(!SOMADataFrame::exists(uri, ctx));
 
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
     SOMADataFrame::create(
         uri,
         std::move(schema),
@@ -148,7 +150,7 @@ TEST_CASE("SOMADataFrame: platform_config") {
                                     R"(]}})";
         }
 
-        auto [schema, index_columns] = helper::create_arrow_schema();
+        auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
         SOMADataFrame::create(
             uri,
             std::move(schema),
@@ -184,7 +186,7 @@ TEST_CASE("SOMADataFrame: platform_config") {
 TEST_CASE("SOMADataFrame: metadata") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-collection";
-    auto [schema, index_columns] = helper::create_arrow_schema();
+    auto [schema, index_columns] = helper::create_arrow_schema(DIM_MAX);
     SOMADataFrame::create(
         uri,
         std::move(schema),

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -32,13 +32,15 @@
 
 #include "common.h"
 
+#define DIM_MAX 1000
+
 TEST_CASE("SOMADenseNDArray: basic") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-dense-ndarray-basic";
 
     REQUIRE(!SOMADenseNDArray::exists(uri, ctx));
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMADenseNDArray::create(
         uri,
         "l",
@@ -91,7 +93,7 @@ TEST_CASE("SOMADenseNDArray: platform_config") {
     PlatformConfig platform_config;
     platform_config.dense_nd_array_dim_zstd_level = 6;
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMADenseNDArray::create(
         uri,
         "l",
@@ -117,7 +119,7 @@ TEST_CASE("SOMADenseNDArray: metadata") {
 
     std::string uri = "mem://unit-test-dense-ndarray";
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMASparseNDArray::create(
         uri,
         "l",

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -31,6 +31,7 @@
  */
 
 #include "common.h"
+#define DIM_MAX 1000
 
 TEST_CASE("SOMASparseNDArray: basic") {
     auto ctx = std::make_shared<SOMAContext>();
@@ -38,7 +39,7 @@ TEST_CASE("SOMASparseNDArray: basic") {
 
     REQUIRE(!SOMASparseNDArray::exists(uri, ctx));
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMASparseNDArray::create(
         uri,
         "l",
@@ -95,7 +96,7 @@ TEST_CASE("SOMASparseNDArray: platform_config") {
     PlatformConfig platform_config;
     platform_config.sparse_nd_array_dim_zstd_level = 6;
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMASparseNDArray::create(
         uri,
         "l",
@@ -121,7 +122,7 @@ TEST_CASE("SOMASparseNDArray: metadata") {
 
     std::string uri = "mem://unit-test-sparse-ndarray";
 
-    auto index_columns = helper::create_column_index_info();
+    auto index_columns = helper::create_column_index_info(DIM_MAX);
     SOMASparseNDArray::create(
         uri,
         "l",


### PR DESCRIPTION
**Issue and/or context:** This is a line-count-reducing under-diff split out from #2785 for issue #2407; [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). It will help reduce distractions on upcoming review of more substantial PRs.

**Changes:**

Up until now the number of rows in arrow-schema/arrow-data for dataframe setup from Python/R to C++ has had 3 slots. On #2785 it will necessarily have 5. This PR parameterizes some hard-coded values of `3` to now reference `n`, after `int n = 3`.

Similarly, this PR replaces a hard-coded within-function 1000 to a new parameter `dim_max` for use by callers, who will need explicit construction access to test resize logic for upcoming PRs on #2407.

**Notes for Reviewer:**

#2785 is unreviewable as-is: besides being a WIP, it's an all-in-one experimental area. Smaller PRs such as this one are being offered for manageable review.