### PR TITLE
[c++] Clarify dataframe-shaping test/access points

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1208,14 +1208,14 @@ std::vector<int64_t> SOMAArray::maxshape() {
     return _tiledb_domain();
 }
 
-std::optional<int64_t> SOMAArray::_maybe_sjid_shape() {
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape() {
     return _get_current_domain().is_empty() ?
-               _maybe_sjid_tiledb_domain() :
-               _maybe_sjid_tiledb_current_domain();
+               _maybe_soma_joinid_tiledb_domain() :
+               _maybe_soma_joinid_tiledb_current_domain();
 }
 
-std::optional<int64_t> SOMAArray::_maybe_sjid_maxshape() {
-    return _maybe_sjid_tiledb_domain();
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_maxshape() {
+    return _maybe_soma_joinid_tiledb_domain();
 }
 
 std::vector<int64_t> SOMAArray::_tiledb_current_domain() {
@@ -1262,7 +1262,7 @@ std::vector<int64_t> SOMAArray::_tiledb_domain() {
     return result;
 }
 
-std::optional<int64_t> SOMAArray::_maybe_sjid_tiledb_current_domain() {
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_current_domain() {
     const std::string dim_name = "soma_joinid";
 
     auto dom = arr_->schema().domain();
@@ -1296,7 +1296,7 @@ std::optional<int64_t> SOMAArray::_maybe_sjid_tiledb_current_domain() {
     return std::optional<int64_t>(max);
 }
 
-std::optional<int64_t> SOMAArray::_maybe_sjid_tiledb_domain() {
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_domain() {
     const std::string dim_name = "soma_joinid";
 
     auto dom = arr_->schema().domain();

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -30,10 +30,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1353,7 +1353,7 @@ void SOMAArray::resize(const std::vector<int64_t>& newshape) {
     schema_evolution.array_evolve(uri_);
 }
 
-void SOMAArray::maybe_resize_sjid(const std::vector<int64_t>& newshape) {
+void SOMAArray::maybe_resize_soma_joinid(const std::vector<int64_t>& newshape) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError(
             "[SOMAArray::resize] array must be opened in write mode");

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -30,10 +30,10 @@
  *   This file defines the SOMAArray class.
  */
 
-#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
+#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1030,6 +1030,19 @@ void SOMAArray::_cast_bit_to_uint8(
     }
 }
 
+uint64_t SOMAArray::ndim() const {
+    return tiledb_schema()->domain().ndim();
+}
+
+std::vector<std::string> SOMAArray::dimension_names() const {
+    std::vector<std::string> result;
+    auto dimensions = tiledb_schema()->domain().dimensions();
+    for (const auto& dim : dimensions) {
+        result.push_back(dim.name());
+    }
+    return result;
+}
+
 void SOMAArray::write(bool sort_coords) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError("[SOMAArray] array must be opened in write mode");
@@ -1047,365 +1060,6 @@ void SOMAArray::consolidate_and_vacuum(std::vector<std::string> modes) {
         Array::consolidate(Context(cfg), uri_);
         Array::vacuum(Context(cfg), uri_);
     }
-}
-
-uint64_t SOMAArray::nnz() {
-    // Verify array is sparse
-    if (mq_->schema()->array_type() != TILEDB_SPARSE) {
-        throw TileDBSOMAError(
-            "[SOMAArray] nnz is only supported for sparse arrays");
-    }
-
-    // Load fragment info
-    FragmentInfo fragment_info(*ctx_->tiledb_ctx(), uri_);
-    fragment_info.load();
-
-    LOG_DEBUG(fmt::format("[SOMAArray] Fragment info for array '{}'", uri_));
-    if (LOG_DEBUG_ENABLED()) {
-        fragment_info.dump();
-    }
-
-    // Find the subset of fragments contained within the read timestamp range
-    // [if any]
-    std::vector<uint32_t> relevant_fragments;
-    for (uint32_t fid = 0; fid < fragment_info.fragment_num(); fid++) {
-        auto frag_ts = fragment_info.timestamp_range(fid);
-        assert(frag_ts.first <= frag_ts.second);
-        if (timestamp_) {
-            if (frag_ts.first > timestamp_->second ||
-                frag_ts.second < timestamp_->first) {
-                // fragment is fully outside the read timestamp range: skip it
-                continue;
-            } else if (!(frag_ts.first >= timestamp_->first &&
-                         frag_ts.second <= timestamp_->second)) {
-                // fragment overlaps read timestamp range, but isn't fully
-                // contained within: fall back to count_cells to sort that out.
-                return nnz_slow();
-            }
-        }
-        // fall through: fragment is fully contained within the read timestamp
-        // range
-        relevant_fragments.push_back(fid);
-
-        // If any relevant fragment is a consolidated fragment, fall back to
-        // counting cells, because the fragment may contain duplicates.
-        // If the application is allowing duplicates (in which case it's the
-        // application's job to otherwise ensure uniqueness), then
-        // sum-over-fragments is the right thing to do.
-        if (!mq_->schema()->allows_dups() && frag_ts.first != frag_ts.second) {
-            return nnz_slow();
-        }
-    }
-
-    auto fragment_count = relevant_fragments.size();
-
-    if (fragment_count == 0) {
-        // No data have been written [in the read timestamp range]
-        return 0;
-    }
-
-    if (fragment_count == 1) {
-        // Only one fragment; return its cell_num
-        return fragment_info.cell_num(relevant_fragments[0]);
-    }
-
-    // Check for overlapping fragments on the first dimension and
-    // compute total_cell_num while going through the loop
-    uint64_t total_cell_num = 0;
-    std::vector<std::array<uint64_t, 2>> non_empty_domains(fragment_count);
-    for (uint32_t i = 0; i < fragment_count; i++) {
-        // TODO[perf]: Reading fragment info is not supported on TileDB Cloud
-        // yet, but reading one fragment at a time will be slow. Is there
-        // another way?
-        total_cell_num += fragment_info.cell_num(relevant_fragments[i]);
-        fragment_info.get_non_empty_domain(
-            relevant_fragments[i], 0, &non_empty_domains[i]);
-        LOG_DEBUG(fmt::format(
-            "[SOMAArray] fragment {} non-empty domain = [{}, {}]",
-            i,
-            non_empty_domains[i][0],
-            non_empty_domains[i][1]));
-    }
-
-    // Sort non-empty domains by the start of their ranges
-    std::sort(non_empty_domains.begin(), non_empty_domains.end());
-
-    // After sorting, if the end of a non-empty domain is >= the beginning of
-    // the next non-empty domain, there is an overlap
-    bool overlap = false;
-    for (uint32_t i = 0; i < fragment_count - 1; i++) {
-        LOG_DEBUG(fmt::format(
-            "[SOMAArray] Checking {} < {}",
-            non_empty_domains[i][1],
-            non_empty_domains[i + 1][0]));
-        if (non_empty_domains[i][1] >= non_empty_domains[i + 1][0]) {
-            overlap = true;
-            break;
-        }
-    }
-
-    // If relevant fragments do not overlap, return the total cell_num
-    if (!overlap) {
-        return total_cell_num;
-    }
-    // Found relevant fragments with overlap, count cells
-    return nnz_slow();
-}
-
-uint64_t SOMAArray::nnz_slow() {
-    LOG_DEBUG(
-        "[SOMAArray] nnz() found consolidated or overlapping fragments, "
-        "counting cells...");
-
-    auto sr = SOMAArray::open(
-        OpenMode::read,
-        uri_,
-        ctx_,
-        "count_cells",
-        {mq_->schema()->domain().dimension(0).name()},
-        batch_size_,
-        result_order_,
-        timestamp_);
-
-    uint64_t total_cell_num = 0;
-    while (auto batch = sr->read_next()) {
-        total_cell_num += (*batch)->num_rows();
-    }
-
-    return total_cell_num;
-}
-
-bool SOMAArray::_dims_are_int64() {
-    ArraySchema schema = arr_->schema();
-    Domain domain = schema.domain();
-    for (auto dimension : domain.dimensions()) {
-        if (dimension.type() != TILEDB_INT64) {
-            return false;
-        }
-    }
-    return true;
-}
-
-void SOMAArray::_check_dims_are_int64() {
-    if (!_dims_are_int64()) {
-        throw TileDBSOMAError(
-            "[SOMAArray] internal coding error: expected all dims to be int64");
-    }
-}
-
-std::vector<int64_t> SOMAArray::shape() {
-    // There are two reasons for this:
-    // * Transitional, non-monolithic, phased, careful development for the
-    //   new-shape feature
-    // * Even after the new-shape feature is fully released, there will be old
-    //   arrays on disk that were created before this feature existed.
-    // So this is long-term code.
-    return _get_current_domain().is_empty() ? _tiledb_domain() :
-                                              _tiledb_current_domain();
-}
-
-std::vector<int64_t> SOMAArray::maxshape() {
-    return _tiledb_domain();
-}
-
-std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape() {
-    return _get_current_domain().is_empty() ?
-               _maybe_soma_joinid_tiledb_domain() :
-               _maybe_soma_joinid_tiledb_current_domain();
-}
-
-std::optional<int64_t> SOMAArray::_maybe_soma_joinid_maxshape() {
-    return _maybe_soma_joinid_tiledb_domain();
-}
-
-std::vector<int64_t> SOMAArray::_tiledb_current_domain() {
-    // Variant-indexed dataframes must use a separate path
-    _check_dims_are_int64();
-
-    std::vector<int64_t> result;
-
-    auto current_domain = tiledb::ArraySchemaExperimental::current_domain(
-        *ctx_->tiledb_ctx(), arr_->schema());
-
-    if (current_domain.is_empty()) {
-        throw TileDBSOMAError(
-            "Internal error: current domain requested for an array which does "
-            "not support it");
-    }
-
-    auto t = current_domain.type();
-    if (t != TILEDB_NDRECTANGLE) {
-        throw TileDBSOMAError("current_domain type is not NDRECTANGLE");
-    }
-
-    NDRectangle ndrect = current_domain.ndrectangle();
-
-    for (auto dimension_name : dimension_names()) {
-        auto range = ndrect.range<int64_t>(dimension_name);
-        result.push_back(range[1] + 1);
-    }
-    return result;
-}
-
-std::vector<int64_t> SOMAArray::_tiledb_domain() {
-    // Variant-indexed dataframes must use a separate path
-    _check_dims_are_int64();
-
-    std::vector<int64_t> result;
-    auto dimensions = mq_->schema()->domain().dimensions();
-
-    for (const auto& dim : dimensions) {
-        result.push_back(
-            dim.domain<int64_t>().second - dim.domain<int64_t>().first + 1);
-    }
-
-    return result;
-}
-
-std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_current_domain() {
-    const std::string dim_name = "soma_joinid";
-
-    auto dom = arr_->schema().domain();
-    if (!dom.has_dimension(dim_name)) {
-        return std::nullopt;
-    }
-
-    auto current_domain = _get_current_domain();
-    if (current_domain.is_empty()) {
-        throw TileDBSOMAError("internal coding error");
-    }
-
-    auto t = current_domain.type();
-    if (t != TILEDB_NDRECTANGLE) {
-        throw TileDBSOMAError("current_domain type is not NDRECTANGLE");
-    }
-
-    NDRectangle ndrect = current_domain.ndrectangle();
-
-    auto dim = dom.dimension(dim_name);
-    if (dim.type() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
-            "expected {} dim to be {}; got {}",
-            dim_name,
-            tiledb::impl::type_to_str(TILEDB_INT64),
-            tiledb::impl::type_to_str(dim.type())));
-    }
-
-    auto range = ndrect.range<int64_t>(dim_name);
-    auto max = range[1] + 1;
-    return std::optional<int64_t>(max);
-}
-
-std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_domain() {
-    const std::string dim_name = "soma_joinid";
-
-    auto dom = arr_->schema().domain();
-    if (!dom.has_dimension(dim_name)) {
-        return std::nullopt;
-    }
-
-    auto dim = dom.dimension(dim_name);
-    if (dim.type() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
-            "expected {} dim to be {}; got {}",
-            dim_name,
-            tiledb::impl::type_to_str(TILEDB_INT64),
-            tiledb::impl::type_to_str(dim.type())));
-    }
-
-    auto max = dim.domain<int64_t>().second + 1;
-
-    return std::optional<int64_t>(max);
-}
-
-void SOMAArray::resize(const std::vector<int64_t>& newshape) {
-    if (mq_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must be opened in write mode");
-    }
-
-    if (_get_current_domain().is_empty()) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must already be sized");
-    }
-
-    auto tctx = ctx_->tiledb_ctx();
-    ArraySchema schema = arr_->schema();
-    Domain domain = schema.domain();
-    ArraySchemaEvolution schema_evolution(*tctx);
-    CurrentDomain new_current_domain(*tctx);
-
-    NDRectangle ndrect(*tctx, domain);
-
-    // TODO: non-int64 for DataFrame when it has extra index dims.
-    // This will be via a resize-helper.
-
-    unsigned n = domain.ndim();
-    if ((unsigned)newshape.size() != n) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::resize]: newshape has dimension count {}; array has "
-            "{} ",
-            newshape.size(),
-            n));
-    }
-
-    for (unsigned i = 0; i < n; i++) {
-        ndrect.set_range<int64_t>(
-            domain.dimension(i).name(), 0, newshape[i] - 1);
-    }
-
-    new_current_domain.set_ndrectangle(ndrect);
-    schema_evolution.expand_current_domain(new_current_domain);
-    schema_evolution.array_evolve(uri_);
-}
-
-void SOMAArray::maybe_resize_sjid(const std::vector<int64_t>& newshape) {
-    if (mq_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must be opened in write mode");
-    }
-
-    ArraySchema schema = arr_->schema();
-    Domain domain = schema.domain();
-    unsigned ndim = domain.ndim();
-    if (newshape.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::resize]: newshape has dimension count {}; needed 1",
-            newshape.size(),
-            ndim));
-    }
-
-    auto tctx = ctx_->tiledb_ctx();
-    CurrentDomain old_current_domain = ArraySchemaExperimental::current_domain(
-        *tctx, schema);
-    NDRectangle ndrect = old_current_domain.ndrectangle();
-
-    CurrentDomain new_current_domain(*tctx);
-    ArraySchemaEvolution schema_evolution(*tctx);
-
-    for (unsigned i = 0; i < ndim; i++) {
-        if (domain.dimension(i).name() == "soma_joinid") {
-            ndrect.set_range<int64_t>(
-                domain.dimension(i).name(), 0, newshape[0] - 1);
-        }
-    }
-
-    new_current_domain.set_ndrectangle(ndrect);
-    schema_evolution.expand_current_domain(new_current_domain);
-    schema_evolution.array_evolve(uri_);
-}
-
-uint64_t SOMAArray::ndim() const {
-    return tiledb_schema()->domain().ndim();
-}
-
-std::vector<std::string> SOMAArray::dimension_names() const {
-    std::vector<std::string> result;
-    auto dimensions = tiledb_schema()->domain().dimensions();
-    for (const auto& dim : dimensions) {
-        result.push_back(dim.name());
-    }
-    return result;
 }
 
 std::map<std::string, Enumeration> SOMAArray::get_attr_to_enum_mapping() {
@@ -1516,6 +1170,351 @@ void SOMAArray::validate(
 
 std::optional<TimestampRange> SOMAArray::timestamp() {
     return timestamp_;
+}
+
+uint64_t SOMAArray::nnz() {
+    // Verify array is sparse
+    if (mq_->schema()->array_type() != TILEDB_SPARSE) {
+        throw TileDBSOMAError(
+            "[SOMAArray] nnz is only supported for sparse arrays");
+    }
+
+    // Load fragment info
+    FragmentInfo fragment_info(*ctx_->tiledb_ctx(), uri_);
+    fragment_info.load();
+
+    LOG_DEBUG(fmt::format("[SOMAArray] Fragment info for array '{}'", uri_));
+    if (LOG_DEBUG_ENABLED()) {
+        fragment_info.dump();
+    }
+
+    // Find the subset of fragments contained within the read timestamp range
+    // [if any]
+    std::vector<uint32_t> relevant_fragments;
+    for (uint32_t fid = 0; fid < fragment_info.fragment_num(); fid++) {
+        auto frag_ts = fragment_info.timestamp_range(fid);
+        assert(frag_ts.first <= frag_ts.second);
+        if (timestamp_) {
+            if (frag_ts.first > timestamp_->second ||
+                frag_ts.second < timestamp_->first) {
+                // fragment is fully outside the read timestamp range: skip it
+                continue;
+            } else if (!(frag_ts.first >= timestamp_->first &&
+                         frag_ts.second <= timestamp_->second)) {
+                // fragment overlaps read timestamp range, but isn't fully
+                // contained within: fall back to count_cells to sort that out.
+                return _nnz_slow();
+            }
+        }
+        // fall through: fragment is fully contained within the read timestamp
+        // range
+        relevant_fragments.push_back(fid);
+
+        // If any relevant fragment is a consolidated fragment, fall back to
+        // counting cells, because the fragment may contain duplicates.
+        // If the application is allowing duplicates (in which case it's the
+        // application's job to otherwise ensure uniqueness), then
+        // sum-over-fragments is the right thing to do.
+        if (!mq_->schema()->allows_dups() && frag_ts.first != frag_ts.second) {
+            return _nnz_slow();
+        }
+    }
+
+    auto fragment_count = relevant_fragments.size();
+
+    if (fragment_count == 0) {
+        // No data have been written [in the read timestamp range]
+        return 0;
+    }
+
+    if (fragment_count == 1) {
+        // Only one fragment; return its cell_num
+        return fragment_info.cell_num(relevant_fragments[0]);
+    }
+
+    // Check for overlapping fragments on the first dimension and
+    // compute total_cell_num while going through the loop
+    uint64_t total_cell_num = 0;
+    std::vector<std::array<uint64_t, 2>> non_empty_domains(fragment_count);
+    for (uint32_t i = 0; i < fragment_count; i++) {
+        // TODO[perf]: Reading fragment info is not supported on TileDB Cloud
+        // yet, but reading one fragment at a time will be slow. Is there
+        // another way?
+        total_cell_num += fragment_info.cell_num(relevant_fragments[i]);
+        fragment_info.get_non_empty_domain(
+            relevant_fragments[i], 0, &non_empty_domains[i]);
+        LOG_DEBUG(fmt::format(
+            "[SOMAArray] fragment {} non-empty domain = [{}, {}]",
+            i,
+            non_empty_domains[i][0],
+            non_empty_domains[i][1]));
+    }
+
+    // Sort non-empty domains by the start of their ranges
+    std::sort(non_empty_domains.begin(), non_empty_domains.end());
+
+    // After sorting, if the end of a non-empty domain is >= the beginning of
+    // the next non-empty domain, there is an overlap
+    bool overlap = false;
+    for (uint32_t i = 0; i < fragment_count - 1; i++) {
+        LOG_DEBUG(fmt::format(
+            "[SOMAArray] Checking {} < {}",
+            non_empty_domains[i][1],
+            non_empty_domains[i + 1][0]));
+        if (non_empty_domains[i][1] >= non_empty_domains[i + 1][0]) {
+            overlap = true;
+            break;
+        }
+    }
+
+    // If relevant fragments do not overlap, return the total cell_num
+    if (!overlap) {
+        return total_cell_num;
+    }
+    // Found relevant fragments with overlap, count cells
+    return _nnz_slow();
+}
+
+uint64_t SOMAArray::_nnz_slow() {
+    LOG_DEBUG(
+        "[SOMAArray] nnz() found consolidated or overlapping fragments, "
+        "counting cells...");
+
+    auto sr = SOMAArray::open(
+        OpenMode::read,
+        uri_,
+        ctx_,
+        "count_cells",
+        {mq_->schema()->domain().dimension(0).name()},
+        batch_size_,
+        result_order_,
+        timestamp_);
+
+    uint64_t total_cell_num = 0;
+    while (auto batch = sr->read_next()) {
+        total_cell_num += (*batch)->num_rows();
+    }
+
+    return total_cell_num;
+}
+
+std::vector<int64_t> SOMAArray::shape() {
+    // There are two reasons for this:
+    // * Transitional, non-monolithic, phased, careful development for the
+    //   new-shape feature
+    // * Even after the new-shape feature is fully released, there will be old
+    //   arrays on disk that were created before this feature existed.
+    // So this is long-term code.
+    return _get_current_domain().is_empty() ? _tiledb_domain() :
+                                              _tiledb_current_domain();
+}
+
+std::vector<int64_t> SOMAArray::maxshape() {
+    return _tiledb_domain();
+}
+
+void SOMAArray::resize(const std::vector<int64_t>& newshape) {
+    if (mq_->query_type() != TILEDB_WRITE) {
+        throw TileDBSOMAError(
+            "[SOMAArray::resize] array must be opened in write mode");
+    }
+
+    if (_get_current_domain().is_empty()) {
+        throw TileDBSOMAError(
+            "[SOMAArray::resize] array must already be sized");
+    }
+
+    _check_dims_are_int64();
+
+    auto tctx = ctx_->tiledb_ctx();
+    ArraySchema schema = arr_->schema();
+    Domain domain = schema.domain();
+    ArraySchemaEvolution schema_evolution(*tctx);
+    CurrentDomain new_current_domain(*tctx);
+
+    NDRectangle ndrect(*tctx, domain);
+
+    unsigned n = domain.ndim();
+    if ((unsigned)newshape.size() != n) {
+        throw TileDBSOMAError(fmt::format(
+            "[SOMAArray::resize]: newshape has dimension count {}; array has "
+            "{} ",
+            newshape.size(),
+            n));
+    }
+
+    for (unsigned i = 0; i < n; i++) {
+        ndrect.set_range<int64_t>(
+            domain.dimension(i).name(), 0, newshape[i] - 1);
+    }
+
+    new_current_domain.set_ndrectangle(ndrect);
+    schema_evolution.expand_current_domain(new_current_domain);
+    schema_evolution.array_evolve(uri_);
+}
+
+void SOMAArray::maybe_resize_sjid(const std::vector<int64_t>& newshape) {
+    if (mq_->query_type() != TILEDB_WRITE) {
+        throw TileDBSOMAError(
+            "[SOMAArray::resize] array must be opened in write mode");
+    }
+
+    ArraySchema schema = arr_->schema();
+    Domain domain = schema.domain();
+    unsigned ndim = domain.ndim();
+    if (newshape.size() != 1) {
+        throw TileDBSOMAError(fmt::format(
+            "[SOMAArray::resize]: newshape has dimension count {}; needed 1",
+            newshape.size(),
+            ndim));
+    }
+
+    auto tctx = ctx_->tiledb_ctx();
+    CurrentDomain old_current_domain = ArraySchemaExperimental::current_domain(
+        *tctx, schema);
+    NDRectangle ndrect = old_current_domain.ndrectangle();
+
+    CurrentDomain new_current_domain(*tctx);
+    ArraySchemaEvolution schema_evolution(*tctx);
+
+    for (unsigned i = 0; i < ndim; i++) {
+        if (domain.dimension(i).name() == "soma_joinid") {
+            ndrect.set_range<int64_t>(
+                domain.dimension(i).name(), 0, newshape[0] - 1);
+        }
+    }
+
+    new_current_domain.set_ndrectangle(ndrect);
+    schema_evolution.expand_current_domain(new_current_domain);
+    schema_evolution.array_evolve(uri_);
+}
+
+std::vector<int64_t> SOMAArray::_tiledb_current_domain() {
+    // Variant-indexed dataframes must use a separate path
+    _check_dims_are_int64();
+
+    std::vector<int64_t> result;
+
+    auto current_domain = tiledb::ArraySchemaExperimental::current_domain(
+        *ctx_->tiledb_ctx(), arr_->schema());
+
+    if (current_domain.is_empty()) {
+        throw TileDBSOMAError(
+            "Internal error: current domain requested for an array which does "
+            "not support it");
+    }
+
+    auto t = current_domain.type();
+    if (t != TILEDB_NDRECTANGLE) {
+        throw TileDBSOMAError("current_domain type is not NDRECTANGLE");
+    }
+
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    for (auto dimension_name : dimension_names()) {
+        auto range = ndrect.range<int64_t>(dimension_name);
+        result.push_back(range[1] + 1);
+    }
+    return result;
+}
+
+std::vector<int64_t> SOMAArray::_tiledb_domain() {
+    // Variant-indexed dataframes must use a separate path
+    _check_dims_are_int64();
+
+    std::vector<int64_t> result;
+    auto dimensions = mq_->schema()->domain().dimensions();
+
+    for (const auto& dim : dimensions) {
+        result.push_back(
+            dim.domain<int64_t>().second - dim.domain<int64_t>().first + 1);
+    }
+
+    return result;
+}
+
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape() {
+    return _get_current_domain().is_empty() ?
+               _maybe_soma_joinid_tiledb_domain() :
+               _maybe_soma_joinid_tiledb_current_domain();
+}
+
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_maxshape() {
+    return _maybe_soma_joinid_tiledb_domain();
+}
+
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_current_domain() {
+    const std::string dim_name = "soma_joinid";
+
+    auto dom = arr_->schema().domain();
+    if (!dom.has_dimension(dim_name)) {
+        return std::nullopt;
+    }
+
+    auto current_domain = _get_current_domain();
+    if (current_domain.is_empty()) {
+        throw TileDBSOMAError("internal coding error");
+    }
+
+    auto t = current_domain.type();
+    if (t != TILEDB_NDRECTANGLE) {
+        throw TileDBSOMAError("current_domain type is not NDRECTANGLE");
+    }
+
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    auto dim = dom.dimension(dim_name);
+    if (dim.type() != TILEDB_INT64) {
+        throw TileDBSOMAError(fmt::format(
+            "expected {} dim to be {}; got {}",
+            dim_name,
+            tiledb::impl::type_to_str(TILEDB_INT64),
+            tiledb::impl::type_to_str(dim.type())));
+    }
+
+    auto range = ndrect.range<int64_t>(dim_name);
+    auto max = range[1] + 1;
+    return std::optional<int64_t>(max);
+}
+
+std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_domain() {
+    const std::string dim_name = "soma_joinid";
+
+    auto dom = arr_->schema().domain();
+    if (!dom.has_dimension(dim_name)) {
+        return std::nullopt;
+    }
+
+    auto dim = dom.dimension(dim_name);
+    if (dim.type() != TILEDB_INT64) {
+        throw TileDBSOMAError(fmt::format(
+            "expected {} dim to be {}; got {}",
+            dim_name,
+            tiledb::impl::type_to_str(TILEDB_INT64),
+            tiledb::impl::type_to_str(dim.type())));
+    }
+
+    auto max = dim.domain<int64_t>().second + 1;
+
+    return std::optional<int64_t>(max);
+}
+
+bool SOMAArray::_dims_are_int64() {
+    ArraySchema schema = arr_->schema();
+    Domain domain = schema.domain();
+    for (auto dimension : domain.dimensions()) {
+        if (dimension.type() != TILEDB_INT64) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void SOMAArray::_check_dims_are_int64() {
+    if (!_dims_are_int64()) {
+        throw TileDBSOMAError(
+            "[SOMAArray] internal coding error: expected all dims to be int64");
+    }
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1186,7 +1186,7 @@ bool SOMAArray::_dims_are_int64() {
     return true;
 }
 
-void SOMAArray::_assert_dims_are_int64() {
+void SOMAArray::_check_dims_are_int64() {
     if (!_dims_are_int64()) {
         throw TileDBSOMAError(
             "[SOMAArray] internal coding error: expected all dims to be int64");
@@ -1220,7 +1220,7 @@ std::optional<int64_t> SOMAArray::_maybe_sjid_maxshape() {
 
 std::vector<int64_t> SOMAArray::_tiledb_current_domain() {
     // Variant-indexed dataframes must use a separate path
-    _assert_dims_are_int64();
+    _check_dims_are_int64();
 
     std::vector<int64_t> result;
 
@@ -1249,7 +1249,7 @@ std::vector<int64_t> SOMAArray::_tiledb_current_domain() {
 
 std::vector<int64_t> SOMAArray::_tiledb_domain() {
     // Variant-indexed dataframes must use a separate path
-    _assert_dims_are_int64();
+    _check_dims_are_int64();
 
     std::vector<int64_t> result;
     auto dimensions = mq_->schema()->domain().dimensions();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -869,7 +869,7 @@ class SOMAArray : public SOMAObject {
     /**
      * Same, but throws.
      */
-    void _assert_dims_are_int64();
+    void _check_dims_are_int64();
 
     /**
      * With old shape: core domain mapped to tiledbsoma shape; core current

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -830,8 +830,8 @@ class SOMAArray : public SOMAObject {
     // the array has one. These are important test-points and dev-internal
     // access-points, in particular, for the tiledbsoma-io experiment-level
     // resizer.
-    std::optional<int64_t> _maybe_sjid_shape();
-    std::optional<int64_t> _maybe_sjid_maxshape();
+    std::optional<int64_t> _maybe_soma_joinid_shape();
+    std::optional<int64_t> _maybe_soma_joinid_maxshape();
 
    private:
     //===================================================================
@@ -882,8 +882,8 @@ class SOMAArray : public SOMAObject {
      */
     std::vector<int64_t> _tiledb_domain();
     std::vector<int64_t> _tiledb_current_domain();
-    std::optional<int64_t> _maybe_sjid_tiledb_current_domain();
-    std::optional<int64_t> _maybe_sjid_tiledb_domain();
+    std::optional<int64_t> _maybe_soma_joinid_tiledb_current_domain();
+    std::optional<int64_t> _maybe_soma_joinid_tiledb_domain();
 
     bool _extend_enumeration(
         ArrowSchema* value_schema,

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -270,6 +270,20 @@ class SOMAArray : public SOMAObject {
         ResultOrder result_order = ResultOrder::automatic);
 
     /**
+     * @brief Get the number of dimensions.
+     *
+     * @return uint64_t Number of dimensions.
+     */
+    uint64_t ndim() const;
+
+    /**
+     * @brief Get the name of each dimensions.
+     *
+     * @return std::vector<std::string> Name of each dimensions.
+     */
+    std::vector<std::string> dimension_names() const;
+
+    /**
      * @brief Set the dimension slice using one point
      *
      * @note Partitioning is not supported
@@ -544,13 +558,6 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
-     * @brief Get the total number of unique cells in the array.
-     *
-     * @return uint64_t Total number of unique cells
-     */
-    uint64_t nnz();
-
-    /**
      * @brief Get the TileDB ArraySchema. This should eventually
      * be removed in lieu of arrow_schema below.
      *
@@ -569,6 +576,173 @@ class SOMAArray : public SOMAObject {
         return ArrowAdapter::arrow_schema_from_tiledb_array(
             ctx_->tiledb_ctx(), arr_);
     }
+
+    /**
+     * @brief Get the mapping of attributes to Enumerations.
+     *
+     * @return std::map<std::string, Enumeration>
+     */
+    std::map<std::string, Enumeration> get_attr_to_enum_mapping();
+
+    /**
+     * @brief Get the Enumeration name associated with the given Attr.
+     *
+     * @return std::optional<std::string> The enumeration name if one exists.
+     */
+    std::optional<std::string> get_enum_label_on_attr(std::string attr_name);
+
+    /**
+     * @brief Check if the given attribute has an associated enumeration.
+     *
+     * @return bool
+     */
+    bool attr_has_enum(std::string attr_name);
+
+    /**
+     * Set metadata key-value items to an open array. The array must
+     * opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be added. UTF-8 encodings
+     *     are acceptable.
+     * @param value_type The datatype of the value.
+     * @param value_num The value may consist of more than one items of the
+     *     same datatype. This argument indicates the number of items in the
+     *     value component of the metadata.
+     * @param value The metadata value in binary form.
+     * @param force A boolean toggle to suppress internal checks, defaults to
+     *     false.
+     *
+     * @note The writes will take effect only upon closing the array.
+     */
+    void set_metadata(
+        const std::string& key,
+        tiledb_datatype_t value_type,
+        uint32_t value_num,
+        const void* value,
+        bool force = false);
+
+    /**
+     * Delete a metadata key-value item from an open array. The array must
+     * be opened in WRITE mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be deleted.
+     *
+     * @note The writes will take effect only upon closing the array.
+     *
+     * @note If the key does not exist, this will take no effect
+     *     (i.e., the function will not error out).
+     */
+    void delete_metadata(const std::string& key);
+
+    /**
+     * @brief Given a key, get the associated value datatype, number of
+     * values, and value in binary form. The array must be opened in READ
+     * mode, otherwise the function will error out.
+     *
+     * The value may consist of more than one items of the same datatype.
+     * Keys that do not exist in the metadata will be return NULL for the value.
+     *
+     * **Example:**
+     * @code{.cpp}
+     * // Open the array for reading
+     * tiledbsoma::SOMAArray soma_array = SOMAArray::open(TILEDB_READ,
+     "s3://bucket-name/group-name");
+     * tiledbsoma::MetadataValue meta_val = soma_array->get_metadata("key");
+     * std::string key = std::get<MetadataInfo::key>(meta_val);
+     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
+     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
+     * const void* value = *((const
+     int32_t*)std::get<MetadataInfo::value>(meta_val));
+     * @endcode
+     *
+     * @param key The key of the metadata item to be retrieved. UTF-8
+     * encodings are acceptable.
+     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
+     * uint32_t, const void*>)
+     */
+    std::optional<MetadataValue> get_metadata(const std::string& key);
+
+    /**
+     * Get a mapping of all metadata keys with its associated value datatype,
+     * number of values, and value in binary form.
+     *
+     * @return std::map<std::string, MetadataValue>
+     */
+    std::map<std::string, MetadataValue> get_metadata();
+
+    /**
+     * Check if the key exists in metadata from an open array. The array
+     * must be opened in READ mode, otherwise the function will error out.
+     *
+     * @param key The key of the metadata item to be checked. UTF-8
+     * encodings are acceptable.
+     * @return true if the key exists, else false.
+     */
+    bool has_metadata(const std::string& key);
+
+    /**
+     * Return then number of metadata items in an open array. The array must
+     * be opened in READ mode, otherwise the function will error out.
+     */
+    uint64_t metadata_num() const;
+
+    /**
+     * Validates input parameters before opening array.
+     */
+    void validate(
+        OpenMode mode,
+        std::string_view name,
+        std::optional<TimestampRange> timestamp);
+
+    /**
+     * Return optional timestamp pair SOMAArray was opened with.
+     */
+    std::optional<TimestampRange> timestamp();
+
+    /**
+     * Retrieves the non-empty domain from the array. This is the union of the
+     * non-empty domains of the array fragments.
+     */
+    template <typename T>
+    std::pair<T, T> non_empty_domain(const std::string& name) {
+        try {
+            return arr_->non_empty_domain<T>(name);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(e.what());
+        }
+    }
+
+    /**
+     * Retrieves the non-empty domain from the array on the given dimension.
+     * This is the union of the non-empty domains of the array fragments.
+     * Applicable only to var-sized dimensions.
+     */
+    std::pair<std::string, std::string> non_empty_domain_var(
+        const std::string& name) {
+        try {
+            return arr_->non_empty_domain_var(name);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(e.what());
+        }
+    }
+
+    /**
+     * Returns the domain of the given dimension.
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> domain(const std::string& name) const {
+        return arr_->schema().domain().dimension(name).domain<T>();
+    }
+
+    /**
+     * @brief Get the total number of unique cells in the array.
+     *
+     * @return uint64_t Total number of unique cells
+     */
+    uint64_t nnz();
 
     /**
      * @brief Get the current capacity of each dimension.
@@ -634,183 +808,6 @@ class SOMAArray : public SOMAObject {
      * maxshape. Throws if the array does not have current-domain support.
      */
     void maybe_resize_sjid(const std::vector<int64_t>& newshape);
-
-    /**
-     * @brief Get the number of dimensions.
-     *
-     * @return uint64_t Number of dimensions.
-     */
-    uint64_t ndim() const;
-
-    /**
-     * Retrieves the non-empty domain from the array. This is the union of the
-     * non-empty domains of the array fragments.
-     */
-    template <typename T>
-    std::pair<T, T> non_empty_domain(const std::string& name) {
-        try {
-            return arr_->non_empty_domain<T>(name);
-        } catch (const std::exception& e) {
-            throw TileDBSOMAError(e.what());
-        }
-    }
-
-    /**
-     * Retrieves the non-empty domain from the array on the given dimension.
-     * This is the union of the non-empty domains of the array fragments.
-     * Applicable only to var-sized dimensions.
-     */
-    std::pair<std::string, std::string> non_empty_domain_var(
-        const std::string& name) {
-        try {
-            return arr_->non_empty_domain_var(name);
-        } catch (const std::exception& e) {
-            throw TileDBSOMAError(e.what());
-        }
-    }
-
-    /**
-     * Returns the domain of the given dimension.
-     *
-     * @tparam T Domain datatype
-     * @return Pair of [lower, upper] inclusive bounds.
-     */
-    template <typename T>
-    std::pair<T, T> domain(const std::string& name) const {
-        return arr_->schema().domain().dimension(name).domain<T>();
-    }
-
-    /**
-     * @brief Get the name of each dimensions.
-     *
-     * @return std::vector<std::string> Name of each dimensions.
-     */
-    std::vector<std::string> dimension_names() const;
-
-    /**
-     * @brief Get the mapping of attributes to Enumerations.
-     *
-     * @return std::map<std::string, Enumeration>
-     */
-    std::map<std::string, Enumeration> get_attr_to_enum_mapping();
-
-    /**
-     * @brief Get the Enumeration name associated with the given Attr.
-     *
-     * @return std::optional<std::string> The enumeration name if one exists.
-     */
-    std::optional<std::string> get_enum_label_on_attr(std::string attr_name);
-
-    /**
-     * @brief Check if the given attribute has an associated enumeration.
-     *
-     * @return bool
-     */
-    bool attr_has_enum(std::string attr_name);
-
-    /**
-     * Set metadata key-value items to an open array. The array must
-     * opened in WRITE mode, otherwise the function will error out.
-     *
-     * @param key The key of the metadata item to be added. UTF-8 encodings
-     *     are acceptable.
-     * @param value_type The datatype of the value.
-     * @param value_num The value may consist of more than one items of the
-     *     same datatype. This argument indicates the number of items in the
-     *     value component of the metadata.
-     * @param value The metadata value in binary form.
-     * @param force A boolean toggle to suppress internal checks, defaults to
-     *     false.
-     *
-     * @note The writes will take effect only upon closing the array.
-     */
-    void set_metadata(
-        const std::string& key,
-        tiledb_datatype_t value_type,
-        uint32_t value_num,
-        const void* value,
-        bool force = false);
-
-    /**
-     * Delete a metadata key-value item from an open array. The array must
-     * be opened in WRITE mode, otherwise the function will error out.
-     *
-     * @param key The key of the metadata item to be deleted.
-     *
-     * @note The writes will take effect only upon closing the array.
-     *
-     * @note If the key does not exist, this will take no effect
-     *     (i.e., the function will not error out).
-     */
-    void delete_metadata(const std::string& key);
-
-    /**
-     * @brief Given a key, get the associated value datatype, number of
-     * values, and value in binary form. The array must be opened in READ
-     mode,
-     * otherwise the function will error out.
-     *
-     * The value may consist of more than one items of the same datatype.
-     Keys
-     * that do not exist in the metadata will be return NULL for the value.
-     *
-     * **Example:**
-     * @code{.cpp}
-     * // Open the array for reading
-     * tiledbsoma::SOMAArray soma_array = SOMAArray::open(TILEDB_READ,
-     "s3://bucket-name/group-name");
-     * tiledbsoma::MetadataValue meta_val = soma_array->get_metadata("key");
-     * std::string key = std::get<MetadataInfo::key>(meta_val);
-     * tiledb_datatype_t dtype = std::get<MetadataInfo::dtype>(meta_val);
-     * uint32_t num = std::get<MetadataInfo::num>(meta_val);
-     * const void* value = *((const
-     int32_t*)std::get<MetadataInfo::value>(meta_val));
-     * @endcode
-     *
-     * @param key The key of the metadata item to be retrieved. UTF-8
-     encodings
-     *     are acceptable.
-     * @return MetadataValue (std::tuple<std::string, tiledb_datatype_t,
-     * uint32_t, const void*>)
-     */
-    std::optional<MetadataValue> get_metadata(const std::string& key);
-
-    /**
-     * Get a mapping of all metadata keys with its associated value datatype,
-     * number of values, and value in binary form.
-     *
-     * @return std::map<std::string, MetadataValue>
-     */
-    std::map<std::string, MetadataValue> get_metadata();
-
-    /**
-     * Check if the key exists in metadata from an open array. The array
-     * must be opened in READ mode, otherwise the function will error out.
-     *
-     * @param key The key of the metadata item to be checked. UTF-8
-     * encodings are acceptable.
-     * @return true if the key exists, else false.
-     */
-    bool has_metadata(const std::string& key);
-
-    /**
-     * Return then number of metadata items in an open array. The array must
-     * be opened in READ mode, otherwise the function will error out.
-     */
-    uint64_t metadata_num() const;
-
-    /**
-     * Validates input parameters before opening array.
-     */
-    void validate(
-        OpenMode mode,
-        std::string_view name,
-        std::optional<TimestampRange> timestamp);
-
-    /**
-     * Return optional timestamp pair SOMAArray was opened with.
-     */
-    std::optional<TimestampRange> timestamp();
 
     /**
      * Exposed for testing purposes.
@@ -1374,7 +1371,7 @@ class SOMAArray : public SOMAObject {
     bool submitted_ = false;
 
     // Unoptimized method for computing nnz() (issue `count_cells` query)
-    uint64_t nnz_slow();
+    uint64_t _nnz_slow();
 
     // ArrayBuffers to hold ColumnBuffers alive when submitting to write
     // query

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -807,7 +807,7 @@ class SOMAArray : public SOMAObject {
      * @return Throws if the requested shape exceeds the array's create-time
      * maxshape. Throws if the array does not have current-domain support.
      */
-    void maybe_resize_sjid(const std::vector<int64_t>& newshape);
+    void maybe_resize_soma_joinid(const std::vector<int64_t>& newshape);
 
     /**
      * Exposed for testing purposes.

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -94,12 +94,12 @@ uint64_t SOMADataFrame::count() {
     return this->nnz();
 }
 
-std::optional<int64_t> SOMADataFrame::maybe_sjid_shape() {
-    return _maybe_sjid_shape();
+std::optional<int64_t> SOMADataFrame::maybe_soma_joinid_shape() {
+    return _maybe_soma_joinid_shape();
 }
 
-std::optional<int64_t> SOMADataFrame::maybe_sjid_maxshape() {
-    return _maybe_sjid_maxshape();
+std::optional<int64_t> SOMADataFrame::maybe_soma_joinid_maxshape() {
+    return _maybe_soma_joinid_maxshape();
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -94,10 +94,12 @@ uint64_t SOMADataFrame::count() {
     return this->nnz();
 }
 
-std::vector<int64_t> SOMADataFrame::shape() {
-    std::optional<int64_t> attempt = _shape_slot_if_soma_joinid_dim();
-    int64_t max = attempt.has_value() ? attempt.value() : this->nnz();
-    return std::vector<int64_t>({max});
+std::optional<int64_t> SOMADataFrame::maybe_sjid_shape() {
+    return _maybe_sjid_shape();
+}
+
+std::optional<int64_t> SOMADataFrame::maybe_sjid_maxshape() {
+    return _maybe_sjid_maxshape();
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -165,20 +165,23 @@ class SOMADataFrame : public SOMAArray {
     uint64_t count();
 
     /**
-     * For DataFrame with default indexing, namely, a single int64_t
-     * soma_joinid, returns the same as SOMAArray. For DataFrame with
-     * soma_joinid being a dim along with other dims (optional behavior), return
-     * the slot along that dim. For DataFrame with soma_joinid being an attr,
-     * not a dim at all, returns nnz().
+     * While application-level SOMA DataFrame doesn't have shape
+     * and maxshape, these are important test-point accessors,
+     * as well as crucial for experiment-level resize within tiledbsoma.io.
      *
      * Note that the SOMA spec for SOMADataFrame mandates a .domain() accessor,
-     * which is distinct, and type-polymorphic. This shape accessor exists
-     * because people can and do call .shape() on SOMA DataFrames, and we have
-     * to keep letting them do that.
+     * which is distinct, and type-polymorphic.
      *
-     * @return int64_t
+     * @return std::optional<int64_t>
      */
-    std::vector<int64_t> shape();
+    std::optional<int64_t> maybe_sjid_shape();
+
+    /**
+     * See comments for maybe_sjid_shape.
+     *
+     * @return std::optional<int64_t>
+     */
+    std::optional<int64_t> maybe_sjid_maxshape();
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -174,14 +174,14 @@ class SOMADataFrame : public SOMAArray {
      *
      * @return std::optional<int64_t>
      */
-    std::optional<int64_t> maybe_sjid_shape();
+    std::optional<int64_t> maybe_soma_joinid_shape();
 
     /**
-     * See comments for maybe_sjid_shape.
+     * See comments for maybe_soma_joinid_shape.
      *
      * @return std::optional<int64_t>
      */
-    std::optional<int64_t> maybe_sjid_maxshape();
+    std::optional<int64_t> maybe_soma_joinid_maxshape();
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -461,7 +461,7 @@ TEST_CASE_METHOD(
     soma_dataframe->close();
 
     soma_dataframe = open(OpenMode::write);
-    soma_dataframe->maybe_resize_sjid(std::vector<int64_t>({new_max}));
+    soma_dataframe->maybe_resize_soma_joinid(std::vector<int64_t>({new_max}));
     soma_dataframe->close();
 
     soma_dataframe = open(OpenMode::write);
@@ -513,7 +513,8 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+        std::optional<int64_t> actual = soma_dataframe
+                                            ->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
 
@@ -533,7 +534,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -544,17 +545,18 @@ TEST_CASE_METHOD(
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
 
-            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+            std::optional<int64_t> actual = soma_dataframe
+                                                ->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_sjid(new_shape);
+            soma_dataframe->maybe_resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -617,7 +619,8 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+        std::optional<int64_t> actual = soma_dataframe
+                                            ->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -645,7 +648,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -655,17 +658,18 @@ TEST_CASE_METHOD(
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
-            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+            std::optional<int64_t> actual = soma_dataframe
+                                                ->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_sjid(new_shape);
+            soma_dataframe->maybe_resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -732,7 +736,8 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+        std::optional<int64_t> actual = soma_dataframe
+                                            ->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -760,7 +765,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -770,17 +775,18 @@ TEST_CASE_METHOD(
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
-            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+            std::optional<int64_t> actual = soma_dataframe
+                                                ->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_sjid(new_shape);
+            soma_dataframe->maybe_resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -845,7 +851,8 @@ TEST_CASE_METHOD(
         }
 
         // Check shape before write
-        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+        std::optional<int64_t> actual = soma_dataframe
+                                            ->maybe_soma_joinid_shape();
         REQUIRE(!actual.has_value());
         soma_dataframe->close();
 
@@ -870,22 +877,23 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
-            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
+            std::optional<int64_t> actual = soma_dataframe
+                                                ->maybe_soma_joinid_shape();
             REQUIRE(!actual.has_value());
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_sjid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_sjid(new_shape);
+            soma_dataframe->maybe_resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize -- noting soma_joinid is not a dim here

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -513,7 +513,7 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
 
@@ -544,7 +544,7 @@ TEST_CASE_METHOD(
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
 
-            std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
@@ -560,7 +560,7 @@ TEST_CASE_METHOD(
             // Check shape after resize
             soma_dataframe = open(OpenMode::read);
             expect = SOMA_JOINID_RESIZE_DIM_MAX;  // XXX MISSING A + 1 SOMEWHERE
-            actual = soma_dataframe->maybe_sjid_shape();
+            actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
 
@@ -617,7 +617,7 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -628,7 +628,7 @@ TEST_CASE_METHOD(
         // Check shape after write
         soma_dataframe = open(OpenMode::read);
         expect = dim_infos[0].dim_max + 1;
-        actual = soma_dataframe->maybe_sjid_shape();
+        actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -655,7 +655,7 @@ TEST_CASE_METHOD(
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
-            std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
@@ -671,7 +671,7 @@ TEST_CASE_METHOD(
             // Check shape after resize
             soma_dataframe = open(OpenMode::read);
             expect = SOMA_JOINID_RESIZE_DIM_MAX;
-            actual = soma_dataframe->maybe_sjid_shape();
+            actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
@@ -732,7 +732,7 @@ TEST_CASE_METHOD(
 
         // Check shape before write
         int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -743,7 +743,7 @@ TEST_CASE_METHOD(
         // Check shape after write
         soma_dataframe = open(OpenMode::read);
         expect = dim_infos[0].dim_max + 1;
-        actual = soma_dataframe->maybe_sjid_shape();
+        actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
         soma_dataframe->close();
@@ -770,7 +770,7 @@ TEST_CASE_METHOD(
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
             expect = dim_infos[0].dim_max + 1;
-            std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
@@ -786,7 +786,7 @@ TEST_CASE_METHOD(
             // Check shape after resize
             soma_dataframe = open(OpenMode::read);
             expect = SOMA_JOINID_RESIZE_DIM_MAX;
-            actual = soma_dataframe->maybe_sjid_shape();
+            actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
             soma_dataframe->close();
@@ -845,7 +845,7 @@ TEST_CASE_METHOD(
         }
 
         // Check shape before write
-        std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+        std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(!actual.has_value());
         soma_dataframe->close();
 
@@ -854,7 +854,7 @@ TEST_CASE_METHOD(
 
         // Check shape after write
         soma_dataframe = open(OpenMode::read);
-        actual = soma_dataframe->maybe_sjid_shape();
+        actual = soma_dataframe->maybe_soma_joinid_shape();
         REQUIRE(!actual.has_value());
         soma_dataframe->close();
 
@@ -876,7 +876,7 @@ TEST_CASE_METHOD(
         } else {
             // Check shape after write
             soma_dataframe = open(OpenMode::read);
-            std::optional<int64_t> actual = soma_dataframe->maybe_sjid_shape();
+            std::optional<int64_t> actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(!actual.has_value());
             soma_dataframe->close();
 
@@ -890,7 +890,7 @@ TEST_CASE_METHOD(
 
             // Check shape after resize -- noting soma_joinid is not a dim here
             soma_dataframe = open(OpenMode::read);
-            actual = soma_dataframe->maybe_sjid_shape();
+            actual = soma_dataframe->maybe_soma_joinid_shape();
             REQUIRE(!actual.has_value());
             soma_dataframe->close();
 


### PR DESCRIPTION
**Issue and/or context:** This is iterative progress for issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). 

The intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

While iterating at the application level (#2950) I realized I'd needlessly confused myself with the accessors to get a dataframe's shape/maxshape along the `soma_joinid` dimension (if it has one).

These clarify the picture.

**Notes for Reviewer:**

In this PR these methods are unit-tested against their stated semantics. They'll get put to work in a PR split out from #2950.