### PR TITLE
[r] Fix bug in blockwise iterator

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.13.99.5
+Version: 1.13.99.6
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -5,6 +5,7 @@
 * Make use of timestamp ranges in libtiledbsoma
 * Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
 * Use cached timestamps in `$write()` and `$create()`
+* Fix bug in blockwise iteration
 
 # tiledbsoma 1.13.0
 

--- a/apis/r/R/CoordsStrider.R
+++ b/apis/r/R/CoordsStrider.R
@@ -86,7 +86,11 @@ CoordsStrider <- R6::R6Class(
     #'
     length = function() {
       if (is.null(self$coords)) {
-        return(as.numeric(abs(self$end - self$start)))
+        len <- as.numeric(abs(self$end - self$start))
+        if (!self$start) {
+          len <- len + 1L
+        }
+        return(len)
       }
       return(length(self$coords))
     },

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -25,7 +25,7 @@ SOMASparseNDArrayReadBase <- R6::R6Class(
         for (i in seq_along(private$.coords)) {
           private$.coords[[i]] <- CoordsStrider$new(
             start = 0L,
-            end = shape[i],
+            end = shape[i] - 1L,
             stride = .Machine$integer.max
           )
         }


### PR DESCRIPTION
When using the blockwise iterator, I get the following error on the last iteration's read:
```
Error: Subarray: Cannot add range to dimension 'soma_dim_0'; Range [2638, 2638] is out of domain bounds [0, 2637]
```
It turns out we were not handling 0-based coordinates correctly. When creating a new blockwise read, we would start at 0L, but then go up to `array$shape()[dimension]`, which is a 1-indexed value. This needed to be corrected to `array$shape()[dimension] - 1L`

However, this messed up calculating a dimension for the returning matrix; to get around this, if `coords$start == 0L`, we increase the length of the coords by 1 (eg. if the coordinates run from `[0, 499]`, then the length should be 500, not 499)

Modified SOMA methods:
 - `SOMASparseNDArray$new()`: decrease the end of the coordinate strider by 1
 - `CoordsStrider$length()`: if `coords$start` is 0, increase the length by 1

[SC-54350](https://app.shortcut.com/tiledb-inc/story/54350/)