### PR TITLE
[python/r] Array-creation mods for new shape

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -129,12 +129,19 @@ jobs:
       env:
         TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
 
-    - name: Run pytests for Python
+    - name: Run pytests for Python without new shape
       shell: bash
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
       run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20
+
+    - name: Run pytests for Python with new shape
+      shell: bash
+      # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
+      # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
+      # coverage analysis to work.
+      run: export SOMA_PY_NEW_SHAPE=true; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -148,10 +148,15 @@ jobs:
       #      -e "devtools::install(upgrade = FALSE)" \
       #      -e "testthat::test_local('tests/testthat', load_package = 'installed')"
 
-      - name: Test
+      - name: Test without new shape
         if: ${{ matrix.covr == 'no' }}
         run: cd apis/r/tests && Rscript testthat.R
-      
+
+      # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+      - name: Test with new shape
+        if: ${{ matrix.covr == 'no' }}
+        run: export SOMA_R_NEW_SHAPE=true && cd apis/r/tests && Rscript testthat.R
+
       - name: Coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}
         run: apis/r/tools/r-ci.sh coverage

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -97,6 +97,18 @@ import ctypes
 import os
 import sys
 
+# Temporary for https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+_new_shape_feature_flag = os.getenv("SOMA_PY_NEW_SHAPE") is not None
+
+
+def _new_shape_feature_flag_enabled() -> bool:
+    """
+    This is temporary only and will be removed once
+    https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    is complete.
+    """
+    return _new_shape_feature_flag
+
 
 # Load native libraries. On wheel builds, we may have a shared library
 # already linked. In this case, we can import directly

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -14,6 +14,8 @@ import somacore
 from somacore import options
 from typing_extensions import Self
 
+from tiledbsoma import _new_shape_feature_flag_enabled
+
 from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_JOINID
@@ -215,10 +217,33 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         context = _validate_soma_tiledb_context(context)
         schema = _canonicalize_schema(schema, index_column_names)
-        if domain is None:
-            domain = tuple(None for _ in index_column_names)
+
+        # SOMA-to-core mappings:
+        #
+        # Before the current-domain feature was enabled (possible after core 2.25):
+        #
+        # * SOMA domain <-> core domain, AKA "max domain" which is a name we'll use for clarity
+        # * core current domain did not exist
+        #
+        # After the current-domain feature was enabled:
+        #
+        # * SOMA max_domain <-> core domain
+        # * SOMA domain <-> core current domain
+        #
+        # As far as the user is concerned, the SOMA-level domain is the only
+        # thing they see and care about. Before 2.25 support, it was immutable
+        # (since it was implemented by core domain). After 2.25 support, it is
+        # mutable/up-resizeable (since it is implemented by core current domain).
+
+        # At this point shift from API terminology "domain" to specifying a soma_ or core_
+        # prefix for these variables. This is crucial to avoid developer confusion.
+        soma_domain = domain
+        domain = None
+
+        if soma_domain is None:
+            soma_domain = tuple(None for _ in index_column_names)
         else:
-            ndom = len(domain)
+            ndom = len(soma_domain)
             nidx = len(index_column_names)
             if ndom != nidx:
                 raise ValueError(
@@ -228,25 +253,56 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         index_column_schema = []
         index_column_data = {}
 
-        for index_column_name, slot_domain in zip(index_column_names, domain):
+        for index_column_name, slot_soma_domain in zip(index_column_names, soma_domain):
             pa_field = schema.field(index_column_name)
             dtype = _arrow_types.tiledb_type_from_arrow_type(
                 pa_field.type, is_indexed_column=True
             )
 
-            slot_domain = _fill_out_slot_domain(
-                slot_domain, index_column_name, pa_field.type, dtype
+            (slot_core_current_domain, saturated_cd) = _fill_out_slot_soma_domain(
+                slot_soma_domain, index_column_name, pa_field.type, dtype
+            )
+            (slot_core_max_domain, saturated_md) = _fill_out_slot_soma_domain(
+                None, index_column_name, pa_field.type, dtype
             )
 
             extent = _find_extent_for_domain(
                 index_column_name,
                 TileDBCreateOptions.from_platform_config(platform_config),
                 dtype,
-                slot_domain,
+                slot_core_current_domain,
             )
 
+            # Necessary to avoid core array-creation error "Reduce domain max by
+            # 1 tile extent to allow for expansion."
+            slot_core_current_domain = _revise_domain_for_extent(
+                slot_core_current_domain, extent, saturated_cd
+            )
+            slot_core_max_domain = _revise_domain_for_extent(
+                slot_core_max_domain, extent, saturated_md
+            )
+
+            # Here is our Arrow data API for communicating schema info between
+            # Python/R and C++ libtiledbsoma:
+            #
+            # [0] core max domain lo
+            # [1] core max domain hi
+            # [2] core extent parameter
+            # If present, these next two signal to use the current-domain feature:
+            # [3] core current domain lo
+            # [4] core current domain hi
+
             index_column_schema.append(pa_field)
-            index_column_data[pa_field.name] = [*slot_domain, extent]
+            if _new_shape_feature_flag_enabled():
+
+                index_column_data[pa_field.name] = [
+                    *slot_core_max_domain,
+                    extent,
+                    *slot_core_current_domain,
+                ]
+
+            else:
+                index_column_data[pa_field.name] = [*slot_core_current_domain, extent]
 
         index_column_info = pa.RecordBatch.from_pydict(
             index_column_data, schema=pa.schema(index_column_schema)
@@ -718,17 +774,20 @@ def _canonicalize_schema(
     return schema
 
 
-def _fill_out_slot_domain(
+def _fill_out_slot_soma_domain(
     slot_domain: AxisDomain,
     index_column_name: str,
     pa_type: pa.DataType,
     dtype: Any,
-) -> Tuple[Any, Any]:
+) -> Tuple[Tuple[Any, Any], bool]:
     """Helper function for _build_tiledb_schema. Given a user-specified domain for a
     dimension slot -- which may be ``None``, or a two-tuple of which either element
     may be ``None`` -- return either what the user specified (if adequate) or
     sensible type-inferred values appropriate to the datatype.
+
+    Returns a boolean for whether the underlying datatype's max range was used.
     """
+    saturated_range = False
     if slot_domain is not None:
         # User-specified; go with it when possible
         if (
@@ -769,9 +828,12 @@ def _fill_out_slot_domain(
         # The SOMA spec disallows negative soma_joinid.
         if index_column_name == SOMA_JOINID:
             slot_domain = (0, 2**31 - 2)  # R-friendly, which 2**63-1 is not
+        else:
+            saturated_range = True
     elif np.issubdtype(dtype, NPFloating):
         finfo = np.finfo(cast(NPFloating, dtype))
         slot_domain = finfo.min, finfo.max
+        saturated_range = True
 
     # The `iinfo.min+1` is necessary as of tiledb core 2.15 / tiledb-py 0.21.1 since
     # `iinfo.min` maps to `NaT` (not a time), resulting in
@@ -806,7 +868,7 @@ def _fill_out_slot_domain(
     else:
         raise TypeError(f"Unsupported dtype {dtype}")
 
-    return slot_domain
+    return (slot_domain, saturated_range)
 
 
 def _find_extent_for_domain(
@@ -823,7 +885,7 @@ def _find_extent_for_domain(
     # Default 2048 mods to 0 for 8-bit types and 0 is an invalid extent
     extent = tiledb_create_write_options.dim_tile(index_column_name)
     if isinstance(dtype, np.dtype) and dtype.itemsize == 1:
-        extent = 64
+        extent = 1
 
     if isinstance(dtype, str):
         return ""
@@ -860,3 +922,17 @@ def _find_extent_for_domain(
         return np.datetime64(iextent, "ns")
 
     return extent
+
+
+# We need to do this to avoid this error at array-creation time:
+#
+# Error: Tile extent check failed; domain max expanded to multiple of tile
+# extent exceeds max value representable by domain type. Reduce domain max
+# by 1 tile extent to allow for expansion.
+def _revise_domain_for_extent(
+    domain: Tuple[Any, Any], extent: Any, saturated_range: bool
+) -> Tuple[Any, Any]:
+    if saturated_range:
+        return (domain[0], domain[1] - extent)
+    else:
+        return domain

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -626,14 +626,18 @@ void load_soma_array(py::module& m) {
                 py::gil_scoped_release release;
 
                 // Try to read more data
-                auto buffers = array.read_next();
+                try {
+                    auto buffers = array.read_next();
 
-                // If more data was read, convert it to an arrow table and
-                // return
-                if (buffers.has_value()) {
-                    // Acquire python GIL before accessing python objects
-                    py::gil_scoped_acquire acquire;
-                    return to_table(*buffers);
+                    // If more data was read, convert it to an arrow table and
+                    // return
+                    if (buffers.has_value()) {
+                        // Acquire python GIL before accessing python objects
+                        py::gil_scoped_acquire acquire;
+                        return to_table(*buffers);
+                    }
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
                 }
 
                 // No data was read, the query is complete, return nullopt

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -91,7 +91,7 @@ def test_dataframe(tmp_path, arrow_schema):
         assert len(sdf) == 5
 
         # More to come on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-        assert not sdf.has_upgraded_domain
+        assert sdf.has_upgraded_domain == soma._new_shape_feature_flag_enabled()
 
         with pytest.raises(AttributeError):
             assert sdf.shape is None

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1070,8 +1070,9 @@ def test_bad_coords(tmp_path, bad_coords):
 
 
 def test_tile_extents(tmp_path):
+    uri = tmp_path.as_posix()
     soma.SparseNDArray.create(
-        tmp_path.as_posix(),
+        uri,
         type=pa.float32(),
         shape=(100, 10000),
         platform_config={
@@ -1086,9 +1087,13 @@ def test_tile_extents(tmp_path):
         },
     ).close()
 
-    with tiledb.open(tmp_path.as_posix()) as A:
-        assert A.schema.domain.dim(0).tile == 100
-        assert A.schema.domain.dim(1).tile == 2048
+    with tiledb.open(uri) as A:
+        if soma._new_shape_feature_flag_enabled():
+            assert A.schema.domain.dim(0).tile == 2048
+            assert A.schema.domain.dim(1).tile == 2048
+        else:
+            assert A.schema.domain.dim(0).tile == 100
+            assert A.schema.domain.dim(1).tile == 2048
 
 
 @pytest.mark.parametrize(

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -17,6 +17,39 @@
                        sQuote(rpkg_lib_version), sQuote(soma_lib_version))
         stop(msg, call. = FALSE)
     }
+
+    # This is temporary for https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    # It will be removed once 2407 is complete.
+    if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {
+      .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
+      cdmsg <- " SOMA_R_NEW_SHAPE enabled"
+    } else {
+      .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
+      cdmsg <- ""
+    }
+     msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s [%s]",
+                    sQuote(rpkg_lib_version), sQuote(soma_lib_version), sQuote(cdmsg))
+}
+
+# This is temporary only. Please see:
+# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+.new_shape_feature_flag_enable <- function() {
+    .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
+}
+
+# This is temporary only. Please see:
+# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+.new_shape_feature_flag_disable <- function() {
+    .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
+}
+
+# This is temporary only. Please see:
+# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
+.new_shape_feature_flag_is_enabled <- function() {
+    .pkgenv[["use_current_domain_transitional_internal_only"]]
 }
 
 ## An .onAttach() function is not allowed to use cat() etc but _must_ communicate via

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -22,27 +22,13 @@
     # It will be removed once 2407 is complete.
     if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {
       .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
-      cdmsg <- " SOMA_R_NEW_SHAPE enabled"
     } else {
       .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
-      cdmsg <- ""
     }
-     msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s [%s]",
-                    sQuote(rpkg_lib_version), sQuote(soma_lib_version), sQuote(cdmsg))
-}
-
-# This is temporary only. Please see:
-# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
-.new_shape_feature_flag_enable <- function() {
-    .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
-}
-
-# This is temporary only. Please see:
-# * https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-# * https://github.com/single-cell-data/TileDB-SOMA/pull/2950
-.new_shape_feature_flag_disable <- function() {
-    .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
+    if (rpkg_lib_version != soma_lib_version) {
+      msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s [%s]",
+                     sQuote(rpkg_lib_version), sQuote(soma_lib_version), sQuote(cdmsg))
+    }
 }
 
 # This is temporary only. Please see:

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -39,7 +39,7 @@ SOMANDArrayBase <- R6::R6Class(
 
       #spdl::warn("[SOMANDArrayBase::create] type cached as {}", private$.type)
 
-      dom_ext_tbl <- get_domain_and_extent_array(shape)
+      dom_ext_tbl <- get_domain_and_extent_array(shape, private$.is_sparse)
 
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
@@ -133,6 +133,21 @@ SOMANDArrayBase <- R6::R6Class(
       coords <- lapply(coords, function(x) if (inherits(x, "integer")) bit64::as.integer64(x) else x)
 
       coords
+    },
+
+    #  @description Converts a vector of ints into a vector of int64 in a format
+    #  acceptable for libtiledbsoma
+
+    .convert_shape_argument = function(newshape) {
+
+      ## ensure newshape is a vector of int64
+      stopifnot("'newshape' must be a vector of integers" = is.vector(newshape));
+                # XXX "'newshape' must be a vector of integers" = all(vapply_lgl(newshape, is.integer)),
+
+      ## convert integer to integer64 to match dimension type
+      newshape <- lapply(newshape, function(x) if (inherits(x, "integer")) bit64::as.integer64(x) else x)
+
+      as.vector(newshape)
     },
 
     # Internal marking of one or zero based matrices for iterated reads

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -138,16 +138,15 @@ SOMANDArrayBase <- R6::R6Class(
     #  @description Converts a vector of ints into a vector of int64 in a format
     #  acceptable for libtiledbsoma
 
-    .convert_shape_argument = function(newshape) {
+    .convert_shape_argument = function(new_shape) {
+      # ensure new_shape is an integerish vector
+      stopifnot(
+        "'new_shape' must be an integerish vector with the same length as the array's maxshape" = rlang::is_integerish(new_shape, n = self$ndim(), finite = TRUE) ||
+          (bit64::is.integer64(new_shape) && length(new_shape) == self$ndim() && all(is.finite(new_shape)))
+      )
 
-      ## ensure newshape is a vector of int64
-      stopifnot("'newshape' must be a vector of integers" = is.vector(newshape));
-                # XXX "'newshape' must be a vector of integers" = all(vapply_lgl(newshape, is.integer)),
-
-      ## convert integer to integer64 to match dimension type
-      newshape <- lapply(newshape, function(x) if (inherits(x, "integer")) bit64::as.integer64(x) else x)
-
-      as.vector(newshape)
+      # convert integer to integer64 to match dimension type
+      return(bit64::as.integer64(new_shape))
     },
 
     # Internal marking of one or zero based matrices for iterated reads

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -382,7 +382,7 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
         if (ind_col_type_name %in% c("string", "large_utf8", "utf8")) ind_ext <- NA
 
         # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-        if (.pkgenv[["use_current_domain_transitional_internal_only"]]) {
+        if (.new_shape_feature_flag_is_enabled()) {
             if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
                 aa <- arrow::arrow_array(c("", "", "", "", ""), ind_col_type)
             } else {
@@ -433,7 +433,7 @@ get_domain_and_extent_array <- function(shape, is_sparse) {
         # TODO: support current domain for dense arrays once we have that support
         # from core.
         # https://github.com/single-cell-data/TileDB-SOMA/issues/2955
-        if (.pkgenv[["use_current_domain_transitional_internal_only"]] && is_sparse) {
+        if (.new_shape_feature_flag_is_enabled() && is_sparse) {
             aa <- arrow::arrow_array(c(ind_max_dom, ind_ext, ind_cur_dom), ind_col_type)
         } else {
             aa <- arrow::arrow_array(c(ind_cur_dom, ind_ext), ind_col_type)

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -360,18 +360,42 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
         ind_col <- tbl_schema$GetFieldByName(ind_col_name)
         ind_col_type <- ind_col$type
         ind_col_type_name <- ind_col$type$name
-        ind_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,1) ## FIXME
+
+        # TODO: tiledbsoma-r does not accept the domain argument to SOMADataFrame::create, but should
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2967
         ind_ext <- tdco$dim_tile(ind_col_name)
-        if (ind_col_type_name %in% c("string", "large_utf8", "utf8")) ind_ext <- NA
+
         # Default 2048 mods to 0 for 8-bit types and 0 is an invalid extent
         if (ind_col$type$bit_width %||% 0L == 8L) {
             ind_ext <- 64L
         }
-        if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
-            aa <- arrow::arrow_array(c("", "", ""), ind_col_type)
+
+        # We need to do this because if we don't:
+        #
+        # Error: [TileDB::Dimension] Error: Tile extent check failed; domain max
+        # expanded to multiple of tile extent exceeds max value representable by
+        # domain type. Reduce domain max by 1 tile extent to allow for
+        # expansion.
+        ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,ind_ext)
+
+        ind_cur_dom <- ind_max_dom
+        if (ind_col_type_name %in% c("string", "large_utf8", "utf8")) ind_ext <- NA
+
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        if (.pkgenv[["use_current_domain_transitional_internal_only"]]) {
+            if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
+                aa <- arrow::arrow_array(c("", "", "", "", ""), ind_col_type)
+            } else {
+                aa <- arrow::arrow_array(c(ind_max_dom, ind_ext, ind_cur_dom), ind_col_type)
+            }
         } else {
-            aa <- arrow::arrow_array(c(ind_dom, ind_ext), ind_col_type)
+            if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
+                aa <- arrow::arrow_array(c("", "", ""), ind_col_type)
+            } else {
+                aa <- arrow::arrow_array(c(ind_max_dom, ind_ext), ind_col_type)
+            }
         }
+
         aa
     })
     names(rl) <- ind_col_names
@@ -382,15 +406,39 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
 #' Domain and extent table creation helper for array writes returning a Table with
 #' a column per dimension for the given (incoming) arrow schema of a Table
 #' @noRd
-get_domain_and_extent_array <- function(shape) {
+get_domain_and_extent_array <- function(shape, is_sparse) {
     stopifnot("First argument must be vector of positive values" = is.vector(shape) && all(shape > 0))
     indvec <- seq_len(length(shape)) - 1   # sequence 0, ..., length()-1
     rl <- sapply(indvec, \(ind) {
         ind_col <- sprintf("soma_dim_%d", ind)
         ind_col_type <- arrow::int64()
-        ind_dom <- c(0L, shape[ind+1] - 1L)
+
+        # TODO:  this function needs to take a
+        # TileDBCreateOptions$new(PlatformConfig option as
+        # get_domain_and_extent_dataframe does.
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2966
+        # For now, the core extent is not taken from the platform_config.
         ind_ext <- shape[ind+1]
-        aa <- arrow::arrow_array(c(ind_dom, ind_ext), ind_col_type)
+
+        ind_cur_dom <- c(0L, shape[ind+1] - 1L)
+
+        # We need to do this because if we don't:
+        #
+        # Error: [TileDB::Dimension] Error: Tile extent check failed; domain max
+        # expanded to multiple of tile extent exceeds max value representable by
+        # domain type. Reduce domain max by 1 tile extent to allow for
+        # expansion.
+        ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,ind_ext)
+
+        # TODO: support current domain for dense arrays once we have that support
+        # from core.
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2955
+        if (.pkgenv[["use_current_domain_transitional_internal_only"]] && is_sparse) {
+            aa <- arrow::arrow_array(c(ind_max_dom, ind_ext, ind_cur_dom), ind_col_type)
+        } else {
+            aa <- arrow::arrow_array(c(ind_cur_dom, ind_ext), ind_col_type)
+        }
+
         aa
     })
     names(rl) <- sprintf("soma_dim_%d", indvec)

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -62,7 +62,11 @@ test_that("SOMASparseNDArray creation", {
   ## maxshape
   # TODO: more testing with current-domain feature integrated
   # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-  expect_false(ndarray$has_upgraded_shape())
+  if (.new_shape_feature_flag_is_enabled()) {
+    expect_true(ndarray$has_upgraded_shape())
+  } else {
+    expect_false(ndarray$has_upgraded_shape())
+  }
   shape <- ndarray$shape()
   maxshape <- ndarray$maxshape()
   expect_equal(length(shape), length(maxshape))

--- a/apis/r/tests/testthat/test-shape.r
+++ b/apis/r/tests/testthat/test-shape.r
@@ -30,7 +30,11 @@ test_that("SOMADataFrame shape", {
 
     sdf <- SOMADataFrameOpen(uri)
 
-    expect_false(sdf$has_upgraded_domain())
+    if (.new_shape_feature_flag_is_enabled()) {
+      expect_true(sdf$has_upgraded_domain())
+    } else {
+      expect_false(sdf$has_upgraded_domain())
+    }
     expect_error(sdf$shape(), class = "notYetImplementedError")
     expect_error(sdf$maxshape(), class = "notYetImplementedError")
 
@@ -83,11 +87,9 @@ test_that("SOMASparseNDArray shape", {
       readback_shape <- ndarray$shape()
       readback_maxshape <- ndarray$maxshape()
       expect_equal(length(readback_shape), length(readback_maxshape))
-      for (i in 1:length(shape)) {
-        s <- as.integer(readback_shape[[i]])
-        ms <- as.integer(readback_maxshape[[i]])
-        expect_true(s <= ms)
-      }
+      # We can't as.integer things that don't fit in a 32-bit int -- they come
+      # back as NA. :(
+      expect_true(all(readback_shape <= readback_maxshape))
 
       # Resize tests upcoming on
       # https://github.com/single-cell-data/TileDB-SOMA/issues/2407


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

* Array-creation mods including the crucial arrow-table link are already bullet-proof tested in C++ on #2911 
* More unit-test cases for Python and R are upcoming on #2407
* The status-quo code and the opt-in to-be-released-later code are both tested in CI
* There are further upcoming PRs as tracked on #2407

**Notes for Reviewer:**

