### PR TITLE
[c++/python/r] Use `libtiledbsoma` for R schema evolution

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.14.99.2
+Version: 1.14.99.3
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+* Use `libtiledbsoma` for R schema evolution [#3100](https://github.com/single-cell-data/TileDB-SOMA/pull/3100)
 * Implement missing `domain` argument to `SOMADataFrame` `create` [#3032](https://github.com/single-cell-data/TileDB-SOMA/pull/3032)
 * Remove unused `fragment_count` accessor [#3054](https://github.com/single-cell-data/TileDB-SOMA/pull/3054)
 

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -226,6 +226,10 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, ctxxp) {
     invisible(.Call(`_tiledbsoma_tiledbsoma_upgrade_shape`, uri, new_shape, ctxxp))
 }
 
+c_update_dataframe_schema <- function(uri, ctxxp, column_names_to_drop, add_cols_types, add_cols_enum_value_types, add_cols_enum_ordered) {
+    invisible(.Call(`_tiledbsoma_c_update_dataframe_schema`, uri, ctxxp, column_names_to_drop, add_cols_types, add_cols_enum_value_types, add_cols_enum_ordered))
+}
+
 #' Iterator-Style Access to SOMA Array via SOMAArray
 #'
 #' The `sr_*` functions provide low-level access to an instance of the SOMAArray

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -301,9 +301,12 @@ SOMADataFrame <- R6::R6Class(
       )
 
       drop_cols_for_clib <- drop_cols
-      add_cols_types_for_clib <- list()
-      add_cols_enum_value_types_for_clib <- list()
-      add_cols_enum_ordered_for_clib <- list()
+      add_cols_types_for_clib <- 
+        add_cols_enum_value_types_for_clib <- 
+        add_cols_enum_ordered_for_clib <- vector("list", length = length(add_cols))
+      names(add_cols_types_for_clib) <- 
+        names(add_cols_enum_value_types_for_clib) <- 
+        names(add_cols_enum_ordered_for_clib) <- add_cols
 
       # Add columns
       for (add_col in add_cols) {
@@ -331,9 +334,10 @@ SOMADataFrame <- R6::R6Class(
           self$uri,
           private$.soma_context,
           drop_cols_for_clib,
-          add_cols_types_for_clib,
-          add_cols_enum_value_types_for_clib,
-          add_cols_enum_ordered_for_clib)
+          Filter(Negate(is.null), add_cols_types_for_clib),
+          Filter(Negate(is.null), add_cols_enum_value_types_for_clib),
+          Filter(Negate(is.null), add_cols_enum_ordered_for_clib)
+        )
       }
 
       # Reopen array for writing with new schema

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -238,6 +238,7 @@ SOMADataFrame <- R6::R6Class(
     #' prior to performing the update. The name of this new column will be set
     #' to the value specified by `row_index_name`.
     update = function(values, row_index_name = NULL) {
+
       private$check_open_for_write()
       stopifnot(
         "'values' must be a data.frame, Arrow Table or RecordBatch" =
@@ -299,47 +300,45 @@ SOMADataFrame <- R6::R6Class(
         new_schema[common_cols]
       )
 
-      # Drop columns
-      se <- tiledb::tiledb_array_schema_evolution()
-      for (drop_col in drop_cols) {
-        spdl::debug("[SOMADataFrame update]: dropping column '{}'", drop_col)
-        se <- tiledb::tiledb_array_schema_evolution_drop_attribute(
-          object = se,
-          attrname = drop_col
-        )
-      }
+      drop_cols_for_clib <- drop_cols
+      add_cols_types_for_clib <- list()
+      add_cols_enum_value_types_for_clib <- list()
+      add_cols_enum_ordered_for_clib <- list()
 
       # Add columns
       for (add_col in add_cols) {
-        spdl::debug("[SOMADataFrame update]: adding column '{}'", add_col)
 
         col_type <- new_schema$GetFieldByName(add_col)$type
-        attr <- tiledb_attr_from_arrow_field(
-          field = new_schema$GetFieldByName(add_col),
-          tiledb_create_options = tiledb_create_options
-        )
 
         if (inherits(col_type, "DictionaryType")) {
           spdl::debug(
-            "[SOMADataFrame update]: adding column '{}' as an enumerated type",
-            add_col
+            "[SOMADataFrame update]: adding enum column '{}' index type '{}' value type '{}' ordered {}",
+            add_col, col_type$index_type$name, col_type$value_type$name, col_type$ordered
           )
-          se <- tiledb::tiledb_array_schema_evolution_add_enumeration(
-            object = se,
-            name = add_col,
-            enums = levels(values$GetColumnByName(add_col)$as_vector()),
-            ordered = col_type$ordered
-          )
-          attr <- tiledb::tiledb_attribute_set_enumeration_name(attr, add_col)
-        }
 
-        se <- tiledb::tiledb_array_schema_evolution_add_attribute(se, attr)
+          add_cols_types_for_clib[[add_col]] <- col_type$index_type$name
+          add_cols_enum_value_types_for_clib[[add_col]] <- col_type$value_type$name
+          add_cols_enum_ordered_for_clib[[add_col]] <- col_type$ordered
+        } else {
+          spdl::debug("[SOMADataFrame update]: adding column '{}' type '{}'", add_col, col_type$name)
+
+          add_cols_types_for_clib[[add_col]] <- col_type$name
+        }
       }
 
-      se <- tiledb::tiledb_array_schema_evolution_array_evolve(se, self$uri)
+      if (length(drop_cols_for_clib) > 0 || length(add_cols_types_for_clib) > 0) {
+        c_update_dataframe_schema(
+          self$uri,
+          private$.soma_context,
+          drop_cols_for_clib,
+          add_cols_types_for_clib,
+          add_cols_enum_value_types_for_clib,
+          add_cols_enum_ordered_for_clib)
+      }
 
       # Reopen array for writing with new schema
       self$reopen(mode = "WRITE")
+
       spdl::debug("[SOMADataFrame update]: Writing new data")
       self$write(values)
     },

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -24,6 +24,7 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-domain}{\code{SOMADataFrame$domain()}}
 \item \href{#method-SOMADataFrame-maxdomain}{\code{SOMADataFrame$maxdomain()}}
 \item \href{#method-SOMADataFrame-tiledbsoma_has_upgraded_domain}{\code{SOMADataFrame$tiledbsoma_has_upgraded_domain()}}
+\item \href{#method-SOMADataFrame-resize_soma_joinid}{\code{SOMADataFrame$resize_soma_joinid()}}
 \item \href{#method-SOMADataFrame-clone}{\code{SOMADataFrame$clone()}}
 }
 }
@@ -277,6 +278,34 @@ or it has had \code{upgrade_domain} applied to it.
 
 \subsection{Returns}{
 Logical
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-resize_soma_joinid"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-resize_soma_joinid}{}}}
+\subsection{Method \code{resize_soma_joinid()}}{
+Increases the shape of the dataframe on the \code{soma_joinid}
+index column, if it indeed is an index column, leaving all other index
+columns as-is. If the \code{soma_joinid} is not an index column, no change is
+made.  This is a special case of \code{upgrade_domain} (WIP for 1.15), but
+simpler to keystroke, and handles the most common case for dataframe
+domain expansion.  Raises an error if the dataframe doesn't already have a
+domain: in that case please call \code{tiledbsoma_upgrade_domain} (WIP for
+1.15).
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$resize_soma_joinid(new_shape)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{new_shape}}{An integer, greater than or equal to 1 + the
+\code{soma_joinid} domain slot.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+No return value
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -512,6 +512,21 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// c_update_dataframe_schema
+void c_update_dataframe_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::CharacterVector column_names_to_drop, Rcpp::List add_cols_types, Rcpp::List add_cols_enum_value_types, Rcpp::List add_cols_enum_ordered);
+RcppExport SEXP _tiledbsoma_c_update_dataframe_schema(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP column_names_to_dropSEXP, SEXP add_cols_typesSEXP, SEXP add_cols_enum_value_typesSEXP, SEXP add_cols_enum_orderedSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type column_names_to_drop(column_names_to_dropSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type add_cols_types(add_cols_typesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type add_cols_enum_value_types(add_cols_enum_value_typesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type add_cols_enum_ordered(add_cols_enum_orderedSEXP);
+    c_update_dataframe_schema(uri, ctxxp, column_names_to_drop, add_cols_types, add_cols_enum_value_types, add_cols_enum_ordered);
+    return R_NilValue;
+END_RCPP
+}
 // sr_setup
 Rcpp::XPtr<tdbs::SOMAArray> sr_setup(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::CharacterVector> colnames, Rcpp::Nullable<Rcpp::XPtr<tiledb::QueryCondition>> qc, Rcpp::Nullable<Rcpp::List> dim_points, Rcpp::Nullable<Rcpp::List> dim_ranges, std::string batch_size, std::string result_order, Rcpp::Nullable<Rcpp::DatetimeVector> timestamprange, const std::string& loglevel);
 RcppExport SEXP _tiledbsoma_sr_setup(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP colnamesSEXP, SEXP qcSEXP, SEXP dim_pointsSEXP, SEXP dim_rangesSEXP, SEXP batch_sizeSEXP, SEXP result_orderSEXP, SEXP timestamprangeSEXP, SEXP loglevelSEXP) {
@@ -722,6 +737,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 3},
     {"_tiledbsoma_resize_soma_joinid", (DL_FUNC) &_tiledbsoma_resize_soma_joinid, 3},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 3},
+    {"_tiledbsoma_c_update_dataframe_schema", (DL_FUNC) &_tiledbsoma_c_update_dataframe_schema, 6},
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},
     {"_tiledbsoma_create_empty_arrow_table", (DL_FUNC) &_tiledbsoma_create_empty_arrow_table, 0},

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -511,8 +511,11 @@ static std::map<std::string, std::string> _type_name_remap = {
     {"uint16", "S"},
     {"uint32", "I"},
     {"uint64", "L"},
-    {"utf8", "U"},
-    {"bool", "b"}};
+    {"utf8", "u"},
+    {"large_utf8", "U"},
+    {"bool", "b"},
+    {"float", "f"},
+    {"double", "g"}};
 
 std::string remap_arrow_type_code_r_to_c(std::string input) {
     auto it = _type_name_remap.find(input);

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -501,3 +501,24 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
 
     return arrayxp;
 }
+
+static std::map<std::string, std::string> _type_name_remap = {
+    {"int8", "c"},
+    {"int16", "s"},
+    {"int32", "i"},
+    {"int64", "l"},
+    {"uint8", "C"},
+    {"uint16", "S"},
+    {"uint32", "I"},
+    {"uint64", "L"},
+    {"utf8", "U"},
+    {"bool", "b"}};
+
+std::string remap_arrow_type_code_r_to_c(std::string input) {
+    auto it = _type_name_remap.find(input);
+    if (it == _type_name_remap.end()) {
+        return input;
+    } else {
+        return it->second;
+    }
+}

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -76,3 +76,6 @@ std::vector<int64_t> i64_from_rcpp_numeric(const Rcpp::NumericVector& input);
 // * obtain an ArrowTable
 // * need to map that to an R list of lo/hi pairs
 SEXP convert_domainish(const tdbs::ArrowTable& arrow_table);
+
+// Maps e.g. "int8" and "float32" to "c" and "f".
+std::string remap_arrow_type_code_r_to_c(std::string input);


### PR DESCRIPTION
**Issue and/or context:** This is an item on #2406: in particular #3057 / [[sc-55679]](https://app.shortcut.com/tiledb-inc/story/55679/r-use-libtiledbsoma-for-schema-evolution)/

**Changes:**

* Move the `pybind11` `update_dataframe` entirely to `libtiledbsoma` (it's ready to go, no mods needed)
* Call that from R, removing another TileDB-R callsite

**Notes for Reviewer:**

See also #3115.