### PR TITLE
[r] Remove core version check

### DIFF
--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -8,16 +8,6 @@
     ## create a slot for somactx in per-package enviroment, do no fill it yet to allow 'lazy load'
     .pkgenv[["somactx"]] <- NULL
 
-    rpkg_lib <- tiledb::tiledb_version(compact = FALSE)
-    # Check major and minor but not micro: sc-50464
-    rpkg_lib_version <- paste(rpkg_lib[["major"]], rpkg_lib[["minor"]], sep = ".")
-    soma_lib_version <- libtiledbsoma_version(compact = TRUE, major_minor_only = TRUE)
-    if (rpkg_lib_version != soma_lib_version) {
-        msg <- sprintf("TileDB Core version %s used by TileDB-R package, but TileDB-SOMA uses %s",
-                       sQuote(rpkg_lib_version), sQuote(soma_lib_version))
-        stop(msg, call. = FALSE)
-    }
-
     # This is temporary for https://github.com/single-cell-data/TileDB-SOMA/issues/2407
     # It will be removed once 2407 is complete.
     if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {


### PR DESCRIPTION
This was very much put in place for a good reason. However, as of recently we no longer use the tiledb-r path to read or write arrays.