### PR TITLE
[r] Run `clang-format` on `apis/r/src`

### DIFF
--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -1,5 +1,6 @@
-#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <Rcpp/Lighter>             // for R interface to C++
+
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
 #include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
 

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -1,25 +1,29 @@
-#include <Rcpp/Lighter>                         // for R interface to C++
-#include <nanoarrow/r.h>                        // for C/C++ interface to Arrow (via header exported from the R package)
-#include <nanoarrow/nanoarrow.hpp>              // for C/C++ interface to Arrow (vendored)
-#include <RcppInt64>                            // for fromInteger64
+#include <Rcpp/Lighter>  // for R interface to C++
 
-#include <tiledbsoma/tiledbsoma>
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
+#include <RcppInt64>                // for fromInteger64
+#include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
+
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <tiledbsoma/tiledbsoma>
 
-#include "rutilities.h"         				// local declarations
-#include "xptr-utils.h"         				// xptr taggging utilities
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilities
 
 namespace tdbs = tiledbsoma;
 
 //' @noRd
 // [[Rcpp::export]]
-void c_group_create(std::string& uri, std::string& type, Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                    Rcpp::Nullable<Rcpp::DatetimeVector> timestamp = R_NilValue) {
-
+void c_group_create(
+    std::string& uri,
+    std::string& type,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::DatetimeVector> timestamp = R_NilValue) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // shared pointer to TileDB Context from SOMAContext
-    // not needed here:  std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+    // not needed here:  std::shared_ptr<tiledb::Context> ctx =
+    // sctx->tiledb_ctx();
 
     // optional timestamp range
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamp);
@@ -35,10 +39,11 @@ void c_group_create(std::string& uri, std::string& type, Rcpp::XPtr<somactx_wrap
 
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::XPtr<somagrp_wrap_t> c_group_open(std::string& uri, std::string& type,
-                                        Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                                        Rcpp::Nullable<Rcpp::DatetimeVector> timestamp = R_NilValue) {
-
+Rcpp::XPtr<somagrp_wrap_t> c_group_open(
+    std::string& uri,
+    std::string& type,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::DatetimeVector> timestamp = R_NilValue) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // shared pointer to TileDB Context from SOMAContext
@@ -52,17 +57,17 @@ Rcpp::XPtr<somagrp_wrap_t> c_group_open(std::string& uri, std::string& type,
     auto sgrpptr = tdbs::SOMAGroup::open(mode, uri, sctx, "unnamed", tsrng);
 
     somagrp_wrap_t* somagrp_p = new SOMAGroupWrapper(std::move(sgrpptr));
-    Rcpp::XPtr<somagrp_wrap_t> somagrp_xptr = make_xptr<somagrp_wrap_t>(somagrp_p);
+    Rcpp::XPtr<somagrp_wrap_t> somagrp_xptr = make_xptr<somagrp_wrap_t>(
+        somagrp_p);
     return somagrp_xptr;
 }
-
 
 //' @noRd
 // [[Rcpp::export]]
 double c_group_member_count(Rcpp::XPtr<somagrp_wrap_t> xp) {
     check_xptr_tag<somagrp_wrap_t>(xp);  // throws if mismatched
     // unique pointer to SOMAGroup from external pointer wrapper
-    return static_cast<double>( xp->grpptr->count() );
+    return static_cast<double>(xp->grpptr->count());
 }
 
 //' @noRd
@@ -76,11 +81,12 @@ Rcpp::List c_group_members(Rcpp::XPtr<somagrp_wrap_t> xp) {
     Rcpp::List lst(n);
     Rcpp::CharacterVector names(n);
     int i = 0;
-    for (auto const& key: mm) {
+    for (auto const& key : mm) {
         names[i] = key.first;
-        Rcpp::List row = Rcpp::List::create(Rcpp::Named("type") = std::string(key.second.second),
-                                            Rcpp::Named("uri") = std::string(key.second.first),
-                                            Rcpp::Named("name") = key.first);
+        Rcpp::List row = Rcpp::List::create(
+            Rcpp::Named("type") = std::string(key.second.second),
+            Rcpp::Named("uri") = std::string(key.second.first),
+            Rcpp::Named("name") = key.first);
         lst[i] = row;
         i++;
     }
@@ -92,44 +98,52 @@ Rcpp::List c_group_members(Rcpp::XPtr<somagrp_wrap_t> xp) {
 // helper function to copy int vector
 template <typename T>
 Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
-  // Strictly speaking a check for under/overflow would be needed here yet this for
-  // metadata annotation (and not data payload) so extreme ranges are less likely
-  Rcpp::IntegerVector vec(v_num);
-  const T *ivec = static_cast<const T*>(v);
-  size_t n = static_cast<size_t>(v_num);
-  for (size_t i=0; i<n; i++) vec[i] = static_cast<int32_t>(ivec[i]);
-  return(vec);
+    // Strictly speaking a check for under/overflow would be needed here yet
+    // this for metadata annotation (and not data payload) so extreme ranges are
+    // less likely
+    Rcpp::IntegerVector vec(v_num);
+    const T* ivec = static_cast<const T*>(v);
+    size_t n = static_cast<size_t>(v_num);
+    for (size_t i = 0; i < n; i++)
+        vec[i] = static_cast<int32_t>(ivec[i]);
+    return (vec);
 }
 // helper function to convert_metadata
-SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
+SEXP _metadata_to_sexp(
+    const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
     // This supports a limited set of basic types as the metadata
     // annotation is not meant to support complete serialization
     if (v_type == TILEDB_INT32) {
         Rcpp::IntegerVector vec(v_num);
-        std::memcpy(vec.begin(), v, v_num*sizeof(int32_t));
-        return(vec);
+        std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
+        return (vec);
     } else if (v_type == TILEDB_FLOAT64) {
         Rcpp::NumericVector vec(v_num);
-        std::memcpy(vec.begin(), v, v_num*sizeof(double));
-        return(vec);
+        std::memcpy(vec.begin(), v, v_num * sizeof(double));
+        return (vec);
     } else if (v_type == TILEDB_FLOAT32) {
         Rcpp::NumericVector vec(v_num);
-        const float *fvec = static_cast<const float*>(v);
+        const float* fvec = static_cast<const float*>(v);
         size_t n = static_cast<size_t>(v_num);
-        for (size_t i=0; i<n; i++) vec[i] = static_cast<double>(fvec[i]);
-        return(vec);
-    } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8) {
+        for (size_t i = 0; i < n; i++)
+            vec[i] = static_cast<double>(fvec[i]);
+        return (vec);
+    } else if (
+        v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII ||
+        v_type == TILEDB_STRING_UTF8) {
         std::string s(static_cast<const char*>(v), v_num);
-        return(Rcpp::wrap(s));
+        return (Rcpp::wrap(s));
     } else if (v_type == TILEDB_INT8) {
         Rcpp::LogicalVector vec(v_num);
-        const int8_t *ivec = static_cast<const int8_t*>(v);
+        const int8_t* ivec = static_cast<const int8_t*>(v);
         size_t n = static_cast<size_t>(v_num);
-        for (size_t i=0; i<n; i++) vec[i] = static_cast<bool>(ivec[i]);
-        return(vec);
+        for (size_t i = 0; i < n; i++)
+            vec[i] = static_cast<bool>(ivec[i]);
+        return (vec);
     } else if (v_type == TILEDB_UINT8) {
-        // Strictly speaking a check for under/overflow would be needed here (and below) yet this
-        // is for metadata annotation (and not data payload) so extreme ranges are less likely
+        // Strictly speaking a check for under/overflow would be needed here
+        // (and below) yet this is for metadata annotation (and not data
+        // payload) so extreme ranges are less likely
         return copy_int_vector<uint8_t>(v_num, v);
     } else if (v_type == TILEDB_INT16) {
         return copy_int_vector<int16_t>(v_num, v);
@@ -139,16 +153,16 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
         return copy_int_vector<uint32_t>(v_num, v);
     } else if (v_type == TILEDB_INT64) {
         std::vector<int64_t> iv(v_num);
-        std::memcpy(&(iv[0]), v, v_num*sizeof(int64_t));
+        std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
         return Rcpp::toInteger64(iv);
     } else if (v_type == TILEDB_UINT64) {
         return copy_int_vector<uint64_t>(v_num, v);
     } else {
-        Rcpp::stop("No support yet for TileDB data type %s", tiledb::impl::type_to_str(v_type));
-  }
+        Rcpp::stop(
+            "No support yet for TileDB data type %s",
+            tiledb::impl::type_to_str(v_type));
+    }
 }
-
-
 
 //' @noRd
 // [[Rcpp::export]]
@@ -161,11 +175,13 @@ Rcpp::List c_group_get_metadata(Rcpp::XPtr<somagrp_wrap_t> xp) {
     Rcpp::List lst(n);
     Rcpp::CharacterVector names(n);
     int i = 0;
-    for (auto const& key: mm) {
+    for (auto const& key : mm) {
         names[i] = key.first;
-        // what is keyed using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>
+        // what is keyed using MetadataValue = std::tuple<tiledb_datatype_t,
+        // uint32_t, const void*>
         auto tpl = key.second;
-        auto sxp = _metadata_to_sexp(std::get<0>(tpl), std::get<1>(tpl), std::get<2>(tpl));
+        auto sxp = _metadata_to_sexp(
+            std::get<0>(tpl), std::get<1>(tpl), std::get<2>(tpl));
         Rcpp::List row = Rcpp::List::create(Rcpp::Named("name") = sxp);
         lst[i] = row;
         i++;
@@ -182,68 +198,75 @@ void c_group_close(Rcpp::XPtr<somagrp_wrap_t> xp) {
     xp->grpptr->close();
 }
 
-std::map<int, URIType> uritypemap = { { 0, URIType::automatic },
-                                      { 1, URIType::absolute },
-                                      { 2, URIType::relative } };
-
+std::map<int, URIType> uritypemap = {
+    {0, URIType::automatic}, {1, URIType::absolute}, {2, URIType::relative}};
 
 //' @noRd
 // [[Rcpp::export]]
-void c_group_set(Rcpp::XPtr<somagrp_wrap_t> xp,
-                 const std::string& uri,
-                 int uri_type_int,  							// "automatic", "absolute", "relative"
-                 const std::string& name,
-                 const std::string& soma_type) {
+void c_group_set(
+    Rcpp::XPtr<somagrp_wrap_t> xp,
+    const std::string& uri,
+    int uri_type_int,  // "automatic", "absolute", "relative"
+    const std::string& name,
+    const std::string& soma_type) {
     check_xptr_tag<somagrp_wrap_t>(xp);  // throws if mismatched
     xp->grpptr->set(uri, uritypemap[uri_type_int], name, soma_type);
 }
 
 //' @noRd
 // [[Rcpp::export]]
-void c_group_remove_member(Rcpp::XPtr<somagrp_wrap_t> xp, const std::string& name) {
+void c_group_remove_member(
+    Rcpp::XPtr<somagrp_wrap_t> xp, const std::string& name) {
     check_xptr_tag<somagrp_wrap_t>(xp);  // throws if mismatched
     xp->grpptr->del(name);
 }
 
 //' @noRd
 // [[Rcpp::export]]
-void c_group_put_metadata(Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP obj) {
+void c_group_put_metadata(
+    Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP obj) {
     check_xptr_tag<somagrp_wrap_t>(xp);  // throws if mismatched
-    // we implement a simpler interface here as the 'type' is given from the supplied SEXP, as is the extent
-    switch(TYPEOF(obj)) {
-    case VECSXP: {
-        Rcpp::stop("List objects are not supported.");
-        break;// not reached
+    // we implement a simpler interface here as the 'type' is given from the
+    // supplied SEXP, as is the extent
+    switch (TYPEOF(obj)) {
+        case VECSXP: {
+            Rcpp::stop("List objects are not supported.");
+            break;  // not reached
         }
-    case REALSXP: {
-        Rcpp::NumericVector v(obj);
-        if (Rcpp::isInteger64(obj)) {
-            xp->grpptr->set_metadata(key, TILEDB_INT64, v.size(), v.begin());
-        } else {
-            xp->grpptr->set_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
+        case REALSXP: {
+            Rcpp::NumericVector v(obj);
+            if (Rcpp::isInteger64(obj)) {
+                xp->grpptr->set_metadata(
+                    key, TILEDB_INT64, v.size(), v.begin());
+            } else {
+                xp->grpptr->set_metadata(
+                    key, TILEDB_FLOAT64, v.size(), v.begin());
+            }
+            break;
         }
-        break;
+        case INTSXP: {
+            Rcpp::IntegerVector v(obj);
+            xp->grpptr->set_metadata(key, TILEDB_INT32, v.size(), v.begin());
+            break;
+        }
+        case STRSXP: {
+            Rcpp::CharacterVector v(obj);
+            std::string s(v[0]);
+            // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
+            // this best string type?
+            xp->grpptr->set_metadata(
+                key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+            break;
+        }
+        case LGLSXP: {  // experimental: map R logical (ie TRUE, FALSE, NA) to
+                        // int8
+            Rcpp::stop("Logical vector objects are not supported.");
+            break;  // not reached
+        }
+        default: {
+            Rcpp::stop(
+                "No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+            break;  // not reached
+        }
     }
-    case INTSXP: {
-        Rcpp::IntegerVector v(obj);
-        xp->grpptr->set_metadata(key, TILEDB_INT32, v.size(), v.begin());
-        break;
-    }
-    case STRSXP: {
-        Rcpp::CharacterVector v(obj);
-        std::string s(v[0]);
-        // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-        xp->grpptr->set_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
-        break;
-    }
-    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-        Rcpp::stop("Logical vector objects are not supported.");
-        break;// not reached
-    }
-    default: {
-        Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-        break; // not reached
-    }
-    }
-
 }

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -1,27 +1,35 @@
-#include <Rcpp/Lighter>                         // for R interface to C++
-#include <nanoarrow/r.h>                        // for C/C++ interface to Arrow (via header exported from the R package)
-#include <nanoarrow/nanoarrow.hpp>              // for C/C++ interface to Arrow (vendored)
-#include <RcppInt64>                            // for fromInteger64
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
+#include <Rcpp/Lighter>             // for R interface to C++
+#include <RcppInt64>                // for fromInteger64
+#include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
 
-#include <tiledbsoma/tiledbsoma>
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <tiledbsoma/tiledbsoma>
 
-#include "rutilities.h"         				// local declarations
-#include "xptr-utils.h"         				// xptr taggging utilities
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilities
 
 namespace tdbs = tiledbsoma;
 
-std::unique_ptr<tdbs::SOMAObject> getObjectUniquePointer(bool is_array, OpenMode mode,
-                                                         std::string& uri,
-                                                         std::shared_ptr<tdbs::SOMAContext> ctx,
-                                                         Rcpp::Nullable<Rcpp::DatetimeVector> tsvec = R_NilValue) {
-
+std::unique_ptr<tdbs::SOMAObject> getObjectUniquePointer(
+    bool is_array,
+    OpenMode mode,
+    std::string& uri,
+    std::shared_ptr<tdbs::SOMAContext> ctx,
+    Rcpp::Nullable<Rcpp::DatetimeVector> tsvec = R_NilValue) {
     // optional timestamp range
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(tsvec);
 
     if (is_array) {
-        return tdbs::SOMAArray::open(mode, uri, ctx, "unnamed", {}, "auto",
-                                     ResultOrder::automatic, tsrng);
+        return tdbs::SOMAArray::open(
+            mode,
+            uri,
+            ctx,
+            "unnamed",
+            {},
+            "auto",
+            ResultOrder::automatic,
+            tsrng);
     } else {
         return tdbs::SOMAGroup::open(mode, uri, ctx, "unnamed", tsrng);
     }
@@ -33,7 +41,8 @@ std::unique_ptr<tdbs::SOMAObject> getObjectUniquePointer(bool is_array, OpenMode
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
-int32_t get_metadata_num(std::string& uri, bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+int32_t get_metadata_num(
+    std::string& uri, bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
@@ -44,14 +53,13 @@ int32_t get_metadata_num(std::string& uri, bool is_array, Rcpp::XPtr<somactx_wra
 
 //' Read all metadata (as named list)
 //'
-//' This function currently supports metadata as either a string or an 'int64' (or 'int32').
-//' It will error if a different datatype is encountered.
-//' @param uri The array URI
-//' @param is_array A boolean to indicate array or group
-//' @param ctxxp An external pointer to the SOMAContext wrapper
-//' @export
+//' This function currently supports metadata as either a string or an 'int64'
+//(or 'int32'). ' It will error if a different datatype is encountered. ' @param
+//uri The array URI ' @param is_array A boolean to indicate array or group '
+//@param ctxxp An external pointer to the SOMAContext wrapper ' @export
 // [[Rcpp::export]]
-Rcpp::List get_all_metadata(std::string& uri, bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::List get_all_metadata(
+    std::string& uri, bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
 
@@ -69,15 +77,15 @@ Rcpp::List get_all_metadata(std::string& uri, bool is_array, Rcpp::XPtr<somactx_
         auto len = std::get<1>(val);
         const void* ptr = std::get<2>(val);
         if (dtype == TILEDB_STRING_UTF8 || dtype == TILEDB_STRING_ASCII) {
-            auto str = std::string((char*) ptr, len);
+            auto str = std::string((char*)ptr, len);
             lst.push_back(str);
         } else if (dtype == TILEDB_INT64) {
             std::vector<int64_t> v(len);
-            std::memcpy(&(v[0]), ptr, len*sizeof(int64_t));
+            std::memcpy(&(v[0]), ptr, len * sizeof(int64_t));
             lst.push_back(Rcpp::toInteger64(v));
         } else if (dtype == TILEDB_INT32) {
             Rcpp::IntegerVector v(len);
-            std::memcpy(v.begin(), ptr, len*sizeof(int32_t));
+            std::memcpy(v.begin(), ptr, len * sizeof(int32_t));
         } else {
             auto txt = tiledb::impl::type_to_str(dtype);
             Rcpp::stop("Currently unsupported type '%s'", txt.c_str());
@@ -95,8 +103,11 @@ Rcpp::List get_all_metadata(std::string& uri, bool is_array, Rcpp::XPtr<somactx_
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
-std::string get_metadata(std::string& uri, std::string& key, bool is_array,
-                         Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+std::string get_metadata(
+    std::string& uri,
+    std::string& key,
+    bool is_array,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
 
@@ -114,10 +125,9 @@ std::string get_metadata(std::string& uri, std::string& key, bool is_array,
     }
     auto len = std::get<1>(val);
     const void* ptr = std::get<2>(val);
-    auto str = std::string((char*) ptr, len);
+    auto str = std::string((char*)ptr, len);
     return str;
 }
-
 
 //' Check for metadata given key
 //'
@@ -127,15 +137,17 @@ std::string get_metadata(std::string& uri, std::string& key, bool is_array,
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
-bool has_metadata(std::string& uri, std::string& key, bool is_array,
-                  Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+bool has_metadata(
+    std::string& uri,
+    std::string& key,
+    bool is_array,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
     auto soup = getObjectUniquePointer(is_array, OpenMode::read, uri, sctx);
     return soup->has_metadata(key);
 }
-
 
 //' Delete metadata for given key
 //'
@@ -145,8 +157,11 @@ bool has_metadata(std::string& uri, std::string& key, bool is_array,
 //' @param ctxxp An external pointer to the SOMAContext wrapper
 //' @export
 // [[Rcpp::export]]
-void delete_metadata(std::string& uri, std::string& key, bool is_array,
-                     Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+void delete_metadata(
+    std::string& uri,
+    std::string& key,
+    bool is_array,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
@@ -154,7 +169,6 @@ void delete_metadata(std::string& uri, std::string& key, bool is_array,
     soup->delete_metadata(key);
     soup->close();
 }
-
 
 //' Set metadata (as a string)
 //'
@@ -167,25 +181,42 @@ void delete_metadata(std::string& uri, std::string& key, bool is_array,
 //' @param tsvec An optional two-element datetime vector
 //' @export
 // [[Rcpp::export]]
-void set_metadata(std::string& uri, std::string& key, SEXP valuesxp, std::string& type,
-                  bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                  Rcpp::Nullable<Rcpp::DatetimeVector> tsvec = R_NilValue) {
+void set_metadata(
+    std::string& uri,
+    std::string& key,
+    SEXP valuesxp,
+    std::string& type,
+    bool is_array,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::DatetimeVector> tsvec = R_NilValue) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::write, uri, sctx, tsvec);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::write, uri, sctx, tsvec);
 
     if (type == "character") {
         const tiledb_datatype_t value_type = TILEDB_STRING_UTF8;
         std::string value = Rcpp::as<std::string>(valuesxp);
-        spdl::debug("[set_metadata] key {} value {} is_array {} type {}", key, value, is_array, type);
-        soup->set_metadata(key, value_type, value.length(), (void*) value.c_str(), true);
+        spdl::debug(
+            "[set_metadata] key {} value {} is_array {} type {}",
+            key,
+            value,
+            is_array,
+            type);
+        soup->set_metadata(
+            key, value_type, value.length(), (void*)value.c_str(), true);
     } else if (type == "integer64") {
         const tiledb_datatype_t value_type = TILEDB_INT64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
-        spdl::debug("[set_metadata] key {} value {} is_array {} type {}", key, value, is_array, type);
-        soup->set_metadata(key, value_type, 1, (void*) &value, true);
+        spdl::debug(
+            "[set_metadata] key {} value {} is_array {} type {}",
+            key,
+            value,
+            is_array,
+            type);
+        soup->set_metadata(key, value_type, 1, (void*)&value, true);
     } else {
         Rcpp::stop("Unsupported type '%s'", type);
     }

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -1,5 +1,6 @@
-#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <Rcpp/Lighter>             // for R interface to C++
+
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
 #include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
 
@@ -54,9 +55,11 @@ int32_t get_metadata_num(
 //' Read all metadata (as named list)
 //'
 //' This function currently supports metadata as either a string or an 'int64'
-//(or 'int32'). ' It will error if a different datatype is encountered. ' @param
-//uri The array URI ' @param is_array A boolean to indicate array or group '
-//@param ctxxp An external pointer to the SOMAContext wrapper ' @export
+//' (or 'int32'). ' It will error if a different datatype is encountered.
+//' @param uri The array URI
+//' @param is_array A boolean to indicate array or group
+//' @param ctxxp An external pointer to the SOMAContext wrapper
+//' @export
 // [[Rcpp::export]]
 Rcpp::List get_all_metadata(
     std::string& uri, bool is_array, Rcpp::XPtr<somactx_wrap_t> ctxxp) {

--- a/apis/r/src/reindexer.cpp
+++ b/apis/r/src/reindexer.cpp
@@ -1,5 +1,5 @@
-#include <Rcpp/Lightest>        // for R interface to C++
-#include <RcppInt64>            // for fromInteger64
+#include <Rcpp/Lightest>  // for R interface to C++
+#include <RcppInt64>      // for fromInteger64
 
 #include <tiledbsoma/tiledbsoma>
 #if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 4
@@ -9,9 +9,8 @@
 
 namespace tdbs = tiledbsoma;
 
-#include "rutilities.h"         // local declarations
-#include "xptr-utils.h"         // xptr taggging utilitie
-
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilitie
 
 // [[Rcpp::export]]
 Rcpp::XPtr<tdbs::IntIndexer> reindex_create() {
@@ -20,8 +19,8 @@ Rcpp::XPtr<tdbs::IntIndexer> reindex_create() {
 }
 
 // [[Rcpp::export]]
-Rcpp::XPtr<tdbs::IntIndexer> reindex_map(Rcpp::XPtr<tdbs::IntIndexer> idx,
-                                         const Rcpp::NumericVector nvec) {
+Rcpp::XPtr<tdbs::IntIndexer> reindex_map(
+    Rcpp::XPtr<tdbs::IntIndexer> idx, const Rcpp::NumericVector nvec) {
     check_xptr_tag<tdbs::IntIndexer>(idx);
     const std::vector<int64_t> vec = Rcpp::fromInteger64(nvec);
     idx->map_locations(vec);
@@ -29,8 +28,8 @@ Rcpp::XPtr<tdbs::IntIndexer> reindex_map(Rcpp::XPtr<tdbs::IntIndexer> idx,
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector reindex_lookup(Rcpp::XPtr<tdbs::IntIndexer> idx,
-                                   const Rcpp::NumericVector kvec) {
+Rcpp::NumericVector reindex_lookup(
+    Rcpp::XPtr<tdbs::IntIndexer> idx, const Rcpp::NumericVector kvec) {
     check_xptr_tag<tdbs::IntIndexer>(idx);
     const std::vector<int64_t> keys = Rcpp::fromInteger64(kvec);
     int sz = keys.size();

--- a/apis/r/src/reindexer.cpp
+++ b/apis/r/src/reindexer.cpp
@@ -1,4 +1,5 @@
 #include <Rcpp/Lightest>  // for R interface to C++
+
 #include <RcppInt64>      // for fromInteger64
 
 #include <tiledbsoma/tiledbsoma>

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -1,7 +1,7 @@
-#include <Rcpp.h>                               // for R interface to C++
-#include <nanoarrow/r.h>                        // for C interface to Arrow (via R package)
-#include <nanoarrow/nanoarrow.hpp>              // for C/C++ interface to Arrow
-#include <RcppInt64>                            // for fromInteger64
+#include <Rcpp.h>                   // for R interface to C++
+#include <nanoarrow/r.h>            // for C interface to Arrow (via R package)
+#include <RcppInt64>                // for fromInteger64
+#include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow
 
 // we currently get deprecation warnings by default which are noisy
 #ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
@@ -10,14 +10,14 @@
 
 // We get these via nanoarrow and must cannot include carrow.h again
 #define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
-#include <tiledbsoma/tiledbsoma>
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <tiledbsoma/tiledbsoma>
 #if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 4
 #include <tiledb/tiledb_experimental>
 #endif
 
-#include "rutilities.h"         // local declarations
-#include "xptr-utils.h"         // xptr taggging utilities
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilities
 
 // (Adapted) helper functions from nanoarrow
 //
@@ -25,38 +25,42 @@
 // non-null, non-released pointer when garbage collected. We use a tagged XPtr,
 // but do not set an XPtr finalizer
 Rcpp::XPtr<ArrowSchema> schema_owning_xptr(void) {
-  struct ArrowSchema* schema = (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
-  if (schema == NULL) Rcpp::stop("Failed to allocate ArrowSchema");
-  schema->release = NULL;
-  Rcpp::XPtr<ArrowSchema> schema_xptr = make_xptr(schema, false);
-  return schema_xptr;
+    struct ArrowSchema* schema = (struct ArrowSchema*)ArrowMalloc(
+        sizeof(struct ArrowSchema));
+    if (schema == NULL)
+        Rcpp::stop("Failed to allocate ArrowSchema");
+    schema->release = NULL;
+    Rcpp::XPtr<ArrowSchema> schema_xptr = make_xptr(schema, false);
+    return schema_xptr;
 }
 // Create an external pointer with the proper class and that will release any
 // non-null, non-released pointer when garbage collected. We use a tagged XPtr,
 // but do not set an XPtr finalizer
 Rcpp::XPtr<ArrowArray> array_owning_xptr(void) {
-  struct ArrowArray* array = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));
-  if (array == NULL) Rcpp::stop("Failed to allocate ArrowArray");
-  array->release = NULL;
-  Rcpp::XPtr<ArrowArray> array_xptr = make_xptr(array, false);
-  return array_xptr;
+    struct ArrowArray* array = (struct ArrowArray*)ArrowMalloc(
+        sizeof(struct ArrowArray));
+    if (array == NULL)
+        Rcpp::stop("Failed to allocate ArrowArray");
+    array->release = NULL;
+    Rcpp::XPtr<ArrowArray> array_xptr = make_xptr(array, false);
+    return array_xptr;
 }
 
 namespace tdbs = tiledbsoma;
 
 //' @noRd
 // [[Rcpp::export(soma_array_reader_impl)]]
-SEXP soma_array_reader(const std::string& uri,
-                       Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                       Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
-                       Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
-                       Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
-                       Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
-                       std::string batch_size = "auto",
-                       std::string result_order = "auto",
-                       const std::string& loglevel = "auto",
-                       Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue) {
-
+SEXP soma_array_reader(
+    const std::string& uri,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
+    Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
+    Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
+    Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
+    std::string batch_size = "auto",
+    std::string result_order = "auto",
+    const std::string& loglevel = "auto",
+    Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue) {
     if (loglevel != "auto") {
         spdl::set_level(loglevel);
         tdbs::LOG_SET_LEVEL(loglevel);
@@ -68,39 +72,48 @@ SEXP soma_array_reader(const std::string& uri,
     spdl::info("[soma_array_reader] Reading from {}", uri);
 
     std::vector<std::string> column_names = {};
-    if (!colnames.isNull()) {    // If we have column names, select them
+    if (!colnames.isNull()) {  // If we have column names, select them
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
-        spdl::debug("[soma_array_reader] Selecting {} columns", column_names.size());
+        spdl::debug(
+            "[soma_array_reader] Selecting {} columns", column_names.size());
     }
 
     auto tdb_result_order = get_tdb_result_order(result_order);
 
     // optional timestamp range
-    std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamprange);
+    std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(
+        timestamprange);
     if (timestamprange.isNotNull()) {
         Rcpp::DatetimeVector vec(timestamprange);
-        spdl::debug("[soma_array_reader] timestamprange ({},{})", vec[0], vec[1]);
+        spdl::debug(
+            "[soma_array_reader] timestamprange ({},{})", vec[0], vec[1]);
     }
 
     // Read selected columns from the uri (return is unique_ptr<SOMAArray>)
-    auto sr = tdbs::SOMAArray::open(OpenMode::read,
-                                    uri,
-                                    somactx,
-                                    "unnamed",         // name parameter could be added
-                                    column_names,
-                                    batch_size,
-                                    tdb_result_order,
-                                    tsrng);
+    auto sr = tdbs::SOMAArray::open(
+        OpenMode::read,
+        uri,
+        somactx,
+        "unnamed",  // name parameter could be added
+        column_names,
+        batch_size,
+        tdb_result_order,
+        tsrng);
 
-    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
+    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>
+        name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = sr->tiledb_schema();
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
-    for (auto& dim: dims) {
-        spdl::info("[soma_array_reader] Dimension {} type {} domain {} extent {}",
-                   dim.name(), tiledb::impl::to_str(dim.type()),
-                   dim.domain_to_str(), dim.tile_extent_to_str());
-        name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
+    for (auto& dim : dims) {
+        spdl::info(
+            "[soma_array_reader] Dimension {} type {} domain {} extent {}",
+            dim.name(),
+            tiledb::impl::to_str(dim.type()),
+            dim.domain_to_str(),
+            dim.tile_extent_to_str());
+        name2dim.emplace(std::make_pair(
+            dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
     // If we have a query condition, apply it
@@ -111,8 +124,9 @@ SEXP soma_array_reader(const std::string& uri,
     }
 
     // If we have dimension points, apply them
-    // The interface is named list, where each (named) list elements is one (named) dimesion
-    // The List element is a simple vector of points and each point is applied to the named dimension
+    // The interface is named list, where each (named) list elements is one
+    // (named) dimesion The List element is a simple vector of points and each
+    // point is applied to the named dimension
     if (!dim_points.isNull()) {
         Rcpp::List lst(dim_points);
         apply_dim_points(sr.get(), name2dim, lst);
@@ -127,30 +141,39 @@ SEXP soma_array_reader(const std::string& uri,
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto sr_data = sr->read_next();
     if (!sr->results_complete()) {
-        Rcpp::stop("Read of '%s' is incomplete.\nConsider increasing the memory "
-                   "allocation via the configuration\noption 'soma.init_buffer_bytes', "
-                   "or using iterated partial reads.", uri);
+        Rcpp::stop(
+            "Read of '%s' is incomplete.\nConsider increasing the memory "
+            "allocation via the configuration\noption "
+            "'soma.init_buffer_bytes', "
+            "or using iterated partial reads.",
+            uri);
     }
-    spdl::info("[soma_array_reader] Read complete with {} rows and {} cols",
-               sr_data->get()->num_rows(), sr_data->get()->names().size());
+    spdl::info(
+        "[soma_array_reader] Read complete with {} rows and {} cols",
+        sr_data->get()->num_rows(),
+        sr_data->get()->names().size());
 
     const std::vector<std::string> names = sr_data->get()->names();
     auto ncol = names.size();
     // Schema first
     auto schemaxp = nanoarrow_schema_owning_xptr();
     auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-    exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
+    exitIfError(
+        ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
     exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
-    exitIfError(ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
+    exitIfError(
+        ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
 
     // Array second
     auto arrayxp = nanoarrow_array_owning_xptr();
     auto arr = nanoarrow_output_array_from_xptr(arrayxp);
-    exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
-    exitIfError(ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
+    exitIfError(
+        ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
+    exitIfError(
+        ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
 
-    arr->length = 0;             // initial value
-    for (size_t i=0; i<ncol; i++) {
+    arr->length = 0;  // initial value
+    for (size_t i = 0; i < ncol; i++) {
         spdl::info("[soma_array_reader] Accessing '{}' at pos {}", names[i], i);
 
         // now buf is a shared_ptr to ColumnBuffer
@@ -159,32 +182,37 @@ SEXP soma_array_reader(const std::string& uri,
         // this is pair of array and schema pointer
         auto pp = tdbs::ArrowAdapter::to_arrow(buf);
 
-        //memcpy((void*) sch->children[i], pp.second.get(), sizeof(ArrowSchema));
-        //memcpy((void*) arr->children[i], pp.first.get(), sizeof(ArrowArray));
-        ArrowArrayMove(pp.first.get(),  arr->children[i]);
+        // memcpy((void*) sch->children[i], pp.second.get(),
+        // sizeof(ArrowSchema)); memcpy((void*) arr->children[i],
+        // pp.first.get(), sizeof(ArrowArray));
+        ArrowArrayMove(pp.first.get(), arr->children[i]);
         ArrowSchemaMove(pp.second.get(), sch->children[i]);
 
-        spdl::info("[soma_array_reader] Incoming name {} length {}",
-                   std::string(pp.second->name), pp.first->length);
+        spdl::info(
+            "[soma_array_reader] Incoming name {} length {}",
+            std::string(pp.second->name),
+            pp.first->length);
 
         if (pp.first->length > arr->length) {
-            spdl::debug("[soma_array_reader] Setting array length to {}", pp.first->length);
+            spdl::debug(
+                "[soma_array_reader] Setting array length to {}",
+                pp.first->length);
             arr->length = pp.first->length;
         }
     }
 
-   // Nanoarrow special: stick schema into xptr tag to return single SEXP
-   array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
-   sr->close();
-   return arrayxp;
+    // Nanoarrow special: stick schema into xptr tag to return single SEXP
+    array_xptr_set_schema(arrayxp, schemaxp);  // embed schema in array
+    sr->close();
+    return arrayxp;
 }
 
 //' Set the logging level for the R package and underlying C++ library
 //'
-//' @param level A character value with logging level understood by \sQuote{spdlog}
-//' such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or \dQuote{warn}.
-//' @return Nothing is returned as the function is invoked for the side-effect.
-//' @export
+//' @param level A character value with logging level understood by
+//\sQuote{spdlog} ' such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or
+//\dQuote{warn}. ' @return Nothing is returned as the function is invoked for
+//the side-effect. ' @export
 // [[Rcpp::export]]
 void set_log_level(const std::string& level) {
     spdl::setup("R", level);
@@ -193,14 +221,13 @@ void set_log_level(const std::string& level) {
 
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::CharacterVector get_column_types(const std::string& uri,
-                                       const std::vector<std::string>& colnames) {
-
+Rcpp::CharacterVector get_column_types(
+    const std::string& uri, const std::vector<std::string>& colnames) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri);
     auto sr_data = sr->read_next();
     size_t n = colnames.size();
     Rcpp::CharacterVector vs(n);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
         auto datatype = sr_data->get()->at(colnames[i])->type();
         vs[i] = std::string(tiledb::impl::to_str(datatype));
     }
@@ -220,19 +247,20 @@ double nnz(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
 //' @noRd
 // [[Rcpp::export]]
 bool check_arrow_schema_tag(Rcpp::XPtr<ArrowSchema> xp) {
-  check_xptr_tag<ArrowSchema>(xp);  // throws if mismatched
-  return true;
+    check_xptr_tag<ArrowSchema>(xp);  // throws if mismatched
+    return true;
 }
 
 //' @noRd
 // [[Rcpp::export]]
 bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
-  check_xptr_tag<ArrowArray>(xp);  // throws if mismatched
-  return true;
+    check_xptr_tag<ArrowArray>(xp);  // throws if mismatched
+    return true;
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::NumericVector shape(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
     auto retval = Rcpp::toInteger64(sr->shape());
     sr->close();
@@ -240,7 +268,8 @@ Rcpp::NumericVector shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctx
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector maxshape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::NumericVector maxshape(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
     auto retval = Rcpp::toInteger64(sr->maxshape());
     sr->close();
@@ -248,37 +277,42 @@ Rcpp::NumericVector maxshape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> 
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector maybe_soma_joinid_shape(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::NumericVector maybe_soma_joinid_shape(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // Pro-tip:
     // * Open with mode and uri gives a SOMAArray.
     // * Open with uri and mode gives a SOMADataFrame.
-    // This was done intentionally to resolve an ambiguous-overload compiler error.
-    // ^ Unsure. This is C++, and it is typed so member functions return objects of their class.
+    // This was done intentionally to resolve an ambiguous-overload compiler
+    // error. ^ Unsure. This is C++, and it is typed so member functions return
+    // objects of their class.
     auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
     auto retval = sr->maybe_soma_joinid_shape();
     sr->close();
     if (retval.has_value()) {
-      return Rcpp::toInteger64(retval.value());
+        return Rcpp::toInteger64(retval.value());
     } else {
-      return Rcpp::NumericVector::create(NA_REAL); // one element vector, and is.na() is true
+        return Rcpp::NumericVector::create(
+            NA_REAL);  // one element vector, and is.na() is true
     }
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector maybe_soma_joinid_maxshape(const std::string& uri,
-                                               Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::NumericVector maybe_soma_joinid_maxshape(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
     auto retval = sr->maybe_soma_joinid_maxshape();
     sr->close();
     if (retval.has_value()) {
-      return Rcpp::toInteger64(retval.value());
+        return Rcpp::toInteger64(retval.value());
     } else {
-      return Rcpp::NumericVector::create(NA_REAL); // one element vector, and is.na() is true
+        return Rcpp::NumericVector::create(
+            NA_REAL);  // one element vector, and is.na() is true
     }
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector has_current_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::LogicalVector has_current_domain(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
     auto retval = Rcpp::LogicalVector(sr->has_current_domain());
     sr->close();
@@ -286,9 +320,10 @@ Rcpp::LogicalVector has_current_domain(const std::string& uri, Rcpp::XPtr<somact
 }
 
 // [[Rcpp::export]]
-void resize(const std::string& uri,
-            Rcpp::NumericVector new_shape,
-            Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+void resize(
+    const std::string& uri,
+    Rcpp::NumericVector new_shape,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // This function is solely for SparseNDArray and DenseNDArray for which the
     // dims are required by the SOMA spec to be of type int64. Domain-resize for
     // variant-indexed dataframes will be separate work as tracked on
@@ -300,9 +335,10 @@ void resize(const std::string& uri,
 }
 
 // [[Rcpp::export]]
-void tiledbsoma_upgrade_shape(const std::string& uri,
-                              Rcpp::NumericVector new_shape,
-                              Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+void tiledbsoma_upgrade_shape(
+    const std::string& uri,
+    Rcpp::NumericVector new_shape,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // This function is solely for SparseNDArray and DenseNDArray for which the
     // dims are required by the SOMA spec to be of type int64. Domain-resize for
     // variant-indexed dataframes will be separate work as tracked on

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -3,53 +3,52 @@
 #define TILEDB_NO_API_DEPRECATION_WARNINGS
 #endif
 
-#include <Rcpp.h>                        // for R interface to C++
-#include <nanoarrow/r.h>                 // for C interface to Arrow (via R package nanoarrow)
+#include <Rcpp.h>  // for R interface to C++
 #include <nanoarrow/nanoarrow.h>
-#include <RcppInt64>                    // for fromInteger64
+#include <nanoarrow/r.h>  // for C interface to Arrow (via R package nanoarrow)
+#include <RcppInt64>      // for fromInteger64
 
 #include <tiledb/tiledb>
 #if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 4
 #include <tiledb/tiledb_experimental>
 #endif
-#include <tiledbsoma/tiledbsoma>
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <tiledbsoma/tiledbsoma>
 
-#include "rutilities.h"         // local declarations
-#include "xptr-utils.h"         // xptr taggging utilitie
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilitie
 
 namespace tdbs = tiledbsoma;
 
 //' Iterator-Style Access to SOMA Array via SOMAArray
 //'
-//' The `sr_*` functions provide low-level access to an instance of the SOMAArray
-//' class so that iterative access over parts of a (large) array is possible.
-//' \describe{
-//'   \item{\code{sr_setup}}{instantiates and by default also submits a query}
-//'   \item{\code{sr_complete}}{checks if more data is available}
-//'   \item{\code{sr_next}}{returns the next chunk}
-//' }
+//' The `sr_*` functions provide low-level access to an instance of the
+//SOMAArray ' class so that iterative access over parts of a (large) array is
+//possible. ' \describe{ '   \item{\code{sr_setup}}{instantiates and by default
+//also submits a query} '   \item{\code{sr_complete}}{checks if more data is
+//available} '   \item{\code{sr_next}}{returns the next chunk} ' }
 //'
 //' @param uri Character value with URI path to a SOMA data set
-//' @param config Named chracter vector with \sQuote{key} and \sQuote{value} pairs
-//' used as TileDB config parameters.
-//' @param colnames Optional vector of character value with the name of the columns to retrieve
-//' @param qc Optional external Pointer object to TileDB Query Condition, defaults to \sQuote{NULL} i.e.
-//' no query condition
-//' @param dim_points Optional named list with vector of data points to select on the given
-//' dimension(s). Each dimension can be one entry in the list.
-//' @param dim_ranges Optional named list with two-column matrix where each row select a range
-//' for the given dimension. Each dimension can be one entry in the list.
-//' @param batch_size Optional argument for size of data batches, defaults to \sQuote{auto}
-//' @param result_order Optional argument for query result order, defaults to \sQuote{auto}
-//' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
-//' which lets prior setting prevail, any other value is set as new logging level.
-//' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start and end of
-//' interval for which data is considered.
-//' @param sr An external pointer to a TileDB SOMAArray object
+//' @param config Named chracter vector with \sQuote{key} and \sQuote{value}
+//pairs ' used as TileDB config parameters. ' @param colnames Optional vector of
+//character value with the name of the columns to retrieve ' @param qc Optional
+//external Pointer object to TileDB Query Condition, defaults to \sQuote{NULL}
+//i.e. ' no query condition ' @param dim_points Optional named list with vector
+//of data points to select on the given ' dimension(s). Each dimension can be
+//one entry in the list. ' @param dim_ranges Optional named list with two-column
+//matrix where each row select a range ' for the given dimension. Each dimension
+//can be one entry in the list. ' @param batch_size Optional argument for size
+//of data batches, defaults to \sQuote{auto} ' @param result_order Optional
+//argument for query result order, defaults to \sQuote{auto} ' @param loglevel
+//Character value with the desired logging level, defaults to \sQuote{auto} '
+//which lets prior setting prevail, any other value is set as new logging level.
+//' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start and
+//end of ' interval for which data is considered. ' @param sr An external
+//pointer to a TileDB SOMAArray object
 //'
-//' @return \code{sr_setup} returns an external pointer to a SOMAArray. \code{sr_complete}
-//' returns a boolean, and \code{sr_next} returns an Arrow array helper object.
+//' @return \code{sr_setup} returns an external pointer to a SOMAArray.
+//\code{sr_complete} ' returns a boolean, and \code{sr_next} returns an Arrow
+//array helper object.
 //'
 //' @examples
 //' \dontrun{
@@ -66,17 +65,17 @@ namespace tdbs = tiledbsoma;
 //' }
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
-                                     Rcpp::XPtr<somactx_wrap_t> ctxxp,
-                                     Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
-                                     Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
-                                     Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
-                                     Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
-                                     std::string batch_size = "auto",
-                                     std::string result_order = "auto",
-                                     Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue,
-                                     const std::string& loglevel = "auto") {
-
+Rcpp::XPtr<tdbs::SOMAArray> sr_setup(
+    const std::string& uri,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::CharacterVector> colnames = R_NilValue,
+    Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc = R_NilValue,
+    Rcpp::Nullable<Rcpp::List> dim_points = R_NilValue,
+    Rcpp::Nullable<Rcpp::List> dim_ranges = R_NilValue,
+    std::string batch_size = "auto",
+    std::string result_order = "auto",
+    Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange = R_NilValue,
+    const std::string& loglevel = "auto") {
     if (loglevel != "auto") {
         spdl::set_level(loglevel);
         tdbs::LOG_SET_LEVEL(loglevel);
@@ -93,42 +92,56 @@ Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri,
     std::shared_ptr<tiledb::Context> ctxptr = somactx->tiledb_ctx();
 
     ctx_wrap_t* ctxwrap_p = new ContextWrapper(ctxptr);
-    Rcpp::XPtr<ctx_wrap_t> ctx_wrap_xptr = make_xptr<ctx_wrap_t>(ctxwrap_p, false);
+    Rcpp::XPtr<ctx_wrap_t> ctx_wrap_xptr = make_xptr<ctx_wrap_t>(
+        ctxwrap_p, false);
 
     if (!colnames.isNull()) {
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
     }
 
     // optional timestamp range
-    std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamprange);
+    std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(
+        timestamprange);
 
     auto tdb_result_order = get_tdb_result_order(result_order);
 
-    auto ptr = new tdbs::SOMAArray(OpenMode::read, uri, somactx,
-                                   name, column_names, batch_size,
-                                   tdb_result_order, tsrng);
+    auto ptr = new tdbs::SOMAArray(
+        OpenMode::read,
+        uri,
+        somactx,
+        name,
+        column_names,
+        batch_size,
+        tdb_result_order,
+        tsrng);
 
-    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>> name2dim;
+    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>
+        name2dim;
     std::shared_ptr<tiledb::ArraySchema> schema = ptr->tiledb_schema();
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
-    for (auto& dim: dims) {
-        spdl::debug("[sr_setup] Dimension {} type {} domain {} extent {}",
-                    dim.name(), tiledb::impl::to_str(dim.type()),
-                    dim.domain_to_str(), dim.tile_extent_to_str());
-        name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
+    for (auto& dim : dims) {
+        spdl::debug(
+            "[sr_setup] Dimension {} type {} domain {} extent {}",
+            dim.name(),
+            tiledb::impl::to_str(dim.type()),
+            dim.domain_to_str(),
+            dim.tile_extent_to_str());
+        name2dim.emplace(std::make_pair(
+            dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdl::debug("[sr_setup] Applying query condition") ;
+        spdl::debug("[sr_setup] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         ptr->set_condition(*qcxp);
     }
 
     // If we have dimension points, apply them
-    // The interface is named list, where each (named) list elements is one (named) dimesion
-    // The List element is a simple vector of points and each point is applied to the named dimension
+    // The interface is named list, where each (named) list elements is one
+    // (named) dimesion The List element is a simple vector of points and each
+    // point is applied to the named dimension
     if (!dim_points.isNull()) {
         Rcpp::List lst(dim_points);
         apply_dim_points(ptr, name2dim, lst);
@@ -149,8 +162,13 @@ bool sr_complete(Rcpp::XPtr<tdbs::SOMAArray> sr) {
     check_xptr_tag<tdbs::SOMAArray>(sr);
     bool complt = sr->is_complete(true);
     bool initial = sr->is_initial_read();
-    bool res = complt && !initial; // completed transfer if query status complete and query ran once
-    spdl::debug("[sr_complete] Complete query test {} (compl {} initial {})", res, complt, initial);
+    bool res = complt && !initial;  // completed transfer if query status
+                                    // complete and query ran once
+    spdl::debug(
+        "[sr_complete] Complete query test {} (compl {} initial {})",
+        res,
+        complt,
+        initial);
     return res;
 }
 
@@ -163,83 +181,98 @@ SEXP create_empty_arrow_table() {
     // Schema first
     auto schemaxp = nanoarrow_schema_owning_xptr();
     auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-    exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
+    exitIfError(
+        ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
     exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
-    exitIfError(ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
+    exitIfError(
+        ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
 
     // Array second
     auto arrayxp = nanoarrow_array_owning_xptr();
     auto arr = nanoarrow_output_array_from_xptr(arrayxp);
-    exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
-    exitIfError(ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
+    exitIfError(
+        ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
+    exitIfError(
+        ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
     arr->length = 0;
 
     // Nanoarrow special: stick schema into xptr tag to return single SEXP
-    array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
+    array_xptr_set_schema(arrayxp, schemaxp);  // embed schema in array
 
     return arrayxp;
 }
 
-
 // [[Rcpp::export]]
 SEXP sr_next(Rcpp::XPtr<tdbs::SOMAArray> sr) {
-   check_xptr_tag<tdbs::SOMAArray>(sr);
+    check_xptr_tag<tdbs::SOMAArray>(sr);
 
-   if (sr_complete(sr)) {
-       spdl::trace("[sr_next] complete {} num_cells {}",
-                   sr->is_complete(true), sr->total_num_cells());
-       return create_empty_arrow_table();
-   }
+    if (sr_complete(sr)) {
+        spdl::trace(
+            "[sr_next] complete {} num_cells {}",
+            sr->is_complete(true),
+            sr->total_num_cells());
+        return create_empty_arrow_table();
+    }
 
-   if (!sr->is_initial_read() && sr->total_num_cells() == 0) {
-       spdl::trace("[sr_next] is_initial_read {} num_cells {}",
-                   sr->is_initial_read(), sr->total_num_cells());
-       return create_empty_arrow_table();
-   }
+    if (!sr->is_initial_read() && sr->total_num_cells() == 0) {
+        spdl::trace(
+            "[sr_next] is_initial_read {} num_cells {}",
+            sr->is_initial_read(),
+            sr->total_num_cells());
+        return create_empty_arrow_table();
+    }
 
-   auto sr_data = sr->read_next();
-   spdl::debug("[sr_next] Read {} rows and {} cols",
-               sr_data->get()->num_rows(), sr_data->get()->names().size());
+    auto sr_data = sr->read_next();
+    spdl::debug(
+        "[sr_next] Read {} rows and {} cols",
+        sr_data->get()->num_rows(),
+        sr_data->get()->names().size());
 
-   const std::vector<std::string> names = sr_data->get()->names();
-   auto ncol = names.size();
-   // Schema first
-   auto schemaxp = nanoarrow_schema_owning_xptr();
-   auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-   exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
-   exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
-   exitIfError(ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
+    const std::vector<std::string> names = sr_data->get()->names();
+    auto ncol = names.size();
+    // Schema first
+    auto schemaxp = nanoarrow_schema_owning_xptr();
+    auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
+    exitIfError(
+        ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
+    exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
+    exitIfError(
+        ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
 
-   // Array second
-   auto arrayxp = nanoarrow_array_owning_xptr();
-   auto arr = nanoarrow_output_array_from_xptr(arrayxp);
-   exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
-   exitIfError(ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
+    // Array second
+    auto arrayxp = nanoarrow_array_owning_xptr();
+    auto arr = nanoarrow_output_array_from_xptr(arrayxp);
+    exitIfError(
+        ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
+    exitIfError(
+        ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
 
-   arr->length = 0;             // initial value
+    arr->length = 0;  // initial value
 
-   for (size_t i=0; i<ncol; i++) {
-       spdl::trace("[sr_next] Accessing {} at {}", names[i], i);
+    for (size_t i = 0; i < ncol; i++) {
+        spdl::trace("[sr_next] Accessing {} at {}", names[i], i);
 
-       // now buf is a shared_ptr to ColumnBuffer
-       auto buf = sr_data->get()->at(names[i]);
+        // now buf is a shared_ptr to ColumnBuffer
+        auto buf = sr_data->get()->at(names[i]);
 
-       // this is pair of array and schema pointer
-       auto pp = tdbs::ArrowAdapter::to_arrow(buf);
+        // this is pair of array and schema pointer
+        auto pp = tdbs::ArrowAdapter::to_arrow(buf);
 
-       ArrowArrayMove(pp.first.get(),   arr->children[i]);
-       ArrowSchemaMove(pp.second.get(), sch->children[i]);
+        ArrowArrayMove(pp.first.get(), arr->children[i]);
+        ArrowSchemaMove(pp.second.get(), sch->children[i]);
 
-       if (pp.first->length > arr->length) {
-           spdl::debug("[soma_array_reader] Setting array length to {}", pp.first->length);
-           arr->length = pp.first->length;
-       }
-   }
+        if (pp.first->length > arr->length) {
+            spdl::debug(
+                "[soma_array_reader] Setting array length to {}",
+                pp.first->length);
+            arr->length = pp.first->length;
+        }
+    }
 
-   spdl::debug("[sr_next] Exporting chunk with {} rows", arr->length);
-   // Nanoarrow special: stick schema into xptr tag to return single SEXP
-   array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
-   return arrayxp;
+    spdl::debug("[sr_next] Exporting chunk with {} rows", arr->length);
+    // Nanoarrow special: stick schema into xptr tag to return single SEXP
+    array_xptr_set_schema(arrayxp, schemaxp);  // embed schema in array
+    return arrayxp;
 }
 
 // [[Rcpp::export]]
@@ -250,13 +283,20 @@ void sr_reset(Rcpp::XPtr<tdbs::SOMAArray> sr) {
 }
 
 // [[Rcpp::export]]
-void sr_set_dim_points(Rcpp::XPtr<tdbs::SOMAArray> sr, std::string dim,
-                       Rcpp::NumericVector points) {
+void sr_set_dim_points(
+    Rcpp::XPtr<tdbs::SOMAArray> sr,
+    std::string dim,
+    Rcpp::NumericVector points) {
     check_xptr_tag<tdbs::SOMAArray>(sr);
     // check args ?
 
     std::vector<int64_t> vec = Rcpp::fromInteger64(points);
     sr->set_dim_points<int64_t>(dim, vec);
-    spdl::debug("[sr_set_dim_points] Set on dim '{}' for {} points, first two are {} and {}",
-                dim, points.length(), vec[0], vec[1]);
+    spdl::debug(
+        "[sr_set_dim_points] Set on dim '{}' for {} points, first two are {} "
+        "and {}",
+        dim,
+        points.length(),
+        vec[0],
+        vec[1]);
 }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -20,35 +20,43 @@
 
 namespace tdbs = tiledbsoma;
 
+// clang-format off
 //' Iterator-Style Access to SOMA Array via SOMAArray
 //'
-//' The `sr_*` functions provide low-level access to an instance of the
-//SOMAArray ' class so that iterative access over parts of a (large) array is
-//possible. ' \describe{ '   \item{\code{sr_setup}}{instantiates and by default
-//also submits a query} '   \item{\code{sr_complete}}{checks if more data is
-//available} '   \item{\code{sr_next}}{returns the next chunk} ' }
+//' The `sr_*` functions provide low-level access to an instance of the SOMAArray
+//' class so that iterative access over parts of a (large) array is possible.
+//' \describe{
+//'   \item{\code{sr_setup}}{instantiates and by default also submits a query}
+//'   \item{\code{sr_complete}}{checks if more data is available}
+//'   \item{\code{sr_next}}{returns the next chunk}
+//' }
 //'
 //' @param uri Character value with URI path to a SOMA data set
-//' @param config Named chracter vector with \sQuote{key} and \sQuote{value}
-//pairs ' used as TileDB config parameters. ' @param colnames Optional vector of
-//character value with the name of the columns to retrieve ' @param qc Optional
-//external Pointer object to TileDB Query Condition, defaults to \sQuote{NULL}
-//i.e. ' no query condition ' @param dim_points Optional named list with vector
-//of data points to select on the given ' dimension(s). Each dimension can be
-//one entry in the list. ' @param dim_ranges Optional named list with two-column
-//matrix where each row select a range ' for the given dimension. Each dimension
-//can be one entry in the list. ' @param batch_size Optional argument for size
-//of data batches, defaults to \sQuote{auto} ' @param result_order Optional
-//argument for query result order, defaults to \sQuote{auto} ' @param loglevel
-//Character value with the desired logging level, defaults to \sQuote{auto} '
-//which lets prior setting prevail, any other value is set as new logging level.
-//' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start and
-//end of ' interval for which data is considered. ' @param sr An external
-//pointer to a TileDB SOMAArray object
+//' @param config Named chracter vector with \sQuote{key} and \sQuote{value} pairs
+//' used as TileDB config parameters.
+//' @param colnames Optional vector of character value with the name of the
+//' columns to retrieve
+//' @param qc Optional external Pointer object to TileDB Query Condition,
+//' defaults to \sQuote{NULL} i.e. no query condition
+//' @param dim_points Optional named list with vector of data points to select
+//' on the given dimension(s). Each dimension can be one entry in the list.
+//' @param dim_ranges Optional named list with two-column matrix where each row
+//' select a range for the given dimension. Each dimension can be one entry in
+//'the list.
+//' @param batch_size Optional argument for size of data batches, defaults to
+//'\sQuote{auto}
+//' @param result_order Optional argument for query result order, defaults to
+//' \sQuote{auto}
+//' @param loglevel Character value with the desired logging level, defaults to
+//' \sQuote{auto} which lets prior setting prevail, any other value is set as
+//new logging level.
+//' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start
+//' and end of ' interval for which data is considered.
+//' @param sr An external pointer to a TileDB SOMAArray object.
 //'
 //' @return \code{sr_setup} returns an external pointer to a SOMAArray.
-//\code{sr_complete} ' returns a boolean, and \code{sr_next} returns an Arrow
-//array helper object.
+//' \code{sr_complete} ' returns a boolean, and \code{sr_next} returns an Arrow
+//' array helper object.
 //'
 //' @examples
 //' \dontrun{
@@ -64,6 +72,7 @@ namespace tdbs = tiledbsoma;
 //' summary(rl)
 //' }
 //' @noRd
+// clang-format on
 // [[Rcpp::export]]
 Rcpp::XPtr<tdbs::SOMAArray> sr_setup(
     const std::string& uri,

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -4,22 +4,24 @@
 #define TILEDB_NO_API_DEPRECATION_WARNINGS
 #endif
 
-#include <Rcpp.h>                           // for R interface to C++
-#include <nanoarrow/nanoarrow.h>            // for C interface to Arrow
-#include <RcppInt64>                        // for fromInteger64
-#include <tiledbsoma/tiledbsoma>
+#include <Rcpp.h>                 // for R interface to C++
+#include <nanoarrow/nanoarrow.h>  // for C interface to Arrow
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <RcppInt64>  // for fromInteger64
+#include <tiledbsoma/tiledbsoma>
 
-#include "rutilities.h"         // local declarations
-#include "xptr-utils.h"         // xptr taggging utilitie
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilitie
 
 namespace tdbs = tiledbsoma;
 
-void apply_dim_points(tdbs::SOMAArray *sr,
-                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
-                      Rcpp::List lst) {
+void apply_dim_points(
+    tdbs::SOMAArray* sr,
+    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>&
+        name2dim,
+    Rcpp::List lst) {
     std::vector<std::string> colnames = lst.attr("names");
-    for (auto& nm: colnames) {
+    for (auto& nm : colnames) {
         auto dm = name2dim[nm];
         auto tp = dm->type();
         bool suitable = false;
@@ -27,154 +29,238 @@ void apply_dim_points(tdbs::SOMAArray *sr,
             Rcpp::NumericVector payload = lst[nm];
             std::vector<int64_t> iv = Rcpp::fromInteger64(payload, false);
             std::vector<uint64_t> uv(iv.size());
-            const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
-            for (size_t i=0; i<iv.size(); i++) {
+            const std::pair<uint64_t, uint64_t> pr = dm->domain<uint64_t>();
+            for (size_t i = 0; i < iv.size(); i++) {
                 uv[i] = static_cast<uint64_t>(iv[i]);
                 if (uv[i] >= pr.first && uv[i] <= pr.second) {
-                    sr->set_dim_point<uint64_t>(nm, uv[i]);  // bonked when use with vector
-                    spdl::info("[apply_dim_points] Applying dim point {} on {}", uv[i], nm);
+                    sr->set_dim_point<uint64_t>(
+                        nm, uv[i]);  // bonked when use with vector
+                    spdl::info(
+                        "[apply_dim_points] Applying dim point {} on {}",
+                        uv[i],
+                        nm);
                     suitable = true;
                 }
             }
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericVector payload = lst[nm];
             std::vector<int64_t> iv = Rcpp::fromInteger64(payload, false);
-            const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
-            for (size_t i=0; i<iv.size(); i++) {
+            const std::pair<int64_t, int64_t> pr = dm->domain<int64_t>();
+            for (size_t i = 0; i < iv.size(); i++) {
                 if (iv[i] >= pr.first && iv[i] <= pr.second) {
                     sr->set_dim_point<int64_t>(nm, iv[i]);
-                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", iv[i], nm);
+                    spdl::debug(
+                        "[apply_dim_points] Applying dim point {} on {}",
+                        iv[i],
+                        nm);
                     suitable = true;
                 }
             }
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericVector payload = lst[nm];
-            const std::pair<float,float> pr = dm->domain<float>();
-            for (R_xlen_t i=0; i<payload.size(); i++) {
+            const std::pair<float, float> pr = dm->domain<float>();
+            for (R_xlen_t i = 0; i < payload.size(); i++) {
                 float v = static_cast<float>(payload[i]);
                 if (v >= pr.first && v <= pr.second) {
                     sr->set_dim_point<float>(nm, v);
-                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", v, nm);
+                    spdl::debug(
+                        "[apply_dim_points] Applying dim point {} on {}",
+                        v,
+                        nm);
                     suitable = true;
                 }
             }
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericVector payload = lst[nm];
-            const std::pair<double,double> pr = dm->domain<double>();
-            for (R_xlen_t i=0; i<payload.size(); i++) {
+            const std::pair<double, double> pr = dm->domain<double>();
+            for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
-                    sr->set_dim_point<double>(nm,payload[i]);
-                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                    sr->set_dim_point<double>(nm, payload[i]);
+                    spdl::debug(
+                        "[apply_dim_points] Applying dim point {} on {}",
+                        payload[i],
+                        nm);
                     suitable = true;
                 }
             }
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerVector payload = lst[nm];
-            const std::pair<int32_t,int32_t> pr = dm->domain<int32_t>();
-            for (R_xlen_t i=0; i<payload.size(); i++) {
+            const std::pair<int32_t, int32_t> pr = dm->domain<int32_t>();
+            for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
-                    sr->set_dim_point<int32_t>(nm,payload[i]);
-                    spdl::debug("[apply_dim_points] Applying dim point {} on {}", payload[i], nm);
+                    sr->set_dim_point<int32_t>(nm, payload[i]);
+                    spdl::debug(
+                        "[apply_dim_points] Applying dim point {} on {}",
+                        payload[i],
+                        nm);
                     suitable = true;
                 }
             }
         } else {
-            Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));
+            Rcpp::stop(
+                "Currently unsupported type: ", tiledb::impl::to_str(tp));
         }
         if (!suitable) {
-            Rcpp::stop("Unsuitable dim points on dimension '%s' with domain %s", nm, dm->domain_to_str());
+            Rcpp::stop(
+                "Unsuitable dim points on dimension '%s' with domain %s",
+                nm,
+                dm->domain_to_str());
         }
     }
 }
 
-void apply_dim_ranges(tdbs::SOMAArray* sr,
-                      std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>& name2dim,
-                      Rcpp::List lst) {
+void apply_dim_ranges(
+    tdbs::SOMAArray* sr,
+    std::unordered_map<std::string, std::shared_ptr<tiledb::Dimension>>&
+        name2dim,
+    Rcpp::List lst) {
     std::vector<std::string> colnames = lst.attr("names");
-    for (auto& nm: colnames) {
+    for (auto& nm : colnames) {
         auto dm = name2dim[nm];
         auto tp = dm->type();
         bool suitable = false;
         if (tp == TILEDB_UINT64) {
             Rcpp::NumericMatrix mm = lst[nm];
-            Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
-            Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column lo = mm.column(
+                0);  // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column hi = mm.column(
+                1);  // works as proxy for int and float types
             std::vector<std::pair<uint64_t, uint64_t>> vp(mm.nrow());
-            const std::pair<uint64_t,uint64_t> pr = dm->domain<uint64_t>();
-            for (int i=0; i<mm.nrow(); i++) {
+            const std::pair<uint64_t, uint64_t> pr = dm->domain<uint64_t>();
+            for (int i = 0; i < mm.nrow(); i++) {
                 uint64_t l = static_cast<uint64_t>(Rcpp::fromInteger64(lo[i]));
                 uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
-                vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
-                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
-                suitable = l < pr.second && h > pr.first; // lower must be less than max, higher more than min
+                vp[i] = std::make_pair(
+                    std::max(l, pr.first), std::min(h, pr.second));
+                spdl::debug(
+                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                    "{}",
+                    i,
+                    nm,
+                    l,
+                    h);
+                suitable = l < pr.second &&
+                           h > pr.first;  // lower must be less than max, higher
+                                          // more than min
             }
-            if (suitable) sr->set_dim_ranges<uint64_t>(nm, vp);
+            if (suitable)
+                sr->set_dim_ranges<uint64_t>(nm, vp);
         } else if (tp == TILEDB_INT64) {
             Rcpp::NumericMatrix mm = lst[nm];
             std::vector<int64_t> lo = Rcpp::fromInteger64(mm.column(0), false);
             std::vector<int64_t> hi = Rcpp::fromInteger64(mm.column(1), false);
             std::vector<std::pair<int64_t, int64_t>> vp(mm.nrow());
-            const std::pair<int64_t,int64_t> pr = dm->domain<int64_t>();
-            for (int i=0; i<mm.nrow(); i++) {
-                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
-                suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
+            const std::pair<int64_t, int64_t> pr = dm->domain<int64_t>();
+            for (int i = 0; i < mm.nrow(); i++) {
+                vp[i] = std::make_pair(
+                    std::max(lo[i], pr.first), std::min(hi[i], pr.second));
+                spdl::debug(
+                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                    "{}",
+                    i,
+                    nm,
+                    lo[i],
+                    hi[i]);
+                suitable = lo[i] < pr.second &&
+                           hi[i] > pr.first;  // lower must be less than max,
+                                              // higher more than min
             }
-            if (suitable) sr->set_dim_ranges<int64_t>(nm, vp);
+            if (suitable)
+                sr->set_dim_ranges<int64_t>(nm, vp);
         } else if (tp == TILEDB_FLOAT32) {
             Rcpp::NumericMatrix mm = lst[nm];
-            Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
-            Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column lo = mm.column(
+                0);  // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column hi = mm.column(
+                1);  // works as proxy for int and float types
             std::vector<std::pair<float, float>> vp(mm.nrow());
-            const std::pair<float,float> pr = dm->domain<float>();
-            for (int i=0; i<mm.nrow(); i++) {
+            const std::pair<float, float> pr = dm->domain<float>();
+            for (int i = 0; i < mm.nrow(); i++) {
                 float l = static_cast<float>(lo[i]);
                 float h = static_cast<float>(hi[i]);
-                vp[i] = std::make_pair(std::max(l,pr.first), std::min(h, pr.second));
-                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, l, h) ;
-                suitable = l < pr.second && h > pr.first; // lower must be less than max, higher more than min
+                vp[i] = std::make_pair(
+                    std::max(l, pr.first), std::min(h, pr.second));
+                spdl::debug(
+                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                    "{}",
+                    i,
+                    nm,
+                    l,
+                    h);
+                suitable = l < pr.second &&
+                           h > pr.first;  // lower must be less than max, higher
+                                          // more than min
             }
-            if (suitable) sr->set_dim_ranges<float>(nm, vp);
+            if (suitable)
+                sr->set_dim_ranges<float>(nm, vp);
         } else if (tp == TILEDB_FLOAT64) {
             Rcpp::NumericMatrix mm = lst[nm];
-            Rcpp::NumericMatrix::Column lo = mm.column(0); // works as proxy for int and float types
-            Rcpp::NumericMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column lo = mm.column(
+                0);  // works as proxy for int and float types
+            Rcpp::NumericMatrix::Column hi = mm.column(
+                1);  // works as proxy for int and float types
             std::vector<std::pair<double, double>> vp(mm.nrow());
-            const std::pair<double,double> pr = dm->domain<double>();
-            for (int i=0; i<mm.nrow(); i++) {
-                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm, lo[i], hi[i]) ;
-                suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
+            const std::pair<double, double> pr = dm->domain<double>();
+            for (int i = 0; i < mm.nrow(); i++) {
+                vp[i] = std::make_pair(
+                    std::max(lo[i], pr.first), std::min(hi[i], pr.second));
+                spdl::debug(
+                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                    "{}",
+                    i,
+                    nm,
+                    lo[i],
+                    hi[i]);
+                suitable = lo[i] < pr.second &&
+                           hi[i] > pr.first;  // lower must be less than max,
+                                              // higher more than min
             }
-            if (suitable) sr->set_dim_ranges<double>(nm, vp);
+            if (suitable)
+                sr->set_dim_ranges<double>(nm, vp);
         } else if (tp == TILEDB_INT32) {
             Rcpp::IntegerMatrix mm = lst[nm];
-            Rcpp::IntegerMatrix::Column lo = mm.column(0); // works as proxy for int and float types
-            Rcpp::IntegerMatrix::Column hi = mm.column(1); // works as proxy for int and float types
+            Rcpp::IntegerMatrix::Column lo = mm.column(
+                0);  // works as proxy for int and float types
+            Rcpp::IntegerMatrix::Column hi = mm.column(
+                1);  // works as proxy for int and float types
             std::vector<std::pair<int32_t, int32_t>> vp(mm.nrow());
-            const std::pair<int32_t,int32_t> pr = dm->domain<int32_t>();
-            for (int i=0; i<mm.nrow(); i++) {
-                vp[i] = std::make_pair(std::max(lo[i],pr.first), std::min(hi[i], pr.second));
-                spdl::debug("[apply_dim_ranges] Applying dim point {} on {} with {} - {}", i, nm[i], lo[i], hi[i]) ;
-                suitable = lo[i] < pr.second && hi[i] > pr.first; // lower must be less than max, higher more than min
+            const std::pair<int32_t, int32_t> pr = dm->domain<int32_t>();
+            for (int i = 0; i < mm.nrow(); i++) {
+                vp[i] = std::make_pair(
+                    std::max(lo[i], pr.first), std::min(hi[i], pr.second));
+                spdl::debug(
+                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                    "{}",
+                    i,
+                    nm[i],
+                    lo[i],
+                    hi[i]);
+                suitable = lo[i] < pr.second &&
+                           hi[i] > pr.first;  // lower must be less than max,
+                                              // higher more than min
             }
-            if (suitable) sr->set_dim_ranges<int32_t>(nm, vp);
+            if (suitable)
+                sr->set_dim_ranges<int32_t>(nm, vp);
         } else {
-            Rcpp::stop("Currently unsupported type: ", tiledb::impl::to_str(tp));
+            Rcpp::stop(
+                "Currently unsupported type: ", tiledb::impl::to_str(tp));
         }
         if (!suitable) {
-            Rcpp::stop("Unsuitable dim ranges on dimension '%s' with domain %s", nm, dm->domain_to_str());
+            Rcpp::stop(
+                "Unsuitable dim ranges on dimension '%s' with domain %s",
+                nm,
+                dm->domain_to_str());
         }
     }
 }
 
-
 // initialize arrow schema and array, respectively
-Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64_t n_children) {
+Rcpp::XPtr<ArrowSchema> schema_setup_struct(
+    Rcpp::XPtr<ArrowSchema> schxp, int64_t n_children) {
     ArrowSchema* schema = schxp.get();
     auto type = NANOARROW_TYPE_STRUCT;
 
-    ArrowSchemaInit(schema);    					// modified from ArrowSchemaInitFromType()
+    ArrowSchemaInit(schema);  // modified from ArrowSchemaInitFromType()
     int result = ArrowSchemaSetType(schema, type);
     if (result != NANOARROW_OK) {
         schema->release(schema);
@@ -182,20 +268,24 @@ Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64
     }
 
     // now adapted from ArrowSchemaAllocateChildren
-    if (schema->children != NULL) Rcpp::stop("Error allocation as children not null");
+    if (schema->children != NULL)
+        Rcpp::stop("Error allocation as children not null");
 
     if (n_children > 0) {
-        auto ptr = (struct ArrowSchema**) ArrowMalloc(n_children * sizeof(struct ArrowSchema*));
+        auto ptr = (struct ArrowSchema**)ArrowMalloc(
+            n_children * sizeof(struct ArrowSchema*));
         Rcpp::XPtr<ArrowSchema*> schema_ptrxp = make_xptr(ptr, false);
         schema->children = schema_ptrxp.get();
-        if (schema->children == NULL) Rcpp::stop("Failed to allocate ArrowSchema*");
+        if (schema->children == NULL)
+            Rcpp::stop("Failed to allocate ArrowSchema*");
 
         schema->n_children = n_children;
         memset(schema->children, 0, n_children * sizeof(struct ArrowSchema*));
 
         for (int64_t i = 0; i < n_children; i++) {
             schema->children[i] = schema_owning_xptr();
-            if (schema->children[i] == NULL) Rcpp::stop("Error allocation schema child %ld", i);
+            if (schema->children[i] == NULL)
+                Rcpp::stop("Error allocation schema child %ld", i);
             schema->children[i]->release = NULL;
         }
     }
@@ -203,28 +293,27 @@ Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64
 }
 
 std::vector<int64_t> i64_from_rcpp_numeric(const Rcpp::NumericVector& input) {
+    auto ndim = input.size();
+    std::vector<int64_t> output(ndim);
+    for (auto i = 0; i < ndim; i++) {
+        output[i] = input[i];
+    }
 
-  auto ndim = input.size();
-  std::vector<int64_t> output(ndim);
-  for (auto i = 0; i < ndim; i++) {
-    output[i] = input[i];
-  }
-
-  return output;
+    return output;
 }
-
 
 // formerly stats.cpp
 
 //' TileDB SOMA statistics
 //'
-//' These functions expose the TileDB Core functionality for performance measurements
-//' and statistics.
+//' These functions expose the TileDB Core functionality for performance
+//measurements ' and statistics.
 //'
-//' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and disable TileDB's internal statistics.
-//' - `tiledbsoma_stats_reset()`: Reset all statistics to 0.
-//' - `tiledbsoma_stats_dump()`: Dump all statistics to a JSON string.
-//' - `tiledbsoma_stats_show()`: Print all statistics to the console.
+//' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and
+//disable TileDB's internal statistics. ' - `tiledbsoma_stats_reset()`: Reset
+//all statistics to 0. ' - `tiledbsoma_stats_dump()`: Dump all statistics to a
+//JSON string. ' - `tiledbsoma_stats_show()`: Print all statistics to the
+//console.
 //'
 //' @name tiledbsoma_stats
 //' @export
@@ -258,19 +347,20 @@ std::string tiledbsoma_stats_dump() {
 
 //' libtiledbsoma version
 //'
-//' Returns a string with version information for libtiledbsoma and the linked TileDB Embedded library.
-//' If argument `compact` is set to `TRUE`, a shorter version of just the TileDB Embedded library
-//' version is returned,
-//' @noRd
+//' Returns a string with version information for libtiledbsoma and the linked
+//TileDB Embedded library. ' If argument `compact` is set to `TRUE`, a shorter
+//version of just the TileDB Embedded library ' version is returned, ' @noRd
 // [[Rcpp::export]]
-std::string libtiledbsoma_version(const bool compact = false, const bool major_minor_only = false) {
+std::string libtiledbsoma_version(
+    const bool compact = false, const bool major_minor_only = false) {
     if (compact) {
         auto v = tiledbsoma::version::embedded_version_triple();
         std::ostringstream txt;
         if (major_minor_only) {
             txt << std::get<0>(v) << "." << std::get<1>(v);
         } else {
-            txt << std::get<0>(v) << "." << std::get<1>(v) << "." << std::get<2>(v);
+            txt << std::get<0>(v) << "." << std::get<1>(v) << "."
+                << std::get<2>(v);
         }
         return txt.str();
     } else {
@@ -284,8 +374,10 @@ std::string libtiledbsoma_version(const bool compact = false, const bool major_m
 //' @noRd
 // [[Rcpp::export]]
 Rcpp::IntegerVector tiledb_embedded_version() {
-    std::tuple<int, int, int> triple = tiledbsoma::version::embedded_version_triple();
-    return Rcpp::IntegerVector::create(std::get<0>(triple), std::get<1>(triple), std::get<2>(triple));
+    std::tuple<int, int, int>
+        triple = tiledbsoma::version::embedded_version_triple();
+    return Rcpp::IntegerVector::create(
+        std::get<0>(triple), std::get<1>(triple), std::get<2>(triple));
 }
 
 // Also present in tiledb-r but only after 0.23.0 so this can be removed (and
@@ -293,32 +385,50 @@ Rcpp::IntegerVector tiledb_embedded_version() {
 //' @noRd
 // [[Rcpp::export]]
 size_t tiledb_datatype_max_value(const std::string& datatype) {
-    if      (datatype == "INT8")   return std::numeric_limits<int8_t>::max();
-    else if (datatype == "UINT8")  return std::numeric_limits<uint8_t>::max();
-    else if (datatype == "INT16")  return std::numeric_limits<int16_t>::max();
-    else if (datatype == "UINT16") return std::numeric_limits<uint16_t>::max();
-    else if (datatype == "INT32")  return std::numeric_limits<int32_t>::max();
-    else if (datatype == "UINT32") return std::numeric_limits<uint32_t>::max();
-    else if (datatype == "INT64")  return std::numeric_limits<int64_t>::max();
-    else if (datatype == "UINT64") return std::numeric_limits<uint64_t>::max();
-    else Rcpp::stop("currently unsupported datatype (%s)", datatype);
+    if (datatype == "INT8")
+        return std::numeric_limits<int8_t>::max();
+    else if (datatype == "UINT8")
+        return std::numeric_limits<uint8_t>::max();
+    else if (datatype == "INT16")
+        return std::numeric_limits<int16_t>::max();
+    else if (datatype == "UINT16")
+        return std::numeric_limits<uint16_t>::max();
+    else if (datatype == "INT32")
+        return std::numeric_limits<int32_t>::max();
+    else if (datatype == "UINT32")
+        return std::numeric_limits<uint32_t>::max();
+    else if (datatype == "INT64")
+        return std::numeric_limits<int64_t>::max();
+    else if (datatype == "UINT64")
+        return std::numeric_limits<uint64_t>::max();
+    else
+        Rcpp::stop("currently unsupported datatype (%s)", datatype);
 }
 
-// Make (optional) TimestampRange from (nullable, two-element) Rcpp::DatetimeVector
-std::optional<tdbs::TimestampRange> makeTimestampRange(Rcpp::Nullable<Rcpp::DatetimeVector> tsvec) {
-
+// Make (optional) TimestampRange from (nullable, two-element)
+// Rcpp::DatetimeVector
+std::optional<tdbs::TimestampRange> makeTimestampRange(
+    Rcpp::Nullable<Rcpp::DatetimeVector> tsvec) {
     // optional timestamp, defaults to 'none' aka std::nullopt
     std::optional<tdbs::TimestampRange> tsrng = std::nullopt;
 
     if (tsvec.isNotNull()) {
-        // an Rcpp 'Nullable' is a decent compromise between adhering to SEXP semantics
-        // and having 'optional' behaviour -- but when there is a value we need to be explicit
-        Rcpp::DatetimeVector vec(tsvec); // vector of Rcpp::Datetime ie POSIXct w/ (fract.) secs since epoch
+        // an Rcpp 'Nullable' is a decent compromise between adhering to SEXP
+        // semantics and having 'optional' behaviour -- but when there is a
+        // value we need to be explicit
+        Rcpp::DatetimeVector vec(tsvec);  // vector of Rcpp::Datetime ie POSIXct
+                                          // w/ (fract.) secs since epoch
         if (vec.size() == 1) {
-            tsrng = std::make_pair<uint64_t>( 0, static_cast<uint64_t>(Rcpp::Datetime(vec[0]).getFractionalTimestamp() * 1000) );
+            tsrng = std::make_pair<uint64_t>(
+                0,
+                static_cast<uint64_t>(
+                    Rcpp::Datetime(vec[0]).getFractionalTimestamp() * 1000));
         } else if (vec.size() == 2) {
-        tsrng = std::make_pair<uint64_t>( static_cast<uint64_t>(Rcpp::Datetime(vec[0]).getFractionalTimestamp() * 1000),
-                                          static_cast<uint64_t>(Rcpp::Datetime(vec[1]).getFractionalTimestamp() * 1000) );
+            tsrng = std::make_pair<uint64_t>(
+                static_cast<uint64_t>(
+                    Rcpp::Datetime(vec[0]).getFractionalTimestamp() * 1000),
+                static_cast<uint64_t>(
+                    Rcpp::Datetime(vec[1]).getFractionalTimestamp() * 1000));
         } else {
             Rcpp::stop("TimestampRange must be a one or two-element vector");
         }

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -307,13 +307,13 @@ std::vector<int64_t> i64_from_rcpp_numeric(const Rcpp::NumericVector& input) {
 //' TileDB SOMA statistics
 //'
 //' These functions expose the TileDB Core functionality for performance
-//measurements ' and statistics.
+//'  measurements and statistics.
 //'
 //' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and
-//disable TileDB's internal statistics. ' - `tiledbsoma_stats_reset()`: Reset
-//all statistics to 0. ' - `tiledbsoma_stats_dump()`: Dump all statistics to a
-//JSON string. ' - `tiledbsoma_stats_show()`: Print all statistics to the
-//console.
+//' disable TileDB's internal statistics.
+//' - `tiledbsoma_stats_reset()`: Reset all statistics to 0.
+//' - `tiledbsoma_stats_dump()`: Dump all statistics to a JSON string.
+//' - `tiledbsoma_stats_show()`: Print all statistics to the console.
 //'
 //' @name tiledbsoma_stats
 //' @export
@@ -348,8 +348,9 @@ std::string tiledbsoma_stats_dump() {
 //' libtiledbsoma version
 //'
 //' Returns a string with version information for libtiledbsoma and the linked
-//TileDB Embedded library. ' If argument `compact` is set to `TRUE`, a shorter
-//version of just the TileDB Embedded library ' version is returned, ' @noRd
+// TileDB Embedded library. If argument `compact` is set to `TRUE`, a shorter
+// version of just the TileDB Embedded library version is returned.
+//' @noRd
 // [[Rcpp::export]]
 std::string libtiledbsoma_version(
     const bool compact = false, const bool major_minor_only = false) {

--- a/apis/r/src/soma.cpp
+++ b/apis/r/src/soma.cpp
@@ -1,18 +1,19 @@
-#include <Rcpp/Lighter>                         // for R interface to C++
-#include <nanoarrow/r.h>                        // for C/C++ interface to Arrow (via header exported from the R package)
-#include <nanoarrow/nanoarrow.hpp>              // for C/C++ interface to Arrow (vendored)
-#include <RcppInt64>                            // for fromInteger64
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
+#include <Rcpp/Lighter>             // for R interface to C++
+#include <RcppInt64>                // for fromInteger64
+#include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
 
-#include <tiledbsoma/tiledbsoma>
 #include <tiledbsoma/reindexer/reindexer.h>
+#include <tiledbsoma/tiledbsoma>
 
-#include "rutilities.h"         				// local declarations
-#include "xptr-utils.h"         				// xptr taggging utilities
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilities
 
 namespace tdbs = tiledbsoma;
 
 // [[Rcpp::export]]
-std::string get_soma_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+std::string get_soma_object_type(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // shared pointer to TileDB Context from SOMAContext
@@ -27,7 +28,8 @@ std::string get_soma_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap
 }
 
 // [[Rcpp::export]]
-std::string get_tiledb_object_type(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+std::string get_tiledb_object_type(
+    const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // shared pointer to TileDB Context from SOMAContext
@@ -45,7 +47,10 @@ std::string get_tiledb_object_type(const std::string& uri, Rcpp::XPtr<somactx_wr
             return std::string("INVALID");
             break;
         default:
-            Rcpp::stop("Inadmissable object type ('%d') for URI '%s'", (int)objtype, uri);
+            Rcpp::stop(
+                "Inadmissable object type ('%d') for URI '%s'",
+                (int)objtype,
+                uri);
             break;
     }
     Rcpp::stop("No object type value for URI '%s'", uri);

--- a/apis/r/src/soma.cpp
+++ b/apis/r/src/soma.cpp
@@ -1,5 +1,6 @@
-#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <Rcpp/Lighter>             // for R interface to C++
+
+#include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
 #include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow (vendored)
 


### PR DESCRIPTION
While working on #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048) and #2406.

This was fully automated via

```
 clang-format -i  apis/r/src/[a-z]*.cpp
```

with the exception of a couple fix-ups on `//'`-style comments.

Note that we enitrely avoid `apis/r/src/RcppExports.cpp` which is auto-generated.

On this PR I just manually ran the formatter on the relevant source files. On a follow-up PR I'll stop excluding these files from the format-checker which we run on the rest of our `libtiledbsoma` and `pybind11` C++ source:
https://github.com/single-cell-data/TileDB-SOMA/blob/1.14.1/.github/workflows/python-ci-single.yml#L62-L64

Also note that we should move the `clang-format` checker from `python-ci-single.yml` to another C++-specific YAML file.