### PR TITLE
[r] Address some pkgdown GHA warnings

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,13 +26,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v1
-        with:
-          working-directory: "apis/r"
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          working-directory: "apis/r"
 
       - name: Set additional repositories (macOS)
         if: ${{ matrix.os != 'ubuntu-latest' }}


### PR DESCRIPTION
**Issue and/or context:** Address some warnings in [pkgdown GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/pkgdown.yaml) ([example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11058461787))

- Neither [setup-pandoc@v1] nor [setup-r@v2](https://github.com/r-lib/actions/blob/v2/setup-r/action.yml) takes a `working-directory` input
- [setup-pandoc@v1] is deprecated; bumping to `@v2`

**Notes for Reviewer:**
How can I verify that bumping to [setup-pandoc@v2] is a no-op?

I've manually run it against this PR [here](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11059535835/job/30728069442).

[setup-pandoc@v1]: https://github.com/r-lib/actions/blob/v1/setup-pandoc/action.yml
[setup-pandoc@v2]: https://github.com/r-lib/actions/blob/v2/setup-pandoc/action.yml