### PR TITLE
[c++] Propagate Python/R function names to C++ for upgrade/resize methods

### DIFF
--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -161,7 +161,8 @@ void load_soma_dataframe(py::module& m) {
             "resize_soma_joinid_shape",
             [](SOMADataFrame& sdf, int64_t newshape) {
                 try {
-                    sdf.resize_soma_joinid_shape(newshape);
+                    sdf.resize_soma_joinid_shape(
+                        newshape, "resize_soma_joinid_shape");
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -132,7 +132,7 @@ void load_soma_sparse_ndarray(py::module& m) {
             "tiledbsoma_upgrade_shape",
             [](SOMAArray& array, const std::vector<int64_t>& newshape) {
                 try {
-                    array.upgrade_shape(newshape);
+                    array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -121,7 +121,7 @@ void load_soma_sparse_ndarray(py::module& m) {
             "resize",
             [](SOMAArray& array, const std::vector<int64_t>& newshape) {
                 try {
-                    array.resize(newshape);
+                    array.resize(newshape, "resize");
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -227,7 +227,7 @@ resize <- function(uri, new_shape, ctxxp) {
 }
 
 resize_soma_joinid_shape <- function(uri, new_shape, ctxxp) {
-    invisible(.Call(`_tiledbsoma_resize_soma_joinid`, uri, new_shape, ctxxp))
+    invisible(.Call(`_tiledbsoma_resize_soma_joinid_shape`, uri, new_shape, ctxxp))
 }
 
 tiledbsoma_upgrade_shape <- function(uri, new_shape, ctxxp) {

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -514,7 +514,7 @@ END_RCPP
 }
 // resize_soma_joinid_shape
 void resize_soma_joinid_shape(const std::string& uri, Rcpp::NumericVector new_shape, Rcpp::XPtr<somactx_wrap_t> ctxxp);
-RcppExport SEXP _tiledbsoma_resize_soma_joinid(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP ctxxpSEXP) {
+RcppExport SEXP _tiledbsoma_resize_soma_joinid_shape(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
@@ -761,7 +761,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_c_attrnames", (DL_FUNC) &_tiledbsoma_c_attrnames, 2},
     {"_tiledbsoma_c_schema", (DL_FUNC) &_tiledbsoma_c_schema, 2},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 3},
-    {"_tiledbsoma_resize_soma_joinid", (DL_FUNC) &_tiledbsoma_resize_soma_joinid, 3},
+    {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 3},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 3},
     {"_tiledbsoma_c_update_dataframe_schema", (DL_FUNC) &_tiledbsoma_c_update_dataframe_schema, 6},
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -455,7 +455,7 @@ void tiledbsoma_upgrade_shape(
     // https://github.com/single-cell-data/TileDB-SOMA/issues/2407.
     auto sr = tdbs::SOMAArray::open(OpenMode::write, uri, ctxxp->ctxptr);
     std::vector<int64_t> new_shape_i64 = i64_from_rcpp_numeric(new_shape);
-    sr->upgrade_shape(new_shape_i64);
+    sr->upgrade_shape(new_shape_i64, "tiledbsoma_upgrade_shape");
     sr->close();
 }
 

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -428,7 +428,7 @@ void resize(
     // https://github.com/single-cell-data/TileDB-SOMA/issues/2407.
     auto sr = tdbs::SOMAArray::open(OpenMode::write, uri, ctxxp->ctxptr);
     std::vector<int64_t> new_shape_i64 = i64_from_rcpp_numeric(new_shape);
-    sr->resize(new_shape_i64);
+    sr->resize(new_shape_i64, "resize");
     sr->close();
 }
 

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -440,7 +440,7 @@ void resize_soma_joinid_shape(
     // This function is solely for SOMADataFrame.
     auto sr = tdbs::SOMADataFrame::open(uri, OpenMode::write, ctxxp->ctxptr);
     std::vector<int64_t> new_shape_i64 = i64_from_rcpp_numeric(new_shape);
-    sr->resize_soma_joinid_shape(new_shape_i64[0]);
+    sr->resize_soma_joinid_shape(new_shape_i64[0], "resize_soma_joinid_shape");
     sr->close();
 }
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
-#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
+#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1553,7 +1553,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
                 return std::pair(
                     false,
                     fmt::format(
-                        "cannot {} for {}: new {} < existing shape {}",
+                        "{} for {}: new {} < existing shape {}",
                         function_name_for_messages,
                         dim_name,
                         newshape[i],
@@ -1569,7 +1569,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
                 return std::pair(
                     false,
                     fmt::format(
-                        "cannot {} for {}: new {} < maxshape {}",
+                        "{} for {}: new {} < maxshape {}",
                         function_name_for_messages,
                         dim_name,
                         newshape[i],
@@ -1625,10 +1625,12 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
     return std::pair(true, "");
 }
 
-void SOMAArray::resize(const std::vector<int64_t>& newshape) {
+void SOMAArray::resize(
+    const std::vector<int64_t>& newshape,
+    std::string function_name_for_messages) {
     if (_get_current_domain().is_empty()) {
         throw TileDBSOMAError(
-            "[SOMAArray::resize] array must already have a shape");
+            fmt::format("{} array must already have a shape", function_name_for_messages));
     }
     _set_current_domain_from_shape(newshape);
 }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1580,14 +1580,15 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
     return std::pair(true, "");
 }
 
-std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid(
+std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
     int64_t newshape) {
     // Fail if the array doesn't already have a shape yet (they should upgrade
     // first).
     if (!has_current_domain()) {
         return std::pair(
             false,
-            "can_resize_soma_joinid: dataframe currently has no domain set: "
+            "can_resize_soma_joinid_shape: dataframe currently has no domain "
+            "set: "
             "please use tiledbsoma_upgrade_domain.");
     }
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1603,7 +1603,7 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
         return std::pair(
             false,
             fmt::format(
-                "cannot resize_soma_joinid_shape: new soma_joinid shape {} < "
+                "resize_soma_joinid_shape: new soma_joinid shape {} < "
                 "existing shape {}",
                 newshape,
                 cur_dom_lo_hi.second));
@@ -1629,8 +1629,8 @@ void SOMAArray::resize(
     const std::vector<int64_t>& newshape,
     std::string function_name_for_messages) {
     if (_get_current_domain().is_empty()) {
-        throw TileDBSOMAError(
-            fmt::format("{} array must already have a shape", function_name_for_messages));
+        throw TileDBSOMAError(fmt::format(
+            "{} array must already have a shape", function_name_for_messages));
     }
     _set_current_domain_from_shape(newshape);
 }
@@ -1680,10 +1680,12 @@ void SOMAArray::_set_current_domain_from_shape(
     schema_evolution.array_evolve(uri_);
 }
 
-void SOMAArray::resize_soma_joinid_shape(int64_t newshape) {
+void SOMAArray::resize_soma_joinid_shape(
+    int64_t newshape, std::string function_name_for_messages) {
     if (mq_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must be opened in write mode");
+        throw TileDBSOMAError(fmt::format(
+            "{}: array must be opened in write mode",
+            function_name_for_messages));
     }
 
     ArraySchema schema = arr_->schema();

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1452,7 +1452,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
         return std::pair(
             false,
             fmt::format(
-                "cannot {}: provided shape has ndim {}, while the array has {}",
+                "{}: provided shape has ndim {}, while the array has {}",
                 function_name_for_messages,
                 arg_ndim,
                 array_ndim));

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1581,15 +1581,16 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
 }
 
 std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
-    int64_t newshape) {
+    int64_t newshape, std::string function_name_for_messages) {
     // Fail if the array doesn't already have a shape yet (they should upgrade
     // first).
     if (!has_current_domain()) {
         return std::pair(
             false,
-            "can_resize_soma_joinid_shape: dataframe currently has no domain "
-            "set: "
-            "please use tiledbsoma_upgrade_domain.");
+            fmt::format(
+                "{}: dataframe currently has no domain set: please use "
+                "tiledbsoma_upgrade_domain.",
+                function_name_for_messages));
     }
 
     // OK if soma_joinid isn't a dim.
@@ -1603,8 +1604,8 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
         return std::pair(
             false,
             fmt::format(
-                "resize_soma_joinid_shape: new soma_joinid shape {} < "
-                "existing shape {}",
+                "{}: new soma_joinid shape {} < existing shape {}",
+                function_name_for_messages,
                 newshape,
                 cur_dom_lo_hi.second));
     }
@@ -1615,8 +1616,8 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
         return std::pair(
             false,
             fmt::format(
-                "cannot resize_soma_joinid_shape: new soma_joinid shape {} > "
-                "maxshape {}",
+                "{}: new soma_joinid shape {} > maxshape {}",
+                function_name_for_messages,
                 newshape,
                 dom_lo_hi.second));
     }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -524,8 +524,8 @@ void SOMAArray::_promote_indexes_to_values(
             return _cast_dictionary_values<double>(schema, array);
         default:
             throw TileDBSOMAError(fmt::format(
-                "Saw invalid TileDB value type when attempting to "
-                "promote indexes to values: {}",
+                "Saw invalid TileDB value type when attempting to promote "
+                "indexes to values: {}",
                 tiledb::impl::type_to_str(value_type)));
     }
 }
@@ -1481,8 +1481,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
                 false,
                 fmt::format(
                     "{}: array already has a shape: please use resize rather "
-                    "than "
-                    "tiledbsoma_upgrade_shape.",
+                    "than tiledbsoma_upgrade_shape.",
                     function_name_for_messages));
         }
     }
@@ -1536,8 +1535,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
         // library-internal code, it's not the user's fault if we got here.
         if (dim.type() != TILEDB_INT64) {
             throw TileDBSOMAError(fmt::format(
-                "{}: internal error: expected {} dim to "
-                "be {}; got {}",
+                "{}: internal error: expected {} dim to be {}; got {}",
                 function_name_for_messages,
                 dim_name,
                 tiledb::impl::type_to_str(TILEDB_INT64),
@@ -1588,8 +1586,8 @@ std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
         return std::pair(
             false,
             fmt::format(
-                "{}: dataframe currently has no domain set: please use "
-                "tiledbsoma_upgrade_domain.",
+                "{}: dataframe currently has no domain set: please "
+                "upgrade the array.",
                 function_name_for_messages));
     }
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1497,7 +1497,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
     //
     // if the requested shape fits in the array's core domain, it's good to go
     // as a new shape.
-    auto domain_check = _can_set_shape_domainish_helper(
+    auto domain_check = _can_set_shape_domainish_subhelper(
         newshape, false, function_name_for_messages);
     if (!domain_check.first) {
         return domain_check;
@@ -1506,7 +1506,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
     // For new-style arrays, we need to additionally that the the requested
     // shape (core current domain) isn't a downsize of the current one.
     if (has_shape) {
-        auto current_domain_check = _can_set_shape_domainish_helper(
+        auto current_domain_check = _can_set_shape_domainish_subhelper(
             newshape, true, function_name_for_messages);
         if (!current_domain_check.first) {
             return current_domain_check;
@@ -1519,7 +1519,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
 // This is a helper for _can_set_shape_helper: it's used for comparing
 // the user's requested shape against the core current domain or core (max)
 // domain.
-std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_helper(
+std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
     const std::vector<int64_t>& newshape,
     bool check_current_domain,
     std::string function_name_for_messages) {

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
-#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
+#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1632,22 +1632,27 @@ void SOMAArray::resize(
         throw TileDBSOMAError(fmt::format(
             "{} array must already have a shape", function_name_for_messages));
     }
-    _set_current_domain_from_shape(newshape);
+    _set_current_domain_from_shape(newshape, function_name_for_messages);
 }
 
-void SOMAArray::upgrade_shape(const std::vector<int64_t>& newshape) {
+void SOMAArray::upgrade_shape(
+    const std::vector<int64_t>& newshape,
+    std::string function_name_for_messages) {
     if (!_get_current_domain().is_empty()) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must not already have a shape");
+        throw TileDBSOMAError(fmt::format(
+            "{}: array must not already have a shape",
+            function_name_for_messages));
     }
-    _set_current_domain_from_shape(newshape);
+    _set_current_domain_from_shape(newshape, function_name_for_messages);
 }
 
 void SOMAArray::_set_current_domain_from_shape(
-    const std::vector<int64_t>& newshape) {
+    const std::vector<int64_t>& newshape,
+    std::string function_name_for_messages) {
     if (mq_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(
-            "[SOMAArray::resize] array must be opened in write mode");
+        throw TileDBSOMAError(fmt::format(
+            "{} array must be opened in write mode",
+            function_name_for_messages));
     }
 
     // Variant-indexed dataframes must use a separate path

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1095,7 +1095,8 @@ class SOMAArray : public SOMAObject {
      * This is similar to can_upgrade_shape, but it's a can-we call
      * for maybe_resize_soma_joinid.
      */
-    std::pair<bool, std::string> can_resize_soma_joinid_shape(int64_t newshape);
+    std::pair<bool, std::string> can_resize_soma_joinid_shape(
+        int64_t newshape, std::string function_name_for_messages);
 
     /**
      * @brief Resize the shape (what core calls "current domain") up to the

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1061,8 +1061,10 @@ class SOMAArray : public SOMAObject {
      * existing core domain.
      */
     std::pair<bool, std::string> can_resize(
-        const std::vector<int64_t>& newshape) {
-        return _can_set_shape_helper(newshape, true, "resize");
+        const std::vector<int64_t>& newshape,
+        std::string function_name_for_messages) {
+        return _can_set_shape_helper(
+            newshape, true, function_name_for_messages);
     }
 
     /**
@@ -1212,7 +1214,9 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a code-dedupe helper method for resize and upgrade_shape.
      */
-    void _set_current_domain_from_shape(const std::vector<int64_t>& newshape, std::string function_name_for_messages);
+    void _set_current_domain_from_shape(
+        const std::vector<int64_t>& newshape,
+        std::string function_name_for_messages);
 
     /**
      * While SparseNDArray, DenseNDArray, and default-indexed DataFrame

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1116,7 +1116,9 @@ class SOMAArray : public SOMAObject {
      * of int64 type. Namely, all SparseNDArray/DenseNDArray, and
      * default-indexed DataFrame.
      */
-    void upgrade_shape(const std::vector<int64_t>& newshape);
+    void upgrade_shape(
+        const std::vector<int64_t>& newshape,
+        std::string function_name_for_messages);
 
     /**
      * @brief Increases the tiledbsoma shape up to at most the maxshape,
@@ -1210,7 +1212,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a code-dedupe helper method for resize and upgrade_shape.
      */
-    void _set_current_domain_from_shape(const std::vector<int64_t>& newshape);
+    void _set_current_domain_from_shape(const std::vector<int64_t>& newshape, std::string function_name_for_messages);
 
     /**
      * While SparseNDArray, DenseNDArray, and default-indexed DataFrame

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -997,8 +997,7 @@ class SOMAArray : public SOMAObject {
             default:
                 throw std::runtime_error(
                     "internal coding error in "
-                    "SOMAArray::_core_domainish_slot_string: "
-                    "unknown kind");
+                    "SOMAArray::_core_domainish_slot_string: unknown kind");
         }
     }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1106,7 +1106,9 @@ class SOMAArray : public SOMAObject {
      * @return Nothing. Raises an exception if the resize would be a downsize,
      * which is not supported.
      */
-    void resize(const std::vector<int64_t>& newshape);
+    void resize(
+        const std::vector<int64_t>& newshape,
+        std::string function_name_for_messages);
 
     /**
      * @brief Given an old-style array without current domain, sets its

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1083,9 +1083,10 @@ class SOMAArray : public SOMAObject {
      * domain.
      */
     std::pair<bool, std::string> can_upgrade_shape(
-        const std::vector<int64_t>& newshape) {
+        const std::vector<int64_t>& newshape,
+        std::string function_name_for_messages) {
         return _can_set_shape_helper(
-            newshape, false, "tiledbsoma_upgrade_shape");
+            newshape, false, function_name_for_messages);
     }
 
     /**

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1132,7 +1132,8 @@ class SOMAArray : public SOMAObject {
      * @return Throws if the requested shape exceeds the array's create-time
      * maxshape. Throws if the array does not have current-domain support.
      */
-    void resize_soma_joinid_shape(int64_t newshape);
+    void resize_soma_joinid_shape(
+        int64_t newshape, std::string function_name_for_messages);
 
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1198,7 +1198,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a second-level code-dedupe helper for _can_set_shape_helper.
      */
-    std::pair<bool, std::string> _can_set_shape_domainish_helper(
+    std::pair<bool, std::string> _can_set_shape_domainish_subhelper(
         const std::vector<int64_t>& newshape,
         bool check_current_domain,
         std::string function_name_for_messages);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1093,7 +1093,7 @@ class SOMAArray : public SOMAObject {
      * This is similar to can_upgrade_shape, but it's a can-we call
      * for maybe_resize_soma_joinid.
      */
-    std::pair<bool, std::string> can_resize_soma_joinid(int64_t newshape);
+    std::pair<bool, std::string> can_resize_soma_joinid_shape(int64_t newshape);
 
     /**
      * @brief Resize the shape (what core calls "current domain") up to the

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -662,8 +662,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please use "
-                "tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please "
+                "upgrade the array.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -894,8 +894,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please use "
-                "tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please "
+                "upgrade the array.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -1142,8 +1142,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please use "
-                "tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please "
+                "upgrade the array.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -1351,8 +1351,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please use "
-                "tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please "
+                "upgrade the array.");
         } else {
             // Must pass since soma_joinid isn't a dim in this case.
             REQUIRE(check.first == true);

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -655,13 +655,15 @@ TEST_CASE_METHOD(
             REQUIRE(maxdom_sjid[1] > 2000000000);
         }
 
-        // Check can_resize_soma_joinid
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid(1);
+        // Check can_resize_soma_joinid_shape
+        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
+            1);
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid: dataframe currently has no domain "
+                "can_resize_soma_joinid_shape: dataframe currently has no "
+                "domain "
                 "set: please use tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
@@ -671,7 +673,8 @@ TEST_CASE_METHOD(
                 "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
                 "existing "
                 "shape 199");
-            check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            check = sdf->can_resize_soma_joinid_shape(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -887,13 +890,15 @@ TEST_CASE_METHOD(
             REQUIRE(maxdom_u32[1] > 2000000000);
         }
 
-        // Check can_resize_soma_joinid
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid(1);
+        // Check can_resize_soma_joinid_shape
+        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
+            1);
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid: dataframe currently has no domain "
+                "can_resize_soma_joinid_shape: dataframe currently has no "
+                "domain "
                 "set: please use tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
@@ -903,7 +908,8 @@ TEST_CASE_METHOD(
                 "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
                 "existing "
                 "shape 199");
-            check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            check = sdf->can_resize_soma_joinid_shape(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -1135,13 +1141,15 @@ TEST_CASE_METHOD(
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));
 
-        // Check can_resize_soma_joinid
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid(1);
+        // Check can_resize_soma_joinid_shape
+        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
+            1);
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid: dataframe currently has no domain "
+                "can_resize_soma_joinid_shape: dataframe currently has no "
+                "domain "
                 "set: please use tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
@@ -1151,7 +1159,8 @@ TEST_CASE_METHOD(
                 "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
                 "existing "
                 "shape 99");
-            check = sdf->can_resize_soma_joinid(SOMA_JOINID_RESIZE_DIM_MAX + 1);
+            check = sdf->can_resize_soma_joinid_shape(
+                SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -1344,13 +1353,15 @@ TEST_CASE_METHOD(
             REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
         }
 
-        // Check can_resize_soma_joinid
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid(0);
+        // Check can_resize_soma_joinid_shape
+        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
+            0);
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid: dataframe currently has no domain "
+                "can_resize_soma_joinid_shape: dataframe currently has no "
+                "domain "
                 "set: please use tiledbsoma_upgrade_domain.");
         } else {
             // Must pass since soma_joinid isn't a dim in this case.

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -657,23 +657,21 @@ TEST_CASE_METHOD(
 
         // Check can_resize_soma_joinid_shape
         std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1);
+            1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid_shape: dataframe currently has no "
-                "domain "
-                "set: please use tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please use "
+                "tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "resize_soma_joinid_shape: new soma_joinid shape 1 < existing "
-                "shape 199");
+                "testing: new soma_joinid shape 1 < existing shape 199");
             check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -891,23 +889,21 @@ TEST_CASE_METHOD(
 
         // Check can_resize_soma_joinid_shape
         std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1);
+            1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid_shape: dataframe currently has no "
-                "domain "
-                "set: please use tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please use "
+                "tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "resize_soma_joinid_shape: new soma_joinid shape 1 < "
-                "existing shape 199");
+                "testing: new soma_joinid shape 1 < existing shape 199");
             check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -1141,23 +1137,21 @@ TEST_CASE_METHOD(
 
         // Check can_resize_soma_joinid_shape
         std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1);
+            1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid_shape: dataframe currently has no "
-                "domain "
-                "set: please use tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please use "
+                "tiledbsoma_upgrade_domain.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "resize_soma_joinid_shape: new soma_joinid shape 1 < existing "
-                "shape 99");
+                "testing: new soma_joinid shape 1 < existing shape 99");
             check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1);
+                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         }
@@ -1352,14 +1346,13 @@ TEST_CASE_METHOD(
 
         // Check can_resize_soma_joinid_shape
         std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            0);
+            0, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "can_resize_soma_joinid_shape: dataframe currently has no "
-                "domain "
-                "set: please use tiledbsoma_upgrade_domain.");
+                "testing: dataframe currently has no domain set: please use "
+                "tiledbsoma_upgrade_domain.");
         } else {
             // Must pass since soma_joinid isn't a dim in this case.
             REQUIRE(check.first == true);

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -472,7 +472,7 @@ TEST_CASE_METHOD(
     sdf->close();
 
     sdf = open(OpenMode::write);
-    sdf->resize_soma_joinid_shape(int64_t{new_max});
+    sdf->resize_soma_joinid_shape(int64_t{new_max}, "testing");
     sdf->close();
 
     sdf = open(OpenMode::write);
@@ -591,7 +591,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
         } else {
@@ -608,11 +608,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape, "testing");
             sdf->close();
 
             // Check shape after resize
@@ -670,8 +670,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
-                "existing "
+                "resize_soma_joinid_shape: new soma_joinid shape 1 < existing "
                 "shape 199");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1);
@@ -808,7 +807,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
         } else {
@@ -824,11 +823,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape, "testing");
             sdf->close();
 
             // Check shape after resize
@@ -905,9 +904,8 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
-                "existing "
-                "shape 199");
+                "resize_soma_joinid_shape: new soma_joinid shape 1 < "
+                "existing shape 199");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1);
             REQUIRE(check.first == true);
@@ -1061,7 +1059,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
         } else {
@@ -1077,11 +1075,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape, "testing");
             sdf->close();
 
             // Check shape after resize
@@ -1156,8 +1154,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "cannot resize_soma_joinid_shape: new soma_joinid shape 1 < "
-                "existing "
+                "resize_soma_joinid_shape: new soma_joinid shape 1 < existing "
                 "shape 99");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1);
@@ -1295,7 +1292,7 @@ TEST_CASE_METHOD(
 
             sdf = open(OpenMode::write);
             // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
         } else {
@@ -1306,11 +1303,11 @@ TEST_CASE_METHOD(
             sdf->close();
 
             sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape));
+            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
             sdf->close();
 
             sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape);
+            sdf->resize_soma_joinid_shape(new_shape, "testing");
             sdf->close();
 
             // Check shape after resize -- noting soma_joinid is not a dim here

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -147,7 +147,7 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
             //   been sized.
             // * When use_current_domain is true: TODO: current domain not
             //   supported for dense arrays yet (see above).
-            REQUIRE_THROWS(dnda->resize(new_shape));
+            REQUIRE_THROWS(dnda->resize(new_shape, "testing"));
             dnda->close();
         }
     }

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -462,18 +462,18 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
     std::vector<int64_t> newshape_too_small({40});
     std::vector<int64_t> newshape_good({2000});
 
-    auto check = snda->can_resize(newshape_wrong_dims);
+    auto check = snda->can_resize(newshape_wrong_dims, "testing");
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "resize: provided shape has ndim 2, while the array has 1");
+        "testing: provided shape has ndim 2, while the array has 1");
 
-    check = snda->can_resize(newshape_too_small);
+    check = snda->can_resize(newshape_too_small, "testing");
     REQUIRE(check.first == false);
     REQUIRE(
-        check.second == "resize for soma_dim_0: new 40 < existing shape 1000");
+        check.second == "testing for soma_dim_0: new 40 < existing shape 1000");
 
-    check = snda->can_resize(newshape_good);
+    check = snda->can_resize(newshape_good, "testing");
     REQUIRE(check.first == true);
     REQUIRE(check.second == "");
 }

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -471,8 +471,7 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
     check = snda->can_resize(newshape_too_small);
     REQUIRE(check.first == false);
     REQUIRE(
-        check.second ==
-        "resize for soma_dim_0: new 40 < existing shape 1000");
+        check.second == "resize for soma_dim_0: new 40 < existing shape 1000");
 
     check = snda->can_resize(newshape_good);
     REQUIRE(check.first == true);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -148,7 +148,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             REQUIRE(!snda->has_current_domain());
             REQUIRE_THROWS(snda->resize(new_shape, "testing"));
             // Now set the shape
-            snda->upgrade_shape(new_shape);
+            snda->upgrade_shape(new_shape, "testing");
             snda->close();
 
             snda->open(OpenMode::read);
@@ -171,7 +171,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             snda = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
             // Should throw since this already has a shape (core current
             // domain).
-            REQUIRE_THROWS(snda->upgrade_shape(new_shape));
+            REQUIRE_THROWS(snda->upgrade_shape(new_shape, "testing"));
             snda->resize(new_shape, "testing");
             snda->close();
 

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -394,21 +394,21 @@ TEST_CASE(
     std::vector<int64_t> newshape_too_big({dim_max + 10});
     std::vector<int64_t> newshape_good({40});
 
-    auto check = snda->can_upgrade_shape(newshape_wrong_dims);
+    auto check = snda->can_upgrade_shape(newshape_wrong_dims, "testing");
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "cannot tiledbsoma_upgrade_shape: provided shape has ndim 2, while the "
+        "testing: provided shape has ndim 2, while the "
         "array has 1");
 
-    check = snda->can_upgrade_shape(newshape_too_big);
+    check = snda->can_upgrade_shape(newshape_too_big, "testing");
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "cannot tiledbsoma_upgrade_shape for soma_dim_0: new 1009 < maxshape "
+        "testing for soma_dim_0: new 1009 < maxshape "
         "1000");
 
-    check = snda->can_upgrade_shape(newshape_good);
+    check = snda->can_upgrade_shape(newshape_good, "testing");
     REQUIRE(check.first == true);
     REQUIRE(check.second == "");
 }

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -146,7 +146,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             // Without current-domain support: this should throw since
             // one cannot resize what has not been sized.
             REQUIRE(!snda->has_current_domain());
-            REQUIRE_THROWS(snda->resize(new_shape));
+            REQUIRE_THROWS(snda->resize(new_shape, "testing"));
             // Now set the shape
             snda->upgrade_shape(new_shape);
             snda->close();
@@ -158,7 +158,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             snda->open(OpenMode::write);
             REQUIRE(snda->has_current_domain());
             // Should not fail since we're setting it to what it already is.
-            snda->resize(new_shape);
+            snda->resize(new_shape, "testing");
             snda->close();
 
             snda = SOMASparseNDArray::open(uri, OpenMode::read, ctx);
@@ -172,7 +172,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             // Should throw since this already has a shape (core current
             // domain).
             REQUIRE_THROWS(snda->upgrade_shape(new_shape));
-            snda->resize(new_shape);
+            snda->resize(new_shape, "testing");
             snda->close();
 
             // Try out-of-bounds write after resize.
@@ -466,13 +466,13 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "cannot resize: provided shape has ndim 2, while the array has 1");
+        "resize: provided shape has ndim 2, while the array has 1");
 
     check = snda->can_resize(newshape_too_small);
     REQUIRE(check.first == false);
     REQUIRE(
         check.second ==
-        "cannot resize for soma_dim_0: new 40 < existing shape 1000");
+        "resize for soma_dim_0: new 40 < existing shape 1000");
 
     check = snda->can_resize(newshape_good);
     REQUIRE(check.first == true);


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

* This is underpinning for #2964
* As @nguyenv pointed out, it might be nice for the C++ layer to just return enums only ...
* ... but as I pointed out
  * informative messages really require specific context such as the user-provided shape and the limit it ran into
  * I don't want to write those all twice in Python and R
  * So we are making user-presentable strings in the C++ code
* That said, we should not be hard-coding the function names from the caller -- given that C++ is creating user-facing error strings _on behalf of_ Python and R, the C++ code should enable and empower the Python/R code to pass in their function names (whatever those are)

**Notes for Reviewer:**

Despite the line-count this is a trivial PR. I'm splitting out this PR (as well as recents #3125 #3127 #3130) in order to clear the picture for #2964 which is the contentful goal of my recent work this week.