### PR TITLE
[python/r] Expose shape-related accessors to Python/R bindings

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -95,6 +95,28 @@ class NDArray(SOMAArray, somacore.NDArray):
         """
         return cast(Tuple[int, ...], tuple(self._handle.shape))
 
+    @property
+    def maxshape(self) -> Tuple[int, ...]:
+        """Returns the maximum resizable capacity of each dimension, always a list of length
+        ``ndim``.  This will not necessarily match the bounds of occupied cells within the array.
+        It is the upper limit for ``resize`` on the array.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(Tuple[int, ...], tuple(self._handle.maxshape))
+
+    @property
+    def has_upgraded_shape(self) -> bool:
+        """Returns true if the array has the upgraded resizeable shape feature
+        from TileDB-SOMA 1.14: the array was created with this support, or it has
+        had ``.upgrade_shape`` applied to it.
+
+        Lifecycle:
+            Maturing.
+        """
+        return self._handle.has_upgraded_shape
+
     @classmethod
     def _dim_capacity_and_extent(
         cls,

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -317,6 +317,40 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         # if is it in read open mode, then it is a DataFrameWrapper
         return cast(DataFrameWrapper, self._handle).count
 
+    @property
+    def _maybe_soma_joinid_shape(self) -> Optional[int]:
+        """An internal helper method that returns the shape
+        value along the ``soma_joinid`` index column, if the ``DataFrame
+        has one, else ``None``.
+
+
+        Lifecycle:
+            Experimental.
+        """
+        return self._handle.maybe_soma_joinid_shape
+
+    @property
+    def _maybe_soma_joinid_maxshape(self) -> Optional[int]:
+        """An internal helper method that returns the maxshape
+        value along the ``soma_joinid`` index column, if the ``DataFrame
+        has one, else ``None``.
+
+        Lifecycle:
+            Experimental.
+        """
+        return self._handle.maybe_soma_joinid_maxshape
+
+    @property
+    def has_upgraded_domain(self) -> bool:
+        """Returns true if the array has the upgraded resizeable domain feature
+        from TileDB-SOMA 1.14: the array was created with this support, or it has
+        had ``.upgrade_domain`` applied to it.
+
+        Lifecycle:
+            Maturing.
+        """
+        return self._handle.has_upgraded_domain
+
     def __len__(self) -> int:
         """Returns the number of rows in the dataframe. Same as ``df.count``."""
         return self.count

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -406,7 +406,33 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
 
     @property
     def shape(self) -> Tuple[int, ...]:
-        return tuple(self._handle.shape)
+        """Not implemented for DataFrame."""
+        return cast(Tuple[int, ...], tuple(self._handle.shape))
+
+    @property
+    def maxshape(self) -> Tuple[int, ...]:
+        """Not implemented for DataFrame."""
+        return cast(Tuple[int, ...], tuple(self._handle.maxshape))
+
+    @property
+    def maybe_soma_joinid_shape(self) -> Optional[int]:
+        """Only implemented for DataFrame."""
+        raise NotImplementedError
+
+    @property
+    def maybe_soma_joinid_maxshape(self) -> Optional[int]:
+        """Only implemented for DataFrame."""
+        raise NotImplementedError
+
+    @property
+    def has_upgraded_shape(self) -> bool:
+        """Not implemented for DataFrame."""
+        raise NotImplementedError
+
+    @property
+    def has_upgraded_domain(self) -> bool:
+        """Only implemented for DataFrame."""
+        raise NotImplementedError
 
 
 class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
@@ -422,15 +448,54 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
         self._handle.write(values)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        # Shape is not implemented for DataFrames
-        raise NotImplementedError
+    def maybe_soma_joinid_shape(self) -> Optional[int]:
+        """Return the shape slot for the soma_joinid dim, if the array has one.
+        This is an important test-point and dev-internal access-point,
+        in particular, for the tiledbsoma-io experiment-level resizer.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(Optional[int], self._handle.maybe_soma_joinid_shape)
+
+    @property
+    def maybe_soma_joinid_maxshape(self) -> Optional[int]:
+        """Return the maxshape slot for the soma_joinid dim, if the array has one.
+        This is an important test-point and dev-internal access-point,
+        in particular, for the tiledbsoma-io experiment-level resizer.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(Optional[int], self._handle.maybe_soma_joinid_maxshape)
+
+    @property
+    def has_upgraded_domain(self) -> bool:
+        """Returns true if the array has the upgraded resizeable domain feature
+        from TileDB-SOMA 1.14: the array was created with this support, or it has
+        had ``.upgrade_domain`` applied to it.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(bool, self._handle.has_upgraded_domain)
 
 
 class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     """Wrapper around a Pybind11 DenseNDArrayWrapper handle."""
 
     _ARRAY_WRAPPED_TYPE = clib.SOMADenseNDArray
+
+    @property
+    def has_upgraded_shape(self) -> bool:
+        """Returns true if the array has the upgraded resizeable shape feature
+        from TileDB-SOMA 1.14: the array was created with this support, or it has
+        had ``.upgrade_shape`` applied to it.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(bool, self._handle.has_upgraded_shape)
 
 
 class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
@@ -441,6 +506,17 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
     @property
     def nnz(self) -> int:
         return int(self._handle.nnz())
+
+    @property
+    def has_upgraded_shape(self) -> bool:
+        """Returns true if the array has the upgraded resizeable shape feature
+        from TileDB-SOMA 1.14: the array was created with this support, or it has
+        had ``.upgrade_shape`` applied to it.
+
+        Lifecycle:
+            Maturing.
+        """
+        return cast(bool, self._handle.has_upgraded_shape)
 
 
 class _DictMod(enum.Enum):

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -144,9 +144,17 @@ void load_soma_dataframe(py::module& m) {
         .def_static("exists", &SOMADataFrame::exists)
         .def_property_readonly(
             "index_column_names", &SOMADataFrame::index_column_names)
+
         .def_property_readonly(
             "count",
             &SOMADataFrame::count,
-            py::call_guard<py::gil_scoped_release>());
+            py::call_guard<py::gil_scoped_release>())
+        .def_property_readonly(
+            "maybe_soma_joinid_shape", &SOMADataFrame::maybe_soma_joinid_shape)
+        .def_property_readonly(
+            "maybe_soma_joinid_maxshape",
+            &SOMADataFrame::maybe_soma_joinid_maxshape)
+        .def_property_readonly(
+            "has_upgraded_domain", &SOMAArray::has_current_domain);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -124,6 +124,11 @@ void load_soma_dense_ndarray(py::module& m) {
 
         .def_static("exists", &SOMADenseNDArray::exists)
 
-        .def("write", write);
+        .def("write", write)
+
+        .def_property_readonly("shape", &SOMADenseNDArray::shape)
+        .def_property_readonly("maxshape", &SOMADenseNDArray::maxshape)
+        .def_property_readonly(
+            "has_upgraded_shape", &SOMAArray::has_current_domain);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -110,6 +110,11 @@ void load_soma_sparse_ndarray(py::module& m) {
             "result_order"_a = ResultOrder::automatic,
             "timestamp"_a = py::none())
 
-        .def_static("exists", &SOMASparseNDArray::exists);
+        .def_static("exists", &SOMASparseNDArray::exists)
+
+        .def_property_readonly("shape", &SOMASparseNDArray::shape)
+        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape)
+        .def_property_readonly(
+            "has_upgraded_shape", &SOMAArray::has_current_domain);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -90,8 +90,15 @@ def test_dataframe(tmp_path, arrow_schema):
         assert sdf.count == 5
         assert len(sdf) == 5
 
+        # More to come on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        assert not sdf.has_upgraded_domain
+
         with pytest.raises(AttributeError):
             assert sdf.shape is None
+
+        # soma_joinid is not a dim here
+        assert sdf._maybe_soma_joinid_shape is None
+        assert sdf._maybe_soma_joinid_maxshape is None
 
         # Read all
         table = sdf.read().concat()

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import tiledbsoma
+
+from tests._util import maybe_raises
+
+
+@pytest.mark.parametrize(
+    "element_dtype",
+    [
+        pa.float64(),
+        pa.float32(),
+        pa.int64(),
+        pa.uint16(),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape_exc",
+    [
+        # Note: non-None exceptions are coming on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        [(100,), None],
+        [(100, 200), None],
+        [(100, 200, 300), None],
+    ],
+)
+def test_sparse_nd_array_basics(
+    tmp_path,
+    element_dtype,
+    shape_exc,
+):
+    uri = tmp_path.as_posix()
+    arg_shape, arg_create_exc = shape_exc
+    ndim = len(arg_shape)
+
+    # Create the array
+    with maybe_raises(arg_create_exc):
+        snda = tiledbsoma.SparseNDArray.create(
+            uri,
+            type=element_dtype,
+            shape=arg_shape,
+        )
+    if arg_create_exc is not None:
+        return
+
+    assert tiledbsoma.SparseNDArray.exists(uri)
+
+    # Test the various accessors
+    with tiledbsoma.SparseNDArray.open(uri) as snda:
+
+        assert snda.shape == arg_shape
+
+        # More to come on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        assert not snda.has_upgraded_shape
+
+        # Before current-domain support: shape is maxshape.
+        #
+        # With current-domain support: We expect the maxshape to be set to a big
+        # signed int32. (There are details on the exact value of that number,
+        # involving R compatibility, and leaving room for a single tile
+        # capacity, etc ...  we could check for some magic value but it suffices
+        # to check that it's over 2 billion.)
+        assert snda.shape == snda.maxshape
+        # for e in snda.maxshape:
+        #    assert e > 2_000_000_000
+
+        # No data have been written for this test case
+        assert snda.non_empty_domain() == tuple([(0, 0)] * ndim)
+
+    # soma_dim_0: (0,1)
+    # soma_dim_1: (2,3)
+    # soma_dim_2: (4,5)
+    coords = []
+    dim_names = []
+    for i in range(ndim):
+        dim_names.append(f"soma_dim_{i}")
+        coords.append((2 * i, 2 * i + 1))
+    coords = tuple(coords)
+
+    # Write some data
+    with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
+        dikt = {"soma_data": [4, 5]}
+        for i in range(ndim):
+            dikt[dim_names[i]] = coords[i]
+        table = pa.Table.from_pydict(dikt)
+        snda.write(table)
+
+    # Test the various accessors
+    with tiledbsoma.SparseNDArray.open(uri) as snda:
+        assert snda.shape == arg_shape
+        # This will change with current-domain support
+        assert snda.shape == snda.maxshape
+        # for e in snda.maxshape:
+        #    assert e > 2_000_000_000
+        assert snda.non_empty_domain() == coords
+
+    # Test reads out of bounds
+    with tiledbsoma.SparseNDArray.open(uri) as snda:
+        # TODO: make sure this doesn't come through as RuntimeError
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        with pytest.raises((RuntimeError, ValueError)):
+            coords = tuple(arg_shape[i] + 10 for i in range(ndim))
+            snda.read(coords).tables().concat()
+
+    # Test writes out of bounds
+    with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
+        with pytest.raises(tiledbsoma.SOMAError):
+            dikt = {"soma_data": [30]}
+            dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
+            table = pa.Table.from_pydict(dikt)
+            snda.write(table)
+
+    with tiledbsoma.SparseNDArray.open(uri) as snda:
+        assert snda.shape == arg_shape
+        assert snda.shape == snda.maxshape
+
+
+## Pending 2.27 timeframe for dense support for current domain, including resize
+## TODO: mark these with a linked GitHub tracking issue
+def test_dense_nd_array_basics(tmp_path):
+    uri = tmp_path.as_posix()
+    shape = (100, 200)
+    tiledbsoma.DenseNDArray.create(uri, type=pa.float64(), shape=shape)
+
+    with tiledbsoma.DenseNDArray.open(uri) as dnda:
+        assert dnda.shape == (100, 200)
+        assert dnda.maxshape == (100, 200)
+
+        assert dnda.non_empty_domain() == ((0, 0), (0, 0))
+
+
+@pytest.mark.parametrize(
+    "soma_joinid_domain",
+    [
+        # TODO: https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        # None,
+        (0, 1),
+        (0, 3),
+        (0, 100),
+    ],
+)
+@pytest.mark.parametrize(
+    "index_column_names",
+    [
+        ["soma_joinid"],
+        ["soma_joinid", "myint"],
+        ["soma_joinid", "mystring"],
+        ["mystring", "myint"],
+    ],
+)
+def test_dataframe_basics(tmp_path, soma_joinid_domain, index_column_names):
+    uri = tmp_path.as_posix()
+
+    schema = pa.schema(
+        [
+            ("soma_joinid", pa.int64()),
+            ("mystring", pa.string()),
+            ("myint", pa.int16()),
+            ("myfloat", pa.float32()),
+        ]
+    )
+
+    data = pa.Table.from_pydict(
+        {
+            "soma_joinid": [0, 1, 2, 3],
+            "mystring": ["a", "b", "a", "b"],
+            "myint": [20, 30, 40, 50],
+            "myfloat": [1.0, 2.5, 4.0, 5.5],
+        }
+    )
+
+    domain_slots = {
+        "soma_joinid": soma_joinid_domain,
+        "mystring": None,
+        "myint": (-1000, 1000),
+        "myfloat": (-999.5, 999.5),
+    }
+
+    domain = tuple([domain_slots[name] for name in index_column_names])
+
+    soma_joinid_coords = data["soma_joinid"]
+    oob_write = any(
+        e.as_py() < soma_joinid_domain[0] or e.as_py() > soma_joinid_domain[1]
+        for e in soma_joinid_coords
+    )
+    oob_write = oob_write and "soma_joinid" in index_column_names
+
+    with tiledbsoma.DataFrame.create(
+        uri,
+        schema=schema,
+        index_column_names=index_column_names,
+        domain=domain,
+    ) as sdf:
+        if oob_write:
+            with pytest.raises(tiledbsoma.SOMAError):
+                sdf.write(data)
+        else:
+            sdf.write(data)
+
+    with tiledbsoma.DataFrame.open(uri) as sdf:
+        has_sjid_dim = "soma_joinid" in index_column_names
+        if has_sjid_dim:
+            assert sdf._maybe_soma_joinid_shape == 1 + soma_joinid_domain[1]
+            assert sdf._maybe_soma_joinid_maxshape == 1 + soma_joinid_domain[1]
+        else:
+            assert sdf._maybe_soma_joinid_shape is None
+            assert sdf._maybe_soma_joinid_maxshape is None
+
+        assert len(sdf.non_empty_domain()) == len(index_column_names)

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -51,6 +51,14 @@ def test_sparse_nd_array_create_ok(
     assert a.uri == tmp_path.as_posix()
     assert a.ndim == len(shape)
     assert a.shape == tuple(shape)
+
+    # TODO: more testing with current-domain feature integrated
+    # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    assert isinstance(a.maxshape, tuple)
+    assert len(a.maxshape) == len(a.shape)
+    for ms, s in zip(a.maxshape, a.shape):
+        assert ms >= s
+
     assert a.is_sparse is True
 
     assert a.schema is not None

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -126,6 +126,22 @@ shape <- function(uri, config = NULL) {
     .Call(`_tiledbsoma_shape`, uri, config)
 }
 
+maxshape <- function(uri, config = NULL) {
+    .Call(`_tiledbsoma_maxshape`, uri, config)
+}
+
+maybe_soma_joinid_shape <- function(uri, config = NULL) {
+    .Call(`_tiledbsoma_maybe_soma_joinid_shape`, uri, config)
+}
+
+maybe_soma_joinid_maxshape <- function(uri, config = NULL) {
+    .Call(`_tiledbsoma_maybe_soma_joinid_maxshape`, uri, config)
+}
+
+has_current_domain <- function(uri, config = NULL) {
+    .Call(`_tiledbsoma_has_current_domain`, uri, config)
+}
+
 #' Iterator-Style Access to SOMA Array via SOMAArray
 #'
 #' The `sr_*` functions provide low-level access to an instance of the SOMAArray

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -327,9 +327,65 @@ SOMADataFrame <- R6::R6Class(
     #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
     #'
     shape = function() stop(errorCondition(
-      "'SOMADataFrame$shape()' is not implemented yet",
+      "'SOMADataFrame$shape()' is not implemented",
       class = 'notYetImplementedError'
-    ))
+    )),
+
+    #' @description Retrieve the maxshape; as \code{SOMADataFrames} are shapeless,
+    #' simply raises an error
+    #'
+    #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
+    #'
+    maxshape = function() stop(errorCondition(
+      "'SOMADataFrame$maxshape()' is not implemented",
+      class = 'notYetImplementedError'
+    )),
+
+    #' @description Returns the shape slot for the soma_joinid dim, if the array
+    #' has one.  This is an important test-point and dev-internal access-point.
+    #' (lifecycle: maturing)
+    #' @return An integer64 for the soma_joinid dim's shape, if soma_joinid is
+    #' a dim, else NA.
+    .maybe_soma_joinid_shape = function() {
+      retval <- as.integer64(maybe_soma_joinid_shape(
+        self$uri,
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      ))
+      if (retval == as.integer64(-1)) {
+        NA
+      } else {
+        retval
+      }
+    },
+
+    #' @description Returns the maxshape slot for the soma_joinid dim, if the array
+    #' has one.  This is an important test-point and dev-internal access-point.
+    #' (lifecycle: maturing)
+    #' @return An integer64 for the soma_joinid dim's shape, if soma_joinid is
+    #' a dim, else NA.
+    .maybe_soma_joinid_maxshape = function() {
+      retval <- as.integer64(maybe_soma_joinid_maxshape(
+        self$uri,
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      ))
+      if (retval == as.integer64(-1)) {
+        NA
+      } else {
+        retval
+      }
+    },
+
+    #' @description Returns TRUE if the array has the upgraded resizeable domain
+    #' feature from TileDB-SOMA 1.14: the array was created with this support,
+    #' or it has had ``upgrade_domain`` applied to it.
+    #' (lifecycle: maturing)
+    #' @return Logical
+    has_upgraded_domain = function() {
+      has_current_domain(
+        self$uri,
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      )
+    }
 
   ),
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -341,40 +341,6 @@ SOMADataFrame <- R6::R6Class(
       class = 'notYetImplementedError'
     )),
 
-    #' @description Returns the shape slot for the soma_joinid dim, if the array
-    #' has one.  This is an important test-point and dev-internal access-point.
-    #' (lifecycle: maturing)
-    #' @return An integer64 for the soma_joinid dim's shape, if soma_joinid is
-    #' a dim, else NA.
-    .maybe_soma_joinid_shape = function() {
-      retval <- as.integer64(maybe_soma_joinid_shape(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      ))
-      if (retval == as.integer64(-1)) {
-        NA
-      } else {
-        retval
-      }
-    },
-
-    #' @description Returns the maxshape slot for the soma_joinid dim, if the array
-    #' has one.  This is an important test-point and dev-internal access-point.
-    #' (lifecycle: maturing)
-    #' @return An integer64 for the soma_joinid dim's shape, if soma_joinid is
-    #' a dim, else NA.
-    .maybe_soma_joinid_maxshape = function() {
-      retval <- as.integer64(maybe_soma_joinid_maxshape(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      ))
-      if (retval == as.integer64(-1)) {
-        NA
-      } else {
-        retval
-      }
-    },
-
     #' @description Returns TRUE if the array has the upgraded resizeable domain
     #' feature from TileDB-SOMA 1.14: the array was created with this support,
     #' or it has had ``upgrade_domain`` applied to it.

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -327,7 +327,7 @@ SOMADataFrame <- R6::R6Class(
     #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
     #'
     shape = function() stop(errorCondition(
-      "'SOMADataFrame$shape()' is not implemented",
+      "'SOMADataFrame$shape()' is not implemented yet",
       class = 'notYetImplementedError'
     )),
 

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -84,7 +84,20 @@ SOMANDArrayBase <- R6::R6Class(
     set_data_type = function(type) {
       spdl::debug("[SOMANDArrayBase::set_data_type] caching type {}", type$ToString())
       private$.type <- type
+    },
+
+    #' @description Returns TRUE if the array has the upgraded resizeable shape
+    #' feature from TileDB-SOMA 1.14: the array was created with this support,
+    #' or it has had ``upgrade_domain`` applied to it.
+    #' (lifecycle: maturing)
+    #' @return Logical
+    has_upgraded_shape = function() {
+      has_current_domain(
+        self$uri,
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      )
     }
+
   ),
 
   private = list(

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -158,6 +158,17 @@ TileDBArray <- R6::R6Class(
       ))
     },
 
+    #' @description Retrieve the maxshape, i.e. maximum possible that the
+    # shape can be resized up to.
+    #' (lifecycle: maturing)
+    #' @return A named vector of dimension length (and the same type as the dimension)
+    maxshape = function() {
+      as.integer64(maxshape(
+        self$uri,
+        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      ))
+    },
+
     #' @description Retrieve the range of indexes for a dimension that were
     #'  explicitly written.  This method is deprecated as of TileDB-SOMA 1.13, and will be
     #' removed in TileDB-SOMA 1.14.

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -260,6 +260,54 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// maxshape
+Rcpp::NumericVector maxshape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
+RcppExport SEXP _tiledbsoma_maxshape(SEXP uriSEXP, SEXP configSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
+    rcpp_result_gen = Rcpp::wrap(maxshape(uri, config));
+    return rcpp_result_gen;
+END_RCPP
+}
+// maybe_soma_joinid_shape
+Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
+RcppExport SEXP _tiledbsoma_maybe_soma_joinid_shape(SEXP uriSEXP, SEXP configSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
+    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_shape(uri, config));
+    return rcpp_result_gen;
+END_RCPP
+}
+// maybe_soma_joinid_maxshape
+Rcpp::NumericVector maybe_soma_joinid_maxshape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
+RcppExport SEXP _tiledbsoma_maybe_soma_joinid_maxshape(SEXP uriSEXP, SEXP configSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
+    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_maxshape(uri, config));
+    return rcpp_result_gen;
+END_RCPP
+}
+// has_current_domain
+Rcpp::LogicalVector has_current_domain(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
+RcppExport SEXP _tiledbsoma_has_current_domain(SEXP uriSEXP, SEXP configSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
+    rcpp_result_gen = Rcpp::wrap(has_current_domain(uri, config));
+    return rcpp_result_gen;
+END_RCPP
+}
 // sr_setup
 Rcpp::List sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
 RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
@@ -449,6 +497,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_check_arrow_schema_tag", (DL_FUNC) &_tiledbsoma_check_arrow_schema_tag, 1},
     {"_tiledbsoma_check_arrow_array_tag", (DL_FUNC) &_tiledbsoma_check_arrow_array_tag, 1},
     {"_tiledbsoma_shape", (DL_FUNC) &_tiledbsoma_shape, 2},
+    {"_tiledbsoma_maxshape", (DL_FUNC) &_tiledbsoma_maxshape, 2},
+    {"_tiledbsoma_maybe_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_maybe_soma_joinid_shape, 2},
+    {"_tiledbsoma_maybe_soma_joinid_maxshape", (DL_FUNC) &_tiledbsoma_maybe_soma_joinid_maxshape, 2},
+    {"_tiledbsoma_has_current_domain", (DL_FUNC) &_tiledbsoma_has_current_domain, 2},
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_create_empty_arrow_table", (DL_FUNC) &_tiledbsoma_create_empty_arrow_table, 0},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -234,3 +234,47 @@ Rcpp::NumericVector shape(const std::string& uri,
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
     return Rcpp::toInteger64(sr->shape());
 }
+
+// [[Rcpp::export]]
+Rcpp::NumericVector maxshape(const std::string& uri,
+                          Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    return Rcpp::toInteger64(sr->maxshape());
+}
+
+// [[Rcpp::export]]
+Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri,
+                          Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
+    // Pro-tip:
+    // * Open with mode and uri gives a SOMAArray.
+    // * Open with uri and mode gives a SOMADataFrame.
+    // This was done intentionally to resolve an ambiguous-overload compiler error.
+    auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::read, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    auto retval = sr->maybe_soma_joinid_shape();
+    if (retval.has_value()) {
+      return Rcpp::toInteger64(retval.value());
+    } else {
+      // We use this sentinel to facilitate a pure-R return value of NA.
+      return Rcpp::toInteger64(-1);
+    }
+}
+
+// [[Rcpp::export]]
+Rcpp::NumericVector maybe_soma_joinid_maxshape(const std::string& uri,
+                          Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
+    auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::read, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    auto retval = sr->maybe_soma_joinid_maxshape();
+    if (retval.has_value()) {
+      return Rcpp::toInteger64(retval.value());
+    } else {
+      // We use this sentinel to facilitate a pure-R return value of NA.
+      return Rcpp::toInteger64(-1);
+    }
+}
+
+// [[Rcpp::export]]
+Rcpp::LogicalVector has_current_domain(const std::string& uri,
+                          Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, "unnamed", config_vector_to_map(Rcpp::wrap(config)));
+    return Rcpp::LogicalVector(sr->has_current_domain());
+}

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -59,6 +59,17 @@ test_that("SOMASparseNDArray creation", {
   ## shape
   expect_equal(ndarray$shape(), as.integer64(c(10, 10)))
 
+  ## maxshape
+  # TODO: more testing with current-domain feature integrated
+  # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+  expect_false(ndarray$has_upgraded_shape())
+  shape <- ndarray$shape()
+  maxshape <- ndarray$maxshape()
+  expect_equal(length(shape), length(maxshape))
+  for (i in 1:length(shape)) {
+    expect(maxshape[[i]] >= shape[[i]])
+  }
+
   ## ndim
   expect_equal(ndarray$ndim(), 2L)
 

--- a/apis/r/tests/testthat/test-shape.r
+++ b/apis/r/tests/testthat/test-shape.r
@@ -33,17 +33,22 @@ test_that("SOMADataFrame shape", {
     expect_false(sdf$has_upgraded_domain())
     expect_error(sdf$shape(), class = "notYetImplementedError")
     expect_error(sdf$maxshape(), class = "notYetImplementedError")
-    sjid_shape <- sdf$.maybe_soma_joinid_shape()
-    sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
+
+    # Not implemented this way per
+    # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
+    # sjid_shape <- sdf$.maybe_soma_joinid_shape()
+    # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
+    sjid_shape <- maybe_soma_joinid_shape(sdf$uri, config = as.character(tiledb::config(sdf$tiledbsoma_ctx$context())))
+    sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, config = as.character(tiledb::config(sdf$tiledbsoma_ctx$context())))
+
     if (has_soma_joinid_dim) {
       # More testing to come on
       # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-      expect_false(is.na(sjid_shape))
-      #expect_equal(as.integer(sjid_shape), 100)
-      #expect_equal(as.integer(sjid_maxshape), 100)
+      expect_false(sjid_shape == -1)
+      expect_false(sjid_maxshape == -1)
     } else {
-      expect_true(is.na(sjid_shape))
-      expect_true(is.na(sjid_maxshape))
+      expect_true(sjid_shape == -1)
+      expect_true(sjid_maxshape == -1)
     }
 
     sdf$close()

--- a/apis/r/tests/testthat/test-shape.r
+++ b/apis/r/tests/testthat/test-shape.r
@@ -1,0 +1,95 @@
+test_that("SOMADataFrame shape", {
+  #uri <- withr::local_tempdir("soma-dataframe-shape")
+  uri <- "/tmp/fooze"
+  asch <- create_arrow_schema()
+
+  index_column_name_choices = list(
+    "soma_joinid",
+    c("soma_joinid", "foo"),
+    c("soma_joinid", "baz"),
+    c("baz", "foo")
+  )
+
+  for (index_column_names in index_column_name_choices) {
+    has_soma_joinid_dim <- "soma_joinid" %in% index_column_names
+
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+
+    sdf <- SOMADataFrameCreate(uri, asch, index_column_names = index_column_names)
+    expect_true(sdf$exists())
+    expect_true(dir.exists(uri))
+
+    tbl0 <- arrow::arrow_table(foo = 1L:4L,
+                               soma_joinid = 1L:4L,
+                               bar = 1.1:4.1,
+                               baz = c("apple", "ball", "cat", "dog"),
+                               schema = asch)
+
+    sdf$write(tbl0)
+    sdf$close()
+
+    sdf <- SOMADataFrameOpen(uri)
+
+    expect_false(sdf$has_upgraded_domain())
+    expect_error(sdf$shape(), class = "notYetImplementedError")
+    expect_error(sdf$maxshape(), class = "notYetImplementedError")
+    sjid_shape <- sdf$.maybe_soma_joinid_shape()
+    sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
+    if (has_soma_joinid_dim) {
+      # More testing to come on
+      # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+      expect_false(is.na(sjid_shape))
+      #expect_equal(as.integer(sjid_shape), 100)
+      #expect_equal(as.integer(sjid_maxshape), 100)
+    } else {
+      expect_true(is.na(sjid_shape))
+      expect_true(is.na(sjid_maxshape))
+    }
+
+    sdf$close()
+
+    rm(sdf, tbl0)
+
+    gc()
+  }
+})
+
+test_that("SOMASparseNDArray shape", {
+  uri <- withr::local_tempdir("soma-sparse-ndarray-shape")
+  asch <- create_arrow_schema()
+
+  element_type_choices = list(arrow::float32(), arrow::int16())
+  shape_choices = list(
+    c(100),
+    c(100,200),
+    c(100,200,300)
+  )
+  for (element_type in element_type_choices) {
+    for (shape in shape_choices) {
+
+      if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+      ndarray <- SOMASparseNDArrayCreate(uri, element_type, shape = shape)
+
+      expect_equal(ndarray$ndim(), length(shape))
+
+      expect_equal(ndarray$shape(), as.integer64(shape))
+
+      # More generally after current-domain support:
+      readback_shape <- ndarray$shape()
+      readback_maxshape <- ndarray$maxshape()
+      expect_equal(length(readback_shape), length(readback_maxshape))
+      for (i in 1:length(shape)) {
+        s <- as.integer(readback_shape[[i]])
+        ms <- as.integer(readback_maxshape[[i]])
+        expect_true(s <= ms)
+      }
+
+      # Resize tests upcoming on
+      # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+      ndarray$close()
+
+      rm(ndarray)
+      gc()
+    }
+  }
+})

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -824,6 +824,18 @@ class SOMAArray : public SOMAObject {
         return _get_current_domain();
     }
 
+    /**
+     * @brief Returns true if the array has a non-empty current domain, else
+     * false.  Note that at the core level it's "current domain" for all arrays;
+     * at the SOMA-API level it's "upgraded_shape" for SOMASparseNDArray and
+     * SOMADenseNDArray, and "upgraded_domain" for SOMADataFrame; here
+     * we use the core language and defer to Python/R to conform to
+     * SOMA-API syntax.
+     */
+    bool has_current_domain() {
+        return !_get_current_domain().is_empty();
+    }
+
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in
     // its entirety to SOMADataFrame, but it would entail moving several

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -68,6 +68,14 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
         mode, uri, ctx, column_names, result_order, timestamp);
 }
 
+std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
+    std::string_view uri,
+    OpenMode mode,
+    std::string_view name,
+    std::map<std::string, std::string> platform_config) {
+    return std::make_unique<SOMADataFrame>(mode, uri, name, platform_config);
+}
+
 bool SOMADataFrame::exists(
     std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
     try {

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -71,6 +71,13 @@ class SOMADataFrame : public SOMAArray {
     /**
      * @brief Open and return a SOMADataFrame object at the given URI.
      *
+     * Note: the first two arguments uri and mode are reversed from
+     * the SOMAArrayConstructor. This is an intentional decision to
+     * avoid ambiguous-overload compiler errors. Even though
+     * SOMADataFrame extends SOMAArray, callers using open
+     * and wishing to obtain a SOMADataFrame rather than a SOMAArray
+     * are advised to place the uri argument before the mode argument.
+     *
      * @param uri URI to create the SOMADataFrame
      * @param mode read or write
      * @param ctx SOMAContext
@@ -90,6 +97,26 @@ class SOMADataFrame : public SOMAArray {
         std::vector<std::string> column_names = {},
         ResultOrder result_order = ResultOrder::automatic,
         std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open and return a SOMADataFrame object at the given URI.
+     *
+     * This is nominally for TileDB-SOMA R use, since while we have
+     * TileDB-SOMA-R and TileDB-R co-existing, it's less desirable
+     * to pass ctx from one copy of core to another, and more
+     * desirable to pass a config map.
+     *
+     * @param uri URI to create the SOMADataFrame
+     * @param mode read or write
+     * @param name Name of the array
+     * @param platform_config Config parameter dictionary
+     * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
+     */
+    static std::unique_ptr<SOMADataFrame> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::string_view name,
+        std::map<std::string, std::string> platform_config);
 
     /**
      * @brief Check if the SOMADataFrame exists at the URI.
@@ -130,6 +157,35 @@ class SOMADataFrame : public SOMAArray {
               "auto",  // batch_size
               result_order,
               timestamp) {
+    }
+
+    /**
+     * @brief Construct a new SOMADataFrame object.
+     *
+     * This is nominally for TileDB-SOMA R use, since while we have
+     * TileDB-SOMA-R and TileDB-R co-existing, it's less desirable
+     * to pass ctx from one copy of core to another, and more
+     * desirable to pass a config map.
+     *
+     * @param uri URI to create the SOMADataFrame
+     * @param mode read or write
+     * @param name Name of the array
+     * @param platform_config Config parameter dictionary
+     * @return std::unique_ptr<SOMADataFrame> SOMADataFrame
+     */
+    SOMADataFrame(
+        OpenMode mode,
+        std::string_view uri,
+        std::string_view name,
+        std::map<std::string, std::string> platform_config)
+        : SOMAArray(
+              mode,
+              uri,
+              std::make_shared<SOMAContext>(platform_config),
+              name,
+              {},
+              "auto",
+              ResultOrder::automatic) {
     }
 
     SOMADataFrame(const SOMAArray& other)

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -119,6 +119,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     SOMACollection::create(base_uri, ctx, ts);
     // TODO: add support for current domain in dense arrays once we have that
     // support from core
+    // https://github.com/single-cell-data/TileDB-SOMA/issues/2955
     std::vector<helper::DimInfo> dim_infos(
         {{.name = dim_name,
           .tiledb_datatype = tiledb_datatype,

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -135,9 +135,11 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
             // Without current-domain support: this should throw since
             // one cannot resize what has not been sized.
+            REQUIRE(!soma_sparse->has_current_domain());
             REQUIRE_THROWS(soma_sparse->resize(new_shape));
             // Now set the shape
             soma_sparse->upgrade_shape(new_shape);
+            REQUIRE(soma_sparse->has_current_domain());
             // Should not fail since we're setting it to what it already is.
             soma_sparse->resize(new_shape);
             soma_sparse->close();


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

* These accessors are already implemented and unit-tested in C++
* On this PR, I expose only the language bindings as-is with minimal unit-testing -- more unit-testing to follow (including feature-flag logic) as tracked on #2407 
* The `_maybe_sjid_shape` and `_maybe_sjid_maxshape` accessors will be crucial for experiment-level resize logic as on append mode, which does not yet exist in TileDB-SOMA-R (see #1630)

**Notes for Reviewer:**
