### PR TITLE
[c++] Geometry Dataframe [draft]

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_context.cc
@@ -211,6 +212,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_dataframe.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud_dataframe.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -252,6 +252,18 @@ size_t ColumnBuffer::update_size(const Query& query) {
     return num_cells_;
 }
 
+std::vector<std::vector<uint8_t>> ColumnBuffer::binary() {
+    std::vector<std::vector<uint8_t>> result;
+
+    for (size_t i = 0; i < num_cells_; i++) {
+        result.emplace_back(std::vector<uint8_t>(
+            (char*)(data_.data() + offsets_[i]),
+            (char*)(data_.data() + offsets_[i + 1])));
+    }
+
+    return result;
+}
+
 std::vector<std::string> ColumnBuffer::strings() {
     std::vector<std::string> result;
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -203,6 +203,13 @@ class ColumnBuffer {
     std::vector<std::string> strings();
 
     /**
+     * @brief Return data in a vector of binary buffers.
+     *
+     * @return std::vector<std::vector<uint8_t>>
+     */
+    std::vector<std::vector<uint8_t>> binary();
+
+    /**
      * @brief Return a string_view of the string at the provided cell index.
      *
      * @param index Cell index

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -413,6 +413,7 @@ bool SOMAArray::_cast_column(
         case TILEDB_CHAR:
         case TILEDB_GEOM_WKB:
         case TILEDB_GEOM_WKT:
+        case TILEDB_BLOB:
             return _cast_column_aux<std::string>(schema, array, se);
         case TILEDB_BOOL:
             return _cast_column_aux<bool>(schema, array, se);
@@ -786,6 +787,9 @@ bool SOMAArray::_extend_enumeration(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
             return _extend_and_evolve_schema<std::string>(
                 value_schema, value_array, index_schema, index_array, se);
         case TILEDB_INT8:

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -411,6 +411,8 @@ bool SOMAArray::_cast_column(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
             return _cast_column_aux<std::string>(schema, array, se);
         case TILEDB_BOOL:
             return _cast_column_aux<bool>(schema, array, se);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -503,7 +503,7 @@ class SOMAArray : public SOMAObject {
      * @param arrow_schema
      * @param arrow_array
      */
-    void set_array_data(
+    virtual void set_array_data(
         std::unique_ptr<ArrowSchema> arrow_schema,
         std::unique_ptr<ArrowArray> arrow_array);
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -108,7 +108,8 @@ void SOMADataFrame::update_dataframe_schema(
             attr_name,
             ArrowAdapter::to_tiledb_format(attr_type));
 
-        if (ArrowAdapter::arrow_is_string_type(attr_type.c_str())) {
+        if (ArrowAdapter::arrow_is_string_type(attr_type.c_str()) ||
+            ArrowAdapter::arrow_is_binary_type(attr_type.c_str())) {
             attr.set_cell_val_num(TILEDB_VAR_NUM);
         }
 

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -1,0 +1,219 @@
+/**
+ * @file   soma_geometry_dataframe.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryDataFrame class.
+ */
+
+#include "soma_geometry_dataframe.h"
+#include "../utils/util.h"
+
+#include <regex>
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+//===================================================================
+//= public static
+//===================================================================
+
+void SOMAGeometryDataFrame::create(
+    std::string_view uri,
+    std::unique_ptr<ArrowSchema> schema,
+    ArrowTable index_columns,
+    ArrowTable spatial_columns,
+    std::shared_ptr<SOMAContext> ctx,
+    PlatformConfig platform_config,
+    std::optional<TimestampRange> timestamp) {
+    std::vector<std::string> spatial_axes;
+    auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
+        ctx->tiledb_ctx(),
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        ArrowTable(
+            std::move(spatial_columns.first),
+            std::move(spatial_columns.second)),
+        "SOMAGeometryDataFrame",
+        true,
+        platform_config);
+    auto array = SOMAArray::create(
+        ctx, uri, tiledb_schema, "SOMAGeometryDataFrame", timestamp);
+}
+
+std::unique_ptr<SOMAGeometryDataFrame> SOMAGeometryDataFrame::open(
+    std::string_view uri,
+    OpenMode mode,
+    std::shared_ptr<SOMAContext> ctx,
+    std::vector<std::string> column_names,
+    ResultOrder result_order,
+    std::optional<TimestampRange> timestamp) {
+    return std::make_unique<SOMAGeometryDataFrame>(
+        mode, uri, ctx, column_names, result_order, timestamp);
+}
+
+bool SOMAGeometryDataFrame::exists(
+    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+    try {
+        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
+        return "SOMAGeometryDataFrame" == obj->type();
+    } catch (TileDBSOMAError& e) {
+        return false;
+    }
+}
+
+//===================================================================
+//= public non-static
+//===================================================================
+
+std::unique_ptr<ArrowSchema> SOMAGeometryDataFrame::schema() const {
+    return this->arrow_schema();
+}
+
+const std::vector<std::string> SOMAGeometryDataFrame::index_column_names()
+    const {
+    return this->dimension_names();
+}
+
+const std::vector<std::string> SOMAGeometryDataFrame::spatial_column_names()
+    const {
+    std::vector<std::string> names;
+    std::unordered_set<std::string> unique_names;
+    std::regex rgx("tiledb__internal__(\\S+)__");
+    std::smatch matches;
+    for (auto dimension : this->dimension_names()) {
+        if (std::regex_search(dimension, matches, rgx)) {
+            if (unique_names.count(matches[1].str()) == 0) {
+                unique_names.insert(matches[1].str());
+                names.push_back(matches[1].str());
+            }
+        }
+    }
+
+    return names;
+}
+
+uint64_t SOMAGeometryDataFrame::count() {
+    return this->nnz();
+}
+
+void SOMAGeometryDataFrame::set_array_data(
+    std::unique_ptr<ArrowSchema> arrow_schema,
+    std::unique_ptr<ArrowArray> arrow_array) {
+    std::vector<std::string> spatial_axes = this->spatial_column_names();
+
+    for (auto i = 0; i < arrow_schema->n_children; ++i) {
+        if (strcmp(arrow_schema->children[i]->name, "soma_geometry") == 0 &&
+            strcmp(arrow_schema->children[i]->format, "+l") == 0) {
+            std::vector<ArrowArray*> arrays = util::cast_vertices_to_wkb(
+                arrow_array->children[i], spatial_axes);
+
+            // Reconstruct new array and schema
+            std::unique_ptr<ArrowSchema>
+                transformed_arrow_schema = std::make_unique<ArrowSchema>(
+                    ArrowSchema{});
+            std::unique_ptr<ArrowArray>
+                transformed_arrow_array = std::make_unique<ArrowArray>(
+                    ArrowArray{});
+
+            NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(
+                transformed_arrow_schema.get(),
+                ArrowType::NANOARROW_TYPE_STRUCT));
+            NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(
+                transformed_arrow_schema.get(),
+                arrow_schema->n_children + 2 * spatial_axes.size()));
+
+            NANOARROW_THROW_NOT_OK(ArrowArrayInitFromType(
+                transformed_arrow_array.get(),
+                ArrowType::NANOARROW_TYPE_STRUCT));
+            NANOARROW_THROW_NOT_OK(ArrowArrayAllocateChildren(
+                transformed_arrow_array.get(),
+                arrow_array->n_children + 2 * spatial_axes.size()));
+
+            for (int64_t j = 0; j < arrow_schema->n_children; ++j) {
+                if (strcmp(arrow_schema->children[j]->name, "soma_geometry") ==
+                    0) {
+                    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(
+                        transformed_arrow_schema->children[j],
+                        ArrowType::NANOARROW_TYPE_LARGE_BINARY));
+                    NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(
+                        transformed_arrow_schema->children[j],
+                        "soma_geometry"));
+
+                    ArrowArrayMove(
+                        arrays.front(), transformed_arrow_array->children[j]);
+                } else {
+                    ArrowSchemaMove(
+                        arrow_schema->children[j],
+                        transformed_arrow_schema->children[j]);
+                    ArrowArrayMove(
+                        arrow_array->children[j],
+                        transformed_arrow_array->children[j]);
+                }
+            }
+
+            for (size_t j = 0; j < spatial_axes.size(); ++j) {
+                NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(
+                    transformed_arrow_schema
+                        ->children[arrow_schema->n_children + 2 * j],
+                    ArrowType::NANOARROW_TYPE_DOUBLE));
+                NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(
+                    transformed_arrow_schema
+                        ->children[arrow_schema->n_children + 2 * j],
+                    ("tiledb__internal__" + spatial_axes[j] + "__min")
+                        .c_str()));
+                ArrowArrayMove(
+                    arrays[2 * j + 1],
+                    transformed_arrow_array
+                        ->children[arrow_schema->n_children + 2 * j]);
+
+                NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(
+                    transformed_arrow_schema
+                        ->children[arrow_schema->n_children + 2 * j + 1],
+                    ArrowType::NANOARROW_TYPE_DOUBLE));
+                NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(
+                    transformed_arrow_schema
+                        ->children[arrow_schema->n_children + 2 * j + 1],
+                    ("tiledb__internal__" + spatial_axes[j] + "__max")
+                        .c_str()));
+                ArrowArrayMove(
+                    arrays[2 * j + 2],
+                    transformed_arrow_array
+                        ->children[arrow_schema->n_children + 2 * j + 1]);
+            }
+
+            SOMAArray::set_array_data(
+                std::move(transformed_arrow_schema),
+                std::move(transformed_arrow_array));
+            return;
+        }
+    }
+
+    SOMAArray::set_array_data(std::move(arrow_schema), std::move(arrow_array));
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -1,0 +1,190 @@
+/**
+ * @file   soma_geometry_dataframe.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryDataFrame class.
+ */
+
+#ifndef SOMA_GEOMETRY_DATAFRAME
+#define SOMA_GEOMETRY_DATAFRAME
+
+#include <filesystem>
+
+#include "soma_array.h"
+
+namespace tiledbsoma {
+
+class ArrayBuffers;
+
+using namespace tiledb;
+
+class SOMAGeometryDataFrame : virtual public SOMAArray {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMAGeometryDataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param schema Arrow schema
+     * @param index_columns The index column names with associated domains
+     * and tile extents per dimension
+     * @param spatial_columns The spatial column names with associated domains
+     * and tile extents per dimension
+     * @param ctx SOMAContext
+     * @param platform_config Optional config parameter dictionary
+     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     */
+    static void create(
+        std::string_view uri,
+        std::unique_ptr<ArrowSchema> schema,
+        ArrowTable index_columns,
+        ArrowTable spatial_columns,
+        std::shared_ptr<SOMAContext> ctx,
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open and return a SOMAGeometryDataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param mode read or write
+     * @param ctx SOMAContext
+     * @param column_names A list of column names to use as user-defined index
+     * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
+     * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
+     * @param timestamp If specified, overrides the default timestamp used to
+     * open this object. If unset, uses the timestamp provided by the context.
+     * @return std::unique_ptr<SOMAGeometryDataFrame> SOMAGeometryDataFrame
+     */
+    static std::unique_ptr<SOMAGeometryDataFrame> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<SOMAContext> ctx,
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Check if the SOMAGeometryDataFrame exists at the URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param ctx SOMAContext
+     */
+    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    /**
+     * @brief Construct a new SOMAGeometryDataFrame object.
+     *
+     * @param mode read or write
+     * @param uri URI of the array
+     * @param ctx TileDB context
+     * @param column_names Columns to read
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
+     * @param timestamp Timestamp
+     */
+    SOMAGeometryDataFrame(
+        OpenMode mode,
+        std::string_view uri,
+        std::shared_ptr<SOMAContext> ctx,
+        std::vector<std::string> column_names,
+        ResultOrder result_order,
+        std::optional<TimestampRange> timestamp = std::nullopt)
+        : SOMAArray(
+              mode,
+              uri,
+              ctx,
+              std::filesystem::path(uri).filename().string(),  // array name
+              column_names,
+              "auto",  // batch_size
+              result_order,
+              timestamp) {
+    }
+
+    SOMAGeometryDataFrame(const SOMAArray& other)
+        : SOMAArray(other) {
+    }
+
+    SOMAGeometryDataFrame() = delete;
+    SOMAGeometryDataFrame(const SOMAGeometryDataFrame&) = default;
+    SOMAGeometryDataFrame(SOMAGeometryDataFrame&&) = delete;
+    ~SOMAGeometryDataFrame() = default;
+
+    using SOMAArray::open;
+
+    /**
+     * Return the data schema, in the form of a ArrowSchema.
+     *
+     * @return std::unique_ptr<ArrowSchema>
+     */
+    std::unique_ptr<ArrowSchema> schema() const;
+
+    /**
+     * Return the index (dimension) column names.
+     *
+     * @return std::vector<std::string>
+     */
+    const std::vector<std::string> index_column_names() const;
+
+    /**
+     * Return the spatial column names.
+     *
+     * @return std::vector<std::string>
+     */
+    const std::vector<std::string> spatial_column_names() const;
+
+    /**
+     * Return the number of rows.
+     *
+     * @return int64_t
+     */
+    uint64_t count();
+
+    /**
+     * @brief Set the write buffers for an Arrow Table or Batch as represented
+     * by an ArrowSchema and ArrowArray.
+     *
+     * @param arrow_schema
+     * @param arrow_array
+     */
+    void set_array_data(
+        std::unique_ptr<ArrowSchema> arrow_schema,
+        std::unique_ptr<ArrowArray> arrow_array) override;
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_GEOMETRY_DATAFRAME

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -7,6 +7,7 @@
 #include "soma_dataframe.h"
 #include "soma_dense_ndarray.h"
 #include "soma_experiment.h"
+#include "soma_geometry_dataframe.h"
 #include "soma_measurement.h"
 #include "soma_multiscale_image.h"
 #include "soma_point_cloud_dataframe.h"
@@ -61,8 +62,7 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
         } else if (array_type == "somapointclouddataframe") {
             return std::make_unique<SOMAPointCloudDataFrame>(*array_);
         } else if (array_type == "somageometrydataframe") {
-            throw TileDBSOMAError(
-                "Support for SOMAGeometryDataFrame is not yet implemented");
+            return std::make_unique<SOMAGeometryDataFrame>(*array_);
         } else {
             throw TileDBSOMAError("Saw invalid SOMAArray type");
         }

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -54,6 +54,7 @@
 #include "soma/soma_experiment.h"
 #include "soma/soma_measurement.h"
 #include "soma/soma_scene.h"
+#include "soma/soma_geometry_dataframe.h"
 #include "soma/soma_point_cloud_dataframe.h"
 #include "soma/soma_multiscale_image.h"
 #include "soma/soma_object.h"

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -615,6 +615,8 @@ Dimension ArrowAdapter::_create_dim(
     std::shared_ptr<Context> ctx) {
     switch (type) {
         case TILEDB_STRING_ASCII:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
             return Dimension::create(*ctx, name, type, nullptr, nullptr);
         case TILEDB_TIME_SEC:
         case TILEDB_TIME_MS:
@@ -1073,7 +1075,8 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     continue;
                 }
 
-                if (ArrowAdapter::arrow_is_string_type(child->format)) {
+                if (ArrowAdapter::arrow_is_string_type(child->format) ||
+                    ArrowAdapter::arrow_is_binary_type(child->format)) {
                     // In the core API:
                     //
                     // * domain for strings must be set as (nullptr, nullptr)

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -156,9 +156,11 @@ std::vector<ArrowArray*> cast_vertices_to_wkb(
         geometry::BinaryBuffer wkb = geometry::to_wkb(geometry);
         geometry::Envelope envelope = geometry::envelope(geometry);
 
-        NANOARROW_THROW_NOT_OK(ArrowArrayAppendBytes(
-            arrays.front(),
-            {.data = wkb.data(), .size_bytes = (int64_t)wkb.size()}));
+        ArrowBufferView wkb_view;
+        wkb_view.data.data = wkb.data();
+        wkb_view.size_bytes = (int64_t)wkb.size();
+
+        NANOARROW_THROW_NOT_OK(ArrowArrayAppendBytes(arrays.front(), wkb_view));
 
         for (size_t i = 0; i < spatial_axes.size(); ++i) {
             NANOARROW_THROW_NOT_OK(ArrowArrayAppendDouble(

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -35,6 +35,7 @@
 
 #include <regex>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
+#include <string>
 
 #include "arrow_adapter.h"
 #include "common.h"
@@ -79,6 +80,9 @@ std::string rstrip_uri(std::string_view uri);
  * @return std::vector<uint8_t>
  */
 std::vector<uint8_t> cast_bit_to_uint8(ArrowSchema* schema, ArrowArray* array);
+
+std::vector<ArrowArray*> cast_vertices_to_wkb(
+    ArrowArray* array, std::vector<std::string> spatial_axes);
 
 }  // namespace tiledbsoma::util
 

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(unit_soma
     unit_soma_sparse_ndarray.cc
     unit_soma_collection.cc
     unit_soma_scene.cc
+    unit_soma_geometry_dataframe.cc
     unit_soma_point_cloud_dataframe.cc
     unit_soma_multiscale_image.cc
     test_indexer.cc

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -210,6 +210,25 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
                 std::vector<std::string> dom({"", "", ""});
                 dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
             }
+        } else if (info.tiledb_datatype == TILEDB_GEOM_WKB) {
+            // No domain can be set for WKB. The domain will be set to the
+            // individual spatial axes.
+            dim_array = ArrowAdapter::make_arrow_array_child_wkb();
+        } else if (info.tiledb_datatype == TILEDB_FLOAT64) {
+            if (info.use_current_domain) {
+                // domain big; current_domain small
+                std::vector<double_t> dom(
+                    {0,
+                     (double_t)CORE_DOMAIN_MAX,
+                     1,
+                     0,
+                     (double_t)info.dim_max});
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
+            } else {
+                // domain small; current_domain feature not being used
+                std::vector<double_t> dom({0, (double_t)info.dim_max, 1});
+                dim_array = ArrowAdapter::make_arrow_array_child(dom);
+            }
         }
 
         if (dim_array == nullptr) {

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -1,0 +1,283 @@
+/**
+ * @file   unit_soma_geometry_dataframe.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for the SOMAGeometryDataFrame class
+ */
+
+#include <vector>
+#include "../src/geometry/geometry.h"
+#include "../src/geometry/operators/io/write.h"
+#include "common.h"
+
+const int64_t SOMA_JOINID_DIM_MAX = 99;
+
+TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
+    auto use_current_domain = GENERATE(false, true);
+    // TODO this could be formatted with fmt::format which is part of internal
+    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
+    // replaced with std::format.
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string uri{"mem://unit-test-geometry-basic"};
+        PlatformConfig platform_config{};
+
+        std::vector<helper::DimInfo> dim_infos(
+            {helper::DimInfo(
+                 {.name = "soma_joinid",
+                  .tiledb_datatype = TILEDB_INT64,
+                  .dim_max = SOMA_JOINID_DIM_MAX,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain}),
+             helper::DimInfo(
+                 {.name = "soma_geometry",
+                  .tiledb_datatype = TILEDB_GEOM_WKB,
+                  .dim_max = 100,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain})});
+
+        std::vector<helper::DimInfo> spatial_dim_infos(
+            {helper::DimInfo(
+                 {.name = "x",
+                  .tiledb_datatype = TILEDB_FLOAT64,
+                  .dim_max = 200,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain}),
+             helper::DimInfo(
+                 {.name = "y",
+                  .tiledb_datatype = TILEDB_FLOAT64,
+                  .dim_max = 100,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain})});
+
+        std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
+            {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});
+
+        // Check the point cloud doesn't exist yet.
+        REQUIRE(!SOMAGeometryDataFrame::exists(uri, ctx));
+
+        // Create the point cloud.
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        auto spatial_columns = helper::create_column_index_info(
+            spatial_dim_infos);
+
+        SOMAGeometryDataFrame::create(
+            uri,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ArrowTable(
+                std::move(spatial_columns.first),
+                std::move(spatial_columns.second)),
+            ctx,
+            platform_config,
+            std::nullopt);
+
+        // Check the point cloud exists and it cannot be read as a different
+        // object.
+        REQUIRE(SOMAGeometryDataFrame::exists(uri, ctx));
+        REQUIRE(!SOMASparseNDArray::exists(uri, ctx));
+        REQUIRE(!SOMADenseNDArray::exists(uri, ctx));
+        REQUIRE(!SOMADataFrame::exists(uri, ctx));
+
+        auto soma_geometry = SOMAGeometryDataFrame::open(
+            uri,
+            OpenMode::read,
+            ctx,
+            {},  // column_names,
+            ResultOrder::automatic,
+            std::nullopt);
+        REQUIRE(soma_geometry->uri() == uri);
+        REQUIRE(soma_geometry->ctx() == ctx);
+        REQUIRE(soma_geometry->type() == "SOMAGeometryDataFrame");
+        std::vector<std::string> expected_index_column_names = {
+            dim_infos[0].name,
+            "tiledb__internal__" + spatial_dim_infos[0].name + "__min",
+            "tiledb__internal__" + spatial_dim_infos[1].name + "__min",
+            "tiledb__internal__" + spatial_dim_infos[0].name + "__max",
+            "tiledb__internal__" + spatial_dim_infos[1].name + "__max"};
+
+        std::vector<std::string> expected_spatial_column_names = {
+            spatial_dim_infos[0].name, spatial_dim_infos[1].name};
+        REQUIRE(
+            soma_geometry->index_column_names() == expected_index_column_names);
+        REQUIRE(
+            soma_geometry->spatial_column_names() ==
+            expected_spatial_column_names);
+        REQUIRE(soma_geometry->nnz() == 0);
+        soma_geometry->close();
+
+        // Create table of data for writing
+        std::unique_ptr<ArrowSchema>
+            data_schema = std::make_unique<ArrowSchema>(ArrowSchema{});
+        std::unique_ptr<ArrowArray> data_array = std::make_unique<ArrowArray>(
+            ArrowArray{});
+
+        ArrowSchemaInitFromType(data_schema.get(), NANOARROW_TYPE_STRUCT);
+        ArrowSchemaAllocateChildren(data_schema.get(), 3);
+        ArrowSchemaInitFromType(data_schema->children[0], NANOARROW_TYPE_LIST);
+        ArrowSchemaSetType(
+            data_schema->children[0]->children[0], NANOARROW_TYPE_DOUBLE);
+        ArrowSchemaSetName(data_schema->children[0], "soma_geometry");
+        ArrowSchemaInitFromType(data_schema->children[1], NANOARROW_TYPE_INT64);
+        ArrowSchemaSetName(data_schema->children[1], "soma_joinid");
+        ArrowSchemaInitFromType(
+            data_schema->children[2], NANOARROW_TYPE_DOUBLE);
+        ArrowSchemaSetName(data_schema->children[2], "quality");
+
+        ArrowArrayInitFromType(data_array.get(), NANOARROW_TYPE_STRUCT);
+        ArrowArrayAllocateChildren(data_array.get(), 3);
+        ArrowArrayInitFromType(data_array->children[0], NANOARROW_TYPE_LIST);
+        ArrowArrayInitFromType(data_array->children[1], NANOARROW_TYPE_INT64);
+        ArrowArrayInitFromType(data_array->children[2], NANOARROW_TYPE_DOUBLE);
+        ArrowArrayAllocateChildren(data_array->children[0], 1);
+        ArrowArrayInitFromType(
+            data_array->children[0]->children[0], NANOARROW_TYPE_DOUBLE);
+        ArrowArrayStartAppending(data_array->children[0]);
+        ArrowArrayStartAppending(data_array->children[0]->children[0]);
+        ArrowArrayStartAppending(data_array->children[1]);
+        ArrowArrayStartAppending(data_array->children[2]);
+
+        geometry::GenericGeometry polygon = geometry::Polygon(
+            std::vector<geometry::BasePoint>(
+                {geometry::BasePoint(0, 0),
+                 geometry::BasePoint(1, 0),
+                 geometry::BasePoint(0, 1)}));
+        NANOARROW_THROW_NOT_OK(ArrowBufferAppendUInt32(
+            ArrowArrayBuffer(data_array->children[0], 1), 0));
+        data_array->children[0]->length = 1;
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 0));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 0));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 1));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 0));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 0));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[0]->children[0], 1));
+        NANOARROW_THROW_NOT_OK(ArrowArrayAppendInt(data_array->children[1], 1));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayAppendDouble(data_array->children[2], 63));
+
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayFinishBuildingDefault(data_array->children[0], nullptr));
+        NANOARROW_THROW_NOT_OK(ArrowArrayFinishBuildingDefault(
+            data_array->children[0]->children[0], nullptr));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayFinishBuildingDefault(data_array->children[1], nullptr));
+        NANOARROW_THROW_NOT_OK(
+            ArrowArrayFinishBuildingDefault(data_array->children[2], nullptr));
+
+        // Write to point cloud.
+        soma_geometry = SOMAGeometryDataFrame::open(
+            uri,
+            OpenMode::write,
+            ctx,
+            {},  // column_names
+            ResultOrder::automatic,
+            std::nullopt);
+
+        soma_geometry->set_array_data(
+            std::move(data_schema), std::move(data_array));
+        soma_geometry->write();
+        soma_geometry->close();
+
+        // Read back the data.
+        soma_geometry = SOMAGeometryDataFrame::open(
+            uri,
+            OpenMode::read,
+            ctx,
+            {},  // column_names,
+            ResultOrder::automatic,
+            std::nullopt);
+
+        while (auto batch = soma_geometry->read_next()) {
+            auto arrbuf = batch.value();
+            auto d0span = arrbuf->at(dim_infos[0].name)->data<int64_t>();
+            auto d1span = arrbuf
+                              ->at(
+                                  "tiledb__internal__" +
+                                  spatial_dim_infos[0].name + "__min")
+                              ->data<double_t>();
+            auto d2span = arrbuf
+                              ->at(
+                                  "tiledb__internal__" +
+                                  spatial_dim_infos[0].name + "__max")
+                              ->data<double_t>();
+            auto d3span = arrbuf
+                              ->at(
+                                  "tiledb__internal__" +
+                                  spatial_dim_infos[1].name + "__min")
+                              ->data<double_t>();
+            auto d4span = arrbuf
+                              ->at(
+                                  "tiledb__internal__" +
+                                  spatial_dim_infos[1].name + "__max")
+                              ->data<double_t>();
+            auto wkbs = arrbuf->at(dim_infos[1].name)->binary();
+            auto a0span = arrbuf->at(attr_infos[0].name)->data<double>();
+            CHECK(
+                std::vector<int64_t>({1}) ==
+                std::vector<int64_t>(d0span.begin(), d0span.end()));
+            CHECK(
+                std::vector<double_t>({0}) ==
+                std::vector<double_t>(d1span.begin(), d1span.end()));
+            CHECK(
+                std::vector<double_t>({1}) ==
+                std::vector<double_t>(d2span.begin(), d2span.end()));
+            CHECK(
+                std::vector<double_t>({0}) ==
+                std::vector<double_t>(d3span.begin(), d3span.end()));
+            CHECK(
+                std::vector<double_t>({1}) ==
+                std::vector<double_t>(d4span.begin(), d4span.end()));
+            CHECK(geometry::to_wkb(polygon) == wkbs[0]);
+            CHECK(
+                std::vector<double_t>({63}) ==
+                std::vector<double>(a0span.begin(), a0span.end()));
+        }
+        soma_geometry->close();
+
+        auto soma_object = SOMAObject::open(uri, OpenMode::read, ctx);
+        REQUIRE(soma_object->uri() == uri);
+        REQUIRE(soma_object->type() == "SOMAGeometryDataFrame");
+        soma_object->close();
+    }
+}


### PR DESCRIPTION
This PR adds a C++ implementation for `SOMAGeometryDataFrame`. The implementation differs from other `SOMAArray` derived objects in a few areas:

- `SOMAGeometryDataFrame` requires two schemas to create itself, one schema similar to all other objects and a schema for the spatial axes. The second schema is necessary to create some additional internal dimension to allow indexing for geometry data.
- `SOMAGeometryDataFrame` can transform geometry data from a list of vertices to the on-disk WKB format automatically. Specifically if the array of data contains a list of vertices in the geometry column (opposed to a binary buffer), the WKB buffer as well as any additional index column are generated automatically. This feature allows both R and Python APIs to behave the same and does not require from them additional dependencies to construct the binary buffers. Moreover in case the indexing for `SOMAGeometryDataFrame` changes in the future minor changes should be necessary to the R and Python APIs.

