### PR TITLE
[c++] Also check for leading slash when checking for 'relative' URLs

### DIFF
--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -220,7 +220,7 @@ void SOMAGroup::set(
     const std::string& soma_type) {
     bool relative = uri_type == URIType::relative;
     if (uri_type == URIType::automatic) {
-        relative = uri.find("://") != std::string::npos;
+        relative = ! ((uri.find("://") != std::string::npos)|| (uri.find("/") == 0));
     }
     group_->add_member(uri, relative, name);
     members_map_[name] = SOMAGroupEntry(uri, soma_type);

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -220,7 +220,8 @@ void SOMAGroup::set(
     const std::string& soma_type) {
     bool relative = uri_type == URIType::relative;
     if (uri_type == URIType::automatic) {
-        relative = ! ((uri.find("://") != std::string::npos)|| (uri.find("/") == 0));
+        relative = !(
+            (uri.find("://") != std::string::npos) || (uri.find("/") == 0));
     }
     group_->add_member(uri, relative, name);
     members_map_[name] = SOMAGroupEntry(uri, soma_type);


### PR DESCRIPTION
**Issue and/or context:**

As discussed over DMs, the check for 'absolute vs relative' URLs was not checking for leading slashes as on local filesystems.

**Changes:**

The check has been expanded.  

**Notes for Reviewer:**

[SC 54529](https://app.shortcut.com/tiledb-inc/story/54529/c-generalize-relative-vs-absolute-check-for-group-url)