### PR TITLE
[c++] Remove `ArrayBuffers` from `SOMAArray`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -234,6 +234,9 @@ class ManagedQuery {
      */
     void set_column_data(std::shared_ptr<ColumnBuffer> buffer);
 
+    // Helper function for set_column_data
+    std::shared_ptr<ColumnBuffer> setup_column_data(std::string_view name);
+
     /**
      * @brief Configure query and allocate result buffers for reads.
      *

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -180,8 +180,7 @@ class SOMAArray : public SOMAObject {
         , arr_(other.arr_)
         , meta_cache_arr_(other.meta_cache_arr_)
         , first_read_next_(other.first_read_next_)
-        , submitted_(other.submitted_)
-        , array_buffer_(other.array_buffer_) {
+        , submitted_(other.submitted_) {
         fill_metadata_cache();
     }
 
@@ -1415,9 +1414,6 @@ class SOMAArray : public SOMAObject {
     // Helper function to cast Boolean of bits (Arrow) to uint8 (TileDB)
     void _cast_bit_to_uint8(ArrowSchema* arrow_schema, ArrowArray* arrow_array);
 
-    // Helper function for set_column_data
-    std::shared_ptr<ColumnBuffer> _setup_column_data(std::string_view name);
-
     // Fills the metadata cache upon opening the array.
     void fill_metadata_cache();
 
@@ -1467,10 +1463,6 @@ class SOMAArray : public SOMAObject {
 
     // Unoptimized method for computing nnz() (issue `count_cells` query)
     uint64_t _nnz_slow();
-
-    // ArrayBuffers to hold ColumnBuffers alive when submitting to write
-    // query
-    std::shared_ptr<ArrayBuffers> array_buffer_ = nullptr;
 };
 
 }  // namespace tiledbsoma


### PR DESCRIPTION
**Issue and/or context:**

[[sc-54744]](https://app.shortcut.com/tiledb-inc/story/54744/python-soma-read-does-an-open-on-an-already-open-array)

https://github.com/single-cell-data/TileDB-SOMA/pull/2975

This is the first of multiple PRs that will be split out from above

**Changes:**

The `ArrayBuffers` are now fully managed by `ManagedQuery` and not `SOMAArray`