### PR TITLE
[python] Domain-at-create unit-test PR 2/5

### DIFF
--- a/apis/python/tests/test_type_system.py
+++ b/apis/python/tests/test_type_system.py
@@ -135,16 +135,21 @@ def test_bool_arrays(tmp_path, bool_array):
         ]
     )
     index_column_names = ["soma_joinid"]
-    with soma.DataFrame.create(
-        tmp_path.as_posix(), schema=schema, index_column_names=index_column_names
-    ) as sdf:
-        n_data = len(bool_array)
 
-        data = {
-            "soma_joinid": list(range(n_data)),
-            "b": bool_array,
-        }
-        rb = pa.Table.from_pydict(data)
+    n_data = len(bool_array)
+    data = {
+        "soma_joinid": list(range(n_data)),
+        "b": bool_array,
+    }
+    rb = pa.Table.from_pydict(data)
+    nrb = len(rb)
+
+    with soma.DataFrame.create(
+        tmp_path.as_posix(),
+        schema=schema,
+        index_column_names=index_column_names,
+        domain=[[0, max(nrb, 1) - 1]],
+    ) as sdf:
         sdf.write(rb)
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:

--- a/apis/python/tests/test_unicode.py
+++ b/apis/python/tests/test_unicode.py
@@ -46,6 +46,7 @@ def sample_dataframe_path(tmp_path, sample_arrow_table):
         tmp_path.as_posix(),
         schema=sample_arrow_table.schema,
         index_column_names=["soma_joinid"],
+        domain=((0, len(sample_arrow_table) - 1),),
     ) as sdf:
         sdf.write(sample_arrow_table)
     return sdf.uri


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Split out from #3189 as described there.