### PR TITLE
[r] Run `devtools::document()`

### DIFF
--- a/apis/r/man/BlockwiseReadIterBase.Rd
+++ b/apis/r/man/BlockwiseReadIterBase.Rd
@@ -8,7 +8,7 @@ Class that allows for blockwise read iteration of SOMA reads
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::ReadIter} -> \code{BlockwiseReadIterBase}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{BlockwiseReadIterBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/BlockwiseSparseReadIter.Rd
+++ b/apis/r/man/BlockwiseSparseReadIter.Rd
@@ -9,7 +9,7 @@ as sparse matrices
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::ReadIter} -> \code{tiledbsoma::BlockwiseReadIterBase} -> \code{BlockwiseSparseReadIter}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseSparseReadIter}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/BlockwiseTableReadIter.Rd
+++ b/apis/r/man/BlockwiseTableReadIter.Rd
@@ -9,7 +9,7 @@ as Arrow \code{\link[Arrow]{Table}s}
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::ReadIter} -> \code{tiledbsoma::BlockwiseReadIterBase} -> \code{BlockwiseTableReadIter}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseTableReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/ConfigList.Rd
+++ b/apis/r/man/ConfigList.Rd
@@ -10,7 +10,7 @@ Essentially, serves as a nested map where the inner map is a
 \code{\{<param>: \link[tiledbsoma:ScalarMap]{\{<key>: <value>\}}\}}
 }
 \section{Super class}{
-\code{tiledbsoma::MappingBase} -> \code{ConfigList}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ConfigList}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/EphemeralCollection.Rd
+++ b/apis/r/man/EphemeralCollection.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralCollection}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralCollection}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralCollectionBase.Rd
+++ b/apis/r/man/EphemeralCollectionBase.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{EphemeralCollectionBase}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{EphemeralCollectionBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralExperiment.Rd
+++ b/apis/r/man/EphemeralExperiment.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralExperiment}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralExperiment}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/EphemeralMeasurement.Rd
+++ b/apis/r/man/EphemeralMeasurement.Rd
@@ -8,7 +8,7 @@
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{tiledbsoma::EphemeralCollectionBase} -> \code{EphemeralMeasurement}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralMeasurement}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/PlatformConfig.Rd
+++ b/apis/r/man/PlatformConfig.Rd
@@ -11,7 +11,7 @@ map is a \code{\link{ScalarMap}} contained within a \code{\link{ConfigList}}
 \code{\{platform: \{param: \{key: value\}\}\}}
 }
 \section{Super class}{
-\code{tiledbsoma::MappingBase} -> \code{PlatformConfig}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{PlatformConfig}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -9,7 +9,7 @@ experimental)
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{SOMAArrayBase}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{SOMAArrayBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -44,6 +44,7 @@ experimental)
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="maxshape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-maxshape'><code>tiledbsoma::TileDBArray$maxshape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain_new"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain_new'><code>tiledbsoma::TileDBArray$non_empty_domain_new()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -10,7 +10,7 @@ the values are any SOMA-defined foundational or composed type, including
 \code{\link{SOMASparseNDArray}}, or \code{\link{SOMAExperiment}}.  (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMACollection}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMACollection}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -12,7 +12,7 @@ objects, mapping string keys to any SOMA object.  (lifecycle: maturing)
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{SOMACollectionBase}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{SOMACollectionBase}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAContextBase.Rd
+++ b/apis/r/man/SOMAContextBase.Rd
@@ -10,7 +10,7 @@ context options
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{SOMAContextBase}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{SOMAContextBase}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -10,7 +10,7 @@ row and is intended to act as a join key for other objects, such as
 \code{\link{SOMASparseNDArray}}.  (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMADataFrame}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMADataFrame}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -21,6 +21,8 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-update}{\code{SOMADataFrame$update()}}
 \item \href{#method-SOMADataFrame-shape}{\code{SOMADataFrame$shape()}}
 \item \href{#method-SOMADataFrame-maxshape}{\code{SOMADataFrame$maxshape()}}
+\item \href{#method-SOMADataFrame-domain}{\code{SOMADataFrame$domain()}}
+\item \href{#method-SOMADataFrame-maxdomain}{\code{SOMADataFrame$maxdomain()}}
 \item \href{#method-SOMADataFrame-tiledbsoma_has_upgraded_domain}{\code{SOMADataFrame$tiledbsoma_has_upgraded_domain()}}
 \item \href{#method-SOMADataFrame-clone}{\code{SOMADataFrame$clone()}}
 }
@@ -44,6 +46,7 @@ row and is intended to act as a join key for other objects, such as
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="index_column_names"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-index_column_names'><code>tiledbsoma::TileDBArray$index_column_names()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain_new"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain_new'><code>tiledbsoma::TileDBArray$non_empty_domain_new()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>
@@ -216,6 +219,38 @@ simply raises an error
 
 \subsection{Returns}{
 None, instead a \code{\link{.NotYetImplemented}()} error is raised
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-domain"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-domain}{}}}
+\subsection{Method \code{domain()}}{
+Returns a named list of minimum/maximum pairs, one per index
+column, currently storable on each index column of the dataframe. These
+can be resized up to \code{maxdomain}.
+(lifecycle: maturing)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$domain()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+Named list of minimum/maximum values.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-maxdomain"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-maxdomain}{}}}
+\subsection{Method \code{maxdomain()}}{
+Returns a named list of minimum/maximum pairs, one per index
+column, which are the limits up to which the dataframe can have its
+domain resized.
+(lifecycle: maturing)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$maxdomain()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+Named list of minimum/maximum values.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -25,7 +25,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 (lifecycle: maturing)
 }
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{tiledbsoma::SOMANDArrayBase} -> \code{SOMADenseNDArray}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{\link[tiledbsoma:SOMANDArrayBase]{tiledbsoma::SOMANDArrayBase}} -> \code{SOMADenseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -56,6 +56,7 @@ The \code{write} method is currently limited to writing from 2-d matrices.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="maxshape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-maxshape'><code>tiledbsoma::TileDBArray$maxshape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain_new"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain_new'><code>tiledbsoma::TileDBArray$non_empty_domain_new()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -23,7 +23,7 @@ default platform configuration by passing a custom configuration to the
 }
 
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAExperiment}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAExperiment}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMAMeasurement.Rd
+++ b/apis/r/man/SOMAMeasurement.Rd
@@ -23,7 +23,7 @@ default platform configuration by passing a custom configuration to the
 }
 
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBGroup} -> \code{tiledbsoma::SOMACollectionBase} -> \code{SOMAMeasurement}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{SOMAMeasurement}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMANDArrayBase.Rd
+++ b/apis/r/man/SOMANDArrayBase.Rd
@@ -9,7 +9,7 @@ Adds NDArray-specific functionality to the \code{\link{SOMAArrayBase}} class.
 }
 \keyword{internal}
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{SOMANDArrayBase}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{SOMANDArrayBase}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -40,6 +40,7 @@ Adds NDArray-specific functionality to the \code{\link{SOMAArrayBase}} class.
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="maxshape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-maxshape'><code>tiledbsoma::TileDBArray$maxshape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain_new"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain_new'><code>tiledbsoma::TileDBArray$non_empty_domain_new()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -23,7 +23,7 @@ the object are overwritten and new index values are added. (lifecycle: maturing)
 }
 }
 \section{Super classes}{
-\code{tiledbsoma::TileDBObject} -> \code{tiledbsoma::TileDBArray} -> \code{tiledbsoma::SOMAArrayBase} -> \code{tiledbsoma::SOMANDArrayBase} -> \code{SOMASparseNDArray}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBArray]{tiledbsoma::TileDBArray}} -> \code{\link[tiledbsoma:SOMAArrayBase]{tiledbsoma::SOMAArrayBase}} -> \code{\link[tiledbsoma:SOMANDArrayBase]{tiledbsoma::SOMANDArrayBase}} -> \code{SOMASparseNDArray}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -56,6 +56,7 @@ the object are overwritten and new index values are added. (lifecycle: maturing)
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="maxshape"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-maxshape'><code>tiledbsoma::TileDBArray$maxshape()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="ndim"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-ndim'><code>tiledbsoma::TileDBArray$ndim()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain'><code>tiledbsoma::TileDBArray$non_empty_domain()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="non_empty_domain_new"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-non_empty_domain_new'><code>tiledbsoma::TileDBArray$non_empty_domain_new()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="open"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-open'><code>tiledbsoma::TileDBArray$open()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsoma::TileDBArray$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="tiledbsoma" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsoma/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsoma::TileDBArray$schema()</code></a></span></li>

--- a/apis/r/man/SOMASparseNDArrayBlockwiseRead.Rd
+++ b/apis/r/man/SOMASparseNDArrayBlockwiseRead.Rd
@@ -8,7 +8,7 @@ Blockwise reader for \code{\link{SOMASparseNDArray}}
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::SOMASparseNDArrayReadBase} -> \code{SOMASparseNDArrayBlockwiseRead}
+\code{\link[tiledbsoma:SOMASparseNDArrayReadBase]{tiledbsoma::SOMASparseNDArrayReadBase}} -> \code{SOMASparseNDArrayBlockwiseRead}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SOMASparseNDArrayRead.Rd
+++ b/apis/r/man/SOMASparseNDArrayRead.Rd
@@ -8,7 +8,7 @@ Intermediate type to choose result format when reading a sparse array
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::SOMASparseNDArrayReadBase} -> \code{SOMASparseNDArrayRead}
+\code{\link[tiledbsoma:SOMASparseNDArrayReadBase]{tiledbsoma::SOMASparseNDArrayReadBase}} -> \code{SOMASparseNDArrayRead}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -7,7 +7,7 @@
 Context map for TileDB-backed SOMA objects
 }
 \section{Super classes}{
-\code{tiledbsoma::MappingBase} -> \code{tiledbsoma::ScalarMap} -> \code{tiledbsoma::SOMAContextBase} -> \code{SOMATileDBContext}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{\link[tiledbsoma:SOMAContextBase]{tiledbsoma::SOMAContextBase}} -> \code{SOMATileDBContext}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/ScalarMap.Rd
+++ b/apis/r/man/ScalarMap.Rd
@@ -10,7 +10,7 @@ optionally be limited further to a specific atomic vector type
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::MappingBase} -> \code{ScalarMap}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ScalarMap}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/apis/r/man/SparseReadIter.Rd
+++ b/apis/r/man/SparseReadIter.Rd
@@ -9,7 +9,7 @@ a reads on \link{SOMASparseNDArray}.
 Iteration chunks are retrieved as 0-based Views \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
 }
 \section{Super class}{
-\code{tiledbsoma::ReadIter} -> \code{SparseReadIter}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{SparseReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TableReadIter.Rd
+++ b/apis/r/man/TableReadIter.Rd
@@ -9,7 +9,7 @@ a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
 Iteration chunks are retrieved as arrow::\link[arrow]{Table}
 }
 \section{Super class}{
-\code{tiledbsoma::ReadIter} -> \code{TableReadIter}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{TableReadIter}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TileDBArray.Rd
+++ b/apis/r/man/TileDBArray.Rd
@@ -9,7 +9,7 @@ Base class for representing an individual TileDB array.
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::TileDBObject} -> \code{TileDBArray}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBArray}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -35,6 +35,7 @@ Base class for representing an individual TileDB array.
 \item \href{#method-TileDBArray-maxshape}{\code{TileDBArray$maxshape()}}
 \item \href{#method-TileDBArray-used_shape}{\code{TileDBArray$used_shape()}}
 \item \href{#method-TileDBArray-non_empty_domain}{\code{TileDBArray$non_empty_domain()}}
+\item \href{#method-TileDBArray-non_empty_domain_new}{\code{TileDBArray$non_empty_domain_new()}}
 \item \href{#method-TileDBArray-ndim}{\code{TileDBArray$ndim()}}
 \item \href{#method-TileDBArray-attributes}{\code{TileDBArray$attributes()}}
 \item \href{#method-TileDBArray-dimnames}{\code{TileDBArray$dimnames()}}
@@ -278,6 +279,26 @@ each dimension in the array.
 \subsection{Returns}{
 A vector of \code{\link[bit64:bit64-package]{bit64::integer64}}s with one entry for
 each dimension.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TileDBArray-non_empty_domain_new"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-non_empty_domain_new}{}}}
+\subsection{Method \code{non_empty_domain_new()}}{
+Returns a named list of minimum/maximum pairs, one per index
+column, which are the smallest and largest values written on that
+index column.
+
+As tracked on https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+this will replace the existing \code{non_empty_domain} method.
+
+(lifecycle: maturing)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TileDBArray$non_empty_domain_new()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+Named list of minimum/maximum values.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/TileDBCreateOptions.Rd
+++ b/apis/r/man/TileDBCreateOptions.Rd
@@ -60,7 +60,7 @@ tdco$attr_filters("non-existant")
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::MappingBase} -> \code{TileDBCreateOptions}
+\code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{TileDBCreateOptions}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/apis/r/man/TileDBGroup.Rd
+++ b/apis/r/man/TileDBGroup.Rd
@@ -11,7 +11,7 @@ Base class for interacting with TileDB groups (lifecycle: maturing)
 }
 \keyword{internal}
 \section{Super class}{
-\code{tiledbsoma::TileDBObject} -> \code{TileDBGroup}
+\code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{TileDBGroup}
 }
 \section{Methods}{
 \subsection{Public methods}{


### PR DESCRIPTION
On conversation with @mojaveazure I realized that while `roxygen2::roxygenise()` and `devtools::document()` both do pretty much the same thing, they differ a little -- namely, lines such as

```diff
-\code{tiledbsoma::ReadIter} -> \code{BlockwiseReadIterBase}
+\code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{BlockwiseReadIterBase}
```

The line-count on #3032 is largeish, mainly because I did `devtools::document()` on 3032 after some prior PR had been merged with the result of `roxygen2::roxygenise()`.

Merging this PR first & rebasing 3032 on top will make 3032 simpler.

Also, @mojaveazure and I have agreed to standardize on `devtools::document()` moving forward, to simplify matters.