### PR TITLE
[python] Add support for transforms in the `Scene` `add_new_*` methods

### DIFF
--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -221,6 +221,8 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         *,
         transform: Optional[CoordinateTransform],
         uri: Optional[str] = None,
+        axis_names: Sequence[str] = ("c", "y", "x"),
+        axis_types: Sequence[str] = ("channel", "height", "width"),
         **kwargs: Any,
     ) -> MultiscaleImage:
         """Adds a ``MultiscaleImage`` to the scene and sets a coordinate transform
@@ -245,20 +247,65 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
             Experimental.
         """
         if transform is not None:
-            raise NotImplementedError()
+            # Get and check the scene coordinate space axis names.
+            if self.coordinate_space is None:
+                raise SOMAError(
+                    "The scene coordinate space must be set before setting a transform."
+                )
+            if transform.input_axes != self.coordinate_space.axis_names:
+                raise ValueError(
+                    f"The name of the transform input axes, {transform.input_axes}, "
+                    f"do not match the name of the axes, "
+                    f"{self.coordinate_space.axis_names}, in the scene coordinate "
+                    f"space."
+                )
 
+            # Get and check the multiscale image coordinata space axis names.
+            # Note: The input paremeters to the MultiscaleImage create method are being
+            #   revisited. The following code will be improved after the create
+            #   parameters stabilize.
+            ordered_axis_names: List[Optional[str]] = [None, None, None]
+            for ax_name, ax_type in zip(axis_names, axis_types):
+                # Validation unneed if the type falls through. Invalid types will be
+                # caught in the MultiscaleImage.create method.
+                if ax_type == "width":
+                    ordered_axis_names[0] = ax_name
+                elif ax_type == "height":
+                    ordered_axis_names[1] = ax_name
+                elif ax_type == "depth":
+                    ordered_axis_names[2] = ax_name
+            ordered_axis_names = [
+                axis_name for axis_name in ordered_axis_names if axis_name is not None
+            ]
+            if transform.output_axes != tuple(ordered_axis_names):
+                raise ValueError(
+                    f"The name of the transform output axes, {transform.output_axes}, "
+                    f"do not match the name of the axes, {tuple(ordered_axis_names)}, "
+                    f"of the coordinate space the multiscale image is defined on."
+                )
+
+        # Open the subcollection and add the new multiscale image.
         coll = self._open_subcollection(subcollection)
-        return coll._add_new_element(
+        image = coll._add_new_element(
             key,
             MultiscaleImage,
             lambda create_uri: MultiscaleImage.create(
                 create_uri,
                 context=self.context,
                 tiledb_timestamp=self.tiledb_timestamp_ms,
+                axis_names=axis_names,
+                axis_types=axis_types,
                 **kwargs,
             ),
             uri,
         )
+
+        # Store the metadata for the transform.
+        if transform is not None:
+            coll.metadata[f"soma_scene_registry_{key}"] = transform_to_json(transform)
+
+        # Return the multiscale image.
+        return image
 
     @_funcs.forwards_kwargs_to(
         PointCloudDataFrame.create, exclude=("context", "tiledb_timestamp")
@@ -270,6 +317,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         *,
         transform: Optional[CoordinateTransform],
         uri: Optional[str] = None,
+        coordinate_space: Union[Sequence[str], CoordinateSpace] = ("x", "y"),
         **kwargs: Any,
     ) -> PointCloudDataFrame:
         """Adds a point cloud to the scene and sets a coordinate transform
@@ -319,13 +367,10 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
                 )
 
             # Get point cloud coordinate space and check
-            coord_space: Union[Sequence[str], CoordinateSpace] = kwargs[
-                "coordinate_space"
-            ]
             elem_axis_names = (
-                coord_space.axis_names
-                if isinstance(coord_space, CoordinateSpace)
-                else tuple(coord_space)
+                coordinate_space.axis_names
+                if isinstance(coordinate_space, CoordinateSpace)
+                else tuple(coordinate_space)
             )
             if transform.output_axes != elem_axis_names:
                 raise ValueError(
@@ -343,6 +388,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
                 create_uri,
                 context=self.context,
                 tiledb_timestamp=self.tiledb_timestamp_ms,
+                coordinate_space=coordinate_space,
                 **kwargs,
             ),
             uri,

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -13,6 +13,13 @@ from anndata import AnnData
 from numpy import array_equal
 from pandas._testing import assert_frame_equal, assert_series_equal
 from scipy.sparse import spmatrix
+from somacore import (
+    AffineTransform,
+    CoordinateTransform,
+    IdentityTransform,
+    ScaleTransform,
+    UniformScaleTransform,
+)
 from typeguard import suppress_type_checks
 
 
@@ -70,6 +77,28 @@ def assert_adata_equal(ad0: AnnData, ad1: AnnData):
     assert_array_dicts_equal(ad0.varm, ad1.varm)
     assert_array_dicts_equal(ad0.obsp, ad1.obsp)
     assert_array_dicts_equal(ad0.varp, ad1.varp)
+
+
+def assert_transform_equal(
+    actual: CoordinateTransform, expected: CoordinateTransform
+) -> None:
+    assert actual.input_axes == expected.input_axes
+    assert actual.output_axes == expected.output_axes
+    if isinstance(expected, IdentityTransform):
+        assert isinstance(actual, IdentityTransform)
+    elif isinstance(expected, UniformScaleTransform):
+        assert isinstance(actual, UniformScaleTransform)
+        assert actual.scale == expected.scale
+    elif isinstance(expected, ScaleTransform):
+        assert isinstance(actual, ScaleTransform)
+        np.testing.assert_array_equal(actual.scale_factors, expected.scale_factors)
+    elif isinstance(expected, AffineTransform):
+        assert isinstance(actual, AffineTransform)
+        np.testing.assert_array_equal(
+            actual.augmented_matrix, expected.augmented_matrix
+        )
+    else:
+        assert False
 
 
 def parse_col(col_str: str) -> Tuple[Optional[str], List[str]]:

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -1,12 +1,13 @@
 import json
 from urllib.parse import urljoin
 
-import numpy as np
 import pyarrow as pa
 import pytest
 import typeguard
 
 import tiledbsoma as soma
+
+from ._util import assert_transform_equal
 
 
 def create_and_populate_df(uri: str) -> soma.DataFrame:
@@ -300,20 +301,7 @@ def test_scene_point_cloud(tmp_path, coord_transform, transform_kwargs):
         scene.set_transform_to_point_cloud_dataframe("ptc", transform)
 
         ptc_transform = scene.get_transform_to_point_cloud_dataframe("ptc")
-        if isinstance(coord_transform, soma.AffineTransform):
-            assert np.array_equal(
-                ptc_transform.augmented_matrix,
-                transform.augmented_matrix,
-            )
-        elif isinstance(coord_transform, soma.ScaleTransform):
-            assert np.array_equal(
-                ptc_transform.scale_factors,
-                transform.scale_factors,
-            )
-        elif isinstance(
-            coord_transform, (soma.UniformScaleTransform, soma.IdentityTransform)
-        ):
-            assert ptc_transform.scale == transform.scale
+        assert_transform_equal(ptc_transform, transform)
 
 
 @pytest.mark.parametrize(
@@ -394,20 +382,7 @@ def test_scene_multiscale_image(tmp_path, coord_transform, transform_kwargs):
         scene.set_transform_to_multiscale_image("msi", transform)
 
         msi_transform = scene.get_transform_to_multiscale_image("msi")
-        if isinstance(coord_transform, soma.AffineTransform):
-            assert np.array_equal(
-                msi_transform.augmented_matrix,
-                transform.augmented_matrix,
-            )
-        elif isinstance(coord_transform, soma.ScaleTransform):
-            assert np.array_equal(
-                msi_transform.scale_factors,
-                transform.scale_factors,
-            )
-        elif isinstance(
-            coord_transform, (soma.UniformScaleTransform, soma.IdentityTransform)
-        ):
-            assert msi_transform.scale == transform.scale
+        assert_transform_equal(msi_transform, transform)
 
 
 @pytest.mark.skip("GeometryDataFrame not supported yet")
@@ -464,17 +439,4 @@ def test_scene_geometry_dataframe(tmp_path, coord_transform, transform_kwargs):
         scene.set_transform_to_geometry_dataframe("gdf", transform)
 
         gdf_transform = scene.get_transform_to_geometry_dataframe("gdf")
-        if isinstance(coord_transform, soma.AffineTransform):
-            assert np.array_equal(
-                gdf_transform.augmented_matrix,
-                transform.augmented_matrix,
-            )
-        elif isinstance(coord_transform, soma.ScaleTransform):
-            assert np.array_equal(
-                gdf_transform.scale_factors,
-                transform.scale_factors,
-            )
-        elif isinstance(
-            coord_transform, (soma.UniformScaleTransform, soma.IdentityTransform)
-        ):
-            assert gdf_transform.scale == transform.scale
+        assert_transform_equal(gdf_transform, transform)


### PR DESCRIPTION
Add support for setting the transform when a `PointCloud` or `MultiscaleImage` is first added to a `Scene`.

