### PR TITLE
[r] Fix up doc blocks and re-run roxygenise

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -69,8 +69,8 @@ get_metadata_num <- function(uri, is_array, ctxxp) {
 
 #' Read all metadata (as named list)
 #'
-#' This function currently supports metadata as either a string or an 'int64' (or 'int32').
-#' It will error if a different datatype is encountered.
+#' This function currently supports metadata as either a string or an 'int64'
+#' (or 'int32'). It will error if a different datatype is encountered.
 #' @param uri The array URI
 #' @param is_array A boolean to indicate array or group
 #' @param ctxxp An external pointer to the SOMAContext wrapper
@@ -145,9 +145,11 @@ soma_array_reader_impl <- function(uri, ctxxp, colnames = NULL, qc = NULL, dim_p
 
 #' Set the logging level for the R package and underlying C++ library
 #'
-#' @param level A character value with logging level understood by \sQuote{spdlog}
-#' such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or \dQuote{warn}.
-#' @return Nothing is returned as the function is invoked for the side-effect.
+#' @param level A character value with logging level understood by
+#' \sQuote{spdlog} such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or
+#' \dQuote{warn}.
+#' @return Nothing is returned as the function is invoked for
+#' the side-effect.
 #' @export
 set_log_level <- function(level) {
     invisible(.Call(`_tiledbsoma_set_log_level`, level))
@@ -217,23 +219,29 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, ctxxp) {
 #' @param uri Character value with URI path to a SOMA data set
 #' @param config Named chracter vector with \sQuote{key} and \sQuote{value} pairs
 #' used as TileDB config parameters.
-#' @param colnames Optional vector of character value with the name of the columns to retrieve
-#' @param qc Optional external Pointer object to TileDB Query Condition, defaults to \sQuote{NULL} i.e.
-#' no query condition
-#' @param dim_points Optional named list with vector of data points to select on the given
-#' dimension(s). Each dimension can be one entry in the list.
-#' @param dim_ranges Optional named list with two-column matrix where each row select a range
-#' for the given dimension. Each dimension can be one entry in the list.
-#' @param batch_size Optional argument for size of data batches, defaults to \sQuote{auto}
-#' @param result_order Optional argument for query result order, defaults to \sQuote{auto}
-#' @param loglevel Character value with the desired logging level, defaults to \sQuote{auto}
-#' which lets prior setting prevail, any other value is set as new logging level.
-#' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start and end of
-#' interval for which data is considered.
-#' @param sr An external pointer to a TileDB SOMAArray object
+#' @param colnames Optional vector of character value with the name of the
+#' columns to retrieve
+#' @param qc Optional external Pointer object to TileDB Query Condition,
+#' defaults to \sQuote{NULL} i.e. no query condition
+#' @param dim_points Optional named list with vector of data points to select
+#' on the given dimension(s). Each dimension can be one entry in the list.
+#' @param dim_ranges Optional named list with two-column matrix where each row
+#' select a range for the given dimension. Each dimension can be one entry in
+#'the list.
+#' @param batch_size Optional argument for size of data batches, defaults to
+#'\sQuote{auto}
+#' @param result_order Optional argument for query result order, defaults to
+#' \sQuote{auto}
+#' @param loglevel Character value with the desired logging level, defaults to
+#' \sQuote{auto} which lets prior setting prevail, any other value is set as
+#' new logging level.
+#' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start
+#' and end of ' interval for which data is considered.
+#' @param sr An external pointer to a TileDB SOMAArray object.
 #'
-#' @return \code{sr_setup} returns an external pointer to a SOMAArray. \code{sr_complete}
-#' returns a boolean, and \code{sr_next} returns an Arrow array helper object.
+#' @return \code{sr_setup} returns an external pointer to a SOMAArray.
+#' \code{sr_complete} ' returns a boolean, and \code{sr_next} returns an Arrow
+#' array helper object.
 #'
 #' @examples
 #' \dontrun{
@@ -249,6 +257,8 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, ctxxp) {
 #' summary(rl)
 #' }
 #' @noRd
+NULL
+
 sr_setup <- function(uri, ctxxp, colnames = NULL, qc = NULL, dim_points = NULL, dim_ranges = NULL, batch_size = "auto", result_order = "auto", timestamprange = NULL, loglevel = "auto") {
     .Call(`_tiledbsoma_sr_setup`, uri, ctxxp, colnames, qc, dim_points, dim_ranges, batch_size, result_order, timestamprange, loglevel)
 }
@@ -277,10 +287,11 @@ sr_set_dim_points <- function(sr, dim, points) {
 
 #' TileDB SOMA statistics
 #'
-#' These functions expose the TileDB Core functionality for performance measurements
-#' and statistics.
+#' These functions expose the TileDB Core functionality for performance
+#'  measurements and statistics.
 #'
-#' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and disable TileDB's internal statistics.
+#' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and
+#'    disable TileDB's internal statistics.
 #' - `tiledbsoma_stats_reset()`: Reset all statistics to 0.
 #' - `tiledbsoma_stats_dump()`: Dump all statistics to a JSON string.
 #' - `tiledbsoma_stats_show()`: Print all statistics to the console.
@@ -311,9 +322,9 @@ tiledbsoma_stats_dump <- function() {
 
 #' libtiledbsoma version
 #'
-#' Returns a string with version information for libtiledbsoma and the linked TileDB Embedded library.
-#' If argument `compact` is set to `TRUE`, a shorter version of just the TileDB Embedded library
-#' version is returned,
+#' Returns a string with version information for libtiledbsoma and the linked
+#' TileDB Embedded library. If argument `compact` is set to `TRUE`, a shorter
+#' version of just the TileDB Embedded library version is returned.
 #' @noRd
 libtiledbsoma_version <- function(compact = FALSE, major_minor_only = FALSE) {
     .Call(`_tiledbsoma_libtiledbsoma_version`, compact, major_minor_only)

--- a/apis/r/man/BlockwiseReadIterBase.Rd
+++ b/apis/r/man/BlockwiseReadIterBase.Rd
@@ -8,7 +8,7 @@ Class that allows for blockwise read iteration of SOMA reads
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{BlockwiseReadIterBase}
+\code{tiledbsoma::ReadIter} -> \code{BlockwiseReadIterBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/BlockwiseSparseReadIter.Rd
+++ b/apis/r/man/BlockwiseSparseReadIter.Rd
@@ -9,7 +9,7 @@ as sparse matrices
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseSparseReadIter}
+\code{tiledbsoma::ReadIter} -> \code{tiledbsoma::BlockwiseReadIterBase} -> \code{BlockwiseSparseReadIter}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/BlockwiseTableReadIter.Rd
+++ b/apis/r/man/BlockwiseTableReadIter.Rd
@@ -9,7 +9,7 @@ as Arrow \code{\link[Arrow]{Table}s}
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseTableReadIter}
+\code{tiledbsoma::ReadIter} -> \code{tiledbsoma::BlockwiseReadIterBase} -> \code{BlockwiseTableReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/ConfigList.Rd
+++ b/apis/r/man/ConfigList.Rd
@@ -10,7 +10,7 @@ Essentially, serves as a nested map where the inner map is a
 \code{\{<param>: \link[tiledbsoma:ScalarMap]{\{<key>: <value>\}}\}}
 }
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ConfigList}
+\code{tiledbsoma::MappingBase} -> \code{ConfigList}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/EphemeralCollection.Rd
+++ b/apis/r/man/EphemeralCollection.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralCollection}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralCollection}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralCollectionBase.Rd
+++ b/apis/r/man/EphemeralCollectionBase.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{EphemeralCollectionBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{EphemeralCollectionBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralExperiment.Rd
+++ b/apis/r/man/EphemeralExperiment.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralExperiment}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralExperiment}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralMeasurement.Rd
+++ b/apis/r/man/EphemeralMeasurement.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralMeasurement}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralMeasurement}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/PlatformConfig.Rd
+++ b/apis/r/man/PlatformConfig.Rd
@@ -11,7 +11,7 @@ map is a \code{\link{ScalarMap}} contained within a \code{\link{ConfigList}}
 \code{\{platform: \{param: \{key: value\}\}\}}
 }
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{PlatformConfig}
+\code{tiledbsoma::MappingBase} -> \code{PlatformConfig}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -9,7 +9,7 @@ experimental)
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{SOMAArrayBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{SOMAArrayBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -10,7 +10,7 @@ the values are any SOMA-defined foundational or composed type, including
 \code{\link{SOMASparseNDArray}}, or \code{\link{SOMAExperiment}}.  (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMACollection}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMACollection}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -12,7 +12,7 @@ objects, mapping string keys to any SOMA object.  (lifecycle: maturing)
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{SOMACollectionBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{SOMACollectionBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAContextBase.Rd
+++ b/apis/r/man/SOMAContextBase.Rd
@@ -10,7 +10,7 @@ context options
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{SOMAContextBase}
+\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{SOMAContextBase}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -10,7 +10,7 @@ row and is intended to act as a join key for other objects, such as
 \code{\link{SOMASparseNDArray}}.  (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMADataFrame}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMADataFrame}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -25,7 +25,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{\link[tiledbsoma:SOMANDArrayBase]{tiledbsoma::SOMANDArrayBase}} -> \code{SOMADenseNDArray}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{tiledbsoma::SOMANDArrayBase} -> \code{SOMADenseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -23,7 +23,7 @@ default platform configuration by passing a custom configuration to the
 }
 
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAExperiment}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAExperiment}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAMeasurement.Rd
+++ b/apis/r/man/SOMAMeasurement.Rd
@@ -23,7 +23,7 @@ default platform configuration by passing a custom configuration to the
 }
 
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAMeasurement}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAMeasurement}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMANDArrayBase.Rd
+++ b/apis/r/man/SOMANDArrayBase.Rd
@@ -9,7 +9,7 @@ Adds NDArray-specific functionality to the \code{\link{SOMAArrayBase}} class.
 }
 \keyword{internal}
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMANDArrayBase}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMANDArrayBase}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -23,7 +23,7 @@ the object are overwritten and new index values are added. (lifecycle: maturing)
 }
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{\link[tiledbsoma:SOMANDArrayBase]{tiledbsoma::SOMANDArrayBase}} -> \code{SOMASparseNDArray}
+\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{tiledbsoma::SOMANDArrayBase} -> \code{SOMASparseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMASparseNDArrayBlockwiseRead.Rd
+++ b/apis/r/man/SOMASparseNDArrayBlockwiseRead.Rd
@@ -8,7 +8,7 @@ Blockwise reader for \code{\link{SOMASparseNDArray}}
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:SOMASparseNDArrayReadBase]{tiledbsoma::SOMASparseNDArrayReadBase}} -> \code{SOMASparseNDArrayBlockwiseRead}
+\code{tiledbsoma::SOMASparseNDArrayReadBase} -> \code{SOMASparseNDArrayBlockwiseRead}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMASparseNDArrayRead.Rd
+++ b/apis/r/man/SOMASparseNDArrayRead.Rd
@@ -8,7 +8,7 @@ Intermediate type to choose result format when reading a sparse array
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:SOMASparseNDArrayReadBase]{tiledbsoma::SOMASparseNDArrayReadBase}} -> \code{SOMASparseNDArrayRead}
+\code{tiledbsoma::SOMASparseNDArrayReadBase} -> \code{SOMASparseNDArrayRead}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -7,7 +7,7 @@
 Context map for TileDB-backed SOMA objects
 }
 \section{Super classes}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{\link[tiledbsoma:SOMAContextBase]{tiledbsoma::SOMAContextBase}} -> \code{SOMATileDBContext}
+\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{tiledbsoma::SOMAContextBase} -> \code{SOMATileDBContext}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/ScalarMap.Rd
+++ b/apis/r/man/ScalarMap.Rd
@@ -10,7 +10,7 @@ optionally be limited further to a specific atomic vector type
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ScalarMap}
+\code{tiledbsoma::MappingBase} -> \code{ScalarMap}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SparseReadIter.Rd
+++ b/apis/r/man/SparseReadIter.Rd
@@ -9,7 +9,7 @@ a reads on \link{SOMASparseNDArray}.
 Iteration chunks are retrieved as 0-based Views \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
 }
 \section{Super class}{
-\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{SparseReadIter}
+\code{tiledbsoma::ReadIter} -> \code{SparseReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TableReadIter.Rd
+++ b/apis/r/man/TableReadIter.Rd
@@ -9,7 +9,7 @@ a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
 Iteration chunks are retrieved as arrow::\link[arrow]{Table}
 }
 \section{Super class}{
-\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{TableReadIter}
+\code{tiledbsoma::ReadIter} -> \code{TableReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TileDBArray.Rd
+++ b/apis/r/man/TileDBArray.Rd
@@ -9,7 +9,7 @@ Base class for representing an individual TileDB array.
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBArray}
+\code{tiledbsoma::TileDBObject} -> \code{TileDBArray}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/TileDBCreateOptions.Rd
+++ b/apis/r/man/TileDBCreateOptions.Rd
@@ -60,7 +60,7 @@ tdco$attr_filters("non-existant")
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{TileDBCreateOptions}
+\code{tiledbsoma::MappingBase} -> \code{TileDBCreateOptions}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TileDBGroup.Rd
+++ b/apis/r/man/TileDBGroup.Rd
@@ -11,7 +11,7 @@ Base class for interacting with TileDB groups (lifecycle: maturing)
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBGroup}
+\code{tiledbsoma::TileDBObject} -> \code{TileDBGroup}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/get_all_metadata.Rd
+++ b/apis/r/man/get_all_metadata.Rd
@@ -14,6 +14,6 @@ get_all_metadata(uri, is_array, ctxxp)
 \item{ctxxp}{An external pointer to the SOMAContext wrapper}
 }
 \description{
-This function currently supports metadata as either a string or an 'int64' (or 'int32').
-It will error if a different datatype is encountered.
+This function currently supports metadata as either a string or an 'int64'
+(or 'int32'). It will error if a different datatype is encountered.
 }

--- a/apis/r/man/set_log_level.Rd
+++ b/apis/r/man/set_log_level.Rd
@@ -7,11 +7,13 @@
 set_log_level(level)
 }
 \arguments{
-\item{level}{A character value with logging level understood by \sQuote{spdlog}
-such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or \dQuote{warn}.}
+\item{level}{A character value with logging level understood by
+\sQuote{spdlog} such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or
+\dQuote{warn}.}
 }
 \value{
-Nothing is returned as the function is invoked for the side-effect.
+Nothing is returned as the function is invoked for
+the side-effect.
 }
 \description{
 Set the logging level for the R package and underlying C++ library

--- a/apis/r/man/tiledbsoma_stats.Rd
+++ b/apis/r/man/tiledbsoma_stats.Rd
@@ -20,12 +20,13 @@ tiledbsoma_stats_dump()
 tiledbsoma_stats_show()
 }
 \description{
-These functions expose the TileDB Core functionality for performance measurements
-and statistics.
+These functions expose the TileDB Core functionality for performance
+measurements and statistics.
 }
 \details{
 \itemize{
-\item \code{tiledbsoma_stats_enable()}/\code{tiledbsoma_stats_disable()}: Enable and disable TileDB's internal statistics.
+\item \code{tiledbsoma_stats_enable()}/\code{tiledbsoma_stats_disable()}: Enable and
+disable TileDB's internal statistics.
 \item \code{tiledbsoma_stats_reset()}: Reset all statistics to 0.
 \item \code{tiledbsoma_stats_dump()}: Dump all statistics to a JSON string.
 \item \code{tiledbsoma_stats_show()}: Print all statistics to the console.

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -1,4 +1,4 @@
-#include <Rcpp/Lighter>             // for R interface to C++
+#include <Rcpp/Lighter>  // for R interface to C++
 
 #include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
@@ -55,7 +55,7 @@ int32_t get_metadata_num(
 //' Read all metadata (as named list)
 //'
 //' This function currently supports metadata as either a string or an 'int64'
-//' (or 'int32'). ' It will error if a different datatype is encountered.
+//' (or 'int32'). It will error if a different datatype is encountered.
 //' @param uri The array URI
 //' @param is_array A boolean to indicate array or group
 //' @param ctxxp An external pointer to the SOMAContext wrapper

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -210,9 +210,11 @@ SEXP soma_array_reader(
 //' Set the logging level for the R package and underlying C++ library
 //'
 //' @param level A character value with logging level understood by
-//\sQuote{spdlog} ' such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or
-//\dQuote{warn}. ' @return Nothing is returned as the function is invoked for
-// the side-effect. ' @export
+//' \sQuote{spdlog} such as \dQuote{trace}, \dQuote{debug}, \dQuote{info}, or
+//' \dQuote{warn}.
+//' @return Nothing is returned as the function is invoked for
+//' the side-effect.
+//' @export
 // [[Rcpp::export]]
 void set_log_level(const std::string& level) {
     spdl::setup("R", level);

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -49,7 +49,7 @@ namespace tdbs = tiledbsoma;
 //' \sQuote{auto}
 //' @param loglevel Character value with the desired logging level, defaults to
 //' \sQuote{auto} which lets prior setting prevail, any other value is set as
-//new logging level.
+//' new logging level.
 //' @param timestamprange Optional POSIXct (i.e. Datetime) vector with start
 //' and end of ' interval for which data is considered.
 //' @param sr An external pointer to a TileDB SOMAArray object.

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -310,7 +310,7 @@ std::vector<int64_t> i64_from_rcpp_numeric(const Rcpp::NumericVector& input) {
 //'  measurements and statistics.
 //'
 //' - `tiledbsoma_stats_enable()`/`tiledbsoma_stats_disable()`: Enable and
-//' disable TileDB's internal statistics.
+//'    disable TileDB's internal statistics.
 //' - `tiledbsoma_stats_reset()`: Reset all statistics to 0.
 //' - `tiledbsoma_stats_dump()`: Dump all statistics to a JSON string.
 //' - `tiledbsoma_stats_show()`: Print all statistics to the console.
@@ -348,8 +348,8 @@ std::string tiledbsoma_stats_dump() {
 //' libtiledbsoma version
 //'
 //' Returns a string with version information for libtiledbsoma and the linked
-// TileDB Embedded library. If argument `compact` is set to `TRUE`, a shorter
-// version of just the TileDB Embedded library version is returned.
+//' TileDB Embedded library. If argument `compact` is set to `TRUE`, a shorter
+//' version of just the TileDB Embedded library version is returned.
 //' @noRd
 // [[Rcpp::export]]
 std::string libtiledbsoma_version(


### PR DESCRIPTION
**Issue and/or context:** Completing #3048. Part of  #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

* Fix bad `//'` formatting in `src/*.cpp`
* Re-run `Rscript -e "Rcpp::compileAttributes()` to regenerate `R/RcppExports.R` and `src/RcppExports.cpp` from that
* Re-run `Rscript -e 'roxygen2::roxygenise()'` to regenerate `*.Rd` files

**Notes for Reviewer:**

There is maybe 'too much' on this PR as I was prompted yesterday or earlier today to upgrade my `roxygen2`:
```
> packageVersion('roxygen2')
[1] ‘7.3.2’
```

I think some of the mods showing on this PR are coming from that.

I'm happy to try to split this PR into (a) mods originating from `src/*.cpp`, and (b) mods from roxygenising with 7.3.2.