### PR TITLE
[r] Port the query-condition logic from TileDB-R to TileDB-SOMA-R

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.99.3
+Version: 1.15.99.4
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -10,6 +10,7 @@
 * Handle `numeric` coords properly when reading arrays
 * Remove two more `tiledb::schema` callsites [#3160](https://github.com/single-cell-data/TileDB-SOMA/pull/3160)
 * Add new Arrow-to-R type mapper
+* Add transitiona/non-exported `parse_query_condition_new` [#3162](https://github.com/single-cell-data/TileDB-SOMA/pull/3162)
 
 # tiledbsoma 1.14.1
 

--- a/apis/r/R/QueryCondition.R
+++ b/apis/r/R/QueryCondition.R
@@ -47,7 +47,9 @@
 #' @param somactx SOMAContext pointer.
 #'
 #' @return A `tiledbsoma_query_condition` object.
-#' @export
+#' 
+#' @noRd
+#'
 parse_query_condition_new <- function(
   expr,
   schema,
@@ -195,7 +197,6 @@ parse_query_condition_new <- function(
 #' @slot ptr An external pointer to the underlying implementation
 #' @slot init A logical variable tracking if the query condition object has been
 #' initialized
-#' @exportClass tiledbsoma_query_condition
 setClass(
     "tiledbsoma_query_condition",
     slots = list(ptr = "externalptr", init = "logical"))
@@ -229,7 +230,9 @@ tiledbsoma_empty_query_condition <- function(somactx) {
 #' 'LT', 'LE', 'GT', 'GE', 'EQ', 'NE'.
 #' @param qc A 'tiledbsoma_query_condition' object to be initialized by this call.
 #' @return The initialized 'tiledbsoma_query_condition' object
-#' @export
+#' 
+#' @noRd
+#'
 tiledbsoma_query_condition_from_triple <- function(
     attr_name,
     value,
@@ -269,7 +272,9 @@ tiledbsoma_query_condition_from_triple <- function(
 #' @param op_name A character value with the relation, which must be one of 'AND', 'OR' or 'NOT'.
 #' @param somactx SOMAContext pointer.
 #' @return The combined 'tiledbsoma_query_condition' object
-#' @export
+#' 
+#' @noRd
+#'
 tiledbsoma_query_condition_combine <- function(lhs, rhs, op_name, somactx) {
     stopifnot(
         "Argument 'lhs' must be a query condition object" = is(lhs, "tiledbsoma_query_condition"),
@@ -298,7 +303,9 @@ tiledbsoma_query_condition_combine <- function(lhs, rhs, op_name, somactx) {
 #' @param somactx SOMAContext pointer.
 #'
 #' @return A query-condition object is returned
-#' @export
+#' 
+#' @noRd
+#'
 tiledbsoma_query_condition_in_nin <- function(
   attr_name,
   op_name = "IN",

--- a/apis/r/R/QueryCondition.R
+++ b/apis/r/R/QueryCondition.R
@@ -55,9 +55,12 @@ parse_query_condition_new <- function(
   somactx
   ) {
 
-  stopifnot("The schema argument must be an Arrow Schema" =
-    is(schema, "ArrowObject") &&
-    is(schema, "Schema"))
+  stopifnot(
+      "The schema argument must be an Arrow Schema" =
+          is(schema, "ArrowObject") &&
+          is(schema, "Schema"),
+    "The argument must be a somactx object" =
+        is(somactx, "externalptr"))
 
     # ----------------------------------------------------------------
     # Helpers for walking the parse tree
@@ -124,7 +127,6 @@ parse_query_condition_new <- function(
             r_op_name <- tolower(as.character(node[1]))
             tdb_op_name <- if (r_op_name == "%in%") "IN" else "NOT_IN"
 
-            # XXX EXTRACT HELPER
             arrow_field <- schema[[attr_name]]
             if (is.null(arrow_field)) {
                 .error_function("No attribute '", attr_name, "' is present.", call. = FALSE)
@@ -168,8 +170,8 @@ parse_query_condition_new <- function(
                     ascii = rhs_text,
                     utf8 = rhs_text,
                     bool = as.logical(rhs_text),
-                    ## XXX DATETIME_MS = as.POSIXct(rhs_text),
-                    ## XXX DATETIME_DAY = as.Date(rhs_text),
+                    date32 = as.POSIXct(rhs_text),
+                    timestamp = as.Date(rhs_text),
                     as.numeric(rhs_text)),
                 arrow_type_name = arrow_type_name,
                 op_name = .map_op_to_character(op_name),
@@ -201,12 +203,12 @@ setClass(
 # ================================================================
 #' Creates a 'tiledbsoma_query_condition' object
 #'
-#' @param ctx (optional) A TileDB Ctx object; if not supplied the default
+#' @param somactx (optional) A TileDB Ctx object; if not supplied the default
 #' context object is retrieved
 #' @return A 'tiledbsoma_query_condition' object
 #' @export
 tiledbsoma_empty_query_condition <- function(somactx) {
-    stopifnot("The argument must be a ctx object" = is(ctx, "externalptr"))
+    stopifnot("The argument must be a somactx object" = is(somactx, "externalptr"))
     ptr <- libtiledbsoma_empty_query_condition(somactx)
     query_condition <- new("tiledbsoma_query_condition", ptr = ptr, init = FALSE)
     invisible(query_condition)

--- a/apis/r/R/QueryCondition.R
+++ b/apis/r/R/QueryCondition.R
@@ -1,0 +1,314 @@
+#  MIT License
+#
+#  Copyright (c) 2021-2024 TileDB Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+# ================================================================
+#' Create a 'tiledbsoma_query_condition' object from an expression
+#'
+#' The grammar for query conditions is constrained to the operators
+#' (\code{">"}, \code{">="}, \code{"<"}, \code{"<="}, \code{"=="},
+#' \code{"!="}, \code{"%in%"}, \code{"%nin%"}), and three boolean operators
+#' (\code{"&&"}, also as \code{"&"}, (\code{"||"}, also as \code{"|"}, and
+#' \code{"!"} for negation.  Note that we locally define \code{"%nin%"} as
+#' \code{Negate()} call around \code{%in%)} which extends R a little for this
+#' use case.
+#'
+#' Expressions, in the R language syntax, are parsed locally by this function.
+#'
+#' @param expr An expression that is understood by the TileDB grammar for
+#' query conditions.
+#'
+#' @param schema The Arrow schema for the array for which a query
+#' condition is being prepared. This is necessary to obtain type information
+#' about left-hand sides of query expressions.
+#'
+#' @param strict A boolean toogle to, if set, errors if a non-existing
+#' attribute is selected or filtered on, defaults to 'TRUE'; if 'FALSE' a
+#' warning is shown but execution proceeds.
+#'
+#' @param somactx SOMAContext pointer.
+#'
+#' @return A `tiledbsoma_query_condition` object.
+#' @export
+parse_query_condition_new <- function(
+  expr,
+  schema,
+  strict=TRUE,
+  somactx
+  ) {
+
+  stopifnot("The schema argument must be an Arrow Schema" =
+    is(schema, "ArrowObject") &&
+    is(schema, "Schema"))
+
+    # ----------------------------------------------------------------
+    # Helpers for walking the parse tree
+
+    # Operators
+    `%!in%` <- Negate(`%in%`)
+    .is_in_operator <- function(node) {
+        return(tolower(as.character(node)) %in% c("%in%", "%nin%"))
+    }
+    .is_comparison_operator <- function(node) {
+        return(tolower(as.character(node)) %in% c(">", ">=", "<", "<=", "==", "!=", "%in%", "%nin%"))
+    }
+    .is_boolean_operator <- function(node) {
+        return(as.character(node) %in% c("&&", "||", "!", "&", "|"))
+    }
+
+    # Leaf nodes
+    .is_ascii <- function(node) {
+        return(grepl("^[[:alnum:]_]+$", node))
+    }
+    .is_integer <- function(node) {
+        return(grepl("^[[:digit:]]+$", as.character(node)))
+    }
+    .is_double <- function(node) {
+        return(grepl("^[[:digit:]\\.]+$", as.character(node)) && length(grepRaw(".", as.character(node), fixed = TRUE, all = TRUE)) == 1)
+    }
+
+    .error_function <- if (strict) stop else warning
+
+    .map_op_to_character <- function(x) {
+        return(switch(x, `>` = "GT", `>=` = "GE", `<` = "LT", `<=` = "LE", `==` = "EQ", `!=` = "NE"))
+    }
+
+    .map_bool_to_character <- function(x) {
+        return(switch(x, `&&` = "AND", `&` = "AND", `||` = "OR", `|` = "OR", `!` = "NOT"))
+    }
+
+    # ----------------------------------------------------------------
+    # Map the R parse tree (from base-r `substitute`) to a TileDB core QueryCondition
+
+    .parse_tree_to_qc <- function(node, debug=FALSE) {
+        if (is.symbol(node)) {
+            stop("Unexpected symbol in expression: ", format(node))
+
+        } else if (.is_boolean_operator(node[1])) {
+            spdl::debug("[parseqc] boolop [{}] [{}] [{}]",
+                as.character(node[2]),
+                as.character(node[1]),
+                as.character(node[3]))
+
+            return(tiledbsoma_query_condition_combine(
+                .parse_tree_to_qc(node[[2]]),
+                .parse_tree_to_qc(node[[3]]),
+                .map_bool_to_character(as.character(node[1])),
+                somactx))
+
+        } else if (.is_in_operator(node[1])) {
+            spdl::debug("[parseqc] inop [{}] [{}] [{}]",
+                as.character(node[2]),
+                as.character(node[1]),
+                as.character(node[3]))
+
+            attr_name <- as.character(node[2])
+            r_op_name <- tolower(as.character(node[1]))
+            tdb_op_name <- if (r_op_name == "%in%") "IN" else "NOT_IN"
+
+            # XXX EXTRACT HELPER
+            arrow_field <- schema[[attr_name]]
+            if (is.null(arrow_field)) {
+                .error_function("No attribute '", attr_name, "' is present.", call. = FALSE)
+            }
+            arrow_type_name <- arrow_field$type$name
+            is_enum <- is(arrow_field$type, "DictionaryType")
+
+            values <- eval(parse(text=as.character(node[3])))
+            if (arrow_type_name == "int32" && !is_enum) {
+                values <- as.integer(values)
+            }
+
+            return(tiledbsoma_query_condition_in_nin(attr_name, tdb_op_name, values, somactx))
+
+        } else if (.is_comparison_operator(node[1])) {
+            spdl::debug("[parseqc] cmpop [{}] [{}] [{}]",
+                as.character(node[2]),
+                as.character(node[1]),
+                as.character(node[3]))
+
+            op_name <- as.character(node[1])
+            attr_name <- as.character(node[2])
+            rhs_text <- as.character(node[3])
+
+            arrow_field <- schema[[attr_name]]
+            if (is.null(arrow_field)) {
+                .error_function("No attribute '", attr_name, "' is present.", call. = FALSE)
+            }
+            arrow_type_name <- arrow_field$type$name
+
+            # Take care of factor (aka "enum" case) and set the data type to ASCII
+            if (arrow_type_name == "dictionary") {
+                arrow_type_name <- "utf8"
+            }
+
+            # General case of extracting appropriate value given type info
+            return(tiledbsoma_query_condition_from_triple(
+                attr_name = attr_name,
+                value = switch(
+                    arrow_type_name,
+                    ascii = rhs_text,
+                    utf8 = rhs_text,
+                    bool = as.logical(rhs_text),
+                    ## XXX DATETIME_MS = as.POSIXct(rhs_text),
+                    ## XXX DATETIME_DAY = as.Date(rhs_text),
+                    as.numeric(rhs_text)),
+                arrow_type_name = arrow_type_name,
+                op_name = .map_op_to_character(op_name),
+                qc = tiledbsoma_empty_query_condition(somactx)))
+
+        } else {
+            stop("Unexpected token in expression: ", format(node))
+        }
+    }
+
+    # Use base-r `substitute` to map the user-provided expression to a parse tree
+    parse_tree <- substitute(expr)
+
+    # Map the parse tree to TileDB core QueryCondition
+    return(.parse_tree_to_qc(parse_tree, debug))
+}
+
+# ================================================================
+#' An S4 class for a TileDB QueryCondition object
+#'
+#' @slot ptr An external pointer to the underlying implementation
+#' @slot init A logical variable tracking if the query condition object has been
+#' initialized
+#' @exportClass tiledbsoma_query_condition
+setClass(
+    "tiledbsoma_query_condition",
+    slots = list(ptr = "externalptr", init = "logical"))
+
+# ================================================================
+#' Creates a 'tiledbsoma_query_condition' object
+#'
+#' @param ctx (optional) A TileDB Ctx object; if not supplied the default
+#' context object is retrieved
+#' @return A 'tiledbsoma_query_condition' object
+#' @export
+tiledbsoma_empty_query_condition <- function(somactx) {
+    stopifnot("The argument must be a ctx object" = is(ctx, "externalptr"))
+    ptr <- libtiledbsoma_empty_query_condition(somactx)
+    query_condition <- new("tiledbsoma_query_condition", ptr = ptr, init = FALSE)
+    invisible(query_condition)
+}
+
+# ================================================================
+#' Initialize a 'tiledbsoma_query_condition' object
+#'
+#' Initializes (and possibly allocates) a query condition object using a triplet of
+#' attribute name, comparison value, and operator.  Six types of conditions are supported,
+#' they all take a single scalar comparison argument and attribute to compare against.
+#' At present only integer or numeric attribute comparisons are implemented.
+#' @param attr_name A character value with the scheme attribute name
+#' @param value A scalar value that the attribute is compared against
+#' @param arrow_type_name A character value with the TileDB data type of the attribute column, for
+#' example 'float' or 'int32'
+#' @param op_name A character value with the comparison operation. This must be one of
+#' 'LT', 'LE', 'GT', 'GE', 'EQ', 'NE'.
+#' @param qc A 'tiledbsoma_query_condition' object to be initialized by this call.
+#' @return The initialized 'tiledbsoma_query_condition' object
+#' @export
+tiledbsoma_query_condition_from_triple <- function(
+    attr_name,
+    value,
+    arrow_type_name,
+    op_name,
+    qc) {
+
+    stopifnot(
+        "Argument 'qc' with query condition object required" = inherits(qc, "tiledbsoma_query_condition"),
+        "Argument 'attr_name' must be character" = is.character(attr_name),
+        "Argument 'value' must be of length one" = (
+            is.vector(value) ||
+            bit64::is.integer64(value) ||
+            inherits(value, "POSIXt") ||
+            inherits(value, "Date")) && all.equal(length(value),1),
+        "Argument 'arrow_type_name' must be character" = is.character(arrow_type_name),
+        "Argument 'op_name' must be character" = is.character(op_name))
+
+    op_name <- match.arg(op_name, c("LT", "LE", "GT", "GE", "EQ", "NE"))
+    # If arrow_type_name is int64 or uint64 but the class of value does not yet inherit from
+    # integer64, cast.
+    if (grepl("int64", arrow_type_name) && !inherits(value, "integer64")) {
+        value <- bit64::as.integer64(value)
+    }
+    libtiledbsoma_query_condition_from_triple(qc@ptr, attr_name, value, arrow_type_name, op_name)
+    qc@init <- TRUE
+    invisible(qc)
+}
+
+# ================================================================
+#' Combine two 'tiledbsoma_query_condition' objects
+#'
+#' Combines two query condition objects using a relatiional operator.
+#'
+#' @param lhs A 'tiledbsoma_query_condition' object on the left-hand side of the relation
+#' @param rhs A 'tiledbsoma_query_condition' object on the right-hand side of the relation
+#' @param op_name A character value with the relation, which must be one of 'AND', 'OR' or 'NOT'.
+#' @param somactx SOMAContext pointer.
+#' @return The combined 'tiledbsoma_query_condition' object
+#' @export
+tiledbsoma_query_condition_combine <- function(lhs, rhs, op_name, somactx) {
+    stopifnot(
+        "Argument 'lhs' must be a query condition object" = is(lhs, "tiledbsoma_query_condition"),
+        "Argument 'rhs' must be a query condition object" = is(rhs, "tiledbsoma_query_condition"),
+        "Argument 'op_name' must be a character" = is.character(op_name))
+    op_name <- match.arg(op_name, c("AND", "OR", "NOT"))
+    qc <- tiledbsoma_empty_query_condition(somactx)
+    qc@ptr <- libtiledbsoma_query_condition_combine(lhs@ptr, rhs@ptr, op_name)
+    qc@init <- TRUE
+    invisible(qc)
+}
+
+# ================================================================
+#' Create a query condition for vector 'IN' and 'NOT_IN' operations
+#'
+#' Uses \sQuote{IN} and \sQuote{NOT_IN} operators on given attribute
+#'
+#' @param attr_name A character value with the schema attribute name.
+#'
+#' @param op_name A character value with the chosen set operation. This must be one of
+#' \sQuote{IN} or \sQuote{NOT_IN}.
+#'
+#' @param values A vector wiith the given values. Supported types are integer, double,
+#' integer64, and character.
+#'
+#' @param somactx SOMAContext pointer.
+#'
+#' @return A query-condition object is returned
+#' @export
+tiledbsoma_query_condition_in_nin <- function(
+  attr_name,
+  op_name = "IN",
+  values,
+  somactx) {
+    stopifnot("Argument 'attr_name' must be character" = is.character(attr_name),
+              "Argument 'values' must be int, double, int64 or char" =
+                  (is.numeric(values) || bit64::is.integer64(values) || is.character(values)),
+              "Argument 'op_name' must be one of 'IN' or 'NOT_IN'" = op_name %in% c("IN", "NOT_IN"))
+
+    qc <- tiledbsoma_empty_query_condition(somactx)
+    qc@ptr <- libtiledbsoma_query_condition_in_nin(somactx, attr_name, op_name, values)
+    qc@init <- TRUE
+    invisible(qc)
+}

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -126,6 +126,22 @@ set_metadata <- function(uri, key, valuesxp, type, is_array, ctxxp, tsvec = NULL
     invisible(.Call(`_tiledbsoma_set_metadata`, uri, key, valuesxp, type, is_array, ctxxp, tsvec))
 }
 
+libtiledbsoma_empty_query_condition <- function(ctxxp) {
+    .Call(`_tiledbsoma_libtiledbsoma_empty_query_condition`, ctxxp)
+}
+
+libtiledbsoma_query_condition_from_triple <- function(query_cond, attr_name, condition_value, arrow_type_name, cond_op_string) {
+    invisible(.Call(`_tiledbsoma_libtiledbsoma_query_condition_from_triple`, query_cond, attr_name, condition_value, arrow_type_name, cond_op_string))
+}
+
+libtiledbsoma_query_condition_combine <- function(lhs, rhs, str) {
+    .Call(`_tiledbsoma_libtiledbsoma_query_condition_combine`, lhs, rhs, str)
+}
+
+libtiledbsoma_query_condition_in_nin <- function(ctxxp, attr_name, op_name, values) {
+    .Call(`_tiledbsoma_libtiledbsoma_query_condition_in_nin`, ctxxp, attr_name, op_name, values)
+}
+
 reindex_create <- function() {
     .Call(`_tiledbsoma_reindex_create`)
 }

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -246,6 +246,58 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// libtiledbsoma_empty_query_condition
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_empty_query_condition(Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_empty_query_condition(SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_empty_query_condition(ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledbsoma_query_condition_from_triple
+void libtiledbsoma_query_condition_from_triple(Rcpp::XPtr<tdbs::QueryCondition> query_cond, const std::string& attr_name, SEXP condition_value, const std::string& arrow_type_name, const std::string& cond_op_string);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_query_condition_from_triple(SEXP query_condSEXP, SEXP attr_nameSEXP, SEXP condition_valueSEXP, SEXP arrow_type_nameSEXP, SEXP cond_op_stringSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<tdbs::QueryCondition> >::type query_cond(query_condSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type attr_name(attr_nameSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type condition_value(condition_valueSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type arrow_type_name(arrow_type_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type cond_op_string(cond_op_stringSEXP);
+    libtiledbsoma_query_condition_from_triple(query_cond, attr_name, condition_value, arrow_type_name, cond_op_string);
+    return R_NilValue;
+END_RCPP
+}
+// libtiledbsoma_query_condition_combine
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_query_condition_combine(Rcpp::XPtr<tdbs::QueryCondition> lhs, Rcpp::XPtr<tdbs::QueryCondition> rhs, const std::string& str);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_query_condition_combine(SEXP lhsSEXP, SEXP rhsSEXP, SEXP strSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<tdbs::QueryCondition> >::type lhs(lhsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<tdbs::QueryCondition> >::type rhs(rhsSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type str(strSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_query_condition_combine(lhs, rhs, str));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledbsoma_query_condition_in_nin
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_query_condition_in_nin(Rcpp::XPtr<somactx_wrap_t> ctxxp, const std::string& attr_name, const std::string& op_name, SEXP values);
+RcppExport SEXP _tiledbsoma_libtiledbsoma_query_condition_in_nin(SEXP ctxxpSEXP, SEXP attr_nameSEXP, SEXP op_nameSEXP, SEXP valuesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type attr_name(attr_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type op_name(op_nameSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type values(valuesSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledbsoma_query_condition_in_nin(ctxxp, attr_name, op_name, values));
+    return rcpp_result_gen;
+END_RCPP
+}
 // reindex_create
 Rcpp::XPtr<tdbs::IntIndexer> reindex_create();
 RcppExport SEXP _tiledbsoma_reindex_create() {
@@ -739,6 +791,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_has_metadata", (DL_FUNC) &_tiledbsoma_has_metadata, 4},
     {"_tiledbsoma_delete_metadata", (DL_FUNC) &_tiledbsoma_delete_metadata, 4},
     {"_tiledbsoma_set_metadata", (DL_FUNC) &_tiledbsoma_set_metadata, 7},
+    {"_tiledbsoma_libtiledbsoma_empty_query_condition", (DL_FUNC) &_tiledbsoma_libtiledbsoma_empty_query_condition, 1},
+    {"_tiledbsoma_libtiledbsoma_query_condition_from_triple", (DL_FUNC) &_tiledbsoma_libtiledbsoma_query_condition_from_triple, 5},
+    {"_tiledbsoma_libtiledbsoma_query_condition_combine", (DL_FUNC) &_tiledbsoma_libtiledbsoma_query_condition_combine, 3},
+    {"_tiledbsoma_libtiledbsoma_query_condition_in_nin", (DL_FUNC) &_tiledbsoma_libtiledbsoma_query_condition_in_nin, 4},
     {"_tiledbsoma_reindex_create", (DL_FUNC) &_tiledbsoma_reindex_create, 0},
     {"_tiledbsoma_reindex_map", (DL_FUNC) &_tiledbsoma_reindex_map, 2},
     {"_tiledbsoma_reindex_lookup", (DL_FUNC) &_tiledbsoma_reindex_lookup, 2},

--- a/apis/r/src/query_condition.cpp
+++ b/apis/r/src/query_condition.cpp
@@ -1,0 +1,220 @@
+#include <Rcpp.h>                   // for R interface to C++
+#include <nanoarrow/r.h>            // for C interface to Arrow (via R package)
+#include <RcppInt64>                // for fromInteger64
+#include <nanoarrow/nanoarrow.hpp>  // for C/C++ interface to Arrow
+
+// we currently get deprecation warnings by default which are noisy
+#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS
+#define TILEDB_NO_API_DEPRECATION_WARNINGS
+#endif
+
+// We get these via nanoarrow and must cannot include carrow.h again
+#define ARROW_SCHEMA_AND_ARRAY_DEFINED 1
+#include <tiledb/tiledb_experimental>
+#include <tiledbsoma/tiledbsoma>
+
+#include "rutilities.h"  // local declarations
+#include "xptr-utils.h"  // xptr taggging utilities
+
+// Helper
+tiledb_query_condition_combination_op_t
+_tiledb_query_string_to_condition_combination_op(const std::string& opstr) {
+    if (opstr == "AND") {
+        return TILEDB_AND;
+    } else if (opstr == "OR") {
+        return TILEDB_OR;
+    } else if (opstr == "NOT") {
+        return TILEDB_NOT;
+    } else {
+        Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
+    }
+}
+
+// Helper
+tiledb_query_condition_op_t _op_name_to_tdb_op(const std::string& opstr) {
+    if (opstr == "LT") {
+        return TILEDB_LT;
+    } else if (opstr == "LE") {
+        return TILEDB_LE;
+    } else if (opstr == "GT") {
+        return TILEDB_GT;
+    } else if (opstr == "GE") {
+        return TILEDB_GE;
+    } else if (opstr == "EQ") {
+        return TILEDB_EQ;
+    } else if (opstr == "NE") {
+        return TILEDB_NE;
+    } else if (opstr == "IN") {
+        return TILEDB_IN;
+    } else if (opstr == "NOT_IN") {
+        return TILEDB_NOT_IN;
+    } else {
+        Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
+    }
+}
+
+// [[Rcpp::export]]
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_empty_query_condition(
+    Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    // Shared pointer to SOMAContext from external pointer wrapper:
+    std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
+    // Shared pointer to TileDB Context from SOMAContext:
+    std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+    // Core constructor
+    return make_xptr<tdbs::QueryCondition>(
+        new tdbs::QueryCondition(*ctx.get()));
+}
+
+// [[Rcpp::export]]
+void libtiledbsoma_query_condition_from_triple(
+    Rcpp::XPtr<tdbs::QueryCondition> query_cond,
+    const std::string& attr_name,
+    SEXP condition_value,
+    const std::string& arrow_type_name,
+    const std::string& cond_op_string) {
+    // No such:
+    // print(arrow::large_string()$name)
+    // print(arrow::double()$name)
+
+    // print(arrow::int64()$name)         [1] "int64"
+    // print(arrow::uint64()$name)        [1] "uint64"
+    // print(arrow::int32()$name)         [1] "int32"
+    // print(arrow::uint32()$name)        [1] "uint32"
+    // print(arrow::int16()$name)         [1] "int16"
+    // print(arrow::uint16()$name)        [1] "uint16"
+    // print(arrow::int8()$name)          [1] "int8"
+    // print(arrow::uint8()$name)         [1] "uint8"
+    // print(arrow::float64()$name)       [1] "double"
+    // print(arrow::float()$name)         [1] "float"
+    // print(arrow::float32()$name)       [1] "float"
+    // print(arrow::string()$name)        [1] "utf8"
+    // print(arrow::binary()$name)        [1] "binary"
+    // print(arrow::large_binary()$name)  [1] "large_binary"
+    // print(arrow::bool()$name)          [1] "bool"
+    // print(arrow::boolean()$name)       [1] "bool"
+    // print(arrow::date64()$name)        [1] "date64"
+    // print(arrow::date32()$name)        [1] "date32"
+    // print(arrow::time32()$name)        [1] "time32"
+    // print(arrow::time64()$name)        [1] "time64"
+
+    check_xptr_tag<tdbs::QueryCondition>(query_cond);
+    tiledb_query_condition_op_t op = _op_name_to_tdb_op(cond_op_string);
+
+    if (arrow_type_name == "int64" || arrow_type_name == "uint64") {
+        int64_t v = Rcpp::fromInteger64(Rcpp::as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "int32" || arrow_type_name == "uint32") {
+        int v = Rcpp::as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "int16" || arrow_type_name == "uint16") {
+        int v = Rcpp::as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int16_t);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "int8" || arrow_type_name == "uint8") {
+        int v = Rcpp::as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int8_t);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "double") {
+        double v = Rcpp::as<double>(condition_value);
+        uint64_t cond_val_size = sizeof(double);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "float") {
+        float v = static_cast<float>(Rcpp::as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(float);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else if (arrow_type_name == "ascii" || arrow_type_name == "utf8") {
+        std::string v = Rcpp::as<std::string>(condition_value);
+        query_cond->init(attr_name, v, op);
+
+    } else if (arrow_type_name == "bool") {
+        bool v = Rcpp::as<bool>(condition_value);
+        uint64_t cond_val_size = sizeof(bool);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+        // XXX FIXME
+        //    } else if (arrow_type_name == "DATETIME_MS") {
+        //        int64_t v = static_cast<int64_t>(
+        //            Rcpp::as<double>(condition_value) * 1000);
+        //        uint64_t cond_val_size = sizeof(int64_t);
+        //        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+        //    } else if (arrow_type_name == "DATETIME_DAY") {
+        //        int64_t v =
+        //        static_cast<int64_t>(Rcpp::as<double>(condition_value));
+        //        uint64_t cond_val_size = sizeof(int64_t);
+        //        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+
+    } else {
+        Rcpp::stop(
+            "tiledbsoma query condition: currently unsupported type \"%s\"",
+            arrow_type_name);
+    }
+}
+
+// [[Rcpp::export]]
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_query_condition_combine(
+    Rcpp::XPtr<tdbs::QueryCondition> lhs,
+    Rcpp::XPtr<tdbs::QueryCondition> rhs,
+    const std::string& str) {
+    check_xptr_tag<tdbs::QueryCondition>(lhs);
+    check_xptr_tag<tdbs::QueryCondition>(lhs);
+    tiledb_query_condition_combination_op_t
+        op = _tiledb_query_string_to_condition_combination_op(str);
+    tdbs::QueryCondition res = lhs->combine(*rhs.get(), op);
+    return make_xptr<tdbs::QueryCondition>(new tdbs::QueryCondition(res));
+}
+
+// [[Rcpp::export]]
+Rcpp::XPtr<tdbs::QueryCondition> libtiledbsoma_query_condition_in_nin(
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    const std::string& attr_name,
+    const std::string& op_name,
+    SEXP values) {
+    // Shared pointer to SOMAContext from external pointer wrapper:
+    std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
+    // Shared pointer to TileDB Context from SOMAContext:
+    std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+
+    tiledb_query_condition_op_t op = _op_name_to_tdb_op(op_name);
+
+    if (TYPEOF(values) == INTSXP) {
+        std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(values);
+        auto qc = tdbs::QueryConditionExperimental::create<int32_t>(
+            *ctx.get(), attr_name, iv, op);
+        return make_xptr<tdbs::QueryCondition>(new tdbs::QueryCondition(qc));
+
+    } else if (TYPEOF(values) == REALSXP) {
+        if (Rcpp::isInteger64(values)) {
+            std::vector<int64_t> dv = Rcpp::fromInteger64(
+                Rcpp::NumericVector(values));
+            auto qc = tdbs::QueryConditionExperimental::create<int64_t>(
+                *ctx.get(), attr_name, dv, op);
+            return make_xptr<tdbs::QueryCondition>(
+                new tdbs::QueryCondition(qc));
+        } else {
+            std::vector<double> dv = Rcpp::as<std::vector<double>>(values);
+            auto qc = tdbs::QueryConditionExperimental::create<double>(
+                *ctx.get(), attr_name, dv, op);
+            return make_xptr<tdbs::QueryCondition>(
+                new tdbs::QueryCondition(qc));
+        }
+
+    } else if (TYPEOF(values) == STRSXP) {
+        std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(
+            values);
+        auto qc = tdbs::QueryConditionExperimental::create(
+            *ctx.get(), attr_name, sv, op);
+        return make_xptr<tdbs::QueryCondition>(new tdbs::QueryCondition(qc));
+
+    } else {
+        Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(values));
+    }
+}

--- a/apis/r/src/query_condition.cpp
+++ b/apis/r/src/query_condition.cpp
@@ -130,7 +130,7 @@ void libtiledbsoma_query_condition_from_triple(
         uint64_t cond_val_size = sizeof(float);
         query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 
-    } else if (arrow_type_name == "ascii" || arrow_type_name == "utf8") {
+    } else if (arrow_type_name == "utf8" || arrow_type_name == "large_utf8") {
         std::string v = Rcpp::as<std::string>(condition_value);
         query_cond->init(attr_name, v, op);
 
@@ -139,18 +139,18 @@ void libtiledbsoma_query_condition_from_triple(
         uint64_t cond_val_size = sizeof(bool);
         query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 
-        // XXX FIXME
-        //    } else if (arrow_type_name == "DATETIME_MS") {
-        //        int64_t v = static_cast<int64_t>(
-        //            Rcpp::as<double>(condition_value) * 1000);
-        //        uint64_t cond_val_size = sizeof(int64_t);
-        //        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+    } else if (arrow_type_name == "timestamp") {
+        // Arrow timestamp TileDB DATETIME_MS
+        int64_t v = static_cast<int64_t>(
+            Rcpp::as<double>(condition_value) * 1000);
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 
-        //    } else if (arrow_type_name == "DATETIME_DAY") {
-        //        int64_t v =
-        //        static_cast<int64_t>(Rcpp::as<double>(condition_value));
-        //        uint64_t cond_val_size = sizeof(int64_t);
-        //        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
+    } else if (arrow_type_name == "date32") {
+        // Arrow date32 TileDB DATETIME_DAY
+        int64_t v = static_cast<int64_t>(Rcpp::as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 
     } else {
         Rcpp::stop(

--- a/apis/r/tests/testthat/test-query-condition.R
+++ b/apis/r/tests/testthat/test-query-condition.R
@@ -1,0 +1,206 @@
+test_that("DataFrame Factory", {
+    uri <- tempfile()
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+
+    ctx <- soma_context()
+
+    sch <- arrow::schema(
+      arrow::field("soma_joinid", arrow::int64()),
+      arrow::field("int8",   arrow::int8()),
+      arrow::field("int16",  arrow::int16()),
+      arrow::field("int32",  arrow::int32()),
+      arrow::field("int64",  arrow::int64()),
+      arrow::field("uint8",  arrow::uint8()),
+      arrow::field("uint16", arrow::uint16()),
+      arrow::field("uint32", arrow::uint32()),
+      arrow::field("uint64", arrow::uint64()),
+      arrow::field("string", arrow::string()),
+      arrow::field("large_utf8", arrow::large_utf8()),
+      arrow::field("enum",
+          arrow::dictionary(
+              index_type = arrow::int8(),
+              value_type = arrow::utf8(),
+              ordered = TRUE)),
+      arrow::field("float32", arrow::float32()),
+      arrow::field("float64", arrow::float64())
+      # TODO: for a follow-up PR
+      # arrow::field("timestamp_s", arrow::timestamp(unit="s")),
+      # arrow::field("timestamp_ms", arrow::timestamp(unit="ms")),
+      # arrow::field("timestamp_us", arrow::timestamp(unit="us")),
+      # arrow::field("timestamp_ns", arrow::timestamp(unit="ns"))
+      # Not supported in libtiledbsoma
+      # arrow::field("datetime_day", arrow::date32())
+    )
+
+    sdf <- SOMADataFrameCreate(uri, sch, index_column_names = "soma_joinid")
+    expect_true(sdf$exists())
+    expect_true(dir.exists(uri))
+
+    tbl <- arrow::arrow_table(
+        soma_joinid = 1L:10L,
+        int8   =  -11L:-20L,
+        int16  = -201L:-210L,
+        int32  = -301L:-310L,
+        int64  = -401L:-410L,
+        uint8  =   11L:20L,
+        uint16 =  201L:210L,
+        uint32 =  301L:310L,
+        uint64 =  401L:410L,
+        string = c("apple", "ball", "cat", "dog", "egg", "fig", "goose", "hay", "ice", "jam"),
+        large_utf8 = c("APPLE", "BALL", "CAT", "DOG", "EGG", "FIG", "GOOSE", "HAY", "ICE", "JAM"),
+        enum = factor(
+            c("red", "yellow", "green", "red", "red", "red", "yellow", "green", "red", "green"),
+            levels = c("red", "yellow", "green")),
+        float32 = 1.5:10.5,
+        float64 = 11.5:20.5,
+        # TODO: for a follow-up PR
+        # timestamp_s  = as.POSIXct(as.numeric(3600 + 1:10), tz="GMT"),
+        # timestamp_ms = as.POSIXct(as.numeric(3600*1000 + 1:10), tz="GMT"),
+        # timestamp_us = as.POSIXct(as.numeric(3600*1000*1000 + 1:10), tz="GMT"),
+        # timestamp_ns = as.POSIXct(as.numeric(3600*1000*1000*1000 + 1:10), tz="GMT"),
+        schema = sch)
+    sdf$write(tbl)
+    sdf$close()
+
+    sdf$reopen("READ")
+
+    good_cases <- list(
+      'soma_joinid > 5' = function(df) {
+          expect_equal(df$soma_joinid, 6:10)
+          expect_equal(df$int32, -306:-310)
+      },
+      'soma_joinid == 10' = function(df) {
+          expect_equal(df$soma_joinid, 10)
+          expect_equal(df$int32, -310)
+          expect_equal(as.character(df$enum), c("green"))
+      },
+      'soma_joinid > 4 && soma_joinid < 8' = function(df) {
+          expect_equal(df$soma_joinid, 5:7)
+          expect_equal(df$string, c("egg", "fig", "goose"))
+          expect_equal(df$large_utf8, c("EGG", "FIG", "GOOSE"))
+      },
+      'soma_joinid < 4 || soma_joinid > 8' = function(df) {
+          expect_equal(df$soma_joinid, c(1:3, 9:10))
+      },
+
+      'int8 == 8' = function(df) {
+          expect_equal(length(df$soma_joinid), 0)
+      },
+      'int8 == -12' = function(df) {
+          expect_equal(df$soma_joinid, c(2))
+      },
+      'int16 > -203' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2))
+      },
+      'uint16 < 204' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3))
+      },
+      'int32 > -303' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2))
+      },
+      'uint32 < 304' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3))
+      },
+      'int64 > -403' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2))
+      },
+      'uint64 < 404' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3))
+      },
+
+      'float32 < 4.5' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3))
+      },
+      'float64 < 14.5' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3))
+      },
+
+      'string == "dog"' = function(df) {
+          expect_equal(df$soma_joinid, c(4))
+      },
+      'string %in% c("fig", "dog")' = function(df) {
+          expect_equal(df$soma_joinid, c(4, 6))
+      },
+      'string %nin% c("fig", "dog")' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 3, 5, 7, 8, 9, 10))
+      },
+
+      'enum == "red"' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 4, 5, 6, 9))
+      },
+      'enum != "red"' = function(df) {
+          expect_equal(df$soma_joinid, c(2, 3, 7, 8, 10))
+      },
+      'enum == "orange"' = function(df) {
+          expect_equal(length(df$soma_joinid), 0)
+      },
+      'enum != "orange"' = function(df) {
+          expect_equal(df$soma_joinid, 1:10)
+      },
+      'enum %in% c("red", "green")' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 3, 4, 5, 6, 8, 9, 10))
+      }, 
+      'enum %nin% c("red", "green")' = function(df) {
+          expect_equal(df$soma_joinid, c(2, 7))
+      },
+      'enum %in% c("orange", "green")' = function(df) {
+          expect_equal(df$soma_joinid, c(3, 8, 10))
+      },
+      'enum %nin% c("orange", "green")' = function(df) {
+          expect_equal(df$soma_joinid, c(1, 2, 4, 5, 6, 7, 9))
+      },
+      'enum %in% c("orange", "purple")' = function(df) {
+          expect_equal(length(df$soma_joinid), 0)
+      },
+      'enum %nin% c("orange", "purple")' = function(df) {
+          expect_equal(df$soma_joinid, 1:10)
+      }
+
+      # TODO: for a follow-up PR
+      # 'timestamp_s < "1969-12-31 20:01:04 EST"' = function(df) {
+      #     expect_equal(df$soma_joinid, 1:3)
+      # },
+      # 'timestamp_ms != "1970-02-11 11:00:05 EST"' = function(df) {
+      #     expect_equal(df$soma_joinid, 1:10)
+      # },
+      # 'timestamp_us > "1970-01-01 00:00:01 GMT"' = function(df) {
+      #     expect_equal(df$soma_joinid, 1:10)
+      # },
+      # 'timestamp_ns > "1970-01-01 00:00:01 GMT"' = function(df) {
+      #     expect_equal(df$soma_joinid, 1:10)
+      # }
+    )
+
+    for (query_string in names(good_cases)) {
+        parsed <- do.call(
+            what = tiledbsoma:::parse_query_condition_new,
+            args = list(expr=str2lang(query_string), schema=sch, somactx=ctx))
+        clib_value_filter <- parsed@ptr
+
+        sr <- sr_setup(uri = sdf$uri, ctx, qc=clib_value_filter)
+        iter <- TableReadIter$new(sr)
+        tbl <- iter$read_next()
+        expect_true(iter$read_complete())
+        df <- as.data.frame(tbl)
+        # Call the validator
+        good_cases[[query_string]](df)
+    }
+
+    bad_cases <- list(
+      '',
+      ' ',
+      'nonesuch < 10',
+      'soma_joinid << 10',
+      'soma_joinid',
+      'soma_joinid < 4 or soma_joinid > 8'
+    )
+
+    for (query_string in names(bad_cases)) {
+        expect_error(
+            do.call(
+                what = tiledbsoma:::parse_query_condition_new,
+                args = list(expr=str2lang(query_string), schema=sch, somactx=ctx)))
+    }
+
+    sdf$close()
+})

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -119,12 +119,17 @@ create_arrow_schema_and_index_columns(
 // Create index-column info only, no schema involving the attrs
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
     for (auto info : dim_infos) {
+        LOG_DEBUG(fmt::format("create_column_index_info name={}", info.name));
+
         LOG_DEBUG(fmt::format(
-            "create_column_index_info name={} type={} dim_max={} ucd={}",
-            info.name,
-            tiledb::impl::to_str(info.tiledb_datatype),
-            info.dim_max,
-            info.use_current_domain));
+            "create_column_index_info type={}",
+            tiledb::impl::to_str(info.tiledb_datatype)));
+
+        LOG_DEBUG(
+            fmt::format("create_column_index_info dim_max={}", info.dim_max));
+
+        LOG_DEBUG(fmt::format(
+            "create_column_index_info ucd={}", info.use_current_domain));
     }
 
     auto index_cols_info_schema = _create_index_cols_info_schema(dim_infos);

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -119,17 +119,12 @@ create_arrow_schema_and_index_columns(
 // Create index-column info only, no schema involving the attrs
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
     for (auto info : dim_infos) {
-        LOG_DEBUG(fmt::format("create_column_index_info name={}", info.name));
-
         LOG_DEBUG(fmt::format(
-            "create_column_index_info type={}",
-            tiledb::impl::to_str(info.tiledb_datatype)));
-
-        LOG_DEBUG(
-            fmt::format("create_column_index_info dim_max={}", info.dim_max));
-
-        LOG_DEBUG(fmt::format(
-            "create_column_index_info ucd={}", info.use_current_domain));
+            "create_column_index_info name={} type={} dim_max={} ucd={}",
+            info.name,
+            tiledb::impl::to_str(info.tiledb_datatype),
+            info.dim_max,
+            info.use_current_domain));
     }
 
     auto index_cols_info_schema = _create_index_cols_info_schema(dim_infos);


### PR DESCRIPTION
**Issue and/or context:** #3051 [[sc-55672]](https://app.shortcut.com/tiledb-inc/story/55672/r-port-the-query-condition-logic-from-tiledb-r-to-tiledb-soma-r)

**Changes:**

Here I am only introducing a non-exported function `parse_query_condition_new`, and unit-testing it thoroughly. Replacing the exiting `parse_query_condition` with this will be a follow-on PR.

**Notes for Reviewer:**

Timestamp handling will be deferred to a follow-up PR: #3163.