### PR TITLE
[ci] Run R/Python interop tests with new/shape flag off/on

### DIFF
--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -110,7 +110,14 @@ jobs:
       - name: Update Packages
         run: Rscript -e 'update.packages(ask=FALSE)'
 
-      - name: Interop Tests
+      - name: Interop tests with new-shape feature flag off
         run: python -m pytest apis/system/tests/
         env:
           TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
+
+      - name: Interop tests with new-shape feature flag on
+        run: python -m pytest apis/system/tests/
+        env:
+          TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
+          SOMA_PY_NEW_SHAPE: true
+          SOMA_R_NEW_SHAPE: true

--- a/apis/system/tests/test_dataframe_write_python_read_r.py
+++ b/apis/system/tests/test_dataframe_write_python_read_r.py
@@ -18,7 +18,9 @@ class TestDataframeWritePythonReadR(TestWritePythonReadR):
             ]
         )
 
-        soma.DataFrame.create(self.uri, schema=asch, index_column_names=["foo"]).close()
+        soma.DataFrame.create(
+            self.uri, schema=asch, index_column_names=["foo"], domain=[[0, 99]]
+        ).close()
 
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]

--- a/apis/system/tests/test_dataframe_write_r_read_python.py
+++ b/apis/system/tests/test_dataframe_write_r_read_python.py
@@ -21,7 +21,7 @@ class TestDataframeWriteRReadPython(TestReadPythonWriteR):
             field("quux", bool())
         )
 
-        sdf <- SOMADataFrameCreate("{self.uri}", df_schema, "foo")
+        sdf <- SOMADataFrameCreate("{self.uri}", df_schema, index_column_names=c("foo"), domain=list(foo=c(0,99)))
 
         df <- data.frame(
             soma_joinid = bit64::as.integer64(c(1,2,3,4,5)),


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

We have four unit-test suites: C++ in `libtiledbsoma/test`; Python in `apis/python/tests`; R in `apis/r/tests/testthat`; R/Python interop in `apis/system/tests`.

I found on #3230 that while I'd been running C++, Python, and R CI "both ways", I'd not been doing the same for R/Python interop testing. This PR fixes that.

**Notes for Reviewer:**

#3230 goes on top of this