### PR TITLE
[c++] Change `BinaryBuffer` type

### DIFF
--- a/libtiledbsoma/src/geometry/geometry.h
+++ b/libtiledbsoma/src/geometry/geometry.h
@@ -22,7 +22,7 @@ enum GeometryType : uint32_t {
     GEOMETRYCOLLECTION = 7
 };
 
-using BinaryBuffer = std::vector<uint8_t>;
+using BinaryBuffer = std::vector<std::byte>;
 
 struct GeometryCollection;
 using GenericGeometry = std::variant<

--- a/libtiledbsoma/src/geometry/operators/io/read.h
+++ b/libtiledbsoma/src/geometry/operators/io/read.h
@@ -38,7 +38,7 @@ struct Reader<BinaryBuffer> {
         return value;
     }
 
-    std::vector<uint8_t> buffer;
+    std::vector<std::byte> buffer;
     size_t position;
 };
 

--- a/libtiledbsoma/src/geometry/operators/io/write.cc
+++ b/libtiledbsoma/src/geometry/operators/io/write.cc
@@ -102,7 +102,7 @@ size_t wkb_size(const GenericGeometry& geometry) {
 }
 
 WKBWriteOperator::WKBWriteOperator(
-    uint8_t* buffer, size_t& position, size_t size)
+    std::byte* buffer, size_t& position, size_t size)
     : buffer(buffer)
     , position(position)
     , size(size) {
@@ -185,7 +185,7 @@ void WKBWriteOperator::operator()(const GeometryCollection& collection) {
     }
 }
 
-void to_wkb(const GenericGeometry& geometry, uint8_t* buffer, size_t size) {
+void to_wkb(const GenericGeometry& geometry, std::byte* buffer, size_t size) {
     size_t position = 0;
 
     std::visit(WKBWriteOperator{buffer, position, size}, geometry);

--- a/libtiledbsoma/src/geometry/operators/io/write.h
+++ b/libtiledbsoma/src/geometry/operators/io/write.h
@@ -28,7 +28,7 @@ struct WKBSizeOperator {
 };
 
 struct WKBWriteOperator {
-    WKBWriteOperator(uint8_t* buffer, size_t& position, size_t size);
+    WKBWriteOperator(std::byte* buffer, size_t& position, size_t size);
 
     template <typename T>
     void write(const T& value) {
@@ -47,7 +47,7 @@ struct WKBWriteOperator {
     void operator()(const MultiPolygon& multi_polygon);
     void operator()(const GeometryCollection& collection);
 
-    uint8_t* buffer;
+    std::byte* buffer;
     size_t& position;
     size_t size;
 };

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -358,10 +358,7 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
             CHECK(
                 std::vector<double_t>({1}) ==
                 std::vector<double_t>(d4span.begin(), d4span.end()));
-            auto a = geometry::to_wkb(polygon);
-            for (size_t i = 0; i < wkbs[0].size(); ++i) {
-                CHECK(a[i] == (unsigned char)wkbs[0][i]);
-            }
+            CHECK(geometry::to_wkb(polygon) == wkbs[0]);
             CHECK(
                 std::vector<double_t>({63}) ==
                 std::vector<double>(a0span.begin(), a0span.end()));


### PR DESCRIPTION
Change BinaryBuffer from `std::vector<uint8_t>` to `std::vector<std::byte>`
