### PR TITLE
[python] Min-sizing for dataframes/arrays [no merge]

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -248,7 +248,11 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         domain = None
 
         if soma_domain is None:
-            soma_domain = tuple(None for _ in index_column_names)
+            # XXX COMMENT
+            if NEW_SHAPE_FEATURE_FLAG_ENABLED:
+                soma_domain = tuple((0,0) for _ in index_column_names)
+            else:
+                soma_domain = tuple(None for _ in index_column_names)
         else:
             ndom = len(soma_domain)
             nidx = len(index_column_names)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -874,7 +874,7 @@ def _fill_out_slot_soma_domain(
         # will (and must) ignore these when creating the TileDB schema.
         slot_domain = "", ""
     elif np.issubdtype(dtype, NPInteger):
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             # Core max domain is immutable. If unspecified, it should be as big
             # as possible since it can never be resized.
             iinfo = np.iinfo(cast(NPInteger, dtype))
@@ -892,7 +892,7 @@ def _fill_out_slot_soma_domain(
             # does mean that "smallest" current domain has shape 1 not 0.
             slot_domain = 0, 0
     elif np.issubdtype(dtype, NPFloating):
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             finfo = np.finfo(cast(NPFloating, dtype))
             slot_domain = finfo.min, finfo.max
             saturated_range = True
@@ -909,7 +909,7 @@ def _fill_out_slot_soma_domain(
     #   expanded to multiple of tile extent exceeds max value representable by domain type. Reduce
     #   domain max by 1 tile extent to allow for expansion.
     elif dtype == "datetime64[s]":
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             iinfo = np.iinfo(cast(NPInteger, np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "s"), np.datetime64(
                 iinfo.max - 1000000, "s"
@@ -917,7 +917,7 @@ def _fill_out_slot_soma_domain(
         else:
             slot_domain = np.datetime64(0, "s"), np.datetime64(0, "s")
     elif dtype == "datetime64[ms]":
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             iinfo = np.iinfo(cast(NPInteger, np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "ms"), np.datetime64(
                 iinfo.max - 1000000, "ms"
@@ -925,7 +925,7 @@ def _fill_out_slot_soma_domain(
         else:
             slot_domain = np.datetime64(0, "ms"), np.datetime64(0, "ms")
     elif dtype == "datetime64[us]":
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             iinfo = np.iinfo(cast(NPInteger, np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "us"), np.datetime64(
                 iinfo.max - 1000000, "us"
@@ -933,7 +933,7 @@ def _fill_out_slot_soma_domain(
         else:
             slot_domain = np.datetime64(0, "us"), np.datetime64(0, "us")
     elif dtype == "datetime64[ns]":
-        if is_max_domain:
+        if is_max_domain or not NEW_SHAPE_FEATURE_FLAG_ENABLED:
             iinfo = np.iinfo(cast(NPInteger, np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "ns"), np.datetime64(
                 iinfo.max - 1000000, "ns"

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -250,7 +250,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if soma_domain is None:
             # XXX COMMENT
             if NEW_SHAPE_FEATURE_FLAG_ENABLED:
-                soma_domain = tuple((0,0) for _ in index_column_names)
+                soma_domain = tuple((0, 0) for _ in index_column_names)
             else:
                 soma_domain = tuple(None for _ in index_column_names)
         else:

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -250,6 +250,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if soma_domain is None:
             # XXX COMMENT
             if NEW_SHAPE_FEATURE_FLAG_ENABLED:
+                # XXX NOT CORRECT FOR VARIOUS TYPES
                 soma_domain = tuple((0, 0) for _ in index_column_names)
             else:
                 soma_domain = tuple(None for _ in index_column_names)

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -122,7 +122,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 if dim_shape == 0:
                     raise ValueError("DenseNDArray shape slots must be at least 1")
                 if dim_shape is None:
-                    dim_shape = dim_capacity
+                    # XXX COMMENT dim_shape = dim_capacity
+                    dim_shape = 1
 
                 index_column_data[pa_field.name] = [
                     0,

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -183,10 +183,10 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
             )
 
             (slot_core_current_domain, saturated_cd) = _fill_out_slot_soma_domain(
-                slot_soma_domain, index_column_name, pa_field.type, dtype
+                slot_soma_domain, False, index_column_name, pa_field.type, dtype
             )
             (slot_core_max_domain, saturated_md) = _fill_out_slot_soma_domain(
-                None, index_column_name, pa_field.type, dtype
+                None, True, index_column_name, pa_field.type, dtype
             )
 
             extent = _find_extent_for_domain(

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -176,7 +176,8 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 if dim_shape == 0:
                     raise ValueError("SparseNDArray shape slots must be at least 1")
                 if dim_shape is None:
-                    dim_shape = dim_capacity
+                    # XXX dim_shape = dim_capacity
+                    dim_shape = 1
 
                 index_column_data[pa_field.name] = [
                     0,

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -80,6 +80,12 @@ class AxisAmbientLabelMapping:
             next_soma_joinid += 1
         return cls(data=data, field_name=index_field_name)
 
+    def get_shape(self) -> int:
+        if len(self.data.values()) == 0:
+            return 0
+        else:
+            return 1 + max(self.data.values())
+
     def to_json(self) -> str:
         return json.dumps(self, default=attrs.asdict, sort_keys=True, indent=4)
 
@@ -490,9 +496,7 @@ class ExperimentAmbientLabelMapping:
         """Reports the new obs shape which the experiment will need to be
         resized to in order to accommodate the data contained within the
         registration."""
-        if len(self.obs_axis.data.values()) == 0:
-            return 0
-        return 1 + max(self.obs_axis.data.values())
+        return self.obs_axis.get_shape()
 
     def get_var_shapes(self) -> Dict[str, int]:
         """Reports the new var shapes, one per measurement, which the experiment
@@ -500,10 +504,7 @@ class ExperimentAmbientLabelMapping:
         within the registration."""
         retval: Dict[str, int] = {}
         for key, axis in self.var_axes.items():
-            if len(axis.data.values()) == 0:
-                retval[key] = 0
-            else:
-                retval[key] = 1 + max(axis.data.values())
+            retval[key] = axis.get_shape()
         return retval
 
     def to_json(self) -> str:

--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -28,6 +28,12 @@ class AxisIDMapping:
                 return False
         return True
 
+    def get_shape(self) -> int:
+        if len(self.data) == 0:
+            return 0
+        else:
+            return 1 + max(self.data)
+
     @classmethod
     def identity(cls, n: int) -> Self:
         """This maps 0-up input-file offsets to 0-up soma_joinid values. This is

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1336,6 +1336,11 @@ def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids):
         var_field_name="var_id",
     )
 
+    if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+        nobs = rd.get_obs_shape()
+        nvars = rd.get_var_shapes()
+        tiledbsoma.io.resize_experiment(SOMA_URI, nobs=nobs, nvars=nvars)
+
     # Append the second anndata object
     tiledbsoma.io.from_anndata(
         experiment_uri=SOMA_URI,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -29,7 +29,7 @@ def create_and_populate_dataframe(path: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(path, schema=arrow_schema) as df:
+    with soma.DataFrame.create(path, schema=arrow_schema, domain=[[0, 999]]) as df:
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]
         pydict["foo"] = [10, 20, 30, 40, 50]

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -426,7 +426,7 @@ def test_columns(tmp_path):
 
 @pytest.fixture
 def make_dataframe(request):
-    index_type = request.param
+    index_type, domain = request.param
 
     index = {
         pa.string(): ["A", "B", "C"],
@@ -458,35 +458,38 @@ def make_dataframe(request):
             "float32": np.array([0.0, 1.1, 2.2], np.float32),
         }
     )
-    return pa.Table.from_pandas(df)
+    return [pa.Table.from_pandas(df), domain]
 
 
 @pytest.mark.parametrize(
     "make_dataframe",
     [
-        pa.float32(),
-        pa.float64(),
-        pa.int8(),
-        pa.uint8(),
-        pa.int16(),
-        pa.uint16(),
-        pa.int32(),
-        pa.uint32(),
-        pa.int64(),
-        pa.uint64(),
-        pa.string(),
-        pa.large_string(),
-        pa.binary(),
-        pa.large_binary(),
+        [pa.float32(), [[-1000, 1000]]],
+        [pa.float64(), [[-1000, 1000]]],
+        [pa.int8(), [[-100, 100]]],
+        [pa.uint8(), [[0, 100]]],
+        [pa.int16(), [[-1000, 1000]]],
+        [pa.uint16(), [[0, 1000]]],
+        [pa.int32(), [[-1000, 1000]]],
+        [pa.uint32(), [[0, 1000]]],
+        [pa.int64(), [[-1000, 1000]]],
+        [pa.uint64(), [[0, 1000]]],
+        [pa.string(), [None]],
+        [pa.large_string(), [None]],
+        [pa.binary(), [None]],
+        [pa.large_binary(), [None]],
     ],
     indirect=True,
 )
 def test_index_types(tmp_path, make_dataframe):
     """Verify that the index columns can be of various types"""
     sdf = soma.DataFrame.create(
-        tmp_path.as_posix(), schema=make_dataframe.schema, index_column_names=["index"]
+        tmp_path.as_posix(),
+        schema=make_dataframe[0].schema,
+        index_column_names=["index"],
+        domain=make_dataframe[1],
     )
-    sdf.write(make_dataframe)
+    sdf.write(make_dataframe[0])
 
 
 def make_multiply_indexed_dataframe(
@@ -538,7 +541,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is None",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [None],
             "A": [10, 11, 12, 13, 14, 15],
             "throws": None,
@@ -546,7 +549,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is int",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [0],
             "A": [10],
             "throws": None,
@@ -554,7 +557,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D no results for 100",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [100],
             "A": [],
             "throws": None,
@@ -562,7 +565,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D no results for -100",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [-100],
             "A": [],
             "throws": None,
@@ -570,7 +573,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is list",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [[1, 3]],
             "A": [11, 13],
             "throws": None,
@@ -578,7 +581,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D no results for -100, 100",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [[-100, 100]],
             "A": [],
             "throws": None,
@@ -586,7 +589,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D empty list returns empty results",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [[]],
             "A": [],
             "throws": None,
@@ -594,7 +597,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is tuple",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [(1, 3)],
             "A": [11, 13],
             "throws": None,
@@ -602,7 +605,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is range",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [range(1, 3)],
             "A": [11, 12],
             "throws": None,
@@ -610,7 +613,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is pa.ChunkedArray",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [pa.chunked_array(pa.array([1, 3]))],
             "A": [11, 13],
             "throws": None,
@@ -618,7 +621,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is pa.Array",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [pa.array([1, 3])],
             "A": [11, 13],
             "throws": None,
@@ -627,7 +630,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing slot is np.ndarray",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [np.asarray([1, 3])],
             "A": [11, 13],
             "throws": None,
@@ -635,7 +638,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by 2D np.ndarray",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [
                 np.asarray([[1, 3], [2, 4]])
             ],  # Error since 2D array in the slot
@@ -645,7 +648,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by slice(None)",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [
                 slice(None)
             ],  # Indexing slot is none-slice i.e. `[:]` which is like None
@@ -655,7 +658,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by empty coords",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [],
             "A": [10, 11, 12, 13, 14, 15],
             "throws": None,
@@ -663,7 +666,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by 1:3",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [slice(1, 3)],  # Indexing slot is double-ended slice
             "A": [11, 12, 13],
             "throws": None,
@@ -671,7 +674,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by [:3]",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [slice(None, 3)],  # Half-slice
             "A": [10, 11, 12, 13],
             "throws": None,
@@ -679,7 +682,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by [2:]",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [slice(2, None)],  # Half-slice
             "A": [12, 13, 14, 15],
             "throws": None,
@@ -695,7 +698,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by ['bbb':'c']",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [slice("bbb", "c")],
             "A": [12, 13],
             "throws": None,
@@ -703,7 +706,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by ['ccc':]",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [slice("ccc", None)],
             "A": [14, 15],
             "throws": None,
@@ -711,7 +714,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "1D indexing by [:'bbd']",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [slice("bbd")],
             "A": [10, 11, 12, 13],
             "throws": None,
@@ -753,7 +756,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "backwards slice",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [slice(1, 0)],
             "A": None,
             "throws": ValueError,
@@ -761,7 +764,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "too many columns",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [(1,), (2,)],
             "A": None,
             "throws": ValueError,
@@ -769,7 +772,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "wrong coords type",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": "bogus",
             "A": None,
             "throws": TypeError,
@@ -777,7 +780,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "bad index type dict",
             "index_column_names": ["0_thru_5"],
-            "domain": [[0, 5]],
+            "domain": [[-1000, 1000]],
             "coords": [{"bogus": True}],
             "A": None,
             "throws": TypeError,
@@ -785,7 +788,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "bad index type bool",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [[True], slice(None)],
             "A": None,
             "throws": TypeError,
@@ -793,7 +796,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index empty",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": (),
             "A": [10, 11, 12, 13, 14, 15],
             "throws": None,
@@ -801,7 +804,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index None",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [None, None],
             "A": [10, 11, 12, 13, 14, 15],
             "throws": None,
@@ -809,7 +812,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index 0, 0",
             "index_column_names": ["0_thru_5", "zero_one"],
-            "domain": [[0, 5], [0, 1]],
+            "domain": [[-1000, 1000], [0, 1]],
             "coords": [0, 0],
             "A": [10],
             "throws": None,
@@ -817,7 +820,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index str, int",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [["aaa"], 0],
             "A": [10],
             "throws": None,
@@ -825,7 +828,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index str, not sequence[str]",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": ["aaa", 0],
             "A": [10],
             "throws": None,
@@ -833,7 +836,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "2D index List[str]",
             "index_column_names": ["strings_aaa", "zero_one"],
-            "domain": [["", "~"], [0, 1]],
+            "domain": [None, [0, 1]],
             "coords": [["aaa", "ccc"], None],
             "A": [10, 11, 14, 15],
             "throws": None,
@@ -841,7 +844,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "3D index List[str]",
             "index_column_names": ["strings_aaa", "zero_one", "thousands"],
-            "domain": [["", "~"], [0, 1], [0, 9999]],
+            "domain": [None, [0, 1], [0, 9999]],
             "coords": [["aaa", "ccc"], None, None],
             "A": [10, 11, 14, 15],
             "throws": None,
@@ -849,7 +852,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "3D index mixed",
             "index_column_names": ["strings_aaa", "zero_one", "thousands"],
-            "domain": [["", "~"], [0, 1], [0, 9999]],
+            "domain": [None, [0, 1], [0, 9999]],
             "coords": [("aaa", "ccc"), None, np.asarray([2000, 9999])],
             "A": [11],
             "throws": None,
@@ -857,7 +860,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "value filter good",
             "index_column_names": ["0_thru_5", "strings_aaa"],
-            "domain": [[0, 5], ["", "~"]],
+            "domain": [[-1000, 1000], None],
             "coords": [None, ("ccc", "zzz")],
             "value_filter": "soma_joinid > 13",
             "A": [14, 15],
@@ -865,7 +868,7 @@ def make_multiply_indexed_dataframe(
         {
             "name": "value filter bad",
             "index_column_names": ["0_thru_5", "strings_aaa"],
-            "domain": [[0, 5], ["", "~"]],
+            "domain": [[-1000, 1000], None],
             "coords": [None, ("bbb", "zzz")],
             "value_filter": "quick brown fox",
             "A": None,

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -60,7 +60,7 @@ def arrow_table():
         [
             "SOMA_JOINID-ALL",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [],
             "default01234",
         ],
@@ -74,7 +74,7 @@ def arrow_table():
         [
             "soma_joinid-py-list",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [[0, 2]],
             {
                 "soma_joinid": pa.array([0, 2], pa.int64()),
@@ -84,7 +84,7 @@ def arrow_table():
         [
             "soma_joinid-py-tuple",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [(0, 2)],
             {
                 "soma_joinid": pa.array([0, 2], pa.int64()),
@@ -94,7 +94,7 @@ def arrow_table():
         [
             "soma_joinid-py-slice",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [slice(0, 2)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -104,7 +104,7 @@ def arrow_table():
         [
             "soma_joinid-py-left-none-slice",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [slice(None, 2)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -114,7 +114,7 @@ def arrow_table():
         [
             "soma_joinid-py-right-none-slice",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [slice(2, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -124,14 +124,14 @@ def arrow_table():
         [
             "soma_joinid-py-both-none-slice",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "soma_joinid-np-array-untyped",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [np.array([0, 2])],
             {
                 "soma_joinid": pa.array([0, 2], pa.int64()),
@@ -141,7 +141,7 @@ def arrow_table():
         [
             "soma_joinid-np-array-typed",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [np.array([0, 2], np.int64)],
             {
                 "soma_joinid": pa.array([0, 2], pa.int64()),
@@ -151,7 +151,7 @@ def arrow_table():
         [
             "soma_joinid-pa-array-untyped",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [pa.array([0, 2])],
             {
                 "soma_joinid": pa.array([0, 2]),
@@ -161,7 +161,7 @@ def arrow_table():
         [
             "soma_joinid-pa-array-typed",
             ["soma_joinid"],
-            None,
+            [[0, 999]],
             [pa.array([0, 2])],
             {
                 "soma_joinid": pa.array([0, 2], pa.int64()),
@@ -172,56 +172,56 @@ def arrow_table():
         [
             "STRING-ALL",
             ["string"],
-            None,
+            [None],
             [],
             "default01234",
         ],
         [
             "string-py-list",
             ["string"],
-            None,
+            [None],
             [["cat", "dog"]],
             "default23",
         ],
         [
             "string-py-tuple",
             ["string"],
-            None,
+            [None],
             [("cat", "dog")],
             "default23",
         ],
         [
             "string-py-slice",
             ["string"],
-            None,
+            [None],
             [("cat", "dog")],
             "default23",
         ],
         [
             "string-pa-array-untyped",
             ["string"],
-            None,
+            [None],
             [pa.array(["cat", "dog"])],
             "default23",
         ],
         [
             "string-pa-array-typed",
             ["string"],
-            None,
+            [None],
             [pa.array(["cat", "dog"], pa.string())],
             "default23",
         ],
         [
             "string-np-array-untyped",
             ["string"],
-            None,
+            [None],
             [np.asarray(["cat", "dog"])],
             "default23",
         ],
         [
             "string-np-array-typed",
             ["string"],
-            None,
+            [None],
             [np.asarray(["cat", "dog"], str)],
             "default23",
         ],
@@ -229,56 +229,56 @@ def arrow_table():
         [
             "BYTES-ALL",
             ["bytes"],
-            None,
+            [None],
             [],
             "default01234",
         ],
         [
             "bytes-py-list",
             ["bytes"],
-            None,
+            [None],
             [[b"cat", b"dog"]],
             "default23",
         ],
         [
             "bytes-py-tuple",
             ["bytes"],
-            None,
+            [None],
             [(b"cat", b"dog")],
             "default23",
         ],
         [
             "bytes-py-slice",
             ["bytes"],
-            None,
+            [None],
             [(b"cat", b"dog")],
             "default23",
         ],
         [
             "bytes-pa-array-untyped",
             ["bytes"],
-            None,
+            [None],
             [pa.array([b"cat", b"dog"])],
             "default23",
         ],
         [
             "bytes-pa-array-typed",
             ["bytes"],
-            None,
+            [None],
             [pa.array([b"cat", b"dog"], pa.binary())],
             "default23",
         ],
         [
             "bytes-np-array-untyped",
             ["bytes"],
-            None,
+            [None],
             [np.asarray([b"cat", b"dog"])],
             "default23",
         ],
         [
             "bytes-np-array-typed",
             ["bytes"],
-            None,
+            [None],
             [np.asarray([b"cat", b"dog"], bytes)],
             "default23",
         ],
@@ -286,7 +286,7 @@ def arrow_table():
         [
             "INT64-ALL",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [],
             "default01234",
         ],
@@ -300,28 +300,28 @@ def arrow_table():
         [
             "int64-py-list",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [[6402, 6403]],
             "default23",
         ],
         [
             "int64-py-tuple",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [[6402, 6403]],
             "default23",
         ],
         [
             "int64-py-slice",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [slice(6402, 6403)],
             "default23",
         ],
         [
             "int64-py-left-none-slice",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [slice(None, 6402)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -331,7 +331,7 @@ def arrow_table():
         [
             "int64-py-right-none-slice",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [slice(6402, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -341,35 +341,35 @@ def arrow_table():
         [
             "int64-py-both-none-slice",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "int64-numpy-untyped",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [np.asarray([6402, 6403])],
             "default23",
         ],
         [
             "int64-numpy-typed",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [np.asarray([6402, 6403], np.int64)],
             "default23",
         ],
         [
             "int64-pa-array-untyped",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [pa.array([6402, 6403])],
             "default23",
         ],
         [
             "int64-pa-array-typed",
             ["int64"],
-            None,
+            [[-10000, 10000]],
             [pa.array([6402, 6403], pa.int64())],
             "default23",
         ],
@@ -377,7 +377,7 @@ def arrow_table():
         [
             "INT32-ALL",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [],
             "default01234",
         ],
@@ -391,28 +391,28 @@ def arrow_table():
         [
             "int32-py-list",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [[3202, 3203]],
             "default23",
         ],
         [
             "int32-py-tuple",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [[3202, 3203]],
             "default23",
         ],
         [
             "int32-py-slice",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [slice(3202, 3203)],
             "default23",
         ],
         [
             "int32-py-left-none-slice",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [slice(None, 3202)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -422,7 +422,7 @@ def arrow_table():
         [
             "int32-py-right-none-slice",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [slice(3202, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -432,28 +432,28 @@ def arrow_table():
         [
             "int32-py-both-none-slice",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "int32-numpy-untyped",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [np.asarray([3202, 3203])],
             "default23",
         ],
         [
             "int32-numpy-typed",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [np.asarray([3202, 3203], np.int32)],
             "default23",
         ],
         [
             "int32-pa-array-typed",
             ["int32"],
-            None,
+            [[-10000, 10000]],
             [pa.array([3202, 3203], pa.int32())],
             "default23",
         ],
@@ -461,7 +461,7 @@ def arrow_table():
         [
             "INT16-ALL",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [],
             "default01234",
         ],
@@ -475,28 +475,28 @@ def arrow_table():
         [
             "int16-py-list",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [[1602, 1603]],
             "default23",
         ],
         [
             "int16-py-tuple",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [[1602, 1603]],
             "default23",
         ],
         [
             "int16-py-slice",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [slice(1602, 1603)],
             "default23",
         ],
         [
             "int16-py-left-none-slice",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [slice(None, 1602)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -506,7 +506,7 @@ def arrow_table():
         [
             "int16-py-right-none-slice",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [slice(1602, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -516,28 +516,28 @@ def arrow_table():
         [
             "int16-py-both-none-slice",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "int16-numpy-untyped",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [np.asarray([1602, 1603])],
             "default23",
         ],
         [
             "int16-numpy-typed",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [np.asarray([1602, 1603], np.int16)],
             "default23",
         ],
         [
             "int16-pa-array-typed",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [pa.array([1602, 1603], pa.int16())],
             "default23",
         ],
@@ -545,7 +545,7 @@ def arrow_table():
         [
             "INT8-ALL",
             ["int8"],
-            None,
+            [[-100, 100]],
             [],
             "default01234",
         ],
@@ -559,28 +559,28 @@ def arrow_table():
         [
             "int8-py-list",
             ["int8"],
-            None,
+            [[-100, 100]],
             [[82, 83]],
             "default23",
         ],
         [
             "int8-py-tuple",
             ["int8"],
-            None,
+            [[-100, 100]],
             [[82, 83]],
             "default23",
         ],
         [
             "int8-py-slice",
             ["int8"],
-            None,
+            [[-100, 100]],
             [slice(82, 83)],
             "default23",
         ],
         [
             "int8-py-left-none-slice",
             ["int8"],
-            None,
+            [[-100, 100]],
             [slice(None, 82)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -590,7 +590,7 @@ def arrow_table():
         [
             "int8-py-right-none-slice",
             ["int8"],
-            None,
+            [[-100, 100]],
             [slice(82, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -600,28 +600,28 @@ def arrow_table():
         [
             "int8-py-both-none-slice",
             ["int8"],
-            None,
+            [[-100, 100]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "int8-numpy-untyped",
             ["int8"],
-            None,
+            [[-100, 100]],
             [np.asarray([82, 83])],
             "default23",
         ],
         [
             "int8-numpy-typed",
             ["int8"],
-            None,
+            [[-100, 100]],
             [np.asarray([82, 83], np.int8)],
             "default23",
         ],
         [
             "int8-pa-array-typed",
             ["int8"],
-            None,
+            [[-100, 100]],
             [pa.array([82, 83], pa.int8())],
             "default23",
         ],
@@ -629,7 +629,7 @@ def arrow_table():
         [
             "UINT64-ALL",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [],
             "default01234",
         ],
@@ -643,28 +643,28 @@ def arrow_table():
         [
             "uint64-py-list",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [[6412, 6413]],
             "default23",
         ],
         [
             "uint64-py-tuple",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [[6412, 6413]],
             "default23",
         ],
         [
             "uint64-py-slice",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [slice(6412, 6413)],
             "default23",
         ],
         [
             "uint64-py-left-none-slice",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [slice(None, 6412)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -674,7 +674,7 @@ def arrow_table():
         [
             "uint64-py-right-none-slice",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [slice(6412, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -684,28 +684,28 @@ def arrow_table():
         [
             "uint64-py-both-none-slice",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "uint64-numpy-untyped",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [np.asarray([6412, 6413])],
             "default23",
         ],
         [
             "uint64-numpy-typed",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [np.asarray([6412, 6413], np.uint64)],
             "default23",
         ],
         [
             "uint64-pa-array-typed",
             ["uint64"],
-            None,
+            [[0, 10000]],
             [pa.array([6412, 6413], pa.uint64())],
             "default23",
         ],
@@ -713,7 +713,7 @@ def arrow_table():
         [
             "UINT32-ALL",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [],
             "default01234",
         ],
@@ -727,28 +727,28 @@ def arrow_table():
         [
             "uint32-py-list",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [[3212, 3213]],
             "default23",
         ],
         [
             "uint32-py-tuple",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [[3212, 3213]],
             "default23",
         ],
         [
             "uint32-py-slice",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [slice(3212, 3213)],
             "default23",
         ],
         [
             "uint32-py-left-none-slice",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [slice(None, 3212)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -758,7 +758,7 @@ def arrow_table():
         [
             "uint32-py-right-none-slice",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [slice(3212, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -768,28 +768,28 @@ def arrow_table():
         [
             "uint32-py-both-none-slice",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "uint32-numpy-untyped",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [np.asarray([3212, 3213])],
             "default23",
         ],
         [
             "uint32-numpy-typed",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [np.asarray([3212, 3213], np.uint32)],
             "default23",
         ],
         [
             "uint32-pa-array-typed",
             ["uint32"],
-            None,
+            [[0, 10000]],
             [pa.array([3212, 3213], pa.uint32())],
             "default23",
         ],
@@ -797,7 +797,7 @@ def arrow_table():
         [
             "UINT16-ALL",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [],
             "default01234",
         ],
@@ -811,28 +811,28 @@ def arrow_table():
         [
             "uint16-py-list",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [[1612, 1613]],
             "default23",
         ],
         [
             "uint16-py-tuple",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [[1612, 1613]],
             "default23",
         ],
         [
             "uint16-py-slice",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [slice(1612, 1613)],
             "default23",
         ],
         [
             "uint16-py-left-none-slice",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [slice(None, 1612)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -842,7 +842,7 @@ def arrow_table():
         [
             "uint16-py-right-none-slice",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [slice(1612, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -852,28 +852,28 @@ def arrow_table():
         [
             "uint16-py-both-none-slice",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "uint16-numpy-untyped",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [np.asarray([1612, 1613])],
             "default23",
         ],
         [
             "uint16-numpy-typed",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [np.asarray([1612, 1613], np.uint16)],
             "default23",
         ],
         [
             "uint16-pa-array-typed",
             ["uint16"],
-            None,
+            [[0, 10000]],
             [pa.array([1612, 1613], pa.uint16())],
             "default23",
         ],
@@ -881,7 +881,7 @@ def arrow_table():
         [
             "UINT8-ALL",
             ["uint8"],
-            None,
+            [[0, 200]],
             [],
             "default01234",
         ],
@@ -895,28 +895,28 @@ def arrow_table():
         [
             "uint8-py-list",
             ["uint8"],
-            None,
+            [[0, 200]],
             [[92, 93]],
             "default23",
         ],
         [
             "uint8-py-tuple",
             ["uint8"],
-            None,
+            [[0, 200]],
             [[92, 93]],
             "default23",
         ],
         [
             "uint8-py-slice",
             ["uint8"],
-            None,
+            [[0, 200]],
             [slice(92, 93)],
             "default23",
         ],
         [
             "uint8-py-left-none-slice",
             ["uint8"],
-            None,
+            [[0, 200]],
             [slice(None, 92)],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -926,7 +926,7 @@ def arrow_table():
         [
             "uint8-py-right-none-slice",
             ["uint8"],
-            None,
+            [[0, 200]],
             [slice(92, None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -936,28 +936,28 @@ def arrow_table():
         [
             "uint8-py-both-none-slice",
             ["uint8"],
-            None,
+            [[0, 200]],
             [slice(None, None)],
             "default01234",
         ],
         [
             "uint8-numpy-untyped",
             ["uint8"],
-            None,
+            [[0, 200]],
             [np.asarray([92, 93])],
             "default23",
         ],
         [
             "uint8-numpy-typed",
             ["uint8"],
-            None,
+            [[0, 200]],
             [np.asarray([92, 93], np.uint8)],
             "default23",
         ],
         [
             "uint8-pa-array-typed",
             ["uint8"],
-            None,
+            [[0, 200]],
             [pa.array([92, 93], pa.uint8())],
             "default23",
         ],
@@ -965,7 +965,7 @@ def arrow_table():
         [
             "FLOAT32-ALL",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [],
             "default01234",
         ],
@@ -979,42 +979,42 @@ def arrow_table():
         [
             "float32-py-list",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [[322.5, 323.5]],
             "default23",
         ],
         [
             "float32-py-tuple",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [(322.5, 323.5)],
             "default23",
         ],
         [
             "float32-py-slice",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [slice(322.5, 323.5)],
             "default23",
         ],
         [
             "float32-np-array-untyped",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [np.asarray([322.5, 323.5])],
             "default23",
         ],
         [
             "float32-np-array-typed",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [np.asarray([322.5, 323.5], np.float32)],
             "default23",
         ],
         [
             "float32-pa-array-typed-float32",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([322.5, 323.5], pa.float32())],
             "default23",
         ],
@@ -1022,7 +1022,7 @@ def arrow_table():
         [
             "FLOAT64-ALL",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [],
             "default01234",
         ],
@@ -1036,49 +1036,49 @@ def arrow_table():
         [
             "float64-py-list",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [[642.5, 643.5]],
             "default23",
         ],
         [
             "float64-py-tuple",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [(642.5, 643.5)],
             "default23",
         ],
         [
             "float64-py-slice",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [slice(642.5, 643.5)],
             "default23",
         ],
         [
             "float64-np-array-untyped",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [np.asarray([642.5, 643.5])],
             "default23",
         ],
         [
             "float64-np-array-typed",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [np.asarray([642.5, 643.5], np.float64)],
             "default23",
         ],
         [
             "float64-pa-array-untyped",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([642.5, 643.5])],
             "default23",
         ],
         [
             "float64-pa-array-typed-float64",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([642.5, 643.5], pa.float64())],
             "default23",
         ],
@@ -1086,7 +1086,7 @@ def arrow_table():
         [
             "INT64+STRING-ALL",
             ["int64", "string"],
-            None,
+            [[-10000, 10000], None],
             [],
             "default01234",
         ],
@@ -1100,35 +1100,35 @@ def arrow_table():
         [
             "int64+string-arrow",
             ["int64", "string"],
-            None,
+            [[-10000, 10000], None],
             [pa.array([6402, 6403]), pa.array(["cat", "dog"])],
             "default23",
         ],
         [
             "string+int64-arrow",
             ["string", "int64"],
-            None,
+            [None, [-10000, 10000]],
             [pa.array(["cat", "dog"]), pa.array([6402, 6403])],
             "default23",
         ],
         [
             "string+int64-numpy",
             ["string", "int64"],
-            None,
+            [None, [-10000, 10000]],
             [np.asarray(["cat", "dog"]), np.asarray([6402, 6403])],
             "default23",
         ],
         [
             "string+int64-py-list",
             ["string", "int64"],
-            None,
+            [None, [-10000, 10000]],
             [["cat", "dog"], [6402, 6403]],
             "default23",
         ],
         [
             "string+int64-py-tuple",
             ["string", "int64"],
-            None,
+            [None, [-10000, 10000]],
             [("cat", "dog"), (6402, 6403)],
             "default23",
         ],
@@ -1136,14 +1136,14 @@ def arrow_table():
         [
             "INT64+FLOAT64+STRING-ALL",
             ["int64", "float64", "string"],
-            None,
+            [[-10000, 10000], [-1e6, 1e6], None],
             [],
             "default01234",
         ],
         [
             "int64+float64+string-arrow",
             ["int64", "float64", "string"],
-            None,
+            [[-10000, 10000], [-1e6, 1e6], None],
             [
                 pa.array([6402, 6403]),
                 pa.array([642.5, 643.5]),
@@ -1154,7 +1154,7 @@ def arrow_table():
         [
             "float64+string+int64-arrow",
             ["float64", "string", "int64"],
-            None,
+            [[-1e6, 1e6], None, [-10000, 10000]],
             [
                 pa.array([642.5, 643.5]),
                 pa.array(["cat", "dog"]),
@@ -1165,7 +1165,7 @@ def arrow_table():
         [
             "string+int64+float64-numpy",
             ["string", "int64", "float64"],
-            None,
+            [None, [-10000, 10000], [-1e6, 1e6]],
             [
                 np.asarray(["cat", "dog"]),
                 np.asarray([6402, 6403]),
@@ -1176,14 +1176,14 @@ def arrow_table():
         [
             "string+int64+float64py-list",
             ["string", "int64", "float64"],
-            None,
+            [None, [-10000, 10000], [-1e6, 1e6]],
             [["cat", "dog"], [6402, 6403], [642.5, 643.5]],
             "default23",
         ],
         [
             "string+int64+float64-py-tuple",
             ["string", "int64", "float64"],
-            None,
+            [None, [-10000, 10000], [-1e6, 1e6]],
             [("cat", "dog"), (6402, 6403), (642.5, 643.5)],
             "default23",
         ],
@@ -1191,7 +1191,12 @@ def arrow_table():
         [
             "TIMESTAMP-SEC-ALL",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [],
             "default01234",
         ],
@@ -1210,28 +1215,48 @@ def arrow_table():
         [
             "tss-py-list",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [[np.datetime64(946684802, "s"), np.datetime64(946684803, "s")]],
             "default23",
         ],
         [
             "tss-py-tuple",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [[np.datetime64(946684802, "s"), np.datetime64(946684803, "s")]],
             "default23",
         ],
         [
             "tss-py-slice",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [slice(np.datetime64(946684802, "s"), np.datetime64(946684803, "s"))],
             "default23",
         ],
         [
             "tss-py-left-none-slice",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [slice(None, np.datetime64(946684802, "s"))],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -1241,7 +1266,12 @@ def arrow_table():
         [
             "tss-py-right-none-slice",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [slice(np.datetime64(946684802, "s"), None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -1251,14 +1281,24 @@ def arrow_table():
         [
             "tss-py-both-none-slice",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [slice(None, None)],
             "default01234",
         ],
         [
             "tss-numpy",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [
                 np.asarray(
                     [np.datetime64(946684802, "s"), np.datetime64(946684803, "s")]
@@ -1269,14 +1309,24 @@ def arrow_table():
         [
             "tss-pa-array-untyped",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [pa.array([946684802, 946684803])],
             "default23",
         ],
         [
             "tss-pa-array-typed",
             ["tss"],
-            None,
+            [
+                [
+                    np.datetime64(0, "s"),
+                    np.datetime64(1000000000, "s"),
+                ]
+            ],
             [pa.array([946684802, 946684803], pa.timestamp("s"))],
             "default23",
         ],
@@ -1284,7 +1334,12 @@ def arrow_table():
         [
             "TIMESTAMP-MSEC-ALL",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [],
             "default01234",
         ],
@@ -1303,21 +1358,36 @@ def arrow_table():
         [
             "tsms-py-list",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [[np.datetime64(946684800002, "ms"), np.datetime64(946684800003, "ms")]],
             "default23",
         ],
         [
             "tsms-py-tuple",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [[np.datetime64(946684800002, "ms"), np.datetime64(946684800003, "ms")]],
             "default23",
         ],
         [
             "tsms-py-slice",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [
                 slice(
                     np.datetime64(946684800002, "ms"), np.datetime64(946684800003, "ms")
@@ -1328,7 +1398,12 @@ def arrow_table():
         [
             "tsms-py-left-none-slice",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [slice(None, np.datetime64(946684800002, "ms"))],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -1338,7 +1413,12 @@ def arrow_table():
         [
             "tsms-py-right-none-slice",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [slice(np.datetime64(946684800002, "ms"), None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -1348,14 +1428,24 @@ def arrow_table():
         [
             "tsms-py-both-none-slice",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [slice(None, None)],
             "default01234",
         ],
         [
             "tsms-numpy",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [
                 np.asarray(
                     [
@@ -1369,14 +1459,24 @@ def arrow_table():
         [
             "tsms-pa-array-untyped",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [pa.array([946684800002, 946684800003])],
             "default23",
         ],
         [
             "tsms-pa-array-typed",
             ["tsms"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ms"),
+                    np.datetime64(1000000000000, "ms"),
+                ]
+            ],
             [pa.array([946684800002, 946684800003], pa.timestamp("ms"))],
             "default23",
         ],
@@ -1384,7 +1484,12 @@ def arrow_table():
         [
             "TIMESTAMP-USEC-ALL",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [],
             "default01234",
         ],
@@ -1403,7 +1508,12 @@ def arrow_table():
         [
             "tsus-py-list",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [
                 [
                     np.datetime64(946684800000002, "us"),
@@ -1415,7 +1525,12 @@ def arrow_table():
         [
             "tsus-py-tuple",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [
                 [
                     np.datetime64(946684800000002, "us"),
@@ -1427,7 +1542,12 @@ def arrow_table():
         [
             "tsus-py-slice",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [
                 slice(
                     np.datetime64(946684800000002, "us"),
@@ -1439,7 +1559,12 @@ def arrow_table():
         [
             "tsus-py-left-none-slice",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [slice(None, np.datetime64(946684800000002, "us"))],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -1449,7 +1574,12 @@ def arrow_table():
         [
             "tsus-py-right-none-slice",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [slice(np.datetime64(946684800000002, "us"), None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -1459,14 +1589,24 @@ def arrow_table():
         [
             "tsus-py-both-none-slice",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [slice(None, None)],
             "default01234",
         ],
         [
             "tsus-numpy",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [
                 np.asarray(
                     [
@@ -1480,14 +1620,24 @@ def arrow_table():
         [
             "tsus-pa-array-untyped",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [pa.array([946684800000002, 946684800000003])],
             "default23",
         ],
         [
             "tsus-pa-array-typed",
             ["tsus"],
-            None,
+            [
+                [
+                    np.datetime64(0, "us"),
+                    np.datetime64(1000000000000000, "us"),
+                ]
+            ],
             [pa.array([946684800000002, 946684800000003], pa.timestamp("us"))],
             "default23",
         ],
@@ -1495,7 +1645,12 @@ def arrow_table():
         [
             "TIMESTAMP-NSEC-ALL",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [],
             "default01234",
         ],
@@ -1514,7 +1669,12 @@ def arrow_table():
         [
             "tsns-py-list",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [
                 [
                     np.datetime64(946684800000000002, "ns"),
@@ -1526,7 +1686,12 @@ def arrow_table():
         [
             "tsns-py-tuple",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [
                 [
                     np.datetime64(946684800000000002, "ns"),
@@ -1538,7 +1703,12 @@ def arrow_table():
         [
             "tsns-py-slice",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [
                 slice(
                     np.datetime64(946684800000000002, "ns"),
@@ -1550,7 +1720,12 @@ def arrow_table():
         [
             "tsns-py-left-none-slice",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [slice(None, np.datetime64(946684800000000002, "ns"))],
             {
                 "soma_joinid": pa.array([0, 1, 2], pa.int64()),
@@ -1560,7 +1735,12 @@ def arrow_table():
         [
             "tsns-py-right-none-slice",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [slice(np.datetime64(946684800000000002, "ns"), None)],
             {
                 "soma_joinid": pa.array([2, 3, 4], pa.int64()),
@@ -1570,14 +1750,24 @@ def arrow_table():
         [
             "tsns-py-both-none-slice",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [slice(None, None)],
             "default01234",
         ],
         [
             "tsns-numpy",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [
                 np.asarray(
                     [
@@ -1591,14 +1781,24 @@ def arrow_table():
         [
             "tsns-pa-array-untyped",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [pa.array([946684800000000002, 946684800000000003])],
             "default23",
         ],
         [
             "tsns-pa-array-typed",
             ["tsns"],
-            None,
+            [
+                [
+                    np.datetime64(0, "ns"),
+                    np.datetime64(1000000000000000000, "ns"),
+                ]
+            ],
             [pa.array([946684800000000002, 946684800000000003], pa.timestamp("ns"))],
             "default23",
         ],
@@ -1809,70 +2009,70 @@ def test_types_write_errors(
         [
             "int32-pa-array-untyped",
             ["int32"],
-            None,
+            [[-20000, 20000]],
             [pa.array([3202, 3203])],
             # Static type (INT64) does not match expected type (INT32)
         ],
         [
             "int16-pa-array-untyped",
             ["int16"],
-            None,
+            [[-2000, 2000]],
             [pa.array([1602, 1603])],
             # Static type (INT64) does not match expected type (INT16)
         ],
         [
             "int8-pa-array-untyped",
             ["int8"],
-            None,
+            [[-100, 100]],
             [pa.array([82, 83])],
             # Static type (INT64) does not match expected type (INT8)
         ],
         [
             "uint64-pa-array-untyped",
             ["uint64"],
-            None,
+            [[0, 100000]],
             [pa.array([6412, 6413])],
             # Static type (INT64) does not match expected type (UINT64)
         ],
         [
             "uint32-pa-array-untyped",
             ["uint32"],
-            None,
+            [[0, 100000]],
             [pa.array([3212, 3213])],
             # Static type (UINT64) does not match expected type (UINT32)
         ],
         [
             "uint16-pa-array-untyped",
             ["uint16"],
-            None,
+            [[0, 2000]],
             [pa.array([1612, 1613])],
             # Static type (UINT64) does not match expected type (UINT16)
         ],
         [
             "uint8-pa-array-untyped",
             ["uint8"],
-            None,
+            [[0, 100]],
             [pa.array([92, 93])],
             # Static type (UINT64) does not match expected type (UINT8)
         ],
         [
             "float32-pa-array-untyped",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([322.5, 323.5])],
             # Static type (FLOAT64) does not match expected type (FLOAT32)
         ],
         [
             "float32-pa-array-typed-float64",
             ["float32"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([322.5, 323.5], pa.float64())],
             # Static type (FLOAT64) does not match expected type (FLOAT32)
         ],
         [
             "float64-pa-array-typed-float32",
             ["float64"],
-            None,
+            [[-1e6, 1e6]],
             [pa.array([322.5, 323.5], pa.float32())],
             # Static type (FLOAT32) does not match expected type (FLOAT64)
         ],

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -21,14 +21,18 @@ def create_and_populate_obs(uri: str) -> soma.DataFrame:
         ]
     )
 
+    pydict = {}
+    pydict["soma_joinid"] = [0, 1, 2, 3, 4]
+    pydict["foo"] = [10, 20, 30, 40, 50]
+    pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
+    pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
+    rb = pa.Table.from_pydict(pydict)
+
+    domain = [[0, len(rb) - 1]]
+
     # TODO: indexing option ...
-    with soma.DataFrame.create(uri, schema=obs_arrow_schema) as obs:
-        pydict = {}
-        pydict["soma_joinid"] = [0, 1, 2, 3, 4]
-        pydict["foo"] = [10, 20, 30, 40, 50]
-        pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
-        pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
-        rb = pa.Table.from_pydict(pydict)
+    with soma.DataFrame.create(uri, schema=obs_arrow_schema, domain=domain) as obs:
+
         obs.write(rb)
 
     return _factory.open(uri)
@@ -43,12 +47,15 @@ def create_and_populate_var(uri: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(uri, schema=var_arrow_schema) as var:
-        pydict = {}
-        pydict["soma_joinid"] = [0, 1, 2, 3]
-        pydict["quux"] = ["zebra", "yak", "xylophone", "wapiti"]
-        pydict["xyzzy"] = [12.3, 23.4, 34.5, 45.6]
-        rb = pa.Table.from_pydict(pydict)
+    pydict = {}
+    pydict["soma_joinid"] = [0, 1, 2, 3]
+    pydict["quux"] = ["zebra", "yak", "xylophone", "wapiti"]
+    pydict["xyzzy"] = [12.3, 23.4, 34.5, 45.6]
+    rb = pa.Table.from_pydict(pydict)
+
+    domain = [[0, len(rb) - 1]]
+
+    with soma.DataFrame.create(uri, schema=var_arrow_schema, domain=domain) as var:
         var.write(rb)
 
     return _factory.open(uri)

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -879,7 +879,7 @@ def add_dataframe(coll: CollectionBase, key: str, sz: int) -> None:
                 ("label", pa.large_string()),
             ]
         ),
-        domain=[[0, sz-1]],
+        domain=[[0, sz - 1]],
         index_column_names=["soma_joinid"],
     )
     df.write(

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -879,6 +879,7 @@ def add_dataframe(coll: CollectionBase, key: str, sz: int) -> None:
                 ("label", pa.large_string()),
             ]
         ),
+        domain=[[0, sz-1]],
         index_column_names=["soma_joinid"],
     )
     df.write(

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -161,8 +161,10 @@ def test_write_arrow_table(tmp_path, num_rows, cap_nbytes):
     uri = tmp_path.as_posix()
     expect_error = cap_nbytes == 1 and num_rows > 0  # Not enough room for even one row
 
-    with soma.DataFrame.create(uri, schema=schema) as sdf:
-        table = pa.Table.from_pydict(pydict)
+    table = pa.Table.from_pydict(pydict)
+    domain = [[0, max(1, len(table) - 1)]]
+
+    with soma.DataFrame.create(uri, schema=schema, domain=domain) as sdf:
         if expect_error:
             with pytest.raises(soma.SOMAError):
                 somaio.ingest._write_arrow_table(table, sdf, tcopt, twopt)

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -127,7 +127,9 @@ def test_point_cloud_bad_read_spatial_region(tmp_path):
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
+    with soma.PointCloudDataFrame.create(
+        uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]
+    ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -281,7 +283,9 @@ def test_point_cloud_read_spatial_region_basic_2d(
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
+    with soma.PointCloudDataFrame.create(
+        uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]
+    ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -436,7 +440,9 @@ def test_point_cloud_read_spatial_region_2d_bad(tmp_path, name, region, exc_type
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
+    with soma.PointCloudDataFrame.create(
+        uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]
+    ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -483,7 +489,9 @@ def test_point_cloud_read_spatial_region_3d_bad(tmp_path, name, region, exc_type
 def point_cloud_read_spatial_region_transform_setup(uri, transform, input_axes, kwargs):
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
+    with soma.PointCloudDataFrame.create(
+        uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]
+    ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -684,7 +692,9 @@ def test_point_cloud_read_spatial_region_region_coord_space(tmp_path):
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
+    with soma.PointCloudDataFrame.create(
+        uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]
+    ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -16,20 +16,26 @@ def test_point_cloud_bad_create(tmp_path):
     asch = pa.schema([("x", pa.float64()), ("y", pa.float64())])
     with pytest.raises(ValueError):
         soma.PointCloudDataFrame.create(
-            urljoin(baseuri, "bad_name_subset"), schema=asch, index_column_names="x"
+            urljoin(baseuri, "bad_name_subset"),
+            schema=asch,
+            index_column_names="x",
         )
 
     # all spatial axis must have the same type
     asch = pa.schema([("x", pa.float64()), ("y", pa.int64())])
     with pytest.raises(ValueError):
         soma.PointCloudDataFrame.create(
-            urljoin(baseuri, "different_types"), schema=asch
+            urljoin(baseuri, "different_types"),
+            schema=asch,
+            domain=[[0, 9]],
         )
 
     # type must be integral or floating-point
     asch = pa.schema([("x", pa.large_string()), ("y", pa.large_string())])
     with pytest.raises(ValueError):
-        soma.PointCloudDataFrame.create(urljoin(baseuri, "bad_type"), schema=asch)
+        soma.PointCloudDataFrame.create(
+            urljoin(baseuri, "bad_type"), schema=asch, domain=[[0, 9]]
+        )
 
 
 def test_point_cloud_basic_read(tmp_path):
@@ -39,7 +45,9 @@ def test_point_cloud_basic_read(tmp_path):
 
     # defaults
     with soma.PointCloudDataFrame.create(
-        urljoin(baseuri, "default"), schema=asch
+        urljoin(baseuri, "default"),
+        schema=asch,
+        domain=[[0, 9], [-10000, 10000], [-10000, 10000]],
     ) as ptc:
         pydict = {}
         pydict["soma_joinid"] = [1, 2, 3, 4, 5]
@@ -67,7 +75,7 @@ def test_point_cloud_basic_read(tmp_path):
         schema=asch,
         index_column_names="x",
         axis_names="x",
-        domain=((1, 10),),
+        domain=[[1, 10]],
     ) as ptc:
         pydict = {}
         pydict["soma_joinid"] = [1, 2, 3, 4, 5]
@@ -119,7 +127,7 @@ def test_point_cloud_bad_read_spatial_region(tmp_path):
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -273,7 +281,7 @@ def test_point_cloud_read_spatial_region_basic_2d(
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -398,6 +406,7 @@ def test_point_cloud_read_spatial_region_basic_3d(
         schema=schema,
         index_column_names=("soma_joinid", "x", "y", "z"),
         axis_names=("x", "y", "z"),
+        domain=[[0, 9], [-10000, 10000], [-10000, 10000], [-10000, 10000]],
     ) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
@@ -427,7 +436,7 @@ def test_point_cloud_read_spatial_region_2d_bad(tmp_path, name, region, exc_type
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -456,7 +465,7 @@ def test_point_cloud_read_spatial_region_3d_bad(tmp_path, name, region, exc_type
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64()), ("z", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -474,7 +483,7 @@ def test_point_cloud_read_spatial_region_3d_bad(tmp_path, name, region, exc_type
 def point_cloud_read_spatial_region_transform_setup(uri, transform, input_axes, kwargs):
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],
@@ -675,7 +684,7 @@ def test_point_cloud_read_spatial_region_region_coord_space(tmp_path):
 
     schema = pa.schema([("x", pa.float64()), ("y", pa.float64())])
 
-    with soma.PointCloudDataFrame.create(uri, schema=schema) as ptc:
+    with soma.PointCloudDataFrame.create(uri, schema=schema, domain=[[0, 9], [-10000, 10000], [-10000, 10000]]) as ptc:
         pydict = {
             "soma_joinid": [1, 2, 3, 4, 5],
             "x": [10, 20, 30, 40, 50],

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -382,6 +382,11 @@ def test_multiples_without_experiment(
             var_field_name=var_field_name,
         )
 
+        if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+            nobs = rd.get_obs_shape()
+            nvars = rd.get_var_shapes()
+            tiledbsoma.io.resize_experiment(experiment_uri, nobs=nobs, nvars=nvars)
+
     else:
         # "Append" all the H5ADs where no experiment exists yet.
         rd = registration.ExperimentAmbientLabelMapping.from_h5ad_appends_on_experiment(
@@ -391,6 +396,8 @@ def test_multiples_without_experiment(
             obs_field_name=obs_field_name,
             var_field_name=var_field_name,
         )
+
+        # XXX TO DO
 
     assert rd.obs_axis.id_mapping_from_values(["AGAG", "GGAG"]).data == (2, 8)
     assert rd.var_axes["measname"].id_mapping_from_values(["ESR1", "VEGFA"]).data == (
@@ -451,6 +458,15 @@ def test_multiples_without_experiment(
         h5ad_file_names[permutation[2]],
         h5ad_file_names[permutation[3]],
     ]:
+        if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+            if tiledbsoma.Experiment.exists(experiment_uri):
+                tiledbsoma.io.resize_experiment(
+                    experiment_uri,
+                    nobs=rd.get_obs_shape(),
+                    nvars=rd.get_var_shapes(),
+                )
+
+        # XXX FIXME
         tiledbsoma.io.from_h5ad(
             experiment_uri,
             h5ad_file_name,
@@ -713,6 +729,13 @@ def test_append_items_with_experiment(obs_field_name, var_field_name):
 
     original = adata2.copy()
 
+    if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+        tiledbsoma.io.resize_experiment(
+            soma1,
+            nobs=rd.get_obs_shape(),
+            nvars=rd.get_var_shapes(),
+        )
+
     with tiledbsoma.Experiment.open(soma1, "w") as exp1:
         tiledbsoma.io.append_obs(
             exp1,
@@ -835,6 +858,14 @@ def test_append_with_disjoint_measurements(
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
     )
+
+    if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+        # XXX FIXME
+        tiledbsoma.io.resize_experiment(
+            soma_uri,
+            nobs=rd.get_obs_shape(),
+            nvars=rd.get_var_shapes(),
+        )
 
     tiledbsoma.io.from_anndata(
         soma_uri,
@@ -1190,6 +1221,15 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
         tiledbsoma.io.from_anndata(
             soma_uri, adata, measurement_name=measurement_name, registration_mapping=rd
         )
+
+        if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+            # XXX FIXME
+            tiledbsoma.io.resize_experiment(
+                soma_uri,
+                nobs=rd.get_obs_shape(),
+                nvars=rd.get_var_shapes(),
+            )
+
         tiledbsoma.io.from_anndata(
             soma_uri, bdata, measurement_name=measurement_name, registration_mapping=rd
         )
@@ -1207,6 +1247,13 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
 
         assert rd.get_obs_shape() == nobs_a + nobs_b
         assert rd.get_var_shapes() == {"meas": 4}
+
+        if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+            tiledbsoma.io.resize_experiment(
+                soma_uri,
+                nobs=rd.get_obs_shape(),
+                nvars=rd.get_var_shapes(),
+            )
 
         tiledbsoma.io.from_anndata(
             soma_uri, bdata, measurement_name=measurement_name, registration_mapping=rd

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -397,8 +397,6 @@ def test_multiples_without_experiment(
             var_field_name=var_field_name,
         )
 
-        # XXX TO DO
-
     assert rd.obs_axis.id_mapping_from_values(["AGAG", "GGAG"]).data == (2, 8)
     assert rd.var_axes["measname"].id_mapping_from_values(["ESR1", "VEGFA"]).data == (
         2,
@@ -466,7 +464,6 @@ def test_multiples_without_experiment(
                     nvars=rd.get_var_shapes(),
                 )
 
-        # XXX FIXME
         tiledbsoma.io.from_h5ad(
             experiment_uri,
             h5ad_file_name,
@@ -860,7 +857,6 @@ def test_append_with_disjoint_measurements(
     )
 
     if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-        # XXX FIXME
         tiledbsoma.io.resize_experiment(
             soma_uri,
             nobs=rd.get_obs_shape(),
@@ -1223,7 +1219,6 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b):
         )
 
         if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-            # XXX FIXME
             tiledbsoma.io.resize_experiment(
                 soma_uri,
                 nobs=rd.get_obs_shape(),

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -18,7 +18,7 @@ def create_and_populate_df(uri: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(uri, schema=obs_arrow_schema, domain=[[0,9]]) as obs:
+    with soma.DataFrame.create(uri, schema=obs_arrow_schema, domain=[[0, 9]]) as obs:
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]
         pydict["foo"] = [10, 20, 30, 40, 50]

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -18,7 +18,7 @@ def create_and_populate_df(uri: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(uri, schema=obs_arrow_schema) as obs:
+    with soma.DataFrame.create(uri, schema=obs_arrow_schema, domain=[[0,9]]) as obs:
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]
         pydict["foo"] = [10, 20, 30, 40, 50]

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -388,9 +388,9 @@ def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     uri = tmp_path.as_posix()
 
     if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-        shape=(2,3)
+        shape = [2, 3]
     else:
-        shape=(None, None) if shape_is_nones else (2, 3),
+        shape = ([None, None] if shape_is_nones else [2, 3])
 
     soma.SparseNDArray.create(
         uri,
@@ -423,7 +423,7 @@ def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     if shape_is_nones:
         if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
             with soma.SparseNDArray.open(uri, "w") as snda:
-                snda.resize((3, 3))
+                snda.resize([3, 3])
         with soma.SparseNDArray.open(uri, "w") as snda:
             snda.write(batch2)
     else:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -390,7 +390,7 @@ def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
         shape = [2, 3]
     else:
-        shape = ([None, None] if shape_is_nones else [2, 3])
+        shape = [None, None] if shape_is_nones else [2, 3]
 
     soma.SparseNDArray.create(
         uri,

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -387,10 +387,15 @@ def test_sparse_nd_array_read_as_pandas(
 def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     uri = tmp_path.as_posix()
 
+    if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+        shape=(2,3)
+    else:
+        shape=(None, None) if shape_is_nones else (2, 3),
+
     soma.SparseNDArray.create(
         uri,
         type=element_type,
-        shape=(None, None) if shape_is_nones else (2, 3),
+        shape=shape,
     ).close()
     assert soma.SparseNDArray.exists(uri)
 
@@ -416,6 +421,9 @@ def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
         assert snda.nnz == 6
 
     if shape_is_nones:
+        if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
+            with soma.SparseNDArray.open(uri, "w") as snda:
+                snda.resize((3, 3))
         with soma.SparseNDArray.open(uri, "w") as snda:
             snda.write(batch2)
     else:

--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -135,16 +135,21 @@ def test_bool_arrays(tmp_path, bool_array):
         ]
     )
     index_column_names = ["soma_joinid"]
-    with soma.DataFrame.create(
-        tmp_path.as_posix(), schema=schema, index_column_names=index_column_names
-    ) as sdf:
-        n_data = len(bool_array)
 
-        data = {
-            "soma_joinid": list(range(n_data)),
-            "b": bool_array,
-        }
-        rb = pa.Table.from_pydict(data)
+    n_data = len(bool_array)
+    data = {
+        "soma_joinid": list(range(n_data)),
+        "b": bool_array,
+    }
+    rb = pa.Table.from_pydict(data)
+    nrb = len(rb)
+
+    with soma.DataFrame.create(
+        tmp_path.as_posix(),
+        schema=schema,
+        index_column_names=index_column_names,
+        domain=[[0, max(nrb, 1) - 1]],
+    ) as sdf:
         sdf.write(rb)
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:

--- a/apis/python/tests/test_unicode.py
+++ b/apis/python/tests/test_unicode.py
@@ -46,7 +46,7 @@ def sample_dataframe_path(tmp_path, sample_arrow_table):
         tmp_path.as_posix(),
         schema=sample_arrow_table.schema,
         index_column_names=["soma_joinid"],
-        domain=((0, len(sample_arrow_table)-1),),
+        domain=((0, len(sample_arrow_table) - 1),),
     ) as sdf:
         sdf.write(sample_arrow_table)
     return sdf.uri

--- a/apis/python/tests/test_unicode.py
+++ b/apis/python/tests/test_unicode.py
@@ -46,6 +46,7 @@ def sample_dataframe_path(tmp_path, sample_arrow_table):
         tmp_path.as_posix(),
         schema=sample_arrow_table.schema,
         index_column_names=["soma_joinid"],
+        domain=((0, len(sample_arrow_table)-1),),
     ) as sdf:
         sdf.write(sample_arrow_table)
     return sdf.uri


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

In the agreed-on design at #2407 we agreed that `None` no longer means "as big a domain as possible" but now rather "as small as possible". This is a breaking change we have already agreed on.

On this PR -- not to be merged -- I've made the mods to the dataframe/array classes as well as unit-test cases. The result is many many lines -- too many.

This PR will be split up into several pieces, and then ultimately abandoned. It is posted here at all (a) for transparency; (b) for a CI check; (c) for bus-factor avoidance.

**Notes for Reviewer:**

This PR will be split up into several pieces, and then ultimately abandoned. It is posted here at all (a) for transparency; (b) for a CI check; (c) for bus-factor avoidance.
