### PR TITLE
[r] Add `axis` checks when initializing a sparse blockwise read

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.13.99.9
+Version: 1.13.99.10
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -9,6 +9,7 @@
 * Fix bug in blockwise iteration
 * Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
 * SOMA context objects are used throughout SOMA object creation
+* Add value-checking for `axis` parameter when initializing blockwise reads
 
 # tiledbsoma 1.13.0
 

--- a/apis/r/R/SOMASparseNDArrayRead.R
+++ b/apis/r/R/SOMASparseNDArrayRead.R
@@ -213,6 +213,7 @@ SOMASparseNDArrayBlockwiseRead <- R6::R6Class(
     ) {
       super$initialize(sr, array, coords)
       stopifnot(
+        "'axis' must be a single integer value" = rlang::is_integerish(axis, n = 1L, finite = TRUE),
         "'size' must be a single integer value" = is.null(size) ||
           rlang::is_integerish(size, 1L, finite = TRUE) ||
           (inherits(size, 'integer64') && length(size) == 1L && is.finite(size)),
@@ -221,9 +222,18 @@ SOMASparseNDArrayBlockwiseRead <- R6::R6Class(
           rlang::is_integerish(reindex_disable_on_axis, finite = TRUE) ||
           (inherits(reindex_disable_on_axis, 'integer64') && all(is.finite(reindex_disable_on_axis)))
       )
+      if (axis < 0L || axis >= self$array$ndim()) {
+        stop(
+          "'axis' must be between 0 and ",
+          self$array$ndim() - 1L,
+          call. = FALSE
+        )
+      }
       private$.axis <- axis
-      for (i in seq_along(self$coords)) {
-        self$coords[[i]]$stride <- size
+      if (!is.null(size)) {
+        for (i in seq_along(self$coords)) {
+          self$coords[[i]]$stride <- size
+        }
       }
       private$.reindex_disable_on_axis <- reindex_disable_on_axis
     },


### PR DESCRIPTION
Add checks to ensure that `axis` is a valid axis when initializing a sparse blockwise read

Modified SOMA methods:
 - `SOMASparseNDArrayBlockwiseRead()`: add value and type checking for `axis`

[SC-55366](https://app.shortcut.com/tiledb-inc/story/55366/)