### PR TITLE
[c++] Include column name in a particular error message

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1267,8 +1267,9 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
 
     if (array->n_buffers != n_buffers) {
         throw TileDBSOMAError(fmt::format(
-            "[ArrowAdapter] expected array n_buffers {}; got {}",
+            "[ArrowAdapter] expected array n_buffers {} for column {}; got {}",
             n_buffers,
+            column->name(),
             array->n_buffers));
     }
 


### PR DESCRIPTION
**Issue and/or context:** Arose while troubleshooting an issue.

**Changes:**

As obvious hindsight, this error message is more helpful when it reports the affected column name.

**Notes for Reviewer:**

