### PR TITLE
[python] Support NumPy 2

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -329,7 +329,7 @@ setuptools.setup(
         "anndata>=0.10.1",
         "attrs>=22.2",
         "numba>=0.58.0",
-        "numpy<2.0",
+        "numpy",
         "pandas",
         "pyarrow",
         "scanpy>=1.9.2",

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -734,7 +734,7 @@ def test_null_obs(conftest_pbmc_small, tmp_path: Path):
     seed = 42
     #   Create column of all null values
     conftest_pbmc_small.obs["empty_categorical_all"] = pd.Categorical(
-        [np.NaN] * conftest_pbmc_small.n_obs,
+        [np.nan] * conftest_pbmc_small.n_obs,
         dtype=pd.CategoricalDtype(categories=[], ordered=False),
     )
     conftest_pbmc_small.obs["empty_extension_all"] = pd.Series(
@@ -744,7 +744,7 @@ def test_null_obs(conftest_pbmc_small, tmp_path: Path):
     rng = np.random.RandomState(seed)
 
     conftest_pbmc_small.obs["empty_categorical_partial"] = rng.choice(
-        (np.NaN, 1.0), conftest_pbmc_small.n_obs, True
+        (np.nan, 1.0), conftest_pbmc_small.n_obs, True
     )
     conftest_pbmc_small.obs["empty_extension_partial"] = pd.Series(
         [1] * conftest_pbmc_small.n_obs + [np.nan], dtype=pd.Int64Dtype()

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1218,7 +1218,7 @@ def test_extend_enumerations(tmp_path):
                 np.array([0, 1.1, 2.1, 0, 1.1, 2.1], dtype=np.float64), dtype="category"
             ),
             "float64_w_non_finite": pd.Series(
-                np.array([0, 1.1, 2.1, 0, np.Inf, np.NINF], dtype=np.float64),
+                np.array([0, 1.1, 2.1, 0, np.inf, -np.inf], dtype=np.float64),
                 dtype="category",
             ),
             "str_ordered": pd.Series(

--- a/apis/python/tests/test_regression.py
+++ b/apis/python/tests/test_regression.py
@@ -10,9 +10,7 @@ def test_nd_dense_non_contiguous_write(tmp_path):
     """Test regression dected in GitHub Issue #2537"""
     # Create data.
     data = (
-        np.arange(np.product(24), dtype=np.uint8)
-        .reshape((4, 3, 2))
-        .transpose((2, 0, 1))
+        np.arange(np.prod(24), dtype=np.uint8).reshape((4, 3, 2)).transpose((2, 0, 1))
     )
     coords = tuple(slice(0, dim_len) for dim_len in data.shape)
     tensor = pa.Tensor.from_numpy(data)


### PR DESCRIPTION
**Issue and/or context:** #2536

**Changes:**

**Notes for Reviewer:**

Main thing to watch for: NumPy 2.0 does not support Python 3.8, while we have not yet dropped support for Python 3.8 (#2141).

Per https://github.com/numpy/numpy/releases/tag/v2.0.0:

> The Python versions supported by this release are 3.9-3.12.

I thought we'd need a bit in `setup.py` like

```
        # There is no Python 3.8 support for NumPy 2
        "numpy<2; python_version<'3.9'",
        "numpy; python_version>='3.9'",
```

but in hindsight it seems not -- a Python 3.8 asking to get NumPy will simply not be _offered_ version 2 in the first place 😎 
