### PR TITLE
[c++] Pre-neatens for polymorphic domainish accessors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ test: ctest
 	pytest apis/python/tests
 
 .PHONY: ctest
-ctest: data
+ctest: data ctest_update
+
+.PHONY: ctest_update
+ctest_update:
 	ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
 
 .PHONY: data

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -820,6 +820,9 @@ def _fill_out_slot_soma_domain(
             )
         slot_domain = slot_domain[0], slot_domain[1]
     elif isinstance(dtype, str):
+        # Core string dims have no extent and no (core) domain.  We return "" here
+        # simply so we can pass libtiledbsoma "" for domain and extent, while it
+        # will (and must) ignore these when creating the TileDB schema.
         slot_domain = "", ""
     elif np.issubdtype(dtype, NPInteger):
         iinfo = np.iinfo(cast(NPInteger, dtype))
@@ -887,6 +890,9 @@ def _find_extent_for_domain(
     if isinstance(dtype, np.dtype) and dtype.itemsize == 1:
         extent = 1
 
+    # Core string dims have no extent and no (core) domain.  We return "" here
+    # simply so we can pass libtiledbsoma "" for domain and extent, while it
+    # will (and must) ignore these when creating the TileDB schema.
     if isinstance(dtype, str):
         return ""
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -728,7 +728,7 @@ class SOMAArray : public SOMAObject {
     /**
      * Exposed for testing purposes.
      */
-    CurrentDomain get_current_domain() const {
+    CurrentDomain get_current_domain_for_test() const {
         return _get_current_domain();
     }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -756,9 +756,9 @@ class SOMAArray : public SOMAObject {
     template <typename T>
     std::pair<T, T> soma_domain_slot(const std::string& name) const {
         if (has_current_domain()) {
-            return core_current_domain_slot<T>(name);
+            return _core_current_domain_slot<T>(name);
         } else {
-            return core_domain_slot<T>(name);
+            return _core_domain_slot<T>(name);
         }
     }
 
@@ -772,58 +772,7 @@ class SOMAArray : public SOMAObject {
      */
     template <typename T>
     std::pair<T, T> soma_maxdomain_slot(const std::string& name) const {
-        return core_domain_slot<T>(name);
-    }
-
-    /**
-     * Returns the core current domain at the given dimension.
-     *
-     * o For arrays with core current-domain support:
-     *   - soma domain is core current domain
-     *   - soma maxdomain is core domain
-     * o For arrays without core current-domain support:
-     *   - soma domain is core domain
-     *   - soma maxdomain is core domain
-     *   - core current domain is not accessed at the soma level
-     *
-     * @tparam T Domain datatype
-     * @return Pair of [lower, upper] inclusive bounds.
-     */
-    template <typename T>
-    std::pair<T, T> core_current_domain_slot(const std::string& name) const {
-        CurrentDomain current_domain = _get_current_domain();
-        if (current_domain.is_empty()) {
-            throw TileDBSOMAError(
-                "core_current_domain_slot: internal coding error");
-        }
-        if (current_domain.type() != TILEDB_NDRECTANGLE) {
-            throw TileDBSOMAError(
-                "core_current_domain_slot: found non-rectangle type");
-        }
-        NDRectangle ndrect = current_domain.ndrectangle();
-
-        // Convert from two-element array (core API) to pair (tiledbsoma API)
-        std::array<T, 2> arr = ndrect.range<T>(name);
-        return std::pair<T, T>(arr[0], arr[1]);
-    }
-
-    /**
-     * Returns the core current domain at the given dimension.
-     *
-     * o For arrays with core current-domain support:
-     *   - soma domain is core current domain
-     *   - soma maxdomain is core domain
-     * o For arrays without core current-domain support:
-     *   - soma domain is core domain
-     *   - soma maxdomain is core domain
-     *   - core current domain is not accessed at the soma level
-     *
-     * @tparam T Domain datatype
-     * @return Pair of [lower, upper] inclusive bounds.
-     */
-    template <typename T>
-    std::pair<T, T> core_domain_slot(const std::string& name) const {
-        return arr_->schema().domain().dimension(name).domain<T>();
+        return _core_domain_slot<T>(name);
     }
 
     /**
@@ -944,6 +893,57 @@ class SOMAArray : public SOMAObject {
     CurrentDomain _get_current_domain() const {
         return tiledb::ArraySchemaExperimental::current_domain(
             *ctx_->tiledb_ctx(), arr_->schema());
+    }
+
+    /**
+     * Returns the core current domain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> _core_current_domain_slot(const std::string& name) const {
+        CurrentDomain current_domain = _get_current_domain();
+        if (current_domain.is_empty()) {
+            throw TileDBSOMAError(
+                "_core_current_domain_slot: internal coding error");
+        }
+        if (current_domain.type() != TILEDB_NDRECTANGLE) {
+            throw TileDBSOMAError(
+                "_core_current_domain_slot: found non-rectangle type");
+        }
+        NDRectangle ndrect = current_domain.ndrectangle();
+
+        // Convert from two-element array (core API) to pair (tiledbsoma API)
+        std::array<T, 2> arr = ndrect.range<T>(name);
+        return std::pair<T, T>(arr[0], arr[1]);
+    }
+
+    /**
+     * Returns the core current domain at the given dimension.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> _core_domain_slot(const std::string& name) const {
+        return arr_->schema().domain().dimension(name).domain<T>();
     }
 
     /**

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -726,7 +726,8 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
-     * Exposed for testing purposes.
+     * Exposed for testing purposes within this library.
+     * Not for use by Python/R.
      */
     CurrentDomain get_current_domain_for_test() const {
         return _get_current_domain();
@@ -963,7 +964,7 @@ class SOMAArray : public SOMAObject {
     void _check_dims_are_int64();
 
     /**
-     * With old shape: core domain mapped to tiledbsoma shape; core current
+     * With old shape: core domain used to map to tiledbsoma shape; core current
      * domain did not exist.
      *
      * With new shape: core domain maps to tiledbsoma maxshape;
@@ -1269,6 +1270,16 @@ class SOMAArray : public SOMAObject {
     // Unoptimized method for computing nnz() (issue `count_cells` query)
     uint64_t _nnz_slow();
 };
+
+// These are all specializations to string/bool of various methods
+// which require special handling for that type.
+//
+// Declaring them down here is a bit weird -- they're easy to miss
+// on a read-through. However, we're in a bit of a bind regarding
+// various compilers: if we do these specializations within the
+// `class SOMAArray { ... }`, then one compiler errors if we do
+// include `template <>`, while another errors if we don't.
+// Doing it down here, no compiler complains.
 
 template <>
 void SOMAArray::_cast_dictionary_values<std::string>(

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -501,7 +501,8 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
+        CurrentDomain current_domain = soma_dataframe
+                                           ->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -602,7 +603,8 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
+        CurrentDomain current_domain = soma_dataframe
+                                           ->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -715,7 +717,8 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
+        CurrentDomain current_domain = soma_dataframe
+                                           ->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -831,7 +834,8 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
+        CurrentDomain current_domain = soma_dataframe
+                                           ->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -501,7 +501,7 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain();
+        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -602,7 +602,7 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain();
+        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -715,7 +715,7 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain();
+        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {
@@ -831,7 +831,7 @@ TEST_CASE_METHOD(
         // Check current domain
         auto soma_dataframe = open(OpenMode::read);
 
-        CurrentDomain current_domain = soma_dataframe->get_current_domain();
+        CurrentDomain current_domain = soma_dataframe->get_current_domain_for_test();
         if (!use_current_domain) {
             REQUIRE(current_domain.is_empty());
         } else {


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

This is split out from #2995 to make 2995 simpler.

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

These are higher-line-count mods, which would distract from the more substantive mods on 2995.

**Changes:**

**Notes for Reviewer:**

