### PR TITLE
[python/c++] Remove tiledb-py from `test_factory.py`

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -236,7 +236,7 @@ void set_metadata(
         value_num,
         value_num > 0 ? value.data() : nullptr,
         force);  // The force flag is intended to only be toggled for testing in
-                 // test_factory.py
+                 // fault-injection scenarios
 }
 
 }  // namespace tiledbsoma

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -209,7 +209,10 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
 }
 
 void set_metadata(
-    SOMAObject& soma_object, const std::string& key, py::array value) {
+    SOMAObject& soma_object,
+    const std::string& key,
+    py::array value,
+    bool force) {
     tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
 
     // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900:
@@ -228,7 +231,12 @@ void set_metadata(
 
     auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
     soma_object.set_metadata(
-        key, value_type, value_num, value_num > 0 ? value.data() : nullptr);
+        key,
+        value_type,
+        value_num,
+        value_num > 0 ? value.data() : nullptr,
+        force);  // The force flag is intended to only be toggled for testing in
+                 // test_factory.py
 }
 
 }  // namespace tiledbsoma

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -28,7 +28,10 @@ std::optional<py::object> to_table(
 
 py::dict meta(std::map<std::string, MetadataValue> metadata_mapping);
 void set_metadata(
-    SOMAObject& soma_object, const std::string& key, py::array value);
+    SOMAObject& soma_object,
+    const std::string& key,
+    py::array value,
+    bool force = false);
 
 class PyQueryCondition {
    private:

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -242,6 +242,9 @@ void load_soma_array(py::module& m) {
                 return pa_schema_import(
                     py::capsule(array.arrow_schema().get()));
             })
+        .def(
+            "config_options_from_schema",
+            &SOMAArray::config_options_from_schema)
         .def("context", &SOMAArray::ctx)
 
         // After this are short functions expected to be invoked when the coords
@@ -951,9 +954,18 @@ void load_soma_array(py::module& m) {
                 return meta(array.get_metadata());
             })
 
-        .def("set_metadata", set_metadata)
+        .def(
+            "set_metadata",
+            set_metadata,
+            py::arg("key"),
+            py::arg("value"),
+            py::arg("force") = false)
 
-        .def("delete_metadata", &SOMAArray::delete_metadata)
+        .def(
+            "delete_metadata",
+            &SOMAArray::delete_metadata,
+            py::arg("key"),
+            py::arg("force") = false)
 
         .def(
             "get_metadata",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -94,7 +94,7 @@ void load_soma_group(py::module& m) {
                     return py::none();
                 return py::cast(group.timestamp()->second);
             })
-            
+
         .def_property_readonly(
             "meta",
             [](SOMAGroup& group) -> py::dict {

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -94,18 +94,28 @@ void load_soma_group(py::module& m) {
                     return py::none();
                 return py::cast(group.timestamp()->second);
             })
+            
         .def_property_readonly(
             "meta",
             [](SOMAGroup& group) -> py::dict {
                 return meta(group.get_metadata());
             })
+
         .def(
             "set_metadata",
-            [](SOMAGroup& group, const std::string& key, py::array value) {
-                set_metadata(group, key, value);
-            })
-        .def("delete_metadata", &SOMAGroup::delete_metadata)
+            set_metadata,
+            py::arg("key"),
+            py::arg("value"),
+            py::arg("force") = false)
+
+        .def(
+            "delete_metadata",
+            &SOMAGroup::delete_metadata,
+            py::arg("key"),
+            py::arg("force") = false)
+
         .def("has_metadata", &SOMAGroup::has_metadata)
+
         .def("metadata_num", &SOMAGroup::metadata_num);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -2,140 +2,86 @@ from time import sleep
 from typing import Type
 
 import numpy as np
+import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
 from tiledbsoma import _constants
-import tiledb
 
 UNKNOWN_ENCODING_VERSION = "3141596"
 
 
 @pytest.fixture
-def tiledb_object_uri(tmp_path, object_type, metadata_typename, encoding_version):
+def tiledb_object_uri(tmp_path, metadata_typename, encoding_version, soma_type):
     """Create an object with specified metadata"""
     object_uri = f"{tmp_path}/object"
+    kwargs = {}
 
-    # create object
-    if object_type == "array":
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="rows", domain=(0, 100), dtype=np.int64)
-            ),
-            attrs=[
-                tiledb.Attr(name="a", dtype=np.int32),
-                tiledb.Attr(name="b", dtype=np.float32),
-            ],
+    if issubclass(soma_type, (soma.DenseNDArray, soma.SparseNDArray)):
+        kwargs["type"] = pa.int64()
+        kwargs["shape"] = (100,)
+    elif issubclass(soma_type, soma.DataFrame):
+        kwargs["schema"] = pa.schema(
+            [("rows", pa.int64()), ("a", pa.int32()), ("b", pa.float32())]
         )
-        tiledb.Array.create(object_uri, schema)
-        with tiledb.open(object_uri, mode="w") as A:
-            _setmetadata(A, metadata_typename, encoding_version)
-    else:
-        tiledb.group_create(object_uri)
-        with tiledb.Group(object_uri, mode="w") as G:
-            _setmetadata(G, metadata_typename, encoding_version)
+
+    with soma_type.create(object_uri, **kwargs) as soma_obj:
+        _setmetadata(soma_obj, metadata_typename, encoding_version)
 
     return object_uri
 
 
 @pytest.mark.parametrize(
-    "object_type,metadata_typename,encoding_version,expected_soma_type",
+    "metadata_typename, encoding_version, soma_type",
     [
-        ("group", "SOMAExperiment", _constants.SOMA_ENCODING_VERSION, soma.Experiment),
-        (
-            "group",
-            "SOMAMeasurement",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.Measurement,
-        ),
-        ("group", "SOMACollection", _constants.SOMA_ENCODING_VERSION, soma.Collection),
-        ("array", "SOMADataFrame", _constants.SOMA_ENCODING_VERSION, soma.DataFrame),
-        (
-            "array",
-            "SOMADenseNDArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.DenseNDArray,
-        ),
-        (
-            "array",
-            "SOMADenseNdArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.DenseNDArray,
-        ),
-        (
-            "array",
-            "SOMASparseNDArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.SparseNDArray,
-        ),
-        (
-            "array",
-            "SOMASparseNdArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.SparseNDArray,
-        ),
+        ("SOMAExperiment", _constants.SOMA_ENCODING_VERSION, soma.Experiment),
+        ("SOMAMeasurement", _constants.SOMA_ENCODING_VERSION, soma.Measurement),
+        ("SOMACollection", _constants.SOMA_ENCODING_VERSION, soma.Collection),
+        ("SOMADataFrame", _constants.SOMA_ENCODING_VERSION, soma.DataFrame),
+        ("SOMADenseNDArray", _constants.SOMA_ENCODING_VERSION, soma.DenseNDArray),
+        ("SOMADenseNdArray", _constants.SOMA_ENCODING_VERSION, soma.DenseNDArray),
+        ("SOMASparseNDArray", _constants.SOMA_ENCODING_VERSION, soma.SparseNDArray),
+        ("SOMASparseNdArray", _constants.SOMA_ENCODING_VERSION, soma.SparseNDArray),
     ],
 )
-def test_open(tiledb_object_uri, expected_soma_type: Type):
+def test_open(tiledb_object_uri, soma_type: Type):
     """Happy path tests"""
     # TODO: Fix Windows test failures without the following.
     sleep(0.01)
     soma_obj = soma.open(tiledb_object_uri)
-    assert isinstance(soma_obj, expected_soma_type)
-    typed_soma_obj = soma.open(tiledb_object_uri, soma_type=expected_soma_type)
-    assert isinstance(typed_soma_obj, expected_soma_type)
-    str_typed_soma_obj = soma.open(
-        tiledb_object_uri, soma_type=expected_soma_type.soma_type
-    )
-    assert isinstance(str_typed_soma_obj, expected_soma_type)
-    assert expected_soma_type.exists(tiledb_object_uri)
+    assert isinstance(soma_obj, soma_type)
+    typed_soma_obj = soma.open(tiledb_object_uri, soma_type=soma_type)
+    assert isinstance(typed_soma_obj, soma_type)
+    str_typed_soma_obj = soma.open(tiledb_object_uri, soma_type=soma_type.soma_type)
+    assert isinstance(str_typed_soma_obj, soma_type)
+    assert soma_type.exists(tiledb_object_uri)
 
 
 @pytest.mark.parametrize(
-    ("object_type", "metadata_typename", "encoding_version", "wrong_type"),
+    ("metadata_typename", "encoding_version", "soma_type"),
     [
-        ("group", "SOMAExperiment", _constants.SOMA_ENCODING_VERSION, soma.Measurement),
-        ("group", "SOMAMeasurement", _constants.SOMA_ENCODING_VERSION, soma.DataFrame),
-        (
-            "group",
-            "SOMAMeasurement",
-            _constants.SOMA_ENCODING_VERSION,
-            "SOMACollection",
-        ),
-        (
-            "array",
-            "SOMADenseNDArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.Collection,
-        ),
-        (
-            "array",
-            "SOMADenseNdArray",
-            _constants.SOMA_ENCODING_VERSION,
-            soma.SparseNDArray,
-        ),
-        (
-            "array",
-            "SOMASparseNDArray",
-            _constants.SOMA_ENCODING_VERSION,
-            "SOMADenseNDArray",
-        ),
+        ("SOMAExperiment", _constants.SOMA_ENCODING_VERSION, soma.Measurement),
+        ("SOMAMeasurement", _constants.SOMA_ENCODING_VERSION, soma.DataFrame),
+        ("SOMAMeasurement", _constants.SOMA_ENCODING_VERSION, soma.Collection),
+        ("SOMADenseNDArray", _constants.SOMA_ENCODING_VERSION, soma.Collection),
+        ("SOMADenseNdArray", _constants.SOMA_ENCODING_VERSION, soma.SparseNDArray),
+        ("SOMASparseNDArray", _constants.SOMA_ENCODING_VERSION, soma.DenseNDArray),
     ],
 )
-def test_open_wrong_type(tiledb_object_uri, wrong_type):
+def test_open_wrong_type(tiledb_object_uri, soma_type):
     with pytest.raises((soma.SOMAError, TypeError)):
-        soma.open(tiledb_object_uri, soma_type=wrong_type)
+        soma.open(tiledb_object_uri, soma_type=soma_type)
 
 
 @pytest.mark.parametrize(
-    "object_type,metadata_typename,encoding_version",
+    "metadata_typename, encoding_version, soma_type",
     [
-        ("group", "SOMAExperiment", UNKNOWN_ENCODING_VERSION),
-        ("group", "SOMAMeasurement", UNKNOWN_ENCODING_VERSION),
-        ("group", "SOMACollection", UNKNOWN_ENCODING_VERSION),
-        ("array", "SOMADataFrame", UNKNOWN_ENCODING_VERSION),
-        ("array", "SOMADenseNDArray", UNKNOWN_ENCODING_VERSION),
-        ("array", "SOMASparseNDArray", UNKNOWN_ENCODING_VERSION),
+        ("SOMAExperiment", UNKNOWN_ENCODING_VERSION, soma.Experiment),
+        ("SOMAMeasurement", UNKNOWN_ENCODING_VERSION, soma.Measurement),
+        ("SOMACollection", UNKNOWN_ENCODING_VERSION, soma.Collection),
+        ("SOMADataFrame", UNKNOWN_ENCODING_VERSION, soma.DataFrame),
+        ("SOMADenseNDArray", UNKNOWN_ENCODING_VERSION, soma.DenseNDArray),
+        ("SOMASparseNDArray", UNKNOWN_ENCODING_VERSION, soma.SparseNDArray),
     ],
 )
 def test_factory_unsupported_version(tiledb_object_uri):
@@ -147,25 +93,33 @@ def test_factory_unsupported_version(tiledb_object_uri):
 
 
 @pytest.mark.parametrize(
-    "object_type,metadata_typename,encoding_version",
+    "metadata_typename, encoding_version, soma_type",
     [
-        ("array", "AnUnknownTypeName", _constants.SOMA_ENCODING_VERSION),
-        ("group", "AnUnknownTypeName", _constants.SOMA_ENCODING_VERSION),
-        ("array", "AnUnknownTypeName", None),
-        ("group", "AnUnknownTypeName", None),
-        ("array", None, _constants.SOMA_ENCODING_VERSION),
-        ("group", None, _constants.SOMA_ENCODING_VERSION),
-        ("array", None, None),
-        ("group", None, None),
         (
-            "array",
+            "AnUnknownTypeName",
+            _constants.SOMA_ENCODING_VERSION,
+            soma.DataFrame,
+        ),  # Invalid type
+        (
+            "AnUnknownTypeName",
+            _constants.SOMA_ENCODING_VERSION,
+            soma.Collection,
+        ),  # Invalid type
+        ("AnUnknownTypeName", None, soma.DataFrame),  # Invalid type and no version
+        ("AnUnknownTypeName", None, soma.Collection),  # Invalid type and no version
+        (None, _constants.SOMA_ENCODING_VERSION, soma.DataFrame),  # No type given
+        (None, _constants.SOMA_ENCODING_VERSION, soma.Collection),  # No type give
+        (None, None, soma.DataFrame),  # Neither type nor version filled
+        (None, None, soma.Collection),  # Neither type nor version filled
+        (
             "SOMACollection",
             _constants.SOMA_ENCODING_VERSION,
-        ),  # Collections can't be arrays
+            soma.DataFrame,
+        ),  # Collections can't be an array
         (
-            "group",
             "SOMADataFrame",
             _constants.SOMA_ENCODING_VERSION,
+            soma.Collection,
         ),  # DataFrame can't be a group
     ],
 )
@@ -182,11 +136,18 @@ def test_factory_unknown_files():
 
 
 def _setmetadata(open_tdb_object, metadata_typename, encoding_version):
-    """set only those values which are not None"""
-    changes = {}
+    """force modify the metadata values"""
+    set_metadata = open_tdb_object._handle._handle.set_metadata
+    del_metadata = open_tdb_object._handle._handle.delete_metadata
+
     if metadata_typename is not None:
-        changes[_constants.SOMA_OBJECT_TYPE_METADATA_KEY] = metadata_typename
+        val = np.array([metadata_typename], "S")
+        set_metadata(_constants.SOMA_OBJECT_TYPE_METADATA_KEY, val, True)
+    else:
+        del_metadata(_constants.SOMA_OBJECT_TYPE_METADATA_KEY, True)
+
     if encoding_version is not None:
-        changes[_constants.SOMA_ENCODING_VERSION_METADATA_KEY] = encoding_version
-    if changes:
-        open_tdb_object.meta.update(changes)
+        val = np.array([encoding_version], "S")
+        set_metadata(_constants.SOMA_ENCODING_VERSION_METADATA_KEY, val, True)
+    else:
+        del_metadata(_constants.SOMA_ENCODING_VERSION_METADATA_KEY, True)

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1094,12 +1094,12 @@ void SOMAArray::set_metadata(
     metadata_.insert(mdpair);
 }
 
-void SOMAArray::delete_metadata(const std::string& key) {
-    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
+void SOMAArray::delete_metadata(const std::string& key, bool force) {
+    if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
         throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
     }
 
-    if (key.compare(ENCODING_VERSION_KEY) == 0) {
+    if (!force && key.compare(ENCODING_VERSION_KEY) == 0) {
         throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
     }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -664,7 +664,7 @@ class SOMAArray : public SOMAObject {
      * @note If the key does not exist, this will take no effect
      *     (i.e., the function will not error out).
      */
-    void delete_metadata(const std::string& key);
+    void delete_metadata(const std::string& key, bool force = false);
 
     /**
      * @brief Given a key, get the associated value datatype, number of

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -261,12 +261,14 @@ void SOMAGroup::set_metadata(
     metadata_.insert(mdpair);
 }
 
-void SOMAGroup::delete_metadata(const std::string& key) {
-    if (key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
+void SOMAGroup::delete_metadata(const std::string& key, bool force) {
+    if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0) {
         throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be deleted.");
+    }
 
-    if (key.compare(ENCODING_VERSION_KEY) == 0)
+    if (!force && key.compare(ENCODING_VERSION_KEY) == 0) {
         throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be deleted.");
+    }
 
     group_->delete_metadata(key);
     metadata_.erase(key);

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -264,7 +264,7 @@ class SOMAGroup : public SOMAObject {
      * @note If the key does not exist, this will take no effect
      *     (i.e., the function will not error out).
      */
-    void delete_metadata(const std::string& key);
+    void delete_metadata(const std::string& key, bool force = false);
 
     /**
      * @brief Given a key, get the associated value datatype, number of

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -124,13 +124,16 @@ class SOMAObject {
      * error out.
      *
      * @param key The key of the metadata item to be deleted.
+     * @param force A boolean toggle to suppress internal checks, defaults to
+     *     false.
      *
      * @note The writes will take effect only upon closing the group.
      *
      * @note If the key does not exist, this will take no effect
      *     (i.e., the function will not error out).
      */
-    virtual void delete_metadata(const std::string& key) = 0;
+    virtual void delete_metadata(
+        const std::string& key, bool force = false) = 0;
 
     /**
      * @brief Given a key, get the associated value datatype, number of


### PR DESCRIPTION
**Issue and/or context:**

As part of https://github.com/single-cell-data/TileDB-SOMA/pull/2883 to remove tiledb-py from unit tests

**Changes:**

* Use the SOMA API to create objects and then modify the reserved metadata values; incorrect encoding versions and SOMA object types should still error out as before
* Add `force` flag to `delete_metadata` to match `set_metadata`

