### PR TITLE
[python/c++] Use `config_options_from_schema` in pytest unit tests

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -63,21 +63,32 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         Arrow Schema, in the form of a PlatformConfig.
 
         Available attributes are:
-            * dataframe_dim_zstd_level
-            * sparse_nd_array_dim_zstd_level
-            * sparse_nd_array_dim_zstd_level
-            * write_X_chunked
-            * goal_chunk_nnz
-            * remote_cap_nbytes
-            * capacity
-            * offsets_filters
-            * validity_filters
-            * attrs
-            * dims
-            * allows_duplicates
-            * tile_order
-            * cell_order
-            * consolidate_and_vacuum
+            * dataframe_dim_zstd_level: int
+            * sparse_nd_array_dim_zstd_level: int
+            * sparse_nd_array_dim_zstd_level: int
+            * write_X_chunked: bool
+            * goal_chunk_nnz: int
+            * remote_cap_nbytes: int
+            * capacity: int
+            * offsets_filters: str
+                * name (of filter): str
+                * compression_level: str
+            * validity_filters: str
+            * attrs: str
+                * name (of attribute): str
+                    * filters: str
+                        * name (of filter): str
+                        * compression_level: str
+            * dims: str
+                * name (of dimension): str
+                    * filters: str
+                        * name (of filter): str
+                        * compression_level: str
+                    * tile: int
+            * allows_duplicates: bool
+            * tile_order: str
+            * cell_order: str
+            * consolidate_and_vacuum: bool
         """
         return self._handle.config_options_from_schema()
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -58,6 +58,29 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.schema
 
+    def config_options_from_schema(self) -> clib.PlatformConfig:
+        """Returns metadata about the array that is not encompassed within the
+        Arrow Schema, in the form of a PlatformConfig.
+
+        Available attributes are:
+            * dataframe_dim_zstd_level
+            * sparse_nd_array_dim_zstd_level
+            * sparse_nd_array_dim_zstd_level
+            * write_X_chunked
+            * goal_chunk_nnz
+            * remote_cap_nbytes
+            * capacity
+            * offsets_filters
+            * validity_filters
+            * attrs
+            * dims
+            * allows_duplicates
+            * tile_order
+            * cell_order
+            * consolidate_and_vacuum
+        """
+        return self._handle.config_options_from_schema()
+
     def non_empty_domain(self) -> Tuple[Tuple[Any, Any], ...]:
         """
         Retrieves the non-empty domain for each dimension, namely the smallest

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -376,6 +376,9 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def schema(self) -> pa.Schema:
         return self._handle.schema
 
+    def config_options_from_schema(self) -> clib.PlatformConfig:
+        return self._handle.config_options_from_schema()
+
     @property
     def meta(self) -> "MetadataWrapper":
         return self.metadata

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import json
 import pathlib
 from typing import Tuple
 
@@ -48,10 +49,6 @@ def test_dense_nd_array_create_ok(
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
     assert not a.schema.field("soma_data").nullable
-
-    # Validate TileDB array schema
-    with tiledb.open(tmp_path.as_posix()) as A:
-        assert not A.schema.sparse
 
     # Ensure read mode uses clib object
     with soma.DenseNDArray.open(tmp_path.as_posix(), "r") as A:
@@ -150,12 +147,9 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
         table = a.read_next()["soma_data"]
         assert np.array_equal(data, table.combine_chunks().to_numpy().reshape(shape))
 
-    # Validate TileDB array schema
-    with tiledb.open(tmp_path.as_posix()) as A:
-        assert not A.schema.sparse
-
     # write a single-value sub-array and recheck
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as c:
+        assert not c.is_sparse
         c.write(
             (0,) * len(shape),
             pa.Tensor.from_numpy(np.zeros((1,) * len(shape), dtype=np.float64)),
@@ -415,9 +409,10 @@ def test_tile_extents(tmp_path):
         },
     ).close()
 
-    with tiledb.open(tmp_path.as_posix()) as A:
-        assert A.schema.domain.dim(0).tile == 100
-        assert A.schema.domain.dim(1).tile == 2048
+    with soma.DenseNDArray.open(tmp_path.as_posix()) as A:
+        dim_info = json.loads(A.config_options_from_schema().dims)
+        assert int(dim_info["soma_dim_0"]["tile"]) == 100
+        assert int(dim_info["soma_dim_1"]["tile"]) == 2048
 
 
 def test_timestamped_ops(tmp_path):

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -201,29 +201,32 @@ PlatformConfig ArrowAdapter::platform_config_from_tiledb_schema(
     platform_config.attrs = ArrowAdapter::_get_attrs_filter_list_json(
                                 tiledb_schema)
                                 .dump();
-    platform_config
-        .dims = ArrowAdapter::_get_dims_filter_list_json(tiledb_schema).dump();
+    platform_config.dims = ArrowAdapter::_get_dims_list_json(tiledb_schema)
+                               .dump();
 
     return platform_config;
 }
 
-json ArrowAdapter::_get_attrs_filter_list_json(ArraySchema tiledb_schema) {
+json ArrowAdapter::_get_attrs_filter_list_json(
+    const ArraySchema& tiledb_schema) {
     json attrs_filter_list_as_json;
-    for (auto attr : tiledb_schema.attributes()) {
-        attrs_filter_list_as_json.emplace(
-            attr.first,
-            ArrowAdapter::_get_filter_list_json(attr.second.filter_list()));
+    for (const auto& attr : tiledb_schema.attributes()) {
+        json attr_info = {
+            {"filters", _get_filter_list_json(attr.second.filter_list())}};
+        attrs_filter_list_as_json.emplace(attr.first, attr_info);
     }
     return attrs_filter_list_as_json;
 }
 
-json ArrowAdapter::_get_dims_filter_list_json(ArraySchema tiledb_schema) {
-    json dims_filter_list_as_json;
-    for (auto dim : tiledb_schema.domain().dimensions()) {
-        dims_filter_list_as_json.emplace(
-            dim.name(), ArrowAdapter::_get_filter_list_json(dim.filter_list()));
+json ArrowAdapter::_get_dims_list_json(const ArraySchema& tiledb_schema) {
+    json dims_as_json;
+    for (const auto& dim : tiledb_schema.domain().dimensions()) {
+        json dim_info = {
+            {"tile", dim.tile_extent_to_str()},
+            {"filters", _get_filter_list_json(dim.filter_list())}};
+        dims_as_json.emplace(dim.name(), dim_info);
     }
-    return dims_filter_list_as_json;
+    return dims_as_json;
 }
 
 json ArrowAdapter::_get_filter_list_json(FilterList filter_list) {

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -720,9 +720,9 @@ class ArrowAdapter {
 
     static tiledb_layout_t _get_order(std::string order);
 
-    static json _get_attrs_filter_list_json(ArraySchema tiledb_schema);
+    static json _get_attrs_filter_list_json(const ArraySchema& tiledb_schema);
 
-    static json _get_dims_filter_list_json(ArraySchema tiledb_schema);
+    static json _get_dims_list_json(const ArraySchema& tiledb_schema);
 
     static json _get_filter_list_json(FilterList filter_list);
 

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -382,12 +382,12 @@ TEST_CASE_METHOD(
                 Filter::to_str(filter.second));
             if (filter.second != TILEDB_FILTER_WEBP) {
                 REQUIRE(
-                    json::parse(config_options.attrs)["a0"][0].at("name") ==
-                    Filter::to_str(filter.second));
+                    json::parse(config_options.attrs)["a0"]["filters"][0].at(
+                        "name") == Filter::to_str(filter.second));
             }
             REQUIRE(
-                json::parse(config_options.dims)["soma_joinid"][0].at("name") ==
-                Filter::to_str(TILEDB_FILTER_ZSTD));
+                json::parse(config_options.dims)["soma_joinid"]["filters"][0]
+                    .at("name") == Filter::to_str(TILEDB_FILTER_ZSTD));
 
             sdf->close();
         }


### PR DESCRIPTION
**Issue and/or context:**

This is the first of multiple changes pulled out from from https://github.com/single-cell-data/TileDB-SOMA/pull/2883 to remove tiledb-py from unit tests

**Changes:**

- Addition of `config_options_from_schema` binding to retrieve `ArraySchema` info not encapsulated by the `ArrowSchema`
- Corrected JSON `dims` and `attrs` by returning `tile` for `dims` and using `filters` keys for `FilterList` values
- Replace `tiledb.FilterList` with `PlatformConfig`'s JSON formatted strings
