### PR TITLE
[c++] Unit-test `resize` for `SparseNDArray` and `DenseNDArray`

### DIFF
--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -34,7 +34,7 @@
 
 #define DIM_MAX 1000
 
-TEST_CASE("SOMADenseNDArray: basic") {
+TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
@@ -98,7 +98,7 @@ TEST_CASE("SOMADenseNDArray: basic") {
             REQUIRE(schema->domain().has_dimension(dim_name));
             REQUIRE(soma_dense->ndim() == 1);
 
-            // Once we have support for current domain in dense arrays
+            // TODO: Once we have support for current domain in dense arrays
             // if (use_current_domain) {
             //    REQUIRE(soma_dense->shape() == std::vector<int64_t>{dim_max +
             //    1});
@@ -129,11 +129,20 @@ TEST_CASE("SOMADenseNDArray: basic") {
                 REQUIRE(a0 == std::vector<int>(a0span.begin(), a0span.end()));
             }
             soma_dense->close();
+
+            soma_dense = SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+            auto new_shape = std::vector<int64_t>({DIM_MAX * 2});
+            // * When use_current_domain is false: can't resize what has not
+            //   been sized.
+            // * When use_current_domain is true: TODO: current domain not
+            //   supported for dense arrays yet (see above).
+            REQUIRE_THROWS(soma_dense->resize(new_shape));
+            soma_dense->close();
         }
     }
 }
 
-TEST_CASE("SOMADenseNDArray: platform_config") {
+TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
@@ -196,7 +205,7 @@ TEST_CASE("SOMADenseNDArray: platform_config") {
     }
 }
 
-TEST_CASE("SOMADenseNDArray: metadata") {
+TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal


### PR DESCRIPTION
**Issue and/or context:** This follows on #2945 for issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). Here we implement `resize`.

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Given the improved fixturing for `libtiledbsoma`, it's now a short hop to implement unit-test coverage for `resize` in these two classes.

**Notes for Reviewer:**
