### PR TITLE
[python] Post-deprecation removal of `consolidate_and_vacuum` from `TileDBCreateOptions`

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -27,7 +27,10 @@ from .options._soma_tiledb_context import (
     SOMATileDBContext,
     _validate_soma_tiledb_context,
 )
-from .options._tiledb_create_write_options import TileDBCreateOptions
+from .options._tiledb_create_write_options import (
+    TileDBCreateOptions,
+    TileDBWriteOptions,
+)
 
 
 class DenseNDArray(NDArray, somacore.DenseNDArray):
@@ -289,10 +292,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         self._set_reader_coords(clib_dense_array, new_coords)
         clib_dense_array.write(input)
 
-        tiledb_create_write_options = TileDBCreateOptions.from_platform_config(
-            platform_config
-        )
-        if tiledb_create_write_options.consolidate_and_vacuum:
+        tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)
+        if tiledb_write_options.consolidate_and_vacuum:
             clib_dense_array.consolidate_and_vacuum()
         return self
 

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -334,7 +334,6 @@ def build_clib_platform_config(
     plt_cfg.cell_order = ops.cell_order
     plt_cfg.dims = _build_column_config(ops.dims)
     plt_cfg.attrs = _build_column_config(ops.attrs)
-    plt_cfg.consolidate_and_vacuum = ops.consolidate_and_vacuum
     return plt_cfg
 
 

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -157,9 +157,6 @@ class TileDBCreateOptions:
     attrs: Mapping[str, _ColumnConfig] = attrs_.field(
         factory=dict, converter=_normalize_columns
     )
-    consolidate_and_vacuum: bool = attrs_.field(
-        validator=vld.instance_of(bool), default=False
-    )
 
     @classmethod
     def from_platform_config(


### PR DESCRIPTION
**Issue and/or context:** Resolves #2579. See also #2999 and [[sc-53002]](https://app.shortcut.com/tiledb-inc/story/53002/update-projects-to-tiledb-2-26).

**Changes:**

**Notes for Reviewer:**

