### PR TITLE
[python] Update TileDB-SOMA to use the `somacore` release with spatial datatypes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore==1.0.17"
+        - "somacore==1.0.18"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -335,7 +335,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is in .pre-commit-config.yaml too
-        "somacore==1.0.17",
+        "somacore==1.0.18",
         "tiledb~=0.32.0",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],

--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -13,6 +13,6 @@ SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
 SOMA_ENCODING_VERSION = "1"
 
 SPATIAL_DISCLAIMER = (
-    "The support for spatial types is experimental. Changes to both the API and data "
+    "Support for spatial types is experimental. Changes to both the API and data "
     "storage may not be backwards compatible."
 )

--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -7,6 +7,12 @@
 """
 
 SOMA_JOINID = "soma_joinid"
+SOMA_GEOMETRY = "soma_geometry"
 SOMA_OBJECT_TYPE_METADATA_KEY = "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
 SOMA_ENCODING_VERSION = "1"
+
+SPATIAL_DISCLAIMER = (
+    "The support for spatial types is experimental. Changes to both the API and data "
+    "storage may not be backwards compatible."
+)

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -6,7 +6,7 @@
 """Implementation of a SOMA Experiment.
 """
 import functools
-from typing import Optional
+from typing import Optional, Union
 
 from somacore import experiment, query
 from typing_extensions import Self
@@ -16,6 +16,7 @@ from ._collection import Collection, CollectionBase
 from ._dataframe import DataFrame
 from ._indexer import IntIndexer
 from ._measurement import Measurement
+from ._scene import Scene
 from ._soma_object import AnySOMAObject
 
 
@@ -24,6 +25,7 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     experiment.Experiment[  # type: ignore[type-var]
         DataFrame,
         Collection[Measurement],
+        Collection[Union[DataFrame, Scene]],
         AnySOMAObject,
     ],
 ):
@@ -43,6 +45,8 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
             defined in this dataframe.
         ms (Collection):
             A collection of named measurements.
+        spatial (Collection):
+            A collection of spatial scenes.
 
     Example:
         >>> import tiledbsoma
@@ -69,6 +73,8 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     _subclass_constrained_soma_types = {
         "obs": ("SOMADataFrame",),
         "ms": ("SOMACollection",),
+        "spatial": ("SOMACollection",),
+        "obs_spatial_presence": ("SOMADataFrame",),
     }
 
     def axis_query(  # type: ignore

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -6,7 +6,7 @@
 """Implementation of a SOMA Experiment.
 """
 import functools
-from typing import Optional, Union
+from typing import Optional
 
 from somacore import experiment, query
 from typing_extensions import Self
@@ -25,7 +25,7 @@ class Experiment(  # type: ignore[misc]  # __eq__ false positive
     experiment.Experiment[  # type: ignore[type-var]
         DataFrame,
         Collection[Measurement],
-        Collection[Union[DataFrame, Scene]],
+        Collection[Scene],
         AnySOMAObject,
     ],
 ):

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -67,7 +67,7 @@ class GeometryDataFrame(somacore.GeometryDataFrame):
             schema: Arrow schema defining the per-column schema. This schema
                 must define all columns, including columns to be named as index
                 columns.  If the schema includes types unsupported by the SOMA
-                implementation, an error will be raised.
+                implementation, a ValueError will be raised.
             index_column_names: A list of column names to use as user-defined
                 index columns (e.g., ``['cell_type', 'tissue_type']``).
                 All named columns must exist in the schema, and at least one

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -12,7 +12,7 @@ from typing import Any, Optional, Sequence, Tuple, Union
 import pyarrow as pa
 import somacore
 from somacore import CoordinateSpace, CoordinateTransform, options
-from typing_extension import Self
+from typing_extensions import Self
 
 from ._constants import SOMA_GEOMETRY, SOMA_JOINID, SPATIAL_DISCLAIMER
 from ._dataframe import Domain

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2024 The Chan Zuckerberg Initiative Foundation
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+"""
+Implementataion of a SOMA Geometry DataFrame
+"""
+
+import warnings
+from typing import Any, Optional, Sequence, Tuple, Union
+
+import pyarrow as pa
+import somacore
+from somacore import CoordinateSpace, CoordinateTransform, options
+from typing_extension import Self
+
+from ._constants import SOMA_GEOMETRY, SOMA_JOINID, SPATIAL_DISCLAIMER
+from ._dataframe import Domain
+from ._read_iters import TableReadIter
+from ._types import OpenTimestamp
+from .options import SOMATileDBContext
+
+_UNBATCHED = options.BatchSize()
+
+
+class GeometryDataFrame(somacore.GeometryDataFrame):
+    """A specialized SOMA object for storing complex geometries with spatial indexing.
+
+    The ``GeometryDataFrame`` class is designed to store and manage geometric shapes
+    such as polygons, lines, and multipoints, along with additional columns for
+    associated attributes.
+
+    Lifecycle:
+        Experimental.
+    """
+
+    __slots__ = ()
+
+    # Lifecycle
+
+    @classmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (SOMA_JOINID, SOMA_GEOMETRY),
+        axis_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Domain] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
+    ) -> Self:
+        """Creates a new ``GeometryDataFrame`` at the given URI.
+
+        The schema of the created geometry dataframe will include a column named
+        ``soma_joinid`` of type ``pyarrow.int64``, with negative values
+        disallowed, and a column named ``soma_geometry of type ``pyarrow.binary`` or
+        ``pyarrow.large_binary``.  If a ``soma_joinid`` column or ``soma_geometry``
+        are present in the provided schema, they must be of the correct type.  If
+        either the ``soma_joinid`` column or ``soma_geometry`` column are not provided,
+        one will be added. The ``soma_joinid`` may be an index column. The
+        ``soma_geometry`` column must be an index column.
+
+        Args:
+            uri: The URI where the dataframe will be created.
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
+            index_column_names: A list of column names to use as user-defined
+                index columns (e.g., ``['cell_type', 'tissue_type']``).
+                All named columns must exist in the schema, and at least one
+                index column name is required.
+            axis_names: An ordered list of axis column names that correspond to the
+                names of the axes of the coordinate space the geometries are defined
+                on.
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Two tuples must be provided for the ``soma_geometry``
+                column which store the width followed by the height. Each tuple should
+                be a pair consisting of the minimum and maximum values storable in the
+                index column. If omitted entirely, or if ``None`` in a given dimension,
+                the corresponding index-column domain will use the minimum and maximum
+                possible values for the column's datatype.  This makes a dataframe
+                growable.
+
+        Returns:
+            The newly created geometry dataframe, opened for writing.
+
+        Lifecycle:
+            Experimental.
+        """
+        warnings.warn(SPATIAL_DISCLAIMER)
+        raise NotImplementedError()
+
+    # Data operations
+
+    def read(
+        self,
+        coords: options.SparseDFCoords = (),
+        column_names: Optional[Sequence[str]] = None,
+        *,
+        batch_size: options.BatchSize = _UNBATCHED,
+        partitions: Optional[options.ReadPartitions] = None,
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
+        value_filter: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> TableReadIter:
+        """Reads a user-defined slice of data into Arrow tables.
+
+        Args:
+            coords: for each index dimension, which rows to read.
+                Defaults to ``()``, meaning no constraint -- all IDs.
+            column_names: the named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            partitions: If present, specifies that this is part of
+                a partitioned read, and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+        Returns:
+            A :class:`ReadIter` of :class:`pa.Table`s.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def read_spatial_region(
+        self,
+        region: Optional[options.SpatialRegion] = None,
+        column_names: Optional[Sequence[str]] = None,
+        *,
+        region_transform: Optional[CoordinateTransform] = None,
+        region_coord_space: Optional[CoordinateSpace] = None,
+        batch_size: options.BatchSize = _UNBATCHED,
+        partitions: Optional[options.ReadPartitions] = None,
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
+        value_filter: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> somacore.SpatialRead[somacore.ReadIter[pa.Table]]:
+        """Reads data intersecting an user-defined region of space into a
+        :class:`SpatialRead` with data in Arrow tables.
+
+
+        Args:
+            region: The region to query. May be a box in the form
+                [x_min, y_min, x_max, y_max] (for 2D images), a box in the form
+                [x_min, y_min, z_min, x_max, y_max, z_max] (for 3D images), or
+                a shapely Geometry.
+            column_names: The named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            region_transform: An optional coordinate transform from the read region to the
+                coordinate system of the spatial dataframe.
+                Defaults to ``None``, meaning an identity transform.
+            region_coord_space: An optional coordinate space for the region being read.
+                Defaults to ``None``, coordinate space will be inferred from transform.
+            batch_size: The size of batched reads.
+                Defaults to `unbatched`.
+            partitions: If present, specifies that this is part of a partitioned read,
+                and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+
+        Returns:
+            A :class:`SpatialRead` with :class:`ReadIter` of :class:`pa.Table`s data.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def write(
+        self,
+        values: Union[pa.RecordBatch, pa.Table],
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> Self:
+        """Writes the data from an Arrow table to the persistent object.
+
+        As duplicate index values are not allowed, index values already present
+        in the object are overwritten and new index values are added.
+
+        Args:
+            values: An Arrow table containing all columns, including
+                the index columns. The schema for the values must match
+                the schema for the ``DataFrame``.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    # Metadata operations
+
+    @property
+    def schema(self) -> pa.Schema:
+        """The schema of the data in this dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def index_column_names(self) -> Tuple[str, ...]:
+        """The names of the index (dimension) columns.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def axis_names(self) -> Tuple[str, ...]:
+        """The names of the axes of the coordinate space the data is defined on.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def coordinate_space(self) -> Optional[CoordinateSpace]:
+        """Coordinate space for this geometry dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @coordinate_space.setter
+    def coordinate_space(self, value: CoordinateSpace) -> None:
+        """Coordinate space for this geometry dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """The allowable range of values in each index column.
+
+        Returns: a tuple of minimum and maximum values, inclusive,
+            storable on each index column of the dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the MIT License.
 """
-Implementataion of a SOMA Geometry DataFrame
+Implementation of a SOMA Geometry DataFrame
 """
 
 import warnings

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -80,4 +80,5 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
         "obsp": ("SOMACollection",),
         "varm": ("SOMACollection",),
         "varp": ("SOMACollection",),
+        "var_spatial_presence": ("SOMADataFrame",),
     }

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -75,7 +75,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[SOMATileDBContext] = None,
     ) -> Self:
-        """Creates a new collection of this type at the given URI.
+        """Creates a new ``MultiscaleImage`` at the given URI.
 
         Args:
             uri: The URI where the collection will be created.
@@ -88,7 +88,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
                 and ``depth``.
 
         Returns:
-            The newly created collection, opened for writing.
+            The newly created ``MultiscaleImage``, opened for writing.
 
         Lifecycle:
             Experimental.
@@ -104,7 +104,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
         shape: Sequence[int],
         **kwargs: Any,
     ) -> DenseNDArray:
-        """Add a new level in the multi-scale image.
+        """Adds a new resolution level to the ``MultiscaleImage``.
 
         Parameters are as in :meth:`DenseNDArray.create`. The provided shape will
         be used to compute the scale between images and must correspond to the image

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -1,0 +1,256 @@
+#
+# Copyright (c) 2024 The Chan Zuckerberg Initiative Foundation
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+"""
+Implementation of a SOMA MultiscaleImage.
+"""
+
+import warnings
+from typing import Any, Optional, Sequence, Tuple, Union
+
+import pyarrow as pa
+import somacore
+from somacore import CoordinateSpace, CoordinateTransform, ScaleTransform, options
+from typing_extensions import Self
+
+from ._constants import SPATIAL_DISCLAIMER
+from ._dense_nd_array import DenseNDArray
+from ._soma_object import AnySOMAObject
+
+
+class ImageProperties:
+    """Properties for a single resolution level in a multiscale image.
+
+    Lifecycle:
+        Experimental.
+    """
+
+    @property
+    def name(self) -> str:
+        """The key for the image.
+
+        Lifecycle:
+            Experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """Size of each axis of the image.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+
+class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
+    """A multiscale image with an extendable number of resolution levels.
+
+    The multiscale image defines the top level properties. Each level must
+    match the expected following properties:
+    * number of channels
+    * axis order
+
+    Lifecycle:
+        Experimental.
+    """
+
+    __slots__ = ()
+
+    # Lifecycle
+
+    @classmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        type: pa.DataType,
+        reference_level_shape: Sequence[int],
+        axis_names: Sequence[str] = ("c", "y", "x"),
+        axis_types: Sequence[str] = ("channel", "height", "width"),
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> Self:
+        """Creates a new collection of this type at the given URI.
+
+        Args:
+            uri: The URI where the collection will be created.
+            reference_level_shape: The shape of the reference level for the multiscale
+                image. In most cases, this corresponds to the size of the image
+                at ``level=0``.
+            axis_names: The names of the axes of the image.
+            axis_types: The types of the axes of the image. Must be the same length as
+                ``axis_names``. Valid types are: ``channel``, ``height``, ``width``,
+                and ``depth``.
+
+        Returns:
+            The newly created collection, opened for writing.
+
+        Lifecycle:
+            Experimental.
+        """
+        warnings.warn(SPATIAL_DISCLAIMER)
+        raise NotImplementedError()
+
+    def add_new_level(
+        self,
+        key: str,
+        *,
+        uri: Optional[str] = None,
+        shape: Sequence[int],
+        **kwargs: Any,
+    ) -> DenseNDArray:
+        """Add a new level in the multi-scale image.
+
+        Parameters are as in :meth:`DenseNDArray.create`. The provided shape will
+        be used to compute the scale between images and must correspond to the image
+        size for the entire image.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    # Data operations
+
+    def read_spatial_region(
+        self,
+        level: Union[int, str],
+        region: Optional[options.SpatialRegion] = None,
+        *,
+        channel_coords: options.DenseCoord = None,
+        region_transform: Optional[CoordinateTransform] = None,
+        region_coord_space: Optional[CoordinateSpace] = None,
+        result_order: options.ResultOrderStr = options.ResultOrder.ROW_MAJOR,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> somacore.SpatialRead[pa.Tensor]:
+        """Reads a user-defined region of space into a :class:`SpatialRead` with data
+        in either an Arrow tensor or table.
+
+        Reads the bounding box of the input region from the requested image level. This
+        will return a :class:`SpatialRead` with the image data stored as a
+        :class:`pa.Tensor`.
+
+        Args:
+            level: The image level to read the data from. May use index of the level
+                or the image name.
+            region: The region to query. May be a box in the form
+                [x_min, y_min, x_max, y_max] (for 2D images), a box in the form
+                [x_min, y_min, z_min, x_max, y_max, z_max] (for 3D images), or
+                a shapely Geometry.
+            channel_coords: An optional slice that defines the channel coordinates
+                to read.
+            region_transform: An optional coordinate transform that provides the
+                transformation from the provided region to the reference level of this
+                image. Defaults to ``None``.
+            region_coord_space: An optional coordinate space for the region being read.
+                The axis names must match the input axis names of the transform.
+                Defaults to ``None``, coordinate space will be inferred from transform.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+
+        Returns:
+            The data bounding the requested region as a :class:`SpatialRead` with
+            :class:`pa.Tensor` data.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    # Metadata operations
+
+    @property
+    def axis_names(self) -> Tuple[str, ...]:
+        """The name of the image axes.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def coordinate_space(self) -> Optional[CoordinateSpace]:
+        """Coordinate space for this multiscale image.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @coordinate_space.setter
+    def coordinate_space(self, value: CoordinateSpace) -> None:
+        """Coordinate space for this multiscale image.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def get_transform_from_level(self, level: Union[int, str]) -> ScaleTransform:
+        """Returns the transformation from user requested level to image reference
+        level.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def get_transform_to_level(self, level: Union[int, str]) -> ScaleTransform:
+        """Returns the transformation from the image reference level to the user
+        requested level.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def image_type(self) -> str:
+        """The order of the axes as stored in the data model.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def level_count(self) -> int:
+        """The number of image levels stored in the MultiscaleImage.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def level_properties(self, level: Union[int, str]) -> somacore.ImageProperties:
+        """The properties of an image at the specified level.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def reference_level(self) -> Optional[int]:
+        """The index of image level that is used as a reference level.
+
+        This will return ``None`` if no current image level matches the size of the
+        reference level.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def reference_level_properties(self) -> "ImageProperties":
+        """The image properties of the reference level.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -48,7 +48,6 @@ class ImageProperties:
 
 
 class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
-    """A multiscale image with an extendable number of resolution levels.
     """A multiscale image represented as a collection of images at multiple resolution levels.
 
     Each level of the multiscale image must have the following consistent properties:

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -49,11 +49,12 @@ class ImageProperties:
 
 class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
     """A multiscale image with an extendable number of resolution levels.
+    """A multiscale image represented as a collection of images at multiple resolution levels.
 
-    The multiscale image defines the top level properties. Each level must
-    match the expected following properties:
-    * number of channels
-    * axis order
+    Each level of the multiscale image must have the following consistent properties:
+
+    * **Number of Channels**: All levels must have the same number of channels.
+    * **Axis Order**: The order of axes (e.g., channels, height, width) must be consistent across levels.
 
     Lifecycle:
         Experimental.

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -220,7 +220,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
 
     @property
     def level_count(self) -> int:
-        """The number of image levels stored in the MultiscaleImage.
+        """The number of image levels stored in the ``MultiscaleImage``.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -18,6 +18,7 @@ from typing_extensions import Self
 from ._constants import SPATIAL_DISCLAIMER
 from ._dense_nd_array import DenseNDArray
 from ._soma_object import AnySOMAObject
+from .options import SOMATileDBContext
 
 
 class ImageProperties:

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -128,12 +128,10 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
         result_order: options.ResultOrderStr = options.ResultOrder.ROW_MAJOR,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> somacore.SpatialRead[pa.Tensor]:
-        """Reads a user-defined region of space into a :class:`SpatialRead` with data
-        in either an Arrow tensor or table.
+        """Reads a user-defined spatial region from a specific level of the ``MultiscaleImage``.
 
-        Reads the bounding box of the input region from the requested image level. This
-        will return a :class:`SpatialRead` with the image data stored as a
-        :class:`pa.Tensor`.
+        Retrieves the data within the specified region from the requested image level, returning
+        a :class:`SpatialRead`, yielding :class:`pa.Tensor`s.
 
         Args:
             level: The image level to read the data from. May use index of the level
@@ -220,7 +218,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
 
     @property
     def level_count(self) -> int:
-        """The number of image levels stored in the ``MultiscaleImage``.
+        """The number of image resolution levels stored in the ``MultiscaleImage``.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -72,7 +72,7 @@ class MultiscaleImage(somacore.MultiscaleImage[DenseNDArray, AnySOMAObject]):
         axis_names: Sequence[str] = ("c", "y", "x"),
         axis_types: Sequence[str] = ("channel", "height", "width"),
         platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[Any] = None,
+        context: Optional[SOMATileDBContext] = None,
     ) -> Self:
         """Creates a new collection of this type at the given URI.
 

--- a/apis/python/src/tiledbsoma/_point_cloud.py
+++ b/apis/python/src/tiledbsoma/_point_cloud.py
@@ -12,7 +12,7 @@ from typing import Any, Optional, Sequence, Tuple, Union
 import pyarrow as pa
 import somacore
 from somacore import CoordinateSpace, CoordinateTransform, options
-from typing_extension import Self
+from typing_extensions import Self
 
 from ._constants import SOMA_JOINID, SPATIAL_DISCLAIMER
 from ._dataframe import Domain

--- a/apis/python/src/tiledbsoma/_point_cloud.py
+++ b/apis/python/src/tiledbsoma/_point_cloud.py
@@ -52,7 +52,7 @@ class PointCloud(somacore.PointCloud):
     ) -> Self:
         """Creates a new ``PointCloud`` at the given URI.
 
-        The schema of the created point cloud will include a column named
+        The schema of the created point cloud dataframe will include a column named
         ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
         at least one axis with numeric type.  If a ``soma_joinid`` column is
         present in the provided schema, it must be of the correct type.  If the

--- a/apis/python/src/tiledbsoma/_point_cloud.py
+++ b/apis/python/src/tiledbsoma/_point_cloud.py
@@ -52,7 +52,7 @@ class PointCloud(somacore.PointCloud):
     ) -> Self:
         """Creates a new ``PointCloud`` at the given URI.
 
-        The schema of the created point cloud  will include a column named
+        The schema of the created point cloud will include a column named
         ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
         at least one axis with numeric type.  If a ``soma_joinid`` column is
         present in the provided schema, it must be of the correct type.  If the
@@ -64,13 +64,14 @@ class PointCloud(somacore.PointCloud):
             schema: Arrow schema defining the per-column schema. This schema
                 must define all columns, including columns to be named as index
                 columns.  If the schema includes types unsupported by the SOMA
-                implementation, an error will be raised.
+                implementation, a ValueError will be raised.
             index_column_names: A list of column names to use as user-defined index
                 columns (e.g., ``['x', 'y']``). All named columns must exist in the
                 schema, and at least one index column name is required.
+                Default is ``("soma_joinid", "x", "y")``.
             axis_names: An ordered list of axis column names that correspond to the
                 names of axes of the the coordinate space the points are defined on.
-                Must be the name of index columns.
+                Must be the name of index columns. Default is ``("x", "y")``.
             domain: An optional sequence of tuples specifying the domain of each
                 index column. Each tuple should be a pair consisting of the minimum
                 and maximum values storable in the index column. If omitted entirely,
@@ -79,7 +80,7 @@ class PointCloud(somacore.PointCloud):
                 column's datatype.  This makes a point cloud dataframe growable.
 
         Returns:
-            The newly created geometry dataframe, opened for writing.
+            The newly created point cloud, opened for writing.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/_point_cloud.py
+++ b/apis/python/src/tiledbsoma/_point_cloud.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2024 The Chan Zuckerberg Initiative Foundation
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+"""
+Implementation of a SOMA Point Cloud
+"""
+
+import warnings
+from typing import Any, Optional, Sequence, Tuple, Union
+
+import pyarrow as pa
+import somacore
+from somacore import CoordinateSpace, CoordinateTransform, options
+from typing_extension import Self
+
+from ._constants import SOMA_JOINID, SPATIAL_DISCLAIMER
+from ._dataframe import Domain
+from ._read_iters import TableReadIter
+from ._types import OpenTimestamp
+from .options import SOMATileDBContext
+
+_UNBATCHED = options.BatchSize()
+
+
+class PointCloud(somacore.PointCloud):
+    """A specialized SOMA DataFrame for storing collections of points in
+    multi-dimensional space.
+
+    The ``PointCloud`` class is designed to efficiently store and query point data,
+    where each point is represented by coordinates in one or more spatial dimensions
+    (e.g., x, y, z) and may have additional columns for associated attributes.
+
+    Lifecycle:
+        Experimental.
+    """
+
+    __slots__ = ()
+
+    @classmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (SOMA_JOINID, "x", "y"),
+        axis_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Domain] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[SOMATileDBContext] = None,
+        tiledb_timestamp: Optional[OpenTimestamp] = None,
+    ) -> Self:
+        """Creates a new ``PointCloud`` at the given URI.
+
+        The schema of the created point cloud  will include a column named
+        ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
+        at least one axis with numeric type.  If a ``soma_joinid`` column is
+        present in the provided schema, it must be of the correct type.  If the
+        ``soma_joinid`` column is not provided, one will be added. The ``soma_joinid``
+        may be an index column. The axis columns must be index columns.
+
+        Args:
+            uri: The URI where the dataframe will be created.
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
+            index_column_names: A list of column names to use as user-defined index
+                columns (e.g., ``['x', 'y']``). All named columns must exist in the
+                schema, and at least one index column name is required.
+            axis_names: An ordered list of axis column names that correspond to the
+                names of axes of the the coordinate space the points are defined on.
+                Must be the name of index columns.
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Each tuple should be a pair consisting of the minimum
+                and maximum values storable in the index column. If omitted entirely,
+                or if ``None`` in a given dimension, the corresponding index-column
+                domain will use the minimum and maximum possible values for the
+                column's datatype.  This makes a point cloud dataframe growable.
+
+        Returns:
+            The newly created geometry dataframe, opened for writing.
+
+        Lifecycle:
+            Experimental.
+        """
+        warnings.warn(SPATIAL_DISCLAIMER)
+        raise NotImplementedError()
+
+    # Data operations
+
+    def read(
+        self,
+        coords: options.SparseDFCoords = (),
+        column_names: Optional[Sequence[str]] = None,
+        *,
+        batch_size: options.BatchSize = _UNBATCHED,
+        partitions: Optional[options.ReadPartitions] = None,
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
+        value_filter: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> TableReadIter:
+        """Reads a user-defined slice of data into Arrow tables.
+
+        Args:
+            coords: for each index dimension, which rows to read.
+                Defaults to ``()``, meaning no constraint -- all IDs.
+            column_names: the named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            partitions: If present, specifies that this is part of
+                a partitioned read, and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+        Returns:
+            A :class:`ReadIter` of :class:`pa.Table`s.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def read_spatial_region(
+        self,
+        region: Optional[options.SpatialRegion] = None,
+        column_names: Optional[Sequence[str]] = None,
+        *,
+        region_transform: Optional[CoordinateTransform] = None,
+        region_coord_space: Optional[CoordinateSpace] = None,
+        batch_size: options.BatchSize = _UNBATCHED,
+        partitions: Optional[options.ReadPartitions] = None,
+        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
+        value_filter: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> somacore.SpatialRead[somacore.ReadIter[pa.Table]]:
+        """Reads data intersecting an user-defined region of space into a
+        :class:`SpatialRead` with data in Arrow tables.
+
+
+        Args:
+            region: The region to query. May be a box in the form
+                [x_min, y_min, x_max, y_max] (for 2D images), a box in the form
+                [x_min, y_min, z_min, x_max, y_max, z_max] (for 3D images), or
+                a shapely Geometry.
+            column_names: The named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            region_transform: An optional coordinate transform from the read region to
+                the coordinate system of the spatial dataframe.
+                Defaults to ``None``, meaning an identity transform.
+            region_coord_space: An optional coordinate space for the region being read.
+                Defaults to ``None``, coordinate space will be inferred from transform.
+            batch_size: The size of batched reads.
+                Defaults to `unbatched`.
+            partitions: If present, specifies that this is part of a partitioned read,
+                and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+
+        Returns:
+            A :class:`SpatialRead` with :class:`ReadIter` of :class:`pa.Table`s data.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    def write(
+        self,
+        values: Union[pa.RecordBatch, pa.Table],
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> Self:
+        """Writes the data from an Arrow table to the persistent object.
+
+        As duplicate index values are not allowed, index values already present
+        in the object are overwritten and new index values are added.
+
+        Args:
+            values: An Arrow table containing all columns, including
+                the index columns. The schema for the values must match
+                the schema for the ``DataFrame``.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    # Metadata operations
+
+    @property
+    def schema(self) -> pa.Schema:
+        """The schema of the data in this dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def index_column_names(self) -> Tuple[str, ...]:
+        """The names of the index (dimension) columns.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def coordinate_space(self) -> Optional[CoordinateSpace]:
+        """Coordinate space for this point cloud.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @coordinate_space.setter
+    def coordinate_space(self, value: CoordinateSpace) -> None:
+        """Coordinate space for this point cloud.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def axis_names(self) -> Tuple[str, ...]:
+        """The names of the axes of the coordinate space the data is defined on.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """The allowable range of values in each index column.
+
+        Returns: a tuple of minimum and maximum values, inclusive,
+            storable on each index column of the dataframe.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2024 The Chan Zuckerberg Initiative Foundation
+# Copyright (c) 2024 TileDB, Inc.
+#
+# Licensed under the MIT License.
+"""
+Implementataion of a SOMA Scene
+"""
+
+from typing import Any, Optional, Sequence, Tuple, Union
+
+import pyarrow as pa
+import somacore
+from somacore import (
+    CoordinateSpace,
+    CoordinateTransform,
+    options,
+)
+
+from ._collection import CollectionBase
+from ._constants import SOMA_GEOMETRY, SOMA_JOINID
+from ._geometry_dataframe import GeometryDataFrame
+from ._multiscale_image import MultiscaleImage
+from ._point_cloud import PointCloud
+from ._soma_object import AnySOMAObject
+
+
+class Scene(  # type: ignore[misc]   # __eq__ false positive
+    CollectionBase[AnySOMAObject],
+    somacore.Scene[MultiscaleImage, PointCloud, GeometryDataFrame, AnySOMAObject],
+):
+    """A collection subtype representing spatial assets that can all be stored
+    on a single coordinate space.
+
+    Lifecycle:
+        Experimental.
+    """
+
+    __slots__ = ()
+
+    _subclass_constrained_soma_types = {
+        "img": ("SOMACollection",),
+        "obsl": ("SOMACollection",),
+        "varl": ("SOMACollection",),
+    }
+
+    @property
+    def coordinate_space(self) -> Optional[CoordinateSpace]:
+        """Coordinate system for this scene.
+
+        Lifecycle:
+            Experimental.
+        """
+        raise NotImplementedError()
+
+    @coordinate_space.setter
+    def coordinate_space(self, value: CoordinateSpace) -> None:
+        raise NotImplementedError()
+
+    def add_geometry_dataframe(
+        self,
+        key: str,
+        subcollection: Union[str, Sequence[str]],
+        transform: Optional[CoordinateTransform],
+        *,
+        uri: str,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (SOMA_JOINID, SOMA_GEOMETRY),
+        axis_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> GeometryDataFrame:
+        """Adds a ``GeometryDataFrame`` to the scene and sets a coordinate transform
+        between the scene and the dataframe.
+
+        If the subcollection the geometry dataframe is inside of is more than one
+        layer deep, the input should be provided as a sequence of names. For example,
+        to set the transformation to a geometry dataframe named  "transcripts" in
+        the "var/RNA" collection::
+
+            scene.add_geometry_dataframe(
+                'cell_boundaries', subcollection=['var', 'RNA'], **kwargs
+            )
+
+        Args:
+            key: The name of the geometry dataframe.
+            transform: The coordinate transformation from the scene to the dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            The newly create ``GeometryDataFrame``, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def add_multiscale_image(
+        self,
+        key: str,
+        subcollection: Union[str, Sequence[str]],
+        transform: Optional[CoordinateTransform],
+        *,
+        uri: str,
+        type: pa.DataType,
+        image_type: str = "CYX",
+        reference_level_shape: Sequence[int],
+        axis_names: Sequence[str] = ("c", "x", "y"),
+    ) -> MultiscaleImage:
+        """Adds a ``MultiscaleImage`` to the scene and sets a coordinate transform
+        between the scene and the dataframe.
+
+        Parameters are as in :meth:`spatial.PointCloud.create`.
+        See :meth:`add_new_collection` for details about child URIs.
+
+        Args:
+            key: The name of the geometry dataframe.
+            transform: The coordinate transformation from the scene to the dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            The newly create ``MultiscaleImage``, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def add_new_point_cloud(
+        self,
+        key: str,
+        subcollection: Union[str, Sequence[str]],
+        transform: Optional[CoordinateTransform],
+        *,
+        uri: Optional[str] = None,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (SOMA_JOINID,),
+        axis_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> PointCloud:
+        """Adds a point cloud to the scene and sets a coordinate transform
+        between the scene and the dataframe.
+
+        Parameters are as in :meth:`spatial.PointCloud.create`.
+        See :meth:`add_new_collection` for details about child URIs.
+
+        Args:
+            key: The name of the geometry dataframe.
+            transform: The coordinate transformation from the scene to the dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            The newly created ``PointCloud``, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def set_transform_to_geometry_dataframe(
+        self,
+        key: str,
+        transform: CoordinateTransform,
+        *,
+        subcollection: Union[str, Sequence[str]] = "obsl",
+        coordinate_space: Optional[CoordinateSpace] = None,
+    ) -> GeometryDataFrame:
+        """Adds the coordinate transform for the scene coordinate space to
+        a geometry dataframe stored in the scene.
+
+        If the subcollection the geometry dataframe is inside of is more than one
+        layer deep, the input should be provided as a sequence of names. For example,
+        to set a transformation for geometry dataframe named  "transcripts" in the
+        "var/RNA" collection::
+
+            scene.set_transfrom_for_geometry_dataframe(
+                'transcripts', transform, subcollection=['var', 'RNA'],
+            )
+
+        Args:
+            key: The name of the geometry dataframe.
+            transform: The coordinate transformation from the scene to the dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+            coordinate_space: Optional coordinate space for the dataframe. This will
+                replace the existing coordinate space of the dataframe.
+
+        Returns:
+            The geometry dataframe, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def set_transform_to_multiscale_image(
+        self,
+        key: str,
+        transform: CoordinateTransform,
+        *,
+        subcollection: Union[str, Sequence[str]] = "img",
+        coordinate_space: Optional[CoordinateSpace] = None,
+    ) -> MultiscaleImage:
+        """Adds the coordinate transform for the scene coordinate space to
+        a multiscale image stored in the scene.
+
+        The transform to the multiscale image must be to the coordinate space
+        defined on the reference level for the image. In most cases, this will be
+        the level ``0`` image.
+
+        Args:
+            key: The name of the multiscale image.
+            transform: The coordinate transformation from the scene to the reference
+                level of the multiscale image.
+            subcollection: The name, or sequence of names, of the subcollection the
+                image is stored in. Defaults to ``'img'``.
+            coordinate_space: Optional coordinate space for the image. This will
+                replace the existing coordinate space of the multiscale image.
+
+        Returns:
+            The multiscale image, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def set_transform_to_point_cloud(
+        self,
+        key: str,
+        transform: CoordinateTransform,
+        *,
+        subcollection: Union[str, Sequence[str]] = "obsl",
+        coordinate_space: Optional[CoordinateSpace] = None,
+    ) -> PointCloud:
+        """Adds the coordinate transform for the scene coordinate space to
+        a point cloud stored in the scene.
+
+        If the subcollection the point cloud is inside of is more than one
+        layer deep, the input should be provided as a sequence of names. For example,
+        to set a transform for  a point named `transcripts` in the `var/RNA`
+        collection::
+
+            scene.set_transformation_for_point_cloud(
+                'transcripts', transform, subcollection=['var', 'RNA'],
+            )
+
+        Args:
+            key: The name of the point cloud.
+            transform: The coordinate transformation from the scene to the point cloud.
+            subcollection: The name, or sequence of names, of the subcollection the
+                point cloud is stored in. Defaults to ``'obsl'``.
+            coordinate_space: Optional coordinate space for the point cloud. This will
+                replace the existing coordinate space of the point cloud. Defaults to
+                ``None``.
+
+        Returns:
+            The point cloud, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_from_geometry_dataframe(
+        self, key: str, *, subcollection: Union[str, Sequence[str]] = "obsl"
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the requested geometry dataframe
+        to the scene.
+
+        Args:
+            key: The name of the geometry dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            Coordinate transform from the dataframe to the scene.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_from_multiscale_image(
+        self,
+        key: str,
+        *,
+        subcollection: str = "img",
+        level: Optional[Union[str, int]] = None,
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the requested multiscale image to
+        the scene.
+
+        Args:
+            key: The name of the multiscale image.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'img'``.
+            level: The level of the image to get the transformation from.
+                Defaults to ``None`` -- the transformation will be to the reference
+                level.
+
+        Returns:
+            Coordinate transform from the multiscale image to the scene.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_from_point_cloud(
+        self, key: str, *, subcollection: str = "obsl"
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the requested point cloud to
+        the scene.
+
+        Args:
+            key: The name of the point cloud.
+            subcollection: The name, or sequence of names, of the subcollection the
+                point cloud is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            Coordinate transform from the scene to the point cloud.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_to_geometry_dataframe(
+        self, key: str, *, subcollection: Union[str, Sequence[str]] = "obsl"
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the scene to a requested
+        geometery dataframe.
+
+        Args:
+            key: The name of the geometry dataframe.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            Coordinate transform from the scene to the requested dataframe.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_to_multiscale_image(
+        self,
+        key: str,
+        *,
+        subcollection: str = "img",
+        level: Optional[Union[str, int]] = None,
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the scene to a requested
+        multiscale image.
+
+        Args:
+            key: The name of the multiscale image.
+            subcollection: The name, or sequence of names, of the subcollection the
+                dataframe is stored in. Defaults to ``'img'``.
+            level: The level of the image to get the transformation to.
+                Defaults to ``None`` -- the transformation will be to the reference
+                level.
+
+        Returns:
+            Coordinate transform from the scene to the requested multiscale image.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    def get_transform_to_point_cloud(
+        self, key: str, *, subcollection: str = "obsl"
+    ) -> CoordinateTransform:
+        """Returns the coordinate transformation from the scene to a requested
+        point cloud.
+
+        Args:
+            key: The name of the point cloud.
+            subcollection: The name, or sequence of names, of the subcollection the
+                point cloud is stored in. Defaults to ``'obsl'``.
+
+        Returns:
+            Coordinate transform from the scene to the requested point cloud.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the MIT License.
 """
-Implementataion of a SOMA Scene
+Implementation of a SOMA Scene
 """
 
 from typing import Any, Optional, Sequence, Tuple, Union


### PR DESCRIPTION
This PR updates somacore and adds the new spatial types to TileDB-SOMA as empty classes that throw `NotImplementedErrors`.  It updates `Experiment` and `Measurement` to match the updated somacore API.

Issues: #3043 #3042


