### PR TITLE
[python] Remove `pyarrow` pin on MacOS

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -332,13 +332,7 @@ setuptools.setup(
         "numba>=0.58.0",
         "numpy<2.0",
         "pandas",
-        # TODO: once we no longer support Python 3.7, remove this and pin to pyarrow >= 14.0.1
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
-        "pyarrow_hotfix",
-        # MacOS issue with import pyarrow before import tiledb at >= 13.0:
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149
-        "pyarrow>=9.0.0,<13.0.0; platform_system=='Darwin'",
-        "pyarrow>=9.0.0; platform_system!='Darwin'",
+        "pyarrow",
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -185,8 +185,8 @@ from .pytiledbsoma import (
     tiledbsoma_stats_reset,
 )
 from .stats import (
-    tiledbsoma_stats_json,
     tiledbsoma_stats_as_py,
+    tiledbsoma_stats_json,
 )
 
 __version__ = get_implementation_version()
@@ -223,4 +223,6 @@ __all__ = [
     "tiledbsoma_stats_dump",
     "tiledbsoma_stats_enable",
     "tiledbsoma_stats_reset",
+    "tiledbsoma_stats_as_py",
+    "tiledbsoma_stats_json",
 ]

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -150,10 +150,11 @@ except ImportError:
 from somacore import AxisColumnNames, AxisQuery, ExperimentAxisQuery
 from somacore.options import ResultOrder
 
-# TODO: once we no longer support Python 3.7, remove this and pin to pyarrow >= 14.0.1
-# https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+# This is important since we need to do the above dll/dylib/so business
+# _before_ imports, but, ruff will tell us that imports need to be
+# at the top of the file:
+#
 # ruff: noqa
-import pyarrow_hotfix
 
 from ._collection import Collection
 from ._constants import SOMA_JOINID


### PR DESCRIPTION
Long-awaited work coming to fruition:

* https://github.com/single-cell-data/TileDB-SOMA/issues/1849
* https://github.com/single-cell-data/TileDB-SOMA/pull/2692
* https://github.com/single-cell-data/TileDB-SOMA/pull/2734
* https://github.com/TileDB-Inc/TileDB/pull/5223 went into [core 2.26](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.0), making this possible

See also https://github.com/single-cell-data/TileDB-SOMA/issues/2999 [[sc-53002]](https://app.shortcut.com/tiledb-inc/story/53002/update-projects-to-tiledb-2-26)
