### PR TITLE
[python/r] Temporary feature-flags for stacked PRs [WIP]

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -98,6 +98,18 @@ import os
 import sys
 
 
+_new_shape_feature_flag = os.getenv("SOMA_PY_NEW_SHAPE") is not None
+
+
+def _new_shape_feature_flag_enabled() -> bool:
+    """
+    This is temporary only. Please see:
+    * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+    """
+    return _new_shape_feature_flag
+
+
 # Load native libraries. On wheel builds, we may have a shared library
 # already linked. In this case, we can import directly
 try:

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -139,6 +139,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
         tiledb_timestamp: Optional[OpenTimestamp] = None,
+        # Temporary only: https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        _use_new_shape: bool = False,
     ) -> "DataFrame":
         """Creates the data structure on disk/S3/cloud.
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -119,6 +119,8 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
         tiledb_timestamp: Optional[OpenTimestamp] = None,
+        # Temporary only: https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        _use_new_shape: bool = False,
     ) -> Self:
         context = _validate_soma_tiledb_context(context)
 

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -27,7 +27,8 @@ SOMADataFrameCreate <- function(
   ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
-  tiledb_timestamp = NULL
+  tiledb_timestamp = NULL,
+  use_new_shape_internal_only = FALSE
 ) {
   ingest_mode <- match.arg(ingest_mode)
   sdf <- SOMADataFrame$new(
@@ -49,7 +50,8 @@ SOMADataFrameCreate <- function(
       schema,
       index_column_names = index_column_names,
       platform_config = platform_config,
-      internal_use_only = "allowed_use"
+      internal_use_only = "allowed_use",
+      use_new_shape_internal_only = use_new_shape_internal_only
     )
   }
   return(sdf)
@@ -104,7 +106,8 @@ SOMASparseNDArrayCreate <- function(
   ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
-  tiledb_timestamp = NULL
+  tiledb_timestamp = NULL,
+  use_new_shape_internal_only = FALSE
 ) {
   ingest_mode <- match.arg(ingest_mode)
   snda <- SOMASparseNDArray$new(
@@ -126,7 +129,8 @@ SOMASparseNDArrayCreate <- function(
       type,
       shape,
       platform_config = platform_config,
-      internal_use_only = "allowed_use"
+      internal_use_only = "allowed_use",
+      use_new_shape_internal_only = use_new_shape_internal_only
     )
   }
   return(snda)

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -8,13 +8,26 @@
     ## create a slot for somactx in per-package enviroment, do no fill it yet to allow 'lazy load'
     .pkgenv[["somactx"]] <- NULL
 
+    cdmsg <- ""
+
+    # This is temporary only. Please see:
+    # * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    # * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+    if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {
+      .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
+      cdmsg <- " SOMA_R_NEW_SHAPE ON"
+    } else {
+      .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
+      cdmsg <- " SOMA_R_NEW_SHAPE OFF"
+    }
+
     rpkg_lib <- tiledb::tiledb_version(compact = FALSE)
     # Check major and minor but not micro: sc-50464
     rpkg_lib_version <- paste(rpkg_lib[["major"]], rpkg_lib[["minor"]], sep = ".")
     soma_lib_version <- libtiledbsoma_version(compact = TRUE, major_minor_only = TRUE)
     if (rpkg_lib_version != soma_lib_version) {
-        msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",
-                       sQuote(rpkg_lib_version), sQuote(soma_lib_version))
+        msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s [%s]",
+                       sQuote(rpkg_lib_version), sQuote(soma_lib_version), sQuote(cdmsg))
         stop(msg, call. = FALSE)
     }
 }
@@ -29,6 +42,20 @@
                               ".\nSee https://github.com/single-cell-data for more information ",
                               "about the SOMA project.")
     }
+}
+
+# This is temporary only. Please see:
+# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+.new_shape_feature_flag_enable <- function() {
+    .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
+}
+
+# This is temporary only. Please see:
+# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+.new_shape_feature_flag_disable <- function() {
+    .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
 }
 
 #' Create and cache a SOMA Context Object

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -27,7 +27,8 @@ SOMADataFrame <- R6::R6Class(
       schema,
       index_column_names = c("soma_joinid"),
       platform_config = NULL,
-      internal_use_only = NULL
+      internal_use_only = NULL,
+      use_new_shape_internal_only = FALSE
     ) {
       if (is.null(internal_use_only) || internal_use_only != "allowed_use") {
         stop(paste("Use of the create() method is for internal use only. Consider using a",

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -27,7 +27,8 @@ SOMANDArrayBase <- R6::R6Class(
       type,
       shape,
       platform_config = NULL,
-      internal_use_only = NULL
+      internal_use_only = NULL,
+      use_new_shape_internal_only = FALSE
     ) {
       if (is.null(internal_use_only) || internal_use_only != "allowed_use") {
         stop(paste("Use of the create() method is for internal use only. Consider using a",


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

This is a temporary feature-flag setup to enable iterative testing of current-domain features over multiple PRs in a stack.

**Notes for Reviewer:**

Not ready for review or merge at this time. In particular, the contents of this PR are not intended to survive to a tagged release of TileDB-SOMA.