### PR TITLE
[python] Drop support for Python 3.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Provide a code example and any sample input data (e.g. an H5AD) as an attachment
 
 **Versions (please complete the following information):**
  - TileDB-SOMA version:
- - Language and language version (e.g. Python 3.8, R 4.2.2):
+ - Language and language version (e.g. Python 3.9, R 4.2.2):
  - OS (e.g. MacOS, Ubuntu Linux):
  - Note: you can use `tiledbsoma.show_package_versions()` (Python) or `tiledbsoma::show_package_versions()` (R)
 

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -25,7 +25,7 @@ jobs:
         # os: [ubuntu-22.04, macos-12, windows-2019]
         # TODO: add 3.12
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -29,7 +29,7 @@ jobs:
 
       matrix:
         os: [ubuntu-22.04, macos-12]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.11']
         include:
           - os: ubuntu-22.04
             cc: gcc-11

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -12,7 +12,7 @@ show_error_codes = true
 ignore_missing_imports = true
 warn_unreachable = true
 strict = true
-python_version = 3.8
+python_version = 3.9
 
 [[tool.mypy.overrides]]
 module = "tiledbsoma._query_condition"

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -288,7 +288,6 @@ setuptools.setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -327,7 +326,7 @@ setuptools.setup(
     setup_requires=["pybind11"],
     install_requires=[
         # Tracked in https://github.com/single-cell-data/TileDB-SOMA/issues/1785
-        "anndata != 0.10.0; python_version>='3.8'",
+        "anndata != 0.10.0",
         "attrs>=22.2",
         "numba>=0.58.0",
         "numpy<2.0",
@@ -349,7 +348,7 @@ setuptools.setup(
     extras_require={
         "dev": open("requirements_dev.txt").read(),
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass={"build_ext": build_ext, "bdist_wheel": bdist_wheel},
     version=version.get_version(),
 )

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -5,6 +5,7 @@
 
 """General utility functions.
 """
+import importlib.metadata
 import platform
 import sys
 import warnings
@@ -34,20 +35,11 @@ def get_implementation_version() -> str:
 
     Lifecycle: Maturing.
     """
-    if sys.version_info < (3, 8, 0):
-        from pkg_resources import DistributionNotFound, get_distribution
 
-        try:
-            return get_distribution("tiledbsoma").version
-        except DistributionNotFound:
-            return "unknown"
-    else:
-        import importlib.metadata
-
-        try:
-            return importlib.metadata.version("tiledbsoma")
-        except importlib.metadata.PackageNotFoundError:
-            return "unknown"
+    try:
+        return importlib.metadata.version("tiledbsoma")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def assert_version_before(major: int, minor: int) -> None:

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -16,30 +16,16 @@ import pyarrow as pa
 from somacore import types
 from typing_extensions import Literal
 
-if TYPE_CHECKING:
-    # `pd.{Series,Index}` require type parameters iff `pandas>=2`. Our pandas dependency (in `setup.py`) is unpinned,
-    # which generally resolves to `pandas>=2`, but may be pandas<2 if something else in the user's environment requires
-    # that. For type-checking purposes, `.pre-commit-config.yaml` specifies `pandas-stubs>=2`, and we type-check against
-    # the `pandas>=2` types here.
-    PDSeries = pd.Series[Any]
-    PDIndex = pd.Index[Any]
+# `pd.{Series,Index}` require type parameters iff `pandas>=2`. Our pandas dependency (in `setup.py`) is unpinned,
+# which generally resolves to `pandas>=2`, but may be pandas<2 if something else in the user's environment requires
+# that. For type-checking purposes, `.pre-commit-config.yaml` specifies `pandas-stubs>=2`, and we type-check against
+# the `pandas>=2` types here.
+PDSeries = pd.Series[Any]
+PDIndex = pd.Index[Any]
 
-    NPInteger = np.integer[npt.NBitBase]
-    NPFloating = np.floating[npt.NBitBase]
-    NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
-else:
-    # When not-type-checking, but running with `pandas>=2`, the "missing" type-params don't affect anything.
-    PDSeries = pd.Series
-    PDIndex = pd.Index
-
-    # Type subscription requires python >= 3.9, and we currently only type-check against 3.11.
-    # TODO: remove these (and unify around subscripted types above) when we drop support for 3.8.
-    NPInteger = np.integer
-    NPFloating = np.floating
-    # This alias likely needs to remain special-cased, even in Python ≥3.11, as tests pass the `Matrix` type alias
-    # (which includes `NPNDArray` via `DenseMatrix`) to `isinstance`, causing error "argument 2 cannot be a
-    # parameterized generic".
-    NPNDArray = np.ndarray
+NPInteger = np.integer[npt.NBitBase]
+NPFloating = np.floating[npt.NBitBase]
+NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
 
 Path = Union[str, pathlib.Path]
 

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
-from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union, get_args
+from typing import Any, List, Sequence, Tuple, Union, get_args
 
 import numpy as np
 import numpy.typing as npt

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
-from typing import Any, List, Sequence, Tuple, Union, get_args
+from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -16,16 +16,26 @@ import pyarrow as pa
 from somacore import types
 from typing_extensions import Literal
 
-# `pd.{Series,Index}` require type parameters iff `pandas>=2`. Our pandas dependency (in `setup.py`) is unpinned,
-# which generally resolves to `pandas>=2`, but may be pandas<2 if something else in the user's environment requires
-# that. For type-checking purposes, `.pre-commit-config.yaml` specifies `pandas-stubs>=2`, and we type-check against
-# the `pandas>=2` types here.
-PDSeries = pd.Series[Any]
-PDIndex = pd.Index[Any]
+if TYPE_CHECKING:
+    # `pd.{Series,Index}` require type parameters iff `pandas>=2`. Our pandas dependency (in `setup.py`) is unpinned,
+    # which generally resolves to `pandas>=2`, but may be pandas<2 if something else in the user's environment requires
+    # that. For type-checking purposes, `.pre-commit-config.yaml` specifies `pandas-stubs>=2`, and we type-check against
+    # the `pandas>=2` types here.
+    PDSeries = pd.Series[Any]
+    PDIndex = pd.Index[Any]
+
+    NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
+else:
+    # When not-type-checking, but running with `pandas>=2`, the "missing" type-params don't affect anything.
+    PDSeries = pd.Series
+    PDIndex = pd.Index
+
+    # Tests pass the `Matrix` type alias (which includes `NPNDArray`, via `DenseMatrix`) to `isinstance`,
+    # causing error "argument 2 cannot be a parameterized generic".
+    NPNDArray = np.ndarray
 
 NPInteger = np.integer[npt.NBitBase]
 NPFloating = np.floating[npt.NBitBase]
-NPNDArray = npt.NDArray[np.number[npt.NBitBase]]
 
 Path = Union[str, pathlib.Path]
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2655,11 +2655,11 @@ def _ingest_uns_string_array(
     """
 
     if len(value.shape) == 1:
-        helper = _ingest_uns_1d_string_array  # type:ignore[unreachable]
+        helper = _ingest_uns_1d_string_array
     elif len(value.shape) == 2:
         helper = _ingest_uns_2d_string_array
     else:
-        msg = (  # type:ignore[unreachable]
+        msg = (
             f"Skipped {coll.uri}[{key!r}]"
             f" (uns object): string array is neither one-dimensional nor two-dimensional"
         )

--- a/apis/python/tests/test_funcs.py
+++ b/apis/python/tests/test_funcs.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 import textwrap
 
 import pytest
@@ -26,13 +25,10 @@ from tiledbsoma import _funcs
             "(__pos_only, *dont_shadow, do_rename: bytes = b'', **kwargs) -> complex",
             "(__pos_only, *dont_shadow_, do_rename: bytes = b'', dont_shadow: int, do_rename_: str, **do_rename__: frozenset) -> complex",
         ),
-        pytest.param(
+        (
             "(pos_only, some_name, /, dst_both_arg, *args, dst_kwarg=1, **dup_dict: complex)",
             "(dst_both_arg, dst_kwarg: int = 10, /, dup_dict: dict = (), **kwargs) -> None",
             "(dst_both_arg_, dst_kwarg_: int = 10, /, dup_dict: dict = (), *, dst_both_arg, dst_kwarg=1, **dup_dict_: complex) -> None",
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 8), reason="/ is new in 3.8"
-            ),
         ),
     ],
 )

--- a/libtiledbsoma/README.md
+++ b/libtiledbsoma/README.md
@@ -3,7 +3,7 @@
 ## System Dependencies
 
 * C++17 compiler
-* Python 3.8+
+* Python 3.9+
 
 Run these commands to setup a fresh Ubuntu 22.04 instance (tested on x86 and Arm):
 ```


### PR DESCRIPTION
**Issue and/or context:** End of life for python 3.8 is Oct. 2024 https://devguide.python.org/versions/ / [[sc-41048](https://app.shortcut.com/tiledb-inc/story/41048/soma-python-drop-support-for-python-3-8)]

**Changes:** 🔥

**Notes for Reviewer:**