### PR TITLE
[python] Use `somacore` 1.0.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore==1.0.14"
+        - "somacore==1.0.15"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -342,7 +342,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore==1.0.14",
+        "somacore==1.0.15",
         "tiledb~=0.32.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],


### PR DESCRIPTION
**Issue and/or context:** [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048)

**Changes:**

Brings in https://github.com/single-cell-data/SOMA/releases/tag/python-v1.0.15 which has https://github.com/single-cell-data/SOMA/pull/216

**Notes for Reviewer:**

