### PR TITLE
[python] Adds Visium ingestion option to set image channel order

### DIFF
--- a/apis/python/notebooks/tutorial_spatial.ipynb
+++ b/apis/python/notebooks/tutorial_spatial.ipynb
@@ -185,7 +185,7 @@
      "output_type": "stream",
      "text": [
       "Ingesting data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/10x to data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma\n",
-      "/tmp/ipykernel_70620/2080821725.py:3: UserWarning: Support for spatial types is experimental. Changes to both the API and data storage may not be backwards compatible.\n",
+      "/tmp/ipykernel_13980/2080821725.py:3: UserWarning: Support for spatial types is experimental. Changes to both the API and data storage may not be backwards compatible.\n",
       "  from_visium(\n"
      ]
     }
@@ -432,7 +432,7 @@
     {
      "data": {
       "text/plain": [
-       "CoordinateSpace(axes=(Axis(name='x', unit=None), Axis(name='y', unit=None)))"
+       "CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels')))"
       ]
      },
      "execution_count": 14,
@@ -490,7 +490,7 @@
     {
      "data": {
       "text/plain": [
-       "ImageProperties(name='reference_level', image_type='YXC', shape=(2000, 1744, 3), width=1744, height=2000, depth=None, nchannels=3)"
+       "ImageProperties(name='reference_level', image_type='CYX', shape=(3, 2000, 1744), width=1744, height=2000, depth=None, nchannels=3)"
       ]
      },
      "execution_count": 16,
@@ -520,8 +520,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Level 0: ImageProperties(name='hires', image_type='YXC', shape=(2000, 1744, 3), width=1744, height=2000, depth=None, nchannels=3)\n",
-      "Level 1: ImageProperties(name='lowres', image_type='YXC', shape=(600, 523, 3), width=523, height=600, depth=None, nchannels=3)\n"
+      "Level 0: ImageProperties(name='hires', image_type='CYX', shape=(3, 2000, 1744), width=1744, height=2000, depth=None, nchannels=3)\n",
+      "Level 1: ImageProperties(name='lowres', image_type='CYX', shape=(3, 600, 523), width=523, height=600, depth=None, nchannels=3)\n"
      ]
     }
    ],
@@ -579,7 +579,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f043c3c64d0>"
+       "<matplotlib.image.AxesImage at 0x7f78c55a4d90>"
       ]
      },
      "execution_count": 20,
@@ -598,6 +598,7 @@
     }
    ],
    "source": [
+    "im = np.moveaxis(im, 0, -1).astype(np.uint8)  # Move channel axis to final axis for viewing.\n",
     "plt.imshow(im)"
    ]
   },
@@ -1053,7 +1054,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.ScaleTransform at 0x7f04178c5d90>"
+       "<somacore.coordinates.ScaleTransform at 0x7f78c4ed9d50>"
       ]
      },
      "execution_count": 28,
@@ -1074,7 +1075,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.ScaleTransform at 0x7f04178ead10>"
+       "<somacore.coordinates.ScaleTransform at 0x7f78c4ef6cd0>"
       ]
      },
      "execution_count": 29,
@@ -1095,7 +1096,7 @@
     {
      "data": {
       "text/plain": [
-       "<somacore.coordinates.IdentityTransform at 0x7f043c678cd0>"
+       "<somacore.coordinates.IdentityTransform at 0x7f78c54c3650>"
       ]
      },
      "execution_count": 30,
@@ -1143,8 +1144,8 @@
       "text/plain": [
        "SpatialRead(data=<pyarrow.Tensor>\n",
        "type: uint8\n",
-       "shape: (753, 853, 3)\n",
-       "strides: (2559, 3, 1), data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit=None), Axis(name='y', unit=None))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit=None), Axis(name='y', unit=None))), coordinate_transform=<somacore.coordinates.AffineTransform object at 0x7f04178f3610>)"
+       "shape: (3, 753, 853)\n",
+       "strides: (642309, 853, 1), data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit=None), Axis(name='y', unit=None))), coordinate_transform=<somacore.coordinates.AffineTransform object at 0x7f78c4f07ad0>)"
       ]
      },
      "execution_count": 32,
@@ -1197,7 +1198,7 @@
     {
      "data": {
       "text/plain": [
-       "SpatialRead(data=<tiledbsoma._read_iters.TableReadIter object at 0x7f043c603350>, data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), coordinate_transform=<somacore.coordinates.IdentityTransform object at 0x7f04178f04d0>)"
+       "SpatialRead(data=<tiledbsoma._read_iters.TableReadIter object at 0x7f78ac192350>, data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), coordinate_transform=<somacore.coordinates.IdentityTransform object at 0x7f78c5516750>)"
       ]
      },
      "execution_count": 34,
@@ -1478,7 +1479,7 @@
    ],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.imshow(hires_read.data)\n",
+    "ax.imshow(np.moveaxis(hires_read.data, 0, -1).astype(np.uint8))\n",
     "ax.add_collection(spot_patches)\n",
     "\n",
     "plt.show()"


### PR DESCRIPTION
Add an input parameter to the experimental `from_visium` ingestor that specifies if images should be ingested with the channel first or last.
