### PR TITLE
[python] One more rename in prep for domainish pushdown

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -397,7 +397,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         return self._get_and_cast_domain(self._handle.soma_maxdomain_slot)
 
     def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._get_and_cast_domain(self._handle.non_empty_domain) or ()
+        return self._get_and_cast_domain(self._handle.non_empty_domain_slot) or ()
 
     @property
     def attr_names(self) -> Tuple[str, ...]:

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -669,7 +669,7 @@ void load_soma_array(py::module& m) {
             })
 
         .def(
-            "non_empty_domain",
+            "non_empty_domain_slot",
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {
                     case TILEDB_UINT64:


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Leveraging PRs on #2407 the full domain will be gotten from C++ `libtiledbsoma` with a simple cast in the `pybind11`/`Rcpp` layers.

However I missed one naming spot in the `pybind11` layer.

**Notes for Reviewer:**
