### PR TITLE
[ci] Default the new-shape feature to enabled, still testing both

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -133,14 +133,14 @@ jobs:
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
+      run: export SOMA_PY_NEW_SHAPE=false; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Run pytests for Python with new shape
       shell: bash
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: export SOMA_PY_NEW_SHAPE=true; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
+      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -150,12 +150,12 @@ jobs:
 
       - name: Test without new shape
         if: ${{ matrix.covr == 'no' }}
-        run: cd apis/r/tests && Rscript testthat.R
+        run: export SOMA_R_NEW_SHAPE=false && cd apis/r/tests && Rscript testthat.R
 
       # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
       - name: Test with new shape
         if: ${{ matrix.covr == 'no' }}
-        run: export SOMA_R_NEW_SHAPE=true && cd apis/r/tests && Rscript testthat.R
+        run: cd apis/r/tests && Rscript testthat.R
 
       - name: Coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -110,7 +110,14 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
-      - name: Interop Tests
+      - name: Interop tests with new-shape feature flag off
         run: python -m pytest apis/system/tests/
         env:
           TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
+
+      - name: Interop tests with new-shape feature flag on
+        run: python -m pytest apis/system/tests/
+        env:
+          TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
+          SOMA_PY_NEW_SHAPE: true
+          SOMA_R_NEW_SHAPE: true

--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -10,4 +10,4 @@ import os
 # removed once https://github.com/single-cell-data/TileDB-SOMA/issues/2407 is
 # complete.
 
-NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") is not None
+NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -20,10 +20,10 @@
 
     # This is temporary for https://github.com/single-cell-data/TileDB-SOMA/issues/2407
     # It will be removed once 2407 is complete.
-    if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {
-      .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
-    } else {
+    if (Sys.getenv("SOMA_R_NEW_SHAPE") == "false") {
       .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
+    } else {
+      .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
     }
 }
 

--- a/apis/system/tests/test_dataframe_write_python_read_r.py
+++ b/apis/system/tests/test_dataframe_write_python_read_r.py
@@ -18,7 +18,9 @@ class TestDataframeWritePythonReadR(TestWritePythonReadR):
             ]
         )
 
-        soma.DataFrame.create(self.uri, schema=asch, index_column_names=["foo"]).close()
+        soma.DataFrame.create(
+            self.uri, schema=asch, index_column_names=["foo"], domain=[[0, 99]]
+        ).close()
 
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]

--- a/apis/system/tests/test_dataframe_write_r_read_python.py
+++ b/apis/system/tests/test_dataframe_write_r_read_python.py
@@ -21,7 +21,7 @@ class TestDataframeWriteRReadPython(TestReadPythonWriteR):
             field("quux", bool())
         )
 
-        sdf <- SOMADataFrameCreate("{self.uri}", df_schema, "foo")
+        sdf <- SOMADataFrameCreate("{self.uri}", df_schema, index_column_names=c("foo"), domain=list(foo=c(0,99)))
 
         df <- data.frame(
             soma_joinid = bit64::as.integer64(c(1,2,3,4,5)),


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

While we're still running CI both ways, set the default to true for sandbox/dogfooding within the team, as discussed earlier this week.

**Notes for Reviewer:**

This is atop #3230.