### PR TITLE
[python] Minor name-neaten in internals for `domain`/`maxdomain`

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -362,15 +362,15 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def ndim(self) -> int:
         return len(self._handle.dimension_names)
 
-    def _cast_domain(
-        self, domain: Callable[[str, DTypeLike], Tuple[object, object]]
+    def _get_and_cast_domain(
+        self, domain_slot_getter: Callable[[str, DTypeLike], Tuple[object, object]]
     ) -> Tuple[Tuple[object, object], ...]:
         result = []
         for name in self._handle.dimension_names:
             dtype = self._handle.schema.field(name).type
             if pa.types.is_timestamp(dtype):
                 np_dtype = np.dtype(dtype.to_pandas_dtype())
-                dom = domain(name, np_dtype)
+                dom = domain_slot_getter(name, np_dtype)
                 result.append(
                     (
                         np_dtype.type(dom[0], dtype.unit),
@@ -384,19 +384,19 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
                     dtype = np.dtype("S")
                 else:
                     dtype = np.dtype(dtype.to_pandas_dtype())
-                result.append(domain(name, dtype))
+                result.append(domain_slot_getter(name, dtype))
         return tuple(result)
 
     @property
     def domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domain(self._handle.domain)
+        return self._get_and_cast_domain(self._handle.soma_domain_slot)
 
     @property
     def maxdomain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domain(self._handle.maxdomain)
+        return self._get_and_cast_domain(self._handle.soma_maxdomain_slot)
 
     def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domain(self._handle.non_empty_domain) or ()
+        return self._get_and_cast_domain(self._handle.non_empty_domain) or ()
 
     @property
     def attr_names(self) -> Tuple[str, ...]:

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -719,7 +719,7 @@ void load_soma_array(py::module& m) {
             })
 
         .def(
-            "domain",
+            "soma_domain_slot",
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:
@@ -767,7 +767,7 @@ void load_soma_array(py::module& m) {
             })
 
         .def(
-            "maxdomain",
+            "soma_maxdomain_slot",
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

This is a minor deconfuse as I was trying to understand `SOMADataFrame`'s `domain` and `maxdomain` on the Python side in prep to port them to R.

**Notes for Reviewer:**

This is follow-on to #2957: this is a spot I missed there, and should (ideally) have done on that PR.