### PR TITLE
[python] Add `Scene` tests

### DIFF
--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -511,9 +511,9 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         if self._coord_space is not None:
             if value.axis_names != self._coord_space.axis_names:
                 raise ValueError(
-                    f"Cannot change axis names of a point cloud dataframe. Existing "
-                    f"axis names are {self._coord_space.axis_names}. New coordinate "
-                    f"space has axis names {self._coord_space.axis_names}."
+                    f"Cannot change axis names of a point cloud. Existing axis names "
+                    f"are {self._coord_space.axis_names}. New coordinate space has "
+                    f"axis names {value.axis_names}."
                 )
         self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(
             value

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Type
 
 import numpy as np
 import pyarrow as pa
@@ -26,31 +26,52 @@ def coordinate_space_to_json(coord_space: somacore.CoordinateSpace) -> str:
 
 
 def transform_from_json(data: str) -> somacore.CoordinateTransform:
-    """TODO: Add docstring"""
+    """Convert a JSON string representing a CoordinateTransform"""
+
     raw = json.loads(data)
+
     try:
         transform_type = raw.pop("transform_type")
     except KeyError:
-        raise KeyError()  # TODO Add error message
+        raise KeyError(
+            "'transform_type' not found when attempting to convert "
+            "JSON to CoordinateTransform child class"
+        )
+
     try:
         kwargs = raw.pop("transform")
     except KeyError:
-        raise KeyError()  # TODO Add error message
-    if transform_type == "IdentityTransform":
-        return somacore.IdentityTransform(**kwargs)
-    elif transform_type == "AffineTransform":
-        return somacore.AffineTransform(**kwargs)
-    else:
-        raise KeyError("Unrecognized transform type key 'transform_type'")
+        raise KeyError(
+            "'transform' kwargs options not found when attempting to "
+            "convert JSON to CoordinateTransform child class"
+        )
+
+    coord_transform_init: Dict[str, Type[somacore.CoordinateTransform]] = {
+        "AffineTransform": somacore.AffineTransform,
+        "ScaleTransform": somacore.ScaleTransform,
+        "UniformScaleTransform": somacore.UniformScaleTransform,
+        "IdentityTransform": somacore.IdentityTransform,
+    }
+
+    try:
+        return coord_transform_init[transform_type](**kwargs)
+    except KeyError:
+        raise KeyError(f"Unrecognized transform type key '{transform_type}'")
 
 
 def transform_to_json(transform: somacore.CoordinateTransform) -> str:
-    kwargs = {
+    """Representing a CoordinateTransform as a JSON string"""
+
+    kwargs: Dict[str, Any] = {
         "input_axes": transform.input_axes,
         "output_axes": transform.output_axes,
     }
     if isinstance(transform, somacore.IdentityTransform):
         pass
+    elif isinstance(transform, somacore.UniformScaleTransform):
+        kwargs["scale"] = transform.scale
+    elif isinstance(transform, somacore.ScaleTransform):
+        kwargs["scale_factors"] = transform.scale_factors.tolist()
     elif isinstance(transform, somacore.AffineTransform):
         kwargs["matrix"] = transform.augmented_matrix.tolist()
     else:

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -1,0 +1,459 @@
+import json
+from urllib.parse import urljoin
+
+import numpy as np
+import pyarrow as pa
+import pytest
+import typeguard
+
+import tiledbsoma as soma
+
+
+def create_and_populate_df(uri: str) -> soma.DataFrame:
+    obs_arrow_schema = pa.schema(
+        [
+            ("foo", pa.int32()),
+            ("bar", pa.float64()),
+            ("baz", pa.large_string()),
+        ]
+    )
+
+    with soma.DataFrame.create(uri, schema=obs_arrow_schema) as obs:
+        pydict = {}
+        pydict["soma_joinid"] = [0, 1, 2, 3, 4]
+        pydict["foo"] = [10, 20, 30, 40, 50]
+        pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
+        pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
+        rb = pa.Table.from_pydict(pydict)
+        obs.write(rb)
+
+    return soma.DataFrame.open(uri)
+
+
+def test_scene_basic(tmp_path):
+    baseuri = tmp_path.as_uri()
+
+    with soma.Scene.create(baseuri) as scene:
+        assert scene.uri == baseuri
+
+        with pytest.raises(TypeError):
+            scene["obsl"] = soma.Experiment.create(urljoin(baseuri, "obs"))
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+        scene["obsl"]["df"] = create_and_populate_df(urljoin(obsl_uri, "df"))
+
+        with pytest.raises(TypeError):
+            scene["varl"] = soma.Measurement.create(urljoin(baseuri, "var"))
+        varl_uri = urljoin(baseuri, "varl")
+        scene["varl"] = soma.Collection.create(varl_uri)
+        scene["varl"]["sparse"] = soma.SparseNDArray.create(
+            urljoin(varl_uri, "sparse"), type=pa.int64(), shape=(10,)
+        )
+        scene["varl"]["dense"] = soma.DenseNDArray.create(
+            urljoin(varl_uri, "dense"), type=pa.int64(), shape=(10,)
+        )
+
+        img_uri = urljoin(baseuri, "img")
+        scene["img"] = soma.Collection.create(img_uri)
+        scene["img"]["col"] = soma.Collection.create(urljoin(img_uri, "col"))
+
+    assert not soma.Collection.exists(baseuri)
+    assert soma.Scene.exists(baseuri)
+    assert soma.Collection.exists(obsl_uri)
+    assert soma.Collection.exists(varl_uri)
+    assert soma.Collection.exists(img_uri)
+    assert soma.Measurement.exists(urljoin(baseuri, "var"))
+    assert soma.SparseNDArray.exists(urljoin(varl_uri, "sparse"))
+    assert soma.DenseNDArray.exists(urljoin(varl_uri, "dense"))
+    assert soma.Collection.exists(urljoin(img_uri, "col"))
+
+    with soma.Scene.open(baseuri) as scene:
+        assert scene is not None
+        assert scene.obsl is not None
+        assert scene.obsl["df"] is not None
+        assert scene.varl is not None
+        assert scene.varl["sparse"] is not None
+        assert scene.varl["dense"] is not None
+        assert scene.img is not None
+        assert scene.img["col"] is not None
+
+        assert len(scene) == 3
+        assert scene.soma_type == "SOMAScene"
+
+        assert scene.obsl == scene["obsl"]
+        assert len(scene.obsl) == 1
+        assert scene.obsl["df"] == scene["obsl"]["df"]
+
+        assert scene.varl == scene["varl"]
+        assert len(scene.varl) == 2
+        assert scene.varl["sparse"] == scene["varl"]["sparse"]
+        assert scene.varl["dense"] == scene["varl"]["dense"]
+
+        assert scene.img == scene["img"]
+        assert len(scene.img) == 1
+        assert scene.img["col"] == scene["img"]["col"]
+
+    with pytest.raises(soma.DoesNotExistError):
+        soma.Scene.open("bad uri")
+
+
+def test_measurement_with_var_scene(tmp_path):
+    baseuri = tmp_path.as_uri()
+    obs_scene_uri = urljoin(baseuri, "obs_scene")
+
+    with soma.Measurement.create(baseuri) as mea:
+        with pytest.raises(TypeError):
+            mea["obs_scene"] = soma.SparseNDArray.create(obs_scene_uri)
+        mea["obs_scene"] = create_and_populate_df(obs_scene_uri)
+
+    assert soma.Measurement.exists(baseuri)
+    assert soma.DataFrame.exists(obs_scene_uri)
+
+
+def test_scene_coord_space(tmp_path):
+    uri = tmp_path.as_uri()
+
+    coord_space = soma.CoordinateSpace(
+        [
+            soma.Axis(name="x"),
+            soma.Axis(name="y"),
+        ]
+    )
+    coord_space_json = """
+    [
+        {"name": "x", "unit": null},
+        {"name": "y", "unit": null}
+    ]
+    """
+
+    with soma.Scene.create(uri) as scene:
+        assert scene.coordinate_space is None
+        assert "soma_coordinate_space" not in scene.metadata
+
+        # Setter only takes in CoordinateSpace
+        with pytest.raises(typeguard.TypeCheckError):
+            scene.coordinate_space = None
+        with pytest.raises(typeguard.TypeCheckError):
+            scene.coordinate_space = [soma.Axis(name="x"), soma.Axis(name="y")]
+
+        # Reserved metadata key should not be settable?
+        # with pytest.raises(soma.SOMAError):
+        #     scene.metadata["soma_coordinate_space"] = coord_space_json
+        scene.coordinate_space = coord_space
+        assert scene.coordinate_space == coord_space
+        assert json.loads(scene.metadata["soma_coordinate_space"]) == json.loads(
+            coord_space_json
+        )
+
+    with soma.Scene.open(uri) as scene:
+        assert scene.coordinate_space == coord_space
+
+
+def test_scene_point_cloud_with_affine_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_point_cloud_with_affine_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        ptc_uri = urljoin(obsl_uri, "ptc")
+        asch = pa.schema([("x", pa.float64()), ("y", pa.float64())])
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_new_point_cloud_dataframe when implemented
+        scene["obsl"]["ptc"] = soma.PointCloudDataFrame.create(ptc_uri, schema=asch)
+
+        transform = soma.AffineTransform(
+            input_axes=("x", "y"),
+            output_axes=("x", "y"),
+            matrix=np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_point_cloud_dataframe("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_point_cloud_dataframe("bad", transform)
+
+        scene.set_transform_to_point_cloud_dataframe("ptc", transform)
+        assert np.array_equal(
+            scene.get_transform_to_point_cloud_dataframe("ptc").augmented_matrix,
+            transform.augmented_matrix,
+        )
+
+
+def test_scene_point_cloud_with_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_point_cloud_with_scale_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        ptc_uri = urljoin(obsl_uri, "ptc")
+        asch = pa.schema([("x", pa.float64()), ("y", pa.float64())])
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_new_point_cloud_dataframe when implemented
+        scene["obsl"]["ptc"] = soma.PointCloudDataFrame.create(ptc_uri, schema=asch)
+
+        transform = soma.ScaleTransform(
+            input_axes=("x", "y"), output_axes=("x", "y"), scale_factors=[1, 1]
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_point_cloud_dataframe("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_point_cloud_dataframe("bad", transform)
+
+        scene.set_transform_to_point_cloud_dataframe("ptc", transform)
+        assert np.array_equal(
+            scene.get_transform_to_point_cloud_dataframe("ptc").scale_factors,
+            transform.scale_factors,
+        )
+
+
+def test_scene_point_cloud_with_uniform_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_point_cloud_with_uniform_scale_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        ptc_uri = urljoin(obsl_uri, "ptc")
+        asch = pa.schema([("x", pa.float64()), ("y", pa.float64())])
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_new_point_cloud_dataframe when implemented
+        scene["obsl"]["ptc"] = soma.PointCloudDataFrame.create(ptc_uri, schema=asch)
+
+        transform = soma.UniformScaleTransform(
+            input_axes=("x", "y"), output_axes=("x", "y"), scale=1
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_point_cloud_dataframe("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_point_cloud_dataframe("bad", transform)
+
+        scene.set_transform_to_point_cloud_dataframe("ptc", transform)
+        assert (
+            scene.get_transform_to_point_cloud_dataframe("ptc").scale == transform.scale
+        )
+
+
+def test_scene_point_cloud_with_identity_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_point_cloud_with_identity_scale_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        ptc_uri = urljoin(obsl_uri, "ptc")
+        asch = pa.schema([("x", pa.float64()), ("y", pa.float64())])
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_new_point_cloud_dataframe when implemented
+        scene["obsl"]["ptc"] = soma.PointCloudDataFrame.create(ptc_uri, schema=asch)
+
+        transform = soma.IdentityTransform(
+            input_axes=("x", "y"), output_axes=("x", "y")
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_point_cloud_dataframe("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_point_cloud_dataframe("bad", transform)
+
+        scene.set_transform_to_point_cloud_dataframe("ptc", transform)
+        assert (
+            scene.get_transform_to_point_cloud_dataframe("ptc").scale == transform.scale
+        )
+
+
+def test_scene_multiscale_image_with_affine_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_multiscale_image_with_affine_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        img_uri = urljoin(baseuri, "img")
+        scene["img"] = soma.Collection.create(img_uri)
+
+        msi_uri = urljoin(img_uri, "msi")
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_multiscale_image when implemented
+        scene["img"]["msi"] = soma.MultiscaleImage.create(
+            msi_uri, type=pa.int64(), reference_level_shape=[1, 2, 3]
+        )
+
+        transform = soma.AffineTransform(
+            input_axes=("x", "y"),
+            output_axes=("x", "y"),
+            matrix=np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_multiscale_image("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_multiscale_image("bad", transform)
+
+        scene.set_transform_to_multiscale_image("msi", transform)
+        assert np.array_equal(
+            scene.get_transform_to_multiscale_image("msi").augmented_matrix,
+            transform.augmented_matrix,
+        )
+
+
+def test_scene_multiscale_image_with_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/", "test_scene_multiscale_image_with_scale_transform"
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        img_uri = urljoin(baseuri, "img")
+        scene["img"] = soma.Collection.create(img_uri)
+
+        msi_uri = urljoin(img_uri, "msi")
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_multiscale_image when implemented
+        scene["img"]["msi"] = soma.MultiscaleImage.create(
+            msi_uri, type=pa.int64(), reference_level_shape=[1, 2, 3]
+        )
+
+        transform = soma.ScaleTransform(
+            input_axes=("x", "y"), output_axes=("x", "y"), scale_factors=[1, 1]
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_multiscale_image("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_multiscale_image("bad", transform)
+
+        scene.set_transform_to_multiscale_image("msi", transform)
+        assert np.array_equal(
+            scene.get_transform_to_multiscale_image("msi").scale_factors,
+            transform.scale_factors,
+        )
+
+
+def test_scene_multiscale_image_with_uniform_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/",
+        "test_scene_multiscale_image_with_uniform_scale_transform",
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        img_uri = urljoin(baseuri, "img")
+        scene["img"] = soma.Collection.create(img_uri)
+
+        msi_uri = urljoin(img_uri, "msi")
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_multiscale_image when implemented
+        scene["img"]["msi"] = soma.MultiscaleImage.create(
+            msi_uri, type=pa.int64(), reference_level_shape=[1, 2, 3]
+        )
+
+        transform = soma.UniformScaleTransform(
+            input_axes=("x", "y"), output_axes=("x", "y"), scale=1
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_multiscale_image("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_multiscale_image("bad", transform)
+
+        scene.set_transform_to_multiscale_image("msi", transform)
+        assert scene.get_transform_to_multiscale_image("msi").scale == transform.scale
+
+
+def test_scene_multiscale_image_with_identity_scale_transform(tmp_path):
+    baseuri = urljoin(
+        f"{tmp_path.as_uri()}/",
+        "test_scene_multiscale_image_with_identity_scale_transform",
+    )
+
+    with soma.Scene.create(baseuri) as scene:
+        obsl_uri = urljoin(baseuri, "obsl")
+        scene["obsl"] = soma.Collection.create(obsl_uri)
+
+        img_uri = urljoin(baseuri, "img")
+        scene["img"] = soma.Collection.create(img_uri)
+
+        msi_uri = urljoin(img_uri, "msi")
+        coord_space = soma.CoordinateSpace([soma.Axis(name="x"), soma.Axis(name="y")])
+
+        # TODO replace with Scene.add_multiscale_image when implemented
+        scene["img"]["msi"] = soma.MultiscaleImage.create(
+            msi_uri, type=pa.int64(), reference_level_shape=[1, 2, 3]
+        )
+
+        transform = soma.IdentityTransform(
+            input_axes=("x", "y"), output_axes=("x", "y")
+        )
+
+        # The scene coordinate space must be set before registering
+        with pytest.raises(soma.SOMAError):
+            scene.set_transform_to_multiscale_image("transcripts", transform)
+
+        scene.coordinate_space = coord_space
+
+        # No PointCloudDataFrame named 'bad' in Scene
+        with pytest.raises(KeyError):
+            scene.set_transform_to_multiscale_image("bad", transform)
+
+        scene.set_transform_to_multiscale_image("msi", transform)
+        assert scene.get_transform_to_multiscale_image("msi").scale == transform.scale


### PR DESCRIPTION
* Added tests for what is currently implemented
* Would still need tests for
        - `subcollection`
        - `add_{spatial_datatype}` (currently using `create`)
        - `GeometryDataFrame` (currently skipping)