### PR TITLE
[python] Fix nightly-build failure

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -32,6 +32,13 @@ PYBIND11_MODULE(pytiledbsoma, m) {
 
     /* We need to make sure C++ TileDBSOMAError is translated to a
      * correctly-typed Python error
+     *
+     * We're aware of
+     * https://pybind11.readthedocs.io/en/stable/advanced/exceptions.html
+     * -- we find empirically that despite this translator, we still
+     * find it necessary to do explicit catch-and-rethrow within our
+     * pybind11 functions. See also
+     * https://github.com/single-cell-data/TileDB-SOMA/pull/2963
      */
     py::register_exception_translator([](std::exception_ptr p) {
         auto tiledb_soma_error = (py::object)py::module::import("tiledbsoma")

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -247,62 +247,67 @@ void load_soma_array(py::module& m) {
 
                     auto coords = array_handle.attr("tolist")();
 
-                    if (!strcmp(arrow_schema.format, "l")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<int64_t>>());
-                    } else if (!strcmp(arrow_schema.format, "i")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<int32_t>>());
-                    } else if (!strcmp(arrow_schema.format, "s")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<int16_t>>());
-                    } else if (!strcmp(arrow_schema.format, "c")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<int8_t>>());
-                    } else if (!strcmp(arrow_schema.format, "L")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<uint64_t>>());
-                    } else if (!strcmp(arrow_schema.format, "I")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<uint32_t>>());
-                    } else if (!strcmp(arrow_schema.format, "S")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<uint16_t>>());
-                    } else if (!strcmp(arrow_schema.format, "C")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<uint8_t>>());
-                    } else if (!strcmp(arrow_schema.format, "f")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<float>>());
-                    } else if (!strcmp(arrow_schema.format, "g")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<double>>());
-                    } else if (
-                        !strcmp(arrow_schema.format, "u") ||
-                        !strcmp(arrow_schema.format, "z")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<std::string>>());
-                    } else if (
-                        !strcmp(arrow_schema.format, "tss:") ||
-                        !strcmp(arrow_schema.format, "tsm:") ||
-                        !strcmp(arrow_schema.format, "tsu:") ||
-                        !strcmp(arrow_schema.format, "tsn:")) {
-                        // convert the Arrow Array to int64
-                        auto pa = py::module::import("pyarrow");
-                        coords = array_handle.attr("cast")(pa.attr("int64")())
-                                     .attr("tolist")();
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<int64_t>>());
-                    } else if (
-                        !strcmp(arrow_schema.format, "U") ||
-                        !strcmp(arrow_schema.format, "Z")) {
-                        array.set_dim_points(
-                            dim, coords.cast<std::vector<std::string>>());
-                    } else {
-                        TPY_ERROR_LOC(
-                            "[pytiledbsoma] set_dim_points: type={} not "
-                            "supported" +
-                            std::string(arrow_schema.format));
+                    try {
+                        if (!strcmp(arrow_schema.format, "l")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<int64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "i")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<int32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "s")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<int16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "c")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<int8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "L")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<uint64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "I")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<uint32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "S")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<uint16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "C")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<uint8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "f")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<float>>());
+                        } else if (!strcmp(arrow_schema.format, "g")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<double>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "u") ||
+                            !strcmp(arrow_schema.format, "z")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<std::string>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "tss:") ||
+                            !strcmp(arrow_schema.format, "tsm:") ||
+                            !strcmp(arrow_schema.format, "tsu:") ||
+                            !strcmp(arrow_schema.format, "tsn:")) {
+                            // convert the Arrow Array to int64
+                            auto pa = py::module::import("pyarrow");
+                            coords = array_handle
+                                         .attr("cast")(pa.attr("int64")())
+                                         .attr("tolist")();
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<int64_t>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "U") ||
+                            !strcmp(arrow_schema.format, "Z")) {
+                            array.set_dim_points(
+                                dim, coords.cast<std::vector<std::string>>());
+                        } else {
+                            TPY_ERROR_LOC(
+                                "[pytiledbsoma] set_dim_points: type={} not "
+                                "supported" +
+                                std::string(arrow_schema.format));
+                        }
+                    } catch (const std::exception& e) {
+                        throw TileDBSOMAError(e.what());
                     }
 
                     // Release arrow schema

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -337,69 +337,135 @@ void load_soma_array(py::module& m) {
 
         .def(
             "set_dim_points_string_or_bytes",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<std::string>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::string>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_double",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<double>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<double>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_float",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<float>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<float>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_int64",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<int64_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<int64_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_int32",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<int32_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<int32_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_int16",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<int16_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<int16_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_int8",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<int8_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<int8_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_uint64",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<uint64_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<uint64_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_uint32",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<uint32_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<uint32_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_uint16",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<uint16_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<uint16_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_points_uint8",
-            static_cast<void (SOMAArray::*)(
-                const std::string&, const std::vector<uint8_t>&)>(
-                &SOMAArray::set_dim_points))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<uint8_t>& points) {
+                try {
+                    array.set_dim_points(dim, points);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         // In an initial version of this file we had `set_dim_ranges` relying
         // solely on type-overloading. This worked since we supported only int
@@ -416,80 +482,135 @@ void load_soma_array(py::module& m) {
 
         .def(
             "set_dim_ranges_string_or_bytes",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<std::string, std::string>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_int64",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<int64_t, int64_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_int32",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<int32_t, int32_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_int16",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<int16_t, int16_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_int8",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<int8_t, int8_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_uint64",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<uint64_t, uint64_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_uint32",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<uint32_t, uint32_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_uint16",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<uint16_t, uint16_t>>&)>(
-                &SOMAArray::set_dim_ranges))
-
-        .def(
-            "set_dim_ranges_uint8",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<uint8_t, uint8_t>>&)>(
-                &SOMAArray::set_dim_ranges))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<std::string, std::string>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_ranges_double",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<double, double>>&)>(
-                &SOMAArray::set_dim_ranges))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<double, double>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def(
             "set_dim_ranges_float",
-            static_cast<void (SOMAArray::*)(
-                const std::string&,
-                const std::vector<std::pair<float, float>>&)>(
-                &SOMAArray::set_dim_ranges))
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<float, float>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_int64",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<int64_t, int64_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_int32",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<int32_t, int32_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_int16",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<int16_t, int16_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_int8",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<int8_t, int8_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_uint64",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<uint64_t, uint64_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_uint32",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_uint16",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<uint16_t, uint16_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
+
+        .def(
+            "set_dim_ranges_uint8",
+            [](SOMAArray& array,
+               const std::string& dim,
+               const std::vector<std::pair<uint8_t, uint8_t>>& ranges) {
+                try {
+                    array.set_dim_ranges(dim, ranges);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            })
 
         .def("results_complete", &SOMAArray::results_complete)
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -736,7 +736,7 @@ def make_multiply_indexed_dataframe(tmp_path, index_column_names: List[str]):
             "index_column_names": ["strings_aaa", "zero_one"],
             "coords": [[True], slice(None)],
             "A": None,
-            "throws": (RuntimeError, tiledb.cc.TileDBError, TypeError),
+            "throws": TypeError,
         },
         {
             "name": "2D index empty",

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -3,7 +3,6 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
-import tiledb
 
 
 @pytest.fixture
@@ -1899,6 +1898,6 @@ def test_types_read_errors(
     with soma.DataFrame.open(uri, "w") as sdf:
         sdf.write(arrow_table)
 
-    with pytest.raises((RuntimeError, tiledb.cc.TileDBError)):
+    with pytest.raises((soma.SOMAError)):
         with soma.DataFrame.open(uri, "r") as sdf:
             sdf.read(coords=coords).concat()

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -311,13 +311,13 @@ def test_dense_nd_array_slicing(tmp_path, io):
             "name": "negative",
             "shape": (10,),
             "coords": (-1,),
-            "throws": (RuntimeError, tiledb.cc.TileDBError),
+            "throws": (soma.SOMAError),
         },
         {
             "name": "12 in 10 domain",
             "shape": (10,),
             "coords": (12,),
-            "throws": (RuntimeError, tiledb.cc.TileDBError),
+            "throws": (soma.SOMAError),
         },
         {
             "name": "too many dims",

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -98,9 +98,8 @@ def test_sparse_nd_array_basics(
 
     # Test reads out of bounds
     with tiledbsoma.SparseNDArray.open(uri) as snda:
-        # TODO: make sure this doesn't come through as RuntimeError
         # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises(tiledbsoma.SOMAError):
             coords = tuple(arg_shape[i] + 10 for i in range(ndim))
             snda.read(coords).tables().concat()
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -624,10 +624,7 @@ def test_csr_csc_2d_read(tmp_path, shape):
             "dims": {
                 "soma_dim_0": [2, 4],
             },
-            "throws": (
-                RuntimeError,
-                tiledb.cc.TileDBError,
-            ),
+            "throws": (soma.SOMAError),
         },
         {
             "name": "coords=[0,0]",


### PR DESCRIPTION
**Issue and/or context:** Resolves #2961 

**Changes:**

Do explicit try-catch. See also #783.

**Notes for Reviewer:**

It's not necessarily causal that this triggered on https://github.com/jdblischak/centralized-tiledb-nightlies/issues/21. It's true that the `apis/python/tests/test_shape.py` was recently introduced on the #2407 stack. However, whether un-rethrown errors (on implicit pybind body, as in the "before" parts of this PR) reach the Python level as `tiledbsoma.SOMAError` or `RuntimeError` or `tiledb.cc.TileDBError` has some element of randomness.

There's an attempt to globally register a rethrow:
https://github.com/single-cell-data/TileDB-SOMA/blob/1.13.1/apis/python/src/tiledbsoma/pytiledbsoma.cc#L36-L50

However, @nguyenv and I have long found that some things come through as `RuntimeError` on one machine, and `tiledb.cc.TileDBError` in another. We suspect that TileDB-Py's exception registrar has a race condition with our own.

Regardless, a safe practice is explicit catch-and-rethrow at the boundary between C++ and Python, which is what we do more of here.