### PR TITLE
[python] Correct `consolidate_and_vacuum` default `modes`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -946,7 +946,11 @@ void load_soma_array(py::module& m) {
 
         .def_property_readonly("dimension_names", &SOMAArray::dimension_names)
 
-        .def("consolidate_and_vacuum", &SOMAArray::consolidate_and_vacuum)
+        .def(
+            "consolidate_and_vacuum",
+            &SOMAArray::consolidate_and_vacuum,
+            py::arg(
+                "modes") = std::vector<std::string>{"fragment_meta", "commits"})
 
         .def_property_readonly(
             "meta",

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1132,20 +1132,18 @@ def test_timestamped_ops(tmp_path, allows_duplicates, consolidate):
             "float": [200.2, 300.3],
             "string": ["ball", "cat"],
         }
-        sidf.write(pa.Table.from_pydict(data))
-        assert sidf.tiledb_timestamp_ms == 1615403005000
-        assert sidf.tiledb_timestamp.isoformat() == "2021-03-10T19:03:25+00:00"
 
-    # Without consolidate:
-    # * There are two fragments:
-    #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (10, 10)
-    #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (20, 20)
-    # With consolidate:
-    # * There is one fragment:
-    #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (10, 20)
-    if consolidate:
-        tiledb.consolidate(uri)
-        tiledb.vacuum(uri)
+        # Without consolidate:
+        # * There are two fragments:
+        #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (10, 10)
+        #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (20, 20)
+        # With consolidate:
+        # * There is one fragment:
+        #   o One with tiledb.fragment.FragmentInfoList[i].timestamp_range = (10, 20)
+        sidf.write(
+            pa.Table.from_pydict(data),
+            soma.TileDBWriteOptions(consolidate_and_vacuum=consolidate),
+        )
 
     # read without timestamp (i.e., after final write) & see final image
     with soma.DataFrame.open(uri) as sidf:


### PR DESCRIPTION
**Issue and/or context:**

This is pulled out from https://github.com/single-cell-data/TileDB-SOMA/pull/2883 to remove tiledb-py from unit tests

**Changes:**

While replacing the tiledb-py `tiledb.consolidate` and `tiledb.vacuum` commands in `test_dataframe.py::test_timestamped_ops` to use the already existing tiledbsoma-py `TileDBWriteOptions.consolidate_and_vacuum`, it was found that the binding for `SOMAArray::consolidate_and_vacuum` was not properly configured to use the default value `{"fragment_meta", "commits"}`.
