### PR TITLE
[r] Make `DataFrame` objects shapeable at ingest

### DIFF
--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -164,6 +164,11 @@ test_that("Resume-mode data frames", {
     }
   }
 
+  if (.new_shape_feature_flag_is_enabled()) {
+    sdfp$reopen("WRITE")
+    sdfp$resize_soma_joinid(nrow(co2))
+  }
+
   expect_s3_class(
     sdfc <- write_soma(
       co2,


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Stacked on top of #3032.

**Notes for Reviewer:**

