### PR TITLE
[c++/python/r] Rename a helper function

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -417,7 +417,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         return self._handle.tiledbsoma_has_upgraded_domain
 
-    def resize_soma_joinid(self, newshape: int) -> None:
+    def resize_soma_joinid_shape(self, newshape: int) -> None:
         """Increases the shape of the dataframe on the ``soma_joinid`` index
         column, if it indeed is an index column, leaving all other index columns
         as-is. If the ``soma_joinid`` is not an index column, no change is made.
@@ -427,7 +427,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         domain: in that case please call ``tiledbsoma_upgrade_domain`` (WIP for
         1.15).
         """
-        self._handle._handle.resize_soma_joinid(newshape)
+        self._handle._handle.resize_soma_joinid_shape(newshape)
 
     def __len__(self) -> int:
         """Returns the number of rows in the dataframe. Same as ``df.count``."""

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -463,7 +463,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
-    def resize_soma_joinid(self, newshape: int) -> None:
+    def resize_soma_joinid_shape(self, newshape: int) -> None:
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
@@ -513,7 +513,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
         """
         return cast(bool, self._handle.tiledbsoma_has_upgraded_domain)
 
-    def resize_soma_joinid(self, newshape: int) -> None:
+    def resize_soma_joinid_shape(self, newshape: int) -> None:
         """Increases the shape of the dataframe on the ``soma_joinid`` index
         column, if it indeed is an index column, leaving all other index columns
         as-is. If the ``soma_joinid`` is not an index column, no change is made.
@@ -523,7 +523,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
         domain: in that case please call ``tiledbsoma_upgrade_domain`` (WIP for
         1.15).
         """
-        self._handle.resize_soma_joinid(newshape)
+        self._handle.resize_soma_joinid_shape(newshape)
 
 
 class PointCloudDataFrameWrapper(SOMAArrayWrapper[clib.SOMAPointCloudDataFrame]):

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -158,10 +158,10 @@ void load_soma_dataframe(py::module& m) {
             "tiledbsoma_has_upgraded_domain", &SOMAArray::has_current_domain)
 
         .def(
-            "resize_soma_joinid",
+            "resize_soma_joinid_shape",
             [](SOMADataFrame& sdf, int64_t newshape) {
                 try {
-                    sdf.resize_soma_joinid(newshape);
+                    sdf.resize_soma_joinid_shape(newshape);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -280,9 +280,9 @@ def test_dataframe_basics(tmp_path, soma_joinid_domain, index_column_names):
                 # TODO: check draft spec
                 # with pytest.raises(ValueError):
                 with pytest.raises(tiledbsoma.SOMAError):
-                    sdf.resize_soma_joinid(new_shape)
+                    sdf.resize_soma_joinid_shape(new_shape)
             else:
-                sdf.resize_soma_joinid(new_shape)
+                sdf.resize_soma_joinid_shape(new_shape)
 
         with tiledbsoma.DataFrame.open(uri) as sdf:
             assert sdf._maybe_soma_joinid_shape == shape_at_create
@@ -302,7 +302,7 @@ def test_dataframe_basics(tmp_path, soma_joinid_domain, index_column_names):
         # Test resize
         new_shape = 0 if shape_at_create is None else shape_at_create + 100
         with tiledbsoma.DataFrame.open(uri, "w") as sdf:
-            sdf.resize_soma_joinid(new_shape)
+            sdf.resize_soma_joinid_shape(new_shape)
 
         # Test writes out of old bounds, within new bounds, after resize
         with tiledbsoma.DataFrame.open(uri, "w") as sdf:

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -226,7 +226,7 @@ resize <- function(uri, new_shape, ctxxp) {
     invisible(.Call(`_tiledbsoma_resize`, uri, new_shape, ctxxp))
 }
 
-resize_soma_joinid <- function(uri, new_shape, ctxxp) {
+resize_soma_joinid_shape <- function(uri, new_shape, ctxxp) {
     invisible(.Call(`_tiledbsoma_resize_soma_joinid`, uri, new_shape, ctxxp))
 }
 

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -416,13 +416,13 @@ SOMADataFrame <- R6::R6Class(
     #' @param new_shape An integer, greater than or equal to 1 + the
     #' `soma_joinid` domain slot.
     #' @return No return value
-    resize_soma_joinid = function(new_shape) {
+    resize_soma_joinid_shape = function(new_shape) {
 
       stopifnot("'new_shape' must be an integer" = rlang::is_integerish(new_shape, n = 1) ||
         (bit64::is.integer64(new_shape) && length(new_shape) == 1)
       )
       # Checking slotwise new shape >= old shape, and <= max_shape, is already done in libtiledbsoma
-      invisible(resize_soma_joinid(self$uri, new_shape, private$.soma_context))
+      invisible(resize_soma_joinid_shape(self$uri, new_shape, private$.soma_context))
     }
 
   ),

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -259,7 +259,7 @@ write_soma.data.frame <- function(
     }
   }
   if (ingest_mode %in% c('resume') && sdf$tiledbsoma_has_upgraded_domain()) {
-    sdf$resize_soma_joinid(nrow(x))
+    sdf$resize_soma_joinid_shape(nrow(x))
   }
   if (!is.null(tbl)) {
     sdf$write(tbl)

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -24,7 +24,7 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-domain}{\code{SOMADataFrame$domain()}}
 \item \href{#method-SOMADataFrame-maxdomain}{\code{SOMADataFrame$maxdomain()}}
 \item \href{#method-SOMADataFrame-tiledbsoma_has_upgraded_domain}{\code{SOMADataFrame$tiledbsoma_has_upgraded_domain()}}
-\item \href{#method-SOMADataFrame-resize_soma_joinid}{\code{SOMADataFrame$resize_soma_joinid()}}
+\item \href{#method-SOMADataFrame-resize_soma_joinid_shape}{\code{SOMADataFrame$resize_soma_joinid_shape()}}
 \item \href{#method-SOMADataFrame-clone}{\code{SOMADataFrame$clone()}}
 }
 }
@@ -281,9 +281,9 @@ Logical
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-SOMADataFrame-resize_soma_joinid"></a>}}
-\if{latex}{\out{\hypertarget{method-SOMADataFrame-resize_soma_joinid}{}}}
-\subsection{Method \code{resize_soma_joinid()}}{
+\if{html}{\out{<a id="method-SOMADataFrame-resize_soma_joinid_shape"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-resize_soma_joinid_shape}{}}}
+\subsection{Method \code{resize_soma_joinid_shape()}}{
 Increases the shape of the dataframe on the \code{soma_joinid}
 index column, if it indeed is an index column, leaving all other index
 columns as-is. If the \code{soma_joinid} is not an index column, no change is
@@ -293,7 +293,7 @@ domain expansion.  Raises an error if the dataframe doesn't already have a
 domain: in that case please call \code{tiledbsoma_upgrade_domain} (WIP for
 1.15).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$resize_soma_joinid(new_shape)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$resize_soma_joinid_shape(new_shape)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -512,15 +512,15 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// resize_soma_joinid
-void resize_soma_joinid(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+// resize_soma_joinid_shape
+void resize_soma_joinid_shape(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_resize_soma_joinid(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type new_shape(new_shapeSEXP);
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
-    resize_soma_joinid(uri, new_shape, ctxxp);
+    resize_soma_joinid_shape(uri, new_shape, ctxxp);
     return R_NilValue;
 END_RCPP
 }

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -433,14 +433,14 @@ void resize(
 }
 
 // [[Rcpp::export]]
-void resize_soma_joinid(
+void resize_soma_joinid_shape(
     const std::string& uri,
     Rcpp::NumericVector new_shape,
     Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     // This function is solely for SOMADataFrame.
     auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::write, ctxxp->ctxptr);
     std::vector<int64_t> new_shape_i64 = i64_from_rcpp_numeric(new_shape);
-    sr->resize_soma_joinid(new_shape_i64[0]);
+    sr->resize_soma_joinid_shape(new_shape_i64[0]);
     sr->close();
 }
 

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -227,11 +227,11 @@ test_that("SOMADataFrame shape", {
         sdf <- SOMADataFrameOpen(uri, "WRITE")
         if (has_soma_joinid_dim) {
           # It's an error to downsize
-          expect_error(sdf$resize_soma_joinid(new_shape))
+          expect_error(sdf$resize_soma_joinid_shape(new_shape))
         } else {
           # There is no problem when soma_joinid is not a dim --
-          # sdf$resize_soma_joinid is a no-op in that case
-          expect_no_condition(sdf$resize_soma_joinid(new_shape))
+          # sdf$resize_soma_joinid_shape is a no-op in that case
+          expect_no_condition(sdf$resize_soma_joinid_shape(new_shape))
         }
         sdf$close()
 
@@ -266,7 +266,7 @@ test_that("SOMADataFrame shape", {
 
         # Test resize
         sdf <- SOMADataFrameOpen(uri, "WRITE")
-        sdf$resize_soma_joinid(new_shape)
+        sdf$resize_soma_joinid_shape(new_shape)
         sdf$close();
 
         # Test writes out of old bounds, within new bounds, after resize

--- a/apis/r/tests/testthat/test-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-write-soma-resume.R
@@ -166,7 +166,7 @@ test_that("Resume-mode data frames", {
 
   if (.new_shape_feature_flag_is_enabled()) {
     sdfp$reopen("WRITE")
-    sdfp$resize_soma_joinid(nrow(co2))
+    sdfp$resize_soma_joinid_shape(nrow(co2))
   }
 
   expect_s3_class(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1602,7 +1602,7 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid(
         return std::pair(
             false,
             fmt::format(
-                "cannot resize_soma_joinid: new soma_joinid shape {} < "
+                "cannot resize_soma_joinid_shape: new soma_joinid shape {} < "
                 "existing shape {}",
                 newshape,
                 cur_dom_lo_hi.second));
@@ -1614,7 +1614,7 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid(
         return std::pair(
             false,
             fmt::format(
-                "cannot resize_soma_joinid: new soma_joinid shape {} > "
+                "cannot resize_soma_joinid_shape: new soma_joinid shape {} > "
                 "maxshape {}",
                 newshape,
                 dom_lo_hi.second));
@@ -1677,7 +1677,7 @@ void SOMAArray::_set_current_domain_from_shape(
     schema_evolution.array_evolve(uri_);
 }
 
-void SOMAArray::resize_soma_joinid(int64_t newshape) {
+void SOMAArray::resize_soma_joinid_shape(int64_t newshape) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError(
             "[SOMAArray::resize] array must be opened in write mode");

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1129,7 +1129,7 @@ class SOMAArray : public SOMAObject {
      * @return Throws if the requested shape exceeds the array's create-time
      * maxshape. Throws if the array does not have current-domain support.
      */
-    void resize_soma_joinid(int64_t newshape);
+    void resize_soma_joinid_shape(int64_t newshape);
 
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -472,7 +472,7 @@ TEST_CASE_METHOD(
     sdf->close();
 
     sdf = open(OpenMode::write);
-    sdf->resize_soma_joinid(int64_t{new_max});
+    sdf->resize_soma_joinid_shape(int64_t{new_max});
     sdf->close();
 
     sdf = open(OpenMode::write);
@@ -591,7 +591,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
         } else {
@@ -608,11 +608,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape);
             sdf->close();
 
             // Check shape after resize
@@ -668,7 +668,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
+                "existing "
                 "shape 199");
             check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
@@ -804,7 +805,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
         } else {
@@ -820,11 +821,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape);
             sdf->close();
 
             // Check shape after resize
@@ -899,7 +900,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
+                "existing "
                 "shape 199");
             check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
@@ -1053,7 +1055,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
         } else {
@@ -1069,11 +1071,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape);
             sdf->close();
 
             // Check shape after resize
@@ -1146,7 +1148,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid: new soma_joinid shape 1 < existing "
+                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
+                "existing "
                 "shape 99");
             check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
@@ -1283,7 +1286,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
         } else {
@@ -1294,11 +1297,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape);
             sdf->close();
 
             // Check shape after resize -- noting soma_joinid is not a dim here


### PR DESCRIPTION
**Issue and/or context:** In support of issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

This is to help me deconfuse on #2964. The method in question is mainly an internal helper for experiment-level resizing. I want its name to be as clear as possible nonetheless.

**Notes for Reviewer:**