### PR TITLE
[c++] Implement `upgrade_shape` for `SparseNDArray` and `DenseNDArray`

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -30,10 +30,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1300,7 +1300,7 @@ void SOMAArray::_set_current_domain_from_shape(
     // Variant-indexed dataframes must use a separate path
     _assert_dims_are_int64();
 
-  if (_get_current_domain().is_empty()) {
+    if (_get_current_domain().is_empty()) {
         throw TileDBSOMAError(
             "[SOMAArray::resize] array must already be sized");
     }
@@ -1349,164 +1349,173 @@ void SOMAArray::_assert_dims_are_int64() {
             "[SOMAArray] internal coding error: expected all dims to be int64");
     }
 
-void SOMAArray::resize_soma_joinid_if_dim(
-    const std::vector<int64_t>& newshape) {
-    if (mq_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must be opened in write mode");
+    void SOMAArray::resize_soma_joinid_if_dim(
+        const std::vector<int64_t>& newshape) {
+        if (mq_->query_type() != TILEDB_WRITE) {
+            throw TileDBSOMAError(
+                "[SOMAArray::resize] array must be opened in write mode");
+        }
+
+        ArraySchema schema = arr_->schema();
+        Domain domain = schema.domain();
+        unsigned ndim = domain.ndim();
+        if (newshape.size() != 1) {
+            throw TileDBSOMAError(fmt::format(
+                "[SOMAArray::resize]: newshape has dimension count {}; needed "
+                "1",
+                newshape.size(),
+                ndim));
+        }
+
+        auto tctx = ctx_->tiledb_ctx();
+        CurrentDomain
+            old_current_domain = ArraySchemaExperimental::current_domain(
+                *tctx, schema);
+        NDRectangle ndrect = old_current_domain.ndrectangle();
+
+        CurrentDomain new_current_domain(*tctx);
+        ArraySchemaEvolution schema_evolution(*tctx);
+
+        for (unsigned i = 0; i < ndim; i++) {
+            if (domain.dimension(i).name() == "soma_joinid") {
+                ndrect.set_range<int64_t>(
+                    domain.dimension(i).name(), 0, newshape[0] - 1);
+            }
+        }
+
+        new_current_domain.set_ndrectangle(ndrect);
+        schema_evolution.expand_current_domain(new_current_domain);
+        schema_evolution.array_evolve(uri_);
     }
 
-    ArraySchema schema = arr_->schema();
-    Domain domain = schema.domain();
-    unsigned ndim = domain.ndim();
-    if (newshape.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::resize]: newshape has dimension count {}; needed 1",
-            newshape.size(),
-            ndim));
+    uint64_t SOMAArray::ndim() const {
+        return tiledb_schema()->domain().ndim();
     }
 
-    auto tctx = ctx_->tiledb_ctx();
-    CurrentDomain old_current_domain = ArraySchemaExperimental::current_domain(
-        *tctx, schema);
-    NDRectangle ndrect = old_current_domain.ndrectangle();
+    std::vector<std::string> SOMAArray::dimension_names() const {
+        std::vector<std::string> result;
+        auto dimensions = tiledb_schema()->domain().dimensions();
+        for (const auto& dim : dimensions) {
+            result.push_back(dim.name());
+        }
+        return result;
+    }
 
-    CurrentDomain new_current_domain(*tctx);
-    ArraySchemaEvolution schema_evolution(*tctx);
+    std::map<std::string, Enumeration> SOMAArray::get_attr_to_enum_mapping() {
+        std::map<std::string, Enumeration> result;
+        for (uint32_t i = 0; i < arr_->schema().attribute_num(); ++i) {
+            auto attr = arr_->schema().attribute(i);
+            if (attr_has_enum(attr.name())) {
+                auto enmr_label = *get_enum_label_on_attr(attr.name());
+                auto enmr = ArrayExperimental::get_enumeration(
+                    *ctx_->tiledb_ctx(), *arr_, enmr_label);
+                result.insert({attr.name(), enmr});
+            }
+        }
+        return result;
+    }
 
-    for (unsigned i = 0; i < ndim; i++) {
-        if (domain.dimension(i).name() == "soma_joinid") {
-            ndrect.set_range<int64_t>(
-                domain.dimension(i).name(), 0, newshape[0] - 1);
+    std::optional<std::string> SOMAArray::get_enum_label_on_attr(
+        std::string attr_name) {
+        auto attr = arr_->schema().attribute(attr_name);
+        return AttributeExperimental::get_enumeration_name(
+            *ctx_->tiledb_ctx(), attr);
+    }
+
+    bool SOMAArray::attr_has_enum(std::string attr_name) {
+        return get_enum_label_on_attr(attr_name).has_value();
+    }
+
+    void SOMAArray::set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value,
+        bool force) {
+        if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
+            throw TileDBSOMAError(
+                SOMA_OBJECT_TYPE_KEY + " cannot be modified.");
+
+        if (!force && key.compare(ENCODING_VERSION_KEY) == 0)
+            throw TileDBSOMAError(
+                ENCODING_VERSION_KEY + " cannot be modified.");
+
+        arr_->put_metadata(key, value_type, value_num, value);
+
+        MetadataValue mdval(value_type, value_num, value);
+        std::pair<std::string, const MetadataValue> mdpair(key, mdval);
+        metadata_.insert(mdpair);
+    }
+
+    void SOMAArray::delete_metadata(const std::string& key) {
+        if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
+            throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
+        }
+
+        if (key.compare(ENCODING_VERSION_KEY) == 0) {
+            throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
+        }
+
+        arr_->delete_metadata(key);
+        metadata_.erase(key);
+    }
+
+    std::optional<MetadataValue> SOMAArray::get_metadata(
+        const std::string& key) {
+        if (metadata_.count(key) == 0) {
+            return std::nullopt;
+        }
+
+        return metadata_[key];
+    }
+
+    std::map<std::string, MetadataValue> SOMAArray::get_metadata() {
+        return metadata_;
+    }
+
+    bool SOMAArray::has_metadata(const std::string& key) {
+        return metadata_.count(key) != 0;
+    }
+
+    uint64_t SOMAArray::metadata_num() const {
+        return metadata_.size();
+    }
+
+    void SOMAArray::validate(
+        OpenMode mode,
+        std::string_view name,
+        std::optional<TimestampRange> timestamp) {
+        // Validate parameters
+        auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
+
+        try {
+            LOG_DEBUG(fmt::format("[SOMAArray] opening array '{}'", uri_));
+            if (timestamp) {
+                arr_ = std::make_shared<Array>(
+                    *ctx_->tiledb_ctx(),
+                    uri_,
+                    tdb_mode,
+                    TemporalPolicy(
+                        TimestampStartEnd,
+                        timestamp->first,
+                        timestamp->second));
+            } else {
+                arr_ = std::make_shared<Array>(
+                    *ctx_->tiledb_ctx(), uri_, tdb_mode);
+            }
+            LOG_TRACE(fmt::format("[SOMAArray] loading enumerations"));
+            ArrayExperimental::load_all_enumerations(
+                *ctx_->tiledb_ctx(), *(arr_.get()));
+            mq_ = std::make_unique<ManagedQuery>(
+                arr_, ctx_->tiledb_ctx(), name);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(
+                fmt::format("Error opening array: '{}'\n  {}", uri_, e.what()));
         }
     }
 
-    new_current_domain.set_ndrectangle(ndrect);
-    schema_evolution.expand_current_domain(new_current_domain);
-    schema_evolution.array_evolve(uri_);
-}
-
-uint64_t SOMAArray::ndim() const {
-    return tiledb_schema()->domain().ndim();
-}
-
-std::vector<std::string> SOMAArray::dimension_names() const {
-    std::vector<std::string> result;
-    auto dimensions = tiledb_schema()->domain().dimensions();
-    for (const auto& dim : dimensions) {
-        result.push_back(dim.name());
+    std::optional<TimestampRange> SOMAArray::timestamp() {
+        return timestamp_;
     }
-    return result;
-}
-
-std::map<std::string, Enumeration> SOMAArray::get_attr_to_enum_mapping() {
-    std::map<std::string, Enumeration> result;
-    for (uint32_t i = 0; i < arr_->schema().attribute_num(); ++i) {
-        auto attr = arr_->schema().attribute(i);
-        if (attr_has_enum(attr.name())) {
-            auto enmr_label = *get_enum_label_on_attr(attr.name());
-            auto enmr = ArrayExperimental::get_enumeration(
-                *ctx_->tiledb_ctx(), *arr_, enmr_label);
-            result.insert({attr.name(), enmr});
-        }
-    }
-    return result;
-}
-
-std::optional<std::string> SOMAArray::get_enum_label_on_attr(
-    std::string attr_name) {
-    auto attr = arr_->schema().attribute(attr_name);
-    return AttributeExperimental::get_enumeration_name(
-        *ctx_->tiledb_ctx(), attr);
-}
-
-bool SOMAArray::attr_has_enum(std::string attr_name) {
-    return get_enum_label_on_attr(attr_name).has_value();
-}
-
-void SOMAArray::set_metadata(
-    const std::string& key,
-    tiledb_datatype_t value_type,
-    uint32_t value_num,
-    const void* value,
-    bool force) {
-    if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
-        throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be modified.");
-
-    if (!force && key.compare(ENCODING_VERSION_KEY) == 0)
-        throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be modified.");
-
-    arr_->put_metadata(key, value_type, value_num, value);
-
-    MetadataValue mdval(value_type, value_num, value);
-    std::pair<std::string, const MetadataValue> mdpair(key, mdval);
-    metadata_.insert(mdpair);
-}
-
-void SOMAArray::delete_metadata(const std::string& key) {
-    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
-        throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
-    }
-
-    if (key.compare(ENCODING_VERSION_KEY) == 0) {
-        throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
-    }
-
-    arr_->delete_metadata(key);
-    metadata_.erase(key);
-}
-
-std::optional<MetadataValue> SOMAArray::get_metadata(const std::string& key) {
-    if (metadata_.count(key) == 0) {
-        return std::nullopt;
-    }
-
-    return metadata_[key];
-}
-
-std::map<std::string, MetadataValue> SOMAArray::get_metadata() {
-    return metadata_;
-}
-
-bool SOMAArray::has_metadata(const std::string& key) {
-    return metadata_.count(key) != 0;
-}
-
-uint64_t SOMAArray::metadata_num() const {
-    return metadata_.size();
-}
-
-void SOMAArray::validate(
-    OpenMode mode,
-    std::string_view name,
-    std::optional<TimestampRange> timestamp) {
-    // Validate parameters
-    auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
-
-    try {
-        LOG_DEBUG(fmt::format("[SOMAArray] opening array '{}'", uri_));
-        if (timestamp) {
-            arr_ = std::make_shared<Array>(
-                *ctx_->tiledb_ctx(),
-                uri_,
-                tdb_mode,
-                TemporalPolicy(
-                    TimestampStartEnd, timestamp->first, timestamp->second));
-        } else {
-            arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, tdb_mode);
-        }
-        LOG_TRACE(fmt::format("[SOMAArray] loading enumerations"));
-        ArrayExperimental::load_all_enumerations(
-            *ctx_->tiledb_ctx(), *(arr_.get()));
-        mq_ = std::make_unique<ManagedQuery>(arr_, ctx_->tiledb_ctx(), name);
-    } catch (const std::exception& e) {
-        throw TileDBSOMAError(
-            fmt::format("Error opening array: '{}'\n  {}", uri_, e.what()));
-    }
-}
-
-std::optional<TimestampRange> SOMAArray::timestamp() {
-    return timestamp_;
-}
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -627,7 +627,7 @@ class SOMAArray : public SOMAObject {
      */
     void upgrade_shape(const std::vector<int64_t>& newshape);
 
-   /**
+    /**
      * @brief Increases the tiledbsoma shape up to at most the maxshape,
      * resizing the soma_joinid dimension if it is a dimension.
      *

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -620,6 +620,14 @@ class SOMAArray : public SOMAObject {
     void resize(const std::vector<int64_t>& newshape);
 
     /**
+     * @brief Given an old-style array without current domain, sets its
+     * current domain. This is applicable only to arrays having all dims
+     * of int64 type. Namely, all SparseNDArray/DenseNDArray, and
+     * default-indexed DataFrame.
+     */
+    void upgrade_shape(const std::vector<int64_t>& newshape);
+
+    /**
      * @brief Get the number of dimensions.
      *
      * @return uint64_t Number of dimensions.
@@ -821,6 +829,23 @@ class SOMAArray : public SOMAObject {
         return tiledb::ArraySchemaExperimental::current_domain(
             *ctx_->tiledb_ctx(), arr_->schema());
     }
+
+    /**
+     * Helper method for resize and upgrade_shape.
+     */
+    void _set_current_domain_from_shape(const std::vector<int64_t>& newshape);
+
+    /**
+     * While SparseNDArray, DenseNDArray, and default-indexed DataFrame
+     * have int64 dims, variant-indexed DataFrames do not. This helper
+     * lets us pre-check any attempts to treat dims as if they were int64.
+     */
+    bool _dims_are_int64();
+
+    /**
+     * Same, but throws.
+     */
+    void _assert_dims_are_int64();
 
     /**
      * With old shape: core domain mapped to tiledbsoma shape; core current

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -34,7 +34,7 @@
 
 #define DIM_MAX 1000
 
-TEST_CASE("SOMADenseNDArray: basic") {
+TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
@@ -98,7 +98,7 @@ TEST_CASE("SOMADenseNDArray: basic") {
             REQUIRE(schema->domain().has_dimension(dim_name));
             REQUIRE(soma_dense->ndim() == 1);
 
-            // Once we have support for current domain in dense arrays
+            // TODO: Once we have support for current domain in dense arrays
             // if (use_current_domain) {
             //    REQUIRE(soma_dense->shape() == std::vector<int64_t>{dim_max +
             //    1});
@@ -129,11 +129,20 @@ TEST_CASE("SOMADenseNDArray: basic") {
                 REQUIRE(a0 == std::vector<int>(a0span.begin(), a0span.end()));
             }
             soma_dense->close();
+
+            soma_dense = SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+            auto new_shape = std::vector<int64_t>({DIM_MAX * 2});
+            // * When use_current_domain is false: can't resize what has not
+            //   been sized.
+            // * When use_current_domain is true: TODO: current domain not
+            //   supported for dense arrays yet (see above).
+            REQUIRE_THROWS(soma_dense->resize(new_shape));
+            soma_dense->close();
         }
     }
 }
 
-TEST_CASE("SOMADenseNDArray: platform_config") {
+TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
@@ -196,7 +205,7 @@ TEST_CASE("SOMADenseNDArray: platform_config") {
     }
 }
 
-TEST_CASE("SOMADenseNDArray: metadata") {
+TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     int64_t dim_max = 1000;
     auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -130,19 +130,34 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
         REQUIRE_THROWS(soma_sparse->write());
         soma_sparse->close();
 
-        soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
-        auto new_shape = std::vector<int64_t>({dim_max * 2});
         if (!use_current_domain) {
+            auto new_shape = std::vector<int64_t>({dim_max});
+
+            soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
             // Without current-domain support: this should throw since
             // one cannot resize what has not been sized.
             REQUIRE_THROWS(soma_sparse->resize(new_shape));
-        } else {
+            // Now set the shape
+            soma_sparse->upgrade_shape(new_shape);
+            // Should not fail since we're setting it to what it already is.
             soma_sparse->resize(new_shape);
-        }
-        soma_sparse->close();
+            soma_sparse->close();
 
-        // Try out-of-bounds write after resize.
-        if (use_current_domain) {
+            soma_sparse = SOMASparseNDArray::open(uri, OpenMode::read, ctx);
+            REQUIRE(soma_sparse->shape() == new_shape);
+            soma_sparse->close();
+
+        } else {
+            auto new_shape = std::vector<int64_t>({dim_max * 2});
+
+            soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
+            // Should throw since this already has a shape (core current
+            // domain).
+            REQUIRE_THROWS(soma_sparse->upgrade_shape(new_shape));
+            soma_sparse->resize(new_shape);
+            soma_sparse->close();
+
+            // Try out-of-bounds write after resize.
             soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
             soma_sparse->set_column_data(dim_name, d0b.size(), d0b.data());
             soma_sparse->set_column_data(attr_name, a0b.size(), a0b.data());


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). 

The intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Implements the `upgrade_shape` method at the C++ level.

**Notes for Reviewer:**