### PR TITLE
[r,c++] Use SOMA Context object throughout

### DIFF
--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -27,7 +27,8 @@ SOMADataFrameCreate <- function(
   ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
-  tiledb_timestamp = NULL
+  tiledb_timestamp = NULL,
+  soma_context = NULL
 ) {
   ingest_mode <- match.arg(ingest_mode)
   sdf <- SOMADataFrame$new(
@@ -35,6 +36,7 @@ SOMADataFrameCreate <- function(
     platform_config,
     tiledbsoma_ctx,
     tiledb_timestamp,
+    soma_context = soma_context,
     internal_use_only = "allowed_use"
   )
   ingest_mode <- switch(
@@ -73,7 +75,8 @@ SOMADataFrameOpen <- function(
   mode = "READ",
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
-  tiledb_timestamp = NULL
+  tiledb_timestamp = NULL,
+  soma_context = NULL
 ) {
   spdl::debug("[SOMADataFrameOpen] uri {} ts ({})", uri, tiledb_timestamp %||% "now")
   sdf <- SOMADataFrame$new(
@@ -81,6 +84,7 @@ SOMADataFrameOpen <- function(
     platform_config,
     tiledbsoma_ctx,
     tiledb_timestamp,
+    soma_context = soma_context,
     internal_use_only = "allowed_use"
   )
   sdf$open(mode, internal_use_only = "allowed_use")

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -58,6 +58,9 @@
 #' @param config A named character vector with \sQuote{key} and \sQuote{value} pairs defining the
 #' configuration setting
 #' @return An external pointer object containing a shared pointer instance of \code{SOMAContext}
+#' @examples
+#' cfgvec <- as.vector(tiledb::tiledb_config())   # TileDB Config in vector form
+#' sctx <- soma_context(cfgvec)
 #' @export
 soma_context <- function(config) {
 

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -139,8 +139,8 @@ reindex_lookup <- function(idx, kvec) {
 }
 
 #' @noRd
-soma_array_reader_impl <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto", config = NULL, timestamprange = NULL) {
-    .Call(`_tiledbsoma_soma_array_reader`, uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config, timestamprange)
+soma_array_reader_impl <- function(uri, ctxxp, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", loglevel = "auto", timestamprange = NULL) {
+    .Call(`_tiledbsoma_soma_array_reader`, uri, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, timestamprange)
 }
 
 #' Set the logging level for the R package and underlying C++ library

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -9,8 +9,8 @@ createSchemaFromArrow <- function(uri, nasp, nadimap, nadimsp, sparse, datatype,
     invisible(.Call(`_tiledbsoma_createSchemaFromArrow`, uri, nasp, nadimap, nadimsp, sparse, datatype, pclst, ctxxp, tsvec))
 }
 
-writeArrayFromArrow <- function(uri, naap, nasp, arraytype = "", config = NULL, tsvec = NULL) {
-    invisible(.Call(`_tiledbsoma_writeArrayFromArrow`, uri, naap, nasp, arraytype, config, tsvec))
+writeArrayFromArrow <- function(uri, naap, nasp, ctxxp, arraytype = "", config = NULL, tsvec = NULL) {
+    invisible(.Call(`_tiledbsoma_writeArrayFromArrow`, uri, naap, nasp, ctxxp, arraytype, config, tsvec))
 }
 
 #' @noRd
@@ -245,8 +245,8 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, config = NULL) {
 #' summary(rl)
 #' }
 #' @noRd
-sr_setup <- function(uri, config, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", timestamprange = NULL, loglevel = "auto") {
-    .Call(`_tiledbsoma_sr_setup`, uri, config, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel)
+sr_setup <- function(uri, config, ctxxp, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", timestamprange = NULL, loglevel = "auto") {
+    .Call(`_tiledbsoma_sr_setup`, uri, config, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel)
 }
 
 sr_complete <- function(sr) {

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -234,8 +234,8 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, config = NULL) {
 #' @examples
 #' \dontrun{
 #' uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
-#' ctx <- tiledb::tiledb_ctx()
-#' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)))
+#' ctxcp <- soma_context()
+#' sr <- sr_setup(uri, ctxxp)
 #' rl <- data.frame()
 #' while (!sr_complete(sr)) {
 #'   dat <- sr_next(sr)
@@ -245,8 +245,8 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, config = NULL) {
 #' summary(rl)
 #' }
 #' @noRd
-sr_setup <- function(uri, config, ctxxp, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", timestamprange = NULL, loglevel = "auto") {
-    .Call(`_tiledbsoma_sr_setup`, uri, config, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel)
+sr_setup <- function(uri, ctxxp, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", timestamprange = NULL, loglevel = "auto") {
+    .Call(`_tiledbsoma_sr_setup`, uri, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel)
 }
 
 sr_complete <- function(sr) {

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -158,8 +158,8 @@ get_column_types <- function(uri, colnames) {
     .Call(`_tiledbsoma_get_column_types`, uri, colnames)
 }
 
-nnz <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_nnz`, uri, config)
+nnz <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_nnz`, uri, ctxxp)
 }
 
 #' @noRd
@@ -172,32 +172,32 @@ check_arrow_array_tag <- function(xp) {
     .Call(`_tiledbsoma_check_arrow_array_tag`, xp)
 }
 
-shape <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_shape`, uri, config)
+shape <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_shape`, uri, ctxxp)
 }
 
-maxshape <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_maxshape`, uri, config)
+maxshape <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_maxshape`, uri, ctxxp)
 }
 
-maybe_soma_joinid_shape <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_maybe_soma_joinid_shape`, uri, config)
+maybe_soma_joinid_shape <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_maybe_soma_joinid_shape`, uri, ctxxp)
 }
 
-maybe_soma_joinid_maxshape <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_maybe_soma_joinid_maxshape`, uri, config)
+maybe_soma_joinid_maxshape <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_maybe_soma_joinid_maxshape`, uri, ctxxp)
 }
 
-has_current_domain <- function(uri, config = NULL) {
-    .Call(`_tiledbsoma_has_current_domain`, uri, config)
+has_current_domain <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_has_current_domain`, uri, ctxxp)
 }
 
-resize <- function(uri, new_shape, config = NULL) {
-    invisible(.Call(`_tiledbsoma_resize`, uri, new_shape, config))
+resize <- function(uri, new_shape, ctxxp) {
+    invisible(.Call(`_tiledbsoma_resize`, uri, new_shape, ctxxp))
 }
 
-tiledbsoma_upgrade_shape <- function(uri, new_shape, config = NULL) {
-    invisible(.Call(`_tiledbsoma_tiledbsoma_upgrade_shape`, uri, new_shape, config))
+tiledbsoma_upgrade_shape <- function(uri, new_shape, ctxxp) {
+    invisible(.Call(`_tiledbsoma_tiledbsoma_upgrade_shape`, uri, new_shape, ctxxp))
 }
 
 #' Iterator-Style Access to SOMA Array via SOMAArray

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -192,7 +192,7 @@ SOMADataFrame <- R6::R6Class(
       spdl::debug("[SOMADataFrame$read] calling sr_setup for {} at ({},{})", self$uri,
                   private$tiledb_timestamp[1], private$tiledb_timestamp[2])
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      rl <- sr_setup(uri = self$uri,
+      sr <- sr_setup(uri = self$uri,
                      config = cfg, # needed ?
                      private$.soma_context,
                      colnames = column_names,
@@ -200,8 +200,7 @@ SOMADataFrame <- R6::R6Class(
                      dim_points = coords,
                      timestamprange = self$.tiledb_timestamp_range,  # NULL or two-elem vector
                      loglevel = log_level)
-      private$ctx_ptr <- rl$ctx # is this still needed?
-      TableReadIter$new(rl$sr)
+      TableReadIter$new(sr)
     },
 
     #' @description Update (lifecycle: maturing)
@@ -400,9 +399,6 @@ SOMADataFrame <- R6::R6Class(
       }
 
       schema
-    },
-
-    # Internal variable to hold onto context returned by sr_setup
-    ctx_ptr = NULL
+    }
   )
 )

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -356,10 +356,7 @@ SOMADataFrame <- R6::R6Class(
     #' (lifecycle: maturing)
     #' @return Logical
     tiledbsoma_has_upgraded_domain = function() {
-      has_current_domain(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      )
+      has_current_domain(self$uri, private$.soma_context)
     }
 
   ),

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -191,9 +191,7 @@ SOMADataFrame <- R6::R6Class(
       }
       spdl::debug("[SOMADataFrame$read] calling sr_setup for {} at ({},{})", self$uri,
                   private$tiledb_timestamp[1], private$tiledb_timestamp[2])
-      cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       sr <- sr_setup(uri = self$uri,
-                     config = cfg, # needed ?
                      private$.soma_context,
                      colnames = column_names,
                      qc = value_filter,

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -27,6 +27,7 @@ SOMADataFrame <- R6::R6Class(
       schema,
       index_column_names = c("soma_joinid"),
       platform_config = NULL,
+      soma_context = NULL,
       internal_use_only = NULL
     ) {
       if (is.null(internal_use_only) || internal_use_only != "allowed_use") {
@@ -42,6 +43,16 @@ SOMADataFrame <- R6::R6Class(
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
       tiledb_create_options <- TileDBCreateOptions$new(platform_config)
+      #print(str(tiledb_create_options$to_list()))
+
+      ## TODO: the private$.soma_context object contains an xptr to a struct containtaining
+      ## a shared point SOMAContext which contains a TileDB Context. The cached variable
+      ## is created in TileDBObject$initialize() so the argument on this signature is not
+      ## strictly needed
+      if (!is.null(soma_context)) {
+          spdl::debug("[SOMADataFrame$create] New soma context")
+          private$.soma_context <- soma_context
+      }
 
       ## we (currently pass domain and extent values in an arrow table (i.e. data.frame alike)
       ## where each dimension is one column (of the same type as in the schema) followed by three
@@ -62,7 +73,6 @@ SOMADataFrame <- R6::R6Class(
       schema$export_to_c(nasp)
 
       spdl::debug("[SOMADataFrame$create] about to create schema from arrow")
-      ctxptr <- super$tiledbsoma_ctx$context()
       createSchemaFromArrow(
         uri = self$uri,
         nasp = nasp,
@@ -71,7 +81,7 @@ SOMADataFrame <- R6::R6Class(
         sparse = TRUE,
         datatype = "SOMADataFrame",
         pclst = tiledb_create_options$to_list(FALSE),
-        ctxxp = soma_context(),
+        ctxxp = private$.soma_context,
         tsvec = self$.tiledb_timestamp_range
       )
 
@@ -121,6 +131,7 @@ SOMADataFrame <- R6::R6Class(
         uri = self$uri,
         naap = naap,
         nasp = nasp,
+        ctxxp = private$.soma_context,
         arraytype = "SOMADataFrame",
         config = NULL,
         tsvec = self$.tiledb_timestamp_range
@@ -182,13 +193,14 @@ SOMADataFrame <- R6::R6Class(
                   private$tiledb_timestamp[1], private$tiledb_timestamp[2])
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       rl <- sr_setup(uri = self$uri,
-                     config = cfg,
+                     config = cfg, # needed ?
+                     private$.soma_context,
                      colnames = column_names,
                      qc = value_filter,
                      dim_points = coords,
                      timestamprange = self$.tiledb_timestamp_range,  # NULL or two-elem vector
                      loglevel = log_level)
-      private$ctx_ptr <- rl$ctx
+      private$ctx_ptr <- rl$ctx # is this still needed?
       TableReadIter$new(rl$sr)
     },
 

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -155,6 +155,7 @@ SOMADenseNDArray <- R6::R6Class(
         uri = self$uri,
         naap = naap,
         nasp = nasp,
+        ctxxp = private$.soma_context,
         arraytype = "SOMADenseNDArray",
         config = NULL,
         tsvec = self$.tiledb_timestamp_range

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -51,7 +51,7 @@ SOMADenseNDArray <- R6::R6Class(
       }
       coords <- private$.convert_coords(coords)
 
-      cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      soma_context <- soma_context()  # package-level cached instance
       spdl::debug(
         "[SOMADenseNDArray$read_arrow_table] timestamp ({})",
         self$tiledb_timestamp %||% "now"
@@ -61,8 +61,8 @@ SOMADenseNDArray <- R6::R6Class(
                               dim_points = coords,
                               result_order = result_order,
                               timestamprange = self$.tiledb_timestamp_range,
-                              loglevel = log_level,
-                              config = cfg)
+                              soma_context = soma_context,
+                              loglevel = log_level)
 
       soma_array_to_arrow_table(rl)
     },

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -94,10 +94,7 @@ SOMANDArrayBase <- R6::R6Class(
     #' (lifecycle: maturing)
     #' @return Logical
     tiledbsoma_has_upgraded_shape = function() {
-      has_current_domain(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      )
+      has_current_domain(self$uri, private$.soma_context)
     }
 
   ),

--- a/apis/r/R/SOMANDArrayBase.R
+++ b/apis/r/R/SOMANDArrayBase.R
@@ -37,6 +37,8 @@ SOMANDArrayBase <- R6::R6Class(
       ## .is_sparse field is being set by dense and sparse private initialisers, respectively
       private$.type <- type                 # Arrow schema type of data
 
+      private$.soma_context <- soma_context() # package-level cache access
+
       #spdl::warn("[SOMANDArrayBase::create] type cached as {}", private$.type)
 
       dom_ext_tbl <- get_domain_and_extent_array(shape, private$.is_sparse)
@@ -69,7 +71,7 @@ SOMANDArrayBase <- R6::R6Class(
         sparse = private$.is_sparse,
         datatype = if (private$.is_sparse) "SOMASparseNDArray" else "SOMADenseNDArray",
         pclst = tiledb_create_options$to_list(FALSE),
-        ctxxp = soma_context(),
+        ctxxp = private$.soma_context,
         tsvec = self$.tiledb_timestamp_range
       )
       #private$write_object_type_metadata(timestamps)  ## FIXME: temp. commented out -- can this be removed overall?

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -221,7 +221,7 @@ SOMASparseNDArray <- R6::R6Class(
         (bit64::is.integer64(shape) && length(shape) == self$ndim())
       )
       # Checking slotwise new shape >= old shape, and <= max_shape, is already done in libtiledbsoma
-      tiledbsoma_upgrade_shape(self$uri, shape, , private$.soma_context)
+      tiledbsoma_upgrade_shape(self$uri, shape, private$.soma_context)
     }
 
   ),

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -187,7 +187,7 @@ SOMASparseNDArray <- R6::R6Class(
     #' @description Retrieve number of non-zero elements (lifecycle: maturing)
     #' @return A scalar with the number of non-zero elements
     nnz = function() {
-      nnz(self$uri, config=as.character(tiledb::config(self$tiledbsoma_ctx$context())))
+      nnz(self$uri, private$.soma_context)
     },
 
     #' @description Increases the shape of the array as specfied. Raises an error
@@ -205,8 +205,7 @@ SOMASparseNDArray <- R6::R6Class(
         (bit64::is.integer64(new_shape) && length(new_shape) == self$ndim())
       )
       # Checking slotwise new shape >= old shape, and <= max_shape, is already done in libtiledbsoma
-
-      resize(self$uri, new_shape, config=as.character(tiledb::config(self$tiledbsoma_ctx$context())))
+      resize(self$uri, new_shape, private$.soma_context)
     },
 
     #' @description Allows the array to have a resizeable shape as described in the
@@ -222,8 +221,7 @@ SOMASparseNDArray <- R6::R6Class(
         (bit64::is.integer64(shape) && length(shape) == self$ndim())
       )
       # Checking slotwise new shape >= old shape, and <= max_shape, is already done in libtiledbsoma
-
-      tiledbsoma_upgrade_shape(self$uri, shape, config=as.character(tiledb::config(self$tiledbsoma_ctx$context())))
+      tiledbsoma_upgrade_shape(self$uri, shape, , private$.soma_context)
     }
 
   ),

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -46,9 +46,8 @@ SOMASparseNDArray <- R6::R6Class(
         coords <- private$.convert_coords(coords)
       }
 
-      cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
+      ## not needed anymore  cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       sr <- sr_setup(uri = self$uri,
-                     config = cfg, # needed ?
                      private$.soma_context,
                      dim_points = coords,
                      result_order = result_order,

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -47,15 +47,14 @@ SOMASparseNDArray <- R6::R6Class(
       }
 
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      rl <- sr_setup(uri = self$uri,
+      sr <- sr_setup(uri = self$uri,
                      config = cfg, # needed ?
                      private$.soma_context,
                      dim_points = coords,
                      result_order = result_order,
                      timestamprange = self$.tiledb_timestamp_range,
                      loglevel = log_level)
-      private$ctx_ptr <- rl$ctx # needed ?
-      SOMASparseNDArrayRead$new(rl$sr, self, coords)
+      SOMASparseNDArrayRead$new(sr, self, coords)
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: maturing)
@@ -302,10 +301,7 @@ SOMASparseNDArray <- R6::R6Class(
     },
 
     # Internal marking of one or zero based matrices for iterated reads
-    zero_based = NA,
-
-    # Internal variable to hold onto context returned by sr_setup
-    ctx_ptr = NULL
+    zero_based = NA
 
   )
 )

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -48,12 +48,13 @@ SOMASparseNDArray <- R6::R6Class(
 
       cfg <- as.character(tiledb::config(self$tiledbsoma_ctx$context()))
       rl <- sr_setup(uri = self$uri,
-                     config = cfg,
+                     config = cfg, # needed ?
+                     private$.soma_context,
                      dim_points = coords,
                      result_order = result_order,
                      timestamprange = self$.tiledb_timestamp_range,
                      loglevel = log_level)
-      private$ctx_ptr <- rl$ctx
+      private$ctx_ptr <- rl$ctx # needed ?
       SOMASparseNDArrayRead$new(rl$sr, self, coords)
     },
 
@@ -293,6 +294,7 @@ SOMASparseNDArray <- R6::R6Class(
         uri = self$uri,
         naap = naap,
         nasp = nasp,
+        ctxxp = private$.soma_context,
         arraytype = "SOMASparseNDArray",
         config = NULL,
         tsvec = self$.tiledb_timestamp_range

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -154,10 +154,7 @@ TileDBArray <- R6::R6Class(
     #' (lifecycle: maturing)
     #' @return A named vector of dimension length (and the same type as the dimension)
     shape = function() {
-      as.integer64(shape(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      ))
+      as.integer64(shape(self$uri, private$.soma_context))
     },
 
     #' @description Retrieve the maxshape, i.e. maximum possible that the
@@ -165,10 +162,7 @@ TileDBArray <- R6::R6Class(
     #' (lifecycle: maturing)
     #' @return A named vector of dimension length (and the same type as the dimension)
     maxshape = function() {
-      as.integer64(maxshape(
-        self$uri,
-        config=as.character(tiledb::config(self$tiledbsoma_ctx$context()))
-      ))
+      as.integer64(maxshape(self$uri, private$.soma_context))
     },
 
     #' @description Retrieve the range of indexes for a dimension that were

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -439,7 +439,7 @@ TileDBGroup <- R6::R6Class(
         # TODO: do we really need the type here?
         # Calling tiledb::tiledb_object_type on remote storage has a cost;
         # perhaps unnecessary to incur.
-        type = tiledb::tiledb_object_type(object$uri),
+        type = get_tiledb_object_type(object$uri, private$.soma_context),
         uri = object$uri,
         name = name,
         object = object

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -15,7 +15,8 @@ TileDBObject <- R6::R6Class(
     #' @param internal_use_only Character value to signal this is a 'permitted' call,
     #' as `new()` is considered internal and should not be called directly.
     initialize = function(uri, platform_config = NULL, tiledbsoma_ctx = NULL,
-                          tiledb_timestamp = NULL, internal_use_only = NULL) {
+                          tiledb_timestamp = NULL, internal_use_only = NULL,
+                          soma_context = NULL) {
       if (is.null(internal_use_only) || internal_use_only != "allowed_use") {
         stop(paste("Use of the new() method is for internal use only. Consider using a",
                    "factory method as e.g. 'SOMADataFrameOpen()'."), call. = FALSE)
@@ -43,7 +44,11 @@ TileDBObject <- R6::R6Class(
       # stopifnot(
       #   "'soma_context' must be a pointer" = inherits(x = soma_context, what = 'externalptr')
       # )
-      private$.soma_context <- soma_context()  # FIXME via factory and paramater_config
+      if (is.null(soma_context)) {
+          private$.soma_context <- soma_context()  # FIXME via factory and paramater_config
+      } else {
+          private$.soma_context <- soma_context
+      }
 
       if (!is.null(tiledb_timestamp)) {
         stopifnot(

--- a/apis/r/R/datasets.R
+++ b/apis/r/R/datasets.R
@@ -67,7 +67,7 @@ load_dataset <- function(name, dir = tempdir(), tiledbsoma_ctx = NULL) {
 
   # Inspect the object's metadata
   object <- switch(
-    tiledb::tiledb_object_type(dataset_uri),
+    get_tiledb_object_type(dataset_uri, soma_context()),
     "ARRAY" = TileDBArray$new(dataset_uri, internal_use_only = "allowed_use"),
     "GROUP" = TileDBGroup$new(dataset_uri, internal_use_only = "allowed_use"),
     stop("The dataset is not a TileDB Array or Group", call. = FALSE)

--- a/apis/r/R/ephemeral.R
+++ b/apis/r/R/ephemeral.R
@@ -330,8 +330,8 @@ EphemeralCollectionBase <- R6::R6Class(
       names(members) <- names(private$.data)
       for (i in seq_along(members)) {
         members[[i]] <- list(
-          type = tiledb::tiledb_object_type(private$.data[[i]]$uri),
-          uri = private$.data[[i]]$uri,
+          type = get_tiledb_object_type(private$.data[[i]]$uri, private$.soma_context),
+            uri = private$.data[[i]]$uri,
           name = names(private$.data)[i]
         )
       }

--- a/apis/r/R/soma_array_reader.R
+++ b/apis/r/R/soma_array_reader.R
@@ -17,7 +17,7 @@
 #' @param result_order Character value with the desired result order, defaults to \sQuote{auto}
 #' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
 #' which lets prior setting prevail, any other value is set as new logging level.
-#' @param config Optional character vector containing TileDB config.
+#' @param soma_context Optional instance of a SOMA Context object
 #' @return A List object with two pointers to Arrow array data and schema is returned
 #' @examples
 #' \dontrun{
@@ -28,7 +28,7 @@
 #' @noRd
 soma_array_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL,
                               batch_size = "auto", result_order = "auto", loglevel = "auto",
-                              config = NULL, timestamprange = NULL) {
+                              soma_context = NULL, timestamprange = NULL) {
 
     stopifnot("'uri' must be character" = is.character(uri),
               "'colnames' must be character or NULL" = is_character_or_null(colnames),
@@ -42,7 +42,8 @@ soma_array_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL
               "'batch_size' must be character" = is.character(batch_size),
               "'result_order' must be character" = is.character(result_order),
               "'loglevel' must be character" = is.character(loglevel),
-              "'config' must be character or NULL" = is_character_or_null(config))
+              "'soma_context' must be external pointer or NULL" =
+                  is.null(soma_context) || inherits(soma_context, "externalptr"))
 
     if (!is.null(dim_points)) {
         for (i in seq_along(dim_points)) {
@@ -53,8 +54,9 @@ soma_array_reader <- function(uri, colnames = NULL, qc = NULL, dim_points = NULL
         }
     }
 
+    if (is.null(soma_context)) soma_context <- soma_context()  # package-level cached instance
     spdl::debug("[soma_array_reader] calling soma_array_reader_impl ({},{}",
                 timestamprange[1], timestamprange[2])
-    soma_array_reader_impl(uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order,
-                           loglevel, config, timestamprange)
+    soma_array_reader_impl(uri, soma_context, colnames, qc, dim_points, dim_ranges, batch_size,
+                           result_order, loglevel, timestamprange)
 }

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -168,6 +168,7 @@ uns_hint <- function(type = c('1d', '2d')) {
   rl <- sr_setup(
     uri = x$uri,
     config = as.character(tiledb::config(x$tiledbsoma_ctx$context())),
+    soma_context(),
     colnames = dimname,
     timestamprange = x$.tiledb_timestamp_range
   )

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -167,7 +167,6 @@ uns_hint <- function(type = c('1d', '2d')) {
   dimname <- x$dimnames()[axis + 1L]
   sr <- sr_setup(
     uri = x$uri,
-    config = as.character(tiledb::config(x$tiledbsoma_ctx$context())),
     soma_context(),
     colnames = dimname,
     timestamprange = x$.tiledb_timestamp_range

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -165,14 +165,14 @@ uns_hint <- function(type = c('1d', '2d')) {
   }
   x$reopen("READ", tiledb_timestamp = x$tiledb_timestamp)
   dimname <- x$dimnames()[axis + 1L]
-  rl <- sr_setup(
+  sr <- sr_setup(
     uri = x$uri,
     config = as.character(tiledb::config(x$tiledbsoma_ctx$context())),
     soma_context(),
     colnames = dimname,
     timestamprange = x$.tiledb_timestamp_range
   )
-  return(TableReadIter$new(rl$sr)$concat()$GetColumnByName(dimname)$as_vector())
+  return(TableReadIter$new(sr)$concat()$GetColumnByName(dimname)$as_vector())
 }
 
 #' Pad Names of a Character Vector

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -441,13 +441,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // sr_setup
-Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
-RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
+Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
+RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type config(configSEXP);
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type colnames(colnamesSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> >::type qc(qcSEXP);
@@ -457,7 +456,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type result_order(result_orderSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type timestamprange(timestamprangeSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type loglevel(loglevelSEXP);
-    rcpp_result_gen = Rcpp::wrap(sr_setup(uri, config, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel));
+    rcpp_result_gen = Rcpp::wrap(sr_setup(uri, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -645,7 +644,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_has_current_domain", (DL_FUNC) &_tiledbsoma_has_current_domain, 2},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 3},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 3},
-    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 11},
+    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_create_empty_arrow_table", (DL_FUNC) &_tiledbsoma_create_empty_arrow_table, 0},
     {"_tiledbsoma_sr_next", (DL_FUNC) &_tiledbsoma_sr_next, 1},

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -281,12 +281,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // soma_array_reader
-SEXP soma_array_reader(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, const std::string& loglevel, Rcpp::Nullable<Rcpp::CharacterVector> config, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange);
-RcppExport SEXP _tiledbsoma_soma_array_reader(SEXP uriSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP, SEXP configSEXP, SEXP timestamprangeSEXP) {
+SEXP soma_array_reader(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, const std::string& loglevel, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange);
+RcppExport SEXP _tiledbsoma_soma_array_reader(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP loglevelSEXP, SEXP timestamprangeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type colnames(colnamesSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> >::type qc(qcSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type dim_points(dim_pointsSEXP);
@@ -294,9 +295,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type batch_size(batch_sizeSEXP);
     Rcpp::traits::input_parameter< std::string >::type result_order(result_orderSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type loglevel(loglevelSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type timestamprange(timestamprangeSEXP);
-    rcpp_result_gen = Rcpp::wrap(soma_array_reader(uri, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, config, timestamprange));
+    rcpp_result_gen = Rcpp::wrap(soma_array_reader(uri, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, loglevel, timestamprange));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -323,14 +323,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // nnz
-double nnz(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_nnz(SEXP uriSEXP, SEXP configSEXP) {
+double nnz(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_nnz(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(nnz(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(nnz(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -357,86 +357,86 @@ BEGIN_RCPP
 END_RCPP
 }
 // shape
-Rcpp::NumericVector shape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_shape(SEXP uriSEXP, SEXP configSEXP) {
+Rcpp::NumericVector shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_shape(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(shape(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(shape(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
 // maxshape
-Rcpp::NumericVector maxshape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_maxshape(SEXP uriSEXP, SEXP configSEXP) {
+Rcpp::NumericVector maxshape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_maxshape(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(maxshape(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(maxshape(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
 // maybe_soma_joinid_shape
-Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_maybe_soma_joinid_shape(SEXP uriSEXP, SEXP configSEXP) {
+Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_maybe_soma_joinid_shape(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_shape(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_shape(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
 // maybe_soma_joinid_maxshape
-Rcpp::NumericVector maybe_soma_joinid_maxshape(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_maybe_soma_joinid_maxshape(SEXP uriSEXP, SEXP configSEXP) {
+Rcpp::NumericVector maybe_soma_joinid_maxshape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_maybe_soma_joinid_maxshape(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_maxshape(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(maybe_soma_joinid_maxshape(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
 // has_current_domain
-Rcpp::LogicalVector has_current_domain(const std::string& uri, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_has_current_domain(SEXP uriSEXP, SEXP configSEXP) {
+Rcpp::LogicalVector has_current_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_has_current_domain(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    rcpp_result_gen = Rcpp::wrap(has_current_domain(uri, config));
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(has_current_domain(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
 // resize
-void resize(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_resize(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP configSEXP) {
+void resize(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_resize(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type new_shape(new_shapeSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    resize(uri, new_shape, config);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    resize(uri, new_shape, ctxxp);
     return R_NilValue;
 END_RCPP
 }
 // tiledbsoma_upgrade_shape
-void tiledbsoma_upgrade_shape(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::Nullable<Rcpp::CharacterVector> config);
-RcppExport SEXP _tiledbsoma_tiledbsoma_upgrade_shape(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP configSEXP) {
+void tiledbsoma_upgrade_shape(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_tiledbsoma_upgrade_shape(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type new_shape(new_shapeSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
-    tiledbsoma_upgrade_shape(uri, new_shape, config);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    tiledbsoma_upgrade_shape(uri, new_shape, ctxxp);
     return R_NilValue;
 END_RCPP
 }

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -41,17 +41,18 @@ BEGIN_RCPP
 END_RCPP
 }
 // writeArrayFromArrow
-void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp, const std::string arraytype, Rcpp::Nullable<Rcpp::CharacterVector> config, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
-RcppExport SEXP _tiledbsoma_writeArrayFromArrow(SEXP uriSEXP, SEXP naapSEXP, SEXP naspSEXP, SEXP arraytypeSEXP, SEXP configSEXP, SEXP tsvecSEXP) {
+void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp, Rcpp::XPtr<somactx_wrap_t> ctxxp, const std::string arraytype, Rcpp::Nullable<Rcpp::CharacterVector> config, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
+RcppExport SEXP _tiledbsoma_writeArrayFromArrow(SEXP uriSEXP, SEXP naapSEXP, SEXP naspSEXP, SEXP ctxxpSEXP, SEXP arraytypeSEXP, SEXP configSEXP, SEXP tsvecSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< naxpArray >::type naap(naapSEXP);
     Rcpp::traits::input_parameter< naxpSchema >::type nasp(naspSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< const std::string >::type arraytype(arraytypeSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type tsvec(tsvecSEXP);
-    writeArrayFromArrow(uri, naap, nasp, arraytype, config, tsvec);
+    writeArrayFromArrow(uri, naap, nasp, ctxxp, arraytype, config, tsvec);
     return R_NilValue;
 END_RCPP
 }
@@ -440,13 +441,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // sr_setup
-Rcpp::List sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
-RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
+Rcpp::List sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
+RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type config(configSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type colnames(colnamesSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> >::type qc(qcSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type dim_points(dim_pointsSEXP);
@@ -455,7 +457,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type result_order(result_orderSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type timestamprange(timestamprangeSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type loglevel(loglevelSEXP);
-    rcpp_result_gen = Rcpp::wrap(sr_setup(uri, config, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel));
+    rcpp_result_gen = Rcpp::wrap(sr_setup(uri, config, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -611,7 +613,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_createSOMAContext", (DL_FUNC) &_tiledbsoma_createSOMAContext, 1},
     {"_tiledbsoma_createSchemaFromArrow", (DL_FUNC) &_tiledbsoma_createSchemaFromArrow, 9},
-    {"_tiledbsoma_writeArrayFromArrow", (DL_FUNC) &_tiledbsoma_writeArrayFromArrow, 6},
+    {"_tiledbsoma_writeArrayFromArrow", (DL_FUNC) &_tiledbsoma_writeArrayFromArrow, 7},
     {"_tiledbsoma_c_group_create", (DL_FUNC) &_tiledbsoma_c_group_create, 4},
     {"_tiledbsoma_c_group_open", (DL_FUNC) &_tiledbsoma_c_group_open, 4},
     {"_tiledbsoma_c_group_member_count", (DL_FUNC) &_tiledbsoma_c_group_member_count, 1},
@@ -643,7 +645,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_has_current_domain", (DL_FUNC) &_tiledbsoma_has_current_domain, 2},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 3},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 3},
-    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
+    {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 11},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_create_empty_arrow_table", (DL_FUNC) &_tiledbsoma_create_empty_arrow_table, 0},
     {"_tiledbsoma_sr_next", (DL_FUNC) &_tiledbsoma_sr_next, 1},

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -441,7 +441,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // sr_setup
-Rcpp::List sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
+Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri, Rcpp::CharacterVector config, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
 RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP configSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -147,6 +147,7 @@ void createSchemaFromArrow(const std::string& uri, naxpSchema nasp, naxpArray na
 
 // [[Rcpp::export]]
 void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp,
+                         Rcpp::XPtr<somactx_wrap_t> ctxxp,
                          const std::string arraytype = "",
                          Rcpp::Nullable<Rcpp::CharacterVector> config = R_NilValue,
                          Rcpp::Nullable<Rcpp::DatetimeVector> tsvec = R_NilValue) {
@@ -169,21 +170,26 @@ void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp
     auto array = std::make_unique<ArrowArray>();
     ap.move(array.get());
 
-    // if we hae a coonfig, use it
-    std::shared_ptr<tdbs::SOMAContext> somactx;
-    if (config.isNotNull()) {
-        std::map<std::string, std::string> smap;
-        auto config_vec = config.as();
-        auto config_names = Rcpp::as<Rcpp::CharacterVector>(config_vec.names());
-        for (auto &name : config_names) {
-            std::string param = Rcpp::as<std::string>(name);
-            std::string value = Rcpp::as<std::string>(config_vec[param]);
-            smap[param] = value;
-        }
-        somactx = std::make_shared<tdbs::SOMAContext>(smap);
-    } else {
-        somactx = std::make_shared<tdbs::SOMAContext>();
-    }
+    // shared pointer to SOMAContext from external pointer wrapper
+    std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;
+    // shared pointer to TileDB Context from SOMAContext -- not needed here
+    // std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+
+    // // if we hae a coonfig, use it
+    // std::shared_ptr<tdbs::SOMAContext> somactx;
+    // if (config.isNotNull()) {
+    //     std::map<std::string, std::string> smap;
+    //     auto config_vec = config.as();
+    //     auto config_names = Rcpp::as<Rcpp::CharacterVector>(config_vec.names());
+    //     for (auto &name : config_names) {
+    //         std::string param = Rcpp::as<std::string>(name);
+    //         std::string value = Rcpp::as<std::string>(config_vec[param]);
+    //         smap[param] = value;
+    //     }
+    //     somactx = std::make_shared<tdbs::SOMAContext>(smap);
+    // } else {
+    //     somactx = std::make_shared<tdbs::SOMAContext>();
+    // }
 
     // optional timestamp range
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(tsvec);

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -54,8 +54,8 @@ namespace tdbs = tiledbsoma;
 //' @examples
 //' \dontrun{
 //' uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
-//' ctx <- tiledb::tiledb_ctx()
-//' sr <- sr_setup(uri, config=as.character(tiledb::config(ctx)))
+//' ctxcp <- soma_context()
+//' sr <- sr_setup(uri, ctxxp)
 //' rl <- data.frame()
 //' while (!sr_complete(sr)) {
 //'   dat <- sr_next(sr)
@@ -67,7 +67,6 @@ namespace tdbs = tiledbsoma;
 //' @noRd
 // [[Rcpp::export]]
 Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
-                                     Rcpp::CharacterVector config,
                                      Rcpp::XPtr<somactx_wrap_t> ctxxp,
                                      Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
                                      Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
@@ -87,10 +86,6 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
 
     std::string_view name = "unnamed";
     std::vector<std::string> column_names = {};
-
-    std::map<std::string, std::string> platform_config = config_vector_to_map(Rcpp::wrap(config));
-    tiledb::Config cfg(platform_config); // no longer needed ?
-    // std::shared_ptr<tiledb::Context> ctxptr = std::make_shared<tiledb::Context>(cfg);
 
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -89,7 +89,7 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
 
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;
-    // shared pointer to TileDB Context from SOMAContext -- not needed here
+    // shared pointer to TileDB Context from SOMAContext
     std::shared_ptr<tiledb::Context> ctxptr = somactx->tiledb_ctx();
 
     ctx_wrap_t* ctxwrap_p = new ContextWrapper(ctxptr);

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -66,17 +66,17 @@ namespace tdbs = tiledbsoma;
 //' }
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::List sr_setup(const std::string& uri,
-                    Rcpp::CharacterVector config,
-                    Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                    Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
-                    Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
-                    Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
-                    Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
-                    std::string batch_size = "auto",
-                    std::string result_order = "auto",
-                    Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue,
-                    const std::string& loglevel = "auto") {
+Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
+                                     Rcpp::CharacterVector config,
+                                     Rcpp::XPtr<somactx_wrap_t> ctxxp,
+                                     Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
+                                     Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
+                                     std::string batch_size = "auto",
+                                     std::string result_order = "auto",
+                                     Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue,
+                                     const std::string& loglevel = "auto") {
 
     if (loglevel != "auto") {
         spdl::set_level(loglevel);
@@ -150,8 +150,7 @@ Rcpp::List sr_setup(const std::string& uri,
     }
 
     Rcpp::XPtr<tdbs::SOMAArray> xptr = make_xptr<tdbs::SOMAArray>(ptr);
-    return Rcpp::List::create(Rcpp::Named("sr") = xptr,
-                              Rcpp::Named("ctx") = ctx_wrap_xptr);
+    return xptr;
 }
 
 // [[Rcpp::export]]

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -12,10 +12,8 @@ test_that("Iterated Interface from SOMAArrayReader", {
     uri <- file.path(tdir, "soco", "pbmc3k_processed", "ms", "RNA", "X", "data")
     expect_true(dir.exists(uri))
 
-    ctx <- tiledb::tiledb_ctx()
-    config <- tiledb::config(ctx)
     somactx <- soma_context()
-    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx, loglevel = "warn")
+    sr <- sr_setup(uri, ctxxp = somactx, loglevel = "warn")
     expect_true(inherits(sr, "externalptr"))
 
     rl <- data.frame()
@@ -32,8 +30,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
     rm(sr)
     gc()
 
-    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
-                   dim_points = list(soma_dim_0=as.integer64(1)))
+    sr <- sr_setup(uri, ctxxp = somactx, dim_points = list(soma_dim_0=as.integer64(1)))
     expect_true(inherits(sr, "externalptr"))
 
     rl <- data.frame()
@@ -51,7 +48,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
     rm(sr)
     gc()
 
-    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
+    sr <- sr_setup(uri, ctxxp = somactx,
                    dim_range = list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
     expect_true(inherits(sr, "externalptr"))
 
@@ -69,7 +66,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
 
     ## test completeness predicate on shorter data
     uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
-    sr <- sr_setup(uri, config=as.character(config), somactx)
+    sr <- sr_setup(uri, somactx)
 
     expect_false(tiledbsoma:::sr_complete(sr))
     dat <- sr_next(sr)
@@ -205,8 +202,6 @@ test_that("Iterated Interface from SOMA Sparse Matrix", {
 test_that("Dimension Point and Ranges Bounds", {
     skip_if(!extended_tests() || covr_tests())
     ctx <- tiledbsoma::SOMATileDBContext$new()
-
-    config <- as.character(tiledb::config(ctx$context()))
     human_experiment <- load_dataset("soma-exp-pbmc-small", tiledbsoma_ctx = ctx)
     X <- human_experiment$ms$get("RNA")$X$get("data")
     expect_equal(X$shape(), c(80, 230))
@@ -216,7 +211,7 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim points
     coords <- list(soma_dim_0=bit64::as.integer64(0:5),
                    soma_dim_1=bit64::as.integer64(0:5))
-    sr <- sr_setup(uri = X$uri, config = config, ctxxp = somactx, dim_points = coords)
+    sr <- sr_setup(uri = X$uri, ctxxp = somactx, dim_points = coords)
 
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(chunk)
@@ -228,7 +223,7 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim ranges
     ranges <- list(soma_dim_0=matrix(bit64::as.integer64(c(1,4)),1),
                    soma_dim_1=matrix(bit64::as.integer64(c(1,4)),1))
-    sr <- sr_setup(uri = X$uri, config = config, somactx, dim_ranges = ranges)
+    sr <- sr_setup(uri = X$uri, somactx, dim_ranges = ranges)
 
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(chunk)
@@ -238,12 +233,12 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'bad case' with unsuitable dim points
     coords <- list(soma_dim_0=bit64::as.integer64(81:86),
                    soma_dim_1=bit64::as.integer64(0:5))
-    expect_error(sr_setup(uri = X$uri, config = config, dim_points = coords))
+    expect_error(sr_setup(uri = X$uri, dim_points = coords))
 
     ## 'bad case' with unsuitable dim range
     ranges <- list(soma_dim_0=matrix(bit64::as.integer64(c(91,94)),1),
                    soma_dim_1=matrix(bit64::as.integer64(c(1,4)),1))
-    expect_error(sr_setup(uri = X$uri, config = config, dim_ranges = ranges))
+    expect_error(sr_setup(uri = X$uri, dim_ranges = ranges))
     rm(sr)
     gc()
 

--- a/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-SOMAArrayReader-Iterated.R
@@ -15,8 +15,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
     ctx <- tiledb::tiledb_ctx()
     config <- tiledb::config(ctx)
     somactx <- soma_context()
-    srret <- sr_setup(uri, config = as.character(config), ctxxp = somactx, loglevel = "warn")
-    sr <- srret$sr
+    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx, loglevel = "warn")
     expect_true(inherits(sr, "externalptr"))
 
     rl <- data.frame()
@@ -33,9 +32,8 @@ test_that("Iterated Interface from SOMAArrayReader", {
     rm(sr)
     gc()
 
-    srret <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
-                      dim_points = list(soma_dim_0=as.integer64(1)))
-    sr <- srret$sr
+    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
+                   dim_points = list(soma_dim_0=as.integer64(1)))
     expect_true(inherits(sr, "externalptr"))
 
     rl <- data.frame()
@@ -53,9 +51,8 @@ test_that("Iterated Interface from SOMAArrayReader", {
     rm(sr)
     gc()
 
-    srret <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
-                      dim_range = list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
-    sr <- srret$sr
+    sr <- sr_setup(uri, config = as.character(config), ctxxp = somactx,
+                   dim_range = list(soma_dim_1=cbind(as.integer64(1),as.integer64(2))))
     expect_true(inherits(sr, "externalptr"))
 
     rl <- data.frame()
@@ -72,8 +69,7 @@ test_that("Iterated Interface from SOMAArrayReader", {
 
     ## test completeness predicate on shorter data
     uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs")
-    srret <- sr_setup(uri, config=as.character(config), somactx)
-    sr <- srret$sr
+    sr <- sr_setup(uri, config=as.character(config), somactx)
 
     expect_false(tiledbsoma:::sr_complete(sr))
     dat <- sr_next(sr)
@@ -220,8 +216,7 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim points
     coords <- list(soma_dim_0=bit64::as.integer64(0:5),
                    soma_dim_1=bit64::as.integer64(0:5))
-    srret <- sr_setup(uri = X$uri, config = config, ctxxp = somactx, dim_points = coords)
-    sr <- srret$sr
+    sr <- sr_setup(uri = X$uri, config = config, ctxxp = somactx, dim_points = coords)
 
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(chunk)
@@ -233,8 +228,7 @@ test_that("Dimension Point and Ranges Bounds", {
     ## 'good case' with suitable dim ranges
     ranges <- list(soma_dim_0=matrix(bit64::as.integer64(c(1,4)),1),
                    soma_dim_1=matrix(bit64::as.integer64(c(1,4)),1))
-    srret <- sr_setup(uri = X$uri, config = config, somactx, dim_ranges = ranges)
-    sr <- srret$sr
+    sr <- sr_setup(uri = X$uri, config = config, somactx, dim_ranges = ranges)
 
     chunk <- sr_next(sr)
     at <- arrow::as_arrow_table(chunk)

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -82,13 +82,15 @@ test_that("SOMASparseNDArray creation", {
   expect_equal(ndarray$nnz(), 60L)
 
   ## nnz as free function
-  expect_equal(nnz(uri), 60L)
-  ## nzz with config, expected breakge as 'bad key' used
-  expect_error(nnz(uri, c(sm.encryption_key="Nope", sm.encryption_type="AES_256_GCM")))
+  expect_equal(nnz(uri, soma_context()), 60L)
+  ## nnz with config, expected breakge as 'bad key' used
+  ## uses 'internal' create function to not cache globally as soma_context() would
+  badconfig <- createSOMAContext(c(sm.encryption_key="Nope", sm.encryption_type="AES_256_GCM"))
+  expect_error(nnz(uri, badconfig))
   ## shape as free function
-  expect_equal(shape(uri), c(10,10))
+  expect_equal(shape(uri, soma_context()), c(10,10))
   ## shape with config, expected breakge as 'bad key' used
-  expect_error(shape(uri, c(sm.encryption_key="Nope", sm.encryption_type="AES_256_GCM")))
+  expect_error(shape(uri, badconfig))
 
   ndarray$close()
 

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -42,17 +42,18 @@ test_that("SOMADataFrame shape", {
     # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
     # sjid_shape <- sdf$.maybe_soma_joinid_shape()
     # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
-    sjid_shape <- maybe_soma_joinid_shape(sdf$uri, config = as.character(tiledb::config(sdf$tiledbsoma_ctx$context())))
-    sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, config = as.character(tiledb::config(sdf$tiledbsoma_ctx$context())))
+    soma_context <- soma_context()
+    sjid_shape <- maybe_soma_joinid_shape(sdf$uri, soma_context)
+    sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, soma_context)
 
     if (has_soma_joinid_dim) {
       # More testing to come on
       # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-      expect_false(sjid_shape == -1)
-      expect_false(sjid_maxshape == -1)
+      expect_false(is.na(sjid_shape))
+      expect_false(is.na(sjid_maxshape))
     } else {
-      expect_true(sjid_shape == -1)
-      expect_true(sjid_maxshape == -1)
+      expect_true(is.na(sjid_shape))
+      expect_true(is.na(sjid_maxshape))
     }
 
     sdf$close()


### PR DESCRIPTION
**Issue and/or context:**

SOMA Context objects are used throughout the C++ library part of SOMA.  Where we previously serialized context and configuration to vector, maps or lists of key-value pairs, we now hold on to an allocated object for longer.

**Changes:**

This PR changes how we provide such a context from the R package by allocating one as a shared pointer and passing it around as an external pointer throuch which the SOMA context object can be accessed.  Where needed, the SOMA context also contains a (core) TileDB context object.  

We currently cache the most-recently created object at the package level and provide it if no new one is demanded.  This scheme is exactly what tiledb-r does, and acts reliably and robust via a single access point `soma_context()`.  One unit test show how to create a different configuration without caching, using it and then reverting to the default.

SOMA classes can obtain their initial default object via the instantiating factory methods.  Access is then provided via a member function, allowing both for simple re-use as well variations (object by object) as needed.  How to split the core object values off the `platform_config` object is left for a subsequent PR that will refine the interface.

All tests pass.

**Notes for Reviewer:**

[SC 55146](https://app.shortcut.com/tiledb-inc/story/55146/r-c-use-somacontext-throughout)
