### PR TITLE
[r] Remove last `private$.tiledb_array` and `self$object` from R classes [WIP]

### DIFF
--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -140,7 +140,6 @@ SOMADataFrame <- R6::R6Class(
       arrow::as_record_batch(values)$export_to_c(naap, nasp)
 
       df <- as.data.frame(values)[schema_names]
-      arr <- self$object
       writeArrayFromArrow(
         uri = self$uri,
         naap = naap,

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -133,14 +133,9 @@ SOMADenseNDArray <- R6::R6Class(
 
       ## the 'soma_data' data type may not have been cached, and if so we need to fetch it
       if (is.null(private$.type)) {
-          ## TODO: replace with a libtiledbsoma accessor as discussed
-          tpstr <- tiledb::datatype(tiledb::attrs(tiledb::schema(self$uri))[["soma_data"]])
-          arstr <- arrow_type_from_tiledb_type(tpstr)
-          private$.type <- arstr
+          private$.type <- self$schema()[["soma_data"]]$type
       }
 
-      arr <- self$object
-      tiledb::query_layout(arr) <- "COL_MAJOR"
       spdl::debug("[SOMADenseNDArray::write] about to call write")
       arrsch <- arrow::schema(arrow::field("soma_data", private$.type))
       tbl <- arrow::arrow_table(soma_data = values, schema = arrsch)
@@ -149,7 +144,6 @@ SOMADenseNDArray <- R6::R6Class(
       naap <- nanoarrow::nanoarrow_allocate_array()
       nasp <- nanoarrow::nanoarrow_allocate_schema()
       arrow::as_record_batch(tbl)$export_to_c(naap, nasp)
-      #arr[] <- values
       writeArrayFromArrow(
         uri = self$uri,
         naap = naap,

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -266,10 +266,7 @@ SOMASparseNDArray <- R6::R6Class(
 
       ## the 'soma_data' data type may not have been cached, and if so we need to fetch it
       if (is.null(private$.type)) {
-          ## TODO: replace with a libtiledbsoma accessor as discussed
-          tpstr <- tiledb::datatype(tiledb::attrs(tiledb::schema(self$uri))[["soma_data"]])
-          arstr <- arrow_type_from_tiledb_type(tpstr)
-          private$.type <- arstr
+          private$.type <- self$schema()[["soma_data"]]$type
       }
 
       arrsch <- arrow::schema(arrow::field(nms[1], arrow::int64()),

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -315,6 +315,7 @@ create_and_populate_32bit_sparse_nd_array <- function(uri) {
     soma_data = c(1L, 2L, 3L)
   )
 
+  # XXX CHANGEME
   tdb_dims <- mapply(
     tiledb::tiledb_dim,
     name = c("soma_dim_0", "soma_dim_1"),

--- a/apis/r/tests/testthat/helper-test-tiledb-objects.R
+++ b/apis/r/tests/testthat/helper-test-tiledb-objects.R
@@ -1,12 +1,17 @@
 create_empty_test_array <- function(uri) {
   stopifnot(!dir.exists(uri))
+  # XXX CHANGEME
   dim <- tiledb::tiledb_dim("d0", type = "ASCII", domain = NULL, tile = NULL)
+  # XXX CHANGEME
   dom <- tiledb::tiledb_domain(dims = dim)
+  # XXX CHANGEME
   schema <- tiledb::tiledb_array_schema(
     domain = dom,
+    # XXX CHANGEME
     attrs = c(tiledb::tiledb_attr("a", type = "INT32")),
     sparse = TRUE
   )
+  # XXX CHANGEME
   tiledb::tiledb_array_create(uri, schema)
   return(uri)
 }

--- a/apis/r/tests/testthat/test-Arrow-utils.R
+++ b/apis/r/tests/testthat/test-Arrow-utils.R
@@ -1,6 +1,7 @@
 test_that("TileDB classes can be converted to Arrow equivalents", {
 
   # Dimension to Arrow field
+  # XXX CHANGEME
   dim0 <- tiledb::tiledb_dim(
     name = "dim0",
     domain = NULL,
@@ -8,6 +9,7 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
     type = "ASCII"
   )
 
+  # XXX CHANGEME
   dim1 <- tiledb::tiledb_dim(
     name = "dim1",
     domain = bit64::as.integer64(c(0, 100)),
@@ -21,27 +23,33 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   # String dimension
   dim0_field <- arrow_field_from_tiledb_dim(dim0)
   expect_true(is_arrow_field(dim0_field))
+  # XXX CHANGEME
   expect_equal(dim0_field$name, tiledb::name(dim0))
   expect_equal(
     tiledb_type_from_arrow_type(dim0_field$type, is_dim=TRUE),
+    # XXX CHANGEME
     tiledb::datatype(dim0)
   )
 
   # Integer dimension
   dim1_field <- arrow_field_from_tiledb_dim(dim1)
   expect_true(is_arrow_field(dim1_field))
+  # XXX CHANGEME
   expect_equal(dim1_field$name, tiledb::name(dim1))
   expect_equal(
     tiledb_type_from_arrow_type(dim1_field$type, is_dim=TRUE),
+    # XXX CHANGEME
     tiledb::datatype(dim1)
   )
 
   # Attribute to Arrow field
+  # XXX CHANGEME
   attr0 <- tiledb::tiledb_attr(
     name = "attr0",
     type = "UTF8"
   )
 
+  # XXX CHANGEME
   attr1 <- tiledb::tiledb_attr(
     name = "attr1",
     type = "INT64"
@@ -53,23 +61,29 @@ test_that("TileDB classes can be converted to Arrow equivalents", {
   # String attribute
   attr0_field <- arrow_field_from_tiledb_attr(attr0)
   expect_true(is_arrow_field(attr0_field))
+  # XXX CHANGEME
   expect_equal(attr0_field$name, tiledb::name(attr0))
   expect_equal(
     tiledb_type_from_arrow_type(attr0_field$type, is_dim=FALSE),
+    # XXX CHANGEME
     tiledb::datatype(attr0)
   )
 
   # Integer attribute
   attr1_field <- arrow_field_from_tiledb_attr(attr1)
   expect_true(is_arrow_field(attr1_field))
+  # XXX CHANGEME
   expect_equal(attr1_field$name, tiledb::name(attr1))
   expect_equal(
     tiledb_type_from_arrow_type(attr1_field$type, is_dim=FALSE),
+    # XXX CHANGEME
     tiledb::datatype(attr1)
   )
 
   # TileDB schema to Arrow schema
+  # XXX CHANGEME
   tdb_schema <- tiledb::tiledb_array_schema(
+    # XXX CHANGEME
     domain = tiledb::tiledb_domain(c(dim0, dim1)),
     attrs = c(attr0, attr1),
     sparse = TRUE

--- a/apis/r/tests/testthat/test-OrderedAndFactor.R
+++ b/apis/r/tests/testthat/test-OrderedAndFactor.R
@@ -79,6 +79,7 @@ test_that("SOMADataFrame round-trip with factor and ordered", {
     ## quick write with tiledb-r so that we get a schema from the manifested array
     ## there should possibly be a helper function to create the schema from a data.frame
     turi <- tempfile()
+    # XXX CHANGEME
     expect_silent(tiledb::fromDataFrame(ett, turi, col_index="soma_joinid"))
 
     tsch <- tiledb::schema(turi)

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -10,7 +10,6 @@ test_that("SOMACollection basics", {
   # Verify the empty collection is accessible and reads back as empty
   collection <- SOMACollectionOpen(uri)
   expect_true(dir.exists(uri))
-  expect_match(tiledb::tiledb_object_type(uri), "GROUP")
   expect_true(collection$soma_type == "SOMACollection")
   expect_true(collection$exists())
   expect_equal(collection$length(), 0)

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -37,6 +37,7 @@ test_that("Basic mechanics", {
 
   # Verify the array is still open for write
   expect_equal(sdf$mode(), "WRITE")
+  # XXX CHANGEME
   expect_true(tiledb::tiledb_array_is_open(sdf$object))
   sdf$close()
 
@@ -47,6 +48,7 @@ test_that("Basic mechanics", {
   expect_error(sdf$shape(), class = "notYetImplementedError")
 
   expect_equivalent(
+    # XXX CHANGEME
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],
     as.list(tbl0),
     ignore_attr = TRUE
@@ -74,6 +76,7 @@ test_that("Basic mechanics", {
   # Read back the data (ignore attributes)
   sdf <- SOMADataFrameOpen(uri)
   expect_equivalent(
+    # XXX CHANGEME
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],
     as.list(rb0),
     ignore_attr = TRUE
@@ -105,6 +108,7 @@ test_that("Basic mechanics", {
   expect_true(tbl1$Equals(tbl0$Filter(tbl0$float_column < 5)))
 
   # Validate TileDB array schema
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   sch <- tiledb::schema(arr)
   expect_true(tiledb::is.sparse(sch))
@@ -156,6 +160,7 @@ test_that("Basic mechanics with default index_column_names", {
 
   # read back the data (ignore attributes)
   expect_equivalent(
+    # XXX CHANGEME
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],
     as.list(tbl0),
     ignore_attr = TRUE
@@ -342,6 +347,7 @@ test_that("soma_joinid is added on creation", {
   sdf <- SOMADataFrameCreate(uri, asch, index_column_names = "int_column")
 
   expect_true("soma_joinid" %in% sdf$attrnames())
+  # XXX CHANGEME
   expect_equal(tiledb::datatype(sdf$attributes()$soma_joinid), "INT64")
   sdf$close()
 })
@@ -411,18 +417,22 @@ test_that("platform_config is respected", {
   sdf <- SOMADataFrameCreate(uri=uri, schema=asch, index_column_names=c("soma_joinid"), platform_config = cfg)
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
+  # XXX CHANGEME
   expect_equal(tiledb::capacity(tsch), 8000)
   expect_equal(tiledb::tile_order(tsch), "COL_MAJOR")
   expect_equal(tiledb::cell_order(tsch), "ROW_MAJOR")
 
+  # XXX CHANGEME
   offsets_filters <- tiledb::filter_list(tsch)$offsets
   expect_equal(tiledb::nfilters(offsets_filters), 1)
   o1 <- offsets_filters[0] # C++ indexing here
   expect_equal(tiledb::tiledb_filter_type(o1), "RLE")
 
+  # XXX CHANGEME
   validity_filters <- tiledb::filter_list(tsch)$validity
   expect_equal(tiledb::nfilters(validity_filters), 2)
   v1 <- validity_filters[0] # C++ indexing here
@@ -430,6 +440,7 @@ test_that("platform_config is respected", {
   expect_equal(tiledb::tiledb_filter_type(v1), "RLE")
   expect_equal(tiledb::tiledb_filter_type(v2), "NONE")
 
+  # XXX CHANGEME
   dom <- tiledb::domain(tsch)
   expect_equal(tiledb::tiledb_ndim(dom), 1)
   dim <- tiledb::dimensions(dom)[[1]]
@@ -446,6 +457,7 @@ test_that("platform_config is respected", {
   expect_equal(tiledb::tiledb_filter_type(d3), "NONE")
   expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
 
+  # XXX CHANGEME
   expect_equal(length(tiledb::attrs(tsch)), 3)
   i32_filters <- tiledb::filter_list(tiledb::attrs(tsch)$i32)
   f64_filters <- tiledb::filter_list(tiledb::attrs(tsch)$f64)
@@ -454,6 +466,7 @@ test_that("platform_config is respected", {
 
   i1 <- i32_filters[0] # C++ indexing here
   i2 <- i32_filters[1] # C++ indexing here
+  # XXX CHANGEME
   expect_equal(tiledb::tiledb_filter_type(i1), "RLE")
   expect_equal(tiledb::tiledb_filter_type(i2), "ZSTD")
   expect_equal(tiledb::tiledb_filter_get_option(i2, "COMPRESSION_LEVEL"), 9)
@@ -486,6 +499,7 @@ test_that("platform_config defaults", {
   )
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
@@ -531,6 +545,7 @@ test_that("platform_config defaults", {
   tsch <- tiledb::schema(arr)
 
   # Here we're snooping on the default dim filter that's used when no other is specified.
+  # XXX CHANGEME
   dom <- tiledb::domain(tsch)
   expect_equal(tiledb::tiledb_ndim(dom), 1)
   dim <- tiledb::dimensions(dom)[[1]]
@@ -820,6 +835,7 @@ test_that("missing levels in enums", {
 
   # Test missingness is preserved
   expect_s3_class(sdf <- SOMADataFrameOpen(uri), "SOMADataFrame")
+  # XXX CHANGEME
   expect_true(tiledb::tiledb_array_has_enumeration(sdf$object)["enum"])
   expect_s4_class(
     attr <- tiledb::attrs(sdf$tiledb_schema())$enum,
@@ -849,6 +865,7 @@ test_that("missing levels in enums", {
 
   # Test missingness is preserved when updating
   expect_s3_class(sdf <- SOMADataFrameOpen(uri), "SOMADataFrame")
+  # XXX CHANGEME
   expect_true(tiledb::tiledb_array_has_enumeration(sdf$object)["miss"])
   expect_s4_class(
     attr <- tiledb::attrs(sdf$tiledb_schema())$miss,

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -12,14 +12,13 @@ test_that("SOMADenseNDArray creation", {
   expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
   expect_equal(ndarray$attrnames(), "soma_data")
-  expect_equal(tiledb::datatype(ndarray$attributes()$soma_data), "INT32")
+  expect_equal(ndarray$schema()[["soma_data"]]$type$name, "int32")
 
   mat <- create_dense_matrix_with_int_dims(10, 5)
   ndarray$write(mat)
 
   # Verify the array is still open for write
   expect_equal(ndarray$mode(), "WRITE")
-  expect_true(tiledb::tiledb_array_is_open(ndarray$object))
   ndarray$close()
 
   # Read result in column-major order to match R matrix layout

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -9,7 +9,6 @@ test_that("SOMADenseNDArray creation", {
   ndarray$close()
   ndarray <- SOMADenseNDArrayOpen(uri, "WRITE")
 
-  expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
   expect_equal(ndarray$attrnames(), "soma_data")
   expect_equal(ndarray$schema()[["soma_data"]]$type$name, "int32")
@@ -72,6 +71,7 @@ test_that("SOMADenseNDArray creation", {
   )
 
   # Validate TileDB array schema
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   sch <- tiledb::schema(arr)
   expect_false(tiledb::is.sparse(sch))
@@ -129,6 +129,7 @@ test_that("platform_config is respected", {
   dnda <- SOMADenseNDArrayCreate(uri=uri, type=arrow::int32(), shape=c(100,100), platform_config = cfg)
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
@@ -197,6 +198,7 @@ test_that("platform_config defaults", {
   dnda <- SOMADenseNDArrayCreate(uri=uri, type=arrow::int32(), shape=c(100,100), platform_config = cfg)
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 

--- a/apis/r/tests/testthat/test-SOMAExperiment-query.R
+++ b/apis/r/tests/testthat/test-SOMAExperiment-query.R
@@ -190,16 +190,6 @@ test_that("query by value filters with enums", {
   expect_identical(levels(obs_df$enum), c("red", "blue", "green"))
   expect_identical(unique(as.vector(obs_df$enum)), "green")
 
-  # Test enum query with present and missing level
-  core <- list(
-    tiledbsoma = numeric_version(tiledbsoma:::libtiledbsoma_version(TRUE)),
-    tiledb.r = numeric_version(paste(tiledb::tiledb_version(), collapse = '.'))
-  )
-  skip_if(
-    any(vapply(core, \(x) x < '2.21', FUN.VALUE = logical(1L))),
-    message = "Handling of missing enum levels is implemented in Core 2.21 and higher"
-  )
-
   query <- SOMAExperimentAxisQuery$new(
     experiment = experiment,
     measurement_name = "RNA",

--- a/apis/r/tests/testthat/test-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMASparseNDArray.R
@@ -3,6 +3,7 @@ test_that("SOMASparseNDArray creation", {
   uri <- tempfile(pattern="sparse-ndarray")
   ndarray <- SOMASparseNDArrayCreate(uri, arrow::int32(), shape = c(10, 10))
 
+  # XXX CHANGEME
   expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
 
@@ -51,6 +52,7 @@ test_that("SOMASparseNDArray creation", {
   )
 
   # Validate TileDB array schema
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   sch <- tiledb::schema(arr)
   expect_true(tiledb::is.sparse(sch))
@@ -175,6 +177,7 @@ test_that("SOMASparseNDArray creation with duplicates", {
 
   create_write_check <- function(uri, D, allows_dups, do_dup, expected_nnz) {
       ## write from tiledb "for now"
+      # XXX CHANGEME
       dom <- tiledb::tiledb_domain(dims = c(tiledb::tiledb_dim("rows", c(1L, 100L), 100L, "INT32"),
                                             tiledb::tiledb_dim("cols", c(1L, 100L), 100L, "INT32")))
       sch <- tiledb::tiledb_array_schema(dom,
@@ -243,6 +246,7 @@ test_that("platform_config is respected", {
   snda <- SOMASparseNDArrayCreate(uri=uri, type=arrow::int32(), shape=c(100,100), platform_config = cfg)
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
@@ -311,6 +315,7 @@ test_that("platform_config defaults", {
   snda <- SOMASparseNDArrayCreate(uri=uri, type=arrow::int32(), shape=c(100,100), platform_config = cfg)
 
   # Read back and check the array schema against the tiledb create options
+  # XXX CHANGEME
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
@@ -426,6 +431,7 @@ test_that("SOMASparseNDArray bounding box", {
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
+  # XXX CHANGEME
   expect_true(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
   for (i in seq_along(bbox_names)) {
     expect_s3_class(x <- ndarray$get_metadata(bbox_names[i]), 'integer64')
@@ -486,6 +492,7 @@ test_that("SOMASparseNDArray without bounding box", {
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
+  # XXX CHANGEME
   expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_error(suppressWarnings(ndarray$used_shape(), classes = "deprecatedWarning"))
@@ -516,6 +523,7 @@ test_that("SOMASparseNDArray with failed bounding box", {
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
+  # XXX CHANGEME
   expect_false(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
 
   expect_error(suppressWarnings(ndarray$used_shape(), classes = "deprecatedWarning"))
@@ -540,6 +548,7 @@ test_that("SOMASparseNDArray bounding box implicitly-stored values", {
     bbox_names[i] <- paste0(dnames[ceiling(i / 2)], '_domain', type)
   }
 
+  # XXX CHANGEME
   expect_true(all(bbox_names %in% names(tiledb::tiledb_get_all_metadata(ndarray$object))))
   for (i in seq_along(bbox_names)) {
     expect_s3_class(x <- ndarray$get_metadata(bbox_names[i]), 'integer64')

--- a/apis/r/tests/testthat/test-SOMATileDBContext.R
+++ b/apis/r/tests/testthat/test-SOMATileDBContext.R
@@ -36,7 +36,6 @@ test_that("SOMATileDBContext SOMA mechanics", {
   expect_identical(ctx$length(), ntiledb + 2L)
   expect_length(ctx$keys(), ntiledb + 2L)
   expect_s4_class(context <- ctx$to_tiledb_context(), 'tiledb_ctx')
-  expect_length(as.vector(tiledb::config(context)), ctx$length())
 })
 
 test_that("SOMATileDBContext TileDB mechanics", {
@@ -84,5 +83,4 @@ test_that("SOMATileDBContext SOMA + TileDB mechanics", {
   expect_type(ctx$get('b'), 'integer')
   expect_equal(head(ctx$keys(), 3L), c('member_uris_are_relative', 'b', 'a'))
   expect_s4_class(context <- ctx$to_tiledb_context(), 'tiledb_ctx')
-  expect_length(as.vector(tiledb::config(context)), ctx$length())
 })

--- a/apis/r/tests/testthat/test-TileDBArray.R
+++ b/apis/r/tests/testthat/test-TileDBArray.R
@@ -10,6 +10,7 @@ test_that("TileDBArray helper functions", {
   # Create an array
   index_cols <- c("Dept", "Gender")
   df <- as.data.frame(UCBAdmissions)
+  # XXX CHANGEME
   tiledb::fromDataFrame(df, uri, col_index = index_cols)
 
   expect_identical(tdba$uri, uri)

--- a/apis/r/tests/testthat/test-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-TileDBGroup.R
@@ -23,7 +23,6 @@ test_that("Create empty", {
   expect_true(file.exists(file.path(uri, "__group")))
   expect_true(group$exists())
   fp = file.path(uri, "__group")
-  expect_match(tiledb::tiledb_object_type(uri), "GROUP")
   group$close()
 })
 
@@ -56,6 +55,7 @@ test_that("Add and remove members", {
     internal_use_only = "allowed_use"
   )
   g1 <- TileDBGroup$new(
+    # XXX CHANGEME
     uri = tiledb::tiledb_group_create(file.path(uri, "g1")),
     internal_use_only = "allowed_use"
   )

--- a/apis/r/tests/testthat/test-example-datasets.R
+++ b/apis/r/tests/testthat/test-example-datasets.R
@@ -7,7 +7,6 @@ test_that("example dataset access", {
   # Test that the dataset can be extracted
   dataset_uri <- extract_dataset("soma-exp-pbmc-small")
   expect_true(dir.exists(dataset_uri))
-  expect_equal(tiledb::tiledb_object_type(dataset_uri), "GROUP")
 
   # Test the datasets can be loaded
   exp <- load_dataset("soma-exp-pbmc-small")


### PR DESCRIPTION
Context: #3059 / [[sc-55685]](https://app.shortcut.com/tiledb-inc/story/55685/r-use-libtiledbsoma-for-array-handles)

As detailed in #3059 this is blocked by #3124.


