### PR TITLE
[python] Domain-at-create unit-test PR 4/5

### DIFF
--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -29,7 +29,7 @@ def create_and_populate_dataframe(path: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(path, schema=arrow_schema) as df:
+    with soma.DataFrame.create(path, schema=arrow_schema, domain=[[0, 999]]) as df:
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]
         pydict["foo"] = [10, 20, 30, 40, 50]

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -21,14 +21,18 @@ def create_and_populate_obs(uri: str) -> soma.DataFrame:
         ]
     )
 
+    pydict = {}
+    pydict["soma_joinid"] = [0, 1, 2, 3, 4]
+    pydict["foo"] = [10, 20, 30, 40, 50]
+    pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
+    pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
+    rb = pa.Table.from_pydict(pydict)
+
+    domain = [[0, len(rb) - 1]]
+
     # TODO: indexing option ...
-    with soma.DataFrame.create(uri, schema=obs_arrow_schema) as obs:
-        pydict = {}
-        pydict["soma_joinid"] = [0, 1, 2, 3, 4]
-        pydict["foo"] = [10, 20, 30, 40, 50]
-        pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
-        pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
-        rb = pa.Table.from_pydict(pydict)
+    with soma.DataFrame.create(uri, schema=obs_arrow_schema, domain=domain) as obs:
+
         obs.write(rb)
 
     return _factory.open(uri)
@@ -43,12 +47,15 @@ def create_and_populate_var(uri: str) -> soma.DataFrame:
         ]
     )
 
-    with soma.DataFrame.create(uri, schema=var_arrow_schema) as var:
-        pydict = {}
-        pydict["soma_joinid"] = [0, 1, 2, 3]
-        pydict["quux"] = ["zebra", "yak", "xylophone", "wapiti"]
-        pydict["xyzzy"] = [12.3, 23.4, 34.5, 45.6]
-        rb = pa.Table.from_pydict(pydict)
+    pydict = {}
+    pydict["soma_joinid"] = [0, 1, 2, 3]
+    pydict["quux"] = ["zebra", "yak", "xylophone", "wapiti"]
+    pydict["xyzzy"] = [12.3, 23.4, 34.5, 45.6]
+    rb = pa.Table.from_pydict(pydict)
+
+    domain = [[0, len(rb) - 1]]
+
+    with soma.DataFrame.create(uri, schema=var_arrow_schema, domain=domain) as var:
         var.write(rb)
 
     return _factory.open(uri)

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -879,6 +879,7 @@ def add_dataframe(coll: CollectionBase, key: str, sz: int) -> None:
                 ("label", pa.large_string()),
             ]
         ),
+        domain=[[0, sz - 1]],
         index_column_names=["soma_joinid"],
     )
     df.write(

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -161,8 +161,10 @@ def test_write_arrow_table(tmp_path, num_rows, cap_nbytes):
     uri = tmp_path.as_posix()
     expect_error = cap_nbytes == 1 and num_rows > 0  # Not enough room for even one row
 
-    with soma.DataFrame.create(uri, schema=schema) as sdf:
-        table = pa.Table.from_pydict(pydict)
+    table = pa.Table.from_pydict(pydict)
+    domain = [[0, max(1, len(table) - 1)]]
+
+    with soma.DataFrame.create(uri, schema=schema, domain=domain) as sdf:
         if expect_error:
             with pytest.raises(soma.SOMAError):
                 somaio.ingest._write_arrow_table(table, sdf, tcopt, twopt)


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Split out from #3189 as described there.