### PR TITLE
[python] Trivial dead-strip

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -646,8 +646,6 @@ void load_soma_array(py::module& m) {
 
         .def("nnz", &SOMAArray::nnz, py::call_guard<py::gil_scoped_release>())
 
-        .def_property_readonly("shape", &SOMAArray::shape)
-
         .def_property_readonly("uri", &SOMAArray::uri)
 
         .def_property_readonly("column_names", &SOMAArray::column_names)


### PR DESCRIPTION
**Issue and/or context:** A minor item on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Since `SOMASparseNDArray` and `SOMADenseNDArray` have `shape` while `SOMADataFrame` has `domain`, what's exposed in Python is correct. However we have a dangling/unused `pybind11` hook for `SOMAArray`.

**Notes for Reviewer:**

```
$ grep '"shape"' *.cc
soma_array.cc:        .def_property_readonly("shape", &SOMAArray::shape)
soma_dense_ndarray.cc:        .def_property_readonly("shape", &SOMADenseNDArray::shape)
soma_sparse_ndarray.cc:        .def_property_readonly("shape", &SOMASparseNDArray::shape)