### PR TITLE
[r] Documentation refresher

### DIFF
--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -25,10 +25,6 @@
     } else {
       .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
     }
-    if (rpkg_lib_version != soma_lib_version) {
-      msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s [%s]",
-                     sQuote(rpkg_lib_version), sQuote(soma_lib_version), sQuote(cdmsg))
-    }
 }
 
 # This is temporary only. Please see:

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -60,6 +60,7 @@ c_group_put_metadata <- function(xp, key, obj) {
 
 #' Get nnumber of metadata items
 #' @param uri The array URI
+#' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
 #' @export
 get_metadata_num <- function(uri, is_array, ctxxp) {
@@ -71,6 +72,7 @@ get_metadata_num <- function(uri, is_array, ctxxp) {
 #' This function currently supports metadata as either a string or an 'int64' (or 'int32').
 #' It will error if a different datatype is encountered.
 #' @param uri The array URI
+#' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
 #' @export
 get_all_metadata <- function(uri, is_array, ctxxp) {
@@ -81,6 +83,7 @@ get_all_metadata <- function(uri, is_array, ctxxp) {
 #'
 #' @param uri The array URI
 #' @param key The array metadata key
+#' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
 #' @export
 get_metadata <- function(uri, key, is_array, ctxxp) {
@@ -91,6 +94,7 @@ get_metadata <- function(uri, key, is_array, ctxxp) {
 #'
 #' @param uri The array URI
 #' @param key The array metadata key
+#' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
 #' @export
 has_metadata <- function(uri, key, is_array, ctxxp) {
@@ -101,6 +105,7 @@ has_metadata <- function(uri, key, is_array, ctxxp) {
 #'
 #' @param uri The array URI
 #' @param key The array metadata key
+#' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
 #' @export
 delete_metadata <- function(uri, key, is_array, ctxxp) {

--- a/apis/r/man/delete_metadata.Rd
+++ b/apis/r/man/delete_metadata.Rd
@@ -11,6 +11,8 @@ delete_metadata(uri, key, is_array, ctxxp)
 
 \item{key}{The array metadata key}
 
+\item{is_array}{A boolean to indicate array or group}
+
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{

--- a/apis/r/man/get_all_metadata.Rd
+++ b/apis/r/man/get_all_metadata.Rd
@@ -9,6 +9,8 @@ get_all_metadata(uri, is_array, ctxxp)
 \arguments{
 \item{uri}{The array URI}
 
+\item{is_array}{A boolean to indicate array or group}
+
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{

--- a/apis/r/man/get_metadata.Rd
+++ b/apis/r/man/get_metadata.Rd
@@ -11,6 +11,8 @@ get_metadata(uri, key, is_array, ctxxp)
 
 \item{key}{The array metadata key}
 
+\item{is_array}{A boolean to indicate array or group}
+
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{

--- a/apis/r/man/get_metadata_num.Rd
+++ b/apis/r/man/get_metadata_num.Rd
@@ -9,6 +9,8 @@ get_metadata_num(uri, is_array, ctxxp)
 \arguments{
 \item{uri}{The array URI}
 
+\item{is_array}{A boolean to indicate array or group}
+
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{

--- a/apis/r/man/has_metadata.Rd
+++ b/apis/r/man/has_metadata.Rd
@@ -11,6 +11,8 @@ has_metadata(uri, key, is_array, ctxxp)
 
 \item{key}{The array metadata key}
 
+\item{is_array}{A boolean to indicate array or group}
+
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -29,6 +29,7 @@ std::unique_ptr<tdbs::SOMAObject> getObjectUniquePointer(bool is_array, OpenMode
 
 //' Get nnumber of metadata items
 //' @param uri The array URI
+//' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
@@ -46,6 +47,7 @@ int32_t get_metadata_num(std::string& uri, bool is_array, Rcpp::XPtr<somactx_wra
 //' This function currently supports metadata as either a string or an 'int64' (or 'int32').
 //' It will error if a different datatype is encountered.
 //' @param uri The array URI
+//' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
@@ -89,6 +91,7 @@ Rcpp::List get_all_metadata(std::string& uri, bool is_array, Rcpp::XPtr<somactx_
 //'
 //' @param uri The array URI
 //' @param key The array metadata key
+//' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
@@ -120,6 +123,7 @@ std::string get_metadata(std::string& uri, std::string& key, bool is_array,
 //'
 //' @param uri The array URI
 //' @param key The array metadata key
+//' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
@@ -137,6 +141,7 @@ bool has_metadata(std::string& uri, std::string& key, bool is_array,
 //'
 //' @param uri The array URI
 //' @param key The array metadata key
+//' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]


### PR DESCRIPTION
**Issue and/or context:**

`R CMD check` was nagging about some missing fields as well as one undefined global

**Changes:**

Injected missing `is_arrow` documentation, removed one stale/unused assignment with a missing global and re-ran `roxygenize()` to refresh Rd files.

`R CMD check` is now down to complaining about `tiledb` being too frequently in Depends, Imports, Suggests or Enhances (which get taken care of) and a pair of missing Rd cross-references, which is in sum a lot quieter.

**Notes for Reviewer:**

[SC 65150](https://app.shortcut.com/tiledb-inc/story/55150/r-package-documentation-refresher_