### PR TITLE
shellcheck `scripts/bld`

### DIFF
--- a/scripts/bld
+++ b/scripts/bld
@@ -74,38 +74,16 @@ fi
 
 # build with custom tiledb
 if [ -n "${tiledb}"  ]; then
-  printf "Build with TileDB: ${tiledb}\n"
+  echo "Build with TileDB: $tiledb"
   extra_opts+=" -DFORCE_BUILD_TILEDB=OFF"
   export TileDB_DIR="${tiledb}"
-
-  # It's more elegant to use
-  #   if [[ -v LD_LIBRARY_PATH ]]; then
-  #     ...
-  #   fi
-  # -- however, this is supported by bash not sh. And this script can
-  # be invoked by python via its shell-out which seems to use sh.
-  # It's simplest to just pause set -u.
-
-  set +u
-
-  if [ -z $"LD_LIBRARY_PATH" ]; then
-    export LD_LIBRARY_PATH="${tiledb}"
-  else
-    export LD_LIBRARY_PATH="${tiledb}:${LD_LIBRARY_PATH}"
-  fi
-
-  if [ -z $"DYLD_LIBRARY_PATH" ]; then
-    export DYLD_LIBRARY_PATH="${tiledb}"
-  else
-    export DYLD_LIBRARY_PATH="${tiledb}:${DYLD_LIBRARY_PATH}"
-  fi
-
-  set -u
+  export LD_LIBRARY_PATH="${tiledb}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  export DYLD_LIBRARY_PATH="${tiledb}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 fi
 
 # run cmake
 # -------------------------------------------------------------------
-printf "Building ${build} build\n"
+echo "Building ${build} build"
 
 # cd to the top level directory of the repo
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
### Issue and/or context

<details>
<summary>
<a href="https://github.com/single-cell-data/TileDB-SOMA/pull/2218/files#r1728970448">
#2218 (comment)
</a>
</summary>

<br/>

> `$"LD_LIBRARY_PATH"` evaluates to the string `LD_LIBRARY_PATH`; the `$` needs to be inside the quotes:
> 
> ```bash
> docker run --rm bash -c 'foo=1; echo $"foo" "$foo"'
> # foo 1
> ```
> 
> `[ -z $"LD_LIBRARY_PATH" ]` is always false, so we've inadvertently been doing what @bkmartinjr suggested (always prepending `${tiledb}:`). I think this is also why the `set +u` seemed necessary; the "append" block was running even with `LD_LIBRARY_PATH` unset, which `set -u` was flagging as an error.
> 
> A common way of doing these two `if` blocks is:
> ```bash
> export LD_LIBRARY_PATH="$tiledb${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
> export DYLD_LIBRARY_PATH="$tiledb${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
> ```
> cf. [SO](https://stackoverflow.com/a/46892074). This also works in `sh`:
> ```bash
> test() {
>   docker run --rm --entrypoint sh ubuntu -c "set -u; $1"
> }
> 
> test 'echo "prepended_val${foo:+:$foo}"'           # `foo` unset
> # prepended_val
> test 'foo=; echo "prepended_val${foo:+:$foo}"'     # `foo` empty
> # prepended_val
> test 'foo=val; echo "prepended_val${foo:+:$foo}"'  # `foo` nonempty
> # prepended_val:val
> test 'echo "prepended_val${foo:+:}$foo"'           # `foo` unset, and used outside `${foo:+…}` guard ⟹ `set -u` errors (as expected)
> # sh: 1: foo: parameter not set
> ```
> though I'd think this file's shebang line ensures we're always running `bash`.

</details> 

### Changes

Fix "`$` outside quotes" issue, replace `if`s with `${var:+…}`, remove `set +u`/`set -u`:

```diff
-if [ -z $"LD_LIBRARY_PATH" ]; then
-  export LD_LIBRARY_PATH="${tiledb}"
-else
-  export LD_LIBRARY_PATH="${tiledb}:${LD_LIBRARY_PATH}"
-fi
+export LD_LIBRARY_PATH="$tiledb${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
```

Use `echo` instead of `printf` (per [SC2059](https://github.com/koalaman/shellcheck/wiki/SC2059)):

```diff
-printf "Building ${build} build\n"
+echo "Building ${build} build"
```
