### PR TITLE
[r] Signal script failure to calling script, polish messages

### DIFF
--- a/apis/r/configure
+++ b/apis/r/configure
@@ -44,6 +44,11 @@ ${R_HOME}/bin/Rscript tools/check_cmake_and_git.R
 export CC="`${R_HOME}/bin/R CMD config CC`"
 export CXX="`${R_HOME}/bin/R CMD config CXX`"
 export CMAKE_OSX_ARCHITECTURES="`uname -m`"
+
+## The 'build_libtiledbsoma.sh' script is made / finalised by an earlier script.
+if [ ! -f tools/build_libtiledbsoma.sh ]; then
+    exit 1
+fi
 tools/build_libtiledbsoma.sh
 
 pkgincl="-I../inst/tiledb/include -I../inst/tiledbsoma/include -I../inst/tiledbsoma/include/tiledbsoma"

--- a/apis/r/tools/check_cmake_and_git.R
+++ b/apis/r/tools/check_cmake_and_git.R
@@ -5,12 +5,14 @@ if (cmake_bin == "" && file.exists("/Applications/CMake.app/Contents/bin/cmake")
     cmake_bin <- "/Applications/CMake.app/Contents/bin/cmake"
 
 if (cmake_bin == "") {
-    stop("No 'cmake' binary found", call. = FALSE)
+    message("\n*** No 'cmake' binary found.\n*** Please install 'cmake' to build from source.\n")
+    q(save = "no", status = 1)
 }
 
 git_bin <- Sys.which("git")
 if (git_bin == "") {
-    stop("No 'git' binary found", call. = FALSE)
+    message("\n*** No 'git' binary found.\n*** Please install 'git' to build from source.\n")
+    q(save = "no", status = 1)
 }
 
 lines <- readLines("tools/build_libtiledbsoma.sh.in")

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -23,7 +23,8 @@ if (isMac) {
 } else if (isLinux) {
     url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.25.0/tiledb-linux-x86_64-2.25.0-bbcbd3f.tar.gz"
 } else {
-    stop("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
+    message("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
+    q(save = "no", status = 1)
 }
 
 tarball <- "tiledb.tar.gz"


### PR DESCRIPTION
**Issue and/or context:**

As seen in #2931, error messages are not clear enough and do not break the build soon enough.

**Changes:**

Ensure the failing error code is transmitted.  Make error text displayed a little 'louder' as well.

**Notes for Reviewer:**

[SC 53847](https://app.shortcut.com/tiledb-inc/story/53847/r-make-some-build-failure-modes-more-visible)