### PR TITLE
[python] Fix `pytest` instructions for first-time users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,7 @@ ctest_update:
 
 .PHONY: data
 data:
-	rm -rvf test/soco
-	./apis/python/devtools/ingestor \
-		--soco \
-		-o test/soco \
-		-n \
-		data/pbmc3k_processed.h5ad \
-		data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
+	cd test && rm -rf soco && tar zxf soco.tgz && cd ..
 
 # format
 # -------------------------------------------------------------------

--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -52,6 +52,7 @@ If this comes up empty for your system, you'll definitely need to build from sou
   ```
 * In either case:
   ```shell
+  make data
   python -m pytest tests
   ```
 

--- a/apis/python/tests/test_aaa_setup.py
+++ b/apis/python/tests/test_aaa_setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import os
+
+TEST_DIR = os.path.dirname(__file__)
+SOMA_URI = f"{TEST_DIR}/../../../test/soco/pbmc3k_processed"
+
+if not os.path.exists(SOMA_URI):
+    raise RuntimeError("Please run `make data` in the repo base directory")


### PR DESCRIPTION
**Issue and/or context:** Found by @kounelisagis . Issue is `test/soco` isn't created by default. It should be.

**Changes:**

* Update the instructions to show the need for `make data`
* On `make data`, extract from the existing tar file rather than re-running the ingestor. ([Our CI already does this](https://github.com/single-cell-data/TileDB-SOMA/blob/1.15.0rc2/.github/workflows/python-ci-single.yml#L119-L125).)
* Surface a better error message in case the user hasn't run `make data`

**Notes for Reviewer:**

This doesn't happen to those of us doing python+soma dev regularly as we have this test data already extracted. And it doesn't happen in CI since CI auto-extracts. This is only a bad-UX issue for first-time/infrequent developers.