### PR TITLE
[python/r] Use pushdown domainish accessors at the Python/R UX level

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -354,8 +354,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
     @property
     def domain(self) -> Tuple[Tuple[Any, Any], ...]:
-        """Returns a tuple of minimum and maximum values, inclusive, storable
-        on each index column of the dataframe.
+        """Returns tuples of minimum and maximum values, one tuple per index column, currently storable
+        on each index column of the dataframe. These can be resized up to ``maxdomain``.
 
         Lifecycle:
             Maturing.
@@ -364,8 +364,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
     @property
     def maxdomain(self) -> Tuple[Tuple[Any, Any], ...]:
-        """Returns a tuple of minimum and maximum values, inclusive, storable
-        on each index column of the dataframe.
+        """Returns tuples of minimum and maximum values, one tuple per index column, to which the dataframe
+        can have its domain resized.
 
         Lifecycle:
             Maturing.

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -12,10 +12,10 @@ import abc
 import enum
 from typing import (
     Any,
-    Callable,
     Dict,
     Generic,
     Iterator,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -30,7 +30,6 @@ from typing import (
 import attrs
 import numpy as np
 import pyarrow as pa
-from numpy.typing import DTypeLike
 from somacore import options
 from typing_extensions import Literal, Self
 
@@ -363,41 +362,36 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def ndim(self) -> int:
         return len(self._handle.dimension_names)
 
-    def _get_and_cast_domain(
-        self, domain_slot_getter: Callable[[str, DTypeLike], Tuple[object, object]]
+    def _cast_domainish(
+        self, domainish: List[Any]
     ) -> Tuple[Tuple[object, object], ...]:
         result = []
-        for name in self._handle.dimension_names:
-            dtype = self._handle.schema.field(name).type
-            if pa.types.is_timestamp(dtype):
-                np_dtype = np.dtype(dtype.to_pandas_dtype())
-                dom = domain_slot_getter(name, np_dtype)
+        for i, slot in enumerate(domainish):
+
+            arrow_type = slot[0].type
+            if pa.types.is_timestamp(arrow_type):
+                pandas_type = np.dtype(arrow_type.to_pandas_dtype())
                 result.append(
-                    (
-                        np_dtype.type(dom[0], dtype.unit),
-                        np_dtype.type(dom[1], dtype.unit),
+                    tuple(
+                        pandas_type.type(e.cast(pa.int64()).as_py(), arrow_type.unit)
+                        for e in slot
                     )
                 )
             else:
-                if pa.types.is_large_string(dtype) or pa.types.is_string(dtype):
-                    dtype = np.dtype("U")
-                elif pa.types.is_large_binary(dtype) or pa.types.is_binary(dtype):
-                    dtype = np.dtype("S")
-                else:
-                    dtype = np.dtype(dtype.to_pandas_dtype())
-                result.append(domain_slot_getter(name, dtype))
+                result.append(tuple(e.as_py() for e in slot))
+
         return tuple(result)
 
     @property
     def domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._get_and_cast_domain(self._handle.soma_domain_slot)
+        return self._cast_domainish(self._handle.domain())
 
     @property
     def maxdomain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._get_and_cast_domain(self._handle.soma_maxdomain_slot)
+        return self._cast_domainish(self._handle.maxdomain())
 
     def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._get_and_cast_domain(self._handle.non_empty_domain_slot) or ()
+        return self._cast_domainish(self._handle.non_empty_domain())
 
     @property
     def attr_names(self) -> Tuple[str, ...]:

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -182,6 +182,18 @@ maxshape <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_maxshape`, uri, ctxxp)
 }
 
+non_empty_domain_new <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_non_empty_domain_new`, uri, ctxxp)
+}
+
+domain <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_domain`, uri, ctxxp)
+}
+
+maxdomain <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_maxdomain`, uri, ctxxp)
+}
+
 maybe_soma_joinid_shape <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_maybe_soma_joinid_shape`, uri, ctxxp)
 }

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -339,6 +339,30 @@ SOMADataFrame <- R6::R6Class(
       class = 'notYetImplementedError'
     )),
 
+    #' @description Returns a named list of minimum/maximum pairs, one per index
+    #' column, currently storable on each index column of the dataframe. These
+    #' can be resized up to `maxdomain`.
+    #' (lifecycle: maturing)
+    #' @return Named list of minimum/maximum values.
+    domain = function() {
+      as.list(
+        arrow::as_record_batch(
+          arrow::as_arrow_table(
+            domain(self$uri, private$.soma_context))))
+    },
+
+    #' @description Returns a named list of minimum/maximum pairs, one per index
+    #' column, which are the limits up to which the dataframe can have its
+    #' domain resized.
+    #' (lifecycle: maturing)
+    #' @return Named list of minimum/maximum values.
+    maxdomain = function() {
+      as.list(
+        arrow::as_record_batch(
+          arrow::as_arrow_table(
+            maxdomain(self$uri, private$.soma_context))))
+    },
+
     #' @description Returns TRUE if the array has the upgraded resizeable domain
     #' feature from TileDB-SOMA 1.15: the array was created with this support,
     #' or it has had ``upgrade_domain`` applied to it.

--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -245,6 +245,22 @@ TileDBArray <- R6::R6Class(
       return(ned)
     },
 
+    #' @description Returns a named list of minimum/maximum pairs, one per index
+    #' column, which are the smallest and largest values written on that
+    #' index column.
+    #'
+    #' As tracked on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+    #' this will replace the existing `non_empty_domain` method.
+    #'
+    #' (lifecycle: maturing)
+    #' @return Named list of minimum/maximum values.
+    non_empty_domain_new = function() {
+      as.list(
+        arrow::as_record_batch(
+          arrow::as_arrow_table(
+            non_empty_domain_new(self$uri, private$.soma_context))))
+    },
+
     #' @description Retrieve number of dimensions (lifecycle: maturing)
     #' @return A scalar with the number of dimensions
     ndim = function() {

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -378,10 +378,10 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
         # expansion.
         if (ind_col_name == "soma_joinid") {
           # Must be non-negative
-          ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,ind_ext)
+          ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0, ind_ext)
         } else {
           # Others can be negative
-          ind_max_dom <- arrow_type_range(ind_col_type) - c(0,ind_ext)
+          ind_max_dom <- arrow_type_range(ind_col_type) - c(0, ind_ext)
         }
 
         ind_cur_dom <- ind_max_dom

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -370,13 +370,19 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
             ind_ext <- 64L
         }
 
-        # We need to do this because if we don't:
+        # We need to subtract off extent from the max because if we don't:
         #
         # Error: [TileDB::Dimension] Error: Tile extent check failed; domain max
         # expanded to multiple of tile extent exceeds max value representable by
         # domain type. Reduce domain max by 1 tile extent to allow for
         # expansion.
-        ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,ind_ext)
+        if (ind_col_name == "soma_joinid") {
+          # Must be non-negative
+          ind_max_dom <- arrow_type_unsigned_range(ind_col_type) - c(0,ind_ext)
+        } else {
+          # Others can be negative
+          ind_max_dom <- arrow_type_range(ind_col_type) - c(0,ind_ext)
+        }
 
         ind_cur_dom <- ind_max_dom
         if (ind_col_type_name %in% c("string", "large_utf8", "utf8")) ind_ext <- NA

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -380,6 +380,42 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// non_empty_domain_new
+SEXP non_empty_domain_new(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_non_empty_domain_new(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(non_empty_domain_new(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// domain
+SEXP domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_domain(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(domain(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// maxdomain
+SEXP maxdomain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_maxdomain(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(maxdomain(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
 // maybe_soma_joinid_shape
 Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_maybe_soma_joinid_shape(SEXP uriSEXP, SEXP ctxxpSEXP) {
@@ -663,6 +699,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_check_arrow_array_tag", (DL_FUNC) &_tiledbsoma_check_arrow_array_tag, 1},
     {"_tiledbsoma_shape", (DL_FUNC) &_tiledbsoma_shape, 2},
     {"_tiledbsoma_maxshape", (DL_FUNC) &_tiledbsoma_maxshape, 2},
+    {"_tiledbsoma_non_empty_domain_new", (DL_FUNC) &_tiledbsoma_non_empty_domain_new, 2},
+    {"_tiledbsoma_domain", (DL_FUNC) &_tiledbsoma_domain, 2},
+    {"_tiledbsoma_maxdomain", (DL_FUNC) &_tiledbsoma_maxdomain, 2},
     {"_tiledbsoma_maybe_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_maybe_soma_joinid_shape, 2},
     {"_tiledbsoma_maybe_soma_joinid_maxshape", (DL_FUNC) &_tiledbsoma_maybe_soma_joinid_maxshape, 2},
     {"_tiledbsoma_has_current_domain", (DL_FUNC) &_tiledbsoma_has_current_domain, 2},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -279,6 +279,34 @@ Rcpp::NumericVector maxshape(
 }
 
 // [[Rcpp::export]]
+SEXP non_empty_domain_new(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sdf = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
+    tdbs::ArrowTable arrow_table = sdf->get_non_empty_domain();
+    SEXP retval = convert_domainish(arrow_table);
+    sdf->close();
+    return retval;
+}
+
+// [[Rcpp::export]]
+SEXP domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sdf = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
+    tdbs::ArrowTable arrow_table = sdf->get_soma_domain();
+    SEXP retval = convert_domainish(arrow_table);
+    sdf->close();
+    return retval;
+}
+
+// [[Rcpp::export]]
+SEXP maxdomain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sdf = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
+    tdbs::ArrowTable arrow_table = sdf->get_soma_maxdomain();
+    SEXP retval = convert_domainish(arrow_table);
+    sdf->close();
+    return retval;
+}
+
+// [[Rcpp::export]]
 Rcpp::NumericVector maybe_soma_joinid_shape(
     const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // Pro-tip:

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -70,3 +70,9 @@ inline void array_xptr_set_schema(SEXP array_xptr, SEXP schema_xptr) {
 std::optional<tdbs::TimestampRange> makeTimestampRange(Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
 
 std::vector<int64_t> i64_from_rcpp_numeric(const Rcpp::NumericVector& input);
+
+// Code reuse for non_empty_domain, domain, and maxdomain all of which:
+// * call a libtiledbsoma function
+// * obtain an ArrowTable
+// * need to map that to an R list of lo/hi pairs
+SEXP convert_domainish(const tdbs::ArrowTable& arrow_table);

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -85,16 +85,16 @@ test_that("SOMADataFrame shape", {
       expect_true(sjid_mxd[[2]] > bit64::as.integer64(10000000000))
     }
 
-    if ("foo" %in% index_column_names) {
-      int_dom <- dom[["foo"]]
-      int_mxd <- mxd[["foo"]]
+    if ("int_column" %in% index_column_names) {
+      int_dom <- dom[["int_column"]]
+      int_mxd <- mxd[["int_column"]]
       expect_true(int_dom[[1]] < -2000000000)
       expect_true(int_dom[[2]] > 2000000000)
     }
 
-    if ("baz" %in% index_column_names) {
-      expect_equal(dom[["baz"]], c("", ""))
-      expect_equal(mxd[["baz"]], c("", ""))
+    if ("string_column" %in% index_column_names) {
+      expect_equal(dom[["string_column"]], c("", ""))
+      expect_equal(mxd[["string_column"]], c("", ""))
     }
 
     sdf$close()

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -8,14 +8,10 @@ test_that("SOMADataFrame shape", {
     c("soma_joinid", "int_column"),
     c("soma_joinid", "string_column"),
     c("string_column", "int_column")
-    one = "soma_joinid",
-    two = c("soma_joinid", "foo"),
-    three = c("soma_joinid", "baz"),
-    four = c("baz", "foo")
   )
 
-  for (case_name in names(index_column_name_choices)) {
-    index_column_names = index_column_name_choices[[case_name]]
+  for (i in seq_along(index_column_name_choices)) {
+    index_column_names <- index_column_name_choices[[i]]
 
     has_soma_joinid_dim <- "soma_joinid" %in% index_column_names
 
@@ -63,33 +59,17 @@ test_that("SOMADataFrame shape", {
       expect_true(is.na(sjid_maxshape))
     }
 
-    dom = sdf$domain()
-    mxd = sdf$maxdomain()
+    dom <- sdf$domain()
+    mxd <- sdf$maxdomain()
 
     # First check names
-    if (case_name == "one") {
-      expect_equal(names(dom), c("soma_joinid"))
-      expect_equal(names(mxd), c("soma_joinid"))
-
-    } else if (case_name == "two") {
-      expect_equal(names(dom), c("soma_joinid", "foo"))
-      expect_equal(names(mxd), c("soma_joinid", "foo"))
-
-    } else if (case_name == "three") {
-      expect_equal(names(dom), c("soma_joinid", "baz"))
-      expect_equal(names(mxd), c("soma_joinid", "baz"))
-
-    } else if (case_name == "four") {
-      expect_equal(names(dom), c("baz", "foo"))
-      expect_equal(names(mxd), c("baz", "foo"))
-    }
+    expect_equal(names(dom), index_column_names)
+    expect_equal(names(mxd), index_column_names)
 
     # Then check all slots are pairs
     for (name in names(dom)) {
-      expect_equal(length(dom[[name]]), 2)
-    }
-    for (name in names(mxd)) {
-      expect_equal(length(mxd[[name]]), 2)
+      expect_length(dom[[name]], 2L)
+      expect_length(mxd[[name]], 2L)
     }
 
     # Then check contents

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1422,11 +1422,6 @@ void SOMAArray::_set_current_domain_from_shape(
     // Variant-indexed dataframes must use a separate path
     _check_dims_are_int64();
 
-    if (_get_current_domain().is_empty()) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must already be sized");
-    }
-
     auto tctx = ctx_->tiledb_ctx();
     ArraySchema schema = arr_->schema();
     Domain domain = schema.domain();

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1173,6 +1173,28 @@ ArrowTable SOMAArray::_get_core_domainish(enum Domainish which_kind) {
 
         switch (core_type_code) {
             case TILEDB_INT64:
+            case TILEDB_DATETIME_YEAR:
+            case TILEDB_DATETIME_MONTH:
+            case TILEDB_DATETIME_WEEK:
+            case TILEDB_DATETIME_DAY:
+            case TILEDB_DATETIME_HR:
+            case TILEDB_DATETIME_MIN:
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+            case TILEDB_DATETIME_PS:
+            case TILEDB_DATETIME_FS:
+            case TILEDB_DATETIME_AS:
+            case TILEDB_TIME_HR:
+            case TILEDB_TIME_MIN:
+            case TILEDB_TIME_SEC:
+            case TILEDB_TIME_MS:
+            case TILEDB_TIME_US:
+            case TILEDB_TIME_NS:
+            case TILEDB_TIME_PS:
+            case TILEDB_TIME_FS:
+            case TILEDB_TIME_AS:
                 child = ArrowAdapter::make_arrow_array_child(
                     _core_domainish_slot<int64_t>(core_dim.name(), which_kind));
                 break;

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -439,8 +439,8 @@ class ArrowAdapter {
 
         if (std::is_same_v<T, std::string>) {
             throw std::runtime_error(
-                "SOMAArray::_core_domain_slot: template-specialization "
-                "failure.");
+                "SOMAArray::get_table_non_string_column_by_index: "
+                "template-specialization failure.");
         }
 
         ArrowArray* child_array = _get_and_check_column(
@@ -542,7 +542,7 @@ class ArrowAdapter {
         const ArrowArray* arrow_array, const ArrowSchema* arrow_schema) {
         if (arrow_array->n_children != 0 || arrow_schema->n_children != 0) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: expected leaf "
+                "ArrowAdapter::get_array_string_column: expected leaf "
                 "node");
         }
         if (arrow_array->n_buffers != 3) {
@@ -567,18 +567,19 @@ class ArrowAdapter {
         }
         if (arrow_array->buffers[1] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_non_string_column_by_index: null "
+                "ArrowAdapter::get_array_string_column: null "
                 "offsets buffer");
         }
         if (arrow_array->buffers[2] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_non_string_column_by_index: null data "
+                "ArrowAdapter::get_array_string_column: null data "
                 "buffer");
         }
 
         const char* data = (char*)arrow_array->buffers[2];
 
-        if (strcmp(arrow_schema->format, "u") == 0) {
+        if (strcmp(arrow_schema->format, "u") == 0 ||
+            strcmp(arrow_schema->format, "z") == 0) {
             uint32_t* offsets = (uint32_t*)arrow_array->buffers[1];
             int num_cells = (int)arrow_array->length;
             std::vector<std::string> retval(num_cells);
@@ -588,7 +589,9 @@ class ArrowAdapter {
             }
             return retval;
 
-        } else if (strcmp(arrow_schema->format, "U") == 0) {
+        } else if (
+            strcmp(arrow_schema->format, "U") == 0 ||
+            strcmp(arrow_schema->format, "Z") == 0) {
             uint64_t* offsets = (uint64_t*)arrow_array->buffers[1];
             int num_cells = (int)arrow_array->length;
             std::vector<std::string> retval(num_cells);
@@ -600,9 +603,8 @@ class ArrowAdapter {
 
         } else {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_non_string_column_by_index: expected "
-                "Arrow "
-                "string or large_string");
+                "ArrowAdapter::get_array_string_column: expected "
+                "Arrow string, large_string, binary, or large_binary");
         }
     }
 

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -414,10 +414,10 @@ class ArrowAdapter {
     // for keystroke-reduction in unit-test cases.
 
     template <typename T>
-    static std::vector<T> get_table_column_by_name(
+    static std::vector<T> get_table_non_string_column_by_name(
         const ArrowTable& arrow_table, std::string column_name) {
         int64_t index = _get_column_index_from_name(arrow_table, column_name);
-        return get_table_column_by_index<T>(arrow_table, index);
+        return get_table_non_string_column_by_index<T>(arrow_table, index);
     }
 
     static std::vector<std::string> get_table_string_column_by_name(
@@ -426,8 +426,12 @@ class ArrowAdapter {
         return get_table_string_column_by_index(arrow_table, index);
     }
 
+    /**
+     * Returns a copy of the data in a specified non-string column of an
+     * ArrowTable as a standard/non-Arrow C++ object.
+     */
     template <typename T>
-    static std::vector<T> get_table_column_by_index(
+    static std::vector<T> get_table_non_string_column_by_index(
         const ArrowTable& arrow_table, int64_t column_index) {
         ArrowArray* arrow_array = arrow_table.first.get();
         ArrowSchema* arrow_schema = arrow_table.second.get();
@@ -439,71 +443,167 @@ class ArrowAdapter {
                 "failure.");
         }
 
-        ArrowArray* child = _get_and_check_column(arrow_table, column_index, 2);
+        ArrowArray* child_array = _get_and_check_column(
+            arrow_table, column_index, 2);
 
-        // For our purposes -- reporting domains, etc. -- we don't use the Arrow
-        // validity buffers. If this class needs to be extended someday to
-        // support arrow-nulls, we can work on that.
-        if (child->buffers[0] != nullptr) {
-            throw std::runtime_error(
-                "ArrowAdapter::get_table_column_by_index: validity buffer "
-                "unsupported here");
-        }
-
-        const void* vdata = child->buffers[1];
-        if (vdata == nullptr) {
-            throw std::runtime_error(
-                "ArrowAdapter::get_table_column_by_index: null data buffer");
-        }
-
-        const T* data = (T*)vdata;
-
-        std::vector<T> retval(child->length);
-        for (auto i = 0; i < child->length; i++) {
-            retval[i] = data[i];
-        }
-        return retval;
+        return get_array_non_string_column<T>(child_array);
     }
 
+    /**
+     * Returns a copy of the data in a specified string column of an
+     * ArrowTable as a standard/non-Arrow C++ object.
+     */
     static std::vector<std::string> get_table_string_column_by_index(
         const ArrowTable& arrow_table, int64_t column_index) {
         ArrowArray* arrow_array = arrow_table.first.get();
         ArrowSchema* arrow_schema = arrow_table.second.get();
         _check_shapes(arrow_array, arrow_schema);
 
-        ArrowArray* child = _get_and_check_column(arrow_table, column_index, 3);
+        ArrowArray* child_array = _get_and_check_column(
+            arrow_table, column_index, 3);
+
+        const ArrowSchema* child_schema = arrow_schema->children[column_index];
+
+        return get_array_string_column(child_array, child_schema);
+    }
+
+    /**
+     * Returns a copy of the data in a specified non-string column of an
+     * ArrowArray as a standard/non-Arrow C++ object. There is no ArrowSchema*
+     * argument, as the caller must have determined the Arrow type, inferred
+     * a C++ type, and have invoked this method with the appropriate C++ type.
+     *
+     * This is a helper for get_table_non_string_column_by_index; also exposed
+     * for callsites which have access to child objects which are not top-level
+     * ArrowTables.
+     */
+    template <typename T>
+    static std::vector<T> get_array_non_string_column(
+        const ArrowArray* arrow_array) {
+        if (arrow_array->n_children != 0) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_array_non_string_column: expected leaf "
+                "node");
+        }
+        if (arrow_array->n_buffers != 2) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_array_non_string_column: expected two "
+                "buffers");
+        }
+
+        if (std::is_same_v<T, std::string>) {
+            throw std::runtime_error(
+                "SOMAArray::get_array_non_string_column: "
+                "template-specialization "
+                "failure.");
+        }
+
+        // Two-buffer model for non-string data:
+        // * Slot 0 is the Arrow validity buffer which we leave null
+        // * Slot 1 is data, void* but will be derefrenced as T*
+        // * There is no offset information
 
         // For our purposes -- reporting domains, etc. -- we don't use the Arrow
         // validity buffers. If this class needs to be extended someday to
         // support arrow-nulls, we can work on that.
-        if (child->buffers[0] != nullptr) {
+        if (arrow_array->buffers[0] != nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_column_by_index: validity buffer "
+                "ArrowAdapter::get_array_non_string_column: validity buffer "
                 "unsupported here");
         }
-
-        const char* data = (char*)child->buffers[2];
-
-        if (data == nullptr) {
+        if (arrow_array->buffers[1] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_column_by_index: null data buffer");
+                "ArrowAdapter::get_array_non_string_column: null data buffer");
         }
 
-        if (strcmp(arrow_schema->children[column_index]->format, "U") != 0) {
+        const void* vdata = arrow_array->buffers[1];
+        if (vdata == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_column_by_index: expected Arrow "
-                "large_string");
-        }
-        uint64_t* offsets = (uint64_t*)child->buffers[1];
-
-        int num_cells = (int)child->length;
-        std::vector<std::string> retval(num_cells);
-        for (int j = 0; j < num_cells; j++) {
-            std::string e(&data[offsets[j]], &data[offsets[j + 1]]);
-            retval[j] = e;
+                "ArrowAdapter::get_array_non_string_column: null data buffer");
         }
 
+        const T* data = (T*)vdata;
+
+        std::vector<T> retval(arrow_array->length);
+        for (auto i = 0; i < arrow_array->length; i++) {
+            retval[i] = data[i];
+        }
         return retval;
+    }
+
+    /**
+     * Returns a copy of the data in a specified non-string column of an
+     * ArrowArray as a standard/non-Arrow C++ object.
+     * Helper for get_table_string_column_by_index. Also exposed for
+     * callsites which have access to child objects which are not top-level
+     * ArrowTables.
+     */
+    static std::vector<std::string> get_array_string_column(
+        const ArrowArray* arrow_array, const ArrowSchema* arrow_schema) {
+        if (arrow_array->n_children != 0 || arrow_schema->n_children != 0) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_array_non_string_column: expected leaf "
+                "node");
+        }
+        if (arrow_array->n_buffers != 3) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_array_string_column: expected three "
+                "buffers");
+        }
+
+        // Three-buffer model for string data:
+        // * Slot 0 is the Arrow uint8_t* validity buffer
+        // * Slot 1 is the Arrow offsets buffer: uint32_t* for Arrow string
+        //   or uint64_t* for Arrow large_string
+        // * Slot 2 is data, void* but will be derefrenced as T*
+
+        // For our purposes -- reporting domains, etc. -- we don't use the Arrow
+        // validity buffers. If this class needs to be extended someday to
+        // support arrow-nulls, we can work on that.
+        if (arrow_array->buffers[0] != nullptr) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_array_string_column: validity buffer "
+                "unsupported here");
+        }
+        if (arrow_array->buffers[1] == nullptr) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_table_non_string_column_by_index: null "
+                "offsets buffer");
+        }
+        if (arrow_array->buffers[2] == nullptr) {
+            throw std::runtime_error(
+                "ArrowAdapter::get_table_non_string_column_by_index: null data "
+                "buffer");
+        }
+
+        const char* data = (char*)arrow_array->buffers[2];
+
+        if (strcmp(arrow_schema->format, "u") == 0) {
+            uint32_t* offsets = (uint32_t*)arrow_array->buffers[1];
+            int num_cells = (int)arrow_array->length;
+            std::vector<std::string> retval(num_cells);
+            for (int j = 0; j < num_cells; j++) {
+                std::string e(&data[offsets[j]], &data[offsets[j + 1]]);
+                retval[j] = e;
+            }
+            return retval;
+
+        } else if (strcmp(arrow_schema->format, "U") == 0) {
+            uint64_t* offsets = (uint64_t*)arrow_array->buffers[1];
+            int num_cells = (int)arrow_array->length;
+            std::vector<std::string> retval(num_cells);
+            for (int j = 0; j < num_cells; j++) {
+                std::string e(&data[offsets[j]], &data[offsets[j + 1]]);
+                retval[j] = e;
+            }
+            return retval;
+
+        } else {
+            throw std::runtime_error(
+                "ArrowAdapter::get_table_non_string_column_by_index: expected "
+                "Arrow "
+                "string or large_string");
+        }
     }
 
    private:

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -8,6 +8,32 @@
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-listing-for-each-layout
 // https://arrow.apache.org/docs/format/CDataInterface.html#exporting-a-simple-int32-array
 
+// A general developer note: in several places we have
+//
+//     template <typename T>
+//     static sometype foo(T arg) {
+//         if (std::is_same_v<T, std::string>) {
+//             throw std::runtime_error(...);
+//         }
+//         }D...
+//     }
+//
+//     static sometype foo_string(std::string arg) { ... }
+//
+// -- with explicit `_string` suffix -- rather than
+//
+//     template <typename T>
+//     static sometype foo(T arg) ...
+//
+//     template <>
+//     static sometype foo(std::string arg) ...
+//
+// We're aware of the former but we've found it a bit fiddly across systems and
+// compiler versions -- namely, with the latter we find it tricky to always
+// avoid the <typename T> variant being templated with std::string. It's simple,
+// explicit, and robust to go the `_string` suffix route, and it's friendlier to
+// current and future maintainers of this code.
+
 #include "nanoarrow/nanoarrow.hpp"
 #include "nlohmann/json.hpp"
 

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -197,7 +197,8 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
             // arrow_adapter for more info. We rely on arrow_adapter to also
             // handle this case.
             if (info.use_current_domain) {
-                std::vector<std::string> dom({"", "", "", "", ""});
+                std::vector<std::string> dom(
+                    {"", "", "", info.string_lo, info.string_hi});
                 dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
             } else {
                 std::vector<std::string> dom({"", "", ""});

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -67,6 +67,8 @@ struct DimInfo {
     std::string name;
     tiledb_datatype_t tiledb_datatype;
     int64_t dim_max;
+    std::string string_lo;  // For custom/restricted DataFrame domains
+    std::string string_hi;  // For custom/restricted DataFrame domains
     bool use_current_domain;
 };
 

--- a/libtiledbsoma/test/unit_arrow_adapter.cc
+++ b/libtiledbsoma/test/unit_arrow_adapter.cc
@@ -73,20 +73,20 @@ TEST_CASE("name", "[pattern]") {
 
     ArrowTable arrow_table(std::move(arrow_array), std::move(arrow_schema));
 
-    std::vector<int64_t>
-        outputs_int64 = ArrowAdapter::get_table_column_by_name<int64_t>(
+    std::vector<int64_t> outputs_int64 =
+        ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             arrow_table, "int64");
-    std::vector<uint8_t>
-        outputs_uint8 = ArrowAdapter::get_table_column_by_name<uint8_t>(
+    std::vector<uint8_t> outputs_uint8 =
+        ArrowAdapter::get_table_non_string_column_by_name<uint8_t>(
             arrow_table, "uint8");
-    std::vector<double>
-        outputs_float64 = ArrowAdapter::get_table_column_by_name<double>(
+    std::vector<double> outputs_float64 =
+        ArrowAdapter::get_table_non_string_column_by_name<double>(
             arrow_table, "float64");
-    std::vector<float>
-        outputs_float32 = ArrowAdapter::get_table_column_by_name<float>(
+    std::vector<float> outputs_float32 =
+        ArrowAdapter::get_table_non_string_column_by_name<float>(
             arrow_table, "float32");
     std::vector<bool>
-        outputs_bool = ArrowAdapter::get_table_column_by_name<bool>(
+        outputs_bool = ArrowAdapter::get_table_non_string_column_by_name<bool>(
             arrow_table, "bool");
     std::vector<std::string>
         outputs_string = ArrowAdapter::get_table_string_column_by_name(

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -71,6 +71,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
@@ -125,6 +127,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         {{.name = dim_name,
           .tiledb_datatype = tiledb_datatype,
           .dim_max = DIM_MAX,
+          .string_lo = "N/A",
+          .string_hi = "N/A",
           .use_current_domain = false}});
     auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -179,6 +183,8 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
@@ -273,6 +279,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
@@ -327,6 +335,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
@@ -440,6 +450,8 @@ TEST_CASE("SOMAExperiment: metadata") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
@@ -532,6 +544,8 @@ TEST_CASE("SOMAMeasurement: metadata") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -879,8 +879,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: variant-indexed dataframe dim-sjid-str attr-u32",
     "[SOMADataFrame]") {
-    // auto use_current_domain = GENERATE(false, true);
-    auto use_current_domain = GENERATE(false);
+    auto use_current_domain = GENERATE(false, true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -979,7 +978,12 @@ TEST_CASE_METHOD(
         REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
         REQUIRE(dom_str == std::vector<std::string>({"", ""}));
 
-        REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        if (!use_current_domain) {
+            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        } else {
+            REQUIRE(maxdom_sjid[0] == 0);
+            REQUIRE(maxdom_sjid[1] > 2000000000);
+        }
         REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
 
         soma_dataframe->close();
@@ -1059,7 +1063,13 @@ TEST_CASE_METHOD(
         REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
         REQUIRE(dom_str == std::vector<std::string>({"", ""}));
 
-        REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        if (!use_current_domain) {
+            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        } else {
+            REQUIRE(maxdom_sjid[0] == 0);
+            REQUIRE(maxdom_sjid[1] > 2000000000);
+        }
+
         REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -548,18 +548,18 @@ TEST_CASE_METHOD(
 
         // Check domainish accessors before resize
         ArrowTable non_empty_domain = soma_dataframe->get_non_empty_domain();
-        std::vector<int64_t>
-            ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> ned_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 non_empty_domain, "soma_joinid");
 
         ArrowTable soma_domain = soma_dataframe->get_soma_domain();
-        std::vector<int64_t>
-            dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> dom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_domain, "soma_joinid");
 
         ArrowTable soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        std::vector<int64_t>
-            maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> maxdom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_maxdomain, "soma_joinid");
 
         REQUIRE(ned_sjid == std::vector<int64_t>({1, 2}));
@@ -634,16 +634,16 @@ TEST_CASE_METHOD(
         soma_dataframe->open(OpenMode::read);
 
         non_empty_domain = soma_dataframe->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             non_empty_domain, "soma_joinid");
 
         soma_domain = soma_dataframe->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             soma_domain, "soma_joinid");
 
         soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
-            soma_maxdomain, "soma_joinid");
+        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+            int64_t>(soma_maxdomain, "soma_joinid");
 
         if (!use_current_domain) {
             REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
@@ -727,27 +727,27 @@ TEST_CASE_METHOD(
         soma_dataframe->open(OpenMode::read);
 
         ArrowTable non_empty_domain = soma_dataframe->get_non_empty_domain();
-        std::vector<int64_t>
-            ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> ned_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 non_empty_domain, "soma_joinid");
-        std::vector<uint32_t>
-            ned_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
+        std::vector<uint32_t> ned_u32 =
+            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
                 non_empty_domain, "myuint32");
 
         ArrowTable soma_domain = soma_dataframe->get_soma_domain();
-        std::vector<int64_t>
-            dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> dom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_domain, "soma_joinid");
-        std::vector<uint32_t>
-            dom_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
+        std::vector<uint32_t> dom_u32 =
+            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
                 soma_domain, "myuint32");
 
         ArrowTable soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        std::vector<int64_t>
-            maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> maxdom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_maxdomain, "soma_joinid");
-        std::vector<uint32_t>
-            maxdom_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
+        std::vector<uint32_t> maxdom_u32 =
+            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
                 soma_maxdomain, "myuint32");
 
         REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
@@ -828,22 +828,22 @@ TEST_CASE_METHOD(
         soma_dataframe->open(OpenMode::read);
 
         non_empty_domain = soma_dataframe->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             non_empty_domain, "soma_joinid");
-        ned_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
+        ned_u32 = ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
             non_empty_domain, "myuint32");
 
         soma_domain = soma_dataframe->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             soma_domain, "soma_joinid");
-        dom_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
+        dom_u32 = ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
             soma_domain, "myuint32");
 
         soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
-            soma_maxdomain, "soma_joinid");
-        maxdom_u32 = ArrowAdapter::get_table_column_by_name<uint32_t>(
-            soma_maxdomain, "myuint32");
+        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+            int64_t>(soma_maxdomain, "soma_joinid");
+        maxdom_u32 = ArrowAdapter::get_table_non_string_column_by_name<
+            uint32_t>(soma_maxdomain, "myuint32");
 
         if (!use_current_domain) {
             REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
@@ -883,10 +883,16 @@ TEST_CASE_METHOD(
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
-        std::string suffix = use_current_domain ? "true" : "false";
+        auto specify_domain = GENERATE(false, true);
+        std::ostringstream section2;
+        section2 << "- specify_domain=" << specify_domain;
+
+        std::string suffix1 = use_current_domain ? "true" : "false";
+        std::string suffix2 = specify_domain ? "true" : "false";
         set_up(
             std::make_shared<SOMAContext>(),
-            "mem://unit-test-variant-indexed-dataframe-3-" + suffix);
+            "mem://unit-test-variant-indexed-dataframe-3-" + suffix1 + "-" +
+                suffix2);
 
         std::vector<helper::DimInfo> dim_infos(
             {i64_dim_info(use_current_domain),
@@ -949,24 +955,24 @@ TEST_CASE_METHOD(
 
         // Check domainish accessors before resize
         ArrowTable non_empty_domain = soma_dataframe->get_non_empty_domain();
-        std::vector<int64_t>
-            ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> ned_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 non_empty_domain, "soma_joinid");
         std::vector<std::string>
             ned_str = ArrowAdapter::get_table_string_column_by_name(
                 non_empty_domain, "mystring");
 
         ArrowTable soma_domain = soma_dataframe->get_soma_domain();
-        std::vector<int64_t>
-            dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> dom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_domain, "soma_joinid");
         std::vector<std::string>
             dom_str = ArrowAdapter::get_table_string_column_by_name(
                 soma_domain, "mystring");
 
         ArrowTable soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        std::vector<int64_t>
-            maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        std::vector<int64_t> maxdom_sjid =
+            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
                 soma_maxdomain, "soma_joinid");
         std::vector<std::string>
             maxdom_str = ArrowAdapter::get_table_string_column_by_name(
@@ -1040,20 +1046,20 @@ TEST_CASE_METHOD(
         soma_dataframe->open(OpenMode::read, TimestampRange(0, 2));
 
         non_empty_domain = soma_dataframe->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             non_empty_domain, "soma_joinid");
         ned_str = ArrowAdapter::get_table_string_column_by_name(
             non_empty_domain, "mystring");
 
         soma_domain = soma_dataframe->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
+        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
             soma_domain, "soma_joinid");
         dom_str = ArrowAdapter::get_table_string_column_by_name(
             soma_domain, "mystring");
 
         soma_maxdomain = soma_dataframe->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_column_by_name<int64_t>(
-            soma_maxdomain, "soma_joinid");
+        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+            int64_t>(soma_maxdomain, "soma_joinid");
         maxdom_str = ArrowAdapter::get_table_string_column_by_name(
             soma_maxdomain, "mystring");
 

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -62,6 +62,8 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
@@ -174,6 +176,8 @@ TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
@@ -236,6 +240,8 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -63,6 +63,8 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
@@ -214,6 +216,8 @@ TEST_CASE("SOMASparseNDArray: platform_config", "[SOMASparseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
@@ -264,6 +268,8 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
             {{.name = dim_name,
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
+              .string_lo = "N/A",
+              .string_hi = "N/A",
               .use_current_domain = use_current_domain}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -150,6 +150,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             soma_sparse->close();
 
             soma_sparse->open(OpenMode::read);
+            REQUIRE(soma_sparse->has_current_domain());
             soma_sparse->close();
 
             soma_sparse->open(OpenMode::write);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -39,8 +39,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     int64_t dim_max = 999;
     int64_t shape = 1000;
 
-    // auto use_current_domain = GENERATE(false, true);
-    auto use_current_domain = GENERATE(true);
+    auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
     // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
     // replaced with std::format.
@@ -148,6 +147,12 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             REQUIRE_THROWS(soma_sparse->resize(new_shape));
             // Now set the shape
             soma_sparse->upgrade_shape(new_shape);
+            soma_sparse->close();
+
+            soma_sparse->open(OpenMode::read);
+            soma_sparse->close();
+
+            soma_sparse->open(OpenMode::write);
             REQUIRE(soma_sparse->has_current_domain());
             // Should not fail since we're setting it to what it already is.
             soma_sparse->resize(new_shape);


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

See also [[sc-55659]](https://app.shortcut.com/tiledb-inc/story/55659/r-current-domain-tasks).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Following #3012 we can now connect tiledbsoma-py to use the full domainish accessors from `libtiledbsoma`.

**Notes for Reviewer:**

R mods to come on this same PR.

This PR is a work in progress. It is not ready for review.


