### PR TITLE
[r] Min-sizing for dataframes/arrays with new shape feature

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.99.8
+Version: 1.15.99.9
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -16,6 +16,7 @@
 * Support for dense current domain with core 2.27 [#3180](https://github.com/single-cell-data/TileDB-SOMA/pull/3180)
 * Fix `is_named_list` bug for half-named lists [#3183](https://github.com/single-cell-data/TileDB-SOMA/pull/3183)
 * Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
+* Min-sizing for dataframes/arrays with new shape feature [#3208](https://github.com/single-cell-data/TileDB-SOMA/pull/3208)
 
 # tiledbsoma 1.14.1
 

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -94,10 +94,11 @@ SOMACollectionBase <- R6::R6Class(
     #' @param key The key to be added.
     #' @param schema Arrow schema argument passed on to DataFrame$create()
     #' @param index_column_names Index column names passed on to DataFrame$create()
+    #' @param domain As in ``SOMADataFrameCreate``.
     #' @template param-platform-config
-    add_new_dataframe = function(key, schema, index_column_names, platform_config = NULL) {
+    add_new_dataframe = function(key, schema, index_column_names, domain, platform_config = NULL) {
       ## TODO: Check argument validity
-      ndf <- SOMADataFrame$new(
+      sdf <- SOMADataFrame$new(
         uri = file_path(self$uri, key),
         platform_config = platform_config %||% private$.tiledb_platform_config,
         tiledbsoma_ctx = private$.tiledbsoma_ctx,
@@ -105,9 +106,9 @@ SOMACollectionBase <- R6::R6Class(
         internal_use_only = "allowed_use"
       )
 
-      ndf$create(schema, index_column_names, internal_use_only = "allowed_use")
-      super$set(ndf, key)
-      ndf
+      sdf$create(schema, index_column_names=index_column_names, domain=domain, internal_use_only = "allowed_use")
+      super$set(sdf, key)
+      sdf
     },
 
     #' @description Add a new SOMA DenseNdArray to this collection. (lifecycle: maturing)

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -488,7 +488,26 @@ get_domain_and_extent_dataframe <- function(tbl_schema, ind_col_names, domain = 
 
         requested_slot <- domain[[ind_col_name]]
         ind_cur_dom <- if (is.null(requested_slot)) {
-          ind_max_dom
+          if (.new_shape_feature_flag_is_enabled()) {
+            # New shape: if the slot is null, make the size as small
+            # as possible since current domain can only be resized upward.
+            #
+            # Core current-domain semantics are (lo, hi) with both
+            # inclusive, with lo <= hi. This means smallest is (0, 0)
+            # which is shape 1, not 0.
+            if (bit64::is.integer64(ind_max_dom)) {
+              c(bit64::as.integer64(0), bit64::as.integer64(0))
+            } else if (is.integer(ind_max_dom)) {
+              c(0L, 0L)
+            } else {
+              c(0, 0)
+            }
+          } else {
+            # Old shape: if the slot is null, make the size as large
+            # as possible since there is not current domain, and the
+            # max domain is immutable.
+            ind_max_dom
+          }
         } else {
           requested_slot
         }

--- a/apis/r/tests/testthat/helper-test-data.R
+++ b/apis/r/tests/testthat/helper-test-data.R
@@ -78,3 +78,15 @@ create_arrow_table <- function(nrows = 10L, factors = FALSE) {
       # schema = create_arrow_schema(false)
     )
 }
+
+domain_for_arrow_table <- function() {
+  return(
+    list(
+      int_column = c(0, 1000000),
+      soma_joinid = c(0, 1000000),
+      float_column = c(-1e6, 1e6),
+      string_column = NULL,
+      grp = NULL
+    )
+  )
+}

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -9,10 +9,22 @@ create_and_populate_soma_dataframe <- function(
 ) {
   set.seed(seed)
 
-  # arrow_schema <- create_arrow_schema()
   tbl <- create_arrow_table(nrows = nrows, factors = factors)
 
-  sdf <- SOMADataFrameCreate(uri, tbl$schema, index_column_names = index_column_names)
+  full_domain <- domain_for_arrow_table()
+  # Pick out the index-column names actually being used in this case
+  domain <- list()
+  for (index_column in index_column_names) {
+    domain[[index_column]] <- full_domain[[index_column]]
+  }
+
+  sdf <- SOMADataFrameCreate(
+    uri,
+    tbl$schema,
+    index_column_names = index_column_names,
+    domain = domain
+  )
+
   sdf$write(tbl)
 
   if (is.null(mode)) {
@@ -67,11 +79,14 @@ create_and_populate_var <- function(
       rep_len("lvl2", length.out = floor(nrows / 2))
     ))
   }
+  domain <- list(
+    soma_joinid = c(0, nrows - 1L)
+  )
 
   dname <- dirname(uri)
   if (!dir.exists(dname)) dir.create(dname)
 
-  sdf <- SOMADataFrameCreate(uri, tbl$schema, index_column_names = "soma_joinid")
+  sdf <- SOMADataFrameCreate(uri, tbl$schema, index_column_names = "soma_joinid", domain = domain)
   sdf$write(tbl)
 
   if (is.null(mode)) {

--- a/apis/r/tests/testthat/test-Factory.R
+++ b/apis/r/tests/testthat/test-Factory.R
@@ -8,9 +8,19 @@ test_that("DataFrame Factory", {
 
     # Check creation of a DF
     asch <- create_arrow_schema(foo_first=FALSE)
-    expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch))
-    tbl <- arrow::arrow_table(soma_joinid = 1L:10L, int_column = 1L:10L, float_column = sqrt(1:10),
-                              string_column = letters[1:10], schema = asch)
+
+    expect_silent(d2 <- SOMADataFrameCreate(
+      uri,
+      schema = asch,
+      domain = list(soma_joinid = c(0, 99))
+    ))
+
+    tbl <- arrow::arrow_table(
+      soma_joinid = 1L:10L,
+      int_column = 1L:10L,
+      float_column = sqrt(1:10),
+      string_column = letters[1:10],
+      schema = asch)
     d2$write(tbl)
 
     # Check opening to read
@@ -26,9 +36,21 @@ test_that("DataFrame Factory with specified index_column_names", {
     # Check creation of a DF
     asch <- create_arrow_schema()
     expect_error(d2 <- SOMADataFrameCreate(uri, index_column_names = "int_column")) # misses schema
-    expect_silent(d2 <- SOMADataFrameCreate(uri, schema = asch, index_column_names = "int_column"))
-    tbl <- arrow::arrow_table(int_column = 1L:10L, soma_joinid = 1L:10L, float_column = sqrt(1:10),
-                              string_column = letters[1:10], schema = asch)
+
+    expect_silent(d2 <- SOMADataFrameCreate(
+      uri,
+      schema = asch,
+      index_column_names = "int_column",
+      domain = list(int_column = c(1, 10))
+    ))
+
+    tbl <- arrow::arrow_table(
+      int_column = 1L:10L,
+      soma_joinid = 1L:10L,
+      float_column = sqrt(1:10),
+      string_column = letters[1:10],
+      schema = asch)
+
     d2$write(tbl)
 
     # Check opening to read

--- a/apis/r/tests/testthat/test-OrderedAndFactor.R
+++ b/apis/r/tests/testthat/test-OrderedAndFactor.R
@@ -97,7 +97,7 @@ test_that("SOMADataFrame round-trip with factor and ordered", {
     expect_equal(names(lvls), colnames(et))
 
     #sdf <- SOMADataFrameCreate(uri, sch)
-    sdf <- SOMADataFrameCreate(uri, att$schema)
+    sdf <- SOMADataFrameCreate(uri, att$schema, domain = list(soma_joinid = c(0, 999)))
     expect_true(inherits(sdf, "SOMADataFrame"))
 
     sdf$write(att)

--- a/apis/r/tests/testthat/test-SOMACollection.R
+++ b/apis/r/tests/testthat/test-SOMACollection.R
@@ -43,7 +43,7 @@ test_that("SOMACollection basics", {
   subcollection$close()
 
   # Add another dataframe to the collection, this time using add_new_dataframe
-  collection$add_new_dataframe("new_df", create_arrow_schema(), "int_column")$close()
+  collection$add_new_dataframe("new_df", create_arrow_schema(), "int_column", domain = list(int_column = c(0, 999)))$close()
   df3 <- collection$get("new_df")
   df3 <- SOMADataFrameOpen(df3$uri)
   expect_true(df3$soma_type == "SOMADataFrame")
@@ -131,7 +131,7 @@ test_that("Platform config and context are respected by add_ methods", {
 
   # Add a dataframe element to the collection
   tbl <- create_arrow_table()
-  sdf1 <- collection$add_new_dataframe("sdf1", tbl$schema, "soma_joinid")
+  sdf1 <- collection$add_new_dataframe("sdf1", tbl$schema, "soma_joinid", domain = list(soma_joinid = c(0, 999)))
   sdf1$write(tbl)
   collection$close()
 
@@ -154,6 +154,7 @@ test_that("Platform config and context are respected by add_ methods", {
     key = "sdf2",
     schema = tbl$schema,
     index_column_names = "soma_joinid",
+    domain = list(soma_joinid = c(0, 999)),
     platform_config = cfg
   )
   sdf2$write(tbl)

--- a/apis/r/tests/testthat/test-Timestamps.R
+++ b/apis/r/tests/testthat/test-Timestamps.R
@@ -8,7 +8,7 @@ test_that("SOMADataFrame", {
 
     ## create at t = 1
     ts1 <- as.POSIXct(1, tz = "UTC", origin = "1970-01-01")
-    sdf <- tiledbsoma::SOMADataFrameCreate(uri, sch, tiledb_timestamp = ts1)
+    sdf <- tiledbsoma::SOMADataFrameCreate(uri, sch, tiledb_timestamp = ts1, domain = list(soma_joinid=c(0, 999)))
 
     ## write part1 at t = 2
     dat2 <- arrow::arrow_table(soma_joinid = bit64::as.integer64(1L:5L),

--- a/apis/r/tests/testthat/test-query-condition.R
+++ b/apis/r/tests/testthat/test-query-condition.R
@@ -34,7 +34,13 @@ test_that("DataFrame Factory", {
       # arrow::field("datetime_day", arrow::date32())
     )
 
-    sdf <- SOMADataFrameCreate(uri, sch, index_column_names = "soma_joinid")
+    sdf <- SOMADataFrameCreate(
+      uri,
+      sch,
+      index_column_names = "soma_joinid",
+      domain = list(soma_joinid = c(0, 999))
+    )
+
     expect_true(sdf$exists())
     expect_true(dir.exists(uri))
 

--- a/apis/r/tests/testthat/test-reopen.R
+++ b/apis/r/tests/testthat/test-reopen.R
@@ -171,7 +171,8 @@ test_that("`reopen()` works on nested collections", {
       soma_joinid = bit64::integer64(),
       int = integer()
     )),
-    index_column_names = "soma_joinid"
+    index_column_names = "soma_joinid",
+    domain = list(soma_joinid = c(0, 999))
   )
   expect_length(col$names(), 4L)
 

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -24,266 +24,237 @@ test_that("SOMADataFrame shape", {
   for (i in seq_along(index_column_name_choices)) {
     index_column_names <- index_column_name_choices[[i]]
 
-    for (use_domain_at_create in c(FALSE, TRUE)) {
+    uri <- withr::local_tempdir("soma-dataframe-shape")
 
-      uri <- withr::local_tempdir("soma-dataframe-shape")
+    # Create
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 
-      # Create
-      if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+    domain_for_create <- domain_at_create_choices[[i]]
 
-      domain_for_create <- NULL
-      if (use_domain_at_create) {
-        domain_for_create <- domain_at_create_choices[[i]]
-      }
+    sdf <- SOMADataFrameCreate(
+      uri,
+      asch,
+      index_column_names = index_column_names,
+      domain = domain_for_create)
 
-      sdf <- SOMADataFrameCreate(
-        uri,
-        asch,
-        index_column_names = index_column_names,
-        domain = domain_for_create)
+    expect_true(sdf$exists())
+    expect_true(dir.exists(uri))
 
-      expect_true(sdf$exists())
-      expect_true(dir.exists(uri))
+    # Write
+    tbl0 <- arrow::arrow_table(int_column = 1L:4L,
+                               soma_joinid = 1L:4L,
+                               float_column = 1.1:4.1,
+                               string_column = c("apple", "ball", "cat", "dog"),
+                               schema = asch)
 
-      # Write
-      tbl0 <- arrow::arrow_table(int_column = 1L:4L,
-                                 soma_joinid = 1L:4L,
-                                 float_column = 1.1:4.1,
-                                 string_column = c("apple", "ball", "cat", "dog"),
-                                 schema = asch)
+    sdf$write(tbl0)
+    sdf$close()
 
-      sdf$write(tbl0)
-      sdf$close()
+    sdf <- SOMADataFrameOpen(uri)
 
-      sdf <- SOMADataFrameOpen(uri)
-
-      # Check shape and maxshape et al.
-      if (!.new_shape_feature_flag_is_enabled()) {
-        expect_false(sdf$tiledbsoma_has_upgraded_domain())
-      } else {
-        expect_true(sdf$tiledbsoma_has_upgraded_domain())
-      }
-      expect_error(sdf$shape(), class = "notYetImplementedError")
-      expect_error(sdf$maxshape(), class = "notYetImplementedError")
-
-      # Not implemented this way per
-      # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
-      # sjid_shape <- sdf$.maybe_soma_joinid_shape()
-      # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
-      soma_context <- soma_context()
-      sjid_shape <- maybe_soma_joinid_shape(sdf$uri, soma_context)
-      sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, soma_context)
-
-      if ("soma_joinid" %in% index_column_names) {
-        # More testing to come on
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
-        expect_false(rlang::is_na(sjid_shape))
-        expect_false(rlang::is_na(sjid_maxshape))
-      } else {
-        expect_true(rlang::is_na(sjid_shape))
-        expect_true(rlang::is_na(sjid_maxshape))
-      }
-
-      # Check has_upgraded_domain
-      if (!.new_shape_feature_flag_is_enabled()) {
-        expect_false(sdf$tiledbsoma_has_upgraded_domain())
-      } else {
-        expect_true(sdf$tiledbsoma_has_upgraded_domain())
-      }
-
-      # Check domain and maxdomain
-      dom <- sdf$domain()
-      mxd <- sdf$maxdomain()
-
-      # First check names
-      expect_equal(names(dom), index_column_names)
-      expect_equal(names(mxd), index_column_names)
-
-      # Then check all slots are pairs
-      for (name in names(dom)) {
-        expect_length(dom[[name]], 2L)
-        expect_length(mxd[[name]], 2L)
-      }
-
-      # Then check contents
-
-      # Old shape/domainishes (without core current domain) for non-string dims:
-      # * There is no core current domain
-      # * Expect domain == maxdomain
-      # * If they asked for NULL: both should be huge (near min/max for datatype)
-      # * If they asked for something specific: they should get it
-      #
-      # New shape/domainishes (with core current domain) for non-string dims:
-      # * Maxdomain should be huge (near min/max for datatype)
-      # * If they asked for NULL: domain should be the same as maxdomain
-      # * If they asked for a specific domain: they should get it
-      #
-      # Old shape/domainishes (without core current domain) for string dims:
-      # * There is no core current domain
-      # * Expect domain == maxdomain
-      # * Core domain for strings is always ("", "")
-      #
-      # New shape/domainishes (with core current domain) for string dims:
-      # * Core domain (soma maxdomain) for strings is always ("", "")
-      # * Core current domain (soma domain) for strings:
-      #   o If they asked for NULL: expect ("", "")
-      #   o If they asked for something specific: they should get it
-
-      if ("soma_joinid" %in% index_column_names) {
-        sjid_dom <- dom[["soma_joinid"]]
-        sjid_mxd <- mxd[["soma_joinid"]]
-        sjid_dfc <- domain_for_create[["soma_joinid"]]
-
-        if (!.new_shape_feature_flag_is_enabled()) {
-          # Old behavior
-          expect_equal(sjid_dom, sjid_mxd)
-        }
-
-        if (!use_domain_at_create) {
-          expect_equal(sjid_dom[[1]], 0)
-          expect_equal(sjid_mxd[[1]], 0)
-          # This is a really big number in the ballpark of 2**63; its exact
-          # value is unimportant.
-          expect_true(sjid_dom[[2]] > bit64::as.integer64(10000000000))
-          expect_true(sjid_mxd[[2]] > bit64::as.integer64(10000000000))
-        } else {
-          # Not: expect_equal(sjid_dom, bit64::as.integer64(sjid_dfc)) The
-          # soma_joinid dim is always of type int64.  Everything coming back
-          # from libtiledbsoma, through C nanoarrow, through the R arrow
-          # package, to Arrow RecordBatch, holds true to that. But the final
-          # as.list() converts the domain to regular integer. This is a feature
-          # TBH: suppressable with `op <- options(arrow.int64_downcast =
-          # FALSE)`. The maxdomainis likely to be in the 2**63 range
-          # but the domain is likely to be ordinary-sized numbers in the
-          # thousands or millions. Users are likely to prefer these
-          # being downcast to regular R integers.
-          expect_equal(sjid_dom, sjid_dfc)
-        }
-      }
-
-      if ("int_column" %in% index_column_names) {
-        int_dom <- dom[["int_column"]]
-        int_mxd <- mxd[["int_column"]]
-        int_dfc <- domain_for_create[["int_column"]]
-
-        if (!.new_shape_feature_flag_is_enabled()) {
-          # Old behavior
-          expect_equal(int_dom, int_mxd)
-        }
-
-        if (!use_domain_at_create) {
-          expect_true(int_dom[[1]] < -2000000000)
-          expect_true(int_dom[[2]] > 2000000000)
-        } else {
-          expect_equal(int_dom, int_dfc)
-        }
-
-        if (!.new_shape_feature_flag_is_enabled()) {
-          if (!use_domain_at_create) {
-            expect_true(int_mxd[[1]] < -2000000000)
-            expect_true(int_mxd[[2]] > 2000000000)
-          } else {
-            expect_equal(int_mxd, int_dfc)
-          }
-        } else {
-          expect_true(int_mxd[[1]] < -2000000000)
-          expect_true(int_mxd[[2]] > 2000000000)
-        }
-      }
-
-      if ("string_column" %in% index_column_names) {
-        str_dom <- dom[["string_column"]]
-        str_mxd <- mxd[["string_column"]]
-        str_dfc <- domain_for_create[["string_column"]]
-
-        if (!.new_shape_feature_flag_is_enabled()) {
-          expect_equal(str_dom, c("", ""))
-          expect_equal(str_mxd, c("", ""))
-
-        } else {
-          if (!use_domain_at_create) {
-            expect_equal(str_dom, c("", ""))
-          } else {
-            if (is.null(str_dfc)) {
-              expect_equal(str_dom, c("", ""))
-            } else {
-              expect_equal(str_dom, str_dfc)
-            }
-          }
-          expect_equal(str_mxd, c("", ""))
-        }
-      }
-
-      sdf$close()
-
-      # Test resize for dataframes (more general upgrade_domain to be tested
-      # separately -- see https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
-      if (.new_shape_feature_flag_is_enabled() && use_domain_at_create) {
-        has_soma_joinid_dim <- "soma_joinid" %in% index_column_names
-        sjid_dfc <- domain_for_create[["soma_joinid"]]
-
-        # Test resize down
-        new_shape <- 0
-        sdf <- SOMADataFrameOpen(uri, "WRITE")
-        if (has_soma_joinid_dim) {
-          # It's an error to downsize
-          expect_error(sdf$resize_soma_joinid_shape(new_shape))
-        } else {
-          # There is no problem when soma_joinid is not a dim --
-          # sdf$resize_soma_joinid_shape is a no-op in that case
-          expect_no_condition(sdf$resize_soma_joinid_shape(new_shape))
-        }
-        sdf$close()
-
-        # Make sure the failed resize really didn't change the shape
-        if (has_soma_joinid_dim) {
-          sdf <- SOMADataFrameOpen(uri, "READ")
-          expect_equal(sdf$domain()[["soma_joinid"]], sjid_dfc)
-          sdf$close()
-        }
-
-        # Test writes out of bounds, before resize
-        old_shape <- 100
-        if (has_soma_joinid_dim) {
-          old_shape <- domain_for_create[["soma_joinid"]][[2]] + 1 + 100
-        }
-        new_shape <- old_shape + 100
-
-        tbl1 <- arrow::arrow_table(
-          int_column = 5L:8L,
-          soma_joinid = (old_shape+1L):(old_shape+4L),
-          float_column = 5.1:8.1,
-          string_column = c("egg", "flag", "geese", "hay"),
-          schema = asch)
-
-        sdf <- SOMADataFrameOpen(uri, "WRITE")
-        if (has_soma_joinid_dim) {
-          expect_error(sdf$write(tbl1))
-        } else {
-          expect_no_condition(sdf$write(tbl1))
-        }
-        sdf$close()
-
-        # Test resize
-        sdf <- SOMADataFrameOpen(uri, "WRITE")
-        sdf$resize_soma_joinid_shape(new_shape)
-        sdf$close();
-
-        # Test writes out of old bounds, within new bounds, after resize
-        sdf <- SOMADataFrameOpen(uri, "WRITE")
-        expect_no_condition(sdf$write(tbl1))
-        sdf$close();
-
-        # To do: test readback
-
-        rm(tbl1)
-      }
-
-      rm(sdf, tbl0)
-
-      gc()
+    # Check shape and maxshape et al.
+    if (!.new_shape_feature_flag_is_enabled()) {
+      expect_false(sdf$tiledbsoma_has_upgraded_domain())
+    } else {
+      expect_true(sdf$tiledbsoma_has_upgraded_domain())
     }
-  }
+    expect_error(sdf$shape(), class = "notYetImplementedError")
+    expect_error(sdf$maxshape(), class = "notYetImplementedError")
+
+    # Not implemented this way per
+    # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089
+    # sjid_shape <- sdf$.maybe_soma_joinid_shape()
+    # sjid_maxshape <- sdf$.maybe_soma_joinid_maxshape()
+    soma_context <- soma_context()
+    sjid_shape <- maybe_soma_joinid_shape(sdf$uri, soma_context)
+    sjid_maxshape <- maybe_soma_joinid_maxshape(sdf$uri, soma_context)
+
+    if ("soma_joinid" %in% index_column_names) {
+      # More testing to come on
+      # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
+      expect_false(rlang::is_na(sjid_shape))
+      expect_false(rlang::is_na(sjid_maxshape))
+    } else {
+      expect_true(rlang::is_na(sjid_shape))
+      expect_true(rlang::is_na(sjid_maxshape))
+    }
+
+    # Check has_upgraded_domain
+    if (!.new_shape_feature_flag_is_enabled()) {
+      expect_false(sdf$tiledbsoma_has_upgraded_domain())
+    } else {
+      expect_true(sdf$tiledbsoma_has_upgraded_domain())
+    }
+
+    # Check domain and maxdomain
+    dom <- sdf$domain()
+    mxd <- sdf$maxdomain()
+
+    # First check names
+    expect_equal(names(dom), index_column_names)
+    expect_equal(names(mxd), index_column_names)
+
+    # Then check all slots are pairs
+    for (name in names(dom)) {
+      expect_length(dom[[name]], 2L)
+      expect_length(mxd[[name]], 2L)
+    }
+
+    # Then check contents
+
+    # Old shape/domainishes (without core current domain) for non-string dims:
+    # * There is no core current domain
+    # * Expect domain == maxdomain
+    # * If they asked for NULL: both should be huge (near min/max for datatype)
+    # * If they asked for something specific: they should get it
+    #
+    # New shape/domainishes (with core current domain) for non-string dims:
+    # * Maxdomain should be huge (near min/max for datatype)
+    # * If they asked for NULL: domain should be the same as maxdomain
+    # * If they asked for a specific domain: they should get it
+    #
+    # Old shape/domainishes (without core current domain) for string dims:
+    # * There is no core current domain
+    # * Expect domain == maxdomain
+    # * Core domain for strings is always ("", "")
+    #
+    # New shape/domainishes (with core current domain) for string dims:
+    # * Core domain (soma maxdomain) for strings is always ("", "")
+    # * Core current domain (soma domain) for strings:
+    #   o If they asked for NULL: expect ("", "")
+    #   o If they asked for something specific: they should get it
+
+    if ("soma_joinid" %in% index_column_names) {
+      sjid_dom <- dom[["soma_joinid"]]
+      sjid_mxd <- mxd[["soma_joinid"]]
+      sjid_dfc <- domain_for_create[["soma_joinid"]]
+
+      if (!.new_shape_feature_flag_is_enabled()) {
+        # Old behavior
+        expect_equal(sjid_dom, sjid_mxd)
+      }
+
+      # Not: expect_equal(sjid_dom, bit64::as.integer64(sjid_dfc)) The
+      # soma_joinid dim is always of type int64.  Everything coming back
+      # from libtiledbsoma, through C nanoarrow, through the R arrow
+      # package, to Arrow RecordBatch, holds true to that. But the final
+      # as.list() converts the domain to regular integer. This is a feature
+      # TBH: suppressable with `op <- options(arrow.int64_downcast =
+      # FALSE)`. The maxdomainis likely to be in the 2**63 range
+      # but the domain is likely to be ordinary-sized numbers in the
+      # thousands or millions. Users are likely to prefer these
+      # being downcast to regular R integers.
+      expect_equal(sjid_dom, sjid_dfc)
+    }
+
+    if ("int_column" %in% index_column_names) {
+      int_dom <- dom[["int_column"]]
+      int_mxd <- mxd[["int_column"]]
+      int_dfc <- domain_for_create[["int_column"]]
+
+      if (!.new_shape_feature_flag_is_enabled()) {
+        # Old behavior
+        expect_equal(int_dom, int_mxd)
+      }
+
+      expect_equal(int_dom, int_dfc)
+
+      if (!.new_shape_feature_flag_is_enabled()) {
+        expect_equal(int_mxd, int_dfc)
+      } else {
+        expect_true(int_mxd[[1]] < -2000000000)
+        expect_true(int_mxd[[2]] > 2000000000)
+      }
+    }
+
+    if ("string_column" %in% index_column_names) {
+      str_dom <- dom[["string_column"]]
+      str_mxd <- mxd[["string_column"]]
+      str_dfc <- domain_for_create[["string_column"]]
+
+      if (!.new_shape_feature_flag_is_enabled()) {
+        expect_equal(str_dom, c("", ""))
+        expect_equal(str_mxd, c("", ""))
+
+      } else {
+        if (is.null(str_dfc)) {
+          expect_equal(str_dom, c("", ""))
+        } else {
+          expect_equal(str_dom, str_dfc)
+        }
+        expect_equal(str_mxd, c("", ""))
+      }
+    }
+
+    sdf$close()
+
+    # Test resize for dataframes (more general upgrade_domain to be tested
+    # separately -- see https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
+    if (.new_shape_feature_flag_is_enabled()) {
+      has_soma_joinid_dim <- "soma_joinid" %in% index_column_names
+      sjid_dfc <- domain_for_create[["soma_joinid"]]
+
+      # Test resize down
+      new_shape <- 0
+      sdf <- SOMADataFrameOpen(uri, "WRITE")
+      if (has_soma_joinid_dim) {
+        # It's an error to downsize
+        expect_error(sdf$resize_soma_joinid_shape(new_shape))
+      } else {
+        # There is no problem when soma_joinid is not a dim --
+        # sdf$resize_soma_joinid_shape is a no-op in that case
+        expect_no_condition(sdf$resize_soma_joinid_shape(new_shape))
+      }
+      sdf$close()
+
+      # Make sure the failed resize really didn't change the shape
+      if (has_soma_joinid_dim) {
+        sdf <- SOMADataFrameOpen(uri, "READ")
+        expect_equal(sdf$domain()[["soma_joinid"]], sjid_dfc)
+        sdf$close()
+      }
+
+      # Test writes out of bounds, before resize
+      old_shape <- 100
+      if (has_soma_joinid_dim) {
+        old_shape <- domain_for_create[["soma_joinid"]][[2]] + 1 + 100
+      }
+      new_shape <- old_shape + 100
+
+      tbl1 <- arrow::arrow_table(
+        int_column = 5L:8L,
+        soma_joinid = (old_shape+1L):(old_shape+4L),
+        float_column = 5.1:8.1,
+        string_column = c("egg", "flag", "geese", "hay"),
+        schema = asch)
+
+      sdf <- SOMADataFrameOpen(uri, "WRITE")
+      if (has_soma_joinid_dim) {
+        expect_error(sdf$write(tbl1))
+      } else {
+        expect_no_condition(sdf$write(tbl1))
+      }
+      sdf$close()
+
+      # Test resize
+      sdf <- SOMADataFrameOpen(uri, "WRITE")
+      sdf$resize_soma_joinid_shape(new_shape)
+      sdf$close();
+
+      # Test writes out of old bounds, within new bounds, after resize
+      sdf <- SOMADataFrameOpen(uri, "WRITE")
+      expect_no_condition(sdf$write(tbl1))
+      sdf$close();
+
+      # To do: test readback
+
+      rm(tbl1)
+    }
+
+    rm(sdf, tbl0)
+
+    gc()
+}
   
   # Test `domain` assertions
   uri <- tempfile()


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

In the design at #2407 we decided that `None` no longer means "as big a domain as possible" but now rather "as small as possible" -- as only upward resizes, not downward resizes, are possible. This is a breaking change we have already agreed on.

This is the R counterpart to the Python PRs #3190 #3191 #3192 #3193 #3194 #3203. I didn't split this one up into multiple PRs as I did those. However, the mods are the same:

* Have unit-test cases always provide `domain` at `create`
* Apply the policy that `domain` being `NULL` overall or slotwise makes smallest-possible rather than largest-possible.

**Notes for Reviewer:**
