### PR TITLE
[r] Improve test-case field names for `DataFrame`

### DIFF
--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -44,14 +44,14 @@ create_arrow_schema <- function(foo_first = TRUE) {
     arrow::schema(
       arrow::field("int_column", arrow::int32(), nullable = bl),
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
-      arrow::field("bar", arrow::float64(), nullable = bl),
+      arrow::field("float_column", arrow::float64(), nullable = bl),
       arrow::field("string_column", arrow::large_utf8(), nullable = bl)
     )
   } else {
     arrow::schema(
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
       arrow::field("int_column", arrow::int32(), nullable = bl),
-      arrow::field("bar", arrow::float64(), nullable = bl),
+      arrow::field("float_column", arrow::float64(), nullable = bl),
       arrow::field("string_column", arrow::large_utf8(), nullable = bl)
     )
   }
@@ -62,7 +62,7 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
     return(arrow::arrow_table(
       int_column = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
-      bar = seq(nrows) + 0.1,
+      float_column = seq(nrows) + 0.1,
       string_column = as.character(seq.int(nrows) + 1000L),
       grp = factor(c(
         rep_len("lvl1", length.out = floor(nrows / 2)),
@@ -73,7 +73,7 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
   arrow::arrow_table(
       int_column = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
-      bar = seq(nrows) + 0.1,
+      float_column = seq(nrows) + 0.1,
       string_column = as.character(seq.int(nrows) + 1000L)
       # schema = create_arrow_schema(false)
     )

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -42,7 +42,7 @@ create_arrow_schema <- function(foo_first = TRUE) {
   bl <- FALSE
   if (foo_first) {
     arrow::schema(
-      arrow::field("foo", arrow::int32(), nullable = bl),
+      arrow::field("int_column", arrow::int32(), nullable = bl),
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
       arrow::field("bar", arrow::float64(), nullable = bl),
       arrow::field("string_column", arrow::large_utf8(), nullable = bl)
@@ -50,7 +50,7 @@ create_arrow_schema <- function(foo_first = TRUE) {
   } else {
     arrow::schema(
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
-      arrow::field("foo", arrow::int32(), nullable = bl),
+      arrow::field("int_column", arrow::int32(), nullable = bl),
       arrow::field("bar", arrow::float64(), nullable = bl),
       arrow::field("string_column", arrow::large_utf8(), nullable = bl)
     )
@@ -60,7 +60,7 @@ create_arrow_schema <- function(foo_first = TRUE) {
 create_arrow_table <- function(nrows = 10L, factors = FALSE) {
   if (isTRUE(factors)) {
     return(arrow::arrow_table(
-      foo = seq.int(nrows) + 1000L,
+      int_column = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
       bar = seq(nrows) + 0.1,
       string_column = as.character(seq.int(nrows) + 1000L),
@@ -71,7 +71,7 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
     ))
   }
   arrow::arrow_table(
-      foo = seq.int(nrows) + 1000L,
+      int_column = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
       bar = seq(nrows) + 0.1,
       string_column = as.character(seq.int(nrows) + 1000L)

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -45,14 +45,14 @@ create_arrow_schema <- function(foo_first = TRUE) {
       arrow::field("foo", arrow::int32(), nullable = bl),
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
       arrow::field("bar", arrow::float64(), nullable = bl),
-      arrow::field("baz", arrow::large_utf8(), nullable = bl)
+      arrow::field("string_column", arrow::large_utf8(), nullable = bl)
     )
   } else {
     arrow::schema(
       arrow::field("soma_joinid", arrow::int64(), nullable = bl),
       arrow::field("foo", arrow::int32(), nullable = bl),
       arrow::field("bar", arrow::float64(), nullable = bl),
-      arrow::field("baz", arrow::large_utf8(), nullable = bl)
+      arrow::field("string_column", arrow::large_utf8(), nullable = bl)
     )
   }
 }
@@ -63,7 +63,7 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
       foo = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
       bar = seq(nrows) + 0.1,
-      baz = as.character(seq.int(nrows) + 1000L),
+      string_column = as.character(seq.int(nrows) + 1000L),
       grp = factor(c(
         rep_len("lvl1", length.out = floor(nrows / 2)),
         rep_len("lvl2", length.out = ceiling(nrows / 2))
@@ -74,7 +74,7 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
       foo = seq.int(nrows) + 1000L,
       soma_joinid = bit64::seq.integer64(from = 0L, to = nrows - 1L),
       bar = seq(nrows) + 0.1,
-      baz = as.character(seq.int(nrows) + 1000L)
+      string_column = as.character(seq.int(nrows) + 1000L)
       # schema = create_arrow_schema(false)
     )
 }

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -3,7 +3,7 @@ create_and_populate_soma_dataframe <- function(
   uri,
   nrows = 10L,
   seed = 1,
-  index_column_names = "foo",
+  index_column_names = "int_column",
   factors = FALSE,
   mode = NULL
 ) {

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -93,8 +93,8 @@ test_that("Validating arrow data type compatibility", {
 })
 
 test_that("Validating arrow schema data type compatibility", {
-  from <- arrow::schema(foo = arrow::int32())
-  to <- arrow::schema(foo = arrow::int32())
+  from <- arrow::schema(int_column = arrow::int32())
+  to <- arrow::schema(int_column = arrow::int32())
   expect_true(check_arrow_schema_data_types(from, to))
 
   # Add incompatible fields

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -106,7 +106,7 @@ test_that("Validating arrow schema data type compatibility", {
   )
 
   # Schemas with different fields
-  from$baz <- arrow::string()
+  from$string_column <- arrow::string()
   expect_error(
     check_arrow_schema_data_types(from, to),
     "'from' and 'to' must have the same number of fields"

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -98,8 +98,8 @@ test_that("Validating arrow schema data type compatibility", {
   expect_true(check_arrow_schema_data_types(from, to))
 
   # Add incompatible fields
-  from$bar <- arrow::int16()
-  to$bar <- arrow::float16()
+  from$float_column <- arrow::int16()
+  to$float_column <- arrow::float16()
   expect_error(
     check_arrow_schema_data_types(from, to),
     "Schemas are incompatible"

--- a/apis/r/tests/testthat/test-EphemeralCollection.R
+++ b/apis/r/tests/testthat/test-EphemeralCollection.R
@@ -29,9 +29,9 @@ test_that("Ephemeral Collection mechanics", {
   # expect_equal(readback_dataframe$object[], df2$object[])
 
   # Add new dataframe to the collection
-  expect_error(collection$add_new_dataframe("new_df", create_arrow_schema(), "foo"))
+  expect_error(collection$add_new_dataframe("new_df", create_arrow_schema(), "int_column"))
   expect_no_condition(collection$set(
-    SOMADataFrameCreate(file.path(uri, 'new_df'), create_arrow_schema(), 'foo'),
+    SOMADataFrameCreate(file.path(uri, 'new_df'), create_arrow_schema(), 'int_column'),
     'new_df'
   ))
   expect_s3_class(df3 <- collection$get("new_df"), 'SOMADataFrame')

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -9,7 +9,7 @@ test_that("DataFrame Factory", {
     # Check creation of a DF
     asch <- create_arrow_schema(foo_first=FALSE)
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch))
-    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, foo = 1L:10L, bar = sqrt(1:10),
+    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, int_column = 1L:10L, bar = sqrt(1:10),
                               string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 
@@ -25,9 +25,9 @@ test_that("DataFrame Factory with specified index_column_names", {
 
     # Check creation of a DF
     asch <- create_arrow_schema()
-    expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "foo")) # misses schema
-    expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "foo"))
-    tbl <- arrow::arrow_table(foo = 1L:10L, soma_joinid = 1L:10L, bar = sqrt(1:10),
+    expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "int_column")) # misses schema
+    expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "int_column"))
+    tbl <- arrow::arrow_table(int_column = 1L:10L, soma_joinid = 1L:10L, bar = sqrt(1:10),
                               string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -9,7 +9,7 @@ test_that("DataFrame Factory", {
     # Check creation of a DF
     asch <- create_arrow_schema(foo_first=FALSE)
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch))
-    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, int_column = 1L:10L, bar = sqrt(1:10),
+    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, int_column = 1L:10L, float_column = sqrt(1:10),
                               string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 
@@ -27,7 +27,7 @@ test_that("DataFrame Factory with specified index_column_names", {
     asch <- create_arrow_schema()
     expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "int_column")) # misses schema
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "int_column"))
-    tbl <- arrow::arrow_table(int_column = 1L:10L, soma_joinid = 1L:10L, bar = sqrt(1:10),
+    tbl <- arrow::arrow_table(int_column = 1L:10L, soma_joinid = 1L:10L, float_column = sqrt(1:10),
                               string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -10,7 +10,7 @@ test_that("DataFrame Factory", {
     asch <- create_arrow_schema(foo_first=FALSE)
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch))
     tbl <- arrow::arrow_table(soma_joinid = 1L:10L, foo = 1L:10L, bar = sqrt(1:10),
-                              baz = letters[1:10], schema = asch)
+                              string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 
     # Check opening to read
@@ -28,7 +28,7 @@ test_that("DataFrame Factory with specified index_column_names", {
     expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "foo")) # misses schema
     expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "foo"))
     tbl <- arrow::arrow_table(foo = 1L:10L, soma_joinid = 1L:10L, bar = sqrt(1:10),
-                              baz = letters[1:10], schema = asch)
+                              string_column = letters[1:10], schema = asch)
     d2$write(tbl)
 
     # Check opening to read

--- a/apis/r/tests/testthat/test-SCEOutgest.R
+++ b/apis/r/tests/testthat/test-SCEOutgest.R
@@ -161,7 +161,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
   expect_error(query$to_single_cell_experiment(obs_index = FALSE))
   expect_error(query$to_single_cell_experiment(obs_index = NA_character_))
   expect_error(query$to_single_cell_experiment(obs_index = 1))
-  expect_error(query$to_single_cell_experiment(obs_index = c('string_column', 'foo')))
+  expect_error(query$to_single_cell_experiment(obs_index = c('string_column', 'int_column')))
   expect_error(query$to_single_cell_experiment(obs_index = 'tomato'))
   # Test `var_index` assertions
   expect_error(query$to_single_cell_experiment(var_index = FALSE))

--- a/apis/r/tests/testthat/test-SCEOutgest.R
+++ b/apis/r/tests/testthat/test-SCEOutgest.R
@@ -82,7 +82,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
   expect_identical(dim(net), c(n_var, n_var))
   # Test named
   expect_warning(obj <- query$to_single_cell_experiment(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_s4_class(obj, 'SingleCellExperiment')
@@ -93,7 +93,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SingleCellExperiment::mainExpName(obj), 'RNA')
   expect_identical(
@@ -104,7 +104,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
     query$obs_df$attrnames() %in% names(SingleCellExperiment::colData(obj))
   ))
   expect_true(all(
-    setdiff(query$obs_df$attrnames(), 'baz') %in% names(SingleCellExperiment::colData(obj))
+    setdiff(query$obs_df$attrnames(), 'string_column') %in% names(SingleCellExperiment::colData(obj))
   ))
   for (slot in SummarizedExperiment::assayNames(obj)) {
     expect_s4_class(mat <- SummarizedExperiment::assay(obj, slot), 'dgTMatrix')
@@ -161,7 +161,7 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
   expect_error(query$to_single_cell_experiment(obs_index = FALSE))
   expect_error(query$to_single_cell_experiment(obs_index = NA_character_))
   expect_error(query$to_single_cell_experiment(obs_index = 1))
-  expect_error(query$to_single_cell_experiment(obs_index = c('baz', 'foo')))
+  expect_error(query$to_single_cell_experiment(obs_index = c('string_column', 'foo')))
   expect_error(query$to_single_cell_experiment(obs_index = 'tomato'))
   # Test `var_index` assertions
   expect_error(query$to_single_cell_experiment(var_index = FALSE))
@@ -307,7 +307,7 @@ test_that("Load SCE object from sliced ExperimentQuery", {
   expect_identical(SingleCellExperiment::colPairNames(obj), 'connectivities')
   expect_identical(SingleCellExperiment::rowPairNames(obj), 'network')
   # Test named
-  expect_no_condition(obj <- query$to_single_cell_experiment(obs_index = 'baz', var_index = 'quux'))
+  expect_no_condition(obj <- query$to_single_cell_experiment(obs_index = 'string_column', var_index = 'quux'))
   expect_s4_class(obj, 'SingleCellExperiment')
   expect_identical(dim(obj), c(n_var_slice, n_obs_slice))
   expect_identical(
@@ -316,7 +316,7 @@ test_that("Load SCE object from sliced ExperimentQuery", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SingleCellExperiment::mainExpName(obj), 'RNA')
   expect_identical(
@@ -355,7 +355,7 @@ test_that("Load SCE object from indexed ExperimentQuery", {
   on.exit(experiment$close())
   # Create the query
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -394,7 +394,7 @@ test_that("Load SCE object from indexed ExperimentQuery", {
   expect_identical(SingleCellExperiment::rowPairNames(obj), 'network')
   # Test named
   expect_no_condition(
-    obj <- query$to_single_cell_experiment(obs_index = 'baz', var_index = 'quux')
+    obj <- query$to_single_cell_experiment(obs_index = 'string_column', var_index = 'quux')
   )
   expect_s4_class(obj, 'SingleCellExperiment')
   expect_identical(dim(obj), c(n_var_select, n_obs_select))
@@ -404,7 +404,7 @@ test_that("Load SCE object from indexed ExperimentQuery", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SingleCellExperiment::mainExpName(obj), 'RNA')
   expect_identical(

--- a/apis/r/tests/testthat/test-SOMAAxisQuery.R
+++ b/apis/r/tests/testthat/test-SOMAAxisQuery.R
@@ -31,7 +31,7 @@ test_that("SOMAAxisQuery", {
     "'value_filter' must be a scalar character"
   )
   expect_error(
-    SOMAAxisQuery$new(value_filter = c("int_column", "bar")),
+    SOMAAxisQuery$new(value_filter = c("int_column", "float_column")),
     "'value_filter' must be a scalar character"
   )
   expect_error(

--- a/apis/r/tests/testthat/test-SOMAAxisQuery.R
+++ b/apis/r/tests/testthat/test-SOMAAxisQuery.R
@@ -4,17 +4,17 @@ test_that("SOMAAxisQuery", {
   expect_null(query$value_filter)
   expect_null(query$coords)
 
-  query <- SOMAAxisQuery$new(value_filter = "foo")
-  expect_equal(query$value_filter, "foo")
+  query <- SOMAAxisQuery$new(value_filter = "int_column")
+  expect_equal(query$value_filter, "int_column")
   expect_null(query$coords)
 
-  query <- SOMAAxisQuery$new(coords = list(foo = 1L:2L))
+  query <- SOMAAxisQuery$new(coords = list(int_column = 1L:2L))
   expect_null(query$value_filter)
-  expect_equal(query$coords, list(foo = 1L:2L))
+  expect_equal(query$coords, list(int_column = 1L:2L))
 
-  query <- SOMAAxisQuery$new(value_filter = "foo", coords = list(foo = 1L:2L))
-  expect_equal(query$value_filter, "foo")
-  expect_equal(query$coords, list(foo = 1L:2L))
+  query <- SOMAAxisQuery$new(value_filter = "int_column", coords = list(int_column = 1L:2L))
+  expect_equal(query$value_filter, "int_column")
+  expect_equal(query$coords, list(int_column = 1L:2L))
 
   # Bare vector is wrapped in a list
   query <- SOMAAxisQuery$new(coords = 1L:2L)
@@ -31,7 +31,7 @@ test_that("SOMAAxisQuery", {
     "'value_filter' must be a scalar character"
   )
   expect_error(
-    SOMAAxisQuery$new(value_filter = c("foo", "bar")),
+    SOMAAxisQuery$new(value_filter = c("int_column", "bar")),
     "'value_filter' must be a scalar character"
   )
   expect_error(
@@ -40,7 +40,7 @@ test_that("SOMAAxisQuery", {
   )
 
   expect_error(
-    SOMAAxisQuery$new(coords = list(foo = letters)),
+    SOMAAxisQuery$new(coords = list(int_column = letters)),
     "'coords' must be a list of numeric vectors"
   )
 

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -43,7 +43,7 @@ test_that("SOMACollection basics", {
   subcollection$close()
 
   # Add another dataframe to the collection, this time using add_new_dataframe
-  collection$add_new_dataframe("new_df", create_arrow_schema(), "foo")$close()
+  collection$add_new_dataframe("new_df", create_arrow_schema(), "int_column")$close()
   df3 <- collection$get("new_df")
   df3 <- SOMADataFrameOpen(df3$uri)
   expect_true(df3$soma_type == "SOMADataFrame")
@@ -115,12 +115,12 @@ test_that("Platform config and context are respected by add_ methods", {
 
   # Set params in the config and context
   cfg <- PlatformConfig$new()
-  cfg$set("tiledb", "test", "foo", "bar")
-  cfg$get("tiledb", "test", "foo")
+  cfg$set("tiledb", "test", "int_column", "bar")
+  cfg$get("tiledb", "test", "int_column")
 
   ctx <- SOMATileDBContext$new()
-  ctx$set("foo", "bar")
-  ctx$get("foo")
+  ctx$set("int_column", "bar")
+  ctx$get("int_column")
 
   # Create an empty collection
   collection <- SOMACollectionCreate(
@@ -138,18 +138,18 @@ test_that("Platform config and context are respected by add_ methods", {
   # Verify the config and context params were inherited
   collection$open("READ", internal_use_only = "allowed_use")
   expect_equal(
-    collection$get("sdf1")$platform_config$get("tiledb", "test", "foo"),
+    collection$get("sdf1")$platform_config$get("tiledb", "test", "int_column"),
     "bar"
   )
   expect_equal(
-    collection$get("sdf1")$tiledbsoma_ctx$get("foo"),
+    collection$get("sdf1")$tiledbsoma_ctx$get("int_column"),
     "bar"
   )
   collection$close()
 
   # Method-level config params override instance params
   collection$open("WRITE", internal_use_only = "allowed_use")
-  cfg$set("tiledb", "test", "foo", "string_column")
+  cfg$set("tiledb", "test", "int_column", "string_column")
   sdf2 <- collection$add_new_dataframe(
     key = "sdf2",
     schema = tbl$schema,
@@ -159,7 +159,7 @@ test_that("Platform config and context are respected by add_ methods", {
   sdf2$write(tbl)
 
   expect_equal(
-    collection$get("sdf2")$platform_config$get("tiledb", "test", "foo"),
+    collection$get("sdf2")$platform_config$get("tiledb", "test", "int_column"),
     "string_column"
   )
   collection$close()

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -115,11 +115,11 @@ test_that("Platform config and context are respected by add_ methods", {
 
   # Set params in the config and context
   cfg <- PlatformConfig$new()
-  cfg$set("tiledb", "test", "int_column", "bar")
+  cfg$set("tiledb", "test", "int_column", "float_column")
   cfg$get("tiledb", "test", "int_column")
 
   ctx <- SOMATileDBContext$new()
-  ctx$set("int_column", "bar")
+  ctx$set("int_column", "float_column")
   ctx$get("int_column")
 
   # Create an empty collection
@@ -139,11 +139,11 @@ test_that("Platform config and context are respected by add_ methods", {
   collection$open("READ", internal_use_only = "allowed_use")
   expect_equal(
     collection$get("sdf1")$platform_config$get("tiledb", "test", "int_column"),
-    "bar"
+    "float_column"
   )
   expect_equal(
     collection$get("sdf1")$tiledbsoma_ctx$get("int_column"),
-    "bar"
+    "float_column"
   )
   collection$close()
 

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -149,7 +149,7 @@ test_that("Platform config and context are respected by add_ methods", {
 
   # Method-level config params override instance params
   collection$open("WRITE", internal_use_only = "allowed_use")
-  cfg$set("tiledb", "test", "foo", "baz")
+  cfg$set("tiledb", "test", "foo", "string_column")
   sdf2 <- collection$add_new_dataframe(
     key = "sdf2",
     schema = tbl$schema,
@@ -160,7 +160,7 @@ test_that("Platform config and context are respected by add_ methods", {
 
   expect_equal(
     collection$get("sdf2")$platform_config$get("tiledb", "test", "foo"),
-    "baz"
+    "string_column"
   )
   collection$close()
 })

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -27,7 +27,7 @@ test_that("Basic mechanics", {
   tbl0 <- arrow::arrow_table(foo = 1L:36L,
                              soma_joinid = 1L:36L,
                              bar = 1.1:36.1,
-                             baz = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
+                             string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
                                      "ź", "Ž", "Ż"),
@@ -62,7 +62,7 @@ test_that("Basic mechanics", {
   rb0 <- arrow::record_batch(foo = 1L:36L,
                              soma_joinid = 1L:36L,
                              bar = 1.1:36.1,
-                             baz = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
+                             string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
                                      "ź", "Ž", "Ż"),
@@ -146,7 +146,7 @@ test_that("Basic mechanics with default index_column_names", {
   tbl0 <- arrow::arrow_table( soma_joinid = 1L:36L,
                              foo = 1L:36L,
                              bar = 1.1:36.1,
-                             baz = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
+                             string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
                                      "ź", "Ž", "Ż"),
@@ -549,22 +549,22 @@ test_that("Metadata", {
   asch <- create_arrow_schema()
   sdf <- SOMADataFrameCreate(uri, asch)
 
-  md <- list(baz = "qux", foo = "bar")
+  md <- list(string_column = "qux", foo = "bar")
   sdf$set_metadata(md)
 
   # Read all metadata while the sdf is still open for write
   expect_equivalent(sdf$get_metadata("foo"), "bar")
-  expect_equivalent(sdf$get_metadata("baz"), "qux")
+  expect_equivalent(sdf$get_metadata("string_column"), "qux")
 
   readmd <- sdf$get_metadata()
-  expect_equivalent(readmd[["baz"]], "qux")
+  expect_equivalent(readmd[["string_column"]], "qux")
   expect_equivalent(readmd[["foo"]], "bar")
   sdf$close()
 
   # Read all metadata while the sdf is open for read
   sdf <- SOMADataFrameOpen(uri)
   readmd <- sdf$get_metadata()
-  expect_equivalent(readmd[["baz"]], "qux")
+  expect_equivalent(readmd[["string_column"]], "qux")
   expect_equivalent(readmd[["foo"]], "bar")
   sdf$close()
 })
@@ -722,7 +722,7 @@ test_that("SOMADataFrame can be updated", {
   tbl0 <- tbl1
 
   # Error on incompatible schema updates
-  tbl0$baz <- tbl0$baz$cast(target_type = arrow::int32()) # string to int
+  tbl0$string_column <- tbl0$string_column$cast(target_type = arrow::int32()) # string to int
   expect_error(
     SOMADataFrameOpen(uri, mode = "WRITE")$update(tbl0),
     "Schemas are incompatible"
@@ -749,17 +749,17 @@ test_that("SOMADataFrame can be updated from a data frame", {
 
   # Convert a column to row names to test that it can be recovered
   df0 <- as.data.frame(df0)
-  rownames(df0) <- df0$baz
-  df0$baz <- NULL
+  rownames(df0) <- df0$string_column
+  df0$string_column <- NULL
   df0$bar <- NULL
 
-  # Update to drop 'bar' from the array and retrieve baz values from row names
+  # Update to drop 'bar' from the array and retrieve string_column values from row names
   expect_silent(
-    SOMADataFrameOpen(uri, "WRITE")$update(df0, row_index_name = "baz")
+    SOMADataFrameOpen(uri, "WRITE")$update(df0, row_index_name = "string_column")
   )
 
   df1 <- SOMADataFrameOpen(uri)$read()$concat()$to_data_frame()
-  expect_setequal(colnames(df1), c("foo", "soma_joinid", "baz"))
+  expect_setequal(colnames(df1), c("foo", "soma_joinid", "string_column"))
 
   # Error if row_index_name conflicts with an existing column name
   expect_error(

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -26,7 +26,7 @@ test_that("Basic mechanics", {
 
   tbl0 <- arrow::arrow_table(int_column = 1L:36L,
                              soma_joinid = 1L:36L,
-                             bar = 1.1:36.1,
+                             float_column = 1.1:36.1,
                              string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
@@ -61,7 +61,7 @@ test_that("Basic mechanics", {
   sdf <- SOMADataFrameOpen(uri, mode = "WRITE")
   rb0 <- arrow::record_batch(int_column = 1L:36L,
                              soma_joinid = 1L:36L,
-                             bar = 1.1:36.1,
+                             float_column = 1.1:36.1,
                              string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
@@ -97,12 +97,12 @@ test_that("Basic mechanics", {
     "'column_names' must only contain valid dimension or attribute columns"
   )
 
-  tbl1 <- sdf$read(column_names = "bar")$concat()
+  tbl1 <- sdf$read(column_names = "float_column")$concat()
   expect_true(tbl1$Equals(tbl0$SelectColumns(2L)))
 
   # Attribute filters
-  tbl1 <- sdf$read(value_filter = "bar < 5")$concat()
-  expect_true(tbl1$Equals(tbl0$Filter(tbl0$bar < 5)))
+  tbl1 <- sdf$read(value_filter = "float_column < 5")$concat()
+  expect_true(tbl1$Equals(tbl0$Filter(tbl0$float_column < 5)))
 
   # Validate TileDB array schema
   arr <- tiledb::tiledb_array(uri)
@@ -145,7 +145,7 @@ test_that("Basic mechanics with default index_column_names", {
 
   tbl0 <- arrow::arrow_table( soma_joinid = 1L:36L,
                              int_column = 1L:36L,
-                             bar = 1.1:36.1,
+                             float_column = 1.1:36.1,
                              string_column = c("á", "ą", "ã", "à", "å", "ä", "æ", "ç", "ć", "Ç", "í",
                                      "ë", "é", "è", "ê", "ł", "Ł", "ñ", "ń", "ó", "ô", "ò",
                                      "ö", "ø", "Ø", "ř", "š", "ś", "ş", "Š", "ú", "ü", "ý",
@@ -549,23 +549,23 @@ test_that("Metadata", {
   asch <- create_arrow_schema()
   sdf <- SOMADataFrameCreate(uri, asch)
 
-  md <- list(string_column = "qux", int_column = "bar")
+  md <- list(string_column = "qux", int_column = "float_column")
   sdf$set_metadata(md)
 
   # Read all metadata while the sdf is still open for write
-  expect_equivalent(sdf$get_metadata("int_column"), "bar")
+  expect_equivalent(sdf$get_metadata("int_column"), "float_column")
   expect_equivalent(sdf$get_metadata("string_column"), "qux")
 
   readmd <- sdf$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["int_column"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "float_column")
   sdf$close()
 
   # Read all metadata while the sdf is open for read
   sdf <- SOMADataFrameOpen(uri)
   readmd <- sdf$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["int_column"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "float_column")
   sdf$close()
 })
 
@@ -622,7 +622,7 @@ test_that("SOMADataFrame can be updated", {
   tbl0 <- SOMADataFrameOpen(uri, "READ")$read()$concat()
 
   # Remove a column and update
-  tbl0$bar <- NULL
+  tbl0$float_column <- NULL
   sdf <- SOMADataFrameOpen(uri, "WRITE")$update(tbl0)
 
   # Verify attribute was removed on disk
@@ -630,7 +630,7 @@ test_that("SOMADataFrame can be updated", {
   expect_true(tbl1$Equals(tbl0))
 
   # # Add a new column and update
-  tbl0$bar <- sample(c(TRUE, FALSE), nrow(tbl0), replace = TRUE)
+  tbl0$float_column <- sample(c(TRUE, FALSE), nrow(tbl0), replace = TRUE)
   sdf <- SOMADataFrameOpen(uri, mode = "WRITE")$update(tbl0)
 
   # Verify attribute was added on disk
@@ -751,9 +751,9 @@ test_that("SOMADataFrame can be updated from a data frame", {
   df0 <- as.data.frame(df0)
   rownames(df0) <- df0$string_column
   df0$string_column <- NULL
-  df0$bar <- NULL
+  df0$float_column <- NULL
 
-  # Update to drop 'bar' from the array and retrieve string_column values from row names
+  # Update to drop 'float_column' from the array and retrieve string_column values from row names
   expect_silent(
     SOMADataFrameOpen(uri, "WRITE")$update(df0, row_index_name = "string_column")
   )

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-m-p.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-m-p.R
@@ -229,7 +229,7 @@ test_that("Load *m and *p layers from indexed SOMAExperimentAxisQuery", {
 
   # Create the query
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(

--- a/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query-matrix-outgest.R
@@ -150,18 +150,18 @@ test_that("matrix outgest assertions", {
   )
 
   expect_error(
-    query$to_sparse_matrix(collection = "foo"),
-    "The following collection does not exist: foo"
+    query$to_sparse_matrix(collection = "int_column"),
+    "The following collection does not exist: int_column"
   )
 
   expect_error(
-    query$to_sparse_matrix(collection = "X", layer_name = "foo"),
-    "The following layer does not exist: foo"
+    query$to_sparse_matrix(collection = "X", layer_name = "int_column"),
+    "The following layer does not exist: int_column"
   )
 
   expect_error(
-    query$to_sparse_matrix(collection = "X", layer_name = "counts", obs_index = "foo"),
-    "The following column does not exist: foo"
+    query$to_sparse_matrix(collection = "X", layer_name = "counts", obs_index = "int_column"),
+    "The following column does not exist: int_column"
   )
 
   # joinds are used as default dimnames if no obs/var_index is provided
@@ -175,12 +175,12 @@ test_that("matrix outgest assertions", {
 
   # error if specified obs/var_index does not exist
   expect_error(
-    query$to_sparse_matrix("X", "counts", obs_index = "foo"),
-    "The following column does not exist: foo"
+    query$to_sparse_matrix("X", "counts", obs_index = "int_column"),
+    "The following column does not exist: int_column"
   )
   expect_error(
-    query$to_sparse_matrix("X", "counts", var_index = "foo"),
-    "The following column does not exist: foo"
+    query$to_sparse_matrix("X", "counts", var_index = "int_column"),
+    "The following column does not exist: int_column"
   )
 
   # only one of obs_index or var_index can be provided

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -43,7 +43,7 @@ test_that("returns all coordinates by default", {
   # X
   expect_error(query$X(), "Must specify an X layer name")
   expect_error(query$X(c("a", "b")), "Must specify a single X layer name")
-  expect_error(query$X("foo"), "The following layer does not exist: foo")
+  expect_error(query$X("int_column"), "The following layer does not exist: int_column")
 
   expect_true(is(query$X("counts"), "SOMASparseNDArrayRead"))
   expect_true(
@@ -443,7 +443,7 @@ test_that("query result value indexer", {
   )
 
   expect_error(
-    indexer$by_obs(c(1, 4, 2, 1000, "foo")),
+    indexer$by_obs(c(1, 4, 2, 1000, "int_column")),
     "'coords' must be a numeric vector or arrow Array"
   )
 
@@ -510,7 +510,7 @@ test_that("query result value indexer upcast", {
   )
 
   expect_error(
-    indexer$by_obs(c(1, 4, 2, 1000, "foo")),
+    indexer$by_obs(c(1, 4, 2, 1000, "int_column")),
     "'coords' must be a numeric vector or arrow Array"
   )
 

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -123,7 +123,7 @@ test_that("querying by value filters", {
 
   # TODO: simplify once tiledb-r supports membership expressions
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -141,7 +141,7 @@ test_that("querying by value filters", {
   expect_true(query$n_obs == length(obs_label_values))
   expect_true(query$n_vars == length(var_label_values))
 
-  expect_equal(query$obs()$concat()$baz$as_vector(), obs_label_values)
+  expect_equal(query$obs()$concat()$string_column$as_vector(), obs_label_values)
   expect_equal(query$var()$concat()$quux$as_vector(), var_label_values)
 
   experiment$close()
@@ -245,7 +245,7 @@ test_that("querying by both coordinates and value filters", {
 
 # TODO: simplify once tiledb-r supports membership expressions
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -309,7 +309,7 @@ test_that("querying by both coordinates and value filters", {
   # Determine expected results
   obs_df <- experiment$obs$read()$concat()$to_data_frame()
   obs_hits <- obs_df$soma_joinid %in% as.integer(obs_slice) &
-    obs_df$baz %in% obs_label_values
+    obs_df$string_column %in% obs_label_values
 
   var_df <- experiment$ms$get("RNA")$var$read()$concat()$to_data_frame()
   var_hits <- var_df$soma_joinid %in% as.integer(var_slice) &
@@ -341,7 +341,7 @@ test_that("queries with empty results", {
     experiment = experiment,
     measurement_name = "RNA",
     obs_query = SOMAAxisQuery$new(
-      value_filter = "baz == 'does-not-exist'"
+      value_filter = "string_column == 'does-not-exist'"
     ),
     var_query = SOMAAxisQuery$new(
       value_filter = "quux == 'does-not-exist'"

--- a/apis/r/tests/testthat/test-SOMAExperiment.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment.R
@@ -78,8 +78,8 @@ test_that("Update obs and var", {
   tbl_var0 <- exp$ms$get("RNA")$var$read()$concat()
 
   # obs: drop an existing column and add a new one
-  tbl_obs0$qux <- tbl_obs0$bar
-  tbl_obs0$bar <- NULL
+  tbl_obs0$qux <- tbl_obs0$float_column
+  tbl_obs0$float_column <- NULL
 
   exp <- SOMAExperimentOpen(uri, "WRITE")
   exp$update_obs(tbl_obs0)

--- a/apis/r/tests/testthat/test-SeuratOutgest-assay.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-assay.R
@@ -63,12 +63,12 @@ test_that("Load assay from ExperimentQuery mechanics", {
 
   # Test using cell and feature names
   expect_no_condition(named <- query$to_seurat_assay(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(named),
@@ -97,14 +97,14 @@ test_that("Load assay from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_assay(obs_index = FALSE))
   expect_error(query$to_seurat_assay(obs_index = NA_character_))
   expect_error(query$to_seurat_assay(obs_index = 1))
-  expect_error(query$to_seurat_assay(obs_index = c('baz', 'foo')))
+  expect_error(query$to_seurat_assay(obs_index = c('string_column', 'foo')))
   expect_error(query$to_seurat_assay(obs_index = 'tomato'))
 
   # Test `var_index` assertions
   expect_error(query$to_seurat_assay(var_index = FALSE))
   expect_error(query$to_seurat_assay(var_index = NA_character_))
   expect_error(query$to_seurat_assay(var_index = 1))
-  expect_error(query$to_seurat_assay(var_index = c('baz', 'foo')))
+  expect_error(query$to_seurat_assay(var_index = c('string_column', 'foo')))
   expect_error(query$to_seurat_assay(var_index = 'tomato'))
 
   # Test `var_column_names` assertions
@@ -234,7 +234,7 @@ test_that("Load assay from sliced ExperimentQuery", {
 
   # Test named
   expect_no_condition(named <- query$to_seurat_assay(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
@@ -243,7 +243,7 @@ test_that("Load assay from sliced ExperimentQuery", {
   )
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
 })
 
@@ -265,7 +265,7 @@ test_that("Load assay from indexed ExperimentQuery", {
   on.exit(experiment$close())
 
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -289,7 +289,7 @@ test_that("Load assay from indexed ExperimentQuery", {
 
   # Test named
   expect_no_condition(named <- query$to_seurat_assay(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
@@ -299,7 +299,7 @@ test_that("Load assay from indexed ExperimentQuery", {
   expect_identical(rownames(named), var_label_values)
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(colnames(named), obs_label_values)
 })

--- a/apis/r/tests/testthat/test-SeuratOutgest-assay.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-assay.R
@@ -97,14 +97,14 @@ test_that("Load assay from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_assay(obs_index = FALSE))
   expect_error(query$to_seurat_assay(obs_index = NA_character_))
   expect_error(query$to_seurat_assay(obs_index = 1))
-  expect_error(query$to_seurat_assay(obs_index = c('string_column', 'foo')))
+  expect_error(query$to_seurat_assay(obs_index = c('string_column', 'int_column')))
   expect_error(query$to_seurat_assay(obs_index = 'tomato'))
 
   # Test `var_index` assertions
   expect_error(query$to_seurat_assay(var_index = FALSE))
   expect_error(query$to_seurat_assay(var_index = NA_character_))
   expect_error(query$to_seurat_assay(var_index = 1))
-  expect_error(query$to_seurat_assay(var_index = c('string_column', 'foo')))
+  expect_error(query$to_seurat_assay(var_index = c('string_column', 'int_column')))
   expect_error(query$to_seurat_assay(var_index = 'tomato'))
 
   # Test `var_column_names` assertions

--- a/apis/r/tests/testthat/test-SeuratOutgest-graph.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-graph.R
@@ -58,7 +58,7 @@ test_that("Load graph from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_graph('connectivities', obs_index = 1))
   expect_error(query$to_seurat_graph(
     'connectivities',
-    obs_index = c('string_column', 'foo'))
+    obs_index = c('string_column', 'int_column'))
   )
   expect_error(query$to_seurat_graph('connectivities', obs_index = 'tomato'))
 })

--- a/apis/r/tests/testthat/test-SeuratOutgest-graph.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-graph.R
@@ -28,16 +28,16 @@ test_that("Load graph from ExperimentQuery mechanics", {
   expect_identical(SeuratObject::DefaultAssay(graph), 'RNA')
 
   # Test named
-  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'baz'))
+  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'string_column'))
   expect_s4_class(named, 'Graph')
   expect_identical(dim(named), c(n_obs, n_obs))
   expect_identical(
     rownames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::DefaultAssay(named), 'RNA')
 
@@ -58,7 +58,7 @@ test_that("Load graph from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_graph('connectivities', obs_index = 1))
   expect_error(query$to_seurat_graph(
     'connectivities',
-    obs_index = c('baz', 'foo'))
+    obs_index = c('string_column', 'foo'))
   )
   expect_error(query$to_seurat_graph('connectivities', obs_index = 'tomato'))
 })
@@ -98,16 +98,16 @@ test_that("Load graph from sliced ExperimentQuery", {
   expect_identical(SeuratObject::DefaultAssay(graph), 'RNA')
 
   # Test named
-  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'baz'))
+  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'string_column'))
   expect_s4_class(named, 'Graph')
   expect_identical(dim(named), c(n_obs_slice, n_obs_slice))
   expect_identical(
     rownames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::DefaultAssay(named), 'RNA')
 })
@@ -133,7 +133,7 @@ test_that("Load graph from indexed ExperimentQuery", {
 
   # Create the query
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -155,17 +155,17 @@ test_that("Load graph from indexed ExperimentQuery", {
   expect_identical(SeuratObject::DefaultAssay(graph), 'RNA')
 
   # Test named
-  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'baz'))
+  expect_no_condition(named <- query$to_seurat_graph('connectivities', 'string_column'))
   expect_s4_class(named, 'Graph')
   expect_identical(dim(named), c(n_obs_select, n_obs_select))
   expect_identical(
     rownames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(rownames(named), obs_label_values)
   expect_identical(
     colnames(named),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(colnames(named), obs_label_values)
   expect_identical(SeuratObject::DefaultAssay(named), 'RNA')

--- a/apis/r/tests/testthat/test-SeuratOutgest-object.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-object.R
@@ -69,7 +69,7 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
 
   # Test named
   expect_no_condition(obj <- query$to_seurat(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_s4_class(obj, 'Seurat')
@@ -80,11 +80,11 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::Assays(obj), 'RNA')
   expect_false(all(query$obs_df$attrnames() %in% names(obj[[]])))
-  expect_true(all(setdiff(query$obs_df$attrnames(), 'baz') %in% names(obj[[]])))
+  expect_true(all(setdiff(query$obs_df$attrnames(), 'string_column') %in% names(obj[[]])))
   expect_s4_class(rna <- obj[['RNA']], 'Assay')
   expect_identical(rownames(rna), rownames(obj))
   expect_identical(colnames(rna), colnames(obj))
@@ -167,7 +167,7 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   expect_error(query$to_seurat(obs_index = FALSE))
   expect_error(query$to_seurat(obs_index = NA_character_))
   expect_error(query$to_seurat(obs_index = 1))
-  expect_error(query$to_seurat(obs_index = c('baz', 'foo')))
+  expect_error(query$to_seurat(obs_index = c('string_column', 'foo')))
   expect_error(query$to_seurat(obs_index = 'tomato'))
 
   # Test `obs_column_names` assertions
@@ -296,7 +296,7 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
 
   # Test named
   expect_no_condition(obj <- query$to_seurat(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_s4_class(obj, 'Seurat')
@@ -307,7 +307,7 @@ test_that("Load Seurat object from sliced ExperimentQuery", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     lapply(list(names(obj)), sort),
@@ -347,7 +347,7 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
 
   # Create the query
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -374,7 +374,7 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
 
   # Test named
   expect_no_condition(obj <- query$to_seurat(
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_s4_class(obj, 'Seurat')
@@ -385,7 +385,7 @@ test_that("Load Seurat object from indexed ExperimentQuery", {
   )
   expect_identical(
     colnames(obj),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     lapply(list(names(obj)), sort),

--- a/apis/r/tests/testthat/test-SeuratOutgest-object.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-object.R
@@ -167,7 +167,7 @@ test_that("Load Seurat object from ExperimentQuery mechanics", {
   expect_error(query$to_seurat(obs_index = FALSE))
   expect_error(query$to_seurat(obs_index = NA_character_))
   expect_error(query$to_seurat(obs_index = 1))
-  expect_error(query$to_seurat(obs_index = c('string_column', 'foo')))
+  expect_error(query$to_seurat(obs_index = c('string_column', 'int_column')))
   expect_error(query$to_seurat(obs_index = 'tomato'))
 
   # Test `obs_column_names` assertions

--- a/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
@@ -182,7 +182,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_reduction('pca', obs_index = FALSE))
   expect_error(query$to_seurat_reduction('pca', obs_index = NA_character_))
   expect_error(query$to_seurat_reduction('pca', obs_index = 1))
-  expect_error(query$to_seurat_reduction('pca', obs_index = c('string_column', 'foo')))
+  expect_error(query$to_seurat_reduction('pca', obs_index = c('string_column', 'int_column')))
   expect_error(query$to_seurat_reduction('pca', obs_index = 'tomato'))
 
   # Test `var_index` assertions
@@ -191,7 +191,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_reduction('pca', var_index = 1))
   expect_error(query$to_seurat_reduction(
     'pca',
-    var_index = c('string_column', 'foo')
+    var_index = c('string_column', 'int_column')
   ))
   expect_error(query$to_seurat_reduction('pca', var_index = 'tomato'))
 })

--- a/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
+++ b/apis/r/tests/testthat/test-SeuratOutgest-reduction.R
@@ -109,16 +109,16 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   # Test adding names
   expect_no_condition(named_pca <- query$to_seurat_reduction(
     'pca',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_pca),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Embeddings(named_pca)),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Loadings(named_pca)),
@@ -126,16 +126,16 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   )
   expect_warning(named_ica <- query$to_seurat_reduction(
     'ica',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_ica),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Embeddings(named_ica)),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Loadings(named_ica)),
@@ -143,19 +143,19 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   )
   expect_no_condition(named_umap <- query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz',
+    obs_index = 'string_column',
   ))
   expect_identical(
     SeuratObject::Cells(named_umap),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Embeddings(named_umap)),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_no_condition(named_umap <- query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
 
@@ -182,7 +182,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_reduction('pca', obs_index = FALSE))
   expect_error(query$to_seurat_reduction('pca', obs_index = NA_character_))
   expect_error(query$to_seurat_reduction('pca', obs_index = 1))
-  expect_error(query$to_seurat_reduction('pca', obs_index = c('baz', 'foo')))
+  expect_error(query$to_seurat_reduction('pca', obs_index = c('string_column', 'foo')))
   expect_error(query$to_seurat_reduction('pca', obs_index = 'tomato'))
 
   # Test `var_index` assertions
@@ -191,7 +191,7 @@ test_that("Load reduction from ExperimentQuery mechanics", {
   expect_error(query$to_seurat_reduction('pca', var_index = 1))
   expect_error(query$to_seurat_reduction(
     'pca',
-    var_index = c('baz', 'foo')
+    var_index = c('string_column', 'foo')
   ))
   expect_error(query$to_seurat_reduction('pca', var_index = 'tomato'))
 })
@@ -284,12 +284,12 @@ test_that("Load reduction from sliced ExperimentQuery", {
   # Test named
   expect_no_condition(named_pca <- query$to_seurat_reduction(
     'pca',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_pca),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Loadings(named_pca)),
@@ -297,12 +297,12 @@ test_that("Load reduction from sliced ExperimentQuery", {
   )
   expect_warning(named_ica <- query$to_seurat_reduction(
     'ica',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_ica),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(
     rownames(SeuratObject::Loadings(named_ica)),
@@ -310,15 +310,15 @@ test_that("Load reduction from sliced ExperimentQuery", {
   )
   expect_no_condition(named_umap <- query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz'
+    obs_index = 'string_column'
   ))
   expect_identical(
     SeuratObject::Cells(named_umap),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_no_condition(query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
 })
@@ -347,7 +347,7 @@ test_that("Load reduction from indexed ExperimentQuery", {
 
   # Create the query
   obs_value_filter <- paste0(
-    sprintf("baz == '%s'", obs_label_values),
+    sprintf("string_column == '%s'", obs_label_values),
     collapse = "||"
   )
   var_value_filter <- paste0(
@@ -434,12 +434,12 @@ test_that("Load reduction from indexed ExperimentQuery", {
   # Test named
   expect_no_condition(named_pca <- query$to_seurat_reduction(
     'pca',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_pca),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::Cells(named_pca), obs_label_values)
   expect_identical(
@@ -449,12 +449,12 @@ test_that("Load reduction from indexed ExperimentQuery", {
   expect_identical(rownames(SeuratObject::Loadings(named_pca)), var_label_values)
   expect_warning(named_ica <- query$to_seurat_reduction(
     'ica',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
   expect_identical(
     SeuratObject::Cells(named_ica),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::Cells(named_ica), obs_label_values)
   expect_identical(
@@ -464,16 +464,16 @@ test_that("Load reduction from indexed ExperimentQuery", {
   expect_identical(rownames(SeuratObject::Loadings(named_ica)), var_label_values)
   expect_no_condition(named_umap <- query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz'
+    obs_index = 'string_column'
   ))
   expect_identical(
     SeuratObject::Cells(named_umap),
-    query$obs('baz')$concat()$GetColumnByName('baz')$as_vector()
+    query$obs('string_column')$concat()$GetColumnByName('string_column')$as_vector()
   )
   expect_identical(SeuratObject::Cells(named_umap), obs_label_values)
   expect_no_condition(query$to_seurat_reduction(
     'umap',
-    obs_index = 'baz',
+    obs_index = 'string_column',
     var_index = 'quux'
   ))
 })

--- a/apis/r/tests/testthat/test-TileDBArray.R
+++ b/apis/r/tests/testthat/test-TileDBArray.R
@@ -25,14 +25,14 @@ test_that("TileDBArray helper functions", {
   expect_setequal(tdba$colnames(), colnames(df))
 
   # metadata
-  md <- list(baz = "qux", foo = "bar")
+  md <- list(string_column = "qux", foo = "bar")
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
   tdba$set_metadata(md)
   tdba$close()
 
   tdba$open(mode = "READ", internal_use_only = "allowed_use")
   expect_equal(tdba$get_metadata(key = "foo"), "bar")
-  expect_equal(tdba$get_metadata(key = "baz"), "qux")
+  expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
 
@@ -40,7 +40,7 @@ test_that("TileDBArray helper functions", {
   # array is opened for write.
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
   expect_equal(tdba$get_metadata(key = "foo"), "bar")
-  expect_equal(tdba$get_metadata(key = "baz"), "qux")
+  expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
 

--- a/apis/r/tests/testthat/test-TileDBArray.R
+++ b/apis/r/tests/testthat/test-TileDBArray.R
@@ -5,7 +5,7 @@ test_that("TileDBArray helper functions", {
 
   # Check errors on non-existent array
   expect_error(tdba$object, "Array does not exist.")
-  ## inactive under new implementation  expect_error(tdba$set_metadata(list(int_column = "bar")), "Item must be open for write.")
+  ## inactive under new implementation  expect_error(tdba$set_metadata(list(int_column = "float_column")), "Item must be open for write.")
 
   # Create an array
   index_cols <- c("Dept", "Gender")
@@ -25,13 +25,13 @@ test_that("TileDBArray helper functions", {
   expect_setequal(tdba$colnames(), colnames(df))
 
   # metadata
-  md <- list(string_column = "qux", int_column = "bar")
+  md <- list(string_column = "qux", int_column = "float_column")
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
   tdba$set_metadata(md)
   tdba$close()
 
   tdba$open(mode = "READ", internal_use_only = "allowed_use")
-  expect_equal(tdba$get_metadata(key = "int_column"), "bar")
+  expect_equal(tdba$get_metadata(key = "int_column"), "float_column")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
@@ -39,7 +39,7 @@ test_that("TileDBArray helper functions", {
   # The SOMA spec requires the ability to read back metadata even when the
   # array is opened for write.
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
-  expect_equal(tdba$get_metadata(key = "int_column"), "bar")
+  expect_equal(tdba$get_metadata(key = "int_column"), "float_column")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()

--- a/apis/r/tests/testthat/test-TileDBArray.R
+++ b/apis/r/tests/testthat/test-TileDBArray.R
@@ -5,7 +5,7 @@ test_that("TileDBArray helper functions", {
 
   # Check errors on non-existent array
   expect_error(tdba$object, "Array does not exist.")
-  ## inactive under new implementation  expect_error(tdba$set_metadata(list(foo = "bar")), "Item must be open for write.")
+  ## inactive under new implementation  expect_error(tdba$set_metadata(list(int_column = "bar")), "Item must be open for write.")
 
   # Create an array
   index_cols <- c("Dept", "Gender")
@@ -25,13 +25,13 @@ test_that("TileDBArray helper functions", {
   expect_setequal(tdba$colnames(), colnames(df))
 
   # metadata
-  md <- list(string_column = "qux", foo = "bar")
+  md <- list(string_column = "qux", int_column = "bar")
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
   tdba$set_metadata(md)
   tdba$close()
 
   tdba$open(mode = "READ", internal_use_only = "allowed_use")
-  expect_equal(tdba$get_metadata(key = "foo"), "bar")
+  expect_equal(tdba$get_metadata(key = "int_column"), "bar")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
@@ -39,7 +39,7 @@ test_that("TileDBArray helper functions", {
   # The SOMA spec requires the ability to read back metadata even when the
   # array is opened for write.
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
-  expect_equal(tdba$get_metadata(key = "foo"), "bar")
+  expect_equal(tdba$get_metadata(key = "int_column"), "bar")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
   expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()

--- a/apis/r/tests/testthat/test-TileDBCreateOptions.R
+++ b/apis/r/tests/testthat/test-TileDBCreateOptions.R
@@ -1,6 +1,6 @@
 # Verify that the TileDBCreateOptions takes a NULL or a PlatformConfig
 test_that("TileDBCreateOptions construction", {
-  expect_error(TileDBCreateOptions$new(c(foo = "bar")))
+  expect_error(TileDBCreateOptions$new(c(int_column = "bar")))
 
   tdco <- TileDBCreateOptions$new(NULL)
 
@@ -103,13 +103,13 @@ test_that("TileDBCreateOptions cell_tile_orders", {
   )
 
   cfg <- PlatformConfig$new()
-  cfg$set('tiledb', 'create', 'cell_order', 'foo')
+  cfg$set('tiledb', 'create', 'cell_order', 'int_column')
   tdco <- TileDBCreateOptions$new(cfg)
   expect_equal(
     tdco$cell_tile_orders(),
-    c(cell_order = 'foo', tile_order = .CREATE_DEFAULTS$tile_order)
+    c(cell_order = 'int_column', tile_order = .CREATE_DEFAULTS$tile_order)
   )
-  # expect_equal(tdco$cell_tile_orders(), c(cell_order = 'foo', tile_order = NULL))
+  # expect_equal(tdco$cell_tile_orders(), c(cell_order = 'int_column', tile_order = NULL))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'tile_order', 'bar')
@@ -121,10 +121,10 @@ test_that("TileDBCreateOptions cell_tile_orders", {
   # expect_equal(tdco$cell_tile_orders(), c(cell_order = NULL, tile_order = 'bar'))
 
   cfg <- PlatformConfig$new()
-  cfg$set('tiledb', 'create', 'cell_order', 'foo')
+  cfg$set('tiledb', 'create', 'cell_order', 'int_column')
   cfg$set('tiledb', 'create', 'tile_order', 'bar')
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$cell_tile_orders(), c(cell_order = 'foo', tile_order = 'bar'))
+  expect_equal(tdco$cell_tile_orders(), c(cell_order = 'int_column', tile_order = 'bar'))
 })
 
 test_that("TileDBCreateOptions dim_tile", {

--- a/apis/r/tests/testthat/test-TileDBCreateOptions.R
+++ b/apis/r/tests/testthat/test-TileDBCreateOptions.R
@@ -1,6 +1,6 @@
 # Verify that the TileDBCreateOptions takes a NULL or a PlatformConfig
 test_that("TileDBCreateOptions construction", {
-  expect_error(TileDBCreateOptions$new(c(int_column = "bar")))
+  expect_error(TileDBCreateOptions$new(c(int_column = "float_column")))
 
   tdco <- TileDBCreateOptions$new(NULL)
 
@@ -112,19 +112,19 @@ test_that("TileDBCreateOptions cell_tile_orders", {
   # expect_equal(tdco$cell_tile_orders(), c(cell_order = 'int_column', tile_order = NULL))
 
   cfg <- PlatformConfig$new()
-  cfg$set('tiledb', 'create', 'tile_order', 'bar')
+  cfg$set('tiledb', 'create', 'tile_order', 'float_column')
   tdco <- TileDBCreateOptions$new(cfg)
   expect_equal(
     tdco$cell_tile_orders(),
-    c(cell_order = .CREATE_DEFAULTS$cell_order, tile_order = 'bar')
+    c(cell_order = .CREATE_DEFAULTS$cell_order, tile_order = 'float_column')
   )
-  # expect_equal(tdco$cell_tile_orders(), c(cell_order = NULL, tile_order = 'bar'))
+  # expect_equal(tdco$cell_tile_orders(), c(cell_order = NULL, tile_order = 'float_column'))
 
   cfg <- PlatformConfig$new()
   cfg$set('tiledb', 'create', 'cell_order', 'int_column')
-  cfg$set('tiledb', 'create', 'tile_order', 'bar')
+  cfg$set('tiledb', 'create', 'tile_order', 'float_column')
   tdco <- TileDBCreateOptions$new(cfg)
-  expect_equal(tdco$cell_tile_orders(), c(cell_order = 'int_column', tile_order = 'bar'))
+  expect_equal(tdco$cell_tile_orders(), c(cell_order = 'int_column', tile_order = 'float_column'))
 })
 
 test_that("TileDBCreateOptions dim_tile", {

--- a/apis/r/tests/testthat/test-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-TileDBGroup.R
@@ -126,28 +126,28 @@ test_that("Non-relative paths", {
 test_that("Metadata", {
   uri <- file.path(withr::local_tempdir(), "group-metadata")
   group <- TileDBGroup$new(uri, internal_use_only = "allowed_use")
-  expect_error(group$set_metadata(list(int_column = "bar")), "Item must be open for write.")
+  expect_error(group$set_metadata(list(int_column = "float_column")), "Item must be open for write.")
 
   group$create(internal_use_only = "allowed_use")
 
-  md <- list(string_column = "qux", int_column = "bar")
+  md <- list(string_column = "qux", int_column = "float_column")
   group$open("WRITE", internal_use_only = "allowed_use") # but be open for write
   group$set_metadata(md)
 
   # Read all metadata while the group is still open for write
-  expect_equivalent(group$get_metadata("int_column"), "bar")
+  expect_equivalent(group$get_metadata("int_column"), "float_column")
   expect_equivalent(group$get_metadata("string_column"), "qux")
 
   readmd <- group$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["int_column"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "float_column")
   group$close()
 
   # Read all metadata while the group is open for read
   group$open(mode = "READ", internal_use_only = "allowed_use")
   readmd <- group$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["int_column"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "float_column")
 
   group$close()
 })

--- a/apis/r/tests/testthat/test-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-TileDBGroup.R
@@ -130,23 +130,23 @@ test_that("Metadata", {
 
   group$create(internal_use_only = "allowed_use")
 
-  md <- list(baz = "qux", foo = "bar")
+  md <- list(string_column = "qux", foo = "bar")
   group$open("WRITE", internal_use_only = "allowed_use") # but be open for write
   group$set_metadata(md)
 
   # Read all metadata while the group is still open for write
   expect_equivalent(group$get_metadata("foo"), "bar")
-  expect_equivalent(group$get_metadata("baz"), "qux")
+  expect_equivalent(group$get_metadata("string_column"), "qux")
 
   readmd <- group$get_metadata()
-  expect_equivalent(readmd[["baz"]], "qux")
+  expect_equivalent(readmd[["string_column"]], "qux")
   expect_equivalent(readmd[["foo"]], "bar")
   group$close()
 
   # Read all metadata while the group is open for read
   group$open(mode = "READ", internal_use_only = "allowed_use")
   readmd <- group$get_metadata()
-  expect_equivalent(readmd[["baz"]], "qux")
+  expect_equivalent(readmd[["string_column"]], "qux")
   expect_equivalent(readmd[["foo"]], "bar")
 
   group$close()

--- a/apis/r/tests/testthat/test-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-TileDBGroup.R
@@ -7,7 +7,7 @@ test_that("Non-exist", {
   expect_false(group$exists())
 
   # Check errors on non-existent group
-  expect_error(group$get("foo"), "Item must be open for read or write.")
+  expect_error(group$get("int_column"), "Item must be open for read or write.")
   expect_error(group$length(), "Item must be open for read or write.")
   expect_error(group$open(internal_use_only = "allowed_use"), "Group does not exist.")
 })
@@ -126,28 +126,28 @@ test_that("Non-relative paths", {
 test_that("Metadata", {
   uri <- file.path(withr::local_tempdir(), "group-metadata")
   group <- TileDBGroup$new(uri, internal_use_only = "allowed_use")
-  expect_error(group$set_metadata(list(foo = "bar")), "Item must be open for write.")
+  expect_error(group$set_metadata(list(int_column = "bar")), "Item must be open for write.")
 
   group$create(internal_use_only = "allowed_use")
 
-  md <- list(string_column = "qux", foo = "bar")
+  md <- list(string_column = "qux", int_column = "bar")
   group$open("WRITE", internal_use_only = "allowed_use") # but be open for write
   group$set_metadata(md)
 
   # Read all metadata while the group is still open for write
-  expect_equivalent(group$get_metadata("foo"), "bar")
+  expect_equivalent(group$get_metadata("int_column"), "bar")
   expect_equivalent(group$get_metadata("string_column"), "qux")
 
   readmd <- group$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["foo"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "bar")
   group$close()
 
   # Read all metadata while the group is open for read
   group$open(mode = "READ", internal_use_only = "allowed_use")
   readmd <- group$get_metadata()
   expect_equivalent(readmd[["string_column"]], "qux")
-  expect_equivalent(readmd[["foo"]], "bar")
+  expect_equivalent(readmd[["int_column"]], "bar")
 
   group$close()
 })

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -5,9 +5,9 @@ test_that("SOMADataFrame shape", {
 
   index_column_name_choices = list(
     "soma_joinid",
-    c("soma_joinid", "foo"),
+    c("soma_joinid", "int_column"),
     c("soma_joinid", "string_column"),
-    c("string_column", "foo")
+    c("string_column", "int_column")
   )
 
   for (index_column_names in index_column_name_choices) {
@@ -19,7 +19,7 @@ test_that("SOMADataFrame shape", {
     expect_true(sdf$exists())
     expect_true(dir.exists(uri))
 
-    tbl0 <- arrow::arrow_table(foo = 1L:4L,
+    tbl0 <- arrow::arrow_table(int_column = 1L:4L,
                                soma_joinid = 1L:4L,
                                bar = 1.1:4.1,
                                string_column = c("apple", "ball", "cat", "dog"),

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -6,8 +6,8 @@ test_that("SOMADataFrame shape", {
   index_column_name_choices = list(
     "soma_joinid",
     c("soma_joinid", "foo"),
-    c("soma_joinid", "baz"),
-    c("baz", "foo")
+    c("soma_joinid", "string_column"),
+    c("string_column", "foo")
   )
 
   for (index_column_names in index_column_name_choices) {
@@ -22,7 +22,7 @@ test_that("SOMADataFrame shape", {
     tbl0 <- arrow::arrow_table(foo = 1L:4L,
                                soma_joinid = 1L:4L,
                                bar = 1.1:4.1,
-                               baz = c("apple", "ball", "cat", "dog"),
+                               string_column = c("apple", "ball", "cat", "dog"),
                                schema = asch)
 
     sdf$write(tbl0)

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -21,7 +21,7 @@ test_that("SOMADataFrame shape", {
 
     tbl0 <- arrow::arrow_table(int_column = 1L:4L,
                                soma_joinid = 1L:4L,
-                               bar = 1.1:4.1,
+                               float_column = 1.1:4.1,
                                string_column = c("apple", "ball", "cat", "dog"),
                                schema = asch)
 

--- a/apis/r/tests/testthat/test-utils-uris.R
+++ b/apis/r/tests/testthat/test-utils-uris.R
@@ -1,11 +1,11 @@
 test_that("file path construction handles remote URLs", {
   expect_identical(
-    file_path("foo"),
-    file.path("foo")
+    file_path("int_column"),
+    file.path("int_column")
   )
   expect_identical(
-    file_path("foo", "bar"),
-    file.path("foo", "bar")
+    file_path("int_column", "bar"),
+    file.path("int_column", "bar")
   )
   expect_identical(
     file_path("s3://my", "bucket", fsep = "\\"),
@@ -18,44 +18,44 @@ test_that("file path construction handles remote URLs", {
 })
 
 test_that("uri schemes are retrieved", {
-  expect_equal(uri_scheme("foo/bar"), NULL)
-  expect_equal(uri_scheme("/foo/bar"), NULL)
-  expect_equal(uri_scheme("file://foo/bar"), "file")
-  expect_equal(uri_scheme("file:///foo/bar"), "file")
+  expect_equal(uri_scheme("int_column/bar"), NULL)
+  expect_equal(uri_scheme("/int_column/bar"), NULL)
+  expect_equal(uri_scheme("file://int_column/bar"), "file")
+  expect_equal(uri_scheme("file:///int_column/bar"), "file")
   expect_equal(uri_scheme("s3://my/bucket"), "s3")
   expect_equal(uri_scheme("tiledb://my/array"), "tiledb")
 })
 
 test_that("schemes are removed from uris", {
-  expect_equal(uri_scheme_remove("foo/bar"), "foo/bar")
-  expect_equal(uri_scheme_remove("/foo/bar"), "/foo/bar")
-  expect_equal(uri_scheme_remove("file://foo/bar"), "foo/bar")
-  expect_equal(uri_scheme_remove("file:///foo/bar"), "/foo/bar")
+  expect_equal(uri_scheme_remove("int_column/bar"), "int_column/bar")
+  expect_equal(uri_scheme_remove("/int_column/bar"), "/int_column/bar")
+  expect_equal(uri_scheme_remove("file://int_column/bar"), "int_column/bar")
+  expect_equal(uri_scheme_remove("file:///int_column/bar"), "/int_column/bar")
   expect_equal(uri_scheme_remove("s3://my/bucket"), "my/bucket")
   expect_equal(uri_scheme_remove("tiledb://my/array"), "my/array")
 })
 
 test_that("relative uris are calculated correctly", {
-  expect_equal(make_uri_relative("foo/bar", "foo"), "bar")
-  expect_equal(make_uri_relative("/foo/bar", "/foo"), "bar")
-  expect_equal(make_uri_relative("file://foo/bar", "file://foo"), "bar")
+  expect_equal(make_uri_relative("int_column/bar", "int_column"), "bar")
+  expect_equal(make_uri_relative("/int_column/bar", "/int_column"), "bar")
+  expect_equal(make_uri_relative("file://int_column/bar", "file://int_column"), "bar")
 
   # Heterogenous schemes
-  expect_equal(make_uri_relative("foo/bar", "file://foo"), "bar")
-  expect_equal(make_uri_relative("file://foo/bar", "foo"), "bar")
+  expect_equal(make_uri_relative("int_column/bar", "file://int_column"), "bar")
+  expect_equal(make_uri_relative("file://int_column/bar", "int_column"), "bar")
 
   # Expected errors
   expect_error(
-    make_uri_relative("file://bar", "file://foo/bar"),
+    make_uri_relative("file://bar", "file://int_column/bar"),
     "Unable to make relative path between URIs with no common parent"
   )
 
   expect_error(
-    make_uri_relative("s3://foo/bar", "file://foo"),
+    make_uri_relative("s3://int_column/bar", "file://int_column"),
     "Unable to make relative path between URIs with different schemes"
   )
   expect_error(
-    make_uri_relative("s3://foo/bar", "file://foo"),
+    make_uri_relative("s3://int_column/bar", "file://int_column"),
     "Unable to make relative path between URIs with different schemes"
   )
 })

--- a/apis/r/tests/testthat/test-utils-uris.R
+++ b/apis/r/tests/testthat/test-utils-uris.R
@@ -4,8 +4,8 @@ test_that("file path construction handles remote URLs", {
     file.path("int_column")
   )
   expect_identical(
-    file_path("int_column", "bar"),
-    file.path("int_column", "bar")
+    file_path("int_column", "float_column"),
+    file.path("int_column", "float_column")
   )
   expect_identical(
     file_path("s3://my", "bucket", fsep = "\\"),
@@ -18,44 +18,44 @@ test_that("file path construction handles remote URLs", {
 })
 
 test_that("uri schemes are retrieved", {
-  expect_equal(uri_scheme("int_column/bar"), NULL)
-  expect_equal(uri_scheme("/int_column/bar"), NULL)
-  expect_equal(uri_scheme("file://int_column/bar"), "file")
-  expect_equal(uri_scheme("file:///int_column/bar"), "file")
+  expect_equal(uri_scheme("int_column/float_column"), NULL)
+  expect_equal(uri_scheme("/int_column/float_column"), NULL)
+  expect_equal(uri_scheme("file://int_column/float_column"), "file")
+  expect_equal(uri_scheme("file:///int_column/float_column"), "file")
   expect_equal(uri_scheme("s3://my/bucket"), "s3")
   expect_equal(uri_scheme("tiledb://my/array"), "tiledb")
 })
 
 test_that("schemes are removed from uris", {
-  expect_equal(uri_scheme_remove("int_column/bar"), "int_column/bar")
-  expect_equal(uri_scheme_remove("/int_column/bar"), "/int_column/bar")
-  expect_equal(uri_scheme_remove("file://int_column/bar"), "int_column/bar")
-  expect_equal(uri_scheme_remove("file:///int_column/bar"), "/int_column/bar")
+  expect_equal(uri_scheme_remove("int_column/float_column"), "int_column/float_column")
+  expect_equal(uri_scheme_remove("/int_column/float_column"), "/int_column/float_column")
+  expect_equal(uri_scheme_remove("file://int_column/float_column"), "int_column/float_column")
+  expect_equal(uri_scheme_remove("file:///int_column/float_column"), "/int_column/float_column")
   expect_equal(uri_scheme_remove("s3://my/bucket"), "my/bucket")
   expect_equal(uri_scheme_remove("tiledb://my/array"), "my/array")
 })
 
 test_that("relative uris are calculated correctly", {
-  expect_equal(make_uri_relative("int_column/bar", "int_column"), "bar")
-  expect_equal(make_uri_relative("/int_column/bar", "/int_column"), "bar")
-  expect_equal(make_uri_relative("file://int_column/bar", "file://int_column"), "bar")
+  expect_equal(make_uri_relative("int_column/float_column", "int_column"), "float_column")
+  expect_equal(make_uri_relative("/int_column/float_column", "/int_column"), "float_column")
+  expect_equal(make_uri_relative("file://int_column/float_column", "file://int_column"), "float_column")
 
   # Heterogenous schemes
-  expect_equal(make_uri_relative("int_column/bar", "file://int_column"), "bar")
-  expect_equal(make_uri_relative("file://int_column/bar", "int_column"), "bar")
+  expect_equal(make_uri_relative("int_column/float_column", "file://int_column"), "float_column")
+  expect_equal(make_uri_relative("file://int_column/float_column", "int_column"), "float_column")
 
   # Expected errors
   expect_error(
-    make_uri_relative("file://bar", "file://int_column/bar"),
+    make_uri_relative("file://float_column", "file://int_column/float_column"),
     "Unable to make relative path between URIs with no common parent"
   )
 
   expect_error(
-    make_uri_relative("s3://int_column/bar", "file://int_column"),
+    make_uri_relative("s3://int_column/float_column", "file://int_column"),
     "Unable to make relative path between URIs with different schemes"
   )
   expect_error(
-    make_uri_relative("s3://int_column/bar", "file://int_column"),
+    make_uri_relative("s3://int_column/float_column", "file://int_column"),
     "Unable to make relative path between URIs with different schemes"
   )
 })

--- a/apis/r/tests/testthat/test-utils.R
+++ b/apis/r/tests/testthat/test-utils.R
@@ -40,7 +40,7 @@ test_that("validate read coords with dimension names", {
 
   # list of named coordinates must match provided dimension names
   expect_error(
-    validate_read_coords(list(foo = 1:10, bar = 1:10), c("foo", "baz")),
+    validate_read_coords(list(foo = 1:10, bar = 1:10), c("foo", "string_column")),
     "names of 'coords' must correspond to dimension names"
   )
 

--- a/apis/r/tests/testthat/test-utils.R
+++ b/apis/r/tests/testthat/test-utils.R
@@ -24,8 +24,8 @@ test_that("validate read coords", {
   )
 
   expect_equal(
-    validate_read_coords(list(int_column = 1:10, bar = 1:10)),
-    list(int_column = 1:10, bar = 1:10)
+    validate_read_coords(list(int_column = 1:10, float_column = 1:10)),
+    list(int_column = 1:10, float_column = 1:10)
   )
 })
 
@@ -40,12 +40,12 @@ test_that("validate read coords with dimension names", {
 
   # list of named coordinates must match provided dimension names
   expect_error(
-    validate_read_coords(list(int_column = 1:10, bar = 1:10), c("int_column", "string_column")),
+    validate_read_coords(list(int_column = 1:10, float_column = 1:10), c("int_column", "string_column")),
     "names of 'coords' must correspond to dimension names"
   )
 
   expect_error(
-    validate_read_coords(list(int_column = 1:10, bar = 1:10), c("int_column")),
+    validate_read_coords(list(int_column = 1:10, float_column = 1:10), c("int_column")),
     "names of 'coords' must correspond to dimension names"
   )
 })

--- a/apis/r/tests/testthat/test-utils.R
+++ b/apis/r/tests/testthat/test-utils.R
@@ -24,8 +24,8 @@ test_that("validate read coords", {
   )
 
   expect_equal(
-    validate_read_coords(list(foo = 1:10, bar = 1:10)),
-    list(foo = 1:10, bar = 1:10)
+    validate_read_coords(list(int_column = 1:10, bar = 1:10)),
+    list(int_column = 1:10, bar = 1:10)
   )
 })
 
@@ -34,18 +34,18 @@ test_that("validate read coords with dimension names", {
 
   # assume vector or unnamed list of length 1 corresponds to first dimension
   expect_equal(
-    validate_read_coords(1:10, dimnames = "foo"),
-    list(foo = 1:10)
+    validate_read_coords(1:10, dimnames = "int_column"),
+    list(int_column = 1:10)
   )
 
   # list of named coordinates must match provided dimension names
   expect_error(
-    validate_read_coords(list(foo = 1:10, bar = 1:10), c("foo", "string_column")),
+    validate_read_coords(list(int_column = 1:10, bar = 1:10), c("int_column", "string_column")),
     "names of 'coords' must correspond to dimension names"
   )
 
   expect_error(
-    validate_read_coords(list(foo = 1:10, bar = 1:10), c("foo")),
+    validate_read_coords(list(int_column = 1:10, bar = 1:10), c("int_column")),
     "names of 'coords' must correspond to dimension names"
   )
 })
@@ -62,8 +62,8 @@ test_that("validate read coords with dimension names and schema", {
 
   # assume vector or unnamed list of length 1 corresponds to first dimension
   expect_equal(
-    validate_read_coords(1:10, dimnames = "foo", schema = asch),
-    list(foo = 1:10)
+    validate_read_coords(1:10, dimnames = "int_column", schema = asch),
+    list(int_column = 1:10)
   )
 
   # integer coordinates corresponding to int64 dimensions are cast to int64
@@ -74,11 +74,11 @@ test_that("validate read coords with dimension names and schema", {
 
   # casting is selective and only applies to int64 dimensions
   test_coords <- validate_read_coords(
-      coords = list(foo = 1:10, soma_joinid = 1:10),
-      dimnames = c("foo", "soma_joinid"),
+      coords = list(int_column = 1:10, soma_joinid = 1:10),
+      dimnames = c("int_column", "soma_joinid"),
       schema = asch
   )
 
-  expect_equal(test_coords$foo, 1:10)
+  expect_equal(test_coords$int_column, 1:10)
   expect_equal(test_coords$soma_joinid, as.integer64(1:10))
 })


### PR DESCRIPTION
**Issue and/or context:** The names `foo` `bar` `baz` are giving me some context-switching headaches -- which one is the string again? This PR simply makes the names of the attributes say what they are.

Part of #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).
