### PR TITLE
[python] add `--maxfail=50` to GHA `pytest` invocations

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -134,14 +134,14 @@ jobs:
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20
+      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Run pytests for Python with new shape
       shell: bash
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: export SOMA_PY_NEW_SHAPE=true; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20
+      run: export SOMA_PY_NEW_SHAPE=true; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov


### PR DESCRIPTION
Mitigate excessive logspam on PRs where many tests fail.

Multiple GHAs recently have failed with a huge amount of logspam, such that my browser tab never finishes loading the page, or any of the logs.

[Here's](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/10910221889/job/30280188276) an example, from #3001; downloading its logs:
```bash
j=30280188276
gh run view -j $j --log > $j.txt
```

Shows 472k lines / 77MiB. It looks like 482 test failures, some of which output ≈700 lines each.

The PRs where I've seen this recently have generally involved changing Python or Typeguard versions; Typeguard issues can cause large numbers of test cases to fail very verbosely.

[This gist](https://gist.github.com/ryan-williams/2206c5b05050ac9d786ad5b20bd5ddf8) has the first 10,000 lines from the example above:
```bash
gh run view -j $j --log | head -n 10000 | gist -opf $j.txt
```

