### PR TITLE
[c++] Improve current-domain signaling for string dims

### DIFF
--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -1144,7 +1144,7 @@ TEST_CASE_METHOD(
             REQUIRE(dom_str == std::vector<std::string>({"", ""}));
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
         } else {
-            REQUIRE(dom_str == std::vector<std::string>({"", "\xff"}));
+            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
         }
 
@@ -1229,7 +1229,7 @@ TEST_CASE_METHOD(
             REQUIRE(dom_str == std::vector<std::string>({"", ""}));
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
         } else {
-            REQUIRE(dom_str == std::vector<std::string>({"", "\xff"}));
+            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
         }
 


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Found while porting domainish accessors to Python on the WIP #3027.

Reasoning is as commented within `soma_array.h`.

**Notes for Reviewer:**
