### PR TITLE
[python] Remove more Python 3.8 references

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '38', '39', '310', '311' ]
+        python-version: [ '39', '310', '311' ]
         cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
           - cibw_build: manylinux_x86_64

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -23,7 +23,7 @@ lint.ignore = ["E501"]  # line too long
 lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293


### PR DESCRIPTION
**Issue and/or context:** https://github.com/single-cell-data/TileDB-SOMA/issues/3072

Daily "TileDB-SOMA python sdist & wheels" workflow was still attempting to use Python 3.8, and failed.