### PR TITLE
[c++/python] More exception-mapping fixes

### DIFF
--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -13,22 +13,7 @@ using namespace std;
 using namespace tiledb;
 namespace py = pybind11;
 
-#define TPY_ERROR_LOC(m) throw TileDBSOMAPyError(m);
-
-class TileDBSOMAPyError : std::runtime_error {
-   public:
-    explicit TileDBSOMAPyError(const char* m)
-        : std::runtime_error(m) {
-    }
-    explicit TileDBSOMAPyError(std::string m)
-        : std::runtime_error(m.c_str()) {
-    }
-
-   public:
-    virtual const char* what() const noexcept override {
-        return std::runtime_error::what();
-    }
-};
+#define TPY_ERROR_LOC(m) throw TileDBSOMAError(m);
 
 namespace tiledbsoma {
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -49,8 +49,6 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                 std::rethrow_exception(p);
         } catch (const TileDBSOMAError& e) {
             PyErr_SetString(tiledb_soma_error.ptr(), e.what());
-        } catch (const TileDBSOMAPyError& e) {
-            PyErr_SetString(tiledb_soma_error.ptr(), e.what());
         } catch (py::builtin_exception& e) {
             throw;
         };

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -46,9 +46,13 @@ void write(SOMAArray& array, py::handle py_batch, bool sort_coords = true) {
     uintptr_t arrow_array_ptr = (uintptr_t)(&arrow_array);
     py_batch.attr("_export_to_c")(arrow_array_ptr, arrow_schema_ptr);
 
-    array.set_array_data(
-        std::make_unique<ArrowSchema>(arrow_schema),
-        std::make_unique<ArrowArray>(arrow_array));
+    try {
+        array.set_array_data(
+            std::make_unique<ArrowSchema>(arrow_schema),
+            std::make_unique<ArrowArray>(arrow_array));
+    } catch (const std::exception& e) {
+        TPY_ERROR_LOC(e.what());
+    }
 
     try {
         array.write(sort_coords);

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -214,7 +214,7 @@ def test_dataframe_with_enumeration(tmp_path):
         data["soma_joinid"] = [0, 1, 2, 3, 4]
         data["foo"] = ["a", "bb", "ccc", "bb", "a"]
         data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
-        with pytest.raises(ValueError):
+        with pytest.raises(soma.SOMAError):
             sdf.write(pa.Table.from_pydict(data))
 
         data["foo"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
@@ -1458,7 +1458,7 @@ def test_enum_extend_past_numerical_limit(tmp_path):
 
     # cannot add additional categories as already maxed out earlier
     tbl = pa.Table.from_pandas(df2, preserve_index=False)
-    with pytest.raises((RuntimeError, soma.SOMAError)):
+    with pytest.raises(soma.SOMAError):
         with soma.open(uri, mode="w") as A:
             A.write(tbl)
 

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
+from tiledbsoma import SOMAError
 from tiledbsoma._indexer import IntIndexer
 from tiledbsoma.options import SOMATileDBContext
 from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_context
@@ -22,7 +23,7 @@ def test_duplicate_key_indexer_error(
     keys: Union[np.array, List[int]], lookups: np.array
 ):
     context = _validate_soma_tiledb_context(SOMATileDBContext())
-    with pytest.raises(RuntimeError, match="There are duplicate keys."):
+    with pytest.raises(SOMAError, match="There are duplicate keys."):
         IntIndexer(keys, context=context)
 
     pd_index = pd.Index(keys)


### PR DESCRIPTION
**Issue and/or context:** [[sc-54978]](https://app.shortcut.com/tiledb-inc/story/54978/tiledbsomaerror-exceptions-from-c-layer-show-up-as-runtimeerror-in-macos)

**Changes:**

* Continues #2963. I missed a couple spots.
* Also fixes a couple spots that were leading to `RuntimeError` on @bkmartinjr 's #2978. (I applied this PR on top of 2978 in my Mac sandbox & observed no more `RuntimeError`.)
* As a neaten (could be a separate PR), `TileDBSOMAPyError` is redundant with `TileDBSOMAError` (multiple-author syndrome I suspect) -- the two serve identical roles and are coalesced on this PR.

**Notes for Reviewer:**

