### PR TITLE
[spatial] Add ValueError for mismatched transform names

### DIFF
--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -456,6 +456,12 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
                     "The number of output coordinates must match the number of "
                     "input coordinates."
                 )
+            if transform.output_axes != self._coord_space.axis_names:
+                raise ValueError(
+                    f"The output axes of '{transform.output_axes}' of the transform "
+                    f"must match the axes '{self._coord_space.axis_names}' of the "
+                    f"coordinate space of this multiscale image."
+                )
             transform = group_to_level @ transform
             assert isinstance(transform, ScaleTransform)
 

--- a/apis/python/src/tiledbsoma/_point_cloud.py
+++ b/apis/python/src/tiledbsoma/_point_cloud.py
@@ -340,6 +340,12 @@ class PointCloud(SpatialDataFrame, somacore.PointCloud):
                     f"match the axes '{region_coord_space.axis_names}' of the "
                     f"coordinate space the requested region is defined in."
                 )
+            if transform.output_axes != self._coord_space.axis_names:
+                raise ValueError(
+                    f"The output axes of '{transform.output_axes}' of the transform "
+                    f"must match the axes '{self._coord_space.axis_names}' of the "
+                    f"coordinate space of this point cloud."
+                )
 
         # Process the user provided region.
         coords, data_region, inv_transform = process_spatial_df_region(


### PR DESCRIPTION
The transformation argument in the `read_region` is easy to misinterpret. Add an explicit check for the correct `output_axes` in the transform for better error messaging.
