### PR TITLE
[c++] Centralize some `nanoarrow` helpers

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1302,6 +1302,9 @@ std::unique_ptr<ArrowArray> ArrowAdapter::make_arrow_array_parent(
     arrow_array->n_children = num_columns;
     arrow_array->release = &ArrowAdapter::release_array;
     arrow_array->children = new ArrowArray*[num_columns];
+    for (int i = 0; i < num_columns; i++) {
+        arrow_array->children[i] = nullptr;
+    }
 
     return arrow_array;
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1252,4 +1252,58 @@ enum ArrowType ArrowAdapter::to_nanoarrow_type(std::string_view sv) {
             fmt::format("ArrowAdapter: Unsupported Arrow format: {} ", sv));
 }
 
+std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
+    const std::vector<std::string>& names,
+    const std::vector<tiledb_datatype_t>& tiledb_datatypes) {
+    auto num_names = names.size();
+    auto num_types = tiledb_datatypes.size();
+
+    if (num_names != num_types) {
+        throw TileDBSOMAError(fmt::format(
+            "ArrowAdapter::make_arrow_schema: internal coding error {} != {}",
+            num_names,
+            num_types));
+    }
+
+    auto arrow_schema = std::make_unique<ArrowSchema>();
+    arrow_schema->format = "+s";           // structure, i.e. non-leaf node
+    arrow_schema->n_children = num_names;  // non-leaf node
+    arrow_schema->dictionary = nullptr;
+    arrow_schema->release = &ArrowAdapter::release_schema;
+    arrow_schema->children = new ArrowSchema*[arrow_schema->n_children];
+
+    for (int i = 0; i < (int)num_names; i++) {
+        ArrowSchema* dim_schema = new ArrowSchema;
+        dim_schema->name = strdup(names[i].c_str());
+        auto arrow_type_name = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatypes[i]);
+        dim_schema->format = strdup(arrow_type_name.c_str());
+        dim_schema->n_children = 0;  // leaf node
+        dim_schema->dictionary = nullptr;
+        dim_schema->release = &ArrowAdapter::release_schema;
+        arrow_schema->children[i] = dim_schema;
+    }
+
+    return arrow_schema;
+}
+
+std::unique_ptr<ArrowArray> ArrowAdapter::make_arrow_array_parent(
+    int num_columns) {
+    auto arrow_array = std::make_unique<ArrowArray>();
+
+    // All zero/null since this is a parent ArrowArray, and each
+    // column/child is also of type ArrowArray.
+    arrow_array->length = 0;
+    arrow_array->null_count = 0;
+    arrow_array->offset = 0;
+    arrow_array->n_buffers = 0;
+    arrow_array->buffers = nullptr;
+
+    arrow_array->n_children = num_columns;
+    arrow_array->release = &ArrowAdapter::release_array;
+    arrow_array->children = new ArrowArray*[num_columns];
+
+    return arrow_array;
+}
+
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -283,17 +283,23 @@ class ArrowAdapter {
         return make_arrow_array_child<T>(v);
     };
 
-    static ArrowArray* make_arrow_array_child(const std::vector<std::string>&) {
-        // We can't throw TileDBSOMAError since that's in a header
-        // file in a certain path, and this is a header file
-        // at a particular fixed path but which is _included_ in
-        // .cc files at varying paths -- so if "a/foo.cc" and "a/b/c/bar.cc"
-        // both include us, there is no one #include syntax we
-        // could put here that would let both of them find
+    static ArrowArray* make_arrow_array_child(
+        const std::vector<std::string>& v) {
+        // For core domain, these are always nullptr.
         // the definition of TileDBSOMAError.
-        throw std::runtime_error(
-            "ArrowAdapter::make_arrow_array_child is not yet implemented for "
-            "string types.");
+        auto arrow_array = new ArrowArray;
+
+        arrow_array->length = v.size();
+        arrow_array->null_count = 0;
+        arrow_array->offset = 0;
+        arrow_array->n_buffers = 2;
+        arrow_array->release = &ArrowAdapter::release_array;
+        arrow_array->buffers = new const void*[2];
+        arrow_array->buffers[0] = nullptr;
+        arrow_array->buffers[1] = nullptr;
+        arrow_array->n_children = 0;  // leaf/child node
+
+        return arrow_array;
     };
 
     template <typename T>

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -164,6 +164,21 @@ class PlatformConfig {
     bool consolidate_and_vacuum = false;
 };
 
+/**
+ * This is our application-specific wrapper around nanoarrow.
+ *
+ * Nominal use-cases include full dataframe-wide schemas from Python/R for
+ * DataFrame::create, domain/extent/etc information from Python/R for
+ * setting core dimensions, and readback to Python/R of core domain, current
+ * domain, and non-empty domain.
+ *
+ * nanoarrow is crucial to our code-centralization efforts in libtiledbsoma.
+ * Python and R can trivially do heterogenous lists like ["abc", 123, true]
+ * or list("abc", 123, TRUE); C++ cannot -- at least not so compactly. The
+ * combination of ArrowSchema (for the types) and ArrowArray (for the data) is
+ * key for Python/R interop with C++ libtiledbsoma.
+ */
+
 class ArrowAdapter {
    public:
     static void release_schema(struct ArrowSchema* schema);
@@ -229,6 +244,85 @@ class ArrowAdapter {
 
     static enum ArrowType to_nanoarrow_type(std::string_view sv);
 
+    /**
+     * @brief This is a keystroke-saver.
+     */
+    static std::string tdb_to_arrow_type(tiledb_datatype_t tiledb_datatype) {
+        return std::string(to_arrow_format(tiledb_datatype));
+    }
+
+    /**
+     * @brief Creates a nanoarrow ArrowSchema given the names and TileDB
+     * datatypes.
+     *
+     * Note that the parents and children in nanoarrow are both of type
+     * ArrowSchema. This constructs the parent and the children.
+     */
+    static std::unique_ptr<ArrowSchema> make_arrow_schema(
+        const std::vector<std::string>& names,
+        const std::vector<tiledb_datatype_t>& tiledb_datatypes);
+
+    /**
+     * @brief Creates a nanoarrow ArrowArray which accommodates
+     * a varying number of columns.
+     *
+     * Note that the parents and children in nanoarrow are both of type
+     * ArrowArray. This constructs the parent and not the children.
+     */
+    static std::unique_ptr<ArrowArray> make_arrow_array_parent(int num_columns);
+
+    /**
+     * @brief Creates a nanoarrow ArrowArray for a single column.
+     *
+     * Note that the parents and children in nanoarrow are both of type
+     * ArrowArray. This constructs not the parent but rather a child.
+     */
+    template <typename T>
+    static ArrowArray* make_arrow_array_child(const std::pair<T, T>& pair) {
+        std::vector<T> v({pair.first, pair.second});
+        return make_arrow_array_child<T>(v);
+    };
+
+    static ArrowArray* make_arrow_array_child(const std::vector<std::string>&) {
+        // We can't throw TileDBSOMAError since that's in a header
+        // file in a certain path, and this is a header file
+        // at a particular fixed path but which is _included_ in
+        // .cc files at varying paths -- so if "a/foo.cc" and "a/b/c/bar.cc"
+        // both include us, there is no one #include syntax we
+        // could put here that would let both of them find
+        // the definition of TileDBSOMAError.
+        throw std::runtime_error(
+            "ArrowAdapter::make_arrow_array_child is not yet implemented for "
+            "string types.");
+    };
+
+    template <typename T>
+    static ArrowArray* make_arrow_array_child(const std::vector<T>& v) {
+        // Use new here, not malloc, to match ArrowAdapter::release_array
+        auto arrow_array = new ArrowArray;
+
+        size_t n = v.size();
+
+        arrow_array->length = n;
+        arrow_array->null_count = 0;
+        arrow_array->offset = 0;
+        arrow_array->n_buffers = 2;
+        arrow_array->release = &ArrowAdapter::release_array;
+        arrow_array->buffers = new const void*[2];
+        arrow_array->buffers[0] = nullptr;
+        arrow_array->buffers[1] = nullptr;
+        arrow_array->n_children = 0;  // leaf/child node
+
+        // Use malloc here, not new, to match ArrowAdapter::release_array
+        T* dest = (T*)malloc(n * sizeof(T));
+        for (size_t i = 0; i < n; i++) {
+            dest[i] = v[i];
+        }
+        arrow_array->buffers[1] = (void*)dest;
+
+        return arrow_array;
+    };
+
    private:
     static std::pair<const void*, std::size_t> _get_data_and_length(
         Enumeration& enmr, const void* dst);
@@ -290,7 +384,8 @@ class ArrowAdapter {
         Filter filter, std::string option_name, json value);
 
     static tiledb_layout_t _get_order(std::string order);
-};
-};  // namespace tiledbsoma
 
+};  // class ArrowAdapter
+
+};  // namespace tiledbsoma
 #endif

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -169,11 +169,11 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
                 // domain big; current_domain small
                 std::vector<int64_t> dom(
                     {0, CORE_DOMAIN_MAX, 1, 0, info.dim_max});
-                dim_array = ArrowAdapter::make_arrow_array_child<int64_t>(dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             } else {
                 // domain small; current_domain feature not being used
                 std::vector<int64_t> dom({0, info.dim_max, 1});
-                dim_array = ArrowAdapter::make_arrow_array_child<int64_t>(dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             }
 
         } else if (info.tiledb_datatype == TILEDB_UINT32) {
@@ -185,11 +185,11 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
                      1,
                      0,
                      (uint32_t)info.dim_max});
-                dim_array = ArrowAdapter::make_arrow_array_child<uint32_t>(dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             } else {
                 // domain small; current_domain feature not being used
                 std::vector<uint32_t> dom({0, (uint32_t)info.dim_max, 1});
-                dim_array = ArrowAdapter::make_arrow_array_child<uint32_t>(dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             }
 
         } else if (info.tiledb_datatype == TILEDB_STRING_ASCII) {
@@ -198,12 +198,10 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
             // handle this case.
             if (info.use_current_domain) {
                 std::vector<std::string> dom({"", "", "", "", ""});
-                dim_array = ArrowAdapter::make_arrow_array_child<std::string>(
-                    dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             } else {
                 std::vector<std::string> dom({"", "", ""});
-                dim_array = ArrowAdapter::make_arrow_array_child<std::string>(
-                    dom);
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
             }
         }
 

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -529,7 +529,8 @@ TEST_CASE("SOMAArray: Write and read back Boolean") {
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->children = new ArrowSchema*[arrow_schema->n_children];
     ArrowSchema* arrow_dim = arrow_schema->children[0] = new ArrowSchema;
-    arrow_dim->format = strdup(helper::to_arrow_format(TILEDB_INT64).c_str());
+    arrow_dim->format = strdup(
+        ArrowAdapter::tdb_to_arrow_type(TILEDB_INT64).c_str());
     arrow_dim->name = dim_name;
     arrow_dim->n_children = 0;
     arrow_dim->dictionary = nullptr;

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -62,7 +62,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
         std::string sub_uri = "mem://unit-test-add-sparse-ndarray/sub";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         SOMACollection::create(base_uri, ctx, ts);
 
@@ -114,7 +115,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     std::string sub_uri = "mem://unit-test-add-dense-ndarray/sub";
     std::string dim_name = "soma_dim_0";
     tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-    std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+    std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(tiledb_datatype);
 
     SOMACollection::create(base_uri, ctx, ts);
     // TODO: add support for current domain in dense arrays once we have that
@@ -169,7 +170,8 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         std::string dim_name = "d0";
         std::string attr_name = "a0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         SOMACollection::create(base_uri, ctx, ts);
 
@@ -227,7 +229,8 @@ TEST_CASE("SOMACollection: add SOMACollection") {
         std::string base_uri = "mem://unit-test-add-collection";
         std::string sub_uri = "mem://unit-test-add-collection/sub";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         SOMACollection::create(base_uri, ctx);
 
@@ -261,7 +264,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         std::string dim_name = "d0";
         std::string attr_name = "a0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         SOMACollection::create(base_uri, ctx);
 
@@ -314,7 +318,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         std::string dim_name = "d0";
         std::string attr_name = "a0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         SOMACollection::create(base_uri, ctx);
 
@@ -428,7 +433,8 @@ TEST_CASE("SOMAExperiment: metadata") {
         std::string dim_name = "soma_dim_0";
         std::string attr_name = "soma_data";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         std::vector<helper::DimInfo> dim_infos(
             {{.name = dim_name,
@@ -519,7 +525,8 @@ TEST_CASE("SOMAMeasurement: metadata") {
         std::string dim_name = "soma_dim_0";
         std::string attr_name = "soma_data";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         std::vector<helper::DimInfo> dim_infos(
             {{.name = dim_name,

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -67,9 +67,12 @@ struct VariouslyIndexedDataFrameFixture {
     tiledb_datatype_t u32_datatype = TILEDB_UINT32;
     tiledb_datatype_t str_datatype = TILEDB_STRING_ASCII;
 
-    std::string i64_arrow_format = helper::to_arrow_format(i64_datatype);
-    std::string u32_arrow_format = helper::to_arrow_format(u32_datatype);
-    std::string attr_1_arrow_format = helper::to_arrow_format(str_datatype);
+    std::string i64_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        i64_datatype);
+    std::string u32_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        u32_datatype);
+    std::string attr_1_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        str_datatype);
 
     helper::DimInfo i64_dim_info(bool use_current_domain) {
         return helper::DimInfo(

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -47,7 +47,8 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
         std::string uri = "mem://unit-test-dense-ndarray-basic";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         REQUIRE(!SOMADenseNDArray::exists(uri, ctx));
 
@@ -157,7 +158,8 @@ TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
         std::string uri = "mem://unit-test-dense-ndarray-platform-config";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         PlatformConfig platform_config;
         platform_config.dense_nd_array_dim_zstd_level = 6;
@@ -221,7 +223,8 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
         std::string uri = "mem://unit-test-dense-ndarray";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         std::vector<helper::DimInfo> dim_infos(
             {{.name = dim_name,

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -47,7 +47,8 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
         std::string dim_name = "soma_dim_0";
         std::string attr_name = "soma_data";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         REQUIRE(!SOMASparseNDArray::exists(uri, ctx));
 
@@ -182,7 +183,8 @@ TEST_CASE("SOMASparseNDArray: platform_config", "[SOMASparseNDArray]") {
         std::string uri = "mem://unit-test-dataframe-platform-config";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         PlatformConfig platform_config;
         platform_config.sparse_nd_array_dim_zstd_level = 6;
@@ -231,7 +233,8 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
         std::string uri = "mem://unit-test-sparse-ndarray";
         std::string dim_name = "soma_dim_0";
         tiledb_datatype_t tiledb_datatype = TILEDB_INT64;
-        std::string arrow_format = helper::to_arrow_format(tiledb_datatype);
+        std::string arrow_format = ArrowAdapter::tdb_to_arrow_type(
+            tiledb_datatype);
 
         std::vector<helper::DimInfo> dim_infos(
             {{.name = dim_name,


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Extracting readback of core domain, current domain, and non-empty domain are all currently:

* Done slotwise within `libtiledbsoma`, templatized;
* For Python: there is a loop over dim names in the `pybind11` layer lke this https://github.com/single-cell-data/TileDB-SOMA/blob/b3feada0d1282442d1190f56a43670a32dad97ae/apis/python/src/tiledbsoma/soma_array.cc#L671-L830;
* For R: currently these are using TileDB-R -- which is a dependency we're currently removing -- and I don't want to imitate the above in R

The best option for Python/R interop is:

* Push down loop-over-dim-names to `libtiledbsoma`
* Make more use of `nanoarrow` to interface with Python and R

The current PR simply moves some code currently used in `libtiledbsoma`'s unit-test logic to `ArrowAdapter`, where it can -- and will -- be used for readback of core domain, current domain, and non-empty domain for #2407.

**Notes for Reviewer:**

This is just a code-move. If all existing unit tests pass, that is success. No new unit tests are introduced here, since no new unit tests are needed.