### PR TITLE
[c++] Fail earlier if `n_buffers` is not as expected

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1114,6 +1114,13 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         array->n_buffers,
         column->is_nullable()));
 
+    if (array->n_buffers != n_buffers) {
+        throw TileDBSOMAError(fmt::format(
+            "[ArrowAdapter] expected array n_buffers {}; got {}",
+            n_buffers,
+            array->n_buffers));
+    }
+
     // After allocating and initializing via nanoarrow we
     // hook our custom release function in
     array->release = &release_array;


### PR DESCRIPTION
While working on #3100 for #3057 / [[sc-55679]](https://app.shortcut.com/tiledb-inc/story/55679/r-use-libtiledbsoma-for-schema-evolution) (parent #2406) I ran into a cryptic error from Arrow. It turns out that when the number of buffers doesn't match -- 2 for non-variable-length validity/data vs. 3 for variable-length validity/offsets/data -- we can get message like

```
tiledbsoma._exception.SOMAError: ArrowInvalid: Column 4: In chunk 0: Invalid: First or last binary offset out of bounds
At:
  pyarrow/error.pxi(92): pyarrow.lib.check_status
```

Now, the dev situation in which I was setting up data to _generate_ such a situation is perhaps incorrect -- but -- we should fail sooner, and more transparently.

The status quo is that I turned on libtiledbsoma trace-logging & saw lines like
```
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] column type i name myint nbuf 2 2 nullable true
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] create array name='myint' use_count=4
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [debug] [ArrowAdapter] release_schema for myint
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema schema->name
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema schema->format
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema done
[2024-10-01 16:02:55.054] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] column type f name myfloat nbuf 2 2 nullable true
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] create array name='myfloat' use_count=4
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [debug] [ArrowAdapter] release_schema for myfloat
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema schema->name
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema schema->format
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] release_schema done
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] column type U name newattr nbuf 2 3 nullable true <---- here
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [trace] [ArrowAdapter] create array name='newattr' use_count=4
[2024-10-01 16:02:55.055] [tiledbsoma] [Process: 5942] [Thread: 5942] [debug] [ArrowAdapter] release_schema for newattr
```

where the `2 3` was the smoking gun.