### PR TITLE
[c++] Remove some dead unit-test code

### DIFF
--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -33,24 +33,6 @@
 #include "common.h"
 
 namespace helper {
-ArraySchema create_schema(
-    Context& ctx, int64_t dim_max, bool allow_duplicates) {
-    // Create schema
-    ArraySchema schema(ctx, TILEDB_SPARSE);
-
-    auto dim = Dimension::create<int64_t>(ctx, "d0", {0, dim_max});
-
-    Domain domain(ctx);
-    domain.add_dimension(dim);
-    schema.set_domain(domain);
-
-    auto attr = Attribute::create<int>(ctx, "a0");
-    schema.add_attribute(attr);
-    schema.set_allows_dups(allow_duplicates);
-    schema.check();
-
-    return schema;
-}
 
 std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema(
     int64_t dim_max) {

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -60,8 +60,6 @@ using namespace Catch::Matchers;
 static const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
 
 namespace helper {
-ArraySchema create_schema(
-    Context& ctx, int64_t dim_max, bool allow_duplicates = false);
 std::pair<std::unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema(
     int64_t dim_max);
 ArrowTable create_column_index_info(int64_t dim_max);

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -56,7 +56,6 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
 
     SOMACollection::create(base_uri, ctx, ts);
     auto index_columns = helper::create_column_index_info(DIM_MAX);
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, true);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
@@ -97,7 +96,6 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
 
     SOMACollection::create(base_uri, ctx, ts);
     auto index_columns = helper::create_column_index_info(DIM_MAX);
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, true);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
@@ -175,7 +173,6 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     std::string sub_uri = "mem://unit-test-add-collection/sub";
 
     SOMACollection::create(base_uri, ctx);
-    auto schema = helper::create_schema(*ctx->tiledb_ctx(), DIM_MAX, false);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};


### PR DESCRIPTION
**Issue and/or context:** Found while working on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:** The three places `create_schema` is called, it is not used.

**Notes for Reviewer:**

