### PR TITLE
[c++] Fix an issue with some compilers

### DIFF
--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -122,7 +122,7 @@ ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
         LOG_DEBUG(fmt::format(
             "create_column_index_info name={} type={} dim_max={} ucd={}",
             info.name,
-            info.tiledb_datatype,
+            tiledb::impl::to_str(info.tiledb_datatype),
             info.dim_max,
             info.use_current_domain));
     }


### PR DESCRIPTION
Issue reported by @aneesav on a Mac not too different from mine (which is odd she sees it & I don't). Regardless:

https://gist.github.com/aneesav/514b43786e666aae2ef7bab2cb13603a#file-gistfile1-txt-L75

which is reminiscent of https://github.com/single-cell-data/TileDB-SOMA/pull/2609/files

The error message just points to something at line 122 of `libtiledbsoma/test/common.cc`, and there are four `{}`, but the others are already `std::string` or `bool` so the only remaining option for which of the four triggers the 'not formattable' error is the `tiledb_datatype_t` enum.

The change I'm making here doesn't hurt, and, will likely help @aneesav with `pip install -e apis/python` on her system.