### PR TITLE
[c++] Simplify internal API for dataframe-resizer

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-linux-x86_64-2.26.1-db1cee4.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-linux-x86_64-2.26.2-30fc114.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -172,7 +172,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-x86_64-2.26.1-db1cee4.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-x86_64-2.26.2-30fc114.tar.gz
           tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
           ls external/lib/
           echo "DYLD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -264,10 +264,10 @@ jobs:
           if [ `uname -s` == "Darwin" ];
           then
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-x86_64-2.26.1-db1cee4.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-x86_64-2.26.2-30fc114.tar.gz
           else
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-linux-x86_64-2.26.1-db1cee4.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-linux-x86_64-2.26.2-30fc114.tar.gz
           fi
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -65,7 +65,7 @@ jobs:
           apt-get install --yes cmake git python-is-python3 python3 python3-pip python3-venv unzip wget
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Configure Git
         run: |
           # This is a permissions quirk due to running Git as root inside of a Docker container
@@ -101,7 +101,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse 'setuptools>=70.1' wheel
           ./venv-soma/bin/pip list
       - name: Build wheel
         run: |
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Check if System Integrity Protection (SIP) is enabled
         run: csrutil status
       - name: Install pre-built libtiledb
@@ -201,7 +201,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel 'setuptools>=70.1'
           ./venv-soma/bin/pip list
       - name: Build wheel
         run: |
@@ -257,7 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Install pre-built libtiledb
         run: |
           mkdir -p external
@@ -302,7 +302,7 @@ jobs:
         run: |
           python --version
           python -m venv ./venv-soma
-          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel setuptools
+          ./venv-soma/bin/pip install --prefer-binary pybind11-global typeguard sparse wheel 'setuptools>=70.1'
           ./venv-soma/bin/pip list
       - name: Install TileDB-SOMA-Py with setuptools and --libtiledbsoma
         run: |
@@ -357,13 +357,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: TileDB-SOMA
-          fetch-depth: 0 # for setuptools-scm
+          fetch-depth: 0  # for setuptools-scm
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install --prefer-binary pybind11 wheel
+        run: pip install --prefer-binary pybind11 'setuptools>=70.1' wheel
       - name: Build source tarball (sdist)
         run: |
           cd TileDB-SOMA/apis/python

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "pybind11[global]>=2.10.0",
-    "setuptools>=65.5.1",
-    "wheel>=0.37.1",
+    "setuptools>=70.1",  # `setuptools.command.bdist_wheel`
     "cmake>=3.21",
 ]
 build-backend = "setuptools.build_meta"

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -21,8 +21,8 @@ import subprocess
 import sys
 from typing import Optional
 
+import setuptools.command.bdist_wheel
 import setuptools.command.build_ext
-import wheel.bdist_wheel
 
 try:
     from pybind11.setup_helpers import Pybind11Extension
@@ -219,7 +219,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
         super().run()
 
 
-class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
+class bdist_wheel(setuptools.command.bdist_wheel.bdist_wheel):
     def run(self):
         find_or_build_package_data(self)
         super().run()

--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -10,7 +10,7 @@ SOMA_JOINID = "soma_joinid"
 SOMA_GEOMETRY = "soma_geometry"
 SOMA_OBJECT_TYPE_METADATA_KEY = "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY = "soma_encoding_version"
-SOMA_ENCODING_VERSION = "1"
+SOMA_ENCODING_VERSION = "1.1.0"
 
 SPATIAL_DISCLAIMER = (
     "Support for spatial types is experimental. Changes to both the API and data "

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -33,7 +33,6 @@ from . import (
     _tdb_handles,
 )
 from ._constants import (
-    SOMA_ENCODING_VERSION,
     SOMA_ENCODING_VERSION_METADATA_KEY,
     SOMA_OBJECT_TYPE_METADATA_KEY,
 )
@@ -200,7 +199,7 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
     if isinstance(encoding_version, bytes):
         encoding_version = str(encoding_version, "utf-8")
 
-    if encoding_version != SOMA_ENCODING_VERSION:
+    if encoding_version not in {"1", "1.1.0"}:
         raise ValueError(f"Unsupported SOMA object encoding version {encoding_version}")
 
     return obj_type

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -89,6 +89,15 @@ def open(
             soma_object, context
         )
     except KeyError:
+        if soma_object.type.lower() in {
+            "somascene",
+            "somapointcloud",
+            "somageometrydataframe",
+            "somamultiscaleimage",
+        }:
+            raise NotImplementedError(
+                f"Support for {soma_object.type!r} is not yet implemented."
+            )
         raise SOMAError(f"{uri!r} has unknown storage type {soma_object.type!r}")
 
 

--- a/apis/r/R/utils.R
+++ b/apis/r/R/utils.R
@@ -219,7 +219,7 @@ read_only_error <- function(field_name) {
 
 SOMA_OBJECT_TYPE_METADATA_KEY <- "soma_object_type"
 SOMA_ENCODING_VERSION_METADATA_KEY <- "soma_encoding_version"
-SOMA_ENCODING_VERSION <- "1"
+SOMA_ENCODING_VERSION <- "1.1.0"
 
 #' @importFrom Matrix as.matrix
 #' @importFrom arrow RecordBatch

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-x86_64-2.26.1-db1cee4.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-x86_64-2.26.2-30fc114.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-arm64-2.26.1-db1cee4.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-arm64-2.26.2-30fc114.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-linux-x86_64-2.26.1-db1cee4.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-linux-x86_64-2.26.2-30fc114.tar.gz"
 } else {
     message("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
     q(save = "no", status = 1)

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -6,7 +6,7 @@ jinja2==3.1.4
 nbsphinx==0.9.3
 pandoc==2.3
 pybind11==2.12.0
-setuptools==70.0.0
+setuptools==75.1.0
 setuptools-scm==8.1.0
 sphinx==7.3.7
 sphinx-rtd-theme==2.0.0

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -58,8 +58,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-windows-x86_64-2.26.1-db1cee4.zip")
-          SET(DOWNLOAD_SHA1 "b5b909511adf4761d546a865839ca92d0ea4f780")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-windows-x86_64-2.26.2-30fc114.zip")
+          SET(DOWNLOAD_SHA1 "43f1cf15c268b8a1367699f84b1138236b9b3e07")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -76,22 +76,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-x86_64-2.26.1-db1cee4.tar.gz")
-            SET(DOWNLOAD_SHA1 "ca9b3e350e3548120b3debd20eaf440b4d8f2c65")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-x86_64-2.26.2-30fc114.tar.gz")
+            SET(DOWNLOAD_SHA1 "6af72d48812792ef815634bb544ef0e332493bf2")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-arm64-2.26.1-db1cee4.tar.gz")
-            SET(DOWNLOAD_SHA1 "0fb117949b7d16213d8b1606ffddf4693745012d")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-arm64-2.26.2-30fc114.tar.gz")
+            SET(DOWNLOAD_SHA1 "f9bc0696cfeab3c87dc0a190109725320fdfcfdf")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-x86_64-2.26.1-db1cee4.tar.gz")
-            SET(DOWNLOAD_SHA1 "ca9b3e350e3548120b3debd20eaf440b4d8f2c65")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-x86_64-2.26.2-30fc114.tar.gz")
+            SET(DOWNLOAD_SHA1 "6af72d48812792ef815634bb544ef0e332493bf2")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-macos-arm64-2.26.1-db1cee4.tar.gz")
-            SET(DOWNLOAD_SHA1 "0fb117949b7d16213d8b1606ffddf4693745012d")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-macos-arm64-2.26.2-30fc114.tar.gz")
+            SET(DOWNLOAD_SHA1 "f9bc0696cfeab3c87dc0a190109725320fdfcfdf")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.1/tiledb-linux-x86_64-2.26.1-db1cee4.tar.gz")
-          SET(DOWNLOAD_SHA1 "e65081a0505733973b106b761f221748a9823474")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.26.2/tiledb-linux-x86_64-2.26.2-30fc114.tar.gz")
+          SET(DOWNLOAD_SHA1 "2c2257dedb8fa6376b0fb6dc9810b6a3b72d0dbb")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -113,8 +113,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.26.1.zip"
-          URL_HASH SHA1=2cd7ec43412698dcf63b314fd04d2aa2dd5a6f23
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.26.2.zip"
+          URL_HASH SHA1=2195ce24487d47a3be0455d482aff05311718f10
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_context.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dense_ndarray.cc
@@ -131,6 +132,7 @@ endif()
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_dense_ndarray.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_experiment.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_measurement.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_multiscale_image.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_object.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_sparse_ndarray.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/logger_public.h
@@ -151,6 +153,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_sparse_ndarray.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h
   DESTINATION "include/tiledbsoma/soma"
 )

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1471,7 +1471,7 @@ void SOMAArray::_set_current_domain_from_shape(
     schema_evolution.array_evolve(uri_);
 }
 
-void SOMAArray::maybe_resize_soma_joinid(const std::vector<int64_t>& newshape) {
+void SOMAArray::resize_soma_joinid(int64_t newshape) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError(
             "[SOMAArray::resize] array must be opened in write mode");
@@ -1480,12 +1480,6 @@ void SOMAArray::maybe_resize_soma_joinid(const std::vector<int64_t>& newshape) {
     ArraySchema schema = arr_->schema();
     Domain domain = schema.domain();
     unsigned ndim = domain.ndim();
-    if (newshape.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::resize]: newshape has dimension count {}; needed 1",
-            newshape.size(),
-            ndim));
-    }
 
     auto tctx = ctx_->tiledb_ctx();
     CurrentDomain old_current_domain = ArraySchemaExperimental::current_domain(
@@ -1498,7 +1492,7 @@ void SOMAArray::maybe_resize_soma_joinid(const std::vector<int64_t>& newshape) {
     for (unsigned i = 0; i < ndim; i++) {
         if (domain.dimension(i).name() == "soma_joinid") {
             ndrect.set_range<int64_t>(
-                domain.dimension(i).name(), 0, newshape[0] - 1);
+                domain.dimension(i).name(), 0, newshape - 1);
         }
     }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1066,7 +1066,7 @@ class SOMAArray : public SOMAObject {
      * @return Throws if the requested shape exceeds the array's create-time
      * maxshape. Throws if the array does not have current-domain support.
      */
-    void maybe_resize_soma_joinid(const std::vector<int64_t>& newshape);
+    void resize_soma_joinid(int64_t newshape);
 
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -1,0 +1,68 @@
+/**
+ * @file   soma_multiscale_image.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAMultiscaleImage class.
+ */
+
+#include "soma_multiscale_image.h"
+#include "soma_collection.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+//===================================================================
+//= public static
+//===================================================================
+
+void SOMAMultiscaleImage::create(
+    std::string_view uri,
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    try {
+        std::filesystem::path image_uri(uri);
+        SOMAGroup::create(
+            ctx, image_uri.string(), "SOMAMultiscaleImage", timestamp);
+    } catch (TileDBError& e) {
+        throw TileDBSOMAError(e.what());
+    }
+}
+
+std::unique_ptr<SOMAMultiscaleImage> SOMAMultiscaleImage::open(
+    std::string_view uri,
+    OpenMode mode,
+    std::shared_ptr<SOMAContext> ctx,
+    std::optional<TimestampRange> timestamp) {
+    try {
+        return std::make_unique<SOMAMultiscaleImage>(mode, uri, ctx, timestamp);
+    } catch (TileDBError& e) {
+        throw TileDBSOMAError(e.what());
+    }
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_multiscale_image.h
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.h
@@ -1,0 +1,105 @@
+/**
+ * @file   soma_multiscale_image.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAMultiscaleImage class.
+ */
+
+#ifndef SOMA_MULTISCALE_IMAGE
+#define SOMA_MULTISCALE_IMAGE
+
+#include <tiledb/tiledb>
+
+#include "soma_collection.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+class SOMAMultiscaleImage : public SOMACollection {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMAMultiscaleImage object at the given URI.
+     *
+     * @param uri URI to create the SOMAMultiscaleImage
+     * @param schema TileDB ArraySchema
+     * @param platform_config Optional config parameter dictionary
+     */
+    static void create(
+        std::string_view uri,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open a group at the specified URI and return SOMAMultiscaleImage
+     * object.
+     *
+     * @param uri URI of the array
+     * @param mode read or write
+     * @param ctx TileDB context
+     * @param timestamp Optional pair indicating timestamp start and end
+     * @return std::shared_ptr<SOMAMultiscaleImage> SOMAMultiscaleImage
+     */
+    static std::unique_ptr<SOMAMultiscaleImage> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    SOMAMultiscaleImage(
+        OpenMode mode,
+        std::string_view uri,
+        std::shared_ptr<SOMAContext> ctx,
+        std::optional<TimestampRange> timestamp = std::nullopt)
+        : SOMACollection(mode, uri, ctx, timestamp) {
+    }
+
+    SOMAMultiscaleImage(const SOMACollection& other)
+        : SOMACollection(other) {
+    }
+
+    SOMAMultiscaleImage() = delete;
+    SOMAMultiscaleImage(const SOMAMultiscaleImage&) = default;
+    SOMAMultiscaleImage(SOMAMultiscaleImage&&) = default;
+    ~SOMAMultiscaleImage() = default;
+
+   private:
+    //===================================================================
+    //= private non-static
+    //===================================================================
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_MULTISCALE_IMAGE

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -55,6 +55,12 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             return std::make_unique<SOMASparseNDArray>(*array_);
         } else if (array_type == "somadensendarray") {
             return std::make_unique<SOMADenseNDArray>(*array_);
+        } else if (array_type == "somapointcloud") {
+            throw TileDBSOMAError(
+                "Support for SOMAPointCloud is not yet implemented");
+        } else if (array_type == "somageometrydataframe") {
+            throw TileDBSOMAError(
+                "Support for SOMAGeometryDataFrame is not yet implemented");
         } else {
             throw TileDBSOMAError("Saw invalid SOMAArray type");
         }
@@ -77,6 +83,12 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             return std::make_unique<SOMAExperiment>(*group_);
         } else if (group_type == "somameasurement") {
             return std::make_unique<SOMAMeasurement>(*group_);
+        } else if (group_type == "somascene") {
+            throw TileDBSOMAError(
+                "Support for SOMAScene is not yet implemented.");
+        } else if (group_type == "somamultiscaleimage") {
+            throw TileDBSOMAError(
+                "Support for SOMAMultiscaleImage is not yet implemented.");
         } else {
             throw TileDBSOMAError("Saw invalid SOMAGroup type");
         }

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -8,6 +8,7 @@
 #include "soma_dense_ndarray.h"
 #include "soma_experiment.h"
 #include "soma_measurement.h"
+#include "soma_multiscale_image.h"
 #include "soma_sparse_ndarray.h"
 
 namespace tiledbsoma {
@@ -87,8 +88,7 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
             throw TileDBSOMAError(
                 "Support for SOMAScene is not yet implemented.");
         } else if (group_type == "somamultiscaleimage") {
-            throw TileDBSOMAError(
-                "Support for SOMAMultiscaleImage is not yet implemented.");
+            return std::make_unique<SOMAMultiscaleImage>(*group_);
         } else {
             throw TileDBSOMAError("Saw invalid SOMAGroup type");
         }

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -41,7 +41,7 @@ namespace tiledbsoma {
 
 const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
 const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
-const std::string ENCODING_VERSION_VAL = "1";
+const std::string ENCODING_VERSION_VAL = "1.1.0";
 
 using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(unit_soma
     unit_soma_dense_ndarray.cc
     unit_soma_sparse_ndarray.cc
     unit_soma_collection.cc
+    unit_soma_multiscale_image.cc
     test_indexer.cc
 # TODO: uncomment when thread_pool is enabled
 #    unit_thread_pool.cc

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -478,7 +478,7 @@ TEST_CASE_METHOD(
     soma_dataframe->close();
 
     soma_dataframe = open(OpenMode::write);
-    soma_dataframe->maybe_resize_soma_joinid(std::vector<int64_t>({new_max}));
+    soma_dataframe->resize_soma_joinid(new_max);
     soma_dataframe->close();
 
     soma_dataframe = open(OpenMode::write);
@@ -588,7 +588,7 @@ TEST_CASE_METHOD(
         REQUIRE(soma_dataframe->nnz() == 4);
 
         // Resize
-        auto new_shape = std::vector<int64_t>({SOMA_JOINID_RESIZE_DIM_MAX + 1});
+        int64_t new_shape = SOMA_JOINID_RESIZE_DIM_MAX + 1;
 
         if (!use_current_domain) {
             // Domain is already set. The domain (not current domain but domain)
@@ -599,7 +599,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -617,11 +617,11 @@ TEST_CASE_METHOD(
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_soma_joinid(new_shape);
+            soma_dataframe->resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -784,7 +784,7 @@ TEST_CASE_METHOD(
         soma_dataframe->close();
 
         // Resize
-        auto new_shape = std::vector<int64_t>({SOMA_JOINID_RESIZE_DIM_MAX + 1});
+        auto new_shape = SOMA_JOINID_RESIZE_DIM_MAX + 1;
 
         if (!use_current_domain) {
             // Domain is already set. The domain (not current domain but domain)
@@ -795,7 +795,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -812,11 +812,11 @@ TEST_CASE_METHOD(
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_soma_joinid(new_shape);
+            soma_dataframe->resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -1016,7 +1016,7 @@ TEST_CASE_METHOD(
         soma_dataframe->close();
 
         // Resize
-        auto new_shape = std::vector<int64_t>({SOMA_JOINID_RESIZE_DIM_MAX + 1});
+        auto new_shape = SOMA_JOINID_RESIZE_DIM_MAX + 1;
 
         if (!use_current_domain) {
             // Domain is already set. The domain (not current domain but domain)
@@ -1027,7 +1027,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -1044,11 +1044,11 @@ TEST_CASE_METHOD(
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_soma_joinid(new_shape);
+            soma_dataframe->resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize
@@ -1229,7 +1229,7 @@ TEST_CASE_METHOD(
         soma_dataframe->close();
 
         // Resize
-        auto new_shape = std::vector<int64_t>({SOMA_JOINID_RESIZE_DIM_MAX + 1});
+        auto new_shape = SOMA_JOINID_RESIZE_DIM_MAX + 1;
 
         if (!use_current_domain) {
             // Domain is already set. The domain (not current domain but domain)
@@ -1240,7 +1240,7 @@ TEST_CASE_METHOD(
 
             soma_dataframe = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
         } else {
@@ -1252,11 +1252,11 @@ TEST_CASE_METHOD(
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::read);
-            REQUIRE_THROWS(soma_dataframe->maybe_resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(soma_dataframe->resize_soma_joinid(new_shape));
             soma_dataframe->close();
 
             soma_dataframe = open(OpenMode::write);
-            soma_dataframe->maybe_resize_soma_joinid(new_shape);
+            soma_dataframe->resize_soma_joinid(new_shape);
             soma_dataframe->close();
 
             // Check shape after resize -- noting soma_joinid is not a dim here

--- a/libtiledbsoma/test/unit_soma_multiscale_image.cc
+++ b/libtiledbsoma/test/unit_soma_multiscale_image.cc
@@ -1,11 +1,11 @@
 /**
- * @file   tiledbsoma
+ * @file   unit_soma_multiscale_image.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,36 +27,19 @@
  *
  * @section DESCRIPTION
  *
- * This is the main import header for the C++ API
+ * This file manages unit tests for the SOMAMultiscaleImage class
  */
+#include "common.h"
 
-#ifndef __TILEDBSOMA__
-#define __TILEDBSOMA__
+TEST_CASE("SOMAMultiscaleImage: basic") {
+    auto ctx = std::make_shared<SOMAContext>();
+    std::string uri = "mem://unit-test-multiscale-image-basic";
 
-// Auto-generated file by CMake, used to define the TILEDBSOMA_EXPORT macro
-// that allows exporting symbols in a cross-platform fashion.
-#include "tiledbsoma_export.h"
-
-#include "utils/arrow_adapter.h"
-#include "utils/common.h"
-#include "utils/stats.h"
-#include "utils/version.h"
-#include "soma/enums.h"
-#include "soma/logger_public.h"
-#include "soma/soma_context.h"
-#include "soma/managed_query.h"
-#include "soma/array_buffers.h"
-#include "soma/column_buffer.h"
-#include "soma/soma_array.h"
-#include "soma/soma_collection.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_group.h"
-#include "soma/soma_experiment.h"
-#include "soma/soma_measurement.h"
-#include "soma/soma_multiscale_image.h"
-#include "soma/soma_object.h"
-#include "soma/soma_dataframe.h"
-#include "soma/soma_dense_ndarray.h"
-#include "soma/soma_sparse_ndarray.h"
-
-#endif
+    SOMAMultiscaleImage::create(uri, ctx, std::nullopt);
+    auto soma_image = SOMAMultiscaleImage::open(
+        uri, OpenMode::read, ctx, std::nullopt);
+    REQUIRE(soma_image->uri() == uri);
+    REQUIRE(soma_image->ctx() == ctx);
+    REQUIRE(soma_image->type() == "SOMAMultiscaleImage");
+    soma_image->close();
+}


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

While the full-generality `upgrade_domain` is tasked out on #2407, the foremost use-case for append mode, and `tests/testthat/test-write-soma-resume.R` for PR #3089, will need a simpller keystroke-saver which is already implemented in C++.

What this existing method does in C++ is resize the `soma_joinid` dim, if it's a dim, and leave the other dims as-is; if `soma_joinid` is not a dim, leave it as-is. This exists in C++, it's unit-tested in C++, and it's ready (and it's time) to be plumbed up to Python and R as well.

I realize now that having C++ `maybe_resize_joinid` take a length-1 vector, and assert that it's length-1, is silly -- it should simply take a single `int64_t`. This PR does just that. It also removes the confusing prefix `maybe_`.

**Notes for Reviewer:**
