### PR TITLE
Bulk-backport Python 3.8 and `somacore` 1.0.17 mods to `release-1.14` branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Provide a code example and any sample input data (e.g. an H5AD) as an attachment
 
 **Versions (please complete the following information):**
  - TileDB-SOMA version:
- - Language and language version (e.g. Python 3.8, R 4.2.2):
+ - Language and language version (e.g. Python 3.9, R 4.3.2):
  - OS (e.g. MacOS, Ubuntu Linux):
  - Note: you can use `tiledbsoma.show_package_versions()` (Python) or `tiledbsoma::show_package_versions()` (R)
 

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -25,7 +25,7 @@ jobs:
         # os: [ubuntu-22.04, macos-12, windows-2019]
         # TODO: add 3.12
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         include:
           - runs-on: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -29,7 +29,7 @@ jobs:
 
       matrix:
         os: [ubuntu-22.04, macos-12]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.11']
         include:
           - os: ubuntu-22.04
             cc: gcc-11

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '38', '39', '310', '311' ]
+        python-version: [ '39', '310', '311' ]
         cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
           - cibw_build: manylinux_x86_64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore==1.0.15"
+        - "somacore==1.0.17"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -12,7 +12,7 @@ show_error_codes = true
 ignore_missing_imports = true
 warn_unreachable = true
 strict = true
-python_version = 3.8
+python_version = 3.9
 
 [[tool.mypy.overrides]]
 module = "tiledbsoma._query_condition"
@@ -23,7 +23,7 @@ lint.ignore = ["E501"]  # line too long
 lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -288,7 +288,6 @@ setuptools.setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -327,7 +326,7 @@ setuptools.setup(
     setup_requires=["pybind11"],
     install_requires=[
         # Tracked in https://github.com/single-cell-data/TileDB-SOMA/issues/1785
-        "anndata != 0.10.0; python_version>='3.8'",
+        "anndata != 0.10.0",
         "attrs>=22.2",
         "numba>=0.58.0",
         "numpy<2.0",
@@ -336,14 +335,14 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore==1.0.15",
+        "somacore==1.0.17",
         "tiledb~=0.32.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={
         "dev": open("requirements_dev.txt").read(),
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass={"build_ext": build_ext, "bdist_wheel": bdist_wheel},
     version=version.get_version(),
 )

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2655,11 +2655,11 @@ def _ingest_uns_string_array(
     """
 
     if len(value.shape) == 1:
-        helper = _ingest_uns_1d_string_array  # type:ignore[unreachable]
+        helper = _ingest_uns_1d_string_array
     elif len(value.shape) == 2:
         helper = _ingest_uns_2d_string_array
     else:
-        msg = (  # type:ignore[unreachable]
+        msg = (
             f"Skipped {coll.uri}[{key!r}]"
             f" (uns object): string array is neither one-dimensional nor two-dimensional"
         )

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.14.1
+Version: 1.14.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,9 @@
+# tiledbsoma 1.14.2
+
+## Changes
+
+* Fixes a Python-only bug [#3074](https://github.com/single-cell-data/TileDB-SOMA/pull/3074)
+
 # tiledbsoma 1.14.1
 
 ## Changes


### PR DESCRIPTION
This contains backports of #3021 #3070 #3073. Done as a  single PR to reduce CI burden.

[[sc-56256]](https://app.shortcut.com/tiledb-inc/story/56256/tiledb-soma-1-14-2)