### PR TITLE
[python] Fix retrieval of named levels from a MultiscaleImage

### DIFF
--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -508,18 +508,20 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         self._coord_space = value
 
     def get_transform_from_level(self, level: Union[int, str]) -> ScaleTransform:
-        """Returns the transformation from user requested level to image reference
+        """Returns the transformation from user requested level to the image reference
         level.
 
         Lifecycle:
             Experimental.
         """
         if isinstance(level, str):
+            level_props = None
             for val in self._levels:
                 if val.name == level:
                     level_props = val
-                else:
-                    raise KeyError(f"No level with name '{level}'")
+                    break
+            else:
+                raise KeyError("No level with name '{level}'")
         else:
             level_props = self._levels[level]
         ref_level_props = self._schema.reference_level_properties
@@ -551,11 +553,13 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             Experimental.
         """
         if isinstance(level, str):
+            level_props = None
             for val in self._levels:
                 if val.name == level:
                     level_props = val
-                else:
-                    raise KeyError(f"No level with name '{level}'")
+                    break
+            else:
+                raise KeyError("No level with name '{level}'")
         else:
             level_props = self._levels[level]
         ref_level_props = self._schema.reference_level_properties


### PR DESCRIPTION
Before this PR:

```py
scene.img["tissue"].get_transform_to_level(0)
## <somacore.coordinates.ScaleTransform at 0x17701b390>

scene.img["tissue"].get_transform_to_level("hires")
## KeyError                                  Traceback (most recent call last)
## Cell In[325], line 1
## ----> 1 scene.img[image_name].get_transform_to_level("hires")
## 
## File ~/Library/CloudStorage/Dropbox-TileDB/Aaron Wolen/customers/czi/TileDB-SOMA2/apis/python/src/tiledbsoma/_multiscale_image.py:551, in MultiscaleImage.get_transform_to_level(self, level)
##     549             level_props = val
##     550         else:
## --> 551             raise KeyError("No level with name '{level}'")
##     552 else:
##     553     level_props = self._levels[level]
## 
## KeyError: "No level with name '{level}'"
```

With this PR:

```py
scene.img["tissue"].get_transform_to_level(0)
## <somacore.coordinates.ScaleTransform object at 0x16f7667d0>

scene.img["tissue"].get_transform_to_level("hires")
## <somacore.coordinates.ScaleTransform object at 0x16f8189d0>
```