### PR TITLE
[c++] More `use_current_domain` unit-test parameterization

### DIFF
--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -106,6 +106,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     std::string sub_uri = "mem://unit-test-add-dense-ndarray/sub";
 
     SOMACollection::create(base_uri, ctx, ts);
+    // TODO: add support for current domain in dense arrays once we have that
+    // support from core
     auto index_columns = helper::create_column_index_info(DIM_MAX, false);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
@@ -139,44 +141,52 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
 }
 
 TEST_CASE("SOMACollection: add SOMADataFrame") {
-    TimestampRange ts(0, 2);
-    auto ctx = std::make_shared<SOMAContext>();
-    std::string base_uri = "mem://unit-test-add-dataframe";
-    std::string sub_uri = "mem://unit-test-add-dataframe/sub";
+    auto use_current_domain = GENERATE(false, true);
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        TimestampRange ts(0, 2);
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string base_uri = "mem://unit-test-add-dataframe";
+        std::string sub_uri = "mem://unit-test-add-dataframe/sub";
 
-    SOMACollection::create(base_uri, ctx, ts);
-    auto [schema, index_columns] =
-        helper::create_arrow_schema_and_index_columns(DIM_MAX, false);
+        SOMACollection::create(base_uri, ctx, ts);
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                DIM_MAX, use_current_domain);
 
-    std::map<std::string, SOMAGroupEntry> expected_map{
-        {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
+        std::map<std::string, SOMAGroupEntry> expected_map{
+            {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
-    auto soma_collection = SOMACollection::open(
-        base_uri, OpenMode::write, ctx, ts);
-    REQUIRE(soma_collection->timestamp() == ts);
+        auto soma_collection = SOMACollection::open(
+            base_uri, OpenMode::write, ctx, ts);
+        REQUIRE(soma_collection->timestamp() == ts);
 
-    auto soma_dataframe = soma_collection->add_new_dataframe(
-        "dataframe",
-        sub_uri,
-        URIType::absolute,
-        ctx,
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members_map() == expected_map);
-    REQUIRE(soma_dataframe->uri() == sub_uri);
-    REQUIRE(soma_dataframe->ctx() == ctx);
-    REQUIRE(soma_dataframe->type() == "SOMADataFrame");
-    std::vector<std::string> expected_index_column_names = {"d0"};
-    REQUIRE(
-        soma_dataframe->index_column_names() == expected_index_column_names);
-    REQUIRE(soma_dataframe->timestamp() == ts);
-    soma_collection->close();
+        auto soma_dataframe = soma_collection->add_new_dataframe(
+            "dataframe",
+            sub_uri,
+            URIType::absolute,
+            ctx,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)));
+        REQUIRE(soma_collection->members_map() == expected_map);
+        REQUIRE(soma_dataframe->uri() == sub_uri);
+        REQUIRE(soma_dataframe->ctx() == ctx);
+        REQUIRE(soma_dataframe->type() == "SOMADataFrame");
+        std::vector<std::string> expected_index_column_names = {"d0"};
+        REQUIRE(
+            soma_dataframe->index_column_names() ==
+            expected_index_column_names);
+        REQUIRE(soma_dataframe->timestamp() == ts);
+        soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members_map() == expected_map);
-    REQUIRE(soma_dataframe->count() == 0);
-    soma_collection->close();
+        soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+        REQUIRE(soma_collection->members_map() == expected_map);
+        REQUIRE(soma_dataframe->count() == 0);
+        soma_collection->close();
+    }
 }
 
 TEST_CASE("SOMACollection: add SOMACollection") {
@@ -204,69 +214,85 @@ TEST_CASE("SOMACollection: add SOMACollection") {
 }
 
 TEST_CASE("SOMACollection: add SOMAExperiment") {
-    auto ctx = std::make_shared<SOMAContext>();
-    std::string base_uri = "mem://unit-test-add-experiment";
-    std::string sub_uri = "mem://unit-test-add-experiment/sub";
+    auto use_current_domain = GENERATE(false, true);
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string base_uri = "mem://unit-test-add-experiment";
+        std::string sub_uri = "mem://unit-test-add-experiment/sub";
 
-    SOMACollection::create(base_uri, ctx);
-    auto [schema, index_columns] =
-        helper::create_arrow_schema_and_index_columns(DIM_MAX, false);
+        SOMACollection::create(base_uri, ctx);
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                DIM_MAX, use_current_domain);
 
-    std::map<std::string, SOMAGroupEntry> expected_map{
-        {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
+        std::map<std::string, SOMAGroupEntry> expected_map{
+            {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
-    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
-    auto soma_experiment = soma_collection->add_new_experiment(
-        "experiment",
-        sub_uri,
-        URIType::absolute,
-        ctx,
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members_map() == expected_map);
-    REQUIRE(soma_experiment->uri() == sub_uri);
-    REQUIRE(soma_experiment->ctx() == ctx);
-    REQUIRE(soma_experiment->type() == "SOMAExperiment");
-    soma_experiment->close();
-    soma_collection->close();
+        auto soma_collection = SOMACollection::open(
+            base_uri, OpenMode::write, ctx);
+        auto soma_experiment = soma_collection->add_new_experiment(
+            "experiment",
+            sub_uri,
+            URIType::absolute,
+            ctx,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)));
+        REQUIRE(soma_collection->members_map() == expected_map);
+        REQUIRE(soma_experiment->uri() == sub_uri);
+        REQUIRE(soma_experiment->ctx() == ctx);
+        REQUIRE(soma_experiment->type() == "SOMAExperiment");
+        soma_experiment->close();
+        soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members_map() == expected_map);
-    soma_collection->close();
+        soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+        REQUIRE(soma_collection->members_map() == expected_map);
+        soma_collection->close();
+    }
 }
 
 TEST_CASE("SOMACollection: add SOMAMeasurement") {
-    auto ctx = std::make_shared<SOMAContext>();
-    std::string base_uri = "mem://unit-test-add-measurement";
-    std::string sub_uri = "mem://unit-test-add-measurement/sub";
+    auto use_current_domain = GENERATE(false, true);
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string base_uri = "mem://unit-test-add-measurement";
+        std::string sub_uri = "mem://unit-test-add-measurement/sub";
 
-    SOMACollection::create(base_uri, ctx);
-    auto [schema, index_columns] =
-        helper::create_arrow_schema_and_index_columns(DIM_MAX, false);
+        SOMACollection::create(base_uri, ctx);
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                DIM_MAX, use_current_domain);
 
-    std::map<std::string, SOMAGroupEntry> expected_map{
-        {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
+        std::map<std::string, SOMAGroupEntry> expected_map{
+            {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
-    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
-    auto soma_measurement = soma_collection->add_new_measurement(
-        "measurement",
-        sub_uri,
-        URIType::absolute,
-        ctx,
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)));
-    REQUIRE(soma_collection->members_map() == expected_map);
-    REQUIRE(soma_measurement->uri() == sub_uri);
-    REQUIRE(soma_measurement->ctx() == ctx);
-    REQUIRE(soma_measurement->type() == "SOMAMeasurement");
-    soma_measurement->close();
-    soma_collection->close();
+        auto soma_collection = SOMACollection::open(
+            base_uri, OpenMode::write, ctx);
+        auto soma_measurement = soma_collection->add_new_measurement(
+            "measurement",
+            sub_uri,
+            URIType::absolute,
+            ctx,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)));
+        REQUIRE(soma_collection->members_map() == expected_map);
+        REQUIRE(soma_measurement->uri() == sub_uri);
+        REQUIRE(soma_measurement->ctx() == ctx);
+        REQUIRE(soma_measurement->type() == "SOMAMeasurement");
+        soma_measurement->close();
+        soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
-    REQUIRE(soma_collection->members_map() == expected_map);
-    soma_collection->close();
+        soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+        REQUIRE(soma_collection->members_map() == expected_map);
+        soma_collection->close();
+    }
 }
 
 TEST_CASE("SOMACollection: metadata") {
@@ -323,136 +349,156 @@ TEST_CASE("SOMACollection: metadata") {
 }
 
 TEST_CASE("SOMAExperiment: metadata") {
-    auto ctx = std::make_shared<SOMAContext>();
+    auto use_current_domain = GENERATE(false, true);
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
 
-    std::string uri = "mem://unit-test-experiment";
-    auto [schema, index_columns] =
-        helper::create_arrow_schema_and_index_columns(DIM_MAX, false);
-    SOMAExperiment::create(
-        uri,
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
-        ctx,
-        PlatformConfig(),
-        TimestampRange(0, 2));
-    auto soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+        std::string uri = "mem://unit-test-experiment";
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                DIM_MAX, use_current_domain);
+        SOMAExperiment::create(
+            uri,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx,
+            PlatformConfig(),
+            TimestampRange(0, 2));
+        auto soma_experiment = SOMAExperiment::open(
+            uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
-    int32_t val = 100;
-    soma_experiment->set_metadata("md", TILEDB_INT32, 1, &val);
-    soma_experiment->close();
+        int32_t val = 100;
+        soma_experiment->set_metadata("md", TILEDB_INT32, 1, &val);
+        soma_experiment->close();
 
-    // Read metadata
-    soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_experiment->metadata_num() == 4);
-    REQUIRE(soma_experiment->has_metadata("dataset_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_object_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
-    REQUIRE(soma_experiment->has_metadata("md"));
-    auto mdval = soma_experiment->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
-    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
-    soma_experiment->close();
+        // Read metadata
+        soma_experiment = SOMAExperiment::open(
+            uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        REQUIRE(soma_experiment->metadata_num() == 4);
+        REQUIRE(soma_experiment->has_metadata("dataset_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_object_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
+        REQUIRE(soma_experiment->has_metadata("md"));
+        auto mdval = soma_experiment->get_metadata("md");
+        REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+        REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+        REQUIRE(
+            *((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+        soma_experiment->close();
 
-    // md should not be available at (2, 2)
-    soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(2, 2));
-    REQUIRE(soma_experiment->metadata_num() == 3);
-    REQUIRE(soma_experiment->has_metadata("dataset_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_object_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
-    REQUIRE(!soma_experiment->has_metadata("md"));
-    soma_experiment->close();
+        // md should not be available at (2, 2)
+        soma_experiment = SOMAExperiment::open(
+            uri, OpenMode::read, ctx, TimestampRange(2, 2));
+        REQUIRE(soma_experiment->metadata_num() == 3);
+        REQUIRE(soma_experiment->has_metadata("dataset_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_object_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
+        REQUIRE(!soma_experiment->has_metadata("md"));
+        soma_experiment->close();
 
-    // Metadata should also be retrievable in write mode
-    soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::write, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_experiment->metadata_num() == 4);
-    REQUIRE(soma_experiment->has_metadata("dataset_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_object_type"));
-    REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
-    REQUIRE(soma_experiment->has_metadata("md"));
-    mdval = soma_experiment->get_metadata("md");
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+        // Metadata should also be retrievable in write mode
+        soma_experiment = SOMAExperiment::open(
+            uri, OpenMode::write, ctx, TimestampRange(0, 2));
+        REQUIRE(soma_experiment->metadata_num() == 4);
+        REQUIRE(soma_experiment->has_metadata("dataset_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_object_type"));
+        REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
+        REQUIRE(soma_experiment->has_metadata("md"));
+        mdval = soma_experiment->get_metadata("md");
+        REQUIRE(
+            *((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
 
-    // Delete and have it reflected when reading metadata while in write mode
-    soma_experiment->delete_metadata("md");
-    mdval = soma_experiment->get_metadata("md");
-    REQUIRE(!mdval.has_value());
-    soma_experiment->close();
+        // Delete and have it reflected when reading metadata while in write
+        // mode
+        soma_experiment->delete_metadata("md");
+        mdval = soma_experiment->get_metadata("md");
+        REQUIRE(!mdval.has_value());
+        soma_experiment->close();
 
-    // Confirm delete in read mode
-    soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
-    REQUIRE(!soma_experiment->has_metadata("md"));
-    REQUIRE(soma_experiment->metadata_num() == 3);
+        // Confirm delete in read mode
+        soma_experiment = SOMAExperiment::open(
+            uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        REQUIRE(!soma_experiment->has_metadata("md"));
+        REQUIRE(soma_experiment->metadata_num() == 3);
+    }
 }
 
 TEST_CASE("SOMAMeasurement: metadata") {
-    auto ctx = std::make_shared<SOMAContext>();
-    std::string uri = "mem://unit-test-measurement";
-    auto [schema, index_columns] =
-        helper::create_arrow_schema_and_index_columns(DIM_MAX, false);
-    SOMAMeasurement::create(
-        uri,
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
-        ctx,
-        PlatformConfig(),
-        TimestampRange(0, 2));
+    auto use_current_domain = GENERATE(false, true);
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string uri = "mem://unit-test-measurement";
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                DIM_MAX, use_current_domain);
+        SOMAMeasurement::create(
+            uri,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx,
+            PlatformConfig(),
+            TimestampRange(0, 2));
 
-    auto soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+        auto soma_measurement = SOMAMeasurement::open(
+            uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
-    int32_t val = 100;
-    soma_measurement->set_metadata("md", TILEDB_INT32, 1, &val);
-    soma_measurement->close();
+        int32_t val = 100;
+        soma_measurement->set_metadata("md", TILEDB_INT32, 1, &val);
+        soma_measurement->close();
 
-    // Read metadata
-    soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_measurement->metadata_num() == 3);
-    REQUIRE(soma_measurement->has_metadata("soma_object_type"));
-    REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
-    REQUIRE(soma_measurement->has_metadata("md"));
-    auto mdval = soma_measurement->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
-    REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
-    soma_measurement->close();
+        // Read metadata
+        soma_measurement = SOMAMeasurement::open(
+            uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        REQUIRE(soma_measurement->metadata_num() == 3);
+        REQUIRE(soma_measurement->has_metadata("soma_object_type"));
+        REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
+        REQUIRE(soma_measurement->has_metadata("md"));
+        auto mdval = soma_measurement->get_metadata("md");
+        REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+        REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
+        REQUIRE(
+            *((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+        soma_measurement->close();
 
-    // md should not be available at (2, 2)
-    soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(2, 2));
-    REQUIRE(soma_measurement->metadata_num() == 2);
-    REQUIRE(soma_measurement->has_metadata("soma_object_type"));
-    REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
-    REQUIRE(!soma_measurement->has_metadata("md"));
-    soma_measurement->close();
+        // md should not be available at (2, 2)
+        soma_measurement = SOMAMeasurement::open(
+            uri, OpenMode::read, ctx, TimestampRange(2, 2));
+        REQUIRE(soma_measurement->metadata_num() == 2);
+        REQUIRE(soma_measurement->has_metadata("soma_object_type"));
+        REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
+        REQUIRE(!soma_measurement->has_metadata("md"));
+        soma_measurement->close();
 
-    // Metadata should also be retrievable in write mode
-    soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::write, ctx, TimestampRange(0, 2));
-    REQUIRE(soma_measurement->metadata_num() == 3);
-    REQUIRE(soma_measurement->has_metadata("soma_object_type"));
-    REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
-    REQUIRE(soma_measurement->has_metadata("md"));
-    mdval = soma_measurement->get_metadata("md");
-    REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
+        // Metadata should also be retrievable in write mode
+        soma_measurement = SOMAMeasurement::open(
+            uri, OpenMode::write, ctx, TimestampRange(0, 2));
+        REQUIRE(soma_measurement->metadata_num() == 3);
+        REQUIRE(soma_measurement->has_metadata("soma_object_type"));
+        REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
+        REQUIRE(soma_measurement->has_metadata("md"));
+        mdval = soma_measurement->get_metadata("md");
+        REQUIRE(
+            *((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
 
-    // Delete and have it reflected when reading metadata while in write mode
-    soma_measurement->delete_metadata("md");
-    mdval = soma_measurement->get_metadata("md");
-    REQUIRE(!mdval.has_value());
-    soma_measurement->close();
+        // Delete and have it reflected when reading metadata while in write
+        // mode
+        soma_measurement->delete_metadata("md");
+        mdval = soma_measurement->get_metadata("md");
+        REQUIRE(!mdval.has_value());
+        soma_measurement->close();
 
-    // Confirm delete in read mode
-    soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
-    REQUIRE(!soma_measurement->has_metadata("md"));
-    REQUIRE(soma_measurement->metadata_num() == 2);
+        // Confirm delete in read mode
+        soma_measurement = SOMAMeasurement::open(
+            uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        REQUIRE(!soma_measurement->has_metadata("md"));
+        REQUIRE(soma_measurement->metadata_num() == 2);
+    }
 }


### PR DESCRIPTION
**Issue and/or context:** This is a line-count-reducing under-diff following on #2911 for issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

The intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

This is more in the vein of https://github.com/single-cell-data/TileDB-SOMA/pull/2911#discussion_r1733506115 -- I missed a few spots

**Notes for Reviewer:**

Suggestion: review with the ignore-white-space option. There's not much here. :)

#2785 is unreviewable as-is: besides being a WIP, it's an all-in-one experimental area. Smaller PRs such as this one are being offered for manageable review.