### PR TITLE
[c++] `can_upgrade_domain`

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1448,7 +1448,7 @@ std::vector<int64_t> SOMAArray::maxshape() {
 
 // This is a helper for can_upgrade_shape and can_resize, which have
 // much overlap.
-std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
+StatusAndReason SOMAArray::_can_set_shape_helper(
     const std::vector<int64_t>& newshape,
     bool is_resize,
     std::string function_name_for_messages) {
@@ -1525,7 +1525,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
 // This is a helper for _can_set_shape_helper: it's used for comparing
 // the user's requested shape against the core current domain or core (max)
 // domain.
-std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
+StatusAndReason SOMAArray::_can_set_shape_domainish_subhelper(
     const std::vector<int64_t>& newshape,
     bool check_current_domain,
     std::string function_name_for_messages) {
@@ -1585,7 +1585,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_domainish_subhelper(
     return std::pair(true, "");
 }
 
-std::pair<bool, std::string> SOMAArray::_can_set_soma_joinid_shape_helper(
+StatusAndReason SOMAArray::_can_set_soma_joinid_shape_helper(
     int64_t newshape, bool is_resize, std::string function_name_for_messages) {
     // Fail if the array doesn't already have a shape yet (they should upgrade
     // first).
@@ -1882,7 +1882,7 @@ void SOMAArray::_set_soma_joinid_shape_helper(
     schema_evolution.array_evolve(uri_);
 }
 
-std::pair<bool, std::string> SOMAArray::can_upgrade_domain(
+StatusAndReason SOMAArray::can_upgrade_domain(
     const ArrowTable& newdomain, std::string function_name_for_messages) {
     // Enforce the semantics that tiledbsoma_upgrade_domain must be called
     // only on arrays that don't have a shape set, and resize must be called
@@ -1927,7 +1927,7 @@ std::pair<bool, std::string> SOMAArray::can_upgrade_domain(
 // This is a helper for can_upgrade_domain: it's used for comparing
 // the user's requested soma domain against the core current domain or core
 // (max) domain.
-std::pair<bool, std::string> SOMAArray::_can_set_dataframe_domainish_subhelper(
+StatusAndReason SOMAArray::_can_set_dataframe_domainish_subhelper(
     const ArrowTable& newdomain,
     bool check_current_domain,
     std::string function_name_for_messages) {
@@ -1957,7 +1957,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_dataframe_domainish_subhelper(
     for (unsigned i = 0; i < domain.ndim(); i++) {
         const auto& dim = domain.dimension(i);
 
-        std::pair<bool, std::string> status_and_reason;
+        StatusAndReason status_and_reason;
 
         switch (dim.type()) {
             case TILEDB_STRING_ASCII:

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1446,7 +1446,7 @@ std::vector<int64_t> SOMAArray::maxshape() {
     return _tiledb_domain();
 }
 
-// This is a helper for can_upgrade_domain and can_resize, which have
+// This is a helper for can_upgrade_shape and can_resize, which have
 // much overlap.
 std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
     const std::vector<int64_t>& newshape,
@@ -1466,7 +1466,7 @@ std::pair<bool, std::string> SOMAArray::_can_set_shape_helper(
                 array_ndim));
     }
 
-    // Enforce the semantics that tiledbsoma_upgrade_domain must be called
+    // Enforce the semantics that tiledbsoma_upgrade_shape must be called
     // only on arrays that don't have a shape set, and resize must be called
     // only on arrays that do.
     bool has_shape = has_current_domain();
@@ -1880,6 +1880,189 @@ void SOMAArray::_set_soma_joinid_shape_helper(
 
     schema_evolution.expand_current_domain(new_current_domain);
     schema_evolution.array_evolve(uri_);
+}
+
+std::pair<bool, std::string> SOMAArray::can_upgrade_domain(
+    const ArrowTable& newdomain, std::string function_name_for_messages) {
+    // Enforce the semantics that tiledbsoma_upgrade_domain must be called
+    // only on arrays that don't have a shape set, and resize must be called
+    // only on arrays that do.
+    if (has_current_domain()) {
+        return std::pair(
+            false,
+            fmt::format(
+                "{}: dataframe already has a domain",
+                function_name_for_messages));
+    }
+
+    // * For old-style dataframe without shape: core domain (soma maxdomain) may
+    //   be small (like 100) or big (like 2 billionish).
+    // * For new-style dataframe with shape: core current domain (soma domain)
+    //   will probably be small and core domain (soma maxdomain) will be huge.
+    //
+    // In either case, we need to check that the user's requested soma domain
+    // isn't outside the core domain, which is immutable. For old-style
+    // dataframes, if the requested domain fits in the array's core domain, it's
+    // good to go as a new soma domain.
+    auto domain_check = _can_set_dataframe_domainish_subhelper(
+        newdomain, false, function_name_for_messages);
+    if (!domain_check.first) {
+        return domain_check;
+    }
+
+    // For new-style dataframes, we need to additionally that the the requested
+    // soma domain (core current domain) isn't a downsize of the current
+    // one.
+    if (has_current_domain()) {
+        auto current_domain_check = _can_set_dataframe_domainish_subhelper(
+            newdomain, true, function_name_for_messages);
+        if (!current_domain_check.first) {
+            return current_domain_check;
+        }
+    }
+
+    return std::pair(true, "");
+}
+
+// This is a helper for can_upgrade_domain: it's used for comparing
+// the user's requested soma domain against the core current domain or core
+// (max) domain.
+std::pair<bool, std::string> SOMAArray::_can_set_dataframe_domainish_subhelper(
+    const ArrowTable& newdomain,
+    bool check_current_domain,
+    std::string function_name_for_messages) {
+    Domain domain = arr_->schema().domain();
+
+    ArrowArray* new_domain_array = newdomain.first.get();
+    ArrowSchema* new_domain_schema = newdomain.second.get();
+
+    if (new_domain_schema->n_children != domain.ndim()) {
+        return std::pair(
+            false,
+            fmt::format(
+                "{}: requested domain has ndim={} but the dataframe has "
+                "ndim={}",
+                function_name_for_messages,
+                new_domain_schema->n_children,
+                domain.ndim()));
+    }
+
+    if (new_domain_schema->n_children != new_domain_array->n_children) {
+        return std::pair(
+            false,
+            fmt::format(
+                "{}: internal coding error", function_name_for_messages));
+    }
+
+    for (unsigned i = 0; i < domain.ndim(); i++) {
+        const auto& dim = domain.dimension(i);
+
+        std::pair<bool, std::string> status_and_reason;
+
+        switch (dim.type()) {
+            case TILEDB_STRING_ASCII:
+            case TILEDB_STRING_UTF8:
+            case TILEDB_CHAR:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_string(
+                        check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_BOOL:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<bool>(
+                        check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_INT8:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        int8_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_UINT8:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        uint8_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_INT16:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        int16_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_UINT16:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        uint16_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_INT32:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        int32_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_UINT32:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        uint32_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_INT64:
+            case TILEDB_DATETIME_YEAR:
+            case TILEDB_DATETIME_MONTH:
+            case TILEDB_DATETIME_WEEK:
+            case TILEDB_DATETIME_DAY:
+            case TILEDB_DATETIME_HR:
+            case TILEDB_DATETIME_MIN:
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+            case TILEDB_DATETIME_PS:
+            case TILEDB_DATETIME_FS:
+            case TILEDB_DATETIME_AS:
+            case TILEDB_TIME_HR:
+            case TILEDB_TIME_MIN:
+            case TILEDB_TIME_SEC:
+            case TILEDB_TIME_MS:
+            case TILEDB_TIME_US:
+            case TILEDB_TIME_NS:
+            case TILEDB_TIME_PS:
+            case TILEDB_TIME_FS:
+            case TILEDB_TIME_AS:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        int64_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_UINT64:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        uint64_t>(check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_FLOAT32:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<float>(
+                        check_current_domain, newdomain, dim.name());
+                break;
+            case TILEDB_FLOAT64:
+                status_and_reason =
+                    _can_set_dataframe_domainish_slot_checker_non_string<
+                        double>(check_current_domain, newdomain, dim.name());
+                break;
+            default:
+                throw TileDBSOMAError(fmt::format(
+                    "{}: saw invalid TileDB type when attempting to cast "
+                    "domain information: {}",
+                    function_name_for_messages,
+                    tiledb::impl::type_to_str(dim.type())));
+        }
+
+        if (status_and_reason.first == false) {
+            return std::pair(
+                false,
+                fmt::format(
+                    "{} for {}: {}",
+                    function_name_for_messages,
+                    dim.name(),
+                    status_and_reason.second));
+        }
+    }
+    return std::pair(true, "");
 }
 
 std::vector<int64_t> SOMAArray::_tiledb_current_domain() {

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -86,6 +86,8 @@
 namespace tiledbsoma {
 using namespace tiledb;
 
+using StatusAndReason = std::pair<bool, std::string>;
+
 // This enables some code deduplication between core domain, core current
 // domain, and core non-empty domain.
 enum class Domainish {
@@ -1144,7 +1146,7 @@ class SOMAArray : public SOMAObject {
      * upgrade_shape), or the requested shape doesn't fit within the array's
      * existing core domain.
      */
-    std::pair<bool, std::string> can_resize(
+    StatusAndReason can_resize(
         const std::vector<int64_t>& newshape,
         std::string function_name_for_messages) {
         return _can_set_shape_helper(
@@ -1168,7 +1170,7 @@ class SOMAArray : public SOMAObject {
      * the requested shape is a downsize of the array's existing core current
      * domain.
      */
-    std::pair<bool, std::string> can_upgrade_shape(
+    StatusAndReason can_upgrade_shape(
         const std::vector<int64_t>& newshape,
         std::string function_name_for_messages) {
         return _can_set_shape_helper(
@@ -1179,7 +1181,7 @@ class SOMAArray : public SOMAObject {
      * This is similar to can_upgrade_shape, but it's a can-we call
      * for resize_soma_joinid_shape.
      */
-    std::pair<bool, std::string> can_resize_soma_joinid_shape(
+    StatusAndReason can_resize_soma_joinid_shape(
         int64_t newshape, std::string function_name_for_messages) {
         return _can_set_soma_joinid_shape_helper(
             newshape, true, function_name_for_messages);
@@ -1189,7 +1191,7 @@ class SOMAArray : public SOMAObject {
      * This is similar to can_upgrade_shape, but it's a can-we call
      * for upgrade_soma_joinid_shape.
      */
-    std::pair<bool, std::string> can_upgrade_soma_joinid_shape(
+    StatusAndReason can_upgrade_soma_joinid_shape(
         int64_t newshape, std::string function_name_for_messages) {
         return _can_set_soma_joinid_shape_helper(
             newshape, false, function_name_for_messages);
@@ -1198,7 +1200,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is for SOMADataFrame.
      */
-    std::pair<bool, std::string> can_upgrade_domain(
+    StatusAndReason can_upgrade_domain(
         const ArrowTable& newdomain, std::string function_name_for_messages);
 
     /**
@@ -1332,7 +1334,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a code-dedupe helper for can_resize and can_upgrade_shape.
      */
-    std::pair<bool, std::string> _can_set_shape_helper(
+    StatusAndReason _can_set_shape_helper(
         const std::vector<int64_t>& newshape,
         bool is_resize,
         std::string function_name_for_messages);
@@ -1340,7 +1342,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a second-level code-dedupe helper for _can_set_shape_helper.
      */
-    std::pair<bool, std::string> _can_set_shape_domainish_subhelper(
+    StatusAndReason _can_set_shape_domainish_subhelper(
         const std::vector<int64_t>& newshape,
         bool check_current_domain,
         std::string function_name_for_messages);
@@ -1348,7 +1350,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a code-dedupe helper for can_upgrade_domain.
      */
-    std::pair<bool, std::string> _can_set_dataframe_domainish_subhelper(
+    StatusAndReason _can_set_dataframe_domainish_subhelper(
         const ArrowTable& newdomain,
         bool check_current_domain,
         std::string function_name_for_messages);
@@ -1357,7 +1359,7 @@ class SOMAArray : public SOMAObject {
      * This is a code-dedupe helper for can_resize_soma_joinid_shape and
      * can_upgrade_domain_soma_joinid_shape.
      */
-    std::pair<bool, std::string> _can_set_soma_joinid_shape_helper(
+    StatusAndReason _can_set_soma_joinid_shape_helper(
         int64_t newshape,
         bool is_resize,
         std::string function_name_for_messages);
@@ -1383,8 +1385,7 @@ class SOMAArray : public SOMAObject {
      * This is a helper for can_upgrade_domain.
      */
     template <typename T>
-    std::pair<bool, std::string>
-    _can_set_dataframe_domainish_slot_checker_non_string(
+    StatusAndReason _can_set_dataframe_domainish_slot_checker_non_string(
         bool check_current_domain,
         const ArrowTable& domain_table,
         std::string dim_name) {
@@ -1428,8 +1429,7 @@ class SOMAArray : public SOMAObject {
     /**
      * This is a helper for can_upgrade_domain.
      */
-    std::pair<bool, std::string>
-    _can_set_dataframe_domainish_slot_checker_string(
+    StatusAndReason _can_set_dataframe_domainish_slot_checker_string(
         bool check_current_domain,
         const ArrowTable& domain_table,
         std::string dim_name) {

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -42,8 +42,6 @@ namespace helper {
 //   array-creation error.)
 const int CORE_DOMAIN_MAX = 2147483646;
 
-static std::unique_ptr<ArrowSchema> _create_index_cols_info_schema(
-    const std::vector<DimInfo>& dim_infos);
 static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
     const std::vector<DimInfo>& dim_infos);
 
@@ -112,7 +110,7 @@ create_arrow_schema_and_index_columns(
     auto arrow_schema = ArrowAdapter::make_arrow_schema(
         names, tiledb_datatypes);
 
-    auto index_cols_info_schema = _create_index_cols_info_schema(dim_infos);
+    auto index_cols_info_schema = create_index_cols_info_schema(dim_infos);
     auto index_cols_info_array = _create_index_cols_info_array(dim_infos);
 
     return std::pair(
@@ -133,14 +131,14 @@ ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
             info.use_current_domain));
     }
 
-    auto index_cols_info_schema = _create_index_cols_info_schema(dim_infos);
+    auto index_cols_info_schema = create_index_cols_info_schema(dim_infos);
     auto index_cols_info_array = _create_index_cols_info_array(dim_infos);
 
     return ArrowTable(
         std::move(index_cols_info_array), std::move(index_cols_info_schema));
 }
 
-static std::unique_ptr<ArrowSchema> _create_index_cols_info_schema(
+std::unique_ptr<ArrowSchema> create_index_cols_info_schema(
     const std::vector<DimInfo>& dim_infos) {
     auto ndim = dim_infos.size();
 

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -90,5 +90,8 @@ std::string to_arrow_format(tiledb_datatype_t tiledb_datatype);
 // Core PR: https://github.com/TileDB-Inc/TileDB/pull/5303
 bool have_dense_current_domain_support();
 
+std::unique_ptr<ArrowSchema> create_index_cols_info_schema(
+    const std::vector<DimInfo>& dim_infos);
+
 }  // namespace helper
 #endif

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -601,8 +601,9 @@ TEST_CASE_METHOD(
         write_sjid_u32_str_data_from(8);
         REQUIRE(sdf->nnz() == 4);
 
-        // Check can_upgrade_soma_joinid_shape
         sdf->open(OpenMode::read);
+
+        // Check can_upgrade_soma_joinid_shape
         if (!use_current_domain) {
             std::pair<bool, std::string>
                 check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
@@ -617,6 +618,35 @@ TEST_CASE_METHOD(
                 check.second ==
                 "testing: dataframe already has its domain set.");
         }
+
+        // Check can_upgrade_domain
+        std::unique_ptr<ArrowSchema>
+            domain_schema = create_index_cols_info_schema(dim_infos);
+        auto domain_array = ArrowAdapter::make_arrow_array_parent(
+            dim_infos.size());
+        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+            std::vector<int64_t>({0, 0}));
+        auto domain_table = ArrowTable(
+            std::move(domain_array), std::move(domain_schema));
+
+        if (!use_current_domain) {
+            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+                domain_table, "testing");
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing for soma_joinid: new upper < old upper (downsize is "
+                "unsupported)");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
+
         sdf->close();
 
         // Resize
@@ -849,6 +879,53 @@ TEST_CASE_METHOD(
         actual = sdf->maybe_soma_joinid_shape();
         REQUIRE(actual.has_value());
         REQUIRE(actual.value() == expect);
+
+        // Check can_upgrade_soma_joinid_shape
+        if (!use_current_domain) {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            REQUIRE(check.first == true);
+            REQUIRE(check.second == "");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
+
+        // Check can_upgrade_domain
+        std::unique_ptr<ArrowSchema>
+            domain_schema = create_index_cols_info_schema(dim_infos);
+        auto domain_array = ArrowAdapter::make_arrow_array_parent(
+            dim_infos.size());
+        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+            std::vector<uint32_t>({0, 0}));
+        domain_array->children[1] = ArrowAdapter::make_arrow_array_child(
+            std::vector<int64_t>({0, 0}));
+        auto domain_table = ArrowTable(
+            std::move(domain_array), std::move(domain_schema));
+
+        if (!use_current_domain) {
+            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+                domain_table, "testing");
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing for myuint32: new upper < old upper (downsize is "
+                "unsupported)");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
+
         sdf->close();
 
         // Resize
@@ -1101,6 +1178,37 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
+        // Check can_upgrade_domain
+        sdf = open(OpenMode::read);
+        std::unique_ptr<ArrowSchema>
+            domain_schema = create_index_cols_info_schema(dim_infos);
+        auto domain_array = ArrowAdapter::make_arrow_array_parent(
+            dim_infos.size());
+        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+            std::vector<int64_t>({0, 0}));
+        domain_array->children[1] = ArrowAdapter::make_arrow_array_child_string(
+            std::vector<std::string>({"a", "z"}));
+        auto domain_table = ArrowTable(
+            std::move(domain_array), std::move(domain_schema));
+        if (!use_current_domain) {
+            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+                domain_table, "testing");
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing for soma_joinid: new upper < old upper (downsize is "
+                "unsupported)");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
+        sdf->close();
+
         // Resize
         auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
 
@@ -1330,6 +1438,37 @@ TEST_CASE_METHOD(
         sdf = open(OpenMode::read);
         actual = sdf->maybe_soma_joinid_shape();
         REQUIRE(!actual.has_value());
+        sdf->close();
+
+        // Check can_upgrade_domain
+        sdf = open(OpenMode::read);
+        std::unique_ptr<ArrowSchema>
+            domain_schema = create_index_cols_info_schema(dim_infos);
+        auto domain_array = ArrowAdapter::make_arrow_array_parent(
+            dim_infos.size());
+        domain_array->children[0] = ArrowAdapter::make_arrow_array_child_string(
+            std::vector<std::string>({"a", "z"}));
+        domain_array->children[1] = ArrowAdapter::make_arrow_array_child(
+            std::vector<uint32_t>({0, 0}));
+        auto domain_table = ArrowTable(
+            std::move(domain_array), std::move(domain_schema));
+        if (!use_current_domain) {
+            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+                domain_table, "testing");
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing for mystring: new lower > old lower (downsize is "
+                "unsupported)");
+        } else {
+            std::pair<bool, std::string>
+                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            // Must fail since this is too small.
+            REQUIRE(check.first == false);
+            REQUIRE(
+                check.second ==
+                "testing: dataframe already has its domain set.");
+        }
         sdf->close();
 
         // Resize

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -618,8 +618,10 @@ TEST_CASE_METHOD(
                 check.second ==
                 "testing: dataframe already has its domain set.");
         }
+        sdf->close();
 
         // Check can_upgrade_domain
+        sdf->open(OpenMode::read);
         std::unique_ptr<ArrowSchema>
             domain_schema = create_index_cols_info_schema(dim_infos);
         auto domain_array = ArrowAdapter::make_arrow_array_parent(
@@ -628,7 +630,6 @@ TEST_CASE_METHOD(
             std::vector<int64_t>({0, 0}));
         auto domain_table = ArrowTable(
             std::move(domain_array), std::move(domain_schema));
-
         if (!use_current_domain) {
             std::pair<bool, std::string> check = sdf->can_upgrade_domain(
                 domain_table, "testing");
@@ -646,7 +647,6 @@ TEST_CASE_METHOD(
                 check.second ==
                 "testing: dataframe already has its domain set.");
         }
-
         sdf->close();
 
         // Resize
@@ -764,6 +764,22 @@ TEST_CASE_METHOD(
             REQUIRE(check.second == "");
         }
 
+        sdf->close();
+
+        // Check can_upgrade_domain
+        sdf->open(OpenMode::read);
+        domain_schema = create_index_cols_info_schema(dim_infos);
+        domain_array = ArrowAdapter::make_arrow_array_parent(dim_infos.size());
+        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+            std::vector<int64_t>({0, 0}));
+        domain_table = ArrowTable(
+            std::move(domain_array), std::move(domain_schema));
+        // The dataframe now has a shape
+        check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+        // Must fail since this is too small.
+        REQUIRE(check.first == false);
+        REQUIRE(
+            check.second == "testing: dataframe already has its domain set.");
         sdf->close();
     }
 }

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -605,13 +605,13 @@ TEST_CASE_METHOD(
 
         // Check can_upgrade_soma_joinid_shape
         if (!use_current_domain) {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -631,7 +631,7 @@ TEST_CASE_METHOD(
         auto domain_table = ArrowTable(
             std::move(domain_array), std::move(domain_schema));
         if (!use_current_domain) {
-            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+            StatusAndReason check = sdf->can_upgrade_domain(
                 domain_table, "testing");
             REQUIRE(check.first == false);
             REQUIRE(
@@ -639,8 +639,8 @@ TEST_CASE_METHOD(
                 "testing for soma_joinid: new upper < old upper (downsize is "
                 "unsupported)");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -729,8 +729,7 @@ TEST_CASE_METHOD(
         }
 
         // Check can_resize_soma_joinid_shape
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1, "testing");
+        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
@@ -898,13 +897,13 @@ TEST_CASE_METHOD(
 
         // Check can_upgrade_soma_joinid_shape
         if (!use_current_domain) {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             REQUIRE(check.first == true);
             REQUIRE(check.second == "");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -925,7 +924,7 @@ TEST_CASE_METHOD(
             std::move(domain_array), std::move(domain_schema));
 
         if (!use_current_domain) {
-            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+            StatusAndReason check = sdf->can_upgrade_domain(
                 domain_table, "testing");
             REQUIRE(check.first == false);
             REQUIRE(
@@ -933,8 +932,8 @@ TEST_CASE_METHOD(
                 "testing for myuint32: new upper < old upper (downsize is "
                 "unsupported)");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1039,8 +1038,7 @@ TEST_CASE_METHOD(
         }
 
         // Check can_resize_soma_joinid_shape
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1, "testing");
+        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1207,7 +1205,7 @@ TEST_CASE_METHOD(
         auto domain_table = ArrowTable(
             std::move(domain_array), std::move(domain_schema));
         if (!use_current_domain) {
-            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+            StatusAndReason check = sdf->can_upgrade_domain(
                 domain_table, "testing");
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1215,8 +1213,8 @@ TEST_CASE_METHOD(
                 "testing for soma_joinid: new upper < old upper (downsize is "
                 "unsupported)");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1318,8 +1316,7 @@ TEST_CASE_METHOD(
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));
 
         // Check can_resize_soma_joinid_shape
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            1, "testing");
+        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1469,7 +1466,7 @@ TEST_CASE_METHOD(
         auto domain_table = ArrowTable(
             std::move(domain_array), std::move(domain_schema));
         if (!use_current_domain) {
-            std::pair<bool, std::string> check = sdf->can_upgrade_domain(
+            StatusAndReason check = sdf->can_upgrade_domain(
                 domain_table, "testing");
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1477,8 +1474,8 @@ TEST_CASE_METHOD(
                 "testing for mystring: new lower > old lower (downsize is "
                 "unsupported)");
         } else {
-            std::pair<bool, std::string>
-                check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
+            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
@@ -1560,8 +1557,7 @@ TEST_CASE_METHOD(
         }
 
         // Check can_resize_soma_joinid_shape
-        std::pair<bool, std::string> check = sdf->can_resize_soma_joinid_shape(
-            0, "testing");
+        StatusAndReason check = sdf->can_resize_soma_joinid_shape(0, "testing");
         if (!use_current_domain) {
             REQUIRE(check.first == false);
             REQUIRE(


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

* This is `can_upgrade_domain` for `SOMADataFrame` at the C++ level

**Notes for Reviewer:**