### PR TITLE
[r] Fix context-propagation issue

### DIFF
--- a/apis/r/R/TileDBArray.R
+++ b/apis/r/R/TileDBArray.R
@@ -116,7 +116,7 @@ TileDBArray <- R6::R6Class(
             valuesxp = val,
             type = class(val),
             is_array = TRUE,
-            ctxxp = soma_context(),
+            ctxxp = private$.soma_context,
             tsvec = self$.tiledb_timestamp_range
           )
       }

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -45,7 +45,13 @@ TileDBObject <- R6::R6Class(
       #   "'soma_context' must be a pointer" = inherits(x = soma_context, what = 'externalptr')
       # )
       if (is.null(soma_context)) {
-          private$.soma_context <- soma_context()  # FIXME via factory and paramater_config
+        # More to work out on
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2406
+        if (is.null(tiledbsoma_ctx)) {
+            private$.soma_context <- soma_context()
+          } else {
+            private$.soma_context <- soma_context(unlist(tiledbsoma_ctx$items()))
+          }
       } else {
           private$.soma_context <- soma_context
       }

--- a/apis/r/R/TileDBObject.R
+++ b/apis/r/R/TileDBObject.R
@@ -50,7 +50,8 @@ TileDBObject <- R6::R6Class(
         if (is.null(tiledbsoma_ctx)) {
             private$.soma_context <- soma_context()
           } else {
-            private$.soma_context <- soma_context(unlist(tiledbsoma_ctx$items()))
+            #private$.soma_context <- soma_context(unlist(tiledbsoma_ctx$items()))
+            private$.soma_context <- createSOMAContext(unlist(tiledbsoma_ctx$items()))
           }
       } else {
           private$.soma_context <- soma_context


### PR DESCRIPTION
**Issue and/or context:** https://github.com/chanzuckerberg/cellxgene-census/issues/1261

**Changes:**

Wire the config correctly

**Notes for Reviewer:**

Repro script:

```
#!/usr/bin/env Rscript

ctx <- tiledbsoma::SOMATileDBContext$new()
ctx[["vfs.s3.region"]] <- "us-west-2"
ctx[["vfs.s3.no_sign_request"]] <- "true"

uri <- 's3://cellxgene-census-public-us-west-2/cell-census/2023-12-15/soma/census_data/homo_sapiens/obs'
sdf <- tiledbsoma::SOMADataFrameOpen(uri, tiledbsoma_ctx=ctx)
print(sdf$schema())
```

