### PR TITLE
[python] Replace deprecated `wheel.bdist_wheel` with `setuptools.command.bdist_wheel`

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -65,7 +65,7 @@ jobs:
           apt-get install --yes cmake git python-is-python3 python3 python3-pip python3-venv unzip wget
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Configure Git
         run: |
           # This is a permissions quirk due to running Git as root inside of a Docker container
@@ -101,7 +101,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse 'setuptools>=70.1' wheel
           ./venv-soma/bin/pip list
       - name: Build wheel
         run: |
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Check if System Integrity Protection (SIP) is enabled
         run: csrutil status
       - name: Install pre-built libtiledb
@@ -201,7 +201,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel 'setuptools>=70.1'
           ./venv-soma/bin/pip list
       - name: Build wheel
         run: |
@@ -257,7 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Install pre-built libtiledb
         run: |
           mkdir -p external
@@ -302,7 +302,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel 'setuptools>=70.1'
           ./venv-soma/bin/pip list
       - name: Install TileDB-SOMA-Py with setuptools and --libtiledbsoma
         run: |
@@ -357,13 +357,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: TileDB-SOMA
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install --prefer-binary pybind11 wheel
+        run: pip install --prefer-binary pybind11 'setuptools>=70.1' wheel
       - name: Build source tarball (sdist)
         run: |
           cd TileDB-SOMA/apis/python

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "pybind11[global]>=2.10.0",
-    "setuptools>=65.5.1",
-    "wheel>=0.37.1",
+    "setuptools>=70.1",  # `setuptools.command.bdist_wheel`
     "cmake>=3.21",
 ]
 build-backend = "setuptools.build_meta"

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -21,8 +21,8 @@ import subprocess
 import sys
 from typing import Optional
 
+import setuptools.command.bdist_wheel
 import setuptools.command.build_ext
-import wheel.bdist_wheel
 
 try:
     from pybind11.setup_helpers import Pybind11Extension
@@ -219,7 +219,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
         super().run()
 
 
-class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
+class bdist_wheel(setuptools.command.bdist_wheel.bdist_wheel):
     def run(self):
         find_or_build_package_data(self)
         super().run()

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -6,7 +6,7 @@ jinja2==3.1.4
 nbsphinx==0.9.3
 pandoc==2.3
 pybind11==2.12.0
-setuptools==70.0.0
+setuptools==75.1.0
 setuptools-scm==8.1.0
 sphinx==7.3.7
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
**Issue and/or context:**

As of `wheel>=44.0.0` (Aug '24), `wheel.bdist_wheel` [warns](https://github.com/pypa/wheel/blob/0.44.0/src/wheel/bdist_wheel.py#L5-L11):

```python
warn(
    "The 'wheel' package is no longer the canonical location of the 'bdist_wheel' "
    "command, and will be removed in a future release. Please update to setuptools "
    "v70.1 or later which contains an integrated version of this command.",
    DeprecationWarning,
    stacklevel=1,
)
```

I've moved us to `setuptools>=70.1` and `setuptools.command.bdist_wheel` here; hopefully this is a no-op / CI will surface any issues…
