### PR TITLE
[c++] Internal function `can_upgrade_soma_joinid_shape` for experiment-level resize

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1578,17 +1578,28 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
     return std::pair(true, "");
 }
 
-std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
-    int64_t newshape, std::string function_name_for_messages) {
+std::pair<bool, std::string> SOMAArray::_can_set_soma_joinid_shape_helper(
+    int64_t newshape, bool is_resize, std::string function_name_for_messages) {
     // Fail if the array doesn't already have a shape yet (they should upgrade
     // first).
-    if (!has_current_domain()) {
-        return std::pair(
-            false,
-            fmt::format(
-                "{}: dataframe currently has no domain set: please "
-                "upgrade the array.",
-                function_name_for_messages));
+    if (is_resize) {
+        if (!has_current_domain()) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{}: dataframe currently has no domain set: please "
+                    "upgrade the array.",
+                    function_name_for_messages));
+        }
+
+    } else {
+        if (!has_current_domain()) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{}: dataframe already has a shape set.",
+                    function_name_for_messages));
+        }
     }
 
     // OK if soma_joinid isn't a dim.

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1095,7 +1095,20 @@ class SOMAArray : public SOMAObject {
      * for maybe_resize_soma_joinid.
      */
     std::pair<bool, std::string> can_resize_soma_joinid_shape(
-        int64_t newshape, std::string function_name_for_messages);
+        int64_t newshape, std::string function_name_for_messages) {
+        return _can_set_soma_joinid_shape_helper(
+            newshape, true, function_name_for_messages);
+    }
+
+    /**
+     * This is similar to can_upgrade_shape, but it's a can-we call
+     * for maybe_resize_soma_joinid.
+     */
+    std::pair<bool, std::string> can_upgrade_soma_joinid_shape(
+        int64_t newshape, std::string function_name_for_messages) {
+        return _can_set_soma_joinid_shape_helper(
+            newshape, false, function_name_for_messages);
+    }
 
     /**
      * @brief Resize the shape (what core calls "current domain") up to the
@@ -1209,6 +1222,15 @@ class SOMAArray : public SOMAObject {
     std::pair<bool, std::string> _can_set_shape_domainish_subhelper(
         const std::vector<int64_t>& newshape,
         bool check_current_domain,
+        std::string function_name_for_messages);
+
+    /**
+     * This is a code-dedupe helper for can_resize_soma_joinid_shape and
+     * can_upgrade_soma_joinid_shape.
+     */
+    std::pair<bool, std::string> _can_set_soma_joinid_shape_helper(
+        int64_t newshape,
+        bool is_resize,
         std::string function_name_for_messages);
 
     /**


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Continues on #3125 #3127 #3130 underpinnings toward the goal of #2964 wherein we need:

* Experiment-level upgrade/resize
* Since there are multiple arrays in an experiment, a can-we-upgrade/resize-them-all pass

Note that `upgrade_domain` is the full-generality dataframe domain-upgrader, but, for experiment-level work we really need the plumbing that focuses on dataframe `soma_joinid` shape.

**Notes for Reviewer:**

This PR is a work in progress. It is not ready for review.

