### PR TITLE
[c++] Pre-neatens before making unit-test helpers for variant-indexed dataframes

### DIFF
--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -85,8 +85,8 @@ create_arrow_schema_and_index_columns(
     int64_t dim_max, bool use_current_domain) {
     // Create ArrowSchema for the entire SOMAArray: dims and attrs both
     auto arrow_schema = std::make_unique<ArrowSchema>();
-    arrow_schema->format = "+s";  // non-leaf node
-    arrow_schema->n_children = 2;
+    arrow_schema->format = "+s";
+    arrow_schema->n_children = 2;  // non-leaf node
     arrow_schema->dictionary = nullptr;
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->children = new ArrowSchema*[arrow_schema->n_children];
@@ -129,8 +129,8 @@ ArrowTable create_column_index_info(int64_t dim_max, bool use_current_domain) {
 static std::unique_ptr<ArrowSchema> _create_index_cols_info_schema(
     std::string dim_name) {
     auto index_cols_info_schema = std::make_unique<ArrowSchema>();
-    index_cols_info_schema->format = "+s";  // non-leaf node
-    index_cols_info_schema->n_children = 1;
+    index_cols_info_schema->format = "+s";
+    index_cols_info_schema->n_children = 1;  // non-leaf node
     index_cols_info_schema->dictionary = nullptr;
     index_cols_info_schema->release = &ArrowAdapter::release_schema;
     index_cols_info_schema


### PR DESCRIPTION
**Issue and/or context:** This is a line-count-reducing under-diff followingon #2919 for issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

The intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Just some prep for my next step to unit-test #2916 and #2917, namely, we need libtiledbsoma-level support for variant-indexed dataframes (those whose dim is something other than a single int64).

**Notes for Reviewer:**

#2785 is unreviewable as-is: besides being a WIP, it's an all-in-one experimental area. Smaller PRs such as this one are being offered for manageable review.