### PR TITLE
[python/c++] Add `SOMAGroup::is_relative` and use in pytest unit tests

### DIFF
--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -76,6 +76,7 @@ void load_soma_group(py::module& m) {
             [](SOMAGroup& group) -> bool { return not group.is_open(); })
         .def_property_readonly("uri", &SOMAGroup::uri)
         .def("context", &SOMAGroup::ctx)
+        .def("is_relative", &SOMAGroup::is_relative)
         .def("has", &SOMAGroup::has)
         .def(
             "add",

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -353,37 +353,30 @@ def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri):
     if use_relative_uri is None:
         expected_relative = True  # since local disk
 
-    exp = tiledbsoma.open(output_path)
-    with tiledb.Group(exp.uri) as G:
-        assert G.is_relative("obs") == expected_relative
-        assert G.is_relative("ms") == expected_relative
+    with tiledbsoma.Experiment.open(output_path) as G:
+        assert G._handle._handle.is_relative("obs") == expected_relative
+        assert G._handle._handle.is_relative("ms") == expected_relative
 
-    with tiledb.Group(exp.ms.uri) as G:
-        assert G.is_relative("RNA") == expected_relative
-    with tiledb.Group(exp.ms["RNA"].uri) as G:
-        assert G.is_relative("var") == expected_relative
-        assert G.is_relative("X") == expected_relative
-    with tiledb.Group(exp.ms["RNA"].X.uri) as G:
-        assert G.is_relative("data") == expected_relative
+        assert G.ms._handle._handle.is_relative("RNA") == expected_relative
+        assert G.ms["RNA"]._handle._handle.is_relative("var") == expected_relative
+        assert G.ms["RNA"]._handle._handle.is_relative("X") == expected_relative
+        assert G.ms["RNA"].X._handle._handle.is_relative("data") == expected_relative
 
-    for collection_name in [
-        "obsm",
-        "obsp",
-        "varm",
-    ]:  # conftest_h5ad_file_extended has no varp
-        with tiledb.Group(exp.ms["RNA"][collection_name].uri) as G:
-            for member in G:
-                assert G.is_relative(member.name) == expected_relative
+        for collection_name in [
+            "obsm",
+            "obsp",
+            "varm",
+        ]:  # conftest_h5ad_file_extended has no varp
+            for member in G.ms["RNA"][collection_name]:
+                assert (
+                    G.ms["RNA"][collection_name]._handle._handle.is_relative(member)
+                    == expected_relative
+                )
 
-    with tiledb.Group(exp.ms.uri) as G:
-        assert G.is_relative("raw") == expected_relative
-    with tiledb.Group(exp.ms["raw"].uri) as G:
-        assert G.is_relative("var") == expected_relative
-        assert G.is_relative("X") == expected_relative
-    with tiledb.Group(exp.ms["raw"].X.uri) as G:
-        assert G.is_relative("data") == expected_relative
-
-    exp.close()
+        assert G.ms._handle._handle.is_relative("raw") == expected_relative
+        assert G.ms["raw"]._handle._handle.is_relative("var") == expected_relative
+        assert G.ms["raw"]._handle._handle.is_relative("X") == expected_relative
+        assert G.ms["raw"].X._handle._handle.is_relative("data") == expected_relative
 
 
 @pytest.mark.parametrize("ingest_uns_keys", [["louvain_colors"], None])

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -172,6 +172,15 @@ class SOMAGroup : public SOMAObject {
     std::shared_ptr<SOMAContext> ctx();
 
     /**
+     * Check if a named member is relative
+     *
+     * @param name of member to retrieve associated relative indicator.
+     */
+    bool is_relative(std::string name) const {
+        return group_->is_relative(name);
+    }
+
+    /**
      * Get a member from the SOMAGroup given the index.
      *
      * @param index of member


### PR DESCRIPTION
**Issue and/or context:**

This is the second of multiple changes pulled out from from https://github.com/single-cell-data/TileDB-SOMA/pull/2883 to remove tiledb-py from unit tests

**Changes:**

- Add `SOMAGroup::is_relative` in C++ and associated binding in Pybind11
- Replace tiledb-py `is_relative` test with new binding