### PR TITLE
[c++] Test core PR 5260 [WIP] [skip ci]

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -473,6 +473,14 @@ uint64_t SOMAArray::_get_max_capacity(tiledb_datatype_t index_type) {
 
 ArraySchemaEvolution SOMAArray::_make_se() {
     ArraySchemaEvolution se(*ctx_->tiledb_ctx());
+    if (timestamp_.has_value()) {
+        // ArraySchemaEvolution requires us to pair (t2, t2) even if our range
+        // is (t1, t2).
+        auto v = timestamp_.value();
+        TimestampRange tr(v.second, v.second);
+        se.set_timestamp_range(tr);
+    }
+
     return se;
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -53,7 +53,8 @@ void SOMADataFrame::create(
             std::move(index_columns.first), std::move(index_columns.second)),
         "SOMADataFrame",
         true,
-        platform_config);
+        platform_config,
+        timestamp);
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMADataFrame", timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -84,7 +84,8 @@ void SOMADenseNDArray::create(
             std::move(index_column_array), std::move(index_column_schema)),
         "SOMADenseNDArray",
         false,
-        platform_config);
+        platform_config,
+        timestamp);
 
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMADenseNDArray", timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -85,7 +85,8 @@ void SOMASparseNDArray::create(
             std::move(index_column_array), std::move(index_column_schema)),
         "SOMASparseNDArray",
         true,
-        platform_config);
+        platform_config,
+        timestamp);
 
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMASparseNDArray", timestamp);
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -479,11 +479,12 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
     ArrowTable index_column_info,
     std::string soma_type,
     bool is_sparse,
-    PlatformConfig platform_config) {
+    PlatformConfig platform_config,
+    std::optional<std::pair<int64_t, int64_t>> timestamp_range) {
     auto index_column_array = std::move(index_column_info.first);
     auto index_column_schema = std::move(index_column_info.second);
 
-    ArraySchema schema(*ctx, is_sparse ? TILEDB_SPARSE : TILEDB_DENSE);
+    ArraySchema schema(*ctx, is_sparse ? TILEDB_SPARSE : TILEDB_DENSE, timestamp_range);
     Domain domain(*ctx);
 
     schema.set_capacity(platform_config.capacity);

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -199,7 +199,8 @@ class ArrowAdapter {
         ArrowTable index_column_info,
         std::string soma_type,
         bool is_sparse = true,
-        PlatformConfig platform_config = PlatformConfig());
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<std::pair<int64_t, int64_t>> timestamp_range = std::nullopt);
 
     /**
      * @brief Get Arrow format string from TileDB datatype.


### PR DESCRIPTION
This exists for testing https://github.com/TileDB-Inc/TileDB/pull/5260. It won't compile without that (e.g. in a sandbox checkout). I put it up as a draft PR for bus-factor avoidance.

Here are some test scripts which will turn into unit-test material:
https://gist.github.com/johnkerl/3a00a28784c1559765b09cd7d7d54b6e

Context: #2920 and [[sc-47660]](https://app.shortcut.com/tiledb-inc/story/47660/core-c-c-api-support-to-set-initial-array-schema-timestamp#activity-53864)