### PR TITLE
[c++] Extend some unit-test cases for new shape

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1422,11 +1422,6 @@ void SOMAArray::_set_current_domain_from_shape(
     // Variant-indexed dataframes must use a separate path
     _check_dims_are_int64();
 
-    if (_get_current_domain().is_empty()) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must already be sized");
-    }
-
     auto tctx = ctx_->tiledb_ctx();
     ArraySchema schema = arr_->schema();
     Domain domain = schema.domain();

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -879,8 +879,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: variant-indexed dataframe dim-sjid-str attr-u32",
     "[SOMADataFrame]") {
-    // auto use_current_domain = GENERATE(false, true);
-    auto use_current_domain = GENERATE(false);
+    auto use_current_domain = GENERATE(false, true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -979,7 +978,12 @@ TEST_CASE_METHOD(
         REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
         REQUIRE(dom_str == std::vector<std::string>({"", ""}));
 
-        REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        if (!use_current_domain) {
+            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        } else {
+            REQUIRE(maxdom_sjid[0] == 0);
+            REQUIRE(maxdom_sjid[1] > 2000000000);
+        }
         REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
 
         soma_dataframe->close();
@@ -1059,7 +1063,13 @@ TEST_CASE_METHOD(
         REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
         REQUIRE(dom_str == std::vector<std::string>({"", ""}));
 
-        REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        if (!use_current_domain) {
+            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+        } else {
+            REQUIRE(maxdom_sjid[0] == 0);
+            REQUIRE(maxdom_sjid[1] > 2000000000);
+        }
+
         REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -150,6 +150,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             soma_sparse->close();
 
             soma_sparse->open(OpenMode::read);
+            REQUIRE(soma_sparse->has_current_domain());
             soma_sparse->close();
 
             soma_sparse->open(OpenMode::write);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -39,8 +39,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     int64_t dim_max = 999;
     int64_t shape = 1000;
 
-    // auto use_current_domain = GENERATE(false, true);
-    auto use_current_domain = GENERATE(true);
+    auto use_current_domain = GENERATE(false, true);
     // TODO this could be formatted with fmt::format which is part of internal
     // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
     // replaced with std::format.
@@ -148,6 +147,12 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             REQUIRE_THROWS(soma_sparse->resize(new_shape));
             // Now set the shape
             soma_sparse->upgrade_shape(new_shape);
+            soma_sparse->close();
+
+            soma_sparse->open(OpenMode::read);
+            soma_sparse->close();
+
+            soma_sparse->open(OpenMode::write);
             REQUIRE(soma_sparse->has_current_domain());
             // Should not fail since we're setting it to what it already is.
             soma_sparse->resize(new_shape);


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

For various debugs a while back I'd apparently left some Catch2 flags to on or off vs. looping over both. This PR fixes those overssights.

**Notes for Reviewer:**
