### PR TITLE
[r] Handle numeric `coords` better in `SOMASparseNDArray$read()`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.99
+Version: 1.15.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,7 @@
 * Use `libtiledbsoma` for R schema evolution [#3100](https://github.com/single-cell-data/TileDB-SOMA/pull/3100)
 * Implement missing `domain` argument to `SOMADataFrame` `create` [#3032](https://github.com/single-cell-data/TileDB-SOMA/pull/3032)
 * Remove unused `fragment_count` accessor [#3054](https://github.com/single-cell-data/TileDB-SOMA/pull/3054)
+* Handle `numeric` coords properly when reading arrays
 
 # tiledbsoma 1.14.1
 

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -46,13 +46,16 @@ SOMASparseNDArray <- R6::R6Class(
         coords <- private$.convert_coords(coords)
       }
 
-      sr <- sr_setup(uri = self$uri,
-                     private$.soma_context,
-                     dim_points = coords,
-                     result_order = result_order,
-                     timestamprange = self$.tiledb_timestamp_range,
-                     loglevel = log_level)
-      SOMASparseNDArrayRead$new(sr, self, coords)
+      sr <- sr_setup(
+        uri = self$uri,
+        private$.soma_context,
+        dim_points = coords,
+        result_order = result_order,
+        timestamprange = self$.tiledb_timestamp_range,
+        loglevel = log_level
+      )
+
+      return(SOMASparseNDArrayRead$new(sr, self, coords))
     },
 
     #' @description Write matrix-like data to the array. (lifecycle: maturing)

--- a/apis/r/tests/testthat/test-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-SOMADenseNDArray.R
@@ -37,7 +37,7 @@ test_that("SOMADenseNDArray creation", {
 
   # Subset the array on both dimensions
   tbl <- ndarray$read_arrow_table(
-    coords = list(soma_dim_0=0:3, soma_dim_1=0:2),
+    coords = list(soma_dim_0 = 0:3, soma_dim_1 = 0:2),
     result_order = "COL_MAJOR"
   )
   expect_identical(
@@ -69,7 +69,7 @@ test_that("SOMADenseNDArray creation", {
   # Validating coords format
   expect_error(
     ndarray$read_arrow_table(coords = list(cbind(0, 1))),
-    "must be a list of vectors"
+    regexp = "'coords' must be a list integerish vectors"
   )
 
   # Validate TileDB array schema


### PR DESCRIPTION
Fix bug in handling of numeric coordinates when reading a sparse array. Now, always cast any integerish value to `bit64::integer64` (casting a `bit64::integer64` to a `bit64::integer64` is a no-op). Also strengthen value checking of `coords` to
 - require `coords` to be a list of `NULL` or positive, finite, integerish values
 - require `coords` to have a length
 - require `coords` to be a list of length `array$dimnames()` or be named with `array$dimnames()`
 - filter `NULLs` from `coords`; if `coords` is all `NULL`, convert to `NULL`

Modified SOMA methods:
 - `SOMANDArrayBase$private$.convert_coords()`: cast all integerish values to `bit64::integer64`; strengthen value checking of `coords`

[SC-57096](https://app.shortcut.com/tiledb-inc/story/57096)