### PR TITLE
[c++] Add can-resize helpers in prep for experiment-level resize

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -291,6 +291,13 @@ class SOMAArray : public SOMAObject {
     std::vector<std::string> dimension_names() const;
 
     /**
+     * @brief Sees if the array has a dimension of the given name.
+     *
+     * @return bool
+     */
+    bool has_dimension_name(const std::string& name) const;
+
+    /**
      * @brief Set the dimension slice using one point
      *
      * @note Partitioning is not supported
@@ -1075,12 +1082,10 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
-     * XXX COMMENT
+     * This is similar to can_upgrade_shape, but it's a can-we call
+     * for maybe_resize_soma_joinid.
      */
-    std::pair<bool, std::string> can_set_shape_soma_joinid(
-        int64_t newshape,
-        bool require_has_shape,
-        std::string method_name_for_messages);
+    std::pair<bool, std::string> can_resize_soma_joinid(int64_t newshape);
 
     /**
      * @brief Resize the shape (what core calls "current domain") up to the

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1032,6 +1032,57 @@ class SOMAArray : public SOMAObject {
     std::vector<int64_t> maxshape();
 
     /**
+     * This wires up to Python/R to tell a user if they can call resize() on an
+     * array without error. For single arrays, they could just call resize() and
+     * take their chances -- but for experiment-level resize (e.g. append mode)
+     * it's crucial that we provide a can-we-do-them-all pass through all arrays
+     * in the experiment before attempting any of them.
+     *
+     * On failure, returns false and an error string suitable for showing
+     * to the user; on success, returns true and the empty string.
+     *
+     * Failure reasons: the requested shape's dimension-count doesn't match the
+     * arrays; the array doesn't have a shape set (they must call
+     * upgrade_shape), or the requested shape doesn't fit within the array's
+     * existing core domain.
+     */
+    std::pair<bool, std::string> can_resize(
+        const std::vector<int64_t>& newshape) {
+        return _can_set_shape_helper(newshape, true, "resize");
+    }
+
+    /**
+     * This wires up to Python/R to tell a user if they can call
+     * upgrade_shape() on an array without error. For single dataframes,
+     * they could just call upgrade_shape() and take their chances -- but for
+     * experiment-level resize (e.g. append mode) it's crucial that we provide a
+     * can-we-do-them-all pass through all arrays in the experiment before
+     * attempting any of them.
+     *
+     * On failure, returns false and an error string suitable for showing
+     * to the user; on success, returns true and the empty string.
+     *
+     * Failure reasons: the requested shape's dimension-count doesn't match the
+     * arrays; the array already has a shape set (they must call resize), the
+     * requested shape doesn't fit within the array's existing core domain, or
+     * the requested shape is a downsize of the array's existing core current
+     * domain.
+     */
+    std::pair<bool, std::string> can_upgrade_shape(
+        const std::vector<int64_t>& newshape) {
+        return _can_set_shape_helper(
+            newshape, false, "tiledbsoma_upgrade_shape");
+    }
+
+    /**
+     * XXX COMMENT
+     */
+    std::pair<bool, std::string> can_set_shape_soma_joinid(
+        int64_t newshape,
+        bool require_has_shape,
+        std::string method_name_for_messages);
+
+    /**
      * @brief Resize the shape (what core calls "current domain") up to the
      * maxshape (what core calls "domain").
      *
@@ -1125,7 +1176,23 @@ class SOMAArray : public SOMAObject {
     }
 
     /**
-     * Helper method for resize and upgrade_shape.
+     * This is a code-dedupe helper for can_resize and can_upgrade_domain.
+     */
+    std::pair<bool, std::string> _can_set_shape_helper(
+        const std::vector<int64_t>& newshape,
+        bool is_resize,
+        std::string method_name_for_messages);
+
+    /**
+     * This is a second-level code-dedupe helper for _can_set_shape_helper.
+     */
+    std::pair<bool, std::string> _can_set_shape_domainish_helper(
+        const std::vector<int64_t>& newshape,
+        bool check_current_domain,
+        std::string method_name_for_messages);
+
+    /**
+     * This is a code-dedupe helper method for resize and upgrade_shape.
      */
     void _set_current_domain_from_shape(const std::vector<int64_t>& newshape);
 

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -664,6 +664,28 @@ TEST_CASE_METHOD(
             REQUIRE(maxdom_sjid[1] > 2000000000);
         }
 
+        // Check can_resize_soma_joinid
+        std::pair<bool, std::string> check = soma_dataframe
+                                                 ->can_resize_soma_joinid(1);
+        if (!use_current_domain) {
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "can_resize_soma_joinid: dataframe currently has no domain "
+                "set: please use tiledbsoma_upgrade_domain.");
+        } else {
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "shape 199");
+            check = soma_dataframe->can_resize_soma_joinid(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
+        }
+
         soma_dataframe->close();
     }
 }
@@ -876,6 +898,28 @@ TEST_CASE_METHOD(
             REQUIRE(maxdom_u32.size() == 2);
             REQUIRE(maxdom_u32[0] == 0);
             REQUIRE(maxdom_u32[1] > 2000000000);
+        }
+
+        // Check can_resize_soma_joinid
+        std::pair<bool, std::string> check = soma_dataframe
+                                                 ->can_resize_soma_joinid(1);
+        if (!use_current_domain) {
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "can_resize_soma_joinid: dataframe currently has no domain "
+                "set: please use tiledbsoma_upgrade_domain.");
+        } else {
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "shape 199");
+            check = soma_dataframe->can_resize_soma_joinid(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
         }
 
         soma_dataframe->close();
@@ -1108,6 +1152,28 @@ TEST_CASE_METHOD(
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));
 
+        // Check can_resize_soma_joinid
+        std::pair<bool, std::string> check = soma_dataframe
+                                                 ->can_resize_soma_joinid(1);
+        if (!use_current_domain) {
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "can_resize_soma_joinid: dataframe currently has no domain "
+                "set: please use tiledbsoma_upgrade_domain.");
+        } else {
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "shape 99");
+            check = soma_dataframe->can_resize_soma_joinid(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
+        }
+
         soma_dataframe->close();
     }
 }
@@ -1297,6 +1363,21 @@ TEST_CASE_METHOD(
                 REQUIRE(dom_str == std::vector<std::string>({"", ""}));
             }
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+        }
+
+        // Check can_resize_soma_joinid
+        std::pair<bool, std::string> check = soma_dataframe
+                                                 ->can_resize_soma_joinid(0);
+        if (!use_current_domain) {
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "can_resize_soma_joinid: dataframe currently has no domain "
+                "set: please use tiledbsoma_upgrade_domain.");
+        } else {
+            // Must pass since soma_joinid isn't a dim in this case.
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
         }
 
         soma_dataframe->close();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -405,8 +405,8 @@ TEST_CASE(
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "cannot tiledbsoma_upgrade_shape for soma_dim_0: new 1009 < existing "
-        "maxshape 1000");
+        "cannot tiledbsoma_upgrade_shape for soma_dim_0: new 1009 < maxshape "
+        "1000");
 
     check = soma_sparse->can_upgrade_shape(newshape_good);
     REQUIRE(check.first == true);
@@ -478,36 +478,3 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
     REQUIRE(check.first == true);
     REQUIRE(check.second == "");
 }
-
-//
-//// array w shape
-//// o set curdom say 1000 and maxdom huge
-//// o test newshape.size() is wrong
-//// o test doing tiledbsoma_upgrade_shape instead of resize
-//// o test resize:
-////   - test too small in any one slot
-////   - test equal -- do it twice
-////   - test larger
-//
-//// ================================================================
-//// OLD
-//// ACC-SNDA URI data-snda-py   <----------------- SLOTWISE NONE
-//// ACC-SNDA NEW SHAPE  False
-//// ACC-SNDA SHAPE      (2147483646, 2147483646)
-//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)
-////
-//// ACC-SNDA URI data-snda-shape-py   <----------------- SLOTWISE SPECIFIED
-//// ACC-SNDA NEW SHAPE  False
-//// ACC-SNDA SHAPE      (100, 200)
-//// ACC-SNDA MAXSHAPE   (100, 200)
-////
-//// ================================================================
-//// ACC-SNDA URI data-snda-py   <----------------- SLOTWISE NONE
-//// ACC-SNDA NEW SHAPE  True
-//// ACC-SNDA SHAPE      (2147483646, 2147483646)
-//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)
-////
-//// ACC-SNDA URI data-snda-shape-py   <----------------- SLOTWISE SPECIFIED
-//// ACC-SNDA NEW SHAPE  True
-//// ACC-SNDA SHAPE      (100, 200)
-//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -340,3 +340,174 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
         REQUIRE(soma_sparse->metadata_num() == 2);
     }
 }
+void breakme() {
+}
+
+TEST_CASE(
+    "SOMASparseNDArray: can_tiledbsoma_upgrade_shape", "[SOMASparseNDArray]") {
+    int64_t dim_max = 999;
+
+    auto ctx = std::make_shared<SOMAContext>();
+    std::string uri = "mem://unit-test-sparse-ndarray-upgrade-shape";
+
+    std::string dim_name = "soma_dim_0";
+    tiledb_datatype_t dim_tiledb_datatype = TILEDB_INT64;
+    tiledb_datatype_t attr_tiledb_datatype = TILEDB_INT32;
+    std::string dim_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        dim_tiledb_datatype);
+    std::string attr_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        attr_tiledb_datatype);
+
+    std::vector<helper::DimInfo> dim_infos(
+        {{.name = dim_name,
+          .tiledb_datatype = dim_tiledb_datatype,
+          .dim_max = dim_max,
+          .string_lo = "N/A",
+          .string_hi = "N/A",
+          .use_current_domain = false}});
+
+    auto index_columns = helper::create_column_index_info(dim_infos);
+
+    SOMASparseNDArray::create(
+        uri,
+        attr_arrow_format,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx);
+
+    auto soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
+    REQUIRE(soma_sparse->has_current_domain() == false);
+
+    // For old-style arrays, from before the current-domain feature:
+    // * The shape specified at create becomes the core (max) domain
+    //   o Recall that the core domain is immutable
+    // * There is no current domain set
+    //   o A current domain can be applied to it, up to <= (max) domain
+    auto dom = soma_sparse->soma_domain_slot<int64_t>(dim_name);
+    auto mxd = soma_sparse->soma_maxdomain_slot<int64_t>(dim_name);
+    REQUIRE(dom == mxd);
+    REQUIRE(dom.first == 0);
+    REQUIRE(dom.second == dim_max);
+
+    breakme();
+    std::vector<int64_t> newshape_wrong_dims({dim_max, 12});
+    std::vector<int64_t> newshape_too_big({dim_max + 10});
+    std::vector<int64_t> newshape_good({40});
+
+    auto check = soma_sparse->can_upgrade_shape(newshape_wrong_dims);
+    REQUIRE(check.first == false);
+    REQUIRE(
+        check.second ==
+        "cannot tiledbsoma_upgrade_shape: provided shape has ndim 2, while the "
+        "array has 1");
+
+    check = soma_sparse->can_upgrade_shape(newshape_too_big);
+    REQUIRE(check.first == false);
+    REQUIRE(
+        check.second ==
+        "cannot tiledbsoma_upgrade_shape for soma_dim_0: new 1009 < existing "
+        "maxshape 1000");
+
+    check = soma_sparse->can_upgrade_shape(newshape_good);
+    REQUIRE(check.first == true);
+    REQUIRE(check.second == "");
+}
+
+TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
+    int64_t dim_max = 999;
+
+    auto ctx = std::make_shared<SOMAContext>();
+    std::string uri = "mem://unit-test-sparse-ndarray-resize";
+
+    std::string dim_name = "soma_dim_0";
+    tiledb_datatype_t dim_tiledb_datatype = TILEDB_INT64;
+    tiledb_datatype_t attr_tiledb_datatype = TILEDB_INT32;
+    std::string dim_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        dim_tiledb_datatype);
+    std::string attr_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        attr_tiledb_datatype);
+
+    std::vector<helper::DimInfo> dim_infos(
+        {{.name = dim_name,
+          .tiledb_datatype = dim_tiledb_datatype,
+          .dim_max = dim_max,
+          .string_lo = "N/A",
+          .string_hi = "N/A",
+          .use_current_domain = true}});
+
+    auto index_columns = helper::create_column_index_info(dim_infos);
+
+    SOMASparseNDArray::create(
+        uri,
+        attr_arrow_format,
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ctx);
+
+    auto soma_sparse = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
+    REQUIRE(soma_sparse->has_current_domain() == true);
+
+    // For new-style arrays, with the current-domain feature:
+    // * The shape specified at create becomes the core current domain
+    //   o Recall that the core current domain is mutable, up tp <= (max) domain
+    // * The core (max) domain is huge
+    //   o Recall that the core max domain is immutable
+    auto dom = soma_sparse->soma_domain_slot<int64_t>(dim_name);
+    auto mxd = soma_sparse->soma_maxdomain_slot<int64_t>(dim_name);
+    REQUIRE(dom != mxd);
+    REQUIRE(dom.first == 0);
+    REQUIRE(dom.second == dim_max);
+
+    std::vector<int64_t> newshape_wrong_dims({dim_max, 12});
+    std::vector<int64_t> newshape_too_small({40});
+    std::vector<int64_t> newshape_good({2000});
+
+    auto check = soma_sparse->can_resize(newshape_wrong_dims);
+    REQUIRE(check.first == false);
+    REQUIRE(
+        check.second ==
+        "cannot resize: provided shape has ndim 2, while the array has 1");
+
+    check = soma_sparse->can_resize(newshape_too_small);
+    REQUIRE(check.first == false);
+    REQUIRE(
+        check.second ==
+        "cannot resize for soma_dim_0: new 40 < existing shape 1000");
+
+    check = soma_sparse->can_resize(newshape_good);
+    REQUIRE(check.first == true);
+    REQUIRE(check.second == "");
+}
+
+//
+//// array w shape
+//// o set curdom say 1000 and maxdom huge
+//// o test newshape.size() is wrong
+//// o test doing tiledbsoma_upgrade_shape instead of resize
+//// o test resize:
+////   - test too small in any one slot
+////   - test equal -- do it twice
+////   - test larger
+//
+//// ================================================================
+//// OLD
+//// ACC-SNDA URI data-snda-py   <----------------- SLOTWISE NONE
+//// ACC-SNDA NEW SHAPE  False
+//// ACC-SNDA SHAPE      (2147483646, 2147483646)
+//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)
+////
+//// ACC-SNDA URI data-snda-shape-py   <----------------- SLOTWISE SPECIFIED
+//// ACC-SNDA NEW SHAPE  False
+//// ACC-SNDA SHAPE      (100, 200)
+//// ACC-SNDA MAXSHAPE   (100, 200)
+////
+//// ================================================================
+//// ACC-SNDA URI data-snda-py   <----------------- SLOTWISE NONE
+//// ACC-SNDA NEW SHAPE  True
+//// ACC-SNDA SHAPE      (2147483646, 2147483646)
+//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)
+////
+//// ACC-SNDA URI data-snda-shape-py   <----------------- SLOTWISE SPECIFIED
+//// ACC-SNDA NEW SHAPE  True
+//// ACC-SNDA SHAPE      (100, 200)
+//// ACC-SNDA MAXSHAPE   (2147483646, 2147483646)


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

For experiment-level resize (e.g. append mode) it will be crucial that we implement a mechanism to detect whether all arrays in the experiment are resizable up to the new `(nobs, nvar)` before attempting any resizes. In particular, it would be bad to succeed in resizing some member arrays and fail on one or more.

**Notes for Reviewer:**
