### PR TITLE
[c++,python] Fix default reads on unwritten dense arrays

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -781,6 +781,62 @@ void load_soma_array(py::module& m) {
             })
 
         .def(
+            "non_empty_domain_slot_opt",
+            [](SOMAArray& array, std::string name, py::dtype dtype) {
+                switch (np_to_tdb_dtype(dtype)) {
+                    case TILEDB_UINT64:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<uint64_t>(name));
+                    case TILEDB_DATETIME_YEAR:
+                    case TILEDB_DATETIME_MONTH:
+                    case TILEDB_DATETIME_WEEK:
+                    case TILEDB_DATETIME_DAY:
+                    case TILEDB_DATETIME_HR:
+                    case TILEDB_DATETIME_MIN:
+                    case TILEDB_DATETIME_SEC:
+                    case TILEDB_DATETIME_MS:
+                    case TILEDB_DATETIME_US:
+                    case TILEDB_DATETIME_NS:
+                    case TILEDB_DATETIME_PS:
+                    case TILEDB_DATETIME_FS:
+                    case TILEDB_DATETIME_AS:
+                    case TILEDB_INT64:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<int64_t>(name));
+                    case TILEDB_UINT32:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<uint32_t>(name));
+                    case TILEDB_INT32:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<int32_t>(name));
+                    case TILEDB_UINT16:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<uint16_t>(name));
+                    case TILEDB_INT16:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<int16_t>(name));
+                    case TILEDB_UINT8:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<uint8_t>(name));
+                    case TILEDB_INT8:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<int8_t>(name));
+                    case TILEDB_FLOAT64:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<double>(name));
+                    case TILEDB_FLOAT32:
+                        return py::cast(
+                            array.non_empty_domain_slot_opt<float>(name));
+                    case TILEDB_STRING_UTF8:
+                    case TILEDB_STRING_ASCII:
+                        return py::cast(array.non_empty_domain_slot_var(name));
+                    default:
+                        throw TileDBSOMAError(
+                            "Unsupported dtype for nonempty domain.");
+                }
+            })
+
+        .def(
             "soma_domain_slot",
             [](SOMAArray& array, std::string name, py::dtype dtype) {
                 switch (np_to_tdb_dtype(dtype)) {

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -176,12 +176,8 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
                     assert X.used_shape() == tuple([(0, e - 1) for e in orig.shape])
             else:
                 assert X.metadata.get(metakey) == "SOMADenseNDArray"
-                if have_ingested:
-                    matrix = X.read(coords=all2d)
-                    assert matrix.size == orig.X.size
-                else:
-                    with pytest.raises(ValueError):
-                        X.read(coords=all2d)
+                matrix = X.read(coords=all2d)
+                assert matrix.size == orig.X.size
 
         # Check raw/X/data (sparse)
         assert exp.ms["raw"].X["data"].metadata.get(metakey) == "SOMASparseNDArray"

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -491,3 +491,18 @@ def test_fixed_timestamp(tmp_path: pathlib.Path):
 
     with pytest.raises(soma.SOMAError):
         soma.open(tmp_path.as_posix(), context=fixed_time, tiledb_timestamp=111)
+
+
+@pytest.mark.parametrize("shape", [(10,), (10, 20), (10, 20, 2), (2, 4, 6, 8)])
+def test_read_to_unwritten_array(tmp_path, shape):
+    uri = tmp_path.as_posix()
+
+    soma.DenseNDArray.create(uri, type=pa.uint8(), shape=shape)
+
+    with tiledb.open(uri, "r") as A:
+        expected = A[:]["soma_data"]
+
+    with soma.DenseNDArray.open(uri, "r") as A:
+        actual = A.read().to_numpy()
+
+    assert np.array_equal(expected, actual)

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -722,12 +722,48 @@ class SOMAArray : public SOMAObject {
 
     /**
      * Retrieves the non-empty domain from the array. This is the union of the
-     * non-empty domains of the array fragments.
+     * non-empty domains of the array fragments. Returns (0, 0) for empty
+     * domains.
      */
     template <typename T>
     std::pair<T, T> non_empty_domain_slot(const std::string& name) const {
         try {
             return arr_->non_empty_domain<T>(name);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(e.what());
+        }
+    }
+
+    /**
+     * Retrieves the non-empty domain from the array. This is the union of the
+     * non-empty domains of the array fragments. Return std::nullopt for empty
+     * domains.
+     */
+    template <typename T>
+    std::optional<std::pair<T, T>> non_empty_domain_slot_opt(
+        const std::string& name) const {
+        try {
+            int32_t is_empty;
+            T ned[2];
+
+            // TODO currently we need to use the TileDB C API in order to check
+            // if the domain is empty or not. The C++ API returns (0, 0)
+            // currently which could also represent a single point at coordinate
+            // 0. Replace this when the C++ API supports correct checking for
+            // empty domains
+            ctx_->tiledb_ctx()->handle_error(
+                tiledb_array_get_non_empty_domain_from_name(
+                    ctx_->tiledb_ctx()->ptr().get(),
+                    arr_->ptr().get(),
+                    name.c_str(),
+                    &ned,
+                    &is_empty));
+
+            if (is_empty == 1) {
+                return std::nullopt;
+            } else {
+                return std::make_pair(ned[0], ned[1]);
+            }
         } catch (const std::exception& e) {
             throw TileDBSOMAError(e.what());
         }


### PR DESCRIPTION
**Issue and/or context:**

Found issue while working on spatial's `MultiscaleImage` and erroring out when applying `read_spatial_region` to a level that had not been written to yet.

**Changes:**

* Add new `non_empty_domain_slot_opt` alongside `non_empty_domain_slot` that returns `std::nullopt` if it is empty rather than (0, 0)
* Fix logic in C++ `ManagedQuery::setup_read` to check if the array has been written to yet. If it hasn't, set the subarray to use soma_dim_0's full domain. Otherwise, use the non-empty domain as before
* Also fix logic in Python `DenseNDArray.read` to use the new `non_empty_domain_slot_opt` and correctly set the `data_shape` to the full domain if the array has not been written to yet
* Add unit test in pytest

