### PR TITLE
[python] Use `pathlib.Path.iterdir` to count fragments

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1,5 +1,4 @@
 import json
-import pathlib
 import tempfile
 from copy import deepcopy
 from pathlib import Path
@@ -265,7 +264,8 @@ def test_named_X_layers(conftest_pbmc_small_h5ad_path, X_layer_name):
 
 
 def _get_fragment_count(array_uri):
-    return len(tiledb.fragment.FragmentInfoList(array_uri=array_uri))
+    fragment_uri = Path(array_uri) / "__fragments"
+    return len(list(fragment_uri.iterdir())) if fragment_uri.exists() else 0
 
 
 @pytest.mark.parametrize(
@@ -381,7 +381,7 @@ def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri):
 
 @pytest.mark.parametrize("ingest_uns_keys", [["louvain_colors"], None])
 def test_ingest_uns(
-    tmp_path: pathlib.Path,
+    tmp_path: Path,
     conftest_pbmc3k_h5ad_path,
     conftest_pbmc3k_adata,
     ingest_uns_keys,

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
 import json
-import os
+from pathlib import Path
 from typing import Dict, List
 
 import numpy as np
@@ -1726,10 +1726,9 @@ def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
 
     # total 3 fragment files
 
-    vfs = tiledb.VFS()
     # subtract 1 for the __schema/__enumerations directory;
     # only looking at fragment files
-    assert len(vfs.ls(os.path.join(uri, "__schema"))) - 1 == 3
+    assert len(list((Path(uri) / "__schema").iterdir())) - 1 == 3
 
 
 def test_fix_update_dataframe_with_var_strings(tmp_path):


### PR DESCRIPTION
**Issue and/or context:**

This is the fourth of multiple changes pulled out from from https://github.com/single-cell-data/TileDB-SOMA/pull/2883 to remove tiledb-py from unit tests

**Changes:**

Replace `tiledb.VFS` and `tiledb.FragmentInfoList` with `pathlib.Path.iterdir` to count fragments without relying on tiledb-py