### PR TITLE
[python] Use same default max domain between Python and R

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -830,9 +830,8 @@ def _fill_out_slot_soma_domain(
         # Here the slot_domain isn't specified by the user; we're setting it.
         # The SOMA spec disallows negative soma_joinid.
         if index_column_name == SOMA_JOINID:
-            slot_domain = (0, 2**31 - 2)  # R-friendly, which 2**63-1 is not
-        else:
-            saturated_range = True
+            slot_domain = (0, 2**63 - 2)
+        saturated_range = True
     elif np.issubdtype(dtype, NPFloating):
         finfo = np.finfo(cast(NPFloating, dtype))
         slot_domain = finfo.min, finfo.max

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -490,8 +490,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         int64 is returned for the capacity.
         """
         if dim_shape is None:
-            dim_capacity = 2**31 - 2  # Make this friendly for reads by tiledbsoma-r
+            dim_capacity = 2**63 - 1
             dim_extent = min(dim_capacity, create_options.dim_tile(dim_name, 2048))
+            # For core: "domain max expanded to multiple of tile extent exceeds max value
+            # representable by domain type. Reduce domain max by 1 tile extent to allow for
+            # expansion."
+            dim_capacity -= dim_extent
         else:
             if dim_shape <= 0:
                 raise ValueError(

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -126,16 +126,6 @@ def test_sparse_nd_array_basics(
         with tiledbsoma.SparseNDArray.open(uri) as snda:
             assert snda.shape == arg_shape
 
-        # Test resize too big
-        new_shape = tuple([4_000_000_000 for i in range(ndim)])
-        # TODO: check draft spec
-        # with pytest.raises(ValueError):
-        with pytest.raises(tiledbsoma.SOMAError):
-            with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
-                snda.resize(new_shape)
-        with tiledbsoma.SparseNDArray.open(uri) as snda:
-            assert snda.shape == arg_shape
-
         # Test writes out of bounds
         with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
             with pytest.raises(tiledbsoma.SOMAError):


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

In Python we were trying to use default max shapes there were 31-bit friendly for R compatibility. However, in R we're already setting 63-bit maxdomain:
https://github.com/single-cell-data/TileDB-SOMA/blob/1.14.1/apis/r/R/utils-arrow.R#L127

**Notes for Reviewer:**
