### PR TITLE
[r] Lower some logging from 'info' to 'debug'

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -279,7 +279,7 @@ SOMADataFrame <- R6::R6Class(
       # Drop columns
       se <- tiledb::tiledb_array_schema_evolution()
       for (drop_col in drop_cols) {
-        spdl::info("[SOMADataFrame update]: dropping column '{}'", drop_col)
+        spdl::debug("[SOMADataFrame update]: dropping column '{}'", drop_col)
         se <- tiledb::tiledb_array_schema_evolution_drop_attribute(
           object = se,
           attrname = drop_col
@@ -288,7 +288,7 @@ SOMADataFrame <- R6::R6Class(
 
       # Add columns
       for (add_col in add_cols) {
-        spdl::info("[SOMADataFrame update]: adding column '{}'", add_col)
+        spdl::debug("[SOMADataFrame update]: adding column '{}'", add_col)
 
         col_type <- new_schema$GetFieldByName(add_col)$type
         attr <- tiledb_attr_from_arrow_field(
@@ -317,7 +317,7 @@ SOMADataFrame <- R6::R6Class(
 
       # Reopen array for writing with new schema
       self$reopen(mode = "WRITE")
-      spdl::info("[SOMADataFrame update]: Writing new data")
+      spdl::debug("[SOMADataFrame update]: Writing new data")
       self$write(values)
     },
 

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -43,7 +43,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
             for (size_t i=0; i<iv.size(); i++) {
                 if (iv[i] >= pr.first && iv[i] <= pr.second) {
                     sr->set_dim_point<int64_t>(nm, iv[i]);
-                    spdl::info("[apply_dim_points] Applying dim point {} on {}", iv[i], nm);
+                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", iv[i], nm);
                     suitable = true;
                 }
             }
@@ -54,7 +54,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
                 float v = static_cast<float>(payload[i]);
                 if (v >= pr.first && v <= pr.second) {
                     sr->set_dim_point<float>(nm, v);
-                    spdl::info("[apply_dim_points] Applying dim point {} on {}", v, nm);
+                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", v, nm);
                     suitable = true;
                 }
             }
@@ -64,7 +64,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
             for (R_xlen_t i=0; i<payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     sr->set_dim_point<double>(nm,payload[i]);
-                    spdl::info("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
                     suitable = true;
                 }
             }
@@ -74,7 +74,7 @@ void apply_dim_points(tdbs::SOMAArray *sr,
             for (R_xlen_t i=0; i<payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     sr->set_dim_point<int32_t>(nm,payload[i]);
-                    spdl::info("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
                     suitable = true;
                 }
             }
@@ -105,7 +105,7 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
                 uint64_t l = static_cast<uint64_t>(Rcpp::fromInteger64(lo[i]));
                 uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
                 vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
-                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
+                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
                 suitable = l < pr.second && h > pr.first; // lower must be less than max, higher more than min
             }
             if (suitable) sr->set_dim_ranges<uint64_t>(nm, vp);
@@ -117,7 +117,7 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
             const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
             for (int i=0; i<mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
+                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
                 suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
             }
             if (suitable) sr->set_dim_ranges<int64_t>(nm, vp);
@@ -131,7 +131,7 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
                 float l = static_cast<float>(lo[i]);
                 float h = static_cast<float>(hi[i]);
                 vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
-                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
+                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
                 suitable = l < pr.second && h > pr.first; // lower must be less than max, higher more than min
             }
             if (suitable) sr->set_dim_ranges<float>(nm, vp);
@@ -143,7 +143,7 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
             const std::pair<double,double> pr = dm->domain<double>();
             for (int i=0; i<mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
+                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
                 suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
             }
             if (suitable) sr->set_dim_ranges<double>(nm, vp);
@@ -155,7 +155,7 @@ void apply_dim_ranges(tdbs::SOMAArray* sr,
             const std::pair<int32_t,int32_t> pr = dm->domain<int32_t>();
             for (int i=0; i<mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::info("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm[i], lo[i], hi[i]) ;
+                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm[i], lo[i], hi[i]) ;
                 suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
             }
             if (suitable) sr->set_dim_ranges<int32_t>(nm, vp);


### PR DESCRIPTION
**Issue and/or context:**

This fairly narrow PR provides a small usage improvement when logging level 'info' is used to test during development (which can be turned on easily now via environment variable `SPDLOG_LEVEL`) as it lowers a few older entries from 'info' to 'debug'.  (Some still remain in other helper files. They can be addressed at a later date.)

**Changes:**

Substitute level 'debug' for 'info' in about a dozen spots.  

No new code, no new tests.

**Notes for Reviewer:**

[SC 55110](https://app.shortcut.com/tiledb-inc/story/55110/r-lower-a-remaining-logging-item-from-info-to-debug)