### PR TITLE
[python] Parallelize `pybind11` build [RFC]

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -34,6 +34,8 @@ except ImportError:
     # read&install our requirements without loading setup.py.
     from setuptools import Extension as Pybind11Extension
 
+from pybind11.setup_helpers import ParallelCompile
+
 this_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.insert(0, str(this_dir))
 
@@ -265,6 +267,10 @@ if os.name == "posix" and sys.platform != "darwin":
 # Don't use `if __name__ == "__main__":` as the `python_requires` must
 # be at top level, outside any if-block
 # https://github.com/pypa/cibuildwheel/blob/7c4bbf8cb31d856a0fe547faf8edf165cd48ce74/cibuildwheel/projectfiles.py#L41-L46
+
+# Optional multithreaded build. Otherwise we spend a big chunk of iterative dev time doing
+# sequential compiles of our apis/python/src/tiledbsoma/*.cc.
+ParallelCompile("NPY_NUM_BUILD_JOBS").install()
 
 setuptools.setup(
     name="tiledbsoma",


### PR DESCRIPTION
**Issue and/or context:** Found while working on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

To speed up iterative dev time, I have separate little aliases & scripts (available on request). One of them is to parallelize `pybind11` builds as they are sequential. It turns out those that there is an option to do this within `setup.py`.

See also https://pybind11.readthedocs.io/en/stable/compiling.html.

**Notes for Reviewer:**

To make this work we'd need to include `pybind11` as an explicit dependency ...