### PR TITLE
[r] Use cached SOMA context rather than re-creating

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.13.99.7
+Version: 1.13.99.8
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,7 @@
 * Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
 * Use cached timestamps in `$write()` and `$create()`
 * Fix bug in blockwise iteration
+* Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
 
 # tiledbsoma 1.13.0
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -34,8 +34,6 @@ TileDBGroup <- R6::R6Class(
 
       spdl::debug("[TileDBGroup$create] Creating new {} at '{}' at {}",
                   self$class(), self$uri, self$tiledb_timestamp)
-
-      private$.soma_context <- soma_context()  # FIXME via factory and paramater_config
       c_group_create(self$uri, self$class(), private$.soma_context,
                      self$.tiledb_timestamp_range)  ## FIXME: use to be added accessor
 
@@ -63,15 +61,23 @@ TileDBGroup <- R6::R6Class(
       }
       if (is.null(private$.group_open_timestamp)) {
         spdl::debug("[TileDBGroup$open] Opening {} '{}' in {} mode", self$class(), self$uri, mode)
-        private$.tiledb_group <- c_group_open(self$uri, type = mode, ctx = soma_context())#private$.some_context)
+        private$.tiledb_group <- c_group_open(
+          uri = self$uri,
+          type = mode,
+          ctxxp = private$.soma_context
+        )
       } else {
         if (internal_use_only != "allowed_use") stopifnot("tiledb_timestamp not yet supported for WRITE mode" = mode == "READ")
         spdl::debug("[TileDBGroup$open] Opening {} '{}' in {} mode at {} ptr null {}",
                     self$class(), self$uri, mode, private$.group_open_timestamp,
                     is.null(private$.soma_context))
         ## The Group API does not expose a timestamp setter so we have to go via the config
-        private$.tiledb_group <- c_group_open(self$uri, type = mode, ctx = soma_context(), #private$.soma_context,
-                                              self$.tiledb_timestamp_range)
+        private$.tiledb_group <- c_group_open(
+          uri = self$uri,
+          type = mode,
+          ctxxp = private$.soma_context,
+          timestamp = self$.tiledb_timestamp_range
+        )
       }
       private$update_member_cache()
       private$update_metadata_cache()
@@ -321,9 +327,6 @@ TileDBGroup <- R6::R6Class(
     # Initially NULL, once the group is created or opened, this is populated
     # with a list that's empty or contains the group metadata.
     .metadata_cache = NULL,
-
-    ## soma_context
-    .soma_context = NULL,
 
     # Instantiate a group member object.
     # Responsible for calling the appropriate R6 class constructor.

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -38,6 +38,13 @@ TileDBObject <- R6::R6Class(
       private$.tiledbsoma_ctx <- tiledbsoma_ctx
       private$.tiledb_ctx <- self$tiledbsoma_ctx$context()
 
+      # TODO: re-enable once new UX is worked out
+      # soma_context <- soma_context %||% soma_context()
+      # stopifnot(
+      #   "'soma_context' must be a pointer" = inherits(x = soma_context, what = 'externalptr')
+      # )
+      private$.soma_context <- soma_context()  # FIXME via factory and paramater_config
+
       if (!is.null(tiledb_timestamp)) {
         stopifnot(
             "'tiledb_timestamp' must be a single POSIXct datetime object" = inherits(tiledb_timestamp, "POSIXct") &&
@@ -185,6 +192,9 @@ TileDBObject <- R6::R6Class(
     # * In particular, an is-open predicate can be reliably implemented by
     #   checking if .mode is non-null.
     .mode = NULL,
+
+    ## soma_context
+    .soma_context = NULL,
 
     # @description Contains TileDBURI object
     tiledb_uri = NULL,

--- a/apis/r/tests/testthat/test-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-TileDBGroup.R
@@ -151,3 +151,12 @@ test_that("Metadata", {
 
   group$close()
 })
+
+# Existence proof test via cached global context
+# soma_context(config = c(vfs.s3.region = "us-west-2"))
+# (grp <- TileDBGroup$new(
+#   uri = 's3://cellxgene-census-public-us-west-2/cell-census/2024-07-01/soma/', 
+#   internal_use_only = 'allowed_use'
+# ))
+# grp$open(mode = 'READ', internal_use_only = 'allowed_use')
+# grp$names()


### PR DESCRIPTION
Cache a SOMA context during `$new()` as a private field when instantiating new objects. This cached context can then be used in other methods. Note, this PR is not yet changing the UX of config/context options. As the context from `soma_context()` is cached globally, we can modify the global one before instantiating to test customized cached contexts

Modified SOMA methods:
 - `TileDBObject$new()`: creates context and caches it within the object
 - `TileDBGroup$create()`: no longer caches context, instead uses cached context from `$new()`
 - `TileDBGroup$open()`: uses cached context rather than calling `soma_context()`

[SC-55084](https://app.shortcut.com/tiledb-inc/story/55084/)