### PR TITLE
[python] Complete TileDB-Py 0.32.0 pin

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,9 +343,7 @@ setuptools.setup(
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
         "somacore==1.0.14",
-        # TEMP WHILE WE AWAIT WHEELS
-        # "tiledb~=0.32.0",
-        "tiledb",
+        "tiledb~=0.32.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={


### PR DESCRIPTION
Follow-up on #2976 now that all 0.32.0 artifacts are available at https://pypi.org/project/tiledb/0.32.0/#files