### PR TITLE
[r] Correct a test expression

### DIFF
--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -67,7 +67,7 @@ test_that("SOMASparseNDArray creation", {
   maxshape <- ndarray$maxshape()
   expect_equal(length(shape), length(maxshape))
   for (i in 1:length(shape)) {
-    expect(maxshape[[i]] >= shape[[i]])
+    expect_true(maxshape[i] >= shape[i])
   }
 
   ## ndim


### PR DESCRIPTION
**Issue and/or context:**

Paul and I both found a test having hiccups. The issue appears to be a `_true` missing, and the indexing can be done as vectors too as opposed to lists (single set of brackets).

**Changes:**

Correct one line. 

No new code. No new tests.

**Notes for Reviewer:**

[SC 54879](https://app.shortcut.com/tiledb-inc/story/54879/r-correct-a-test-expression)