### PR TITLE
[c++/python] Map core-to-soma domains correctly

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -304,7 +304,17 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Lifecycle:
             Maturing.
         """
-        return self._tiledb_domain()
+        return self._domain()
+
+    @property
+    def maxdomain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """Returns a tuple of minimum and maximum values, inclusive, storable
+        on each index column of the dataframe.
+
+        Lifecycle:
+            Maturing.
+        """
+        return self._maxdomain()
 
     @property
     def count(self) -> int:

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -83,8 +83,35 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.attr_names
 
-    def _tiledb_domain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def _domain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """This is the SOMA domain, not the core domain.
+        * For arrays with core current-domain support:
+          o soma domain is core current domain
+          o soma maxdomain is core domain
+        * For arrays without core current-domain support:
+          o soma domain is core domain
+          o soma maxdomain is core domain
+          o core current domain is not accessed at the soma level
+        * Core domain has been around forever and is immutable.
+        * Core current domain is new as of core 2.25 and can be
+          resized up to core (max) domain.
+        """
         return self._handle.domain
+
+    def _maxdomain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """This is the SOMA maxdomain, not the core domain.
+        * For arrays with core current-domain support:
+          o soma domain is core current domain
+          o soma maxdomain is core domain
+        * For arrays without core current-domain support:
+          o soma domain is core domain
+          o soma maxdomain is core domain
+          o core current domain is not accessed at the soma level
+        * Core domain has been around forever and is immutable.
+        * Core current domain is new as of core 2.25 and can be
+          resized up to core (max) domain.
+        """
+        return self._handle.maxdomain
 
     def _set_reader_coords(self, sr: clib.SOMAArray, coords: Sequence[object]) -> None:
         """Parses the given coords and sets them on the SOMA Reader."""

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -391,6 +391,10 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def domain(self) -> Tuple[Tuple[object, object], ...]:
         return self._cast_domain(self._handle.domain)
 
+    @property
+    def maxdomain(self) -> Tuple[Tuple[object, object], ...]:
+        return self._cast_domain(self._handle.maxdomain)
+
     def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
         return self._cast_domain(self._handle.non_empty_domain) or ()
 

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -541,7 +541,8 @@ void load_soma_array(py::module& m) {
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
-                        return py::cast(array.non_empty_domain<uint64_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<uint64_t>(name));
                     case TILEDB_DATETIME_YEAR:
                     case TILEDB_DATETIME_MONTH:
                     case TILEDB_DATETIME_WEEK:
@@ -556,26 +557,35 @@ void load_soma_array(py::module& m) {
                     case TILEDB_DATETIME_FS:
                     case TILEDB_DATETIME_AS:
                     case TILEDB_INT64:
-                        return py::cast(array.non_empty_domain<int64_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<int64_t>(name));
                     case TILEDB_UINT32:
-                        return py::cast(array.non_empty_domain<uint32_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<uint32_t>(name));
                     case TILEDB_INT32:
-                        return py::cast(array.non_empty_domain<int32_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<int32_t>(name));
                     case TILEDB_UINT16:
-                        return py::cast(array.non_empty_domain<uint16_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<uint16_t>(name));
                     case TILEDB_INT16:
-                        return py::cast(array.non_empty_domain<int16_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<int16_t>(name));
                     case TILEDB_UINT8:
-                        return py::cast(array.non_empty_domain<uint8_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<uint8_t>(name));
                     case TILEDB_INT8:
-                        return py::cast(array.non_empty_domain<int8_t>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<int8_t>(name));
                     case TILEDB_FLOAT64:
-                        return py::cast(array.non_empty_domain<double>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<double>(name));
                     case TILEDB_FLOAT32:
-                        return py::cast(array.non_empty_domain<float>(name));
+                        return py::cast(
+                            array.non_empty_domain_slot<float>(name));
                     case TILEDB_STRING_UTF8:
                     case TILEDB_STRING_ASCII:
-                        return py::cast(array.non_empty_domain_var(name));
+                        return py::cast(array.non_empty_domain_slot_var(name));
                     default:
                         throw TileDBSOMAError(
                             "Unsupported dtype for nonempty domain.");
@@ -587,7 +597,7 @@ void load_soma_array(py::module& m) {
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
-                        return py::cast(array.domain<uint64_t>(name));
+                        return py::cast(array.soma_domain_slot<uint64_t>(name));
                     case TILEDB_DATETIME_YEAR:
                     case TILEDB_DATETIME_MONTH:
                     case TILEDB_DATETIME_WEEK:
@@ -602,23 +612,80 @@ void load_soma_array(py::module& m) {
                     case TILEDB_DATETIME_FS:
                     case TILEDB_DATETIME_AS:
                     case TILEDB_INT64:
-                        return py::cast(array.domain<int64_t>(name));
+                        return py::cast(array.soma_domain_slot<int64_t>(name));
                     case TILEDB_UINT32:
-                        return py::cast(array.domain<uint32_t>(name));
+                        return py::cast(array.soma_domain_slot<uint32_t>(name));
                     case TILEDB_INT32:
-                        return py::cast(array.domain<int32_t>(name));
+                        return py::cast(array.soma_domain_slot<int32_t>(name));
                     case TILEDB_UINT16:
-                        return py::cast(array.domain<uint16_t>(name));
+                        return py::cast(array.soma_domain_slot<uint16_t>(name));
                     case TILEDB_INT16:
-                        return py::cast(array.domain<int16_t>(name));
+                        return py::cast(array.soma_domain_slot<int16_t>(name));
                     case TILEDB_UINT8:
-                        return py::cast(array.domain<uint8_t>(name));
+                        return py::cast(array.soma_domain_slot<uint8_t>(name));
                     case TILEDB_INT8:
-                        return py::cast(array.domain<int8_t>(name));
+                        return py::cast(array.soma_domain_slot<int8_t>(name));
                     case TILEDB_FLOAT64:
-                        return py::cast(array.domain<double>(name));
+                        return py::cast(array.soma_domain_slot<double>(name));
                     case TILEDB_FLOAT32:
-                        return py::cast(array.domain<float>(name));
+                        return py::cast(array.soma_domain_slot<float>(name));
+                    case TILEDB_STRING_UTF8:
+                    case TILEDB_STRING_ASCII: {
+                        std::pair<std::string, std::string> str_domain;
+                        return py::cast(std::make_pair("", ""));
+                    }
+                    default:
+                        throw TileDBSOMAError(
+                            "Unsupported dtype for Dimension's domain");
+                }
+            })
+
+        .def(
+            "maxdomain",
+            [](SOMAArray& array, std::string name, py::dtype dtype) {
+                switch (np_to_tdb_dtype(dtype)) {
+                    case TILEDB_UINT64:
+                        return py::cast(
+                            array.soma_maxdomain_slot<uint64_t>(name));
+                    case TILEDB_DATETIME_YEAR:
+                    case TILEDB_DATETIME_MONTH:
+                    case TILEDB_DATETIME_WEEK:
+                    case TILEDB_DATETIME_DAY:
+                    case TILEDB_DATETIME_HR:
+                    case TILEDB_DATETIME_MIN:
+                    case TILEDB_DATETIME_SEC:
+                    case TILEDB_DATETIME_MS:
+                    case TILEDB_DATETIME_US:
+                    case TILEDB_DATETIME_NS:
+                    case TILEDB_DATETIME_PS:
+                    case TILEDB_DATETIME_FS:
+                    case TILEDB_DATETIME_AS:
+                    case TILEDB_INT64:
+                        return py::cast(
+                            array.soma_maxdomain_slot<int64_t>(name));
+                    case TILEDB_UINT32:
+                        return py::cast(
+                            array.soma_maxdomain_slot<uint32_t>(name));
+                    case TILEDB_INT32:
+                        return py::cast(
+                            array.soma_maxdomain_slot<int32_t>(name));
+                    case TILEDB_UINT16:
+                        return py::cast(
+                            array.soma_maxdomain_slot<uint16_t>(name));
+                    case TILEDB_INT16:
+                        return py::cast(
+                            array.soma_maxdomain_slot<int16_t>(name));
+                    case TILEDB_UINT8:
+                        return py::cast(
+                            array.soma_maxdomain_slot<uint8_t>(name));
+                    case TILEDB_INT8:
+                        return py::cast(
+                            array.soma_maxdomain_slot<int8_t>(name));
+                    case TILEDB_FLOAT64:
+                        return py::cast(
+                            array.soma_maxdomain_slot<double>(name));
+                    case TILEDB_FLOAT32:
+                        return py::cast(array.soma_maxdomain_slot<float>(name));
                     case TILEDB_STRING_UTF8:
                     case TILEDB_STRING_ASCII: {
                         std::pair<std::string, std::string> str_domain;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -803,7 +803,8 @@ class SOMAArray : public SOMAObject {
         NDRectangle ndrect = current_domain.ndrectangle();
 
         // Convert from two-element array (core API) to pair (tiledbsoma API)
-        return std::make_pair(arr[0], arr[1]);
+        std::array<T, 2> arr = ndrect.range<T>(name);
+        return std::pair<T, T>(arr[0], arr[1]);
     }
 
     /**

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -704,7 +704,7 @@ class SOMAArray : public SOMAObject {
      * non-empty domains of the array fragments.
      */
     template <typename T>
-    std::pair<T, T> non_empty_domain(const std::string& name) {
+    std::pair<T, T> non_empty_domain_slot(const std::string& name) {
         try {
             return arr_->non_empty_domain<T>(name);
         } catch (const std::exception& e) {
@@ -717,7 +717,7 @@ class SOMAArray : public SOMAObject {
      * This is the union of the non-empty domains of the array fragments.
      * Applicable only to var-sized dimensions.
      */
-    std::pair<std::string, std::string> non_empty_domain_var(
+    std::pair<std::string, std::string> non_empty_domain_slot_var(
         const std::string& name) {
         try {
             return arr_->non_empty_domain_var(name);
@@ -727,13 +727,102 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
-     * Returns the domain of the given dimension.
+     * Exposed for testing purposes.
+     */
+    CurrentDomain get_current_domain() const {
+        return _get_current_domain();
+    }
+
+    /**
+     * @brief Returns true if the array has a non-empty current domain, else
+     * false.  Note that at the core level it's "current domain" for all arrays;
+     * at the SOMA-API level it's "upgraded_shape" for SOMASparseNDArray and
+     * SOMADenseNDArray, and "upgraded_domain" for SOMADataFrame; here
+     * we use the core language and defer to Python/R to conform to
+     * SOMA-API syntax.
+     */
+    bool has_current_domain() const {
+        return !_get_current_domain().is_empty();
+    }
+
+    /**
+     * Returns the SOMA domain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     */
+    template <typename T>
+    std::pair<T, T> soma_domain_slot(const std::string& name) const {
+        if (has_current_domain()) {
+            return core_current_domain_slot<T>(name);
+        } else {
+            return core_domain_slot<T>(name);
+        }
+    }
+
+    /**
+     * Returns the SOMA maxdomain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma maxdomain is core domain
+     */
+    template <typename T>
+    std::pair<T, T> soma_maxdomain_slot(const std::string& name) const {
+        return core_domain_slot<T>(name);
+    }
+
+    /**
+     * Returns the core current domain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
      *
      * @tparam T Domain datatype
      * @return Pair of [lower, upper] inclusive bounds.
      */
     template <typename T>
-    std::pair<T, T> domain(const std::string& name) const {
+    std::pair<T, T> core_current_domain_slot(const std::string& name) const {
+        CurrentDomain current_domain = _get_current_domain();
+        if (current_domain.is_empty()) {
+            throw TileDBSOMAError(
+                "core_current_domain_slot: internal coding error");
+        }
+        if (current_domain.type() != TILEDB_NDRECTANGLE) {
+            throw TileDBSOMAError(
+                "core_current_domain_slot: found non-rectangle type");
+        }
+        NDRectangle ndrect = current_domain.ndrectangle();
+
+        // Convert from two-element array (core API) to pair (tiledbsoma API)
+        std::array<T, 2> arr = ndrect.range<T>(name);
+        return std::pair<T, T>(arr[0], arr[1]);
+    }
+
+    /**
+     * Returns the core current domain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_domain_slot(const std::string& name) const {
         return arr_->schema().domain().dimension(name).domain<T>();
     }
 
@@ -817,25 +906,6 @@ class SOMAArray : public SOMAObject {
      */
     void maybe_resize_soma_joinid(const std::vector<int64_t>& newshape);
 
-    /**
-     * Exposed for testing purposes.
-     */
-    CurrentDomain get_current_domain() {
-        return _get_current_domain();
-    }
-
-    /**
-     * @brief Returns true if the array has a non-empty current domain, else
-     * false.  Note that at the core level it's "current domain" for all arrays;
-     * at the SOMA-API level it's "upgraded_shape" for SOMASparseNDArray and
-     * SOMADenseNDArray, and "upgraded_domain" for SOMADataFrame; here
-     * we use the core language and defer to Python/R to conform to
-     * SOMA-API syntax.
-     */
-    bool has_current_domain() {
-        return !_get_current_domain().is_empty();
-    }
-
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in
     // its entirety to SOMADataFrame, but it would entail moving several
@@ -871,7 +941,7 @@ class SOMAArray : public SOMAObject {
      * We could implement this as a std::optional<CurrentDomain> return value
      * here, but, that would be a redundant indicator.
      */
-    CurrentDomain _get_current_domain() {
+    CurrentDomain _get_current_domain() const {
         return tiledb::ArraySchemaExperimental::current_domain(
             *ctx_->tiledb_ctx(), arr_->schema());
     }

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -803,8 +803,7 @@ class SOMAArray : public SOMAObject {
         NDRectangle ndrect = current_domain.ndrectangle();
 
         // Convert from two-element array (core API) to pair (tiledbsoma API)
-        std::array<T, 2> arr = ndrect.range<T>(name);
-        return std::pair<T, T>(arr[0], arr[1]);
+        return std::make_pair(arr[0], arr[1]);
     }
 
     /**


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

* Exposed SOMA-level `domain` and `maxdomain` to Python
* Reduce name-confusion in C++ via explicit and well-commented delgation

**Notes for Reviewer:**

There is no R counterpart on this PR (compare #2951 which is at parity):

* TileDB-SOMA-R has no `domain` accessor for arrays, and so nothing to put a `maxdomain` next to
* TileDB-SOMA-R is still [going through TileDB-R](https://github.com/single-cell-data/TileDB-SOMA/blob/1e2b13170bfc905483365549fe904cf93e472922/apis/r/R/TileDBArray.R#L132-L137), not libtiledbsoma, for its `$dimensions()` accessor
* Also note (relatedly) TileDB-SOMA-R doesn't support the `domain` argument to `SOMADataFrame`'s `create` as TileDB-SOMA-Py does -- I'll file a tracking issue

```
> sdf <- SOMAOpen('/var/p/obs')

> sdf$ TAB-COMPLETION
sdf$.__enclos_env__              sdf$dimensions                   sdf$ndim                         sdf$soma_type
sdf$.maybe_soma_joinid_maxshape  sdf$dimnames                     sdf$non_empty_domain             sdf$tiledb_array
sdf$.maybe_soma_joinid_shape     sdf$exists                       sdf$object                       sdf$tiledb_schema
sdf$.tiledb_timestamp_range      sdf$fragment_count               sdf$open                         sdf$tiledb_timestamp
sdf$attributes                   sdf$get_metadata                 sdf$platform_config              sdf$tiledbsoma_ctx
sdf$attrnames                    sdf$has_upgraded_domain          sdf$print                        sdf$update
sdf$class                        sdf$index_column_names           sdf$read                         sdf$uri
sdf$clone                        sdf$initialize                   sdf$reopen                       sdf$used_shape
sdf$close                        sdf$is_open                      sdf$schema                       sdf$write
sdf$colnames                     sdf$maxshape                     sdf$set_metadata
sdf$create                       sdf$mode                         sdf$shape

> sdf$dimensions()
$soma_joinid
tiledb_dim(name="soma_joinid", domain=c(0L,2147483646L), tile=2048L, type="INT64", filter_list=tiledb_filter_list(c(tiledb_filter_set_option(tiledb_filter("ZSTD"),"COMPRESSION_LEVEL",3))))
```