### PR TITLE
[python] Drop extra index array schema name

### DIFF
--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -256,7 +256,9 @@ def df_to_arrow(df: pd.DataFrame) -> pa.Table:
     # the bare minimum necessary.
     new_map = {}
     for field in arrow_table.schema:
-        if pa.types.is_dictionary(field.type):
+        if field.name == "__index_level_0__":
+            continue
+        elif pa.types.is_dictionary(field.type):
             old_index_type = field.type.index_type
             new_index_type = (
                 pa.int32()

--- a/apis/python/tests/test_arrow_type.py
+++ b/apis/python/tests/test_arrow_type.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+import tiledbsoma
+
+
+@pytest.mark.parametrize(
+    ("input_df", "expected"),
+    [
+        [
+            pd.DataFrame(
+                data={
+                    "id": np.array([1, 3, 5, 6], dtype=np.int64),
+                    "alpha": np.arange(4, dtype=np.float32),
+                },
+                index=[1, 3, 5, 6],
+            ),
+            pa.Table.from_pydict(
+                {
+                    "id": pa.array([1, 3, 5, 6], type=pa.int64()),
+                    "alpha": pa.array([0, 1, 2, 3], type=pa.float32()),
+                }
+            ),
+        ],
+    ],
+)
+def test_df_to_arrow(input_df: pd.DataFrame, expected: pa.Table):
+    actual = tiledbsoma._arrow_types.df_to_arrow(input_df)
+    assert actual == expected


### PR DESCRIPTION
Prevent extra index column from being added to pandas dataframe generated schema.
