### PR TITLE
[r] Add support for reading v5 assays from an axis query

### DIFF
--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -112,10 +112,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         soma_dim_1 = self$var_joinids()$as_vector()
       )
       # Handle ragged arrays
-      shape <- tryCatch(
-        x_layer$maxshape(),
-        error = function(...) x_layer$shape()
-      )
+      shape <- x_layer$shape()
       for (i in seq_along(along.with = coords)) {
         coords[[i]] <- coords[[i]][coords[[i]] < shape[i]]
       }
@@ -1673,11 +1670,10 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           call. = FALSE
         )
       }
-      dnames <- list(features, cells)
 
       # Find the default layers
       default_layers <- self$ms$X$get_metadata(default_hint)
-      if (!is.null(default_layers) && grepl(pattern = '^[', x = default_layers)) {
+      if (!is.null(default_layers) && grepl(pattern = '^\\[', x = default_layers)) {
         check_package('jsonlite')
         default_layers <- jsonlite::fromJSON(default_layers)
       }
@@ -1705,7 +1701,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         attrn <- self$ms$X$get(lyr)$attrnames()
         pkg <- NULL
         if (!is.null(type_hint)) {
-          if (grepl(pattern = '^[', x = type_hint)) {
+          if (grepl(pattern = '^\\[', x = type_hint)) {
             if (!requireNamespace('jsonlite', quietly = TRUE)) {
               warning(warningCondition(
                 sprintf(

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -778,11 +778,9 @@ SOMAExperimentAxisQuery <- R6::R6Class(
         "'drop_levels' must be TRUE or FALSE" = isTRUE(drop_levels) ||
           isFALSE(drop_levels)
       )
-      # assay_hint <- names(.assay_version_hint())
-      assay_hint <- 'soma_ecosystem_seurat_assay_version'
+      assay_hint <- names(.assay_version_hint())
       # Get the assay version
       version <- version %||%
-        # self$ms$get_metadata(names(.assay_version_hint())) %||%
         self$ms$get_metadata(assay_hint) %||%
         'v3'
       match.arg(version, choices = c('v3', 'v5'))
@@ -835,11 +833,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           )
         },
         v5 = {
-          # cells_hint <- .assay_obs_hint(private$.measurement_name)
-          cells_hint <- sprintf(
-            "soma_ecosystem_seurat_assay_cells_%s",
-            private$.measurement_name
-          )
+          cells_hint <- .assay_obs_hint(private$.measurement_name)
           if (cells_hint %in% private$.experiment$obs$colnames()) {
             cells_idx <- private$.load_df('obs', column_names = cells_hint)[[cells_hint]]
             cells <- cells[cells_idx]
@@ -1652,12 +1646,9 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       }
 
       # Get our metadata hints
-      # ragged_hint <- .ragged_array_hint()
-      ragged_hint <- list(soma_ecosystem_seurat_v5_ragged = 'ragged')
-      # default_hint <- names(.layer_hint(lname))
-      default_hint <- names(list(soma_ecosystem_seurat_v5_default_layers = lname))
-      # type_hint <- names(.type_hint(NULL))
-      r_type_hint <- names(list(soma_r_type_hint = NULL))
+      ragged_hint <- .ragged_array_hint()
+      default_hint <- names(.layer_hint(lname))
+      r_type_hint <- names(.type_hint(NULL))
       s4_type <- paste0('^', .standard_regexps()$valid_package_name, ':')
 
       # Check arguments

--- a/apis/r/R/SOMAExperimentAxisQuery.R
+++ b/apis/r/R/SOMAExperimentAxisQuery.R
@@ -776,7 +776,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
           isFALSE(drop_levels)
       )
       assay_hint <- names(.assay_version_hint())
-      # Get the assay version
+      # Get the Seurat assay version
       version <- version %||%
         self$ms$get_metadata(assay_hint) %||%
         'v3'
@@ -1635,7 +1635,7 @@ SOMAExperimentAxisQuery <- R6::R6Class(
       check_package('SeuratObject', version = '5.0.2')
 
       # Create dummy layer to initialize v5 assay
-      lname <- SeuratObject::RandomName(length = 7L)
+      layer_name <- SeuratObject::RandomName(length = 7L)
       i <- 0L
       while (lname %in% layers) {
         lname <- SeuratObject::RandomName(length = 7L + i)
@@ -1732,8 +1732,8 @@ SOMAExperimentAxisQuery <- R6::R6Class(
             }
           }
         }
-        lcells <- cells
-        lfeatures <- features
+        layer_cells <- cells
+        layer_features <- features
         if (is.null(lyr_hint) || lyr_hint != ragged_hint[[1L]]) {
           mat <- Matrix::t(self$to_sparse_matrix(
             collection = 'X',

--- a/apis/r/man/SOMAExperimentAxisQuery.Rd
+++ b/apis/r/man/SOMAExperimentAxisQuery.Rd
@@ -338,7 +338,8 @@ Loads the query as a \code{\link[SeuratObject]{Seurat}} object
   obsm_layers = NULL,
   varm_layers = NULL,
   obsp_layers = NULL,
-  drop_levels = FALSE
+  drop_levels = FALSE,
+  version = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -362,6 +363,9 @@ Loads the query as a \code{\link[SeuratObject]{Seurat}} object
 \item{\code{obsp_layers}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_players()}}
 
 \item{\code{drop_levels}}{Drop unused levels from \code{obs} and \code{var} factor columns}
+
+\item{\code{version}}{Assay version to read query in as; by default, will try to
+infer assay type from the measurement itself}
 }
 \if{html}{\out{</div>}}
 }
@@ -380,7 +384,8 @@ Loads the query as a Seurat \code{\link[SeuratObject]{Assay}}
   obs_index = NULL,
   var_index = NULL,
   var_column_names = NULL,
-  drop_levels = FALSE
+  drop_levels = FALSE,
+  version = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -396,6 +401,9 @@ Loads the query as a Seurat \code{\link[SeuratObject]{Assay}}
 \item{\code{var_column_names}}{\Sexpr[results=rd]{tiledbsoma:::rd_outgest_metadata_names(axis = 'var')}}
 
 \item{\code{drop_levels}}{Drop unused levels from \code{var} factor columns}
+
+\item{\code{version}}{Assay version to read query in as; by default, will try to
+infer assay type from the measurement itself}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -358,11 +358,9 @@ create_and_populate_ragged_experiment <- function(
   )
   ms_rna$X <- SOMACollectionCreate(file.path(ms_rna$uri, "X"))
 
-  obsv <- seq.int(to = n_obs)
-  varv <- seq.int(to = n_var)
-  nd <- seq(from = 0L, to = 1L, by = 0.1)
-  nd <- rev(nd[nd > 0L])
-  nd <- rep_len(nd, length.out = length(X_layer_names))
+  ragged_density <- seq(from = 0L, to = 1L, by = 0.1)
+  ragged_density <- rev(ragged_density[ragged_density > 0L])
+  ragged_density <- rep_len(ragged_density, length.out = length(X_layer_names))
 
   if (!is.na(seed)) {
     set.seed(seed)
@@ -372,8 +370,8 @@ create_and_populate_ragged_experiment <- function(
     layer_name <- X_layer_names[i]
 
     mat <- Matrix::rsparsematrix(
-      nrow = ceiling(n_obs * nd[i]),
-      ncol = ceiling(n_var * nd[i]),
+      nrow = ceiling(n_obs * ragged_density[i]),
+      ncol = ceiling(n_var * ragged_density[i]),
       density = 0.6,
       rand.x = function(n) as.integer(runif(n, min = 1, max = 100)),
       repr = 'T'
@@ -385,7 +383,7 @@ create_and_populate_ragged_experiment <- function(
       shape = dim(mat)
     )
     ndarray$write(mat)
-    if (nd[i] != 1L) {
+    if (ragged_density[i] != 1L) {
       ndarray$set_metadata(.ragged_array_hint())
     }
     ndarray$set_metadata(.type_hint(class(mat)))

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -349,8 +349,7 @@ create_and_populate_ragged_experiment <- function(
   experiment$ms <- SOMACollectionCreate(file.path(uri, "ms"))
 
   ms_rna <- SOMAMeasurementCreate(file.path(uri, "ms", "RNA"))
-  # ms_rna$set_metadata(.assay_version_hint('v5'))
-  ms_rna$set_metadata(list(soma_ecosystem_seurat_assay_version = 'v5'))
+  ms_rna$set_metadata(.assay_version_hint('v5'))
 
   ms_rna$var <- create_and_populate_var(
     uri = file.path(ms_rna$uri, "var"),
@@ -387,9 +386,9 @@ create_and_populate_ragged_experiment <- function(
     )
     ndarray$write(mat)
     if (nd[i] != 1L) {
-      # ndarray$set_metadata(.ragged_array_hint())
-      ndarray$set_metadata(list(soma_ecosystem_seurat_v5_ragged = 'ragged'))
+      ndarray$set_metadata(.ragged_array_hint())
     }
+    ndarray$set_metadata(.type_hint(class(mat)))
 
     ms_rna$X$set(ndarray, name = layer_name)
   }

--- a/apis/r/tests/testthat/test-14-SeuratOutgest-assay.R
+++ b/apis/r/tests/testthat/test-14-SeuratOutgest-assay.R
@@ -259,13 +259,13 @@ test_that("Load v5 assay", {
 
   # Test using cell and feature names
   expect_no_condition(named <- query$to_seurat_assay(
-    obs_index = "baz",
+    obs_index = "string_column",
     var_index = "quux",
     version = "v5"
   ))
   expect_identical(
     colnames(named),
-    query$obs("baz")$concat()$GetColumnByName("baz")$as_vector()
+    query$obs("string_column")$concat()$GetColumnByName("string_column")$as_vector()
   )
   expect_identical(
     rownames(named),
@@ -280,7 +280,7 @@ test_that("Load v5 ragged assay", {
   skip_if(!extended_tests())
   skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
 
-  uri <- tempfile(pattern = "assay-experiment-query-v5-whole")
+  uri <- tempfile(pattern = "assay-experiment-query-v5-ragged")
   n_obs <- 20L
   n_var <- 10L
   layers <- c("mat", "matA", "matB", "matC")
@@ -389,7 +389,7 @@ test_that("Load v5 assay from sliced ExperimentQuery", {
   # Test named
   expect_no_condition(named <- query$to_seurat_assay(
     "counts",
-    obs_index = "baz",
+    obs_index = "string_column",
     var_index = "quux",
     version = "v5"
   ))
@@ -399,7 +399,7 @@ test_that("Load v5 assay from sliced ExperimentQuery", {
   )
   expect_identical(
     colnames(named),
-    query$obs("baz")$concat()$GetColumnByName("baz")$as_vector()
+    query$obs("string_column")$concat()$GetColumnByName("string_column")$as_vector()
   )
 })
 
@@ -524,7 +524,7 @@ test_that("Load v5 assay from indexed ExperimentQuery", {
   on.exit(experiment$close(), add = TRUE, after = FALSE)
 
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -549,7 +549,7 @@ test_that("Load v5 assay from indexed ExperimentQuery", {
   # Test named
   expect_no_condition(named <- query$to_seurat_assay(
     "counts",
-    obs_index = "baz",
+    obs_index = "string_column",
     var_index = "quux",
     version = "v5"
   ))
@@ -560,7 +560,7 @@ test_that("Load v5 assay from indexed ExperimentQuery", {
   expect_identical(rownames(named), var_label_values)
   expect_identical(
     colnames(named),
-    query$obs("baz")$concat()$GetColumnByName("baz")$as_vector()
+    query$obs("string_column")$concat()$GetColumnByName("string_column")$as_vector()
   )
   expect_identical(colnames(named), obs_label_values)
 })
@@ -585,7 +585,7 @@ test_that("Load v5 ragged assay from indexed ExperimentQuery", {
   on.exit(experiment$close(), add = TRUE, after = FALSE)
 
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(


### PR DESCRIPTION
Seurat v5 adds support for ragged arrays, where not every `X` layer has exactly the same cells and features. To handle this, ragged `X` layers need to be re-indexed and re-shaped on ingestion to resize down to only the data present

Modified SOMA methods:
 - `SOMAExperimentAxisQuery$to_seurat()` and `SOMAExperimentAxisQuery$to_seurat_assay()`: now read in as v5 assays

New SOMA methods:
 - `SOMAExperimentAxisQuery$private$.to_seurat_assay_v5()`: helper method to read in ragged and non-ragged arrays into a v5 assay; note this method only handles expression layers, all other assay-level information is handled by parent `$to_seurat_assay()` to share code with v3 assay outgestion

Requires #2523 and #3007

[SC-52261](https://app.shortcut.com/tiledb-inc/story/52261/) #2673