### PR TITLE
[r] Implement missing `domain` argument to `DataFrame` `create`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.14.99.1
+Version: 1.14.99.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+* Implement missing `domain` argument to `SOMADataFrame` `create` [#3032](https://github.com/single-cell-data/TileDB-SOMA/pull/3032)
 * Remove unused `fragment_count` accessor [#3054](https://github.com/single-cell-data/TileDB-SOMA/pull/3054)
 
 # tiledbsoma 1.14.1

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -8,6 +8,14 @@
 #' @param index_column_names A vector of column names to use as user-defined
 #' index columns; all named columns must exist in the schema, and at least
 #' one index column name is required
+#' @param domain An optional list of 2-element vectors specifying the domain of each index
+#' column. Each vector should be a pair consisting of the minimum and maximum values storable in
+#' the index column. For example, if there is a single int64-valued index column, then `domain`
+#' might be `c(100, 200)` to indicate that values between 100 and 200, inclusive, can be stored
+#' in that column.  If provided, this list must have the same length as `index_column_names`,
+#' and the index-column domain will be as specified.  If omitted entirely, or if `NA` in a given
+#' dimension, the corresponding index-column domain will use the minimum and maximum possible
+#' values for the column's datatype.  This makes a `DataFrame` growable.
 #' @param ingest_mode Ingestion mode when creating the TileDB object; choose from:
 #' \itemize{
 #'  \item \dQuote{\code{write}}: create a new TileDB object and error if it already exists
@@ -24,6 +32,7 @@ SOMADataFrameCreate <- function(
   uri,
   schema,
   index_column_names = c("soma_joinid"),
+  domain = NULL,
   ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
@@ -50,6 +59,7 @@ SOMADataFrameCreate <- function(
     sdf$create(
       schema,
       index_column_names = index_column_names,
+      domain = domain,
       platform_config = platform_config,
       internal_use_only = "allowed_use"
     )

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -13,7 +13,7 @@
 #' the index column. For example, if there is a single int64-valued index column, then `domain`
 #' might be `c(100, 200)` to indicate that values between 100 and 200, inclusive, can be stored
 #' in that column.  If provided, this list must have the same length as `index_column_names`,
-#' and the index-column domain will be as specified.  If omitted entirely, or if `NA` in a given
+#' and the index-column domain will be as specified.  If omitted entirely, or if `NULL` in a given
 #' dimension, the corresponding index-column domain will use the minimum and maximum possible
 #' values for the column's datatype.  This makes a `DataFrame` growable.
 #' @param ingest_mode Ingestion mode when creating the TileDB object; choose from:

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -20,12 +20,21 @@ SOMADataFrame <- R6::R6Class(
     #' @param index_column_names A vector of column names to use as user-defined
     #' index columns.  All named columns must exist in the schema, and at least
     #' one index column name is required.
+    #' @param domain An optional list of 2-element vectors specifying the domain of each index
+    #' column. Each vector should be a pair consisting of the minimum and maximum values storable in
+    #' the index column. For example, if there is a single int64-valued index column, then `domain`
+    #' might be `c(100, 200)` to indicate that values between 100 and 200, inclusive, can be stored
+    #' in that column.  If provided, this list must have the same length as `index_column_names`,
+    #' and the index-column domain will be as specified.  If omitted entirely, or if `NA` in a given
+    #' dimension, the corresponding index-column domain will use the minimum and maximum possible
+    #' values for the column's datatype.  This makes a `DataFrame` growable.
     #' @template param-platform-config
     #' @param internal_use_only Character value to signal this is a 'permitted' call,
     #' as `create()` is considered internal and should not be called directly.
     create = function(
       schema,
       index_column_names = c("soma_joinid"),
+      domain = NULL,
       platform_config = NULL,
       internal_use_only = NULL
     ) {
@@ -35,6 +44,19 @@ SOMADataFrame <- R6::R6Class(
       }
       schema <- private$validate_schema(schema, index_column_names)
 
+      stopifnot(
+        "domain must be NULL or a named list, with values being 2-element vectors or NULL" =
+          is.null(domain) || is.list(domain))
+      if (!is.null(domain)) {
+        stopifnot("domain must be NULL or a named list, with values being 2-element vectors or NULL" =
+          !is.null(names(domain)))
+        for (name in names(domain)) {
+          slot <- domain[[name]]
+          stopifnot("domain must be NULL or a named list, with values being 2-element vectors or NULL" =
+            is.null(slot) || (is.vector(slot) && length(slot) == 2))
+        }
+      }
+
       attr_column_names <- setdiff(schema$names, index_column_names)
       stopifnot("At least one non-index column must be defined in the schema" =
                 length(attr_column_names) > 0)
@@ -43,12 +65,14 @@ SOMADataFrame <- R6::R6Class(
       # typed, queryable data structure.
       tiledb_create_options <- TileDBCreateOptions$new(platform_config)
 
-      ## we (currently pass domain and extent values in an arrow table (i.e. data.frame alike)
-      ## where each dimension is one column (of the same type as in the schema) followed by three
-      ## values for the domain pair and the extent
+      # We currently pass domain and extent values in an arrow table (i.e. data.frame alike)
+      # where each dimension is one column (of the same type as in the schema followed by:
+      # * Before the new shape feature: three values for the domain pair and the extent;
+      # * After the new shape feature: five values for the maxdomain pair, extent, and domain.
       dom_ext_tbl <- get_domain_and_extent_dataframe(
         schema,
         ind_col_names = index_column_names,
+        domain = domain,
         tdco = tiledb_create_options
       )
 

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -358,11 +358,11 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names, domain = 
               "Third argument must be options wrapper" = inherits(tdco, "TileDBCreateOptions"))
     stopifnot(
         "domain must be NULL or a named list, with values being 2-element vectors or NULL" = is.null(domain) ||
-          ( # Check that `domain` is a list of length `length(index_column_names)`
-            # where all values are named after `index_column_names`
+          ( # Check that `domain` is a list of length `length(ind_col_names)`
+            # where all values are named after `ind_col_names`
             # and all values are `NULL` or a two-length atomic non-factor vector
-            rlang::is_list(domain, n = length(index_column_names)) &&
-              identical(sort(names(domain)), sort(index_column_names)) &&
+            rlang::is_list(domain, n = length(ind_col_names)) &&
+              identical(sort(names(domain)), sort(ind_col_names)) &&
               all(vapply_lgl(
                 domain,
                 function(x) is.null(x) || (is.atomic(x) && !is.factor(x) && length(x) == 2L)

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -348,7 +348,7 @@ extract_levels <- function(arrtbl, exclude_cols=c("soma_joinid")) {
 #' Domain and extent table creation helper for data.frame writes returning a Table with
 #' a column per dimension for the given (incoming) arrow schema of a Table
 #' @noRd
-get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
+get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names, domain = NULL,
                                             tdco = TileDBCreateOptions$new(PlatformConfig$new())) {
     stopifnot("First argument must be an arrow schema" = inherits(tbl_schema, "Schema"),
               "Second argument must be character" = is.character(ind_col_names),
@@ -356,13 +356,23 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
               "Second argument index names must be columns in first argument" =
                   all(is.finite(match(ind_col_names, names(tbl_schema)))),
               "Third argument must be options wrapper" = inherits(tdco, "TileDBCreateOptions"))
+    if (!is.null(domain)) {
+      stopifnot("Non-null domain provided to create must have same length as index-column names" =
+        (length(domain) == length(ind_col_names)))
+      for (name in ind_col_names) {
+        slot <- domain[[name]]
+        if (!is.null(slot)) {
+          stopifnot("Non-null domain provided to create must have null or 2-element vector in each slot" =
+            (length(slot) == 2))
+        }
+      }
+    }
+
     rl <- sapply(ind_col_names, \(ind_col_name) {
         ind_col <- tbl_schema$GetFieldByName(ind_col_name)
         ind_col_type <- ind_col$type
         ind_col_type_name <- ind_col$type$name
 
-        # TODO: tiledbsoma-r does not accept the domain argument to SOMADataFrame::create, but should
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/2967
         ind_ext <- tdco$dim_tile(ind_col_name)
 
         # Default 2048 mods to 0 for 8-bit types and 0 is an invalid extent
@@ -384,21 +394,59 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names,
           ind_max_dom <- arrow_type_range(ind_col_type) - c(0, ind_ext)
         }
 
-        ind_cur_dom <- ind_max_dom
+        requested_slot <- domain[[ind_col_name]]
+        if (is.null(requested_slot)) {
+          ind_cur_dom <- ind_max_dom
+        } else {
+          ind_cur_dom <- requested_slot
+        }
+        # Core supports no domain specification for variable-length dims, which
+        # includes string/binary dims.
         if (ind_col_type_name %in% c("string", "large_utf8", "utf8")) ind_ext <- NA
 
         # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
         if (.new_shape_feature_flag_is_enabled()) {
             if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
-                aa <- arrow::arrow_array(c("", "", "", "", ""), ind_col_type)
+                if (is.null(requested_slot)) {
+                  aa <- arrow::arrow_array(c("", "", "", "", ""), ind_col_type)
+                } else {
+                  aa <- arrow::arrow_array(c("", "", "", requested_slot[[1]], requested_slot[[2]]), ind_col_type)
+                }
             } else {
+                # If they wanted (0, 99) then extent must be at most 100.
+                # This is tricky though. Some cases:
+                # * lo = 0, hi = 99, extent = 1000
+                #   We look at hi - lo + 1; resize extent down to 100
+                # * lo = 1000, hi = 1099, extent = 1000
+                #   We look at hi - lo + 1; resize extent down to 100
+                # * lo = min for datatype, hi = max for datatype
+                #   We get integer overflow trying to compute hi - lo + 1
+                # So if lo <= 0 and hi >= ind_ext, this is fine without
+                # computing hi - lo + 1.
+                lo <- ind_max_dom[[1]]
+                hi <- ind_max_dom[[2]]
+                if (lo > 0 || hi < ind_ext) {
+                  dom_span <- hi - lo + 1
+                  if (ind_ext > dom_span) {
+                    ind_ext <- dom_span
+                  }
+                }
                 aa <- arrow::arrow_array(c(ind_max_dom, ind_ext, ind_cur_dom), ind_col_type)
             }
         } else {
             if (ind_col_type_name %in% c("string", "utf8", "large_utf8")) {
                 aa <- arrow::arrow_array(c("", "", ""), ind_col_type)
             } else {
-                aa <- arrow::arrow_array(c(ind_max_dom, ind_ext), ind_col_type)
+                # Same comments as above
+                lo <- ind_cur_dom[[1]]
+                hi <- ind_cur_dom[[2]]
+                if (lo > 0 || hi < ind_ext) {
+                  dom_span <- hi - lo + 1
+                  if (ind_ext > dom_span) {
+                    ind_ext <- dom_span
+                  }
+                }
+                aa <- arrow::arrow_array(c(ind_cur_dom, ind_ext), ind_col_type)
             }
         }
 

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -86,7 +86,7 @@ column. Each vector should be a pair consisting of the minimum and maximum value
 the index column. For example, if there is a single int64-valued index column, then \code{domain}
 might be \code{c(100, 200)} to indicate that values between 100 and 200, inclusive, can be stored
 in that column.  If provided, this list must have the same length as \code{index_column_names},
-and the index-column domain will be as specified.  If omitted entirely, or if \code{NA} in a given
+and the index-column domain will be as specified.  If omitted entirely, or if \code{NULL} in a given
 dimension, the corresponding index-column domain will use the minimum and maximum possible
 values for the column's datatype.  This makes a \code{DataFrame} growable.}
 

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -66,6 +66,7 @@ Create (lifecycle: maturing)
 \if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$create(
   schema,
   index_column_names = c("soma_joinid"),
+  domain = NULL,
   platform_config = NULL,
   internal_use_only = NULL
 )}\if{html}{\out{</div>}}
@@ -79,6 +80,15 @@ Create (lifecycle: maturing)
 \item{\code{index_column_names}}{A vector of column names to use as user-defined
 index columns.  All named columns must exist in the schema, and at least
 one index column name is required.}
+
+\item{\code{domain}}{An optional list of 2-element vectors specifying the domain of each index
+column. Each vector should be a pair consisting of the minimum and maximum values storable in
+the index column. For example, if there is a single int64-valued index column, then \code{domain}
+might be \code{c(100, 200)} to indicate that values between 100 and 200, inclusive, can be stored
+in that column.  If provided, this list must have the same length as \code{index_column_names},
+and the index-column domain will be as specified.  If omitted entirely, or if \code{NA} in a given
+dimension, the corresponding index-column domain will use the minimum and maximum possible
+values for the column's datatype.  This makes a \code{DataFrame} growable.}
 
 \item{\code{platform_config}}{A \link[tiledbsoma:PlatformConfig]{platform configuration}
 object}

--- a/apis/r/man/SOMADataFrameCreate.Rd
+++ b/apis/r/man/SOMADataFrameCreate.Rd
@@ -30,7 +30,7 @@ column. Each vector should be a pair consisting of the minimum and maximum value
 the index column. For example, if there is a single int64-valued index column, then \code{domain}
 might be \code{c(100, 200)} to indicate that values between 100 and 200, inclusive, can be stored
 in that column.  If provided, this list must have the same length as \code{index_column_names},
-and the index-column domain will be as specified.  If omitted entirely, or if \code{NA} in a given
+and the index-column domain will be as specified.  If omitted entirely, or if \code{NULL} in a given
 dimension, the corresponding index-column domain will use the minimum and maximum possible
 values for the column's datatype.  This makes a \code{DataFrame} growable.}
 

--- a/apis/r/man/SOMADataFrameCreate.Rd
+++ b/apis/r/man/SOMADataFrameCreate.Rd
@@ -8,6 +8,7 @@ SOMADataFrameCreate(
   uri,
   schema,
   index_column_names = c("soma_joinid"),
+  domain = NULL,
   ingest_mode = c("write", "resume"),
   platform_config = NULL,
   tiledbsoma_ctx = NULL,
@@ -23,6 +24,15 @@ SOMADataFrameCreate(
 \item{index_column_names}{A vector of column names to use as user-defined
 index columns; all named columns must exist in the schema, and at least
 one index column name is required}
+
+\item{domain}{An optional list of 2-element vectors specifying the domain of each index
+column. Each vector should be a pair consisting of the minimum and maximum values storable in
+the index column. For example, if there is a single int64-valued index column, then \code{domain}
+might be \code{c(100, 200)} to indicate that values between 100 and 200, inclusive, can be stored
+in that column.  If provided, this list must have the same length as \code{index_column_names},
+and the index-column domain will be as specified.  If omitted entirely, or if \code{NA} in a given
+dimension, the corresponding index-column domain will use the minimum and maximum possible
+values for the column's datatype.  This makes a \code{DataFrame} growable.}
 
 \item{ingest_mode}{Ingestion mode when creating the TileDB object; choose from:
 \itemize{

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -4,11 +4,9 @@
 #define TILEDB_NO_API_DEPRECATION_WARNINGS
 #endif
 
-#include <Rcpp.h>                           // for R interface to C++
-#include <nanoarrow/r.h>                    // for C interface to Arrow (via R package)
-#include <nanoarrow/nanoarrow.h>            // for C interface to Arrow
-#include <RcppInt64>                        // for fromInteger64
-#include <tiledbsoma/tiledbsoma>
+#include <Rcpp.h>                 // for R interface to C++
+#include <nanoarrow/nanoarrow.h>  // for C interface to Arrow
+#include <nanoarrow/r.h>          // for C interface to Arrow (via R package)
 #include <tiledbsoma/reindexer/reindexer.h>
 #include <RcppInt64>  // for fromInteger64
 #include <tiledbsoma/tiledbsoma>
@@ -471,10 +469,25 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
         "Bad array children alloc");
 
     for (size_t i = 0; i < ncol; i++) {
-        spdl::info(
-            "[domainish] name {} length {}",
-            std::string(arrow_schema->children[i]->name),
-            arrow_array->children[i]->length);
+        if (arrow_array->children[i]->n_buffers == 3) {
+            std::vector<std::string>
+                lohi = tiledbsoma::ArrowAdapter::get_array_string_column(
+                    arrow_array->children[i], arrow_schema->children[i]);
+            spdl::info(
+                "[domainish] name {} format {} length {} lo {} hi {}",
+                std::string(arrow_schema->children[i]->name),
+                std::string(arrow_schema->children[i]->format),
+                arrow_array->children[i]->length,
+                lohi[0],
+                lohi[1]);
+        } else {
+            spdl::info(
+                "[domainish] name {} format {} length {}",
+                std::string(arrow_schema->children[i]->name),
+                std::string(arrow_schema->children[i]->format),
+                arrow_array->children[i]->length);
+        }
+
         ArrowArrayMove(arrow_array->children[i], arr->children[i]);
         ArrowSchemaMove(arrow_schema->children[i], sch->children[i]);
     }

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -470,6 +470,8 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
 
     for (size_t i = 0; i < ncol; i++) {
         if (arrow_array->children[i]->n_buffers == 3) {
+            // Arrow semantics: variable-length: buffers 0,1,2 are validity,
+            // offsets, data
             std::vector<std::string>
                 lohi = tiledbsoma::ArrowAdapter::get_array_string_column(
                     arrow_array->children[i], arrow_schema->children[i]);
@@ -481,6 +483,8 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
                 lohi[0],
                 lohi[1]);
         } else {
+            // Arrow semantics: non-variable-length: buffers 0,1 are validity &
+            // data
             spdl::info(
                 "[domainish] name {} format {} length {}",
                 std::string(arrow_schema->children[i]->name),

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -1,107 +1,222 @@
 test_that("SOMADataFrame shape", {
-  #uri <- withr::local_tempdir("soma-dataframe-shape")
-  uri <- "/tmp/fooze"
   asch <- create_arrow_schema()
 
   index_column_name_choices = list(
     "soma_joinid",
     c("soma_joinid", "int_column"),
     c("soma_joinid", "string_column"),
+    c("string_column", "int_column"),
     c("string_column", "int_column")
   )
+
+  domain_at_create_choices  = list(
+    list(soma_joinid = c(0, 1000)),
+    list(soma_joinid = c(0, 1000), int_column = c(-10000, 10000)),
+    list(soma_joinid = c(0, 1000), string_column = NULL),
+    list(string_column = NULL, int_column = c(-10000, 10000)),
+    list(string_column = c("apple", "zebra"), int_column = c(-10000, 10000))
+  )
+
+  # Check the test configs themselves to make sure someone (ahem, me)
+  # didn't edit one without forgetting to edit the other
+  expect_equal(length(index_column_name_choices), length(domain_at_create_choices))
 
   for (i in seq_along(index_column_name_choices)) {
     index_column_names <- index_column_name_choices[[i]]
 
-    has_soma_joinid_dim <- "soma_joinid" %in% index_column_names
+    for (use_domain_at_create in c(FALSE, TRUE)) {
 
-    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+      uri <- withr::local_tempdir("soma-dataframe-shape")
 
-    # TODO: test create with specified domain on PR 3032
-    sdf <- SOMADataFrameCreate(uri, asch, index_column_names = index_column_names)
-    expect_true(sdf$exists())
-    expect_true(dir.exists(uri))
+      # Create
+      if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 
-    tbl0 <- arrow::arrow_table(int_column = 1L:4L,
-                               soma_joinid = 1L:4L,
-                               float_column = 1.1:4.1,
-                               string_column = c("apple", "ball", "cat", "dog"),
-                               schema = asch)
+      domain_for_create <- NULL
+      if (use_domain_at_create) {
+        domain_for_create <- domain_at_create_choices[[i]]
+      }
 
-    sdf$write(tbl0)
-    sdf$close()
+      sdf <- SOMADataFrameCreate(
+        uri,
+        asch,
+        index_column_names = index_column_names,
+        domain = domain_for_create)
 
-    sdf <- SOMADataFrameOpen(uri)
+      expect_true(sdf$exists())
+      expect_true(dir.exists(uri))
 
-    if (.new_shape_feature_flag_is_enabled()) {
-      expect_true(sdf$tiledbsoma_has_upgraded_domain())
-    } else {
-      expect_false(sdf$tiledbsoma_has_upgraded_domain())
+      # Write
+      tbl0 <- arrow::arrow_table(int_column = 1L:4L,
+                                 soma_joinid = 1L:4L,
+                                 float_column = 1.1:4.1,
+                                 string_column = c("apple", "ball", "cat", "dog"),
+                                 schema = asch)
+
+      sdf$write(tbl0)
+      sdf$close()
+
+      sdf <- SOMADataFrameOpen(uri)
+
+      # Check shape and maxshape et al.
+      if (!.new_shape_feature_flag_is_enabled()) {
+        expect_false(sdf$tiledbsoma_has_upgraded_domain())
+      } else {
+        expect_true(sdf$tiledbsoma_has_upgraded_domain())
+      }
+      expect_error(sdf$shape(), class = "notYetImplementedError")
+      expect_error(sdf$maxshape(), class = "notYetImplementedError")
+
+      # Not implemented this way per
+      # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
+      # sjid_shape <- sdf$.maybe_soma_joinid_shape()
+      # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
+      soma_context <- soma_context()
+      sjid_shape <- maybe_soma_joinid_shape(sdf$uri, soma_context)
+      sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, soma_context)
+
+      if ("soma_joinid" %in% index_column_names) {
+        # More testing to come on
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+        expect_false(is.na(sjid_shape))
+        expect_false(is.na(sjid_maxshape))
+      } else {
+        expect_true(is.na(sjid_shape))
+        expect_true(is.na(sjid_maxshape))
+      }
+
+      # Check has_upgraded_domain
+      if (!.new_shape_feature_flag_is_enabled()) {
+        expect_false(sdf$tiledbsoma_has_upgraded_domain())
+      } else {
+        expect_true(sdf$tiledbsoma_has_upgraded_domain())
+      }
+
+      # Check domain and maxdomain
+      dom = sdf$domain()
+      mxd = sdf$maxdomain()
+
+      # First check names
+      expect_equal(names(dom), index_column_names)
+      expect_equal(names(mxd), index_column_names)
+
+      # Then check all slots are pairs
+      for (name in names(dom)) {
+        expect_length(dom[[name]], 2L)
+        expect_length(mxd[[name]], 2L)
+      }
+
+      # Then check contents
+
+      # Old shape/domainishes (without core current domain) for non-string dims:
+      # * There is no core current domain
+      # * Expect domain == maxdomain
+      # * If they asked for NULL: both should be huge (near min/max for datatype)
+      # * If they asked for something specific: they should get it
+      #
+      # New shape/domainishes (with core current domain) for non-string dims:
+      # * Maxdomain should be huge (near min/max for datatype)
+      # * If they asked for NULL: domain should be the same as maxdomain
+      # * If they asked for a specific domain: they should get it
+      #
+      # Old shape/domainishes (without core current domain) for string dims:
+      # * There is no core current domain
+      # * Expect domain == maxdomain
+      # * Core domain for strings is always ("", "")
+      #
+      # New shape/domainishes (with core current domain) for string dims:
+      # * Core domain (soma maxdomain) for strings is always ("", "")
+      # * Core current domain (soma domain) for strings:
+      #   o If they asked for NULL: expect ("", "")
+      #   o If they asked for something specific: they should get it
+
+      if ("soma_joinid" %in% index_column_names) {
+        sjid_dom <- dom[["soma_joinid"]]
+        sjid_mxd <- mxd[["soma_joinid"]]
+        sjid_dfc <- domain_for_create[["soma_joinid"]]
+
+        if (!.new_shape_feature_flag_is_enabled()) {
+          # Old behavior
+          expect_equal(sjid_dom, sjid_mxd)
+        }
+
+        if (!use_domain_at_create) {
+          expect_equal(sjid_dom[[1]], 0)
+          expect_equal(sjid_mxd[[1]], 0)
+          # This is a really big number in the ballpark of 2**63; its exact
+          # value is unimportant.
+          expect_true(sjid_dom[[2]] > bit64::as.integer64(10000000000))
+          expect_true(sjid_mxd[[2]] > bit64::as.integer64(10000000000))
+        } else {
+          # The soma_joinid dim is always of type int64.  Everything coming back
+          # from libtiledbsoma, through C nanoarrow, through the R arrow
+          # package, to Arrow RecordBatch, holds true to that. But the final
+          # as.list() converts the domain to regular integer for us.  Not ideal
+          # IMO, but, we need to check against what it actually does.
+          #
+          # Not: expect_equal(sjid_dom, bit64::as.integer64(sjid_dfc))
+          expect_equal(sjid_dom, sjid_dfc)
+        }
+      }
+
+      if ("int_column" %in% index_column_names) {
+        int_dom <- dom[["int_column"]]
+        int_mxd <- mxd[["int_column"]]
+        int_dfc <- domain_for_create[["int_column"]]
+
+        if (!.new_shape_feature_flag_is_enabled()) {
+          # Old behavior
+          expect_equal(int_dom, int_mxd)
+        }
+
+        if (!use_domain_at_create) {
+          expect_true(int_dom[[1]] < -2000000000)
+          expect_true(int_dom[[2]] > 2000000000)
+        } else {
+          expect_equal(int_dom, int_dfc)
+        }
+
+        if (!.new_shape_feature_flag_is_enabled()) {
+          if (!use_domain_at_create) {
+            expect_true(int_mxd[[1]] < -2000000000)
+            expect_true(int_mxd[[2]] > 2000000000)
+          } else {
+            expect_equal(int_mxd, int_dfc)
+          }
+        } else {
+            expect_true(int_mxd[[1]] < -2000000000)
+            expect_true(int_mxd[[2]] > 2000000000)
+        }
+      }
+
+      if ("string_column" %in% index_column_names) {
+        str_dom <- dom[["string_column"]]
+        str_mxd <- mxd[["string_column"]]
+        str_dfc <- domain_for_create[["string_column"]]
+
+        if (!.new_shape_feature_flag_is_enabled()) {
+          expect_equal(str_dom, c("", ""))
+          expect_equal(str_mxd, c("", ""))
+
+        } else {
+          if (!use_domain_at_create) {
+            expect_equal(str_dom, c("", ""))
+          } else {
+            if (is.null(str_dfc)) {
+                expect_equal(str_dom, c("", ""))
+            } else {
+              expect_equal(str_dom, str_dfc)
+            }
+          }
+          expect_equal(str_mxd, c("", ""))
+        }
+      }
+
+      sdf$close()
+
+      rm(sdf, tbl0)
+
+      gc()
     }
-    expect_error(sdf$shape(), class = "notYetImplementedError")
-    expect_error(sdf$maxshape(), class = "notYetImplementedError")
-
-    # Not implemented this way per
-    # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
-    # sjid_shape <- sdf$.maybe_soma_joinid_shape()
-    # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
-    soma_context <- soma_context()
-    sjid_shape <- maybe_soma_joinid_shape(sdf$uri, soma_context)
-    sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, soma_context)
-
-    if (has_soma_joinid_dim) {
-      # More testing to come on
-      # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-      expect_false(is.na(sjid_shape))
-      expect_false(is.na(sjid_maxshape))
-    } else {
-      expect_true(is.na(sjid_shape))
-      expect_true(is.na(sjid_maxshape))
-    }
-
-    dom <- sdf$domain()
-    mxd <- sdf$maxdomain()
-
-    # First check names
-    expect_equal(names(dom), index_column_names)
-    expect_equal(names(mxd), index_column_names)
-
-    # Then check all slots are pairs
-    for (name in names(dom)) {
-      expect_length(dom[[name]], 2L)
-      expect_length(mxd[[name]], 2L)
-    }
-
-    # Then check contents
-    if ("soma_joinid" %in% index_column_names) {
-      sjid_dom <- dom[["soma_joinid"]]
-      sjid_mxd <- mxd[["soma_joinid"]]
-      expect_equal(sjid_dom[[1]], 0)
-      expect_equal(sjid_mxd[[1]], 0)
-      # Really big number; exact value unimportant
-      # TODO: test create with specified domain on PR 3032
-      # -- then, current and max domain will be different
-      expect_true(sjid_dom[[2]] > bit64::as.integer64(10000000000))
-      expect_true(sjid_mxd[[2]] > bit64::as.integer64(10000000000))
-    }
-
-    if ("int_column" %in% index_column_names) {
-      int_dom <- dom[["int_column"]]
-      int_mxd <- mxd[["int_column"]]
-      expect_true(int_dom[[1]] < -2000000000)
-      expect_true(int_dom[[2]] > 2000000000)
-    }
-
-    if ("string_column" %in% index_column_names) {
-      expect_equal(dom[["string_column"]], c("", ""))
-      expect_equal(mxd[["string_column"]], c("", ""))
-    }
-
-    sdf$close()
-
-    rm(sdf, tbl0)
-
-    gc()
   }
 })
 

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -77,11 +77,11 @@ test_that("SOMADataFrame shape", {
       if ("soma_joinid" %in% index_column_names) {
         # More testing to come on
         # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-        expect_false(is.na(sjid_shape))
-        expect_false(is.na(sjid_maxshape))
+        expect_false(rlang::is_na(sjid_shape))
+        expect_false(rlang::is_na(sjid_maxshape))
       } else {
-        expect_true(is.na(sjid_shape))
-        expect_true(is.na(sjid_maxshape))
+        expect_true(rlang::is_na(sjid_shape))
+        expect_true(rlang::is_na(sjid_maxshape))
       }
 
       # Check has_upgraded_domain

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -147,13 +147,16 @@ test_that("SOMADataFrame shape", {
           expect_true(sjid_dom[[2]] > bit64::as.integer64(10000000000))
           expect_true(sjid_mxd[[2]] > bit64::as.integer64(10000000000))
         } else {
-          # The soma_joinid dim is always of type int64.  Everything coming back
+          # Not: expect_equal(sjid_dom, bit64::as.integer64(sjid_dfc)) The
+          # soma_joinid dim is always of type int64.  Everything coming back
           # from libtiledbsoma, through C nanoarrow, through the R arrow
           # package, to Arrow RecordBatch, holds true to that. But the final
-          # as.list() converts the domain to regular integer for us.  Not ideal
-          # IMO, but, we need to check against what it actually does.
-          #
-          # Not: expect_equal(sjid_dom, bit64::as.integer64(sjid_dfc))
+          # as.list() converts the domain to regular integer. This is a feature
+          # TBH: suppressable with `op <- options(arrow.int64_downcast =
+          # FALSE)`. The maxdomainis likely to be in the 2**63 range
+          # but the domain is likely to be ordinary-sized numbers in the
+          # thousands or millions. Users are likely to prefer these
+          # being downcast to regular R integers.
           expect_equal(sjid_dom, sjid_dfc)
         }
       }

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -5,7 +5,7 @@ test_that("SOMADataFrame shape", {
     "soma_joinid",
     c("soma_joinid", "int_column"),
     c("soma_joinid", "string_column"),
-    c("string_column", "int_column"),
+    c("string_column", "int_column"), # duplicate intentional to match `domain_at_create_choices`
     c("string_column", "int_column")
   )
 
@@ -92,8 +92,8 @@ test_that("SOMADataFrame shape", {
       }
 
       # Check domain and maxdomain
-      dom = sdf$domain()
-      mxd = sdf$maxdomain()
+      dom <- sdf$domain()
+      mxd <- sdf$maxdomain()
 
       # First check names
       expect_equal(names(dom), index_column_names)
@@ -218,6 +218,87 @@ test_that("SOMADataFrame shape", {
       gc()
     }
   }
+  
+  # Test `domain` assertions
+  uri <- tempfile()
+
+  # `domain` must be `NULL` or a list
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = NA
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = 1L
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = bit64::as.integer64(c(0L, 99L))
+  ))
+  # `domain` may not be an empty list
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list()
+  ))
+  # `domain` must be named
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(bit64::as.integer64(c(0L, 99L)))
+  ))
+  # `domain` must be a list of two-length atomics
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = list(bit64::as.integer64(0L), bit64::as.integer64(99L)))
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = NA)
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = numeric())
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = numeric(length = 3L))
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = c("soma_joinid", "int_column"),
+    domain = list(soma_joinid = NULL, int_column = data.frame())
+  ))
+  # `names(domain)` must be identical to `index_column_names`
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = NULL, int_column = NULL)
+  ))
+  expect_error(SOMADataFrameCreate(
+    uri,
+    schema = asch,
+    index_column_names = c("soma_joinid", "int_column"),
+    domain = list(soma_joinid = NULL)
+  ))
 })
 
 test_that("SOMASparseNDArray shape", {


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). Fixes #2967 / [[sc-55657]](https://app.shortcut.com/tiledb-inc/story/55657/use-domain-in-somadataframecreate).

**Changes:**

As a legacy R/Python-parity issue, the `domain` argument to `SOMADataFrame`'s `create` -- from the [SOMA spec](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md) -- was never implemented in R. Here we remedy that.

**Notes for Reviewer:**

This PR is a work in progress. It is not ready for review.

Unit-test cases are not yet implemented.