### PR TITLE
[python] Expose tiledbsoma stats as JSON string or Python-parsed

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -172,6 +172,10 @@ from .pytiledbsoma import (
     tiledbsoma_stats_enable,
     tiledbsoma_stats_reset,
 )
+from .stats import (
+    tiledbsoma_stats_json,
+    tiledbsoma_stats_parsed,
+)
 
 __version__ = get_implementation_version()
 

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -174,7 +174,7 @@ from .pytiledbsoma import (
 )
 from .stats import (
     tiledbsoma_stats_json,
-    tiledbsoma_stats_parsed,
+    tiledbsoma_stats_as_py,
 )
 
 __version__ = get_implementation_version()

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -98,6 +98,13 @@ PYBIND11_MODULE(pytiledbsoma, m) {
             py::print(stats);
         },
         "Print TileDB internal statistics. Lifecycle: experimental.");
+    m.def(
+        "tiledbsoma_stats_string",
+        []() {
+            std::string stats = tiledbsoma::stats::dump();
+            return stats;
+        },
+        "Print TileDB internal statistics. Lifecycle: experimental.");
 
     py::class_<PlatformConfig>(m, "PlatformConfig")
         .def(py::init<>())

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+
+import json
+from typing import Any, List, cast
+
+from .pytiledbsoma import tiledbsoma_stats_string
+
+
+def tiledbsoma_stats_json() -> str:
+    """Returns tiledbsoma stats as a JSON string"""
+    # cast is needed for pybind11 things
+    return cast(str, tiledbsoma_stats_string())
+
+
+def tiledbsoma_stats_parsed() -> List[Any]:
+    """Returns tiledbsoma stats as a Python dict"""
+    # cast is needed for pybind11 things
+    return cast(List[Any], json.loads(tiledbsoma_stats_string()))

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License.
 
 import json
-from typing import Any, List, cast
+from typing import Dict, List, Literal, Union, cast
 
 from .pytiledbsoma import tiledbsoma_stats_string
+
+ParsedStats = List[Dict[Literal["counters", "timers"], Dict[str, Union[float, int]]]]
 
 
 def tiledbsoma_stats_json() -> str:
@@ -14,7 +16,7 @@ def tiledbsoma_stats_json() -> str:
     return cast(str, tiledbsoma_stats_string())
 
 
-def tiledbsoma_stats_parsed() -> List[Any]:
+def tiledbsoma_stats_as_py() -> ParsedStats:
     """Returns tiledbsoma stats as a Python dict"""
     # cast is needed for pybind11 things
-    return cast(List[Any], json.loads(tiledbsoma_stats_string()))
+    return cast(ParsedStats, json.loads(tiledbsoma_stats_string()))

--- a/apis/python/tests/test_stats.py
+++ b/apis/python/tests/test_stats.py
@@ -1,0 +1,14 @@
+import tiledbsoma
+
+
+def test_stats_json():
+    out = tiledbsoma.tiledbsoma_stats_json()
+    assert isinstance(out, str)
+    assert out[0] == "["
+    assert out[-2] == "]"
+    assert out[-1] == "\n"
+
+
+def test_stats_parsed():
+    out = tiledbsoma.tiledbsoma_stats_parsed()
+    assert isinstance(out, list)

--- a/apis/python/tests/test_stats.py
+++ b/apis/python/tests/test_stats.py
@@ -9,6 +9,6 @@ def test_stats_json():
     assert out[-1] == "\n"
 
 
-def test_stats_parsed():
-    out = tiledbsoma.tiledbsoma_stats_parsed()
+def test_stats_as_py():
+    out = tiledbsoma.tiledbsoma_stats_as_py()
     assert isinstance(out, list)


### PR DESCRIPTION
**Issue and/or context:** [[sc-54474]](https://app.shortcut.com/tiledb-inc/story/54474/python-tiledb-stats-dump-needs-ability-to-return-stats-as-a-data-structure)

**Changes:**

`tiledbsoma_stats_dump` prints to stdout, with a header. We should have an option to get just the JSON, as a string.

**Notes for Reviewer:**

Demo:

```
>>> print(tiledbsoma.tiledbsoma_stats_json())
[
  {
    "timers": {
      "Context.StorageManager.load_group_from_all_uris.sum": 0.00176317,
      "Context.StorageManager.load_group_from_all_uris.avg": 0.000440792,
      "Context.StorageManager.load_group_details.sum": 0.00189163,
      "Context.StorageManager.load_group_details.avg": 0.000472906,
      "Context.StorageManager.group_open_for_reads.sum": 0.00189546,
      "Context.StorageManager.group_open_for_reads.avg": 0.000473865,
      "Context.StorageManager.group_load_metadata_from_storage.sum": 0.000687458,
      "Context.StorageManager.group_load_metadata_from_storage.avg": 0.000171865
    },
    "counters": {
      "Context.StorageManager.read_unfiltered_byte_num": 1290,
      "Context.StorageManager.read_group_size": 612,
      "Context.StorageManager.group_read_group_meta_size": 678,
      "Context.StorageManager.VFS.read_ops_num": 27,
      "Context.StorageManager.VFS.read_byte_num": 1510,
      "Context.StorageManager.VFS.ls_num": 12
    }
  }
]

>>> for k,v in tiledbsoma.tiledbsoma_stats_as_py()[0]['timers'].items():
...     print(k, v)
...
Context.StorageManager.load_group_from_all_uris.sum 0.00176317
Context.StorageManager.load_group_from_all_uris.avg 0.000440792
Context.StorageManager.load_group_details.sum 0.00189163
Context.StorageManager.load_group_details.avg 0.000472906
Context.StorageManager.group_open_for_reads.sum 0.00189546
Context.StorageManager.group_open_for_reads.avg 0.000473865
Context.StorageManager.group_load_metadata_from_storage.sum 0.000687458
Context.StorageManager.group_load_metadata_from_storage.avg 0.000171865
```