### PR TITLE
[c++/python] Check `arrow_is_string_type` in `_update_dataframe`

### DIFF
--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -154,6 +154,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
                     *ctx->tiledb_ctx(),
                     attr_name,
                     ArrowAdapter::to_tiledb_format(attr_type));
+
+                if (ArrowAdapter::arrow_is_string_type(attr_type.c_str())) {
+                    attr.set_cell_val_num(TILEDB_VAR_NUM);
+                }
+
                 FilterList filter_list(*ctx->tiledb_ctx());
                 filter_list.add_filter(
                     Filter(*ctx->tiledb_ctx(), TILEDB_FILTER_ZSTD));

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -822,7 +822,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
             auto schild = index_column_schema->children[i];
             auto col_name = schild->name;
             if (strcmp(child->name, col_name) == 0) {
-                if (ArrowAdapter::_isvar(child->format)) {
+                if (ArrowAdapter::arrow_is_string_type(child->format)) {
                     type = TILEDB_STRING_ASCII;
                 }
 
@@ -861,7 +861,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                 attr.set_nullable(true);
             }
 
-            if (ArrowAdapter::_isvar(child->format)) {
+            if (ArrowAdapter::arrow_is_string_type(child->format)) {
                 attr.set_cell_val_num(TILEDB_VAR_NUM);
             }
 
@@ -872,7 +872,9 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     *ctx,
                     child->name,
                     enmr_type,
-                    ArrowAdapter::_isvar(enmr_format) ? TILEDB_VAR_NUM : 1,
+                    ArrowAdapter::arrow_is_string_type(enmr_format) ?
+                        TILEDB_VAR_NUM :
+                        1,
                     child->flags & ARROW_FLAG_DICTIONARY_ORDERED);
                 ArraySchemaExperimental::add_enumeration(*ctx, schema, enmr);
                 AttributeExperimental::set_enumeration_name(
@@ -919,7 +921,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     continue;
                 }
 
-                if (ArrowAdapter::_isvar(child->format)) {
+                if (ArrowAdapter::arrow_is_string_type(child->format)) {
                     // In the core API:
                     //
                     // * domain for strings must be set as (nullptr, nullptr)
@@ -1241,12 +1243,10 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     return std::pair(std::move(array), std::move(schema));
 }
 
-bool ArrowAdapter::_isvar(const char* format) {
-    if ((strcmp(format, "U") == 0) || (strcmp(format, "Z") == 0) ||
-        (strcmp(format, "u") == 0) || (strcmp(format, "z") == 0)) {
-        return true;
-    }
-    return false;
+bool ArrowAdapter::arrow_is_string_type(const char* format) {
+    return (
+        (strcmp(format, "U") == 0) || (strcmp(format, "Z") == 0) ||
+        (strcmp(format, "u") == 0) || (strcmp(format, "z") == 0));
 }
 
 std::string_view ArrowAdapter::to_arrow_format(

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -261,6 +261,15 @@ class ArrowAdapter {
         tiledb_datatype_t tiledb_dtype, bool use_large = true);
 
     /**
+     * @brief Keystroke saver to determine whether Arrow type is of string,
+     * large string, binary, or large binary type.
+     *
+     * @param const char* Arrow data format
+     * @return bool Whether the Arrow type represents a string type
+     */
+    static bool arrow_is_string_type(const char* format);
+
+    /**
      * @brief Get TileDB datatype from Arrow format string.
      *
      * @param datatype TileDB datatype.
@@ -672,8 +681,6 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx, std::string name, T* b) {
         return Dimension::create<T>(*ctx, name, {b[0], b[1]}, b[2]);
     }
-
-    static bool _isvar(const char* format);
 
     static FilterList _create_filter_list(
         std::string filters, std::shared_ptr<Context> ctx);


### PR DESCRIPTION
- Rename `ArrowAdapter::_isvar` to `ArrowAdapter::arrow_is_string_type` and expose in public API
- In pybind11 `SOMAArray._update_dataframe`, check if the Arrow column's type is a string type and set the `Attr`'s cell value to `TILEDB_VAR_NUM` if so