### PR TITLE
[ci/python] Use `ubuntu-latest` CI runners

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -21,13 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: decide on Windows CI coverage
-        os: [ubuntu-22.04, macos-latest]
-        # os: [ubuntu-22.04, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest]
+        # os: [ubuntu-latest, macos-latest, windows-2019]
         # TODO: add 3.12
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
         python-version: ['3.9', '3.10', '3.11']
         include:
-          - runs-on: ubuntu-22.04
+          - runs-on: ubuntu-latest
             cc: gcc-11
             cxx: g++-11
           - runs-on: macos-latest
@@ -39,6 +39,6 @@ jobs:
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
-      report_codecov: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.11' }}
-      run_lint: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.11' }}
+      report_codecov: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
+      run_lint: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
     secrets: inherit

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: true
 
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.11']
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             cc: gcc-11
             cxx: g++-11
           - os: macos-latest

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -50,7 +50,7 @@ jobs:
           - TILEDB_EXISTS: "no"
             TILEDBSOMA_EXISTS: "yes"
     container:
-      image: ubuntu:22.04
+      image: ubuntu:latest
     defaults:
       run:
         shell: bash
@@ -259,7 +259,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -362,7 +362,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -70,7 +70,7 @@ jobs:
       run: echo "inputs.os:" ${{ inputs.os }}
 
     - name: Linux CPU info
-      if: ${{ inputs.os == 'ubuntu-22.04' }}
+      if: ${{ inputs.os == 'ubuntu-latest' }}
       run: cat /proc/cpuinfo
 
     - name: MacOS CPU info

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   sdist:
     name: Build source distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
           - cibw_build: manylinux_x86_64
-            os: ubuntu-20.04
+            os: ubuntu-latest
             wheel-name: manylinux2014
           - cibw_build: macosx_x86_64
             os: macos-latest
@@ -125,7 +125,7 @@ jobs:
           - macos-arm64
         include:
           - wheel-name: manylinux2014
-            os: ubuntu-20.04
+            os: ubuntu-latest
             arch: x86_64
             cc: gcc-11
             cxx: g++-11
@@ -164,7 +164,7 @@ jobs:
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           docker run -v $(pwd):/mnt python:${{ matrix.python.dotted-version }} bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
@@ -176,7 +176,7 @@ jobs:
   publish-to-test-pypi:
     name: Publish package to TestPyPI
     needs: smoke-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Download artifacts
@@ -200,7 +200,7 @@ jobs:
   publish-to-pypi:
     name: Publish package to PyPI
     needs: smoke-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
       - name: Download artifacts


### PR DESCRIPTION
**Issue and/or context:** #3185; follow-up from https://github.com/single-cell-data/TileDB-SOMA/pull/3182#discussion_r1803863705

**Changes:**

**Notes for Reviewer:**

Manual run for sdist+wheels CI (normally runs nightly and on tagged releases):
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11375025992