### PR TITLE
[r] Fix `DenseNDArray` write after create

### DIFF
--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -132,6 +132,14 @@ SOMADenseNDArray <- R6::R6Class(
           length(coords) == length(self$dimensions())
       )
 
+      ## the 'soma_data' data type may not have been cached, and if so we need to fetch it
+      if (is.null(private$.type)) {
+          ## TODO: replace with a libtiledbsoma accessor as discussed
+          tpstr <- tiledb::datatype(tiledb::attrs(tiledb::schema(self$uri))[["soma_data"]])
+          arstr <- arrow_type_from_tiledb_type(tpstr)
+          private$.type <- arstr
+      }
+
       arr <- self$object
       tiledb::query_layout(arr) <- "COL_MAJOR"
       spdl::debug("[SOMADenseNDArray::write] about to call write")

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -4,6 +4,11 @@ test_that("SOMADenseNDArray creation", {
 
   ndarray <- SOMADenseNDArrayCreate(uri, arrow::int32(), shape = c(10, 5))
 
+  # The array is open for write on create. Nonetheless, close and
+  # reopen to ensure that state needed for a write is available.
+  ndarray$close()
+  ndarray <- SOMADenseNDArrayOpen(uri, "WRITE")
+
   expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
   expect_equal(ndarray$attrnames(), "soma_data")


### PR DESCRIPTION
**Issue and/or context:** Found while debugging an issue with #2950 for issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Make it possible to write to a `DenseNDArray` using an open-for-write after the array is created.

**Notes for Reviewer:**

Note that the create methods return an array opened for write.

For `SparseNDArray` and `DenseNDArray` you can do:

* create
* write data
* close the handle from create

For `SparseNDArray`, you can do:

* create
* close the handle from create
* open for write
* write data
* close the handle from open

For `DenseNDArray`, this does not work before this PR. The error message is

```
Error: soma_data must be a DataType, not NULL
```

You can reproduce this by including in your checkout the mod to `apis/r/tests/testthat/test-SOMADenseNDArray.R` on this PR but excluding the mod to `apis/r/R/SOMADenseNDArray.R` on this PR, then testing, e.g.:

```
> devtools::test_active_file(file="tests/testthat/test-SOMADenseNDArray.R")
TileDB-SOMA R package 1.13.99.6 with TileDB Embedded 2.25.0 on macOS Sonoma 14.6.1.
See https://github.com/single-cell-data for more information about the SOMA project.

══ Testing test-SOMADenseNDArray.R ═════════════════════════════════════════════════════════════════════════════════════
[ FAIL 1 | WARN 0 | SKIP 0 | PASS 39 ]

── Error (test-SOMADenseNDArray.R:18:3): SOMADenseNDArray creation ─────────────
Error: soma_data must be a DataType, not NULL
Backtrace:
    ▆
 1. └─ndarray$write(mat) at test-SOMADenseNDArray.R:18:3
 2.   ├─arrow::schema(arrow::field("soma_data", private$.type)) at r/R/SOMADenseNDArray.R:138:7
 3.   │ └─rlang::list2(...)
 4.   └─arrow::field("soma_data", private$.type)
 5.     └─arrow:::as_type(type, name)
[ FAIL 1 | WARN 0 | SKIP 0 | PASS 39 ]
```

Including this PR's bugfix on `apis/r/tests/testthat/test-SOMADenseNDArray.R`, one sees

```
> devtools::test_active_file(file="tests/testthat/test-SOMADenseNDArray.R")
TileDB-SOMA R package 1.13.99.6 with TileDB Embedded 2.25.0 on macOS Sonoma 14.6.1.
See https://github.com/single-cell-data for more information about the SOMA project.

══ Testing test-SOMADenseNDArray.R ═════════════════════════════════════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 52 ] Done!
```

The root cause is that `private$.type` is set at create time but not recovered on the open-for-write. This bug was fixed [here](https://github.com/single-cell-data/TileDB-SOMA/blame/248f46e50096eee3c707eb29dd3d0e7a32e6a466/apis/r/R/SOMASparseNDArray.R#L235-L241) for `SOMASparseNDArray`  on PR #2755; here we apply that same fix to `DenseNDArray`.
