### PR TITLE
[python/r/c++] Update allowed soma types and the metadata encoding version

### DIFF
--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -10,7 +10,7 @@ SOMA_JOINID = "soma_joinid"
 SOMA_GEOMETRY = "soma_geometry"
 SOMA_OBJECT_TYPE_METADATA_KEY = "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
-SOMA_ENCODING_VERSION = "1"
+SOMA_ENCODING_VERSION = "1.1.0"
 
 SPATIAL_DISCLAIMER = (
     "Support for spatial types is experimental. Changes to both the API and data "

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -33,7 +33,6 @@ from . import (
     _tdb_handles,
 )
 from ._constants import (
-    SOMA_ENCODING_VERSION,
     SOMA_ENCODING_VERSION_METADATA_KEY,
     SOMA_OBJECT_TYPE_METADATA_KEY,
 )
@@ -200,7 +199,7 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
     if isinstance(encoding_version, bytes):
         encoding_version = str(encoding_version, "utf-8")
 
-    if encoding_version != SOMA_ENCODING_VERSION:
+    if encoding_version not in {"1", "1.1.0"}:
         raise ValueError(f"Unsupported SOMA object encoding version {encoding_version}")
 
     return obj_type

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -89,6 +89,15 @@ def open(
             soma_object, context
         )
     except KeyError:
+        if soma_object.type.lower() in {
+            "somascene",
+            "somapointcloud",
+            "somageometrydataframe",
+            "somamultiscaleimage",
+        }:
+            raise NotImplementedError(
+                f"Support for {soma_object.type!r} is not yet implemented."
+            )
         raise SOMAError(f"{uri!r} has unknown storage type {soma_object.type!r}")
 
 

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -219,7 +219,7 @@ read_only_error <- function(field_name) {
 
 SOMA_OBJECT_TYPE_METADATA_KEY <- "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY <- "soma_encoding_version"
-SOMA_ENCODING_VERSION <- "1"
+SOMA_ENCODING_VERSION <- "1.1.0"
 
 #' @importFrom Matrix as.matrix
 #' @importFrom arrow RecordBatch

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -55,6 +55,12 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             return std::make_unique<SOMASparseNDArray>(*array_);
         } else if (array_type == "somadensendarray") {
             return std::make_unique<SOMADenseNDArray>(*array_);
+        } else if (array_type == "somapointcloud") {
+            throw TileDBSOMAError(
+                "Support for SOMAPointCloud is not yet implemented");
+        } else if (array_type == "somageometrydataframe") {
+            throw TileDBSOMAError(
+                "Support for SOMAGeometryDataFrame is not yet implemented");
         } else {
             throw TileDBSOMAError("Saw invalid SOMAArray type");
         }
@@ -77,6 +83,12 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             return std::make_unique<SOMAExperiment>(*group_);
         } else if (group_type == "somameasurement") {
             return std::make_unique<SOMAMeasurement>(*group_);
+        } else if (group_type == "somascene") {
+            throw TileDBSOMAError(
+                "Support for SOMAScene is not yet implemented.");
+        } else if (group_type == "somamultiscaleimage") {
+            throw TileDBSOMAError(
+                "Support for SOMAMultiscaleImage is not yet implemented.");
         } else {
             throw TileDBSOMAError("Saw invalid SOMAGroup type");
         }

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -41,7 +41,7 @@ namespace tiledbsoma {
 
 const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
 const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
-const std::string ENCODING_VERSION_VAL = "1";
+const std::string ENCODING_VERSION_VAL = "1.1.0";
 
 using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };


### PR DESCRIPTION
**Changes:** 
* Update the SOMA metadata encoding to 1.1.0. 
* Update `soma_type` checks to describe spatial types as "not implemented" instead of "invalid".

**Issue:** #3045

