### PR TITLE
[c++] Dataframe-sizing helpers

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1610,15 +1610,18 @@ std::pair<bool, std::string> SOMAArray::_can_set_soma_joinid_shape_helper(
     }
 
     // Fail if the newshape isn't within the array's core current domain.
-    std::pair cur_dom_lo_hi = _core_current_domain_slot<int64_t>("soma_joinid");
-    if (newshape < cur_dom_lo_hi.second) {
-        return std::pair(
-            false,
-            fmt::format(
-                "{}: new soma_joinid shape {} < existing shape {}",
-                function_name_for_messages,
-                newshape,
-                cur_dom_lo_hi.second));
+    if (is_resize) {
+        std::pair cur_dom_lo_hi = _core_current_domain_slot<int64_t>(
+            "soma_joinid");
+        if (newshape < cur_dom_lo_hi.second) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{}: new soma_joinid shape {} < existing shape {}",
+                    function_name_for_messages,
+                    newshape,
+                    cur_dom_lo_hi.second + 1));
+        }
     }
 
     // Fail if the newshape isn't within the array's core (max) domain.
@@ -1630,7 +1633,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_soma_joinid_shape_helper(
                 "{}: new soma_joinid shape {} > maxshape {}",
                 function_name_for_messages,
                 newshape,
-                dom_lo_hi.second));
+                dom_lo_hi.second + 1));
     }
 
     // Sucess otherwise.

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
+#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
-#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1578,17 +1578,30 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
     return std::pair(true, "");
 }
 
-std::pair<bool, std::string> SOMAArray::can_resize_soma_joinid_shape(
-    int64_t newshape, std::string function_name_for_messages) {
+std::pair<bool, std::string> SOMAArray::_can_set_soma_joinid_shape_helper(
+    int64_t newshape, bool is_resize, std::string function_name_for_messages) {
     // Fail if the array doesn't already have a shape yet (they should upgrade
     // first).
-    if (!has_current_domain()) {
-        return std::pair(
-            false,
-            fmt::format(
-                "{}: dataframe currently has no domain set: please "
-                "upgrade the array.",
-                function_name_for_messages));
+    if (!is_resize) {
+        // Upgrading an array to give it a current domain
+        if (has_current_domain()) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{}: dataframe already has its domain set.",
+                    function_name_for_messages));
+        }
+
+    } else {
+        // Resizing an array's existing current domain
+
+        if (!has_current_domain()) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{}: dataframe currently has no domain set.",
+                    function_name_for_messages));
+        }
     }
 
     // OK if soma_joinid isn't a dim.

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -29,10 +29,10 @@
  *   This file defines the SOMAArray class.
  */
 
-#include "soma_array.h"
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
+#include "soma_array.h"
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -1654,7 +1654,6 @@ void SOMAArray::_set_shape_helper(
                 "{}: array must not already have a shape",
                 function_name_for_messages));
         }
-
     } else {
         // Expanding an array's current domain
         if (_get_current_domain().is_empty()) {
@@ -1694,12 +1693,28 @@ void SOMAArray::_set_shape_helper(
     schema_evolution.array_evolve(uri_);
 }
 
-void SOMAArray::resize_soma_joinid_shape(
-    int64_t newshape, std::string function_name_for_messages) {
+void SOMAArray::_set_soma_joinid_shape_helper(
+    int64_t newshape, bool is_resize, std::string function_name_for_messages) {
     if (mq_->query_type() != TILEDB_WRITE) {
         throw TileDBSOMAError(fmt::format(
             "{}: array must be opened in write mode",
             function_name_for_messages));
+    }
+
+    if (!is_resize) {
+        // Upgrading an array to install a current domain
+        if (!_get_current_domain().is_empty()) {
+            throw TileDBSOMAError(fmt::format(
+                "{}: array must not already have a shape",
+                function_name_for_messages));
+        }
+    } else {
+        // Expanding an array's current domain
+        if (_get_current_domain().is_empty()) {
+            throw TileDBSOMAError(fmt::format(
+                "{} array must already have a shape",
+                function_name_for_messages));
+        }
     }
 
     ArraySchema schema = arr_->schema();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1110,7 +1110,9 @@ class SOMAArray : public SOMAObject {
      */
     void resize(
         const std::vector<int64_t>& newshape,
-        std::string function_name_for_messages);
+        std::string function_name_for_messages) {
+        _set_shape_helper(newshape, true, function_name_for_messages);
+    }
 
     /**
      * @brief Given an old-style array without current domain, sets its
@@ -1120,7 +1122,9 @@ class SOMAArray : public SOMAObject {
      */
     void upgrade_shape(
         const std::vector<int64_t>& newshape,
-        std::string function_name_for_messages);
+        std::string function_name_for_messages) {
+        _set_shape_helper(newshape, false, function_name_for_messages);
+    }
 
     /**
      * @brief Increases the tiledbsoma shape up to at most the maxshape,
@@ -1214,8 +1218,9 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a code-dedupe helper method for resize and upgrade_shape.
      */
-    void _set_current_domain_from_shape(
+    void _set_shape_helper(
         const std::vector<int64_t>& newshape,
+        bool is_resize,
         std::string function_name_for_messages);
 
     /**

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1154,7 +1154,30 @@ class SOMAArray : public SOMAObject {
      * maxshape. Throws if the array does not have current-domain support.
      */
     void resize_soma_joinid_shape(
-        int64_t newshape, std::string function_name_for_messages);
+        int64_t newshape, std::string function_name_for_messages) {
+        return _set_soma_joinid_shape_helper(
+            newshape, true, function_name_for_messages);
+    }
+
+    /**
+     * @brief Increases the tiledbsoma shape up to at most the maxshape,
+     * resizing the soma_joinid dimension if it is a dimension.
+     *
+     * While SOMA SparseNDArray and DenseNDArray, along with default-indexed
+     * DataFrame, have int64_t dims, non-default-indexed DataFrame objects need
+     * not: it is only required that they have a dim _or_ an attr called
+     * soma_joinid. If soma_joinid is one of the dims, it will be resized while
+     * the others will be preserved. If soma_joinid is not one of the dims,
+     * nothing will be changed, as nothing _needs_ to be changed.
+     *
+     * @return Throws if the requested shape exceeds the array's create-time
+     * maxshape. Throws if the array does not have current-domain support.
+     */
+    void upgrade_soma_joinid_shape(
+        int64_t newshape, std::string function_name_for_messages) {
+        return _set_soma_joinid_shape_helper(
+            newshape, false, function_name_for_messages);
+    }
 
    protected:
     // These two are for use nominally by SOMADataFrame. This could be moved in
@@ -1242,6 +1265,15 @@ class SOMAArray : public SOMAObject {
      */
     void _set_shape_helper(
         const std::vector<int64_t>& newshape,
+        bool is_resize,
+        std::string function_name_for_messages);
+
+    /**
+     * This is a code-dedupe helper method for resize_soma_joinid_shape and
+     * upgrade_soma_joinid_shape.
+     */
+    void _set_soma_joinid_shape_helper(
+        int64_t newshape,
         bool is_resize,
         std::string function_name_for_messages);
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1092,10 +1092,23 @@ class SOMAArray : public SOMAObject {
 
     /**
      * This is similar to can_upgrade_shape, but it's a can-we call
-     * for maybe_resize_soma_joinid.
+     * for resize_soma_joinid_shape.
      */
     std::pair<bool, std::string> can_resize_soma_joinid_shape(
-        int64_t newshape, std::string function_name_for_messages);
+        int64_t newshape, std::string function_name_for_messages) {
+        return _can_set_soma_joinid_shape_helper(
+            newshape, true, function_name_for_messages);
+    }
+
+    /**
+     * This is similar to can_upgrade_shape, but it's a can-we call
+     * for upgrade_soma_joinid_shape.
+     */
+    std::pair<bool, std::string> can_upgrade_soma_joinid_shape(
+        int64_t newshape, std::string function_name_for_messages) {
+        return _can_set_soma_joinid_shape_helper(
+            newshape, false, function_name_for_messages);
+    }
 
     /**
      * @brief Resize the shape (what core calls "current domain") up to the
@@ -1213,6 +1226,15 @@ class SOMAArray : public SOMAObject {
     std::pair<bool, std::string> _can_set_shape_domainish_subhelper(
         const std::vector<int64_t>& newshape,
         bool check_current_domain,
+        std::string function_name_for_messages);
+
+    /**
+     * This is a code-dedupe helper for can_resize_soma_joinid_shape and
+     * can_upgrade_domain_soma_joinid_shape.
+     */
+    std::pair<bool, std::string> _can_set_soma_joinid_shape_helper(
+        int64_t newshape,
+        bool is_resize,
         std::string function_name_for_messages);
 
     /**

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -572,12 +572,29 @@ TEST_CASE_METHOD(
         } else {
             REQUIRE(maxdom_sjid[1] > 2000000000);
         }
-
         sdf->close();
 
         REQUIRE(sdf->nnz() == 2);
         write_sjid_u32_str_data_from(8);
         REQUIRE(sdf->nnz() == 4);
+
+        // Check can_upgrade_soma_joinid_shape
+        sdf->open(OpenMode::read);
+        if (!use_current_domain) {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
+        sdf->close();
 
         // Resize
         auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
@@ -668,7 +685,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: new soma_joinid shape 1 < existing shape 199");
+                "testing: new soma_joinid shape 1 < existing shape 200");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);
@@ -899,7 +916,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: new soma_joinid shape 1 < existing shape 199");
+                "testing: new soma_joinid shape 1 < existing shape 200");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);
@@ -1146,7 +1163,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: new soma_joinid shape 1 < existing shape 99");
+                "testing: new soma_joinid shape 1 < existing shape 100");
             check = sdf->can_resize_soma_joinid_shape(
                 SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
             REQUIRE(check.first == true);

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -662,8 +662,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please "
-                "upgrade the array.");
+                "testing: dataframe currently has no domain set.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -894,8 +893,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please "
-                "upgrade the array.");
+                "testing: dataframe currently has no domain set.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -1142,8 +1140,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please "
-                "upgrade the array.");
+                "testing: dataframe currently has no domain set.");
         } else {
             // Must fail since this is too small.
             REQUIRE(check.first == false);
@@ -1351,8 +1348,7 @@ TEST_CASE_METHOD(
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: dataframe currently has no domain set: please "
-                "upgrade the array.");
+                "testing: dataframe currently has no domain set.");
         } else {
             // Must pass since soma_joinid isn't a dim in this case.
             REQUIRE(check.first == true);

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -161,7 +161,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             snda->resize(new_shape, "testing");
             snda->close();
 
-            snda = SOMASparseNDArray::open(uri, OpenMode::read, ctx);
+            snda->open(OpenMode::read);
             REQUIRE(snda->shape() == new_shape);
             snda->close();
 
@@ -176,7 +176,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
             snda->close();
 
             // Try out-of-bounds write after resize.
-            snda = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
+            snda->open(OpenMode::write);
             snda->set_column_data(dim_name, d0b.size(), d0b.data());
             snda->set_column_data(attr_name, a0b.size(), a0b.data());
             // Implicitly checking for no throw


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Continues on #3125 #3127 #3130 underpinnings toward the goal of #2964 wherein we need:

* Experiment-level upgrade/resize
* Since there are multiple arrays in an experiment, a can-we-upgrade/resize-them-all pass

Note that `upgrade_domain` is the full-generality dataframe domain-upgrader, but, for experiment-level work we really need the plumbing that focuses on dataframe `soma_joinid` shape.

**Notes for Reviewer:**