### PR TITLE
Move CoordinateSpace and CoordinateTransform to SOMA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@185d58b"   # DO NOT MERGE TO MAIN
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@685acba"   # DO NOT MERGE TO MAIN
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@685acba"   # DO NOT MERGE TO MAIN
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@4dc6461"   # DO NOT MERGE TO MAIN
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/notebooks/tutorial_spatial.ipynb
+++ b/apis/python/notebooks/tutorial_spatial.ipynb
@@ -415,7 +415,7 @@
     {
      "data": {
       "text/plain": [
-       "<tiledbsoma._coordinates.IdentityCoordinateTransform at 0x7f0415ea2210>"
+       "<somacore.coordinates.IdentityTransform at 0x7ff8e9b2f5d0>"
       ]
      },
      "execution_count": 15,
@@ -436,7 +436,7 @@
     {
      "data": {
       "text/plain": [
-       "<tiledbsoma._coordinates.AffineCoordinateTransform at 0x7f0415e17b10>"
+       "<somacore.coordinates.AffineTransform at 0x7ff903bd8d50>"
       ]
      },
      "execution_count": 16,
@@ -509,7 +509,7 @@
     {
      "data": {
       "text/plain": [
-       "<tiledbsoma._coordinates.IdentityCoordinateTransform at 0x7f040c723c10>"
+       "<somacore.coordinates.IdentityTransform at 0x7ff8fa515490>"
       ]
      },
      "execution_count": 20,

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@685acba",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@4dc6461",  # DO NOT MERGE TO MAIN
         "tiledb~=0.31.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@185d58b",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@685acba",  # DO NOT MERGE TO MAIN
         "tiledb~=0.31.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -145,11 +145,6 @@ import pyarrow_hotfix
 
 from ._collection import Collection
 from ._constants import SOMA_JOINID
-from ._coordinates import (
-    AffineCoordinateTransform,
-    CoordinateTransform,
-    IdentityCoordinateTransform,
-)
 from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
 from ._exception import (
@@ -184,12 +179,10 @@ from .pytiledbsoma import (
 __version__ = get_implementation_version()
 
 __all__ = [
-    "AffineCoordinateTransform",
     "AlreadyExistsError",
     "AxisColumnNames",
     "AxisQuery",
     "Collection",
-    "CoordinateTransform",
     "DataFrame",
     "DenseNDArray",
     "DoesNotExistError",
@@ -203,7 +196,6 @@ __all__ = [
     "Measurement",
     "NotCreateableError",
     "open",
-    "IdentityCoordinateTransform",
     "Image2DCollection",
     "PointCloud",
     "ResultOrder",

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -147,8 +147,6 @@ from ._collection import Collection
 from ._constants import SOMA_JOINID
 from ._coordinates import (
     AffineCoordinateTransform,
-    Axis,
-    CoordinateSpace,
     CoordinateTransform,
     IdentityCoordinateTransform,
 )
@@ -188,11 +186,9 @@ __version__ = get_implementation_version()
 __all__ = [
     "AffineCoordinateTransform",
     "AlreadyExistsError",
-    "Axis",
     "AxisColumnNames",
     "AxisQuery",
     "Collection",
-    "CoordinateSpace",
     "CoordinateTransform",
     "DataFrame",
     "DenseNDArray",

--- a/apis/python/src/tiledbsoma/_coordinates.py
+++ b/apis/python/src/tiledbsoma/_coordinates.py
@@ -1,21 +1,22 @@
-import abc
 import json
-from typing import Any, Dict, Sequence, Tuple, Union
 
-import numpy as np
-import numpy.typing as npt
-import pyarrow as pa
-from somacore import coordinates
+from somacore import (
+    AffineTransform,
+    Axis,
+    CoordinateSpace,
+    CoordinateTransform,
+    IdentityTransform,
+)
 
 
-def coordinate_space_from_json(data: str) -> coordinates.CoordinateSpace:
+def coordinate_space_from_json(data: str) -> CoordinateSpace:
     """Returns a coordinate space from a json string."""
     # TODO: Needs good, comprehensive error handling.
     raw = json.loads(data)
-    return coordinates.CoordinateSpace(tuple(coordinates.Axis(**axis) for axis in raw))
+    return CoordinateSpace(tuple(Axis(**axis) for axis in raw))
 
 
-def coordinate_space_to_json(coord_space: coordinates.CoordinateSpace) -> str:
+def coordinate_space_to_json(coord_space: CoordinateSpace) -> str:
     """Returns json string representation of the coordinate space."""
     return json.dumps(
         tuple(
@@ -23,212 +24,6 @@ def coordinate_space_to_json(coord_space: coordinates.CoordinateSpace) -> str:
             for axis in coord_space.axes
         )
     )
-
-
-class CoordinateTransform(coordinates.CoordinateTransform):
-    def __init__(
-        self,
-        input_axes: Union[str, Sequence[str]],
-        output_axes: Union[str, Sequence[str]],
-    ):
-        self._input_axes = (
-            (input_axes,) if isinstance(input_axes, str) else tuple(input_axes)
-        )
-        self._output_axes = (
-            (output_axes,) if isinstance(output_axes, str) else tuple(output_axes)
-        )
-
-    @abc.abstractmethod
-    def __mul__(self, other: Any) -> "CoordinateTransform":
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def __rmul__(self, other: Any) -> "CoordinateTransform":
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def apply(self, data: Union[pa.Tensor, pa.Table]) -> Union[pa.Tensor, pa.Table]:
-        raise NotImplementedError()
-
-    @property
-    def input_axes(self) -> Tuple[str, ...]:
-        return self._input_axes
-
-    @property
-    def input_rank(self) -> int:
-        return len(self._input_axes)
-
-    @property
-    def output_axes(self) -> Tuple[str, ...]:
-        return self._output_axes
-
-    @property
-    def output_rank(self) -> int:
-        return len(self._output_axes)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {"input_axes": self.input_axes, "output_axes": self.output_axes}
-
-
-class IdentityCoordinateTransform(CoordinateTransform):
-    """TODO: Add docstring"""
-
-    def __init__(
-        self,
-        input_axes: Union[str, Sequence[str]],
-        output_axes: Union[str, Sequence[str]],
-    ):
-        super().__init__(input_axes, output_axes)
-        if self.input_rank != self.output_rank:
-            raise ValueError("Incompatible rank of input and output axes")
-
-    def __mul__(self, other: Any) -> CoordinateTransform:
-        if np.isscalar(other):
-            raise NotImplementedError(
-                "Support for multiplying by scalars is not yet implemented."
-            )
-        if isinstance(other, CoordinateTransform):
-            if isinstance(other, IdentityCoordinateTransform):
-                if self.output_axes != other.input_axes:
-                    raise ValueError("Axis mismatch between transformations.")
-                return IdentityCoordinateTransform(self.input_axes, other.output_axes)
-            return other.__rmul__(self)
-        if isinstance(other, np.ndarray):
-            raise NotImplementedError(
-                "Support for multiplying by numpy arrays is not yet implemented."
-            )
-        raise TypeError(
-            f"Cannot multiply a CoordinateTransform by type {type(other)!r}."
-        )
-
-    def __rmul__(self, other: Any) -> CoordinateTransform:
-        if np.isscalar(other):
-            return self.__mul__(other)
-        if isinstance(other, CoordinateTransform):
-            if isinstance(other, IdentityCoordinateTransform):
-                if other.output_axes != self.input_axes:
-                    raise ValueError("Axis mismatch between transformations.")
-                return IdentityCoordinateTransform(other.input_axes, self.output_axes)
-            return other.__mul__(self)
-        if isinstance(other, np.ndarray):
-            raise NotImplementedError(
-                "Support for multiplying by numpy arrays is not yet implemented."
-            )
-        raise TypeError(
-            f"Cannot multiply a CoordinateTransform by type {type(other)!r}."
-        )
-
-    def apply(self, data: Union[pa.Tensor, pa.Table]) -> Union[pa.Tensor, pa.Table]:
-        # TODO: Check valid rank
-        return data
-
-    def to_dict(self) -> Dict[str, Any]:
-        return super().to_dict()
-
-
-class AffineCoordinateTransform(CoordinateTransform):
-    """TODO: Add docstring"""
-
-    def __init__(
-        self,
-        input_axes: Union[str, Sequence[str]],
-        output_axes: Union[str, Sequence[str]],
-        matrix: npt.ArrayLike,
-    ):
-        super().__init__(input_axes, output_axes)
-
-        # Check the rank of the input/output axes match.
-        if self.input_rank != self.output_rank:
-            raise ValueError(
-                "The input axes and output axes must be the same length for an "
-                "affine transform."
-            )
-        rank = self.input_rank
-
-        # Create and validate the augmented matrix.
-        self._matrix: npt.NDArray[np.float64] = np.array(matrix, dtype=np.float64)
-        if self._matrix.shape == (rank + 1, rank + 1):
-            if not (
-                self._matrix[-1, -1] == 1.0
-                and np.array_equal(self._matrix[-1, :-1], np.zeros((rank,)))
-            ):
-                raise ValueError(
-                    f"Input matrix {self._matrix} has augmented matrix shape, but is not a valid "
-                    f"augmented matrix."
-                )
-        elif self._matrix.shape == (rank, rank + 1):
-            self._matrix = np.vstack(
-                (
-                    self._matrix,
-                    np.hstack((np.zeros((rank,)), np.array([1]))),
-                )
-            )
-        else:
-            raise ValueError(
-                f"Unexpected shape {self._matrix.shape} for the input affine matrix."
-            )
-
-    def __mul__(self, other: Any) -> CoordinateTransform:
-        if np.isscalar(other):
-            return AffineCoordinateTransform(
-                self.input_axes,
-                self.output_axes,
-                other * self.augmented_matrix,  # type: ignore
-            )
-        if isinstance(other, CoordinateTransform):
-            if self.output_axes != other.input_axes:
-                raise ValueError("Axis mismatch between transformations.")
-            if isinstance(other, IdentityCoordinateTransform):
-                return AffineCoordinateTransform(
-                    self.input_axes, other.output_axes, self._matrix
-                )
-            if isinstance(other, AffineCoordinateTransform):
-                return AffineCoordinateTransform(
-                    self.input_axes, other.output_axes, self._matrix @ other._matrix
-                )
-        if isinstance(other, np.ndarray):
-            raise NotImplementedError(
-                "Support for multiplying by numpy arrays is not yet implemented."
-            )
-        raise TypeError(
-            f"Cannot multiply a CoordinateTransform by type {type(other)!r}."
-        )
-
-    def __rmul__(self, other: Any) -> CoordinateTransform:
-        if np.isscalar(other):
-            return self.__mul__(other)
-        if isinstance(other, CoordinateTransform):
-            if other.output_axes != self.input_axes:
-                raise ValueError("Axis mismatch between transformations.")
-            if isinstance(other, IdentityCoordinateTransform):
-                return AffineCoordinateTransform(
-                    other.input_axes, self.output_axes, self._matrix
-                )
-            if isinstance(other, AffineCoordinateTransform):
-                return AffineCoordinateTransform(
-                    other.input_axes, self.output_axes, other._matrix @ self._matrix
-                )
-        if isinstance(other, np.ndarray):
-            raise NotImplementedError(
-                "Support for multiplying by numpy arrays is not yet implemented."
-            )
-        raise TypeError(
-            f"Cannot multiply a CoordinateTransform by type {type(other)!r}."
-        )
-
-    def apply(self, data: Union[pa.Tensor, pa.Table]) -> Union[pa.Tensor, pa.Table]:
-        """TODO: Add docstring"""
-        raise NotImplementedError()
-
-    @property
-    def augmented_matrix(self) -> npt.NDArray[np.float64]:
-        """Returns the augmented affine matrix for the transformation."""
-        return self._matrix
-
-    def to_dict(self) -> Dict[str, Any]:
-        kwargs = super().to_dict()
-        kwargs["matrix"] = self._matrix.tolist()
-        return kwargs
 
 
 def transform_from_json(data: str) -> CoordinateTransform:
@@ -242,15 +37,25 @@ def transform_from_json(data: str) -> CoordinateTransform:
         kwargs = raw.pop("transform")
     except KeyError:
         raise KeyError()  # TODO Add error message
-    if transform_type == "IdentityCoordinateTransform":
-        return IdentityCoordinateTransform(**kwargs)
-    elif transform_type == "AffineCoordinateTransform":
-        return AffineCoordinateTransform(**kwargs)
+    if transform_type == "IdentityTransform":
+        return IdentityTransform(**kwargs)
+    elif transform_type == "AffineTransform":
+        return AffineTransform(**kwargs)
     else:
         raise KeyError("Unrecognized transform type key 'transform_type'")
 
 
 def transform_to_json(transform: CoordinateTransform) -> str:
-    kwargs = transform.to_dict()
+    kwargs = {
+        "input_axes": transform.input_axes,
+        "output_axes": transform.output_axes,
+    }
+    if isinstance(transform, IdentityTransform):
+        pass
+    elif isinstance(transform, AffineTransform):
+        kwargs["matrix"] = transform.augmented_matrix.tolist()
+    else:
+        raise TypeError(f"Unrecognized coordinate transform type {type(transform)!r}.")
+
     transform_type = type(transform).__name__
     return json.dumps({"transform_type": transform_type, "transform": kwargs})

--- a/apis/python/src/tiledbsoma/_coordinates.py
+++ b/apis/python/src/tiledbsoma/_coordinates.py
@@ -6,90 +6,23 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from somacore import coordinates
-from typing_extensions import Self
 
 
-class Axis(coordinates.Axis):
-    """A description of an axis of a coordinate system
-
-    TODO: Note if this class remains more or less as is the base class in somacore
-    can be implemented as a ``dataclasses.dataclass``.
-
-    Lifecycle: experimental
-    """
-
-    @classmethod
-    def from_json(cls, data: str) -> Self:
-        """Create from a json blob.
-
-        Args:
-           data: json blob to deserialize.
-
-        Lifecycle: experimental
-        """
-        kwargs = json.loads(data)
-        if not isinstance(kwargs, dict):
-            raise ValueError()
-        return cls(**kwargs)
-
-    def to_dict(self) -> Dict[str, Any]:
-        """TODO: Add docstring"""
-        kwargs: Dict[str, Any] = {"name": self.name}
-        if self.units is not None:
-            kwargs["units"] = self.units
-        if self.scale is not None:
-            kwargs["scale"] = self.scale
-        return kwargs
-
-    def to_json(self) -> str:
-        """TODO: Add docstring"""
-        return json.dumps(self.to_dict())
+def coordinate_space_from_json(data: str) -> coordinates.CoordinateSpace:
+    """Returns a coordinate space from a json string."""
+    # TODO: Needs good, comprehensive error handling.
+    raw = json.loads(data)
+    return coordinates.CoordinateSpace(tuple(coordinates.Axis(**axis) for axis in raw))
 
 
-class CoordinateSpace(coordinates.CoordinateSpace):
-    """A coordinate system for spatial data."""
-
-    @classmethod
-    def from_json(cls, data: str) -> Self:
-        """TODO: Add docstring"""
-        # TODO: Needs good, comprehensive error handling.
-        raw = json.loads(data)
-        return cls(tuple(Axis(**axis) for axis in raw))
-
-    def __init__(self, axes: Sequence[Axis]):
-        """TODO: Add docstring"""
-        # TODO: Needs good, comprehensive error handling.
-        if len(tuple(axes)) == 0:
-            raise ValueError("Coordinate space must have at least one axis.")
-        self._axes = tuple(axes)
-
-    def __len__(self) -> int:
-        return len(self._axes)
-
-    def __getitem__(self, index: int) -> Axis:
-        return self._axes[index]
-
-    def __repr__(self) -> str:
-        output = f"<{type(self).__name__}\n"
-        for axis in self._axes:
-            output += f"  {axis},\n"
-        return output + ">"
-
-    @property
-    def axes(self) -> Tuple[Axis, ...]:
-        """TODO: Add docstring"""
-        return self._axes
-
-    @property
-    def axis_names(self) -> Tuple[str, ...]:
-        return tuple(axis.name for axis in self._axes)
-
-    def rank(self) -> int:
-        return len(self)
-
-    def to_json(self) -> str:
-        """TODO: Add docstring"""
-        return json.dumps(tuple(axis.to_dict() for axis in self._axes))
+def coordinate_space_to_json(coord_space: coordinates.CoordinateSpace) -> str:
+    """Returns json string representation of the coordinate space."""
+    return json.dumps(
+        tuple(
+            {"name": axis.name, "units": axis.units, "scale": axis.scale}
+            for axis in coord_space.axes
+        )
+    )
 
 
 class CoordinateTransform(coordinates.CoordinateTransform):

--- a/apis/python/src/tiledbsoma/_images.py
+++ b/apis/python/src/tiledbsoma/_images.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
-from somacore import ResultOrder, coordinates, images, options
+from somacore import CoordinateSpace, ResultOrder, coordinates, images, options
 from typing_extensions import Final
 
 from . import _funcs, _tdb_handles
@@ -18,8 +18,9 @@ from ._collection import CollectionBase
 from ._constants import SOMA_COORDINATE_SPACE_METADATA_KEY
 from ._coordinates import (
     AffineCoordinateTransform,
-    CoordinateSpace,
     CoordinateTransform,
+    coordinate_space_from_json,
+    coordinate_space_to_json,
 )
 from ._dense_nd_array import DenseNDArray
 from ._exception import SOMAError
@@ -143,7 +144,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
         if coord_space is None:
             self._coord_space: Optional[CoordinateSpace] = None
         else:
-            self._coord_space = CoordinateSpace.from_json(coord_space)
+            self._coord_space = coordinate_space_from_json(coord_space)
 
         # Update the axis order.
         axis_order = self.metadata.get("soma_axis_order")
@@ -280,7 +281,9 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
             raise ValueError("Coordinate space must have exactly 2 axes.")
         # TODO: Do we need some way to specify YX vs XY and propagate to
         # sub-images.
-        self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = value.to_json()
+        self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(
+            value
+        )
         self._coord_space = value
 
     @property

--- a/apis/python/src/tiledbsoma/_images.py
+++ b/apis/python/src/tiledbsoma/_images.py
@@ -10,15 +10,20 @@ from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
-from somacore import CoordinateSpace, ResultOrder, coordinates, images, options
+from somacore import (
+    AffineTransform,
+    CoordinateSpace,
+    CoordinateTransform,
+    ResultOrder,
+    images,
+    options,
+)
 from typing_extensions import Final
 
 from . import _funcs, _tdb_handles
 from ._collection import CollectionBase
 from ._constants import SOMA_COORDINATE_SPACE_METADATA_KEY
 from ._coordinates import (
-    AffineCoordinateTransform,
-    CoordinateTransform,
     coordinate_space_from_json,
     coordinate_space_to_json,
 )
@@ -67,7 +72,7 @@ class ImageCollection(  # type: ignore[misc]  # __eq__ false positive
         level: int,
         coords: options.DenseNDCoords = (),
         *,
-        transform: Optional[coordinates.CoordinateTransform] = None,
+        transform: Optional[CoordinateTransform] = None,
         result_order: options.ResultOrderStr = ResultOrder.ROW_MAJOR,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> pa.Tensor:
@@ -298,7 +303,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
         level: int,
         coords: options.DenseNDCoords = (),
         *,
-        transform: Optional[coordinates.CoordinateTransform] = None,
+        transform: Optional[CoordinateTransform] = None,
         result_order: options.ResultOrderStr = ResultOrder.ROW_MAJOR,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> pa.Tensor:
@@ -347,7 +352,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
         # TODO: Add in a transformation just for scaling.
         # NOTE: Ignoring possibility of different axis order for different levels
         # since that will be removed.
-        return AffineCoordinateTransform(
+        return AffineTransform(
             input_axes=self._coord_space.axis_names,
             output_axes=self._coord_space.axis_names,
             matrix=np.array(

--- a/apis/python/src/tiledbsoma/_images.py
+++ b/apis/python/src/tiledbsoma/_images.py
@@ -8,13 +8,12 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Optional, Sequence, Tuple, Union
 
-import numpy as np
 import pyarrow as pa
 from somacore import (
-    AffineTransform,
     CoordinateSpace,
     CoordinateTransform,
     ResultOrder,
+    ScaleTransform,
     images,
     options,
 )
@@ -349,18 +348,13 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
             level_props = self._levels[level]
         width = level_props.width
         height = level_props.height
-        # TODO: Add in a transformation just for scaling.
         # NOTE: Ignoring possibility of different axis order for different levels
         # since that will be removed.
-        return AffineTransform(
+        return ScaleTransform(
             input_axes=self._coord_space.axis_names,
             output_axes=self._coord_space.axis_names,
-            matrix=np.array(
-                [
-                    [width / self._reference_shape[0], 0.0, 0.0],
-                    [0.0, height / self._reference_shape[1], 0.0],
-                    [0.0, 0.0, 1.0],
-                ],
-                dtype=np.float64,
-            ),
+            scale_factors=[
+                width / self._reference_shape[0],
+                height / self._reference_shape[1],
+            ],
         )

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -6,16 +6,16 @@
 
 from typing import Any, Optional, Union
 
-from somacore import scene
+from somacore import Axis, CoordinateSpace, scene
 
 from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._constants import SOMA_COORDINATE_SPACE_METADATA_KEY
 from ._coordinates import (
-    Axis,
-    CoordinateSpace,
     CoordinateTransform,
     IdentityCoordinateTransform,
+    coordinate_space_from_json,
+    coordinate_space_to_json,
     transform_from_json,
     transform_to_json,
 )
@@ -57,7 +57,7 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         if coord_space is None:
             self._coord_space: Optional[CoordinateSpace] = None
         else:
-            self._coord_space = CoordinateSpace.from_json(coord_space)
+            self._coord_space = coordinate_space_from_json(coord_space)
 
     @property
     def coordinate_space(self) -> Optional[CoordinateSpace]:
@@ -68,7 +68,9 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
     def coordinate_space(self, value: CoordinateSpace) -> None:
         if not isinstance(value, CoordinateSpace):
             raise TypeError(f"Invalid type {type(value).__name__}.")
-        self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = value.to_json()
+        self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(
+            value
+        )
         self._coord_space = value
 
     def register_point_cloud(

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -6,14 +6,18 @@
 
 from typing import Any, Optional, Union
 
-from somacore import Axis, CoordinateSpace, scene
+from somacore import (
+    Axis,
+    CoordinateSpace,
+    CoordinateTransform,
+    IdentityTransform,
+    scene,
+)
 
 from . import _tdb_handles
 from ._collection import Collection, CollectionBase
 from ._constants import SOMA_COORDINATE_SPACE_METADATA_KEY
 from ._coordinates import (
-    CoordinateTransform,
-    IdentityCoordinateTransform,
     coordinate_space_from_json,
     coordinate_space_to_json,
     transform_from_json,
@@ -89,7 +93,7 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         # Create the coordinate space if it does not exist. Otherwise, check it is
         # compatible with the provide transform.
         if coordinate_space is None:
-            if isinstance(transform, IdentityCoordinateTransform):
+            if isinstance(transform, IdentityTransform):
                 coordinate_space = self.coordinate_space
             else:
                 coordinate_space = CoordinateSpace(
@@ -151,7 +155,7 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         # Create the coordinate space if it does not exist. Otherwise, check it is
         # compatible with the provide transform.
         if coordinate_space is None:
-            if isinstance(transform, IdentityCoordinateTransform):
+            if isinstance(transform, IdentityTransform):
                 coordinate_space = self.coordinate_space
             else:
                 coordinate_space = CoordinateSpace(

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -31,11 +31,10 @@ import pyarrow.compute as pacomp
 import scanpy
 from anndata import AnnData
 from PIL import Image
+from somacore import Axis, CoordinateSpace
 
 from .. import (
-    Axis,
     Collection,
-    CoordinateSpace,
     DataFrame,
     DenseNDArray,
     Experiment,
@@ -72,8 +71,8 @@ from ..options._tiledb_create_write_options import (
 if TYPE_CHECKING:
     from somacore.options import PlatformConfig
 
-    from ..io._registration import ExperimentAmbientLabelMapping
     from ..io._common import AdditionalMetadata
+    from ..io._registration import ExperimentAmbientLabelMapping
     from ..options import SOMATileDBContext
 
 

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -31,14 +31,13 @@ import pyarrow.compute as pacomp
 import scanpy
 from anndata import AnnData
 from PIL import Image
-from somacore import Axis, CoordinateSpace
+from somacore import Axis, CoordinateSpace, IdentityTransform
 
 from .. import (
     Collection,
     DataFrame,
     DenseNDArray,
     Experiment,
-    IdentityCoordinateTransform,
     Image2DCollection,
     PointCloud,
     Scene,
@@ -392,7 +391,7 @@ def _write_visium_data_to_experiment_uri(
                             tissue.coordinate_space = coord_space
                             scene.register_image2d(
                                 "tissue",
-                                IdentityCoordinateTransform(("x", "y"), ("x", "y")),
+                                IdentityTransform(("x", "y"), ("x", "y")),
                             )
 
                 obsl_uri = f"{scene_uri}/obsl"
@@ -413,7 +412,7 @@ def _write_visium_data_to_experiment_uri(
                     ) as loc:
                         _maybe_set(obsl, "loc", loc, use_relative_uri=use_relative_uri)
                         scene.register_point_cloud(
-                            "loc", IdentityCoordinateTransform(("x", "y"), ("x", "y"))
+                            "loc", IdentityTransform(("x", "y"), ("x", "y"))
                         )
 
                 varl_uri = f"{scene_uri}/varl"

--- a/apis/python/tests/test_coordinates.py
+++ b/apis/python/tests/test_coordinates.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from somacore import Axis, CoordinateSpace
 
 import tiledbsoma as soma
 
@@ -21,35 +22,19 @@ def check_transform_is_equal(
 @pytest.mark.parametrize(
     "original",
     [
-        soma.Axis(name="dim0"),
-        soma.Axis(name="dim0", units="micrometer"),
-        soma.Axis(name="dim0", units="nanometer", scale=np.float64(65.0)),
-    ],
-)
-def test_axis_json_roundtrip(original: soma.Axis):
-    json_blob = original.to_json()
-    result = soma.Axis.from_json(json_blob)
-    assert result.name == original.name
-    assert result.units == original.units
-    assert result.scale == original.scale
-
-
-@pytest.mark.parametrize(
-    "original",
-    [
-        soma.CoordinateSpace((soma.Axis(name="dim0", units="meter"),)),
-        soma.CoordinateSpace(
+        CoordinateSpace((Axis(name="dim0", units="meter"),)),
+        CoordinateSpace(
             (
-                soma.Axis(name="dim0", units="micrometer"),
-                soma.Axis(name="dim1"),
-                soma.Axis(name="dim2", units="micrometer", scale=np.float64(65.0)),
+                Axis(name="dim0", units="micrometer"),
+                Axis(name="dim1"),
+                Axis(name="dim2", units="micrometer", scale=np.float64(65.0)),
             ),
         ),
     ],
 )
-def test_coordinate_system_json_roundtrip(original: soma.CoordinateSpace):
-    json_blob = original.to_json()
-    result = soma.CoordinateSpace.from_json(json_blob)
+def test_coordinate_system_json_roundtrip(original: CoordinateSpace):
+    json_blob = soma._coordinates.coordinate_space_to_json(original)
+    result = soma._coordinates.coordinate_space_from_json(json_blob)
     assert len(result) == len(original)
     for index in range(len(result)):
         assert result[index] == original[index]

--- a/apis/python/tests/test_coordinates.py
+++ b/apis/python/tests/test_coordinates.py
@@ -1,19 +1,25 @@
 import numpy as np
 import pytest
-from somacore import Axis, CoordinateSpace
+from somacore import (
+    AffineTransform,
+    Axis,
+    CoordinateSpace,
+    CoordinateTransform,
+    IdentityTransform,
+)
 
 import tiledbsoma as soma
 
 
 def check_transform_is_equal(
-    actual: soma.CoordinateTransform, desired: soma.CoordinateTransform
+    actual: CoordinateTransform, desired: CoordinateTransform
 ) -> None:
     assert actual.input_axes == desired.input_axes
     assert actual.output_axes == desired.output_axes
-    if isinstance(desired, soma.IdentityCoordinateTransform):
-        assert isinstance(actual, soma.IdentityCoordinateTransform)
-    elif isinstance(desired, soma.AffineCoordinateTransform):
-        assert isinstance(actual, soma.AffineCoordinateTransform)
+    if isinstance(desired, IdentityTransform):
+        assert isinstance(actual, IdentityTransform)
+    elif isinstance(desired, AffineTransform):
+        assert isinstance(actual, AffineTransform)
         np.testing.assert_array_equal(actual.augmented_matrix, desired.augmented_matrix)
     else:
         assert False
@@ -43,8 +49,8 @@ def test_coordinate_system_json_roundtrip(original: CoordinateSpace):
 @pytest.mark.parametrize(
     "original",
     [
-        soma.IdentityCoordinateTransform(["y1", "x1"], ["y2", "x2"]),
-        soma.AffineCoordinateTransform(
+        IdentityTransform(["y1", "x1"], ["y2", "x2"]),
+        AffineTransform(
             ["x1", "y1"],
             ["x2", "y2"],
             np.array([[1.5, 3, 0], [-1.5, 3, 1]], dtype=np.float64),
@@ -55,83 +61,3 @@ def test_transform_json_roundtrip(original: soma._coordinates.CoordinateTransfor
     json_blob = soma._coordinates.transform_to_json(original)
     result = soma._coordinates.transform_from_json(json_blob)
     check_transform_is_equal(result, original)
-
-
-@pytest.mark.parametrize(
-    ("input", "expected"),
-    [
-        (
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x2", "y2"],
-                [[2, 2, 0], [0, 3, 1]],
-            ),
-            np.array([[2, 2, 0], [0, 3, 1], [0, 0, 1]], np.float64),
-        )
-    ],
-)
-def test_affine_augmented_matrix(input, expected):
-    result = input.augmented_matrix
-    np.testing.assert_array_equal(result, expected)
-
-
-@pytest.mark.parametrize(
-    ("transform_a", "transform_b", "expected"),
-    [
-        (
-            soma.IdentityCoordinateTransform(["x1", "y1"], ["x2", "y2"]),
-            soma.IdentityCoordinateTransform(["x2", "y2"], ["x3", "y3"]),
-            soma.IdentityCoordinateTransform(["x1", "y1"], ["x3", "y3"]),
-        ),
-        (
-            soma.IdentityCoordinateTransform(["x1", "y1"], ["x2", "y2"]),
-            soma.AffineCoordinateTransform(
-                ["x2", "y2"],
-                ["x3", "y3"],
-                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
-            ),
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x3", "y3"],
-                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
-            ),
-        ),
-        (
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x2", "y2"],
-                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
-            ),
-            soma.IdentityCoordinateTransform(["x2", "y2"], ["x3", "y3"]),
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x3", "y3"],
-                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
-            ),
-        ),
-        (
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x2", "y2"],
-                np.array([[2.0, 0.0, 1.0], [0.0, 4.0, 1.0]], dtype=np.float64),
-            ),
-            soma.AffineCoordinateTransform(
-                ["x2", "y2"],
-                ["x3", "y3"],
-                np.array([[1.0, 1.0, -1.0], [0.0, 1.0, 2.0]], dtype=np.float64),
-            ),
-            soma.AffineCoordinateTransform(
-                ["x1", "y1"],
-                ["x3", "y3"],
-                np.array([[2.0, 2.0, -1.0], [0.0, 4.0, 9.0]], dtype=np.float64),
-            ),
-        ),
-    ],
-)
-def test_multiply_tranform(
-    transform_a,
-    transform_b,
-    expected: soma.CoordinateTransform,
-):
-    result = transform_a * transform_b
-    check_transform_is_equal(result, expected)


### PR DESCRIPTION
This removes the `Axis`, `CoordinateSpace`, and `CoordinateTransform` classes from TileDB-SOMA and instead imports them from somacore. It also replaces the return type of `AffineTransform` with `ScaleTransform` when getting transformations of the levels of the `Image2DCollection` (soon to be `MultiscaleImage`).