### PR TITLE
Replace `Image2DCollection` with `MultiscaleImage` in Python and C++

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@4dc6461"   # DO NOT MERGE TO MAIN
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@3215a82"   # DO NOT MERGE TO MAIN
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/notebooks/tutorial_spatial.ipynb
+++ b/apis/python/notebooks/tutorial_spatial.ipynb
@@ -326,9 +326,7 @@
     {
      "data": {
       "text/plain": [
-       "<Image2DCollection 'file:///home/julia/Software/TileDB-Inc/TileDB-SOMA/apis/python/notebooks/data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma/spatial/scene1/img/tissue' (open for 'r') (2 items)\n",
-       "    'hires': 'file:///home/julia/Software/TileDB-Inc/TileDB-SOMA/apis/python/notebooks/data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma/spatial/scene1/img/tissue/hires' (unopened)\n",
-       "    'lowres': 'file:///home/julia/Software/TileDB-Inc/TileDB-SOMA/apis/python/notebooks/data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma/spatial/scene1/img/tissue/lowres' (unopened)>"
+       "<MultiscaleImage 'file:///home/julia/Software/TileDB-Inc/TileDB-SOMA/apis/python/notebooks/data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma/spatial/scene1/img/tissue' (open for 'r')>"
       ]
      },
      "execution_count": 11,
@@ -396,8 +394,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Level 0: Image2DCollection.LevelProperties(name='soma_level_hires', axis_order='YXC', shape=[2000, 1744, 3], width=1744, height=2000, nchannels=None)\n",
-      "Level 1: Image2DCollection.LevelProperties(name='soma_level_lowres', axis_order='YXC', shape=[600, 523, 3], width=523, height=600, nchannels=None)\n"
+      "Level 0: MultiscaleImage.LevelProperties(name='soma_level_hires', axis_order='YXC', shape=[2000, 1744, 3], width=1744, height=2000, nchannels=None)\n",
+      "Level 1: MultiscaleImage.LevelProperties(name='soma_level_lowres', axis_order='YXC', shape=[600, 523, 3], width=523, height=600, nchannels=None)\n"
      ]
     }
    ],
@@ -415,7 +413,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.IdentityTransform at 0x7ff8e9b2f5d0>"
+       "<somacore.coordinates.IdentityTransform at 0x7f37a863aad0>"
       ]
      },
      "execution_count": 15,
@@ -424,7 +422,7 @@
     }
    ],
    "source": [
-    "scene.transform_to_image2d(\"tissue\")"
+    "scene.transform_to_multiscale_image(\"tissue\")"
    ]
   },
   {
@@ -436,7 +434,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.AffineTransform at 0x7ff903bd8d50>"
+       "<somacore.coordinates.ScaleTransform at 0x7f37a8142e90>"
       ]
      },
      "execution_count": 16,
@@ -445,7 +443,7 @@
     }
    ],
    "source": [
-    "scene.transform_to_image2d(\"tissue\", level=0)"
+    "scene.transform_to_multiscale_image(\"tissue\", level=0)"
    ]
   },
   {
@@ -509,7 +507,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.IdentityTransform at 0x7ff8fa515490>"
+       "<somacore.coordinates.IdentityTransform at 0x7f379ea63410>"
       ]
      },
      "execution_count": 20,
@@ -873,9 +871,9 @@
    "outputs": [],
    "source": [
     "# TODO: Replace this with direct coordinate transforms\n",
-    "hires_transform = scene.transform_to_image2d(\"tissue\", level=0) \n",
-    "scale_x = hires_transform.augmented_matrix[0, 0]\n",
-    "scale_y = hires_transform.augmented_matrix[1, 1]"
+    "hires_transform = scene.transform_to_multiscale_image(\"tissue\", level=0) \n",
+    "scale_x = hires_transform.scale_factors[0]\n",
+    "scale_y = hires_transform.scale_factors[1]"
    ]
   },
   {

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@4dc6461",  # DO NOT MERGE TO MAIN
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@3215a82",  # DO NOT MERGE TO MAIN
         "tiledb~=0.31.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -165,7 +165,7 @@ from ._general_utilities import (
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
 from ._scene import Scene
-from ._images import Image2DCollection
+from ._images import MultiscaleImage
 from ._point_cloud import PointCloud
 from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead
 from .options import SOMATileDBContext, TileDBCreateOptions, TileDBWriteOptions
@@ -196,7 +196,7 @@ __all__ = [
     "Measurement",
     "NotCreateableError",
     "open",
-    "Image2DCollection",
+    "MultiscaleImage",
     "PointCloud",
     "ResultOrder",
     "show_package_versions",

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -8,16 +8,12 @@
 from __future__ import annotations
 
 import itertools
-import re
 from typing import (
     Any,
     Callable,
     ClassVar,
     Dict,
-    Iterable,
-    Iterator,
     Optional,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -25,7 +21,6 @@ from typing import (
     overload,
 )
 
-import attrs
 import somacore
 import somacore.collection
 from somacore import options
@@ -38,18 +33,13 @@ from ._dataframe import DataFrame
 from ._dense_nd_array import DenseNDArray
 from ._exception import (
     SOMAError,
-    is_does_not_exist_error,
     map_exception_for_create,
 )
 from ._funcs import typeguard_ignore
+from ._soma_group import SOMAGroup
 from ._soma_object import AnySOMAObject, SOMAObject
 from ._sparse_nd_array import SparseNDArray
 from ._types import OpenTimestamp
-from ._util import (
-    is_relative_uri,
-    make_relative_path,
-    uri_joinpath,
-)
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
 
@@ -60,17 +50,8 @@ _Coll = TypeVar("_Coll", bound="CollectionBase[AnySOMAObject]")
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 
 
-@attrs.define()
-class _CachedElement:
-    """Item we have loaded in the cache of a collection."""
-
-    entry: _tdb_handles.GroupEntry
-    soma: Optional[AnySOMAObject] = None
-    """The reified object, if it has been opened."""
-
-
 class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
-    SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]],
+    SOMAGroup[CollectionElementType],
     somacore.collection.BaseCollection[CollectionElementType],
 ):
     """Contains a key-value mapping where the keys are string names and the values
@@ -78,7 +59,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     :class:`DataFrame`, :class:`DenseNDArray`, :class:`SparseNDArray` or :class:`Experiment`.
     """
 
-    __slots__ = ("_contents", "_mutated_keys")
+    __slots__ = ()
 
     # TODO: Implement additional creation of members on collection subclasses.
     @classmethod
@@ -171,21 +152,6 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     type names of the types that may be set to the key.  See :class:`Experiment` and
     :class:`Measurement` for details.
     """
-
-    def __init__(
-        self,
-        handle: _tdb_handles.SOMAGroupWrapper[Any],
-        **kwargs: Any,
-    ):
-        super().__init__(handle, **kwargs)
-        self._contents = {
-            key: _CachedElement(entry) for key, entry in handle.initial_contents.items()
-        }
-        """The contents of the persisted TileDB Group.
-
-        This is loaded at startup when we have a read handle.
-        """
-        self._mutated_keys: Set[str] = set()
 
     # Overloads to allow type inference to work when doing:
     #
@@ -433,122 +399,15 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
                 If set, the URI to use for the child
                 instead of the default.
         """
-        if key in self:
-            raise KeyError(f"{key!r} already exists in {type(self)}")
         self._check_allows_child(key, kind)
-        child_uri = self._new_child_uri(key=key, user_uri=user_uri)
-        child = factory(child_uri.full_uri)
-        # The resulting element may not be the right type for this collection,
-        # but we can't really handle that within the type system.
-        self._set_element(
-            key,
-            uri=child_uri.add_uri,
-            relative=child_uri.relative,
-            soma_object=child,  # type: ignore[arg-type]
+        return super()._add_new_element(
+            key, kind=kind, factory=factory, user_uri=user_uri
         )
-        self._close_stack.enter_context(child)
-        return child
-
-    def __len__(self) -> int:
-        """Return the number of members in the collection"""
-        return len(self._contents)
-
-    def __getitem__(self, key: str) -> CollectionElementType:
-        """Gets the value associated with the key."""
-        err_str = f"{self.__class__.__name__} has no item {key!r}"
-
-        try:
-            entry = self._contents[key]
-        except KeyError:
-            raise KeyError(err_str) from None
-        if entry.soma is None:
-            from . import _factory  # Delayed binding to resolve circular import.
-
-            uri = entry.entry.uri
-            mode = self.mode
-            context = self.context
-            timestamp = self.tiledb_timestamp_ms
-            clib_type = entry.entry.wrapper_type.clib_type
-
-            wrapper = _tdb_handles.open(uri, mode, context, timestamp, clib_type)
-            entry.soma = _factory.reify_handle(wrapper)
-
-            # Since we just opened this object, we own it and should close it.
-            self._close_stack.enter_context(entry.soma)
-        return cast(CollectionElementType, entry.soma)
-
-    def set(
-        self,
-        key: str,
-        value: CollectionElementType,
-        *,
-        use_relative_uri: Optional[bool] = None,
-    ) -> Self:
-        """Adds an element to the collection.
-
-        Args:
-            key:
-                The key of the element to be added.
-            value:
-                The value to be added to this collection.
-            use_relative_uri:
-                By default (None), the collection will determine whether the
-                element should be stored by relative URI.
-                If True, the collection will store the child by absolute URI.
-                If False, the collection will store the child by relative URI.
-
-        Raises:
-            SOMAError:
-                If an existing key is set (replacement is unsupported).
-
-        Lifecycle:
-            Maturing.
-        """
-        uri_to_add = value.uri
-        # The SOMA API supports use_relative_uri in [True, False, None].
-        # The TileDB-Py API supports use_relative_uri in [True, False].
-        # Map from the former to the latter -- and also honor our somacore contract for None --
-        # using the following rule.
-        if use_relative_uri is None and value.uri.startswith("tiledb://"):
-            # TileDB-Cloud does not use relative URIs, ever.
-            use_relative_uri = False
-
-        if use_relative_uri is not False:
-            try:
-                uri_to_add = make_relative_path(value.uri, relative_to=self.uri)
-                use_relative_uri = True
-            except ValueError:
-                if use_relative_uri:
-                    # We couldn't construct a relative URI, but we were asked
-                    # to use one, so raise the error.
-                    raise
-                use_relative_uri = False
-
-        self._set_element(
-            key, uri=uri_to_add, relative=use_relative_uri, soma_object=value
-        )
-        return self
 
     def members(self) -> Dict[str, Tuple[str, str]]:
         """Get a mapping of {member_name: (uri, soma_object_type)}"""
         handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
         return handle.members()
-
-    def __setitem__(self, key: str, value: CollectionElementType) -> None:
-        """Default collection __setattr__"""
-        self.set(key, value, use_relative_uri=None)
-
-    def __delitem__(self, key: str) -> None:
-        """Removes a member from the collection, when invoked as ``del collection["namegoeshere"]``.
-
-        Raises:
-            SOMAError:
-                Upon deletion of a mutated key.
-        """
-        self._del_element(key)
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._contents)
 
     def __repr__(self) -> str:
         """Default display for :class:`Collection`."""
@@ -572,20 +431,6 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             count = f"{n} items"
         return f"{start} ({count})"
 
-    def _contents_lines(self, last_indent: str) -> Iterable[str]:
-        indent = last_indent + "    "
-        if self.closed:
-            return
-        for key, entry in self._contents.items():
-            obj = entry.soma
-            if obj is None:
-                # We haven't reified this SOMA object yet. Don't try to open it.
-                yield f"{indent}{key!r}: {entry.entry.uri!r} (unopened)"
-            else:
-                yield f"{indent}{key!r}: {obj._my_repr()}"
-                if isinstance(obj, CollectionBase):
-                    yield from obj._contents_lines(indent)
-
     def _set_element(
         self,
         key: str,
@@ -608,60 +453,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
 
         self._check_allows_child(key, type(soma_object))
-
-        if key in self._mutated_keys.union(self._contents):
-            # TileDB groups currently do not support replacing elements.
-            # If we use a hack to flush writes, corruption is possible.
-            raise SOMAError(f"replacing key {key!r} is unsupported")
-        clib_collection = self._handle._handle
-        relative_type = clib.URIType.relative if relative else clib.URIType.absolute
-        clib_collection.add(
-            uri=uri,
-            uri_type=relative_type,
-            name=key,
-            soma_type=clib_collection.type,
-        )
-        self._contents[key] = _CachedElement(
-            entry=_tdb_handles.GroupEntry(soma_object.uri, soma_object._wrapper_type),
-            soma=soma_object,
-        )
-        self._mutated_keys.add(key)
-
-    def _del_element(self, key: str) -> None:
-        if key in self._mutated_keys:
-            raise SOMAError(f"cannot delete previously-mutated key {key!r}")
-        try:
-            self._handle.writer.remove(key)
-        except RuntimeError as tdbe:
-            if is_does_not_exist_error(tdbe):
-                raise KeyError(tdbe) from tdbe
-            raise
-        self._contents.pop(key, None)
-        self._mutated_keys.add(key)
-
-    def _new_child_uri(self, *, key: str, user_uri: Optional[str]) -> "_ChildURI":
-        maybe_relative_uri = user_uri or _sanitize_for_path(key)
-        if not is_relative_uri(maybe_relative_uri):
-            # It's an absolute URI.
-            return _ChildURI(
-                add_uri=maybe_relative_uri,
-                full_uri=maybe_relative_uri,
-                relative=False,
-            )
-        if not self.uri.startswith("tiledb://"):
-            # We don't need to post-process anything.
-            return _ChildURI(
-                add_uri=maybe_relative_uri,
-                full_uri=uri_joinpath(self.uri, maybe_relative_uri),
-                relative=True,
-            )
-        # Our own URI is a ``tiledb://`` URI. Since TileDB Cloud requires absolute
-        # URIs, we need to calculate the absolute URI to pass to Group.add
-        # based on our creation URI.
-        # TODO: Handle the case where we reopen a TileDB Cloud Group, but by
-        # name rather than creation path.
-        absolute_uri = uri_joinpath(self.uri, maybe_relative_uri)
-        return _ChildURI(add_uri=absolute_uri, full_uri=absolute_uri, relative=False)
+        super()._set_element(key, uri=uri, relative=relative, soma_object=soma_object)
 
     @classmethod
     def _check_allows_child(cls, key: str, child_cls: type) -> None:
@@ -760,22 +552,3 @@ def _real_class(cls: Type[Any]) -> type:
     except (AttributeError, TypeError) as exc:
         raise err from exc
     raise err
-
-
-_NON_WORDS = re.compile(r"[\W_]+")
-
-
-def _sanitize_for_path(key: str) -> str:
-    """Prepares the given key for use as a path component."""
-    sanitized = "_".join(_NON_WORDS.split(key))
-    return sanitized
-
-
-@attrs.define(frozen=True, kw_only=True)
-class _ChildURI:
-    add_uri: str
-    """The URI of the child for passing to :meth:``clib.SOMAGroup.add``."""
-    full_uri: str
-    """The full URI of the child, used to create a new element."""
-    relative: bool
-    """The ``relative`` value to pass to :meth:``clib.SOMAGroup.add``."""

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -219,7 +219,7 @@ def _type_name_to_cls(type_name: str) -> Type[AnySOMAObject]:
             _dense_nd_array.DenseNDArray,
             _experiment.Experiment,
             _measurement.Measurement,
-            _images.Image2DCollection,
+            _images.MultiscaleImage,
             _sparse_nd_array.SparseNDArray,
             _scene.Scene,
             _point_cloud.PointCloud,

--- a/apis/python/src/tiledbsoma/_images.py
+++ b/apis/python/src/tiledbsoma/_images.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 """Implementation of a SOMA image collections."""
 
-import abc
 import json
 from dataclasses import dataclass, field
 from typing import Any, Optional, Sequence, Tuple, Union
@@ -31,65 +30,18 @@ from ._exception import SOMAError
 from ._soma_object import AnySOMAObject
 
 
-class ImageCollection(  # type: ignore[misc]  # __eq__ false positive
+class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     CollectionBase[AnySOMAObject],
-    images.ImageCollection[DenseNDArray, AnySOMAObject],
-    metaclass=abc.ABCMeta,
+    images.MultiscaleImage[DenseNDArray, AnySOMAObject],
 ):
-
-    @abc.abstractmethod
-    def add_new_level(
-        self,
-        key: str,
-        *,
-        uri: Optional[str] = None,
-        type: pa.DataType,
-        shape: Sequence[int],
-    ) -> DenseNDArray:
-        """TODO: Add dcoumentation."""
-        raise NotImplementedError()
-
-    @property
-    def axis_order(self) -> str:
-        """The order of the axes in the stored images."""
-        raise NotImplementedError()
-
-    @property
-    @abc.abstractmethod
-    def level_count(self) -> int:
-        """The number of image levels stored in the ImageCollection."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def level_properties(self, level: int) -> images.ImageCollection.LevelProperties:
-        """The properties of an image at the specified level."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def read_level(
-        self,
-        level: int,
-        coords: options.DenseNDCoords = (),
-        *,
-        transform: Optional[CoordinateTransform] = None,
-        result_order: options.ResultOrderStr = ResultOrder.ROW_MAJOR,
-        platform_config: Optional[options.PlatformConfig] = None,
-    ) -> pa.Tensor:
-        """TODO: Add read_image_level documentation"""
-        raise NotImplementedError()
-
-
-class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
-    ImageCollection, images.Image2DCollection
-):
-    """TODO: Add documentation for Image2DCollection
+    """TODO: Add documentation for MultiscaleImage
 
     Lifecycle:
         Experimental.
     """
 
     __slots__ = ("_axis_order", "_coord_space", "_levels", "_reference_shape")
-    _wrapper_type = _tdb_handles.Image2DCollectionWrapper
+    _wrapper_type = _tdb_handles.MultiscaleImageWrapper
 
     _level_prefix: Final = "soma_level_"
 
@@ -159,7 +111,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
                 axis_order = str(axis_order, "uft-8")
             if not isinstance(axis_order, str):
                 raise SOMAError(
-                    f"Stored Image2DCollection 'soma_axis_order' is unexpected type "
+                    f"Stored 'soma_axis_order' is unexpected type "
                     f"{type(axis_order)}."
                 )
             if not (
@@ -174,7 +126,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
 
         # Get the image levels.
         self._levels = [
-            Image2DCollection.LevelProperties(name=key, **json.loads(val))
+            MultiscaleImage.LevelProperties(name=key, **json.loads(val))
             for key, val in self.metadata.items()
             if key.startswith(self._level_prefix)
         ]
@@ -205,7 +157,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
             raise KeyError(f"{key!r} already exists in {type(self)} scales")
 
         # Create the level property and store as metadata.
-        props = Image2DCollection.LevelProperties(
+        props = MultiscaleImage.LevelProperties(
             axis_order=self.axis_order, name=key, shape=tuple(shape)
         )
         props_str = json.dumps({"axis_order": self.axis_order, "shape": shape})
@@ -294,7 +246,7 @@ class Image2DCollection(  # type: ignore[misc]  # __eq__ false positive
     def level_count(self) -> int:
         return len(self._levels)
 
-    def level_properties(self, level: int) -> images.ImageCollection.LevelProperties:
+    def level_properties(self, level: int) -> images.MultiscaleImage.LevelProperties:
         return self._levels[level]
 
     def read_level(

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -24,7 +24,7 @@ from ._coordinates import (
     transform_to_json,
 )
 from ._exception import SOMAError
-from ._images import Image2DCollection
+from ._images import MultiscaleImage
 from ._point_cloud import PointCloud
 from ._soma_object import AnySOMAObject
 from ._spatial_dataframe import SpatialDataFrame
@@ -33,7 +33,7 @@ from ._spatial_dataframe import SpatialDataFrame
 class Scene(  # type: ignore[misc]  # __eq__ false positive
     CollectionBase[AnySOMAObject],
     scene.Scene[  # type: ignore[type-var]
-        Collection[SpatialDataFrame], Image2DCollection, AnySOMAObject
+        Collection[SpatialDataFrame], MultiscaleImage, AnySOMAObject
     ],
 ):
     """TODO: Add documentation for a Scene
@@ -131,14 +131,14 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         )
         return point_cloud
 
-    def register_image2d(
+    def register_multiscale_image(
         self,
         image_name: str,
         transform: CoordinateTransform,
         *,
         subcollection_name: str = "img",
         coordinate_space: Optional[CoordinateSpace] = None,
-    ) -> Image2DCollection:
+    ) -> MultiscaleImage:
         """TODO Add docstring"""
         # Check the transform matches this
         if self.coordinate_space is None:
@@ -177,14 +177,14 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
                 f"No collection '{subcollection_name}' in this scene."
             ) from ke
         try:
-            image: Image2DCollection = subcollection[image_name]
+            image: MultiscaleImage = subcollection[image_name]
         except KeyError as ke:
             raise KeyError(
-                f"No Image2DCollection named '{image_name}' in '{subcollection_name}'."
+                f"No multiscale image named '{image_name}' in '{subcollection_name}'."
             ) from ke
-        if not isinstance(image, Image2DCollection):
+        if not isinstance(image, MultiscaleImage):
             raise TypeError(
-                f"'{image_name}' in '{subcollection_name}' is not an Image2DCollection."
+                f"'{image_name}' in '{subcollection_name}' is not an MultiscaleImage."
             )
 
         image.coordinate_space = coordinate_space
@@ -219,7 +219,7 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
             ) from ke
         return transform_from_json(transform_json)
 
-    def transform_to_image2d(
+    def transform_to_multiscale_image(
         self,
         image_name: str,
         *,
@@ -230,7 +230,7 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         registered in the scene.
 
         If the name or level of an image is provided, the transformation will be to
-        the requested level instead of the root ImageCollection.
+        the requested level instead of the reference level of the multiscale image.
         """
         try:
             subcollection: Collection = self[subcollection_name]  # type: ignore
@@ -249,10 +249,10 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
         if level is None:
             return base_transform
         try:
-            image: Image2DCollection = subcollection[image_name]
+            image: MultiscaleImage = subcollection[image_name]
         except KeyError as ke:
             raise KeyError(
-                f"No Image2DCollection named '{image_name}' in '{subcollection_name}'."
+                f"No MultiscaleImage named '{image_name}' in '{subcollection_name}'."
             ) from ke
         if isinstance(level, str):
             raise NotImplementedError(

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -258,5 +258,5 @@ class Scene(  # type: ignore[misc]  # __eq__ false positive
             raise NotImplementedError(
                 "Support for querying image level by name is not yet implemented."
             )
-        level_transform = image.transform_to_level(level)
+        level_transform = image.get_transformation_to_level(level)
         return base_transform * level_transform

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2024 The Chan Zuckerberg Initiative Foundation
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+
+import re
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Iterator,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    cast,
+)
+
+import attrs
+from typing_extensions import Self
+
+from . import _tdb_handles
+
+# This package's pybind11 code
+from . import pytiledbsoma as clib  # noqa: E402
+from ._exception import (
+    SOMAError,
+    is_does_not_exist_error,
+)
+from ._soma_object import AnySOMAObject, SOMAObject
+from ._util import (
+    is_relative_uri,
+    make_relative_path,
+    uri_joinpath,
+)
+
+CollectionElementType = TypeVar("CollectionElementType", bound=AnySOMAObject)
+_TDBO = TypeVar("_TDBO", bound=SOMAObject)  # type: ignore[type-arg]
+
+
+@attrs.define()
+class _CachedElement:
+    """Item we have loaded in the cache of a collection."""
+
+    entry: _tdb_handles.GroupEntry
+    soma: Optional[AnySOMAObject] = None
+    """The reified object, if it has been opened."""
+
+
+class SOMAGroup(
+    SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[CollectionElementType]
+):
+    """Base class for all SOMAGroups: CollectionBase and MultiscaleImage.
+
+    Lifecycle:
+        Experimental.
+    """
+
+    __slots__ = ("_contents", "_mutated_keys")
+
+    def __init__(
+        self,
+        handle: _tdb_handles.SOMAGroupWrapper[Any],
+        **kwargs: Any,
+    ):
+        super().__init__(handle, **kwargs)
+        self._contents = {
+            key: _CachedElement(entry) for key, entry in handle.initial_contents.items()
+        }
+        """The contents of the persisted TileDB Group.
+
+        This is loaded at startup when we have a read handle.
+        """
+        self._mutated_keys: Set[str] = set()
+
+    def __len__(self) -> int:
+        """Return the number of members in the collection"""
+        return len(self._contents)
+
+    def __getitem__(self, key: str) -> CollectionElementType:
+        """Gets the value associated with the key."""
+        err_str = f"{self.__class__.__name__} has no item {key!r}"
+
+        try:
+            entry = self._contents[key]
+        except KeyError:
+            raise KeyError(err_str) from None
+        if entry.soma is None:
+            from . import _factory  # Delayed binding to resolve circular import.
+
+            uri = entry.entry.uri
+            mode = self.mode
+            context = self.context
+            timestamp = self.tiledb_timestamp_ms
+            clib_type = entry.entry.wrapper_type.clib_type
+
+            wrapper = _tdb_handles.open(uri, mode, context, timestamp, clib_type)
+            entry.soma = _factory.reify_handle(wrapper)
+
+            # Since we just opened this object, we own it and should close it.
+            self._close_stack.enter_context(entry.soma)
+        return cast(CollectionElementType, entry.soma)
+
+    def __setitem__(self, key: str, value: CollectionElementType) -> None:
+        """Default collection __setattr__"""
+        self.set(key, value, use_relative_uri=None)
+
+    def __delitem__(self, key: str) -> None:
+        """Removes a member from the collection, when invoked as ``del collection["namegoeshere"]``.
+
+        Raises:
+            SOMAError:
+                Upon deletion of a mutated key.
+        """
+        self._del_element(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._contents)
+
+    def _contents_lines(self, last_indent: str) -> Iterable[str]:
+        indent = last_indent + "    "
+        if self.closed:
+            return
+        for key, entry in self._contents.items():
+            obj = entry.soma
+            if obj is None:
+                # We haven't reified this SOMA object yet. Don't try to open it.
+                yield f"{indent}{key!r}: {entry.entry.uri!r} (unopened)"
+            else:
+                yield f"{indent}{key!r}: {obj._my_repr()}"
+                if isinstance(obj, SOMAGroup):
+                    yield from obj._contents_lines(indent)
+
+    def _set_element(
+        self,
+        key: str,
+        *,
+        uri: str,
+        relative: bool,
+        soma_object: CollectionElementType,
+    ) -> None:
+        """Internal implementation of element setting.
+
+        Args:
+            key:
+                The key to set.
+            uri:
+                The resolved URI to pass to :meth:`clib.SOMAGroup.add`.
+            relative:
+                The ``relative`` parameter to pass to ``add``.
+            value:
+                The reified SOMA object to store locally.
+        """
+
+        if key in self._mutated_keys.union(self._contents):
+            # TileDB groups currently do not support replacing elements.
+            # If we use a hack to flush writes, corruption is possible.
+            raise SOMAError(f"replacing key {key!r} is unsupported")
+        clib_collection = self._handle._handle
+        relative_type = clib.URIType.relative if relative else clib.URIType.absolute
+        clib_collection.add(
+            uri=uri,
+            uri_type=relative_type,
+            name=key,
+            soma_type=clib_collection.type,
+        )
+        self._contents[key] = _CachedElement(
+            entry=_tdb_handles.GroupEntry(soma_object.uri, soma_object._wrapper_type),
+            soma=soma_object,
+        )
+        self._mutated_keys.add(key)
+
+    def _del_element(self, key: str) -> None:
+        if key in self._mutated_keys:
+            raise SOMAError(f"cannot delete previously-mutated key {key!r}")
+        try:
+            self._handle.writer.remove(key)
+        except RuntimeError as tdbe:
+            if is_does_not_exist_error(tdbe):
+                raise KeyError(tdbe) from tdbe
+            raise
+        self._contents.pop(key, None)
+        self._mutated_keys.add(key)
+
+    def _add_new_element(
+        self,
+        key: str,
+        kind: Type[_TDBO],
+        factory: Callable[[str], _TDBO],
+        user_uri: Optional[str],
+    ) -> _TDBO:
+        """Handles the common parts of adding new elements.
+
+        Args:
+            key:
+                The key to be added.
+            kind:
+                The type of the element to be added.
+            factory:
+                A callable that, given the full URI to be added,
+                will create the backing storage at that URI and return
+                the reified SOMA object.
+            user_uri:
+                If set, the URI to use for the child
+                instead of the default.
+        """
+        if key in self:
+            raise KeyError(f"{key!r} already exists in {type(self)}")
+        child_uri = self._new_child_uri(key=key, user_uri=user_uri)
+        child = factory(child_uri.full_uri)
+        # The resulting element may not be the right type for this collection,
+        # but we can't really handle that within the type system.
+        self._set_element(
+            key,
+            uri=child_uri.add_uri,
+            relative=child_uri.relative,
+            soma_object=child,  # type: ignore[arg-type]
+        )
+        self._close_stack.enter_context(child)
+        return child
+
+    def _new_child_uri(self, *, key: str, user_uri: Optional[str]) -> "_ChildURI":
+        maybe_relative_uri = user_uri or _sanitize_for_path(key)
+        if not is_relative_uri(maybe_relative_uri):
+            # It's an absolute URI.
+            return _ChildURI(
+                add_uri=maybe_relative_uri,
+                full_uri=maybe_relative_uri,
+                relative=False,
+            )
+        if not self.uri.startswith("tiledb://"):
+            # We don't need to post-process anything.
+            return _ChildURI(
+                add_uri=maybe_relative_uri,
+                full_uri=uri_joinpath(self.uri, maybe_relative_uri),
+                relative=True,
+            )
+        # Our own URI is a ``tiledb://`` URI. Since TileDB Cloud requires absolute
+        # URIs, we need to calculate the absolute URI to pass to Group.add
+        # based on our creation URI.
+        # TODO: Handle the case where we reopen a TileDB Cloud Group, but by
+        # name rather than creation path.
+        absolute_uri = uri_joinpath(self.uri, maybe_relative_uri)
+        return _ChildURI(add_uri=absolute_uri, full_uri=absolute_uri, relative=False)
+
+    def set(
+        self,
+        key: str,
+        value: CollectionElementType,
+        *,
+        use_relative_uri: Optional[bool] = None,
+    ) -> Self:
+        """Adds an element to the collection.
+
+        Args:
+            key:
+                The key of the element to be added.
+            value:
+                The value to be added to this collection.
+            use_relative_uri:
+                By default (None), the collection will determine whether the
+                element should be stored by relative URI.
+                If True, the collection will store the child by absolute URI.
+                If False, the collection will store the child by relative URI.
+
+        Raises:
+            SOMAError:
+                If an existing key is set (replacement is unsupported).
+
+        Lifecycle:
+            Maturing.
+        """
+        uri_to_add = value.uri
+        # The SOMA API supports use_relative_uri in [True, False, None].
+        # The TileDB-Py API supports use_relative_uri in [True, False].
+        # Map from the former to the latter -- and also honor our somacore contract for None --
+        # using the following rule.
+        if use_relative_uri is None and value.uri.startswith("tiledb://"):
+            # TileDB-Cloud does not use relative URIs, ever.
+            use_relative_uri = False
+
+        if use_relative_uri is not False:
+            try:
+                uri_to_add = make_relative_path(value.uri, relative_to=self.uri)
+                use_relative_uri = True
+            except ValueError:
+                if use_relative_uri:
+                    # We couldn't construct a relative URI, but we were asked
+                    # to use one, so raise the error.
+                    raise
+                use_relative_uri = False
+
+        self._set_element(
+            key, uri=uri_to_add, relative=use_relative_uri, soma_object=value
+        )
+        return self
+
+
+_NON_WORDS = re.compile(r"[\W_]+")
+
+
+def _sanitize_for_path(key: str) -> str:
+    """Prepares the given key for use as a path component."""
+    sanitized = "_".join(_NON_WORDS.split(key))
+    return sanitized
+
+
+@attrs.define(frozen=True, kw_only=True)
+class _ChildURI:
+    add_uri: str
+    """The URI of the child for passing to :meth:``clib.SOMAGroup.add``."""
+    full_uri: str
+    """The full URI of the child, used to create a new element."""
+    relative: bool
+    """The ``relative`` value to pass to :meth:``clib.SOMAGroup.add``."""

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -48,7 +48,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Type[_tdb_handles.ExperimentWrapper],
         Type[_tdb_handles.MeasurementWrapper],
         Type[_tdb_handles.SceneWrapper],
-        Type[_tdb_handles.Image2DCollectionWrapper],
+        Type[_tdb_handles.MultiscaleImageWrapper],
     ]
     """Class variable of the Wrapper class used to open this object type."""
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -49,7 +49,7 @@ RawHandle = Union[
     clib.SOMAMeasurement,
     clib.SOMAExperiment,
     clib.SOMAScene,
-    clib.SOMAImage2DCollection,
+    clib.SOMAMultiscaleImage,
 ]
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 """A raw TileDB object. Covariant because Handles are immutable enough."""
@@ -87,7 +87,7 @@ def open(
         "somaexperiment": ExperimentWrapper,
         "somameasurement": MeasurementWrapper,
         "somascene": SceneWrapper,
-        "somaimage2dcollection": Image2DCollectionWrapper,
+        "somamultiscaleimage": MultiscaleImageWrapper,
     }
 
     try:
@@ -324,10 +324,10 @@ class SceneWrapper(SOMAGroupWrapper[clib.SOMAScene]):
     _GROUP_WRAPPED_TYPE = clib.SOMAScene
 
 
-class Image2DCollectionWrapper(SOMAGroupWrapper[clib.SOMAImage2DCollection]):
+class MultiscaleImageWrapper(SOMAGroupWrapper[clib.SOMAMultiscaleImage]):
     """Wrapper around a Pybind11 SceneWrapper handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMAImage2DCollection
+    _GROUP_WRAPPED_TYPE = clib.SOMAMultiscaleImage
 
 
 _ArrType = TypeVar("_ArrType", bound=clib.SOMAArray)

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -369,9 +369,12 @@ def _write_visium_data_to_experiment_uri(
                         for x in (input_hires, input_lowres, input_fullres)
                     ):
                         tissue_uri = f"{img_uri}/tissue"
-                        with _create_or_open_collection(
-                            MultiscaleImage, tissue_uri, **ingest_ctx
+                        with MultiscaleImage.create(
+                            tissue_uri,
+                            axis_order="YXC",
+                            context=ingest_ctx.get("context"),
                         ) as tissue:
+                            add_metadata(tissue, ingest_ctx.get("additional_metadata"))
                             _maybe_set(
                                 img,
                                 "tissue",

--- a/apis/python/src/tiledbsoma/experimental/ingest.py
+++ b/apis/python/src/tiledbsoma/experimental/ingest.py
@@ -38,7 +38,7 @@ from .. import (
     DataFrame,
     DenseNDArray,
     Experiment,
-    Image2DCollection,
+    MultiscaleImage,
     PointCloud,
     Scene,
     SparseNDArray,
@@ -361,7 +361,7 @@ def _write_visium_data_to_experiment_uri(
                 # Write image data and add to the scene.
                 img_uri = f"{scene_uri}/img"
                 with _create_or_open_collection(
-                    Collection[Image2DCollection], img_uri, **ingest_ctx
+                    Collection[MultiscaleImage], img_uri, **ingest_ctx
                 ) as img:
                     _maybe_set(scene, "img", img, use_relative_uri=use_relative_uri)
                     if any(
@@ -370,7 +370,7 @@ def _write_visium_data_to_experiment_uri(
                     ):
                         tissue_uri = f"{img_uri}/tissue"
                         with _create_or_open_collection(
-                            Image2DCollection, tissue_uri, **ingest_ctx
+                            MultiscaleImage, tissue_uri, **ingest_ctx
                         ) as tissue:
                             _maybe_set(
                                 img,
@@ -389,7 +389,7 @@ def _write_visium_data_to_experiment_uri(
                                 **ingest_ctx,
                             )
                             tissue.coordinate_space = coord_space
-                            scene.register_image2d(
+                            scene.register_multiscale_image(
                                 "tissue",
                                 IdentityTransform(("x", "y"), ("x", "y")),
                             )
@@ -574,7 +574,7 @@ def _write_visium_spots(
 
 
 def _write_visium_images(
-    image_pyramid: Image2DCollection,
+    image_pyramid: MultiscaleImage,
     scale_factors: Dict[str, Any],
     *,
     input_hires: Union[None, str, Path],

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -45,8 +45,8 @@ from .. import (
     DataFrame,
     DenseNDArray,
     Experiment,
-    Image2DCollection,
     Measurement,
+    MultiscaleImage,
     PointCloud,
     Scene,
     SparseNDArray,
@@ -1008,13 +1008,13 @@ def _create_or_open_collection(
 
 @overload
 def _create_or_open_collection(
-    cls: Type[Image2DCollection],
+    cls: Type[MultiscaleImage],
     uri: str,
     *,
     ingestion_params: IngestionParams,
     context: Optional["SOMATileDBContext"],
     additional_metadata: "AdditionalMetadata" = None,
-) -> Image2DCollection: ...
+) -> MultiscaleImage: ...
 
 
 @no_type_check

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -46,7 +46,6 @@ from .. import (
     DenseNDArray,
     Experiment,
     Measurement,
-    MultiscaleImage,
     PointCloud,
     Scene,
     SparseNDArray,
@@ -1004,17 +1003,6 @@ def _create_or_open_collection(
     context: Optional["SOMATileDBContext"],
     additional_metadata: "AdditionalMetadata" = None,
 ) -> Scene: ...
-
-
-@overload
-def _create_or_open_collection(
-    cls: Type[MultiscaleImage],
-    uri: str,
-    *,
-    ingestion_params: IngestionParams,
-    context: Optional["SOMATileDBContext"],
-    additional_metadata: "AdditionalMetadata" = None,
-) -> MultiscaleImage: ...
 
 
 @no_type_check

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -78,7 +78,7 @@ void load_soma_collection(py::module& m) {
     py::class_<SOMAScene, SOMACollection, SOMAGroup, SOMAObject>(
         m, "SOMAScene");
 
-    py::class_<SOMAImage2DCollection, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAImage2DCollection");
+    py::class_<SOMAMultiscaleImage, SOMACollection, SOMAGroup, SOMAObject>(
+        m, "SOMAMultiscaleImage");
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -93,9 +93,9 @@ void load_soma_object(py::module& m) {
                             dynamic_cast<SOMAMeasurement&>(*soma_obj));
                     else if (soma_obj_type == "somascene")
                         return py::cast(dynamic_cast<SOMAScene&>(*soma_obj));
-                    else if (soma_obj_type == "somaimage2dcollection")
+                    else if (soma_obj_type == "somamultiscaleimage")
                         return py::cast(
-                            dynamic_cast<SOMAImage2DCollection&>(*soma_obj));
+                            dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
                     return py::none();
                 } catch (...) {
                     return py::none();

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_image2d_collection.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_context.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dense_ndarray.cc
@@ -136,7 +136,7 @@ endif()
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_measurement.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_scene.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_point_cloud.h
-#   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_image2d_collection.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_multiscale_image.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_object.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_sparse_ndarray.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/logger_public.h
@@ -159,7 +159,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_image2d_collection.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h
   DESTINATION "include/tiledbsoma/soma"
 )

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -1,5 +1,5 @@
 /**
- * @file   soma_image2d_collection.cc
+ * @file   soma_multiscale_image.cc
  *
  * @section LICENSE
  *
@@ -27,10 +27,10 @@
  *
  * @section DESCRIPTION
  *
- *   This file defines the SOMAImage2DCollection class.
+ *   This file defines the SOMAMultiscaleImage class.
  */
 
-#include "soma_image2d_collection.h"
+#include "soma_multiscale_image.h"
 #include "soma_collection.h"
 
 namespace tiledbsoma {
@@ -40,27 +40,26 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-void SOMAImage2DCollection::create(
+void SOMAMultiscaleImage::create(
     std::string_view uri,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
         std::filesystem::path image_uri(uri);
         SOMAGroup::create(
-            ctx, image_uri.string(), "SOMAImage2DCollection", timestamp);
+            ctx, image_uri.string(), "SOMAMultiscaleImage", timestamp);
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }
 }
 
-std::unique_ptr<SOMAImage2DCollection> SOMAImage2DCollection::open(
+std::unique_ptr<SOMAMultiscaleImage> SOMAMultiscaleImage::open(
     std::string_view uri,
     OpenMode mode,
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMAImage2DCollection>(
-            mode, uri, ctx, timestamp);
+        return std::make_unique<SOMAMultiscaleImage>(mode, uri, ctx, timestamp);
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_multiscale_image.h
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.h
@@ -1,5 +1,5 @@
 /**
- * @file   soma_image2d_collection.h
+ * @file   soma_multiscale_image.h
  *
  * @section LICENSE
  *
@@ -27,11 +27,11 @@
  *
  * @section DESCRIPTION
  *
- *   This file defines the SOMAImage2DCollection class.
+ *   This file defines the SOMAMultiscaleImage class.
  */
 
-#ifndef SOMA_IMAGE2D_COLLECTION
-#define SOMA_IMAGE2D_COLLECTION
+#ifndef SOMA_MULTISCALE_IMAGE
+#define SOMA_MULTISCALE_IMAGE
 
 #include <tiledb/tiledb>
 
@@ -40,16 +40,16 @@
 namespace tiledbsoma {
 
 using namespace tiledb;
-class SOMAImage2DCollection : public SOMACollection {
+class SOMAMultiscaleImage : public SOMACollection {
    public:
     //===================================================================
     //= public static
     //===================================================================
 
     /**
-     * @brief Create a SOMAImage2DCollection object at the given URI.
+     * @brief Create a SOMAMultiscaleImage object at the given URI.
      *
-     * @param uri URI to create the SOMAImage2DCollection
+     * @param uri URI to create the SOMAMultiscaleImage
      * @param schema TileDB ArraySchema
      * @param platform_config Optional config parameter dictionary
      */
@@ -59,16 +59,16 @@ class SOMAImage2DCollection : public SOMACollection {
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * @brief Open a group at the specified URI and return SOMAImage2DCollection
+     * @brief Open a group at the specified URI and return SOMAMultiscaleImage
      * object.
      *
      * @param uri URI of the array
      * @param mode read or write
      * @param ctx TileDB context
      * @param timestamp Optional pair indicating timestamp start and end
-     * @return std::shared_ptr<SOMAImage2DCollection> SOMAImage2DCollection
+     * @return std::shared_ptr<SOMAMultiscaleImage> SOMAMultiscaleImage
      */
-    static std::unique_ptr<SOMAImage2DCollection> open(
+    static std::unique_ptr<SOMAMultiscaleImage> open(
         std::string_view uri,
         OpenMode mode,
         std::shared_ptr<SOMAContext> ctx,
@@ -78,7 +78,7 @@ class SOMAImage2DCollection : public SOMACollection {
     //= public non-static
     //===================================================================
 
-    SOMAImage2DCollection(
+    SOMAMultiscaleImage(
         OpenMode mode,
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
@@ -86,14 +86,14 @@ class SOMAImage2DCollection : public SOMACollection {
         : SOMACollection(mode, uri, ctx, timestamp) {
     }
 
-    SOMAImage2DCollection(const SOMACollection& other)
+    SOMAMultiscaleImage(const SOMACollection& other)
         : SOMACollection(other) {
     }
 
-    SOMAImage2DCollection() = delete;
-    SOMAImage2DCollection(const SOMAImage2DCollection&) = default;
-    SOMAImage2DCollection(SOMAImage2DCollection&&) = default;
-    ~SOMAImage2DCollection() = default;
+    SOMAMultiscaleImage() = delete;
+    SOMAMultiscaleImage(const SOMAMultiscaleImage&) = default;
+    SOMAMultiscaleImage(SOMAMultiscaleImage&&) = default;
+    ~SOMAMultiscaleImage() = default;
 
    private:
     //===================================================================
@@ -102,4 +102,4 @@ class SOMAImage2DCollection : public SOMACollection {
 };
 }  // namespace tiledbsoma
 
-#endif  // SOMA_IMAGE2D_COLLECTION
+#endif  // SOMA_MULTISCALE_IMAGE

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -7,8 +7,8 @@
 #include "soma_dataframe.h"
 #include "soma_dense_ndarray.h"
 #include "soma_experiment.h"
-#include "soma_image2d_collection.h"
 #include "soma_measurement.h"
+#include "soma_multiscale_image.h"
 #include "soma_point_cloud.h"
 #include "soma_scene.h"
 #include "soma_sparse_ndarray.h"
@@ -84,8 +84,8 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             return std::make_unique<SOMAMeasurement>(*group_);
         } else if (group_type == "somascene") {
             return std::make_unique<SOMAScene>(*group_);
-        } else if (group_type == "somaimage2dcollection") {
-            return std::make_unique<SOMAImage2DCollection>(*group_);
+        } else if (group_type == "somamultiscaleimage") {
+            return std::make_unique<SOMAMultiscaleImage>(*group_);
         } else {
             throw TileDBSOMAError("Saw invalid SOMAGroup type");
         }

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -55,7 +55,7 @@
 #include "soma/soma_measurement.h"
 #include "soma/soma_scene.h"
 #include "soma/soma_point_cloud.h"
-#include "soma/soma_image2d_collection.h"
+#include "soma/soma_multiscale_image.h"
 #include "soma/soma_object.h"
 #include "soma/soma_dataframe.h"
 #include "soma/soma_dense_ndarray.h"


### PR DESCRIPTION
This PR cleans up the multiscale image pyramid class. It includes the following:

- [x] Merge `ImageCollection` and `Image2DCollection` into a single class 
- [x] Rename new class to `MultiscaleImage`
- [x] Remove `Collection` methods from `MultiscaleImage` (e.g. ability to add subcollections, sparse arrays, etc.)
- [ ] Add checking that all images have the same number of channels
- [ ] Add checks for number of dimensions (NotImplemented for more than 2 spatial dimensions + 1 channel dimension for now)
- [ ] Add property to get transformations from image levels
- [ ] Update image name in experimental Visium ingestor
- [ ] Add support for accessing level properties by name