### PR TITLE
[python] Avoid RCs of dependent packages for our RC

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -326,8 +326,10 @@ setuptools.setup(
     zip_safe=False,
     setup_requires=["pybind11"],
     install_requires=[
-        # Tracked in https://github.com/single-cell-data/TileDB-SOMA/issues/1785
-        "anndata != 0.10.0",
+        # Temporary for 1.15.0rc series -- avoid RC versions of these packages
+        "anndata==0.10.9",
+        "networkx==3.2.1",
+        "pyparsing==3.1.4",
         "attrs>=22.2",
         "numba>=0.58.0",
         "numpy<2.0",

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -327,9 +327,9 @@ setuptools.setup(
     setup_requires=["pybind11"],
     install_requires=[
         # Temporary for 1.15.0rc series -- avoid RC versions of these packages
-        "anndata==0.10.9",
-        "networkx==3.2.1",
-        "pyparsing==3.1.4",
+        "anndata>=0.10.1,<0.11.0rc1",
+        "networkx~=3.2.1",
+        "pyparsing~=3.1.4",
         "attrs>=22.2",
         "numba>=0.58.0",
         "numpy<2.0",


### PR DESCRIPTION
We found on `pip install --pre tiledbsoma==0.15.0rc1` that we were getting an undesired `anndata==0.11.0rc2` version of `anndata`.