### PR TITLE
[r]  Small robustification for version comparison

### DIFF
--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -8,11 +8,10 @@
     ## create a slot for somactx in per-package enviroment, do no fill it yet to allow 'lazy load'
     .pkgenv[["somactx"]] <- NULL
 
-    rpkg_lib_version <- tiledb::tiledb_version(compact=TRUE)
-    soma_lib_version <- libtiledbsoma_version(compact=TRUE)
+    rpkg_lib <- tiledb::tiledb_version(compact = FALSE)
     # Check major and minor but not micro: sc-50464
-    rpkg_lib_version <- paste(strsplit(as.character(rpkg_lib_version), "\\.")[[1]][1:2], collapse = ".")
-    soma_lib_version <- paste(strsplit(soma_lib_version, "\\.")[[1]][1:2], collapse = ".")
+    rpkg_lib_version <- paste(rpkg_lib[["major"]], rpkg_lib[["minor"]], sep = ".")
+    soma_lib_version <- libtiledbsoma_version(compact = TRUE, major_minor_only = TRUE)
     if (rpkg_lib_version != soma_lib_version) {
         msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",
                        sQuote(rpkg_lib_version), sQuote(soma_lib_version))

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -235,8 +235,8 @@ tiledbsoma_stats_dump <- function() {
 #' If argument `compact` is set to `TRUE`, a shorter version of just the TileDB Embedded library
 #' version is returned,
 #' @noRd
-libtiledbsoma_version <- function(compact = FALSE) {
-    .Call(`_tiledbsoma_libtiledbsoma_version`, compact)
+libtiledbsoma_version <- function(compact = FALSE, major_minor_only = FALSE) {
+    .Call(`_tiledbsoma_libtiledbsoma_version`, compact, major_minor_only)
 }
 
 #' TileDB embedded version

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -368,13 +368,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledbsoma_version
-std::string libtiledbsoma_version(const bool compact);
-RcppExport SEXP _tiledbsoma_libtiledbsoma_version(SEXP compactSEXP) {
+std::string libtiledbsoma_version(const bool compact, const bool major_minor_only);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_version(SEXP compactSEXP, SEXP major_minor_onlySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const bool >::type compact(compactSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_version(compact));
+    Rcpp::traits::input_parameter< const bool >::type major_minor_only(major_minor_onlySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_version(compact, major_minor_only));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -454,7 +455,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_tiledbsoma_stats_disable", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_disable, 0},
     {"_tiledbsoma_tiledbsoma_stats_reset", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_reset, 0},
     {"_tiledbsoma_tiledbsoma_stats_dump", (DL_FUNC) &_tiledbsoma_tiledbsoma_stats_dump, 0},
-    {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 1},
+    {"_tiledbsoma_libtiledbsoma_version", (DL_FUNC) &_tiledbsoma_libtiledbsoma_version, 2},
     {"_tiledbsoma_tiledb_embedded_version", (DL_FUNC) &_tiledbsoma_tiledb_embedded_version, 0},
     {"_tiledbsoma_tiledb_datatype_max_value", (DL_FUNC) &_tiledbsoma_tiledb_datatype_max_value, 1},
     {"_tiledbsoma_get_soma_object_type", (DL_FUNC) &_tiledbsoma_get_soma_object_type, 2},

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -252,11 +252,15 @@ std::string tiledbsoma_stats_dump() {
 //' version is returned,
 //' @noRd
 // [[Rcpp::export]]
-std::string libtiledbsoma_version(const bool compact = false) {
+std::string libtiledbsoma_version(const bool compact = false, const bool major_minor_only = false) {
     if (compact) {
         auto v = tiledbsoma::version::embedded_version_triple();
         std::ostringstream txt;
-        txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
+        if (major_minor_only) {
+            txt << std::get<0>(v) << "." << std::get<1>(v);
+        } else {
+            txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
+        }
         return txt.str();
     } else {
         return tiledbsoma::version::as_string();


### PR DESCRIPTION
**Issue and/or context:**

When comparing major.minor versions of the underlying library we were reconstruction <major,minor,patch> from the string when we do actually have the components and can use then directly.

**Changes:**

This applies a small simplification to supply a two element <major,minor> vector as needed for the comparison and also uses the vector form the other version.  This allow us to remove two `strsplit()` calls.

**Notes for Reviewer:**

[SC 50630](https://app.shortcut.com/tiledb-inc/story/50630/r-minor-robustification-for-version-comparison) 

I put this together after the previous vacation and didn't PR it yet as it wasn't that important but seeing that we are doing other cleanups this weekend may as well put it up.
