### PR TITLE
[python] Let registrar provide new shapes for resize

### DIFF
--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -313,12 +313,18 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             self._handle.resize(newshape)
             return (True, "")
 
-    def tiledbsoma_upgrade_shape(self, newshape: Sequence[Union[int, None]]) -> None:
+    def tiledbsoma_upgrade_shape(
+        self, newshape: Sequence[Union[int, None]], check_only: bool = False
+    ) -> StatusAndReason:
         """Allows the array to have a resizeable shape as described in the TileDB-SOMA
         1.15 release notes.  Raises an error if the new shape exceeds maxshape in
         any dimension. Raises an error if the array already has a shape.
         """
-        self._handle.tiledbsoma_upgrade_shape(newshape)
+        if check_only:
+            return self._handle.tiledbsoma_can_upgrade_shape(newshape)
+        else:
+            self._handle.tiledbsoma_upgrade_shape(newshape)
+            return (True, "")
 
     def write(
         self,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -469,6 +469,12 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
+    def tiledbsoma_can_upgrade_shape(
+        self, newshape: Sequence[Union[int, None]]
+    ) -> StatusAndReason:
+        """Not implemented for DataFrame."""
+        raise NotImplementedError
+
     def resize_soma_joinid_shape(self, newshape: int) -> None:
         """Only implemented for DataFrame."""
         raise NotImplementedError
@@ -671,6 +677,17 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
         any dimension. Raises an error if the array already has a shape.
         """
         self._handle.tiledbsoma_upgrade_shape(newshape)
+
+    def tiledbsoma_can_upgrade_shape(
+        self, newshape: Sequence[Union[int, None]]
+    ) -> StatusAndReason:
+        """Allows the array to have a resizeable shape as described in the TileDB-SOMA
+        1.15 release notes.  Raises an error if the new shape exceeds maxshape in
+        any dimension. Raises an error if the array already has a shape.
+        """
+        return cast(
+            StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape)
+        )
 
 
 class _DictMod(enum.Enum):

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -354,7 +354,7 @@ class ExperimentAmbientLabelMapping:
 
         if experiment_uri is not None:
             if not tiledbsoma.Experiment.exists(experiment_uri, context=context):
-                raise ValueError("cannot find experiment at URI {experiment_uri}")
+                raise ValueError(f"cannot find experiment at URI {experiment_uri}")
 
             # Pre-check
             with tiledbsoma.Experiment.open(experiment_uri, context=context) as exp:
@@ -487,6 +487,22 @@ class ExperimentAmbientLabelMapping:
         for k, v in self.var_axes.items():
             lines.append(f"{k}/var:{len(v.data)}")
         return "\n".join(lines)
+
+    def get_obs_shape(self) -> int:
+        """XXX WRITE ME"""
+        if len(self.obs_axis.data.values()) == 0:
+            return 0
+        return 1 + max(self.obs_axis.data.values())
+
+    def get_var_shapes(self) -> Dict[str, int]:
+        """XXX WRITE ME"""
+        retval: Dict[str, int] = {}
+        for key, axis in self.var_axes.items():
+            if len(axis.data.values()) == 0:
+                retval[key] = 0
+            else:
+                retval[key] = 1 + max(axis.data.values())
+        return retval
 
     def to_json(self) -> str:
         return json.dumps(self, default=attrs.asdict, sort_keys=True, indent=4)

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -489,13 +489,17 @@ class ExperimentAmbientLabelMapping:
         return "\n".join(lines)
 
     def get_obs_shape(self) -> int:
-        """XXX WRITE ME"""
+        """Reports the new obs shape which the experiment will need to be
+        resized to in order to accommodate the data contained within the
+        registration."""
         if len(self.obs_axis.data.values()) == 0:
             return 0
         return 1 + max(self.obs_axis.data.values())
 
     def get_var_shapes(self) -> Dict[str, int]:
-        """XXX WRITE ME"""
+        """Reports the new var shapes, one per measurement, which the experiment
+        will need to be resized to in order to accommodate the data contained
+        within the registration."""
         retval: Dict[str, int] = {}
         for key, axis in self.var_axes.items():
             if len(axis.data.values()) == 0:

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -127,7 +127,6 @@ void load_soma_sparse_ndarray(py::module& m) {
                 }
             },
             "newshape"_a)
-
         .def(
             "can_resize",
             [](SOMAArray& array, const std::vector<int64_t>& newshape) {
@@ -144,6 +143,17 @@ void load_soma_sparse_ndarray(py::module& m) {
             [](SOMAArray& array, const std::vector<int64_t>& newshape) {
                 try {
                     array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+        .def(
+            "tiledbsoma_can_upgrade_shape",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    return array.can_upgrade_shape(
+                        newshape, "tiledbsoma_can_upgrade_shape");
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -242,8 +242,8 @@ def test_pandas_indexing(
     signature_col_names: List[Union[str, Tuple[str, str]]],
 ):
     """
-    The `default_index_name` for registration can interact with column- and index-names in a variety of ways; this test
-    exercises several of them.
+    The `default_index_name` for registration can interact with column- and
+    index-names in a variety of ways; this test exercises several of them.
     """
     df = PANDAS_INDEXING_TEST_DF.copy()
     index_col = index_col_and_name[0]
@@ -300,6 +300,9 @@ def test_isolated_anndata_mappings(obs_field_name, var_field_name):
         ["RAW2", "TP53", "VEGFA"]
     ).data == (6, 3, 4)
 
+    assert rd.get_obs_shape() == 3
+    assert rd.get_var_shapes() == {"measname": 5, "raw": 7}
+
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
@@ -319,6 +322,9 @@ def test_isolated_h5ad_mappings(obs_field_name, var_field_name):
         ["RAW2", "TP53", "VEGFA"]
     ).data == (6, 3, 4)
 
+    assert rd.get_obs_shape() == 3
+    assert rd.get_var_shapes() == {"measname": 5, "raw": 7}
+
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
@@ -336,6 +342,9 @@ def test_isolated_soma_experiment_mappings(obs_field_name, var_field_name):
     assert rd.var_axes["raw"].id_mapping_from_values(
         ["RAW2", "TP53", "VEGFA"]
     ).data == (6, 3, 4)
+
+    assert rd.get_obs_shape() == 3
+    assert rd.get_var_shapes() == {"measname": 5, "raw": 7}
 
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
@@ -429,6 +438,9 @@ def test_multiples_without_experiment(
         "RAW3": 8,
         "ZZZ3": 9,
     }
+
+    assert rd.get_obs_shape() == 12
+    assert rd.get_var_shapes() == {"measname": 7, "raw": 10}
 
     # Now do the ingestion per se.  Note that once registration is done sequentially, ingest order
     # mustn't matter, and in fact, can be done in parallel. This is why we test various permutations
@@ -677,6 +689,9 @@ def test_multiples_with_experiment(obs_field_name, var_field_name):
         "ZZZ3": 9,
     }
 
+    assert rd.get_obs_shape() == 12
+    assert rd.get_var_shapes() == {"measname": 7, "raw": 10}
+
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
@@ -690,6 +705,9 @@ def test_append_items_with_experiment(obs_field_name, var_field_name):
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
     )
+
+    assert rd.get_obs_shape() == 6
+    assert rd.get_var_shapes() == {"measname": 5, "raw": 7}
 
     adata2 = ad.read_h5ad(h5ad2)
 
@@ -1054,6 +1072,9 @@ def test_registration_with_batched_reads(tmp_path, soma_larger, use_small_buffer
 
     assert len(rd.obs_axis.data) == 1000
 
+    assert rd.get_obs_shape() == 1000
+    assert rd.get_var_shapes() == {"measname": 6}
+
 
 def test_ealm_expose():
     """Checks that this is exported from tiledbsoma.io._registration"""
@@ -1163,6 +1184,9 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
             var_field_name=var_field_name,
         )
 
+        assert rd.get_obs_shape() == nobs_a + nobs_b
+        assert rd.get_var_shapes() == {"meas": 4, "raw": 0}
+
         tiledbsoma.io.from_anndata(
             soma_uri, adata, measurement_name=measurement_name, registration_mapping=rd
         )
@@ -1180,6 +1204,9 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
             obs_field_name=obs_field_name,
             var_field_name=var_field_name,
         )
+
+        assert rd.get_obs_shape() == nobs_a + nobs_b
+        assert rd.get_var_shapes() == {"meas": 4}
 
         tiledbsoma.io.from_anndata(
             soma_uri, bdata, measurement_name=measurement_name, registration_mapping=rd
@@ -1255,6 +1282,9 @@ def test_multimodal_names(tmp_path, conftest_pbmc3k_adata):
         obs_field_name=adata_protein.obs.index.name,
         var_field_name=adata_protein.var.index.name,
     )
+
+    assert rd.get_obs_shape() == 2638
+    assert rd.get_var_shapes() == {"protein": 500, "raw": 13714}
 
     # Ingest the second anndata object into the protein measurement
     tiledbsoma.io.from_anndata(

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -113,7 +113,21 @@ def test_sparse_nd_array_basics(
     with tiledbsoma.SparseNDArray.open(uri) as snda:
         assert snda.shape == arg_shape
 
-    if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+    if not tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+        with tiledbsoma.SparseNDArray.open(uri) as snda:
+            ok, msg = snda.tiledbsoma_upgrade_shape(arg_shape, check_only=True)
+            assert ok
+            assert msg == ""
+
+    else:
+
+        with tiledbsoma.SparseNDArray.open(uri) as snda:
+            ok, msg = snda.tiledbsoma_upgrade_shape(arg_shape, check_only=True)
+            assert not ok
+            assert (
+                msg
+                == "tiledbsoma_can_upgrade_shape: array already has a shape: please use resize"
+            )
 
         # Test resize down
         new_shape = tuple([arg_shape[i] - 50 for i in range(ndim)])


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

For experiment-level resize and append mode (#3148) we'll need the registrar to offer up the new shapes that the experiment will need to be resized to. This PR supports that goal.

**Notes for Reviewer:**

This PR is a work in progress. It is not ready for review.

