### PR TITLE
[c++] Geometry Dataframe

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud_dataframe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_context.cc
@@ -188,6 +189,7 @@ endif()
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_experiment.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_measurement.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_scene.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_geometry_dataframe.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_point_cloud_dataframe.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_multiscale_image.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_object.h
@@ -211,6 +213,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_scene.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_dataframe.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_point_cloud_dataframe.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_multiscale_image.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.h

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -1,0 +1,125 @@
+/**
+ * @file   soma_geometry_dataframe.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryDataFrame class.
+ */
+
+#include "soma_geometry_dataframe.h"
+#include "../utils/util.h"
+
+#include <regex>
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+//===================================================================
+//= public static
+//===================================================================
+
+void SOMAGeometryDataFrame::create(
+    std::string_view uri,
+    std::unique_ptr<ArrowSchema> schema,
+    ArrowTable index_columns,
+    ArrowTable spatial_columns,
+    std::shared_ptr<SOMAContext> ctx,
+    PlatformConfig platform_config,
+    std::optional<TimestampRange> timestamp) {
+    std::vector<std::string> spatial_axes;
+    auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
+        ctx->tiledb_ctx(),
+        std::move(schema),
+        ArrowTable(
+            std::move(index_columns.first), std::move(index_columns.second)),
+        "SOMAGeometryDataFrame",
+        true,
+        platform_config,
+        ArrowTable(
+            std::move(spatial_columns.first),
+            std::move(spatial_columns.second)));
+    auto array = SOMAArray::create(
+        ctx, uri, tiledb_schema, "SOMAGeometryDataFrame", timestamp);
+}
+
+std::unique_ptr<SOMAGeometryDataFrame> SOMAGeometryDataFrame::open(
+    std::string_view uri,
+    OpenMode mode,
+    std::shared_ptr<SOMAContext> ctx,
+    std::vector<std::string> column_names,
+    ResultOrder result_order,
+    std::optional<TimestampRange> timestamp) {
+    return std::make_unique<SOMAGeometryDataFrame>(
+        mode, uri, ctx, column_names, result_order, timestamp);
+}
+
+bool SOMAGeometryDataFrame::exists(
+    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+    try {
+        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
+        return "SOMAGeometryDataFrame" == obj->type();
+    } catch (TileDBSOMAError& e) {
+        return false;
+    }
+}
+
+//===================================================================
+//= public non-static
+//===================================================================
+
+std::unique_ptr<ArrowSchema> SOMAGeometryDataFrame::schema() const {
+    return this->arrow_schema();
+}
+
+const std::vector<std::string> SOMAGeometryDataFrame::index_column_names()
+    const {
+    return this->dimension_names();
+}
+
+const std::vector<std::string> SOMAGeometryDataFrame::spatial_column_names()
+    const {
+    std::vector<std::string> names;
+    std::unordered_set<std::string> unique_names;
+    std::regex rgx("tiledb__internal__(\\S+)__");
+    std::smatch matches;
+    for (auto dimension : this->dimension_names()) {
+        if (std::regex_search(dimension, matches, rgx)) {
+            if (unique_names.count(matches[1].str()) == 0) {
+                unique_names.insert(matches[1].str());
+                names.push_back(matches[1].str());
+            }
+        }
+    }
+
+    return names;
+}
+
+uint64_t SOMAGeometryDataFrame::count() {
+    return this->nnz();
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -44,24 +44,21 @@ using namespace tiledb;
 
 void SOMAGeometryDataFrame::create(
     std::string_view uri,
-    std::unique_ptr<ArrowSchema> schema,
-    ArrowTable index_columns,
-    ArrowTable spatial_columns,
+    const std::unique_ptr<ArrowSchema>& schema,
+    const ArrowTable& index_columns,
+    const ArrowTable& spatial_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
     std::vector<std::string> spatial_axes;
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
+        schema,
+        index_columns,
         "SOMAGeometryDataFrame",
         true,
         platform_config,
-        ArrowTable(
-            std::move(spatial_columns.first),
-            std::move(spatial_columns.second)));
+        spatial_columns);
     auto array = SOMAArray::create(
         ctx, uri, tiledb_schema, "SOMAGeometryDataFrame", timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -1,0 +1,179 @@
+/**
+ * @file   soma_geometry_dataframe.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryDataFrame class.
+ */
+
+#ifndef SOMA_GEOMETRY_DATAFRAME
+#define SOMA_GEOMETRY_DATAFRAME
+
+#include <filesystem>
+
+#include "soma_array.h"
+
+namespace tiledbsoma {
+
+class ArrayBuffers;
+
+using namespace tiledb;
+
+class SOMAGeometryDataFrame : virtual public SOMAArray {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    /**
+     * @brief Create a SOMAGeometryDataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param schema Arrow schema
+     * @param index_columns The index column names with associated domains
+     * and tile extents per dimension
+     * @param spatial_columns The spatial column names with associated domains
+     * and tile extents per dimension
+     * @param ctx SOMAContext
+     * @param platform_config Optional config parameter dictionary
+     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     */
+    static void create(
+        std::string_view uri,
+        std::unique_ptr<ArrowSchema> schema,
+        ArrowTable index_columns,
+        ArrowTable spatial_columns,
+        std::shared_ptr<SOMAContext> ctx,
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Open and return a SOMAGeometryDataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param mode read or write
+     * @param ctx SOMAContext
+     * @param column_names A list of column names to use as user-defined index
+     * columns (e.g., ``['cell_type', 'tissue_type']``). All named columns must
+     * exist in the schema, and at least one index column name is required.
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
+     * @param timestamp If specified, overrides the default timestamp used to
+     * open this object. If unset, uses the timestamp provided by the context.
+     * @return std::unique_ptr<SOMAGeometryDataFrame> SOMAGeometryDataFrame
+     */
+    static std::unique_ptr<SOMAGeometryDataFrame> open(
+        std::string_view uri,
+        OpenMode mode,
+        std::shared_ptr<SOMAContext> ctx,
+        std::vector<std::string> column_names = {},
+        ResultOrder result_order = ResultOrder::automatic,
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Check if the SOMAGeometryDataFrame exists at the URI.
+     *
+     * @param uri URI to create the SOMAGeometryDataFrame
+     * @param ctx SOMAContext
+     */
+    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    /**
+     * @brief Construct a new SOMAGeometryDataFrame object.
+     *
+     * @param mode read or write
+     * @param uri URI of the array
+     * @param ctx TileDB context
+     * @param column_names Columns to read
+     * @param result_order Read result order: automatic (default), rowmajor, or
+     * colmajor
+     * @param timestamp Timestamp
+     */
+    SOMAGeometryDataFrame(
+        OpenMode mode,
+        std::string_view uri,
+        std::shared_ptr<SOMAContext> ctx,
+        std::vector<std::string> column_names,
+        ResultOrder result_order,
+        std::optional<TimestampRange> timestamp = std::nullopt)
+        : SOMAArray(
+              mode,
+              uri,
+              ctx,
+              std::filesystem::path(uri).filename().string(),  // array name
+              column_names,
+              "auto",  // batch_size
+              result_order,
+              timestamp) {
+    }
+
+    SOMAGeometryDataFrame(const SOMAArray& other)
+        : SOMAArray(other) {
+    }
+
+    SOMAGeometryDataFrame() = delete;
+    SOMAGeometryDataFrame(const SOMAGeometryDataFrame&) = default;
+    SOMAGeometryDataFrame(SOMAGeometryDataFrame&&) = delete;
+    ~SOMAGeometryDataFrame() = default;
+
+    using SOMAArray::open;
+
+    /**
+     * Return the data schema, in the form of a ArrowSchema.
+     *
+     * @return std::unique_ptr<ArrowSchema>
+     */
+    std::unique_ptr<ArrowSchema> schema() const;
+
+    /**
+     * Return the index (dimension) column names.
+     *
+     * @return std::vector<std::string>
+     */
+    const std::vector<std::string> index_column_names() const;
+
+    /**
+     * Return the spatial column names.
+     *
+     * @return std::vector<std::string>
+     */
+    const std::vector<std::string> spatial_column_names() const;
+
+    /**
+     * Return the number of rows.
+     *
+     * @return int64_t
+     */
+    uint64_t count();
+};
+}  // namespace tiledbsoma
+
+#endif  // SOMA_GEOMETRY_DATAFRAME

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -64,9 +64,9 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
      */
     static void create(
         std::string_view uri,
-        std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns,
-        ArrowTable spatial_columns,
+        const std::unique_ptr<ArrowSchema>& schema,
+        const ArrowTable& index_columns,
+        const ArrowTable& spatial_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -7,6 +7,7 @@
 #include "soma_dataframe.h"
 #include "soma_dense_ndarray.h"
 #include "soma_experiment.h"
+#include "soma_geometry_dataframe.h"
 #include "soma_measurement.h"
 #include "soma_multiscale_image.h"
 #include "soma_point_cloud_dataframe.h"
@@ -61,8 +62,7 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
         } else if (array_type == "somapointclouddataframe") {
             return std::make_unique<SOMAPointCloudDataFrame>(*array_);
         } else if (array_type == "somageometrydataframe") {
-            throw TileDBSOMAError(
-                "Support for SOMAGeometryDataFrame is not yet implemented");
+            return std::make_unique<SOMAGeometryDataFrame>(*array_);
         } else {
             throw TileDBSOMAError("Saw invalid SOMAArray type");
         }

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -54,6 +54,7 @@
 #include "soma/soma_experiment.h"
 #include "soma/soma_measurement.h"
 #include "soma/soma_scene.h"
+#include "soma/soma_geometry_dataframe.h"
 #include "soma/soma_point_cloud_dataframe.h"
 #include "soma/soma_multiscale_image.h"
 #include "soma/soma_object.h"

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -253,26 +253,14 @@ class ArrowAdapter {
      */
     static ArraySchema tiledb_schema_from_arrow_schema(
         std::shared_ptr<Context> ctx,
-        std::unique_ptr<ArrowSchema> arrow_schema,
-        ArrowTable index_column_info,
+        const std::unique_ptr<ArrowSchema>& arrow_schema,
+        const ArrowTable& index_column_info,
         std::string soma_type,
         bool is_sparse = true,
         PlatformConfig platform_config = PlatformConfig(),
-        ArrowTable spatial_column_info = {
+        const ArrowTable& spatial_column_info = {
             std::unique_ptr<ArrowArray>(nullptr),
             std::unique_ptr<ArrowSchema>(nullptr)});
-
-    /**
-     * @brief Get a TileDB attribute with its enumeration from an Arrow schema.
-     *
-     * @return std::pair<Attribute, std::optional<Enumeration>>
-     */
-    static std::pair<Attribute, std::optional<Enumeration>>
-    tiledb_attribute_from_arrow_schema(
-        std::shared_ptr<Context> ctx,
-        ArrowSchema* arrow_schema,
-        std::string_view type_metadata,
-        PlatformConfig platform_config = PlatformConfig());
 
     /**
      * @brief Get a TileDB dimension from an Arrow schema.
@@ -288,6 +276,18 @@ class ArrowAdapter {
         std::string_view type_metadata,
         std::string prefix = std::string(),
         std::string suffix = std::string(),
+        PlatformConfig platform_config = PlatformConfig());
+
+    /**
+     * @brief Get a TileDB attribute with its enumeration from an Arrow schema.
+     *
+     * @return std::pair<Attribute, std::optional<Enumeration>>
+     */
+    static std::pair<Attribute, std::optional<Enumeration>>
+    tiledb_attribute_from_arrow_schema(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* arrow_schema,
+        std::string_view type_metadata,
         PlatformConfig platform_config = PlatformConfig());
 
     /**
@@ -784,6 +784,14 @@ class ArrowAdapter {
         const ArrowTable& arrow_table,
         int64_t column_index,
         int64_t expected_n_buffers);
+
+    static bool _set_spatial_dimensions(
+        std::map<std::string, Dimension>& dims,
+        const ArrowTable& spatial_column_info,
+        std::string_view type_metadata,
+        std::string soma_type,
+        std::shared_ptr<Context> ctx,
+        PlatformConfig platform_config);
 };  // class ArrowAdapter
 };  // namespace tiledbsoma
 #endif

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -257,6 +257,37 @@ class ArrowAdapter {
         ArrowTable index_column_info,
         std::string soma_type,
         bool is_sparse = true,
+        PlatformConfig platform_config = PlatformConfig(),
+        ArrowTable spatial_column_info = {
+            std::unique_ptr<ArrowArray>(nullptr),
+            std::unique_ptr<ArrowSchema>(nullptr)});
+
+    /**
+     * @brief Get a TileDB attribute with its enumeration from an Arrow schema.
+     *
+     * @return std::pair<Attribute, std::optional<Enumeration>>
+     */
+    static std::pair<Attribute, std::optional<Enumeration>>
+    tiledb_attribute_from_arrow_schema(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* arrow_schema,
+        std::string_view type_metadata,
+        PlatformConfig platform_config = PlatformConfig());
+
+    /**
+     * @brief Get a TileDB dimension from an Arrow schema.
+     *
+     * @return std::pair<Dimension, bool> The TileDB dimension with a boolean
+     * flag indicating whether or not the dimension uses `current domain`.
+     */
+    static std::pair<Dimension, bool> tiledb_dimension_from_arrow_schema(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        ArrowArray* array,
+        std::string soma_type,
+        std::string_view type_metadata,
+        std::string prefix = std::string(),
+        std::string suffix = std::string(),
         PlatformConfig platform_config = PlatformConfig());
 
     /**
@@ -342,6 +373,16 @@ class ArrowAdapter {
         const std::pair<std::string, std::string>& pair) {
         std::vector<std::string> v({pair.first, pair.second});
         return make_arrow_array_child_string(v);
+    }
+
+    static ArrowArray* make_arrow_array_child_binary() {
+        // Use malloc here, not new, to match ArrowAdapter::release_array
+        auto arrow_array = (ArrowArray*)malloc(sizeof(ArrowArray));
+
+        ArrowArrayInitFromType(
+            arrow_array, ArrowType::NANOARROW_TYPE_LARGE_BINARY);
+
+        return arrow_array;
     }
 
     template <typename T>

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -42,6 +42,9 @@ namespace tiledbsoma {
 const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
 const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
 const std::string ENCODING_VERSION_VAL = "1.1.0";
+const std::string SOMA_GEOMETRY_COLUMN_NAME = "soma_geometry";
+const std::string SOMA_GEOMETRY_DIMENSION_PREFIX = "tiledb__internal__";
+const std::string ARROW_DATATYPE_METADATA_KEY = "dtype";
 
 using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(unit_soma
     unit_soma_sparse_ndarray.cc
     unit_soma_collection.cc
     unit_soma_scene.cc
+    unit_soma_geometry_dataframe.cc
     unit_soma_point_cloud_dataframe.cc
     unit_soma_multiscale_image.cc
     test_indexer.cc

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -1,0 +1,149 @@
+/**
+ * @file   unit_soma_geometry_dataframe.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for the SOMAGeometryDataFrame class
+ */
+
+#include <vector>
+#include "../src/geometry/geometry.h"
+#include "../src/geometry/operators/io/write.h"
+#include "common.h"
+
+const int64_t SOMA_JOINID_DIM_MAX = 99;
+
+TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
+    auto use_current_domain = GENERATE(false, true);
+    // TODO this could be formatted with fmt::format which is part of internal
+    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
+    // replaced with std::format.
+    std::ostringstream section;
+    section << "- use_current_domain=" << use_current_domain;
+    SECTION(section.str()) {
+        auto ctx = std::make_shared<SOMAContext>();
+        std::string uri{"mem://unit-test-geometry-basic"};
+        PlatformConfig platform_config{};
+
+        std::vector<helper::DimInfo> dim_infos(
+            {helper::DimInfo(
+                 {.name = "soma_joinid",
+                  .tiledb_datatype = TILEDB_INT64,
+                  .dim_max = SOMA_JOINID_DIM_MAX,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain}),
+             helper::DimInfo(
+                 {.name = "soma_geometry",
+                  .tiledb_datatype = TILEDB_GEOM_WKB,
+                  .dim_max = 100,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain})});
+
+        std::vector<helper::DimInfo> spatial_dim_infos(
+            {helper::DimInfo(
+                 {.name = "x",
+                  .tiledb_datatype = TILEDB_FLOAT64,
+                  .dim_max = 200,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain}),
+             helper::DimInfo(
+                 {.name = "y",
+                  .tiledb_datatype = TILEDB_FLOAT64,
+                  .dim_max = 100,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A",
+                  .use_current_domain = use_current_domain})});
+
+        std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
+            {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});
+
+        // Check the point cloud doesn't exist yet.
+        REQUIRE(!SOMAGeometryDataFrame::exists(uri, ctx));
+
+        // Create the point cloud.
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        auto spatial_columns = helper::create_column_index_info(
+            spatial_dim_infos);
+
+        SOMAGeometryDataFrame::create(
+            uri,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ArrowTable(
+                std::move(spatial_columns.first),
+                std::move(spatial_columns.second)),
+            ctx,
+            platform_config,
+            std::nullopt);
+
+        // Check the point cloud exists and it cannot be read as a different
+        // object.
+        REQUIRE(SOMAGeometryDataFrame::exists(uri, ctx));
+        REQUIRE(!SOMASparseNDArray::exists(uri, ctx));
+        REQUIRE(!SOMADenseNDArray::exists(uri, ctx));
+        REQUIRE(!SOMADataFrame::exists(uri, ctx));
+
+        auto soma_geometry = SOMAGeometryDataFrame::open(
+            uri,
+            OpenMode::read,
+            ctx,
+            {},  // column_names,
+            ResultOrder::automatic,
+            std::nullopt);
+        REQUIRE(soma_geometry->uri() == uri);
+        REQUIRE(soma_geometry->ctx() == ctx);
+        REQUIRE(soma_geometry->type() == "SOMAGeometryDataFrame");
+        std::vector<std::string> expected_index_column_names = {
+            dim_infos[0].name,
+            "tiledb__internal__" + spatial_dim_infos[0].name + "__min",
+            "tiledb__internal__" + spatial_dim_infos[1].name + "__min",
+            "tiledb__internal__" + spatial_dim_infos[0].name + "__max",
+            "tiledb__internal__" + spatial_dim_infos[1].name + "__max"};
+
+        std::vector<std::string> expected_spatial_column_names = {
+            spatial_dim_infos[0].name, spatial_dim_infos[1].name};
+        REQUIRE(
+            soma_geometry->index_column_names() == expected_index_column_names);
+        REQUIRE(
+            soma_geometry->spatial_column_names() ==
+            expected_spatial_column_names);
+        REQUIRE(soma_geometry->nnz() == 0);
+        soma_geometry->close();
+
+        auto soma_object = SOMAObject::open(uri, OpenMode::read, ctx);
+        REQUIRE(soma_object->uri() == uri);
+        REQUIRE(soma_object->type() == "SOMAGeometryDataFrame");
+        soma_object->close();
+    }
+}

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -33,6 +33,7 @@
 #include <vector>
 #include "../src/geometry/geometry.h"
 #include "../src/geometry/operators/io/write.h"
+#include "../src/utils/common.h"
 #include "common.h"
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
@@ -84,10 +85,10 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
         std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
             {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});
 
-        // Check the point cloud doesn't exist yet.
+        // Check the geometry dataframe doesn't exist yet.
         REQUIRE(!SOMAGeometryDataFrame::exists(uri, ctx));
 
-        // Create the point cloud.
+        // Create the geometry dataframe.
         auto [schema, index_columns] =
             helper::create_arrow_schema_and_index_columns(
                 dim_infos, attr_infos);
@@ -107,8 +108,8 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
             platform_config,
             std::nullopt);
 
-        // Check the point cloud exists and it cannot be read as a different
-        // object.
+        // Check the geometry dataframe exists and it cannot be read as a
+        // different object.
         REQUIRE(SOMAGeometryDataFrame::exists(uri, ctx));
         REQUIRE(!SOMASparseNDArray::exists(uri, ctx));
         REQUIRE(!SOMADenseNDArray::exists(uri, ctx));
@@ -126,10 +127,14 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
         REQUIRE(soma_geometry->type() == "SOMAGeometryDataFrame");
         std::vector<std::string> expected_index_column_names = {
             dim_infos[0].name,
-            "tiledb__internal__" + spatial_dim_infos[0].name + "__min",
-            "tiledb__internal__" + spatial_dim_infos[1].name + "__min",
-            "tiledb__internal__" + spatial_dim_infos[0].name + "__max",
-            "tiledb__internal__" + spatial_dim_infos[1].name + "__max"};
+            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[0].name +
+                "__min",
+            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[1].name +
+                "__min",
+            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[0].name +
+                "__max",
+            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[1].name +
+                "__max"};
 
         std::vector<std::string> expected_spatial_column_names = {
             spatial_dim_infos[0].name, spatial_dim_infos[1].name};


### PR DESCRIPTION
This PR adds the new `SOMAGeometryDataFrame` object. This new object requires spatial axes to be determined and uses them internally to index geometry objects stored as a WKB encoded attribute. To differentiate between binary attributes and WKB binary attributes the Arrow schema requires a `dtype` metadata key with the value `WKB`.
