### PR TITLE
[python] Proper prefixing for shape-related methods

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -6,6 +6,7 @@
 """
 Implementation of a SOMA DataFrame
 """
+import inspect
 from typing import Any, List, Optional, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
@@ -437,16 +438,21 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         1.15).  If ``check_only`` is ``True``, returns whether the operation
         would succeed if attempted, and a reason why it would not.
         """
+        frame = inspect.currentframe()
+        function_name_for_messages = frame.f_code.co_name if frame else "tiledbsoma"
+
         if check_only:
             return cast(
                 StatusAndReason,
                 self._handle._handle.can_resize_soma_joinid_shape(
-                    newshape, "tiledbsoma_resize_soma_joinid_shape"
+                    newshape,
+                    function_name_for_messages=function_name_for_messages,
                 ),
             )
         else:
             self._handle._handle.resize_soma_joinid_shape(
-                newshape, "tiledbsoma_resize_soma_joinid_shape"
+                newshape,
+                function_name_for_messages=function_name_for_messages,
             )
             return (True, "")
 
@@ -460,16 +466,21 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         taken.  If ``check_only`` is ``True``, returns whether the operation
         would succeed if attempted, and a reason why it would not.
         """
+        frame = inspect.currentframe()
+        function_name_for_messages = frame.f_code.co_name if frame else "tiledbsoma"
+
         if check_only:
             return cast(
                 StatusAndReason,
                 self._handle._handle.can_upgrade_soma_joinid_shape(
-                    newshape, "tiledbsoma_upgrade_soma_joinid_shape"
+                    newshape,
+                    function_name_for_messages=function_name_for_messages,
                 ),
             )
         else:
             self._handle._handle.upgrade_soma_joinid_shape(
-                newshape, "tiledbsoma_upgrade_soma_joinid_shape"
+                newshape,
+                function_name_for_messages=function_name_for_messages,
             )
             return (True, "")
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -424,7 +424,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         return self._handle.tiledbsoma_has_upgraded_domain
 
-    def resize_soma_joinid_shape(
+    def tiledbsoma_resize_soma_joinid_shape(
         self, newshape: int, check_only: bool = False
     ) -> StatusAndReason:
         """Increases the shape of the dataframe on the ``soma_joinid`` index
@@ -440,13 +440,17 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if check_only:
             return cast(
                 StatusAndReason,
-                self._handle._handle.can_resize_soma_joinid_shape(newshape),
+                self._handle._handle.can_resize_soma_joinid_shape(
+                    newshape, "tiledbsoma_resize_soma_joinid_shape"
+                ),
             )
         else:
-            self._handle._handle.resize_soma_joinid_shape(newshape)
+            self._handle._handle.resize_soma_joinid_shape(
+                newshape, "tiledbsoma_resize_soma_joinid_shape"
+            )
             return (True, "")
 
-    def upgrade_soma_joinid_shape(
+    def tiledbsoma_upgrade_soma_joinid_shape(
         self, newshape: int, check_only: bool = False
     ) -> StatusAndReason:
         """This is like ``upgrade_domain``, but it only applies the specified
@@ -459,10 +463,14 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if check_only:
             return cast(
                 StatusAndReason,
-                self._handle._handle.can_upgrade_soma_joinid_shape(newshape),
+                self._handle._handle.can_upgrade_soma_joinid_shape(
+                    newshape, "tiledbsoma_upgrade_soma_joinid_shape"
+                ),
             )
         else:
-            self._handle._handle.upgrade_soma_joinid_shape(newshape)
+            self._handle._handle.upgrade_soma_joinid_shape(
+                newshape, "tiledbsoma_upgrade_soma_joinid_shape"
+            )
             return (True, "")
 
     def __len__(self) -> int:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -38,6 +38,9 @@ from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import SOMATileDBContext
 
+AxisDomain = Union[None, Tuple[Any, Any], List[Any]]
+Domain = Sequence[AxisDomain]
+
 RawHandle = Union[
     clib.SOMAArray,
     clib.SOMADataFrame,
@@ -478,19 +481,27 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
-    def resize_soma_joinid_shape(self, newshape: int) -> None:
+    def resize_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> None:
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
-    def can_resize_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
+    def can_resize_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> StatusAndReason:
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
-    def upgrade_soma_joinid_shape(self, newshape: int) -> None:
+    def upgrade_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> None:
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
-    def can_upgrade_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
+    def can_upgrade_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> StatusAndReason:
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
@@ -522,24 +533,38 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
         """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_domain)
 
-    def resize_soma_joinid_shape(self, newshape: int) -> None:
+    def resize_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> None:
         """Wrapper-class internals"""
-        self._handle.resize_soma_joinid_shape(newshape)
+        self._handle.resize_soma_joinid_shape(newshape, function_name_for_messages)
 
-    def can_resize_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
+    def can_resize_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(
-            StatusAndReason, self._handle.can_resize_soma_joinid_shape(newshape)
+            StatusAndReason,
+            self._handle.can_resize_soma_joinid_shape(
+                newshape, function_name_for_messages
+            ),
         )
 
-    def upgrade_soma_joinid_shape(self, newshape: int) -> None:
+    def upgrade_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> None:
         """Wrapper-class internals"""
-        self._handle.upgrade_soma_joinid_shape(newshape)
+        self._handle.upgrade_soma_joinid_shape(newshape, function_name_for_messages)
 
-    def can_upgrade_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
+    def can_upgrade_soma_joinid_shape(
+        self, newshape: int, function_name_for_messages: str
+    ) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(
-            StatusAndReason, self._handle.can_upgrade_soma_joinid_shape(newshape)
+            StatusAndReason,
+            self._handle.can_upgrade_soma_joinid_shape(
+                newshape, function_name_for_messages
+            ),
         )
 
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -509,78 +509,35 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
 
     @property
     def maybe_soma_joinid_shape(self) -> Optional[int]:
-        """Return the shape slot for the soma_joinid dim, if the array has one.
-        This is an important test-point and dev-internal access-point,
-        in particular, for the tiledbsoma-io experiment-level resizer.
-
-        Lifecycle:
-            Maturing.
-        """
+        """Wrapper-class internals"""
         return cast(Optional[int], self._handle.maybe_soma_joinid_shape)
 
     @property
     def maybe_soma_joinid_maxshape(self) -> Optional[int]:
-        """Return the maxshape slot for the soma_joinid dim, if the array has one.
-        This is an important test-point and dev-internal access-point,
-        in particular, for the tiledbsoma-io experiment-level resizer.
-
-        Lifecycle:
-            Maturing.
-        """
+        """Wrapper-class internals"""
         return cast(Optional[int], self._handle.maybe_soma_joinid_maxshape)
 
     @property
     def tiledbsoma_has_upgraded_domain(self) -> bool:
-        """Returns true if the array has the upgraded resizeable domain feature
-        from TileDB-SOMA 1.15: the array was created with this support, or it has
-        had ``.tiledbsoma_upgrade_domain`` applied to it.
-
-        Lifecycle:
-            Maturing.
-        """
+        """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_domain)
 
     def resize_soma_joinid_shape(self, newshape: int) -> None:
-        """Increases the shape of the dataframe on the ``soma_joinid`` index
-        column, if it indeed is an index column, leaving all other index columns
-        as-is. If the ``soma_joinid`` is not an index column, no change is made.
-        This is a special case of ``upgrade_domain`` (WIP for 1.15), but simpler
-        to keystroke, and handles the most common case for dataframe domain
-        expansion.  Raises an error if the dataframe doesn't already have a
-        domain: in that case please call ``tiledbsoma_upgrade_domain`` (WIP for
-        1.15).
-        """
+        """Wrapper-class internals"""
         self._handle.resize_soma_joinid_shape(newshape)
 
     def can_resize_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
-        """Increases the shape of the dataframe on the ``soma_joinid`` index
-        column, if it indeed is an index column, leaving all other index columns
-        as-is. If the ``soma_joinid`` is not an index column, no change is made.
-        This is a special case of ``upgrade_domain`` (WIP for 1.15), but simpler
-        to keystroke, and handles the most common case for dataframe domain
-        expansion.  Raises an error if the dataframe doesn't already have a
-        domain: in that case please call ``tiledbsoma_upgrade_domain`` (WIP for
-        1.15).  If ``check_only`` is ``True``, returns whether the operation
-        would succeed if attempted, and a reason why it would not.
-        """
+        """Wrapper-class internals"""
         return cast(
             StatusAndReason, self._handle.can_resize_soma_joinid_shape(newshape)
         )
 
     def upgrade_soma_joinid_shape(self, newshape: int) -> None:
-        """This is like ``upgrade_domain``, but it only applies the specified domain
-        update to the ``soma_joinid`` index column. Any other index columns have their
-        domain set to match the maxdomain. If the ``soma_joinid`` column is not an index
-        column at all, then no action is taken."""
+        """Wrapper-class internals"""
         self._handle.upgrade_soma_joinid_shape(newshape)
 
     def can_upgrade_soma_joinid_shape(self, newshape: int) -> StatusAndReason:
-        """This allows you to see if ``upgrade_soma_joinid_shape`` will succeed
-        before calling it.  This is an important test-point and dev-internal
-        access-point, in particular, for the tiledbsoma-io experiment-level
-        resizer.  If ``check_only`` is ``True``, returns whether the operation
-        would succeed if attempted, and a reason why it would not.
-        """
+        """Wrapper-class internals"""
         return cast(
             StatusAndReason, self._handle.can_upgrade_soma_joinid_shape(newshape)
         )
@@ -606,19 +563,11 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
-        """Returns true if the array has the upgraded resizeable shape feature
-        from TileDB-SOMA 1.15: the array was created with this support, or it has
-        had ``.tiledbsoma_upgrade_shape`` applied to it.
-
-        Lifecycle:
-            Maturing.
-        """
+        """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[Union[int, None]]) -> None:
-        """Supported for ``SparseNDArray``; scheduled for implementation for
-        ``DenseNDArray`` in TileDB-SOMA 1.15
-        """
+        """Wrapper-class internals"""
         if clib.embedded_version_triple() >= (2, 27, 0):
             self._handle.resize(newshape)
         else:
@@ -627,9 +576,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     def tiledbsoma_can_resize(
         self, newshape: Sequence[Union[int, None]]
     ) -> StatusAndReason:
-        """Supported for ``SparseNDArray``; scheduled for implementation for
-        ``DenseNDArray`` in TileDB-SOMA 1.15.
-        """
+        """Wrapper-class internals"""
         if clib.embedded_version_triple() >= (2, 27, 0):
             return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
         else:
@@ -647,49 +594,27 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
-        """Returns true if the array has the upgraded resizeable shape feature
-        from TileDB-SOMA 1.15: the array was created with this support, or it has
-        had ``.tiledbsoma_upgrade_shape`` applied to it.
-
-        Lifecycle:
-            Maturing.
-        """
+        """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[Union[int, None]]) -> None:
-        """Increases the shape of the array as specfied. Raises an error if the new
-        shape is less than the current shape in any dimension. Raises an error if
-        the new shape exceeds maxshape in any dimension. Raises an error if the
-        array doesn't already have a shape: in that case please call
-        tiledbsoma_upgrade_shape.
-        """
+        """Wrapper-class internals"""
         self._handle.resize(newshape)
 
     def tiledbsoma_can_resize(
         self, newshape: Sequence[Union[int, None]]
     ) -> StatusAndReason:
-        """This allows you to see if ``resize`` will succeed before calling it.
-        This is an important test-point and dev-internal access-point, in
-        particular, for the tiledbsoma-io experiment-level resizer.  If
-        ``check_only`` is ``True``, returns whether the operation would succeed
-        if attempted, and a reason why it would not.
-        """
+        """Wrapper-class internals"""
         return cast(StatusAndReason, self._handle.can_resize(newshape))
 
     def tiledbsoma_upgrade_shape(self, newshape: Sequence[Union[int, None]]) -> None:
-        """Allows the array to have a resizeable shape as described in the TileDB-SOMA
-        1.15 release notes.  Raises an error if the new shape exceeds maxshape in
-        any dimension. Raises an error if the array already has a shape.
-        """
+        """Wrapper-class internals"""
         self._handle.tiledbsoma_upgrade_shape(newshape)
 
     def tiledbsoma_can_upgrade_shape(
         self, newshape: Sequence[Union[int, None]]
     ) -> StatusAndReason:
-        """Allows the array to have a resizeable shape as described in the TileDB-SOMA
-        1.15 release notes.  Raises an error if the new shape exceeds maxshape in
-        any dimension. Raises an error if the array already has a shape.
-        """
+        """Wrapper-class internals"""
         return cast(
             StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape)
         )

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -287,20 +287,20 @@ def _leaf_visitor_upgrade(
         _print_leaf_node_banner("DataFrame", node_name, item.uri, args)
         if check_only:
             print(
-                f"  Dry run for: upgrade_soma_joinid_shape({count})",
+                f"  Dry run for: tiledbsoma_upgrade_soma_joinid_shape({count})",
                 file=args["output_handle"],
             )
-            ok, msg = item.upgrade_soma_joinid_shape(count, check_only=True)
+            ok, msg = item.tiledbsoma_upgrade_soma_joinid_shape(count, check_only=True)
             _print_dry_run_result(ok, msg, args)
             retval = retval and ok
         elif not item.tiledbsoma_has_upgraded_domain:
             if verbose:
                 print(
-                    f"  Applying upgrade_soma_joinid_shape({count})",
+                    f"  Applying tiledbsoma_upgrade_soma_joinid_shape({count})",
                     file=args["output_handle"],
                 )
             with tiledbsoma.DataFrame.open(item.uri, "w") as writer:
-                writer.upgrade_soma_joinid_shape(count)
+                writer.tiledbsoma_upgrade_soma_joinid_shape(count)
         else:
             if verbose:
                 print("  Already upgraded", file=args["output_handle"])
@@ -312,7 +312,8 @@ def _leaf_visitor_upgrade(
         _print_leaf_node_banner("SparseNDArray", node_name, item.uri, args)
         if check_only:
             print(
-                f"  Dry run for: upgrade_shape({new_shape})", file=args["output_handle"]
+                f"  Dry run for: tiledbsoma_upgrade_shape({new_shape})",
+                file=args["output_handle"],
             )
             ok, msg = item.tiledbsoma_upgrade_shape(new_shape, check_only=True)
             _print_dry_run_result(ok, msg, args)
@@ -320,7 +321,8 @@ def _leaf_visitor_upgrade(
         elif not item.tiledbsoma_has_upgraded_shape:
             if verbose:
                 print(
-                    f"  Applying upgrade_shape({new_shape})", file=args["output_handle"]
+                    f"  Applying tiledbsoma_upgrade_shape({new_shape})",
+                    file=args["output_handle"],
                 )
             with tiledbsoma.SparseNDArray.open(item.uri, "w") as writer:
                 writer.tiledbsoma_upgrade_shape(new_shape)
@@ -368,10 +370,10 @@ def _leaf_visitor_resize(
 
         if check_only:
             print(
-                f"  Dry run for: resize_soma_joinid_shape({new_soma_joinid_shape})",
+                f"  Dry run for: tiledbsoma_resize_soma_joinid_shape({new_soma_joinid_shape})",
                 file=args["output_handle"],
             )
-            ok, msg = item.resize_soma_joinid_shape(
+            ok, msg = item.tiledbsoma_resize_soma_joinid_shape(
                 new_soma_joinid_shape, check_only=True
             )
             _print_dry_run_result(ok, msg, args)
@@ -379,11 +381,11 @@ def _leaf_visitor_resize(
         else:
             if verbose:
                 print(
-                    f"  Applying resize_soma_joinid_shape({new_soma_joinid_shape})",
+                    f"  Applying tiledbsoma_resize_soma_joinid_shape({new_soma_joinid_shape})",
                     file=args["output_handle"],
                 )
             with tiledbsoma.DataFrame.open(item.uri, "w") as writer:
-                writer.resize_soma_joinid_shape(new_soma_joinid_shape)
+                writer.tiledbsoma_resize_soma_joinid_shape(new_soma_joinid_shape)
 
     elif isinstance(item, tiledbsoma.SparseNDArray):
 

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -160,50 +160,63 @@ void load_soma_dataframe(py::module& m) {
 
         .def(
             "resize_soma_joinid_shape",
-            [](SOMADataFrame& sdf, int64_t newshape) {
+            [](SOMADataFrame& sdf,
+               int64_t newshape,
+               std::string function_name_for_messages) {
                 try {
                     sdf.resize_soma_joinid_shape(
-                        newshape, "resize_soma_joinid_shape");
+                        newshape, function_name_for_messages);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
             },
-            "newshape"_a)
+            "newshape"_a,
+            "function_name_for_messages"_a)
 
         .def(
             "can_resize_soma_joinid_shape",
-            [](SOMADataFrame& sdf, int64_t newshape) {
+            [](SOMADataFrame& sdf,
+               int64_t newshape,
+               std::string function_name_for_messages) {
                 try {
                     return sdf.can_resize_soma_joinid_shape(
-                        newshape, "can_resize_soma_joinid_shape");
+                        newshape, function_name_for_messages);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
             },
-            "newshape"_a)
+            "newshape"_a,
+            "function_name_for_messages"_a)
 
         .def(
             "upgrade_soma_joinid_shape",
-            [](SOMADataFrame& sdf, int64_t newshape) {
+            [](SOMADataFrame& sdf,
+               int64_t newshape,
+               std::string function_name_for_messages) {
                 try {
                     sdf.upgrade_soma_joinid_shape(
-                        newshape, "upgrade_soma_joinid_shape");
+                        newshape, function_name_for_messages);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
             },
-            "newshape"_a)
+            "newshape"_a,
+            "function_name_for_messages"_a)
 
         .def(
             "can_upgrade_soma_joinid_shape",
-            [](SOMADataFrame& sdf, int64_t newshape) {
+            [](SOMADataFrame& sdf,
+               int64_t newshape,
+               std::string function_name_for_messages) {
                 try {
                     return sdf.can_upgrade_soma_joinid_shape(
-                        newshape, "can_upgrade_soma_joinid_shape");
+                        newshape, function_name_for_messages);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
             },
-            "newshape"_a);
+            "newshape"_a,
+            "function_name_for_messages"_a);
 }
+
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -83,7 +83,7 @@ def test_dataframe(tmp_path, arrow_schema):
             rb = pa.Table.from_pydict(pydict)
 
             if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-                sdf.resize_soma_joinid_shape(len(rb))
+                sdf.tiledbsoma_resize_soma_joinid_shape(len(rb))
 
             sdf.write(rb)
 

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -515,271 +515,339 @@ TEST_CASE_METHOD(
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
-        std::string suffix = use_current_domain ? "true" : "false";
-        set_up(
-            std::make_shared<SOMAContext>(),
-            "mem://unit-test-variant-indexed-dataframe-1-" + suffix);
+        std::string suffix1 = use_current_domain ? "true" : "false";
+        // We have these:
+        // * upgrade_domain requires the user to specify values for all index
+        //   columns. This is in the spec.
+        // * resize_soma_joinid_shape allows the user to specify only the
+        //   desired soma_joinid shape. This is crucial for experiment-level
+        //   resize as an internal method at the Python level.
+        // Both need testing. Each one adds a shape where there wasn't one
+        // before. So we need to test one or the other on a given run.
+        auto test_upgrade_domain = GENERATE(false, true);
+        std::ostringstream section2;
+        section2 << "- test_upgrade_domain=" << test_upgrade_domain;
+        SECTION(section2.str()) {
+            std::string suffix2 = test_upgrade_domain ? "true" : "false";
 
-        std::vector<helper::DimInfo> dim_infos(
-            {i64_dim_info(use_current_domain)});
-        std::vector<helper::AttrInfo> attr_infos(
-            {str_attr_info(), u32_attr_info()});
+            set_up(
+                std::make_shared<SOMAContext>(),
+                "mem://unit-test-variant-indexed-dataframe-1-" + suffix1 + "-" +
+                    suffix2);
 
-        // Create
-        create(dim_infos, attr_infos);
+            std::vector<helper::DimInfo> dim_infos(
+                {i64_dim_info(use_current_domain)});
+            std::vector<helper::AttrInfo> attr_infos(
+                {str_attr_info(), u32_attr_info()});
 
-        // Check current domain
-        auto sdf = open(OpenMode::read);
+            // Create
+            create(dim_infos, attr_infos);
 
-        CurrentDomain current_domain = sdf->get_current_domain_for_test();
-        if (!use_current_domain) {
-            REQUIRE(current_domain.is_empty());
-        } else {
-            REQUIRE(!current_domain.is_empty());
-            REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
-            NDRectangle ndrect = current_domain.ndrectangle();
+            // Check current domain
+            auto sdf = open(OpenMode::read);
 
-            std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
-                dim_infos[0].name);
-            REQUIRE(i64_range[0] == (int64_t)0);
-            REQUIRE(i64_range[1] == (int64_t)dim_infos[0].dim_max);
-        }
+            CurrentDomain current_domain = sdf->get_current_domain_for_test();
+            if (!use_current_domain) {
+                REQUIRE(current_domain.is_empty());
+            } else {
+                REQUIRE(!current_domain.is_empty());
+                REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+                NDRectangle ndrect = current_domain.ndrectangle();
 
-        // Check shape before resize
-        int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
+                std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
+                    dim_infos[0].name);
+                REQUIRE(i64_range[0] == (int64_t)0);
+                REQUIRE(i64_range[1] == (int64_t)dim_infos[0].dim_max);
+            }
 
-        REQUIRE(sdf->nnz() == 0);
-
-        sdf->close();
-
-        // Write data
-        write_sjid_u32_str_data_from(0);
-
-        // Check shape after write
-        sdf->open(OpenMode::read);
-
-        REQUIRE(sdf->nnz() == 2);
-
-        expect = dim_infos[0].dim_max + 1;
-        actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
-
-        // Check domainish accessors before resize
-        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
-        std::vector<int64_t> ned_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                non_empty_domain, "soma_joinid");
-
-        ArrowTable soma_domain = sdf->get_soma_domain();
-        std::vector<int64_t> dom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_domain, "soma_joinid");
-
-        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
-        std::vector<int64_t> maxdom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_maxdomain, "soma_joinid");
-
-        REQUIRE(ned_sjid == std::vector<int64_t>({1, 2}));
-
-        REQUIRE(dom_sjid == std::vector<int64_t>({0, SOMA_JOINID_DIM_MAX}));
-
-        REQUIRE(maxdom_sjid.size() == 2);
-        REQUIRE(maxdom_sjid[0] == 0);
-        if (!use_current_domain) {
-            REQUIRE(maxdom_sjid[1] == SOMA_JOINID_DIM_MAX);
-        } else {
-            REQUIRE(maxdom_sjid[1] > 2000000000);
-        }
-        sdf->close();
-
-        REQUIRE(sdf->nnz() == 2);
-        write_sjid_u32_str_data_from(8);
-        REQUIRE(sdf->nnz() == 4);
-
-        sdf->open(OpenMode::read);
-
-        // Check can_upgrade_soma_joinid_shape
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-        sdf->close();
-
-        // Check can_upgrade_domain
-        sdf->open(OpenMode::read);
-        std::unique_ptr<ArrowSchema>
-            domain_schema = create_index_cols_info_schema(dim_infos);
-        auto domain_array = ArrowAdapter::make_arrow_array_parent(
-            dim_infos.size());
-        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
-            std::vector<int64_t>({0, 0}));
-        auto domain_table = ArrowTable(
-            std::move(domain_array), std::move(domain_schema));
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_domain(
-                domain_table, "testing");
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing for soma_joinid: new upper < old upper (downsize is "
-                "unsupported)");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-        sdf->close();
-
-        // Resize
-        auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
-
-        if (!use_current_domain) {
-            // Domain is already set. The domain (not current domain but
-            // domain) is immutable. All we can do is check for:
-            // * throw on write beyond domain
-            // * throw on an attempt to resize.
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            sdf = open(OpenMode::write);
-            // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-        } else {
-            // Expect throw on write beyond current domain before resize
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            // Check shape after write
-            sdf = open(OpenMode::read);
-            expect = dim_infos[0].dim_max + 1;
-
+            // Check shape before resize
+            int64_t expect = dim_infos[0].dim_max + 1;
             std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
+
+            REQUIRE(sdf->nnz() == 0);
+
             sdf->close();
 
-            sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
+            // Write data
+            write_sjid_u32_str_data_from(0);
 
-            sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape, "testing");
-            sdf->close();
+            // Check shape after write
+            sdf->open(OpenMode::read);
 
-            // Check shape after resize
-            sdf = open(OpenMode::read);
-            expect = SOMA_JOINID_RESIZE_DIM_MAX + 1;
+            REQUIRE(sdf->nnz() == 2);
+
+            expect = dim_infos[0].dim_max + 1;
             actual = sdf->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
 
-            sdf->close();
+            // Check domainish accessors before resize
+            ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+            std::vector<int64_t> ned_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    non_empty_domain, "soma_joinid");
 
-            // Implicitly we expect no throw
-            write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
-        }
+            ArrowTable soma_domain = sdf->get_soma_domain();
+            std::vector<int64_t> dom_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    soma_domain, "soma_joinid");
 
-        // Check domainish accessors after resize
-        sdf->open(OpenMode::read);
+            ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+            std::vector<int64_t> maxdom_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    soma_maxdomain, "soma_joinid");
 
-        non_empty_domain = sdf->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            non_empty_domain, "soma_joinid");
+            REQUIRE(ned_sjid == std::vector<int64_t>({1, 2}));
 
-        soma_domain = sdf->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            soma_domain, "soma_joinid");
-
-        soma_maxdomain = sdf->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
-            int64_t>(soma_maxdomain, "soma_joinid");
-
-        if (!use_current_domain) {
-            REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
             REQUIRE(dom_sjid == std::vector<int64_t>({0, SOMA_JOINID_DIM_MAX}));
-            REQUIRE(
-                maxdom_sjid == std::vector<int64_t>({0, SOMA_JOINID_DIM_MAX}));
-        } else {
-            REQUIRE(ned_sjid == std::vector<int64_t>({1, 101}));
-            REQUIRE(
-                dom_sjid ==
-                std::vector<int64_t>({0, SOMA_JOINID_RESIZE_DIM_MAX}));
+
             REQUIRE(maxdom_sjid.size() == 2);
             REQUIRE(maxdom_sjid[0] == 0);
-            REQUIRE(maxdom_sjid[1] > 2000000000);
-        }
-
-        // Check can_resize_soma_joinid_shape
-        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
-        if (!use_current_domain) {
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe currently has no domain set.");
-
-            REQUIRE(!sdf->has_current_domain());
+            if (!use_current_domain) {
+                REQUIRE(maxdom_sjid[1] == SOMA_JOINID_DIM_MAX);
+            } else {
+                REQUIRE(maxdom_sjid[1] > 2000000000);
+            }
             sdf->close();
 
-            sdf = open(OpenMode::write);
-            sdf->upgrade_soma_joinid_shape(SOMA_JOINID_DIM_MAX + 1, "testing");
+            REQUIRE(sdf->nnz() == 2);
+            write_sjid_u32_str_data_from(8);
+            REQUIRE(sdf->nnz() == 4);
+
+            sdf->open(OpenMode::read);
+
+            // Check can_upgrade_domain
+            std::unique_ptr<ArrowSchema>
+                domain_schema = create_index_cols_info_schema(dim_infos);
+            auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                dim_infos.size());
+            domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+                std::vector<int64_t>({0, 0}));
+            auto domain_table = ArrowTable(
+                std::move(domain_array), std::move(domain_schema));
+            if (!use_current_domain) {
+                StatusAndReason check = sdf->can_upgrade_domain(
+                    domain_table, "testing");
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing for soma_joinid: new upper < old upper "
+                    "(downsize "
+                    "is "
+                    "unsupported)");
+            } else {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe already has its domain set.");
+            }
+
+            // Check can_upgrade_soma_joinid_shape
+            if (!use_current_domain) {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                REQUIRE(check.first == true);
+                REQUIRE(check.second == "");
+            } else {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe already has its domain set.");
+            }
+
             sdf->close();
 
-            sdf = open(OpenMode::read);
-            REQUIRE(sdf->has_current_domain());
-            std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(actual.has_value());
-            REQUIRE(actual.value() == SOMA_JOINID_DIM_MAX + 1);
+            // Resize
+            auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
+
+            if (!use_current_domain) {
+                // Core domain is already set. The domain (not core current
+                // domain but core domain)
+                // is immutable. All we can do is check for:
+                // * throw on write beyond domain
+                // * throw on an attempt to resize.
+                REQUIRE_THROWS(
+                    write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                sdf = open(OpenMode::write);
+
+                // Array not resizeable if it has not already been sized
+                if (test_upgrade_domain) {
+                    std::unique_ptr<ArrowSchema>
+                        domain_schema = create_index_cols_info_schema(
+                            dim_infos);
+                    auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                        dim_infos.size());
+                    domain_array
+                        ->children[0] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<int64_t>({0, new_shape - 1}));
+                    auto domain_table = ArrowTable(
+                        std::move(domain_array), std::move(domain_schema));
+                    REQUIRE_THROWS(sdf->change_domain(domain_table, "testing"));
+                } else {
+                    REQUIRE_THROWS(
+                        sdf->resize_soma_joinid_shape(new_shape, "testing"));
+                }
+
+            } else {
+                // Expect throw on write beyond current domain before resize
+                REQUIRE_THROWS(
+                    write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                // Check shape after write
+                sdf = open(OpenMode::read);
+                expect = dim_infos[0].dim_max + 1;
+
+                std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == expect);
+                sdf->close();
+
+                // Apply the domain change
+                if (test_upgrade_domain) {
+                    std::unique_ptr<ArrowSchema>
+                        domain_schema = create_index_cols_info_schema(
+                            dim_infos);
+                    auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                        dim_infos.size());
+                    domain_array
+                        ->children[0] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<int64_t>({0, new_shape - 1}));
+                    auto domain_table = ArrowTable(
+                        std::move(domain_array), std::move(domain_schema));
+
+                    // Not open for write
+                    sdf = open(OpenMode::read);
+                    REQUIRE_THROWS(sdf->change_domain(domain_table, "testing"));
+                    sdf->close();
+
+                    // Open for write
+                    sdf = open(OpenMode::write);
+                    sdf->change_domain(domain_table, "testing");
+                    sdf->close();
+
+                } else {
+                    // Not open for write
+                    sdf = open(OpenMode::read);
+                    REQUIRE_THROWS(
+                        sdf->resize_soma_joinid_shape(new_shape, "testing"));
+                    sdf->close();
+
+                    // Open for write
+                    sdf = open(OpenMode::write);
+                    sdf->resize_soma_joinid_shape(new_shape, "testing");
+                    sdf->close();
+                }
+
+                // Check shape after resize
+                sdf = open(OpenMode::read);
+                expect = SOMA_JOINID_RESIZE_DIM_MAX + 1;
+                actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == expect);
+                sdf->close();
+
+                // Implicitly we expect no throw
+                write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
+            }
+
+            // Check domainish accessors after resize
+            sdf->open(OpenMode::read);
+
+            non_empty_domain = sdf->get_non_empty_domain();
+            ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(non_empty_domain, "soma_joinid");
+
+            soma_domain = sdf->get_soma_domain();
+            dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(soma_domain, "soma_joinid");
+
+            soma_maxdomain = sdf->get_soma_maxdomain();
+            maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(soma_maxdomain, "soma_joinid");
+
+            if (!use_current_domain) {
+                REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
+                REQUIRE(
+                    dom_sjid == std::vector<int64_t>({0, SOMA_JOINID_DIM_MAX}));
+                REQUIRE(
+                    maxdom_sjid ==
+                    std::vector<int64_t>({0, SOMA_JOINID_DIM_MAX}));
+            } else {
+                REQUIRE(ned_sjid == std::vector<int64_t>({1, 101}));
+                REQUIRE(
+                    dom_sjid ==
+                    std::vector<int64_t>({0, SOMA_JOINID_RESIZE_DIM_MAX}));
+                REQUIRE(maxdom_sjid.size() == 2);
+                REQUIRE(maxdom_sjid[0] == 0);
+                REQUIRE(maxdom_sjid[1] > 2000000000);
+            }
+
+            // Check can_resize_soma_joinid_shape
+            StatusAndReason check = sdf->can_resize_soma_joinid_shape(
+                1, "testing");
+            if (!use_current_domain) {
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe currently has no domain set.");
+
+                REQUIRE(!sdf->has_current_domain());
+                sdf->close();
+
+                sdf = open(OpenMode::write);
+                sdf->upgrade_soma_joinid_shape(
+                    SOMA_JOINID_DIM_MAX + 1, "testing");
+                sdf->close();
+
+                sdf = open(OpenMode::read);
+                REQUIRE(sdf->has_current_domain());
+                std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == SOMA_JOINID_DIM_MAX + 1);
+                sdf->close();
+
+            } else {
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: new soma_joinid shape 1 < existing shape "
+                    "200");
+                check = sdf->can_resize_soma_joinid_shape(
+                    SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
+                REQUIRE(check.first == true);
+                REQUIRE(check.second == "");
+            }
+
             sdf->close();
 
-        } else {
+            // Check can_upgrade_domain
+            sdf->open(OpenMode::read);
+            domain_schema = create_index_cols_info_schema(dim_infos);
+            domain_array = ArrowAdapter::make_arrow_array_parent(
+                dim_infos.size());
+            domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+                std::vector<int64_t>({0, 0}));
+            domain_table = ArrowTable(
+                std::move(domain_array), std::move(domain_schema));
+            // The dataframe now has a shape
+            check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
             // Must fail since this is too small.
             REQUIRE(check.first == false);
             REQUIRE(
                 check.second ==
-                "testing: new soma_joinid shape 1 < existing shape "
-                "200");
-            check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
+                "testing: dataframe already has its domain set.");
+            sdf->close();
         }
-
-        sdf->close();
-
-        // Check can_upgrade_domain
-        sdf->open(OpenMode::read);
-        domain_schema = create_index_cols_info_schema(dim_infos);
-        domain_array = ArrowAdapter::make_arrow_array_parent(dim_infos.size());
-        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
-            std::vector<int64_t>({0, 0}));
-        domain_table = ArrowTable(
-            std::move(domain_array), std::move(domain_schema));
-        // The dataframe now has a shape
-        check = sdf->can_upgrade_soma_joinid_shape(1, "testing");
-        // Must fail since this is too small.
-        REQUIRE(check.first == false);
-        REQUIRE(
-            check.second == "testing: dataframe already has its domain set.");
-        sdf->close();
     }
 }
 
@@ -791,273 +859,342 @@ TEST_CASE_METHOD(
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
-        std::string suffix = use_current_domain ? "true" : "false";
-        set_up(
-            std::make_shared<SOMAContext>(),
-            "mem://unit-test-variant-indexed-dataframe-2-" + suffix);
+        std::string suffix1 = use_current_domain ? "true" : "false";
+        // We have these:
+        // * upgrade_domain requires the user to specify values for all
+        // index
+        //   columns. This is in the spec.
+        // * resize_soma_joinid_shape allows the user to specify only the
+        //   desired soma_joinid shape. This is crucial for experiment-level
+        //   resize as an internal method at the Python level.
+        // Both need testing. Each one adds a shape where there wasn't one
+        // before. So we need to test one or the other on a given run.
+        auto test_upgrade_domain = GENERATE(false, true);
+        std::ostringstream section2;
+        section << "- test_upgrade_domain=" << test_upgrade_domain;
+        SECTION(section2.str()) {
+            std::string suffix2 = test_upgrade_domain ? "true" : "false";
+            set_up(
+                std::make_shared<SOMAContext>(),
+                "mem://unit-test-variant-indexed-dataframe-2-" + suffix1 + "-" +
+                    suffix2);
 
-        std::vector<helper::DimInfo> dim_infos(
-            {u32_dim_info(use_current_domain),
-             i64_dim_info(use_current_domain)});
-        std::vector<helper::AttrInfo> attr_infos({str_attr_info()});
+            std::vector<helper::DimInfo> dim_infos(
+                {u32_dim_info(use_current_domain),
+                 i64_dim_info(use_current_domain)});
+            std::vector<helper::AttrInfo> attr_infos({str_attr_info()});
 
-        // Create
-        create(dim_infos, attr_infos);
+            // Create
+            create(dim_infos, attr_infos);
 
-        // Check current domain
-        auto sdf = open(OpenMode::read);
+            // Check current domain
+            auto sdf = open(OpenMode::read);
 
-        CurrentDomain current_domain = sdf->get_current_domain_for_test();
-        if (!use_current_domain) {
-            REQUIRE(current_domain.is_empty());
-        } else {
-            REQUIRE(!current_domain.is_empty());
-            REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
-            NDRectangle ndrect = current_domain.ndrectangle();
+            CurrentDomain current_domain = sdf->get_current_domain_for_test();
+            if (!use_current_domain) {
+                REQUIRE(current_domain.is_empty());
+            } else {
+                REQUIRE(!current_domain.is_empty());
+                REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+                NDRectangle ndrect = current_domain.ndrectangle();
 
-            std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
-                dim_infos[0].name);
-            REQUIRE(u32_range[0] == (uint32_t)0);
-            REQUIRE(u32_range[1] == (uint32_t)dim_infos[0].dim_max);
+                std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
+                    dim_infos[0].name);
+                REQUIRE(u32_range[0] == (uint32_t)0);
+                REQUIRE(u32_range[1] == (uint32_t)dim_infos[0].dim_max);
 
-            std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
-                dim_infos[1].name);
-            REQUIRE(i64_range[0] == (int64_t)0);
-            REQUIRE(i64_range[1] == (int64_t)dim_infos[1].dim_max);
-        }
+                std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
+                    dim_infos[1].name);
+                REQUIRE(i64_range[0] == (int64_t)0);
+                REQUIRE(i64_range[1] == (int64_t)dim_infos[1].dim_max);
+            }
 
-        // Check shape before write
-        int64_t expect = dim_infos[1].dim_max + 1;
-        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
-
-        sdf->close();
-
-        REQUIRE(sdf->nnz() == 0);
-
-        // Write
-        write_sjid_u32_str_data_from(0);
-
-        REQUIRE(sdf->nnz() == 2);
-        write_sjid_u32_str_data_from(8);
-        REQUIRE(sdf->nnz() == 4);
-
-        // Check domainish accessors before resize
-        sdf->open(OpenMode::read);
-
-        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
-        std::vector<int64_t> ned_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                non_empty_domain, "soma_joinid");
-        std::vector<uint32_t> ned_u32 =
-            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
-                non_empty_domain, "myuint32");
-
-        ArrowTable soma_domain = sdf->get_soma_domain();
-        std::vector<int64_t> dom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_domain, "soma_joinid");
-        std::vector<uint32_t> dom_u32 =
-            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
-                soma_domain, "myuint32");
-
-        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
-        std::vector<int64_t> maxdom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_maxdomain, "soma_joinid");
-        std::vector<uint32_t> maxdom_u32 =
-            ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
-                soma_maxdomain, "myuint32");
-
-        REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
-        REQUIRE(ned_u32 == std::vector<uint32_t>({1234, 5678}));
-
-        REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
-        REQUIRE(dom_u32 == std::vector<uint32_t>({0, 9999}));
-
-        REQUIRE(maxdom_sjid.size() == 2);
-        REQUIRE(maxdom_u32.size() == 2);
-
-        REQUIRE(maxdom_u32[0] == 0);
-        if (!use_current_domain) {
-            REQUIRE(maxdom_u32[1] == 9999);
-        } else {
-            REQUIRE(maxdom_u32[1] > 2000000000);
-        }
-
-        sdf->close();
-
-        // Check shape after write
-        sdf = open(OpenMode::read);
-        expect = dim_infos[1].dim_max + 1;
-        actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
-
-        // Check can_upgrade_soma_joinid_shape
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-
-        // Check can_upgrade_domain
-        std::unique_ptr<ArrowSchema>
-            domain_schema = create_index_cols_info_schema(dim_infos);
-        auto domain_array = ArrowAdapter::make_arrow_array_parent(
-            dim_infos.size());
-        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
-            std::vector<uint32_t>({0, 0}));
-        domain_array->children[1] = ArrowAdapter::make_arrow_array_child(
-            std::vector<int64_t>({0, 0}));
-        auto domain_table = ArrowTable(
-            std::move(domain_array), std::move(domain_schema));
-
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_domain(
-                domain_table, "testing");
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing for myuint32: new upper < old upper (downsize is "
-                "unsupported)");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-
-        sdf->close();
-
-        // Resize
-        auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
-
-        if (!use_current_domain) {
-            // Domain is already set. The domain (not current domain but
-            // domain) is immutable. All we can do is check for:
-            // * throw on write beyond domain
-            // * throw on an attempt to resize.
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            sdf = open(OpenMode::write);
-            // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-        } else {
-            // Expect throw on write beyond current domain before resize
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            // Check shape after write
-            sdf = open(OpenMode::read);
-            expect = dim_infos[1].dim_max + 1;
+            // Check shape before write
+            int64_t expect = dim_infos[1].dim_max + 1;
             std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
             REQUIRE(actual.has_value());
             REQUIRE(actual.value() == expect);
+
             sdf->close();
 
-            sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
+            REQUIRE(sdf->nnz() == 0);
 
-            sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape, "testing");
-            sdf->close();
+            // Write
+            write_sjid_u32_str_data_from(0);
 
-            // Check shape after resize
-            sdf = open(OpenMode::read);
-            expect = SOMA_JOINID_RESIZE_DIM_MAX + 1;
-            actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(actual.has_value());
-            REQUIRE(actual.value() == expect);
-            sdf->close();
+            REQUIRE(sdf->nnz() == 2);
+            write_sjid_u32_str_data_from(8);
+            REQUIRE(sdf->nnz() == 4);
 
-            // Implicitly we expect no throw
-            write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
-        }
+            // Check domainish accessors before resize
+            sdf->open(OpenMode::read);
 
-        // Check domainish accessors after resize
-        sdf->open(OpenMode::read);
+            ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+            std::vector<int64_t> ned_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    non_empty_domain, "soma_joinid");
+            std::vector<uint32_t> ned_u32 =
+                ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
+                    non_empty_domain, "myuint32");
 
-        non_empty_domain = sdf->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            non_empty_domain, "soma_joinid");
-        ned_u32 = ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
-            non_empty_domain, "myuint32");
+            ArrowTable soma_domain = sdf->get_soma_domain();
+            std::vector<int64_t> dom_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    soma_domain, "soma_joinid");
+            std::vector<uint32_t> dom_u32 =
+                ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
+                    soma_domain, "myuint32");
 
-        soma_domain = sdf->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            soma_domain, "soma_joinid");
-        dom_u32 = ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
-            soma_domain, "myuint32");
+            ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+            std::vector<int64_t> maxdom_sjid =
+                ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                    soma_maxdomain, "soma_joinid");
+            std::vector<uint32_t> maxdom_u32 =
+                ArrowAdapter::get_table_non_string_column_by_name<uint32_t>(
+                    soma_maxdomain, "myuint32");
 
-        soma_maxdomain = sdf->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
-            int64_t>(soma_maxdomain, "soma_joinid");
-        maxdom_u32 = ArrowAdapter::get_table_non_string_column_by_name<
-            uint32_t>(soma_maxdomain, "myuint32");
-
-        if (!use_current_domain) {
             REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
             REQUIRE(ned_u32 == std::vector<uint32_t>({1234, 5678}));
 
             REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
             REQUIRE(dom_u32 == std::vector<uint32_t>({0, 9999}));
 
-            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
-            REQUIRE(maxdom_u32 == std::vector<uint32_t>({0, 9999}));
-
-        } else {
-            REQUIRE(ned_sjid == std::vector<int64_t>({1, 101}));
-            REQUIRE(ned_u32 == std::vector<uint32_t>({1234, 5678}));
-
-            REQUIRE(dom_sjid == std::vector<int64_t>({0, 199}));
-            REQUIRE(dom_u32 == std::vector<uint32_t>({0, 9999}));
-
             REQUIRE(maxdom_sjid.size() == 2);
-            REQUIRE(maxdom_sjid[0] == 0);
-            REQUIRE(maxdom_sjid[1] > 2000000000);
-
             REQUIRE(maxdom_u32.size() == 2);
+
             REQUIRE(maxdom_u32[0] == 0);
-            REQUIRE(maxdom_u32[1] > 2000000000);
-        }
+            if (!use_current_domain) {
+                REQUIRE(maxdom_u32[1] == 9999);
+            } else {
+                REQUIRE(maxdom_u32[1] > 2000000000);
+            }
 
-        // Check can_resize_soma_joinid_shape
-        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
-        if (!use_current_domain) {
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe currently has no domain set.");
-        } else {
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: new soma_joinid shape 1 < existing shape "
-                "200");
-            check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
-        }
+            sdf->close();
 
-        sdf->close();
+            // Check shape after write
+            sdf = open(OpenMode::read);
+            expect = dim_infos[1].dim_max + 1;
+            actual = sdf->maybe_soma_joinid_shape();
+            REQUIRE(actual.has_value());
+            REQUIRE(actual.value() == expect);
+
+            // Check can_upgrade_soma_joinid_shape
+            if (!use_current_domain) {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                REQUIRE(check.first == true);
+                REQUIRE(check.second == "");
+            } else {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe already has its domain set.");
+            }
+
+            // Check can_upgrade_domain
+            std::unique_ptr<ArrowSchema>
+                domain_schema = create_index_cols_info_schema(dim_infos);
+            auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                dim_infos.size());
+            domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
+                std::vector<uint32_t>({0, 0}));
+            domain_array->children[1] = ArrowAdapter::make_arrow_array_child(
+                std::vector<int64_t>({0, 0}));
+            auto domain_table = ArrowTable(
+                std::move(domain_array), std::move(domain_schema));
+
+            if (!use_current_domain) {
+                StatusAndReason check = sdf->can_upgrade_domain(
+                    domain_table, "testing");
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing for myuint32: new upper < old upper (downsize "
+                    "is "
+                    "unsupported)");
+            } else {
+                StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                    1, "testing");
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe already has its domain set.");
+            }
+
+            sdf->close();
+
+            // Resize
+            auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
+            uint32_t new_u32_dim_max = (uint32_t)u32_dim_max * 2 + 1;
+
+            if (!use_current_domain) {
+                // Domain is already set. The domain (not current domain but
+                // domain) is immutable. All we can do is check for:
+                // * throw on write beyond domain
+                // * throw on an attempt to resize.
+                REQUIRE_THROWS(
+                    write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                sdf = open(OpenMode::write);
+
+                // Array not resizeable if it has not already been sized
+                if (test_upgrade_domain) {
+                    std::unique_ptr<ArrowSchema>
+                        domain_schema = create_index_cols_info_schema(
+                            dim_infos);
+                    auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                        dim_infos.size());
+                    domain_array
+                        ->children[0] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<uint32_t>({0, new_u32_dim_max}));
+                    domain_array
+                        ->children[1] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<int64_t>({0, new_shape - 1}));
+                    auto domain_table = ArrowTable(
+                        std::move(domain_array), std::move(domain_schema));
+                    REQUIRE_THROWS(sdf->change_domain(domain_table, "testing"));
+                } else {
+                    REQUIRE_THROWS(
+                        sdf->resize_soma_joinid_shape(new_shape, "testing"));
+                }
+
+                sdf->close();
+
+            } else {
+                // Expect throw on write beyond current domain before resize
+                REQUIRE_THROWS(
+                    write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                // Check shape after write
+                sdf = open(OpenMode::read);
+                expect = dim_infos[1].dim_max + 1;
+                std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == expect);
+                sdf->close();
+
+                // Apply the domain change
+                if (test_upgrade_domain) {
+                    std::unique_ptr<ArrowSchema>
+                        domain_schema = create_index_cols_info_schema(
+                            dim_infos);
+                    auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                        dim_infos.size());
+                    domain_array
+                        ->children[0] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<uint32_t>({0, new_u32_dim_max}));
+                    domain_array
+                        ->children[1] = ArrowAdapter::make_arrow_array_child(
+                        std::vector<int64_t>({0, new_shape - 1}));
+                    auto domain_table = ArrowTable(
+                        std::move(domain_array), std::move(domain_schema));
+
+                    // Not open for write
+                    sdf = open(OpenMode::read);
+                    REQUIRE_THROWS(sdf->change_domain(domain_table, "testing"));
+                    sdf->close();
+
+                    // Open for write
+                    sdf = open(OpenMode::write);
+                    sdf->change_domain(domain_table, "testing");
+                    sdf->close();
+
+                } else {
+                    // Not open for write
+                    sdf = open(OpenMode::read);
+                    REQUIRE_THROWS(
+                        sdf->resize_soma_joinid_shape(new_shape, "testing"));
+                    sdf->close();
+
+                    // Open for write
+                    sdf = open(OpenMode::write);
+                    sdf->resize_soma_joinid_shape(new_shape, "testing");
+                    sdf->close();
+                }
+                sdf->close();
+
+                // Implicitly we expect no throw
+                write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
+            }
+
+            // Check domainish accessors after resize
+            sdf->open(OpenMode::read);
+
+            non_empty_domain = sdf->get_non_empty_domain();
+            ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(non_empty_domain, "soma_joinid");
+            ned_u32 = ArrowAdapter::get_table_non_string_column_by_name<
+                uint32_t>(non_empty_domain, "myuint32");
+
+            soma_domain = sdf->get_soma_domain();
+            dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(soma_domain, "soma_joinid");
+            dom_u32 = ArrowAdapter::get_table_non_string_column_by_name<
+                uint32_t>(soma_domain, "myuint32");
+
+            soma_maxdomain = sdf->get_soma_maxdomain();
+            maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                int64_t>(soma_maxdomain, "soma_joinid");
+            maxdom_u32 = ArrowAdapter::get_table_non_string_column_by_name<
+                uint32_t>(soma_maxdomain, "myuint32");
+
+            if (!use_current_domain) {
+                REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
+                REQUIRE(ned_u32 == std::vector<uint32_t>({1234, 5678}));
+
+                REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
+                REQUIRE(dom_u32 == std::vector<uint32_t>({0, 9999}));
+
+                REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+                REQUIRE(maxdom_u32 == std::vector<uint32_t>({0, 9999}));
+
+            } else {
+                REQUIRE(ned_sjid == std::vector<int64_t>({1, 101}));
+                REQUIRE(ned_u32 == std::vector<uint32_t>({1234, 5678}));
+
+                REQUIRE(dom_sjid == std::vector<int64_t>({0, 199}));
+                if (test_upgrade_domain) {
+                    REQUIRE(dom_u32 == std::vector<uint32_t>({0, 19999}));
+                } else {
+                    REQUIRE(dom_u32 == std::vector<uint32_t>({0, 9999}));
+                }
+
+                REQUIRE(maxdom_sjid.size() == 2);
+                REQUIRE(maxdom_sjid[0] == 0);
+                REQUIRE(maxdom_sjid[1] > 2000000000);
+
+                REQUIRE(maxdom_u32.size() == 2);
+                REQUIRE(maxdom_u32[0] == 0);
+                REQUIRE(maxdom_u32[1] > 2000000000);
+            }
+
+            // Check can_resize_soma_joinid_shape
+            StatusAndReason check = sdf->can_resize_soma_joinid_shape(
+                1, "testing");
+            if (!use_current_domain) {
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: dataframe currently has no domain set.");
+            } else {
+                // Must fail since this is too small.
+                REQUIRE(check.first == false);
+                REQUIRE(
+                    check.second ==
+                    "testing: new soma_joinid shape 1 < existing shape "
+                    "200");
+                check = sdf->can_resize_soma_joinid_shape(
+                    SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
+                REQUIRE(check.first == true);
+                REQUIRE(check.second == "");
+            }
+
+            sdf->close();
+        }
     }
 }
 
@@ -1072,270 +1209,343 @@ TEST_CASE_METHOD(
         auto specify_domain = GENERATE(false, true);
         std::ostringstream section2;
         section2 << "- specify_domain=" << specify_domain;
+        SECTION(section2.str()) {
+            auto test_upgrade_domain = GENERATE(false, true);
+            std::ostringstream section3;
+            section << "- test_upgrade_domain=" << test_upgrade_domain;
+            SECTION(section3.str()) {
+                std::string suffix1 = use_current_domain ? "true" : "false";
+                std::string suffix2 = specify_domain ? "true" : "false";
+                std::string suffix3 = test_upgrade_domain ? "true" : "false";
+                set_up(
+                    std::make_shared<SOMAContext>(),
+                    "mem://unit-test-variant-indexed-dataframe-3-" + suffix1 +
+                        "-" + suffix2 + "-" + suffix3);
 
-        std::string suffix1 = use_current_domain ? "true" : "false";
-        std::string suffix2 = specify_domain ? "true" : "false";
-        set_up(
-            std::make_shared<SOMAContext>(),
-            "mem://unit-test-variant-indexed-dataframe-3-" + suffix1 + "-" +
-                suffix2);
+                std::string string_lo = specify_domain ? "apple" : "";
+                std::string string_hi = specify_domain ? "zebra" : "";
+                std::vector<helper::DimInfo> dim_infos(
+                    {i64_dim_info(use_current_domain),
+                     str_dim_info(use_current_domain, string_lo, string_hi)});
+                std::vector<helper::AttrInfo> attr_infos({u32_attr_info()});
 
-        std::string string_lo = specify_domain ? "apple" : "";
-        std::string string_hi = specify_domain ? "zebra" : "";
-        std::vector<helper::DimInfo> dim_infos(
-            {i64_dim_info(use_current_domain),
-             str_dim_info(use_current_domain, string_lo, string_hi)});
-        std::vector<helper::AttrInfo> attr_infos({u32_attr_info()});
+                // Create
+                create(dim_infos, attr_infos);
 
-        // Create
-        create(dim_infos, attr_infos);
+                // Check current domain
+                auto sdf = open(OpenMode::read);
 
-        // Check current domain
-        auto sdf = open(OpenMode::read);
+                CurrentDomain
+                    current_domain = sdf->get_current_domain_for_test();
+                if (!use_current_domain) {
+                    REQUIRE(current_domain.is_empty());
+                } else {
+                    REQUIRE(!current_domain.is_empty());
+                    REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+                    NDRectangle ndrect = current_domain.ndrectangle();
 
-        CurrentDomain current_domain = sdf->get_current_domain_for_test();
-        if (!use_current_domain) {
-            REQUIRE(current_domain.is_empty());
-        } else {
-            REQUIRE(!current_domain.is_empty());
-            REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
-            NDRectangle ndrect = current_domain.ndrectangle();
+                    std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
+                        dim_infos[0].name);
+                    REQUIRE(i64_range[0] == (int64_t)0);
+                    REQUIRE(i64_range[1] == (int64_t)dim_infos[0].dim_max);
 
-            std::array<int64_t, 2> i64_range = ndrect.range<int64_t>(
-                dim_infos[0].name);
-            REQUIRE(i64_range[0] == (int64_t)0);
-            REQUIRE(i64_range[1] == (int64_t)dim_infos[0].dim_max);
+                    std::array<std::string, 2>
+                        str_range = ndrect.range<std::string>(
+                            dim_infos[1].name);
+                    if (specify_domain) {
+                        REQUIRE(str_range[0] == dim_infos[1].string_lo);
+                        REQUIRE(str_range[1] == dim_infos[1].string_hi);
+                    } else {
+                        // Can we write empty strings in this range?
+                        REQUIRE(str_range[0] <= "");
+                        REQUIRE(str_range[1] >= "");
+                        // Can we write ASCII values in this range?
+                        REQUIRE(str_range[0] < " ");
+                        REQUIRE(str_range[1] > "~");
+                    }
+                }
 
-            std::array<std::string, 2> str_range = ndrect.range<std::string>(
-                dim_infos[1].name);
-            if (specify_domain) {
-                REQUIRE(str_range[0] == dim_infos[1].string_lo);
-                REQUIRE(str_range[1] == dim_infos[1].string_hi);
-            } else {
-                // Can we write empty strings in this range?
-                REQUIRE(str_range[0] <= "");
-                REQUIRE(str_range[1] >= "");
-                // Can we write ASCII values in this range?
-                REQUIRE(str_range[0] < " ");
-                REQUIRE(str_range[1] > "~");
+                // Check shape before write
+                int64_t expect = dim_infos[0].dim_max + 1;
+                std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == expect);
+                sdf->close();
+
+                REQUIRE(sdf->nnz() == 0);
+
+                // Write
+                write_sjid_u32_str_data_from(0);
+
+                REQUIRE(sdf->nnz() == 2);
+                write_sjid_u32_str_data_from(8);
+                REQUIRE(sdf->nnz() == 4);
+
+                // Check shape after write
+                sdf = open(OpenMode::read);
+                expect = dim_infos[0].dim_max + 1;
+                actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(actual.has_value());
+                REQUIRE(actual.value() == expect);
+
+                // Check domainish accessors before resize
+                ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+                std::vector<int64_t> ned_sjid =
+                    ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                        non_empty_domain, "soma_joinid");
+                std::vector<std::string>
+                    ned_str = ArrowAdapter::get_table_string_column_by_name(
+                        non_empty_domain, "mystring");
+
+                ArrowTable soma_domain = sdf->get_soma_domain();
+                std::vector<int64_t> dom_sjid =
+                    ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                        soma_domain, "soma_joinid");
+                std::vector<std::string>
+                    dom_str = ArrowAdapter::get_table_string_column_by_name(
+                        soma_domain, "mystring");
+
+                ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+                std::vector<int64_t> maxdom_sjid =
+                    ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
+                        soma_maxdomain, "soma_joinid");
+                std::vector<std::string>
+                    maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                        soma_maxdomain, "mystring");
+
+                REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
+                REQUIRE(ned_str == std::vector<std::string>({"apple", "bat"}));
+
+                REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
+
+                if (!use_current_domain) {
+                    REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+                } else {
+                    if (specify_domain) {
+                        REQUIRE(dom_str[0] == dim_infos[1].string_lo);
+                        REQUIRE(dom_str[1] == dim_infos[1].string_hi);
+                    } else {
+                        REQUIRE(dom_str[0] == "");
+                        REQUIRE(dom_str[1] == "");
+                    }
+
+                    REQUIRE(maxdom_sjid[0] == 0);
+                    REQUIRE(maxdom_sjid[1] > 2000000000);
+                }
+                REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+
+                sdf->close();
+
+                // Check can_upgrade_domain
+                sdf = open(OpenMode::read);
+                std::unique_ptr<ArrowSchema>
+                    domain_schema = create_index_cols_info_schema(dim_infos);
+                auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                    dim_infos.size());
+                domain_array
+                    ->children[0] = ArrowAdapter::make_arrow_array_child(
+                    std::vector<int64_t>({0, 0}));
+                domain_array
+                    ->children[1] = ArrowAdapter::make_arrow_array_child_string(
+                    std::vector<std::string>({"a", "z"}));
+                auto domain_table = ArrowTable(
+                    std::move(domain_array), std::move(domain_schema));
+                if (!use_current_domain) {
+                    StatusAndReason check = sdf->can_upgrade_domain(
+                        domain_table, "testing");
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing for soma_joinid: new upper < old upper "
+                        "(downsize is "
+                        "unsupported)");
+                } else {
+                    StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                        1, "testing");
+                    // Must fail since this is too small.
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing: dataframe already has its domain set.");
+                }
+                sdf->close();
+
+                // Resize
+
+                auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
+
+                if (!use_current_domain) {
+                    // Domain is already set. The domain (not current domain
+                    // but domain) is immutable. All we can do is check for:
+                    // * throw on write beyond domain
+                    // * throw on an attempt to resize.
+                    REQUIRE_THROWS(
+                        write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                    sdf = open(OpenMode::write);
+
+                    // Array not resizeable if it has not already been sized
+                    if (test_upgrade_domain) {
+                        std::unique_ptr<ArrowSchema>
+                            domain_schema = create_index_cols_info_schema(
+                                dim_infos);
+                        auto domain_array =
+                            ArrowAdapter::make_arrow_array_parent(
+                                dim_infos.size());
+                        domain_array->children[0] =
+                            ArrowAdapter::make_arrow_array_child(
+                                std::vector<int64_t>({0, new_shape - 1}));
+                        domain_array->children[1] =
+                            ArrowAdapter::make_arrow_array_child_string(
+                                std::vector<std::string>({"", ""}));
+                        auto domain_table = ArrowTable(
+                            std::move(domain_array), std::move(domain_schema));
+                        REQUIRE_THROWS(
+                            sdf->change_domain(domain_table, "testing"));
+                    } else {
+                        REQUIRE_THROWS(sdf->resize_soma_joinid_shape(
+                            new_shape, "testing"));
+                    }
+
+                    sdf->close();
+
+                } else {
+                    // Expect throw on write beyond current domain before
+                    // resize
+                    REQUIRE_THROWS(
+                        write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+
+                    // Check shape after write
+                    sdf = open(OpenMode::read);
+                    expect = dim_infos[0].dim_max + 1;
+                    std::optional<int64_t>
+                        actual = sdf->maybe_soma_joinid_shape();
+                    REQUIRE(actual.has_value());
+                    REQUIRE(actual.value() == expect);
+                    sdf->close();
+
+                    // Apply the domain change
+                    if (test_upgrade_domain) {
+                        std::unique_ptr<ArrowSchema>
+                            domain_schema = create_index_cols_info_schema(
+                                dim_infos);
+                        auto domain_array =
+                            ArrowAdapter::make_arrow_array_parent(
+                                dim_infos.size());
+                        domain_array->children[0] =
+                            ArrowAdapter::make_arrow_array_child(
+                                std::vector<int64_t>({0, new_shape - 1}));
+                        domain_array->children[1] =
+                            ArrowAdapter::make_arrow_array_child_string(
+                                std::vector<std::string>({"", ""}));
+                        auto domain_table = ArrowTable(
+                            std::move(domain_array), std::move(domain_schema));
+
+                        // Not open for write
+                        sdf = open(OpenMode::read);
+                        REQUIRE_THROWS(
+                            sdf->change_domain(domain_table, "testing"));
+                        sdf->close();
+
+                        // Open for write
+                        sdf = open(OpenMode::write);
+                        sdf->change_domain(domain_table, "testing");
+                        sdf->close();
+
+                    } else {
+                        // Not open for write
+                        sdf = open(OpenMode::read);
+                        REQUIRE_THROWS(sdf->resize_soma_joinid_shape(
+                            new_shape, "testing"));
+                        sdf->close();
+
+                        // Open for write
+                        sdf = open(OpenMode::write);
+                        sdf->resize_soma_joinid_shape(new_shape, "testing");
+
+                        sdf->close();
+                    }
+                }
+
+                sdf->open(OpenMode::write);
+                if (!use_current_domain) {
+                    REQUIRE_THROWS(
+                        write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
+                } else {
+                    // Implicitly we expect no throw
+                    write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
+                }
+                sdf->close();
+
+                // Check domainish accessors after resize
+                sdf->open(OpenMode::read, TimestampRange(0, 2));
+
+                non_empty_domain = sdf->get_non_empty_domain();
+                ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                    int64_t>(non_empty_domain, "soma_joinid");
+                ned_str = ArrowAdapter::get_table_string_column_by_name(
+                    non_empty_domain, "mystring");
+
+                soma_domain = sdf->get_soma_domain();
+                dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                    int64_t>(soma_domain, "soma_joinid");
+                dom_str = ArrowAdapter::get_table_string_column_by_name(
+                    soma_domain, "mystring");
+
+                soma_maxdomain = sdf->get_soma_maxdomain();
+                maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
+                    int64_t>(soma_maxdomain, "soma_joinid");
+                maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                    soma_maxdomain, "mystring");
+
+                REQUIRE(ned_sjid == std::vector<int64_t>({0, 0}));
+                REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+                REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
+
+                if (!use_current_domain) {
+                    REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
+                    REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                } else {
+                    if (specify_domain) {
+                        REQUIRE(dom_str[0] == dim_infos[1].string_lo);
+                        REQUIRE(dom_str[1] == dim_infos[1].string_hi);
+                    } else {
+                        REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                    }
+
+                    REQUIRE(maxdom_sjid[0] == 0);
+                    REQUIRE(maxdom_sjid[1] > 2000000000);
+                }
+
+                REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+
+                REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+                // Check can_resize_soma_joinid_shape
+                StatusAndReason check = sdf->can_resize_soma_joinid_shape(
+                    1, "testing");
+                if (!use_current_domain) {
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing: dataframe currently has no domain set.");
+                } else {
+                    // Must fail since this is too small.
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing: new soma_joinid shape 1 < existing shape "
+                        "100");
+                    check = sdf->can_resize_soma_joinid_shape(
+                        SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
+                    REQUIRE(check.first == true);
+                    REQUIRE(check.second == "");
+                }
+
+                sdf->close();
             }
         }
-
-        // Check shape before write
-        int64_t expect = dim_infos[0].dim_max + 1;
-        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
-        sdf->close();
-
-        REQUIRE(sdf->nnz() == 0);
-
-        // Write
-        write_sjid_u32_str_data_from(0);
-
-        REQUIRE(sdf->nnz() == 2);
-        write_sjid_u32_str_data_from(8);
-        REQUIRE(sdf->nnz() == 4);
-
-        // Check shape after write
-        sdf = open(OpenMode::read);
-        expect = dim_infos[0].dim_max + 1;
-        actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(actual.has_value());
-        REQUIRE(actual.value() == expect);
-
-        // Check domainish accessors before resize
-        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
-        std::vector<int64_t> ned_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                non_empty_domain, "soma_joinid");
-        std::vector<std::string>
-            ned_str = ArrowAdapter::get_table_string_column_by_name(
-                non_empty_domain, "mystring");
-
-        ArrowTable soma_domain = sdf->get_soma_domain();
-        std::vector<int64_t> dom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_domain, "soma_joinid");
-        std::vector<std::string>
-            dom_str = ArrowAdapter::get_table_string_column_by_name(
-                soma_domain, "mystring");
-
-        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
-        std::vector<int64_t> maxdom_sjid =
-            ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-                soma_maxdomain, "soma_joinid");
-        std::vector<std::string>
-            maxdom_str = ArrowAdapter::get_table_string_column_by_name(
-                soma_maxdomain, "mystring");
-
-        REQUIRE(ned_sjid == std::vector<int64_t>({1, 10}));
-        REQUIRE(ned_str == std::vector<std::string>({"apple", "bat"}));
-
-        REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
-
-        if (!use_current_domain) {
-            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
-        } else {
-            if (specify_domain) {
-                REQUIRE(dom_str[0] == dim_infos[1].string_lo);
-                REQUIRE(dom_str[1] == dim_infos[1].string_hi);
-            } else {
-                REQUIRE(dom_str[0] == "");
-                REQUIRE(dom_str[1] == "");
-            }
-
-            REQUIRE(maxdom_sjid[0] == 0);
-            REQUIRE(maxdom_sjid[1] > 2000000000);
-        }
-        REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-
-        sdf->close();
-
-        // Check can_upgrade_domain
-        sdf = open(OpenMode::read);
-        std::unique_ptr<ArrowSchema>
-            domain_schema = create_index_cols_info_schema(dim_infos);
-        auto domain_array = ArrowAdapter::make_arrow_array_parent(
-            dim_infos.size());
-        domain_array->children[0] = ArrowAdapter::make_arrow_array_child(
-            std::vector<int64_t>({0, 0}));
-        domain_array->children[1] = ArrowAdapter::make_arrow_array_child_string(
-            std::vector<std::string>({"a", "z"}));
-        auto domain_table = ArrowTable(
-            std::move(domain_array), std::move(domain_schema));
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_domain(
-                domain_table, "testing");
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing for soma_joinid: new upper < old upper (downsize is "
-                "unsupported)");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-        sdf->close();
-
-        // Resize
-        auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
-
-        if (!use_current_domain) {
-            // Domain is already set. The domain (not current domain but
-            // domain) is immutable. All we can do is check for:
-            // * throw on write beyond domain
-            // * throw on an attempt to resize.
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            sdf = open(OpenMode::write);
-            // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-        } else {
-            // Expect throw on write beyond current domain before resize
-            REQUIRE_THROWS(write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX));
-
-            // Check shape after write
-            sdf = open(OpenMode::read);
-            expect = dim_infos[0].dim_max + 1;
-            std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(actual.has_value());
-            REQUIRE(actual.value() == expect);
-            sdf->close();
-
-            sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-            sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape, "testing");
-            sdf->close();
-
-            // Check shape after resize
-            sdf = open(OpenMode::read);
-            expect = SOMA_JOINID_RESIZE_DIM_MAX + 1;
-            actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(actual.has_value());
-            REQUIRE(actual.value() == expect);
-            sdf->close();
-
-            // Implicitly we expect no throw
-            write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
-        }
-
-        // Check domainish accessors after resize
-        sdf->open(OpenMode::read, TimestampRange(0, 2));
-
-        non_empty_domain = sdf->get_non_empty_domain();
-        ned_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            non_empty_domain, "soma_joinid");
-        ned_str = ArrowAdapter::get_table_string_column_by_name(
-            non_empty_domain, "mystring");
-
-        soma_domain = sdf->get_soma_domain();
-        dom_sjid = ArrowAdapter::get_table_non_string_column_by_name<int64_t>(
-            soma_domain, "soma_joinid");
-        dom_str = ArrowAdapter::get_table_string_column_by_name(
-            soma_domain, "mystring");
-
-        soma_maxdomain = sdf->get_soma_maxdomain();
-        maxdom_sjid = ArrowAdapter::get_table_non_string_column_by_name<
-            int64_t>(soma_maxdomain, "soma_joinid");
-        maxdom_str = ArrowAdapter::get_table_string_column_by_name(
-            soma_maxdomain, "mystring");
-
-        REQUIRE(ned_sjid == std::vector<int64_t>({0, 0}));
-        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
-
-        REQUIRE(dom_sjid == std::vector<int64_t>({0, 99}));
-
-        if (!use_current_domain) {
-            REQUIRE(maxdom_sjid == std::vector<int64_t>({0, 99}));
-            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-        } else {
-            if (specify_domain) {
-                REQUIRE(dom_str[0] == dim_infos[1].string_lo);
-                REQUIRE(dom_str[1] == dim_infos[1].string_hi);
-            } else {
-                REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-            }
-
-            REQUIRE(maxdom_sjid[0] == 0);
-            REQUIRE(maxdom_sjid[1] > 2000000000);
-        }
-
-        REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-
-        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
-
-        // Check can_resize_soma_joinid_shape
-        StatusAndReason check = sdf->can_resize_soma_joinid_shape(1, "testing");
-        if (!use_current_domain) {
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe currently has no domain set.");
-        } else {
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: new soma_joinid shape 1 < existing shape "
-                "100");
-            check = sdf->can_resize_soma_joinid_shape(
-                SOMA_JOINID_RESIZE_DIM_MAX + 1, "testing");
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
-        }
-
-        sdf->close();
     }
 }
 
@@ -1350,225 +1560,288 @@ TEST_CASE_METHOD(
         auto specify_domain = GENERATE(false, true);
         std::ostringstream section2;
         section2 << "- specify_domain=" << specify_domain;
+        SECTION(section2.str()) {
+            auto test_upgrade_domain = GENERATE(false, true);
+            std::ostringstream section3;
+            section << "- test_upgrade_domain=" << test_upgrade_domain;
+            SECTION(section3.str()) {
+                std::string suffix1 = use_current_domain ? "true" : "false";
+                std::string suffix2 = specify_domain ? "true" : "false";
+                std::string suffix3 = test_upgrade_domain ? "true" : "false";
+                set_up(
+                    std::make_shared<SOMAContext>(),
+                    "mem://unit-test-variant-indexed-dataframe-4-" + suffix1 +
+                        "-" + suffix2 + "-" + suffix3);
 
-        std::string suffix1 = use_current_domain ? "true" : "false";
-        std::string suffix2 = specify_domain ? "true" : "false";
-        set_up(
-            std::make_shared<SOMAContext>(),
-            "mem://unit-test-variant-indexed-dataframe-4-" + suffix1 + "-" +
-                suffix2);
+                std::string string_lo = specify_domain ? "apple" : "";
+                std::string string_hi = specify_domain ? "zebra" : "";
+                std::vector<helper::DimInfo> dim_infos(
+                    {str_dim_info(use_current_domain, string_lo, string_hi),
+                     u32_dim_info(use_current_domain)});
+                std::vector<helper::AttrInfo> attr_infos({i64_attr_info()});
 
-        std::string string_lo = specify_domain ? "apple" : "";
-        std::string string_hi = specify_domain ? "zebra" : "";
-        std::vector<helper::DimInfo> dim_infos(
-            {str_dim_info(use_current_domain, string_lo, string_hi),
-             u32_dim_info(use_current_domain)});
-        std::vector<helper::AttrInfo> attr_infos({i64_attr_info()});
+                // Create
+                create(dim_infos, attr_infos);
 
-        // Create
-        create(dim_infos, attr_infos);
+                // Check current domain
+                auto sdf = open(OpenMode::read);
 
-        // Check current domain
-        auto sdf = open(OpenMode::read);
+                CurrentDomain
+                    current_domain = sdf->get_current_domain_for_test();
+                if (!use_current_domain) {
+                    REQUIRE(current_domain.is_empty());
+                } else {
+                    REQUIRE(!current_domain.is_empty());
+                    REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+                    NDRectangle ndrect = current_domain.ndrectangle();
 
-        CurrentDomain current_domain = sdf->get_current_domain_for_test();
-        if (!use_current_domain) {
-            REQUIRE(current_domain.is_empty());
-        } else {
-            REQUIRE(!current_domain.is_empty());
-            REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
-            NDRectangle ndrect = current_domain.ndrectangle();
+                    std::array<std::string, 2>
+                        str_range = ndrect.range<std::string>(
+                            dim_infos[0].name);
+                    if (specify_domain) {
+                        REQUIRE(str_range[0] == dim_infos[0].string_lo);
+                        REQUIRE(str_range[1] == dim_infos[0].string_hi);
+                    } else {
+                        // Can we write empty strings in this range?
+                        REQUIRE(str_range[0] <= "");
+                        REQUIRE(str_range[1] >= "");
+                        // Can we write ASCII values in this range?
+                        REQUIRE(str_range[0] < " ");
+                        REQUIRE(str_range[1] > "~");
+                    }
 
-            std::array<std::string, 2> str_range = ndrect.range<std::string>(
-                dim_infos[0].name);
-            if (specify_domain) {
-                REQUIRE(str_range[0] == dim_infos[0].string_lo);
-                REQUIRE(str_range[1] == dim_infos[0].string_hi);
-            } else {
-                // Can we write empty strings in this range?
-                REQUIRE(str_range[0] <= "");
-                REQUIRE(str_range[1] >= "");
-                // Can we write ASCII values in this range?
-                REQUIRE(str_range[0] < " ");
-                REQUIRE(str_range[1] > "~");
+                    std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
+                        dim_infos[1].name);
+                    REQUIRE(u32_range[0] == (uint32_t)0);
+                    REQUIRE(u32_range[1] == (uint32_t)dim_infos[1].dim_max);
+                }
+
+                // Check shape before write
+                std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(!actual.has_value());
+
+                // Check domainish accessors before resize
+                ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+                std::vector<std::string>
+                    ned_str = ArrowAdapter::get_table_string_column_by_name(
+                        non_empty_domain, "mystring");
+
+                ArrowTable soma_domain = sdf->get_soma_domain();
+                std::vector<std::string>
+                    dom_str = ArrowAdapter::get_table_string_column_by_name(
+                        soma_domain, "mystring");
+
+                ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+                std::vector<std::string>
+                    maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                        soma_maxdomain, "mystring");
+
+                REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+                if (!use_current_domain) {
+                    REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                    REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+                } else {
+                    if (specify_domain) {
+                        REQUIRE(dom_str[0] == dim_infos[0].string_lo);
+                        REQUIRE(dom_str[1] == dim_infos[0].string_hi);
+                    } else {
+                        REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                    }
+                    REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+                }
+
+                sdf->close();
+
+                REQUIRE(sdf->nnz() == 0);
+
+                // Write
+                write_sjid_u32_str_data_from(0);
+
+                REQUIRE(sdf->nnz() == 2);
+                write_sjid_u32_str_data_from(8);
+                // soma_joinid is not a dim here and so the second write is
+                // an overwrite of the first here
+                REQUIRE(sdf->nnz() == 2);
+
+                // Check shape after write
+                sdf = open(OpenMode::read);
+                actual = sdf->maybe_soma_joinid_shape();
+                REQUIRE(!actual.has_value());
+                sdf->close();
+
+                // Check can_upgrade_domain
+                sdf = open(OpenMode::read);
+                std::unique_ptr<ArrowSchema>
+                    domain_schema = create_index_cols_info_schema(dim_infos);
+                auto domain_array = ArrowAdapter::make_arrow_array_parent(
+                    dim_infos.size());
+                domain_array
+                    ->children[0] = ArrowAdapter::make_arrow_array_child_string(
+                    std::vector<std::string>({"a", "z"}));
+                domain_array
+                    ->children[1] = ArrowAdapter::make_arrow_array_child(
+                    std::vector<uint32_t>({0, 0}));
+                auto domain_table = ArrowTable(
+                    std::move(domain_array), std::move(domain_schema));
+                if (!use_current_domain) {
+                    StatusAndReason check = sdf->can_upgrade_domain(
+                        domain_table, "testing");
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing for mystring: domain cannot be set for string "
+                        "index columns: please use (\"\", \"\")");
+                } else {
+                    StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
+                        1, "testing");
+                    // Must fail since this is too small.
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing: dataframe already has its domain set.");
+                }
+                sdf->close();
+
+                // Resize
+                int64_t new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
+                uint32_t new_u32_dim_max = u32_dim_max * 2 + 1;
+
+                if (!use_current_domain) {
+                    // Domain is already set. The domain (not current domain
+                    // but domain) is immutable. All we can do is check for:
+                    // * throw on write beyond domain -- except here,
+                    // soma_joinid is not
+                    //   a dim, so no throw
+                    // * throw on an attempt to resize.
+
+                    sdf = open(OpenMode::write);
+
+                    // Array not resizeable if it has not already been sized
+                    if (test_upgrade_domain) {
+                        std::unique_ptr<ArrowSchema>
+                            domain_schema = create_index_cols_info_schema(
+                                dim_infos);
+                        auto domain_array =
+                            ArrowAdapter::make_arrow_array_parent(
+                                dim_infos.size());
+                        domain_array->children[0] =
+                            ArrowAdapter::make_arrow_array_child_string(
+                                std::vector<std::string>({"", ""}));
+                        domain_array->children[1] =
+                            ArrowAdapter::make_arrow_array_child(
+                                std::vector<uint32_t>({0, new_u32_dim_max}));
+                        auto domain_table = ArrowTable(
+                            std::move(domain_array), std::move(domain_schema));
+                        REQUIRE_THROWS(
+                            sdf->change_domain(domain_table, "testing"));
+                    } else {
+                        REQUIRE_THROWS(sdf->resize_soma_joinid_shape(
+                            new_shape, "testing"));
+                    }
+
+                    sdf->close();
+
+                } else {
+                    // Check shape after write
+                    sdf = open(OpenMode::read);
+                    std::optional<int64_t>
+                        actual = sdf->maybe_soma_joinid_shape();
+                    REQUIRE(!actual.has_value());
+                    sdf->close();
+
+                    // Apply the domain change
+                    if (test_upgrade_domain) {
+                        std::unique_ptr<ArrowSchema>
+                            domain_schema = create_index_cols_info_schema(
+                                dim_infos);
+                        auto domain_array =
+                            ArrowAdapter::make_arrow_array_parent(
+                                dim_infos.size());
+                        domain_array->children[0] =
+                            ArrowAdapter::make_arrow_array_child_string(
+                                std::vector<std::string>({"", ""}));
+                        domain_array->children[1] =
+                            ArrowAdapter::make_arrow_array_child(
+                                std::vector<uint32_t>({0, new_u32_dim_max}));
+                        auto domain_table = ArrowTable(
+                            std::move(domain_array), std::move(domain_schema));
+
+                        // Not open for write
+                        sdf = open(OpenMode::read);
+                        REQUIRE_THROWS(
+                            sdf->change_domain(domain_table, "testing"));
+                        sdf->close();
+
+                        // Open for write
+                        sdf = open(OpenMode::write);
+                        sdf->change_domain(domain_table, "testing");
+                        sdf->close();
+
+                    } else {
+                        // Not open for write
+                        sdf = open(OpenMode::read);
+                        REQUIRE_THROWS(sdf->resize_soma_joinid_shape(
+                            new_shape, "testing"));
+                        sdf->close();
+
+                        // Open for write
+                        sdf = open(OpenMode::write);
+                        sdf->resize_soma_joinid_shape(new_shape, "testing");
+                        sdf->close();
+                    }
+                }
+
+                sdf = open(OpenMode::write);
+                write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
+                sdf->close();
+
+                // Check domainish accessors after resize
+                sdf->open(OpenMode::read, TimestampRange(0, 2));
+
+                non_empty_domain = sdf->get_non_empty_domain();
+                ned_str = ArrowAdapter::get_table_string_column_by_name(
+                    non_empty_domain, "mystring");
+
+                soma_domain = sdf->get_soma_domain();
+                dom_str = ArrowAdapter::get_table_string_column_by_name(
+                    soma_domain, "mystring");
+
+                soma_maxdomain = sdf->get_soma_maxdomain();
+                maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                    soma_maxdomain, "mystring");
+
+                REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+                if (!use_current_domain) {
+                    REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                    REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+                } else {
+                    if (specify_domain) {
+                        REQUIRE(dom_str[0] == dim_infos[0].string_lo);
+                        REQUIRE(dom_str[1] == dim_infos[0].string_hi);
+                    } else {
+                        REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+                    }
+                    REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+                }
+
+                // Check can_resize_soma_joinid_shape
+                StatusAndReason check = sdf->can_resize_soma_joinid_shape(
+                    0, "testing");
+                if (!use_current_domain) {
+                    REQUIRE(check.first == false);
+                    REQUIRE(
+                        check.second ==
+                        "testing: dataframe currently has no domain set.");
+                } else {
+                    // Must pass since soma_joinid isn't a dim in this case.
+                    REQUIRE(check.first == true);
+                    REQUIRE(check.second == "");
+                }
+
+                sdf->close();
             }
-
-            std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
-                dim_infos[1].name);
-            REQUIRE(u32_range[0] == (uint32_t)0);
-            REQUIRE(u32_range[1] == (uint32_t)dim_infos[1].dim_max);
         }
-
-        // Check shape before write
-        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(!actual.has_value());
-
-        // Check domainish accessors before resize
-        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
-        std::vector<std::string>
-            ned_str = ArrowAdapter::get_table_string_column_by_name(
-                non_empty_domain, "mystring");
-
-        ArrowTable soma_domain = sdf->get_soma_domain();
-        std::vector<std::string>
-            dom_str = ArrowAdapter::get_table_string_column_by_name(
-                soma_domain, "mystring");
-
-        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
-        std::vector<std::string>
-            maxdom_str = ArrowAdapter::get_table_string_column_by_name(
-                soma_maxdomain, "mystring");
-
-        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
-
-        if (!use_current_domain) {
-            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-            REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-        } else {
-            if (specify_domain) {
-                REQUIRE(dom_str[0] == dim_infos[0].string_lo);
-                REQUIRE(dom_str[1] == dim_infos[0].string_hi);
-            } else {
-                REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-            }
-            REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-        }
-
-        sdf->close();
-
-        REQUIRE(sdf->nnz() == 0);
-
-        // Write
-        write_sjid_u32_str_data_from(0);
-
-        REQUIRE(sdf->nnz() == 2);
-        write_sjid_u32_str_data_from(8);
-        // soma_joinid is not a dim here and so the second write is an
-        // overwrite of the first here
-        REQUIRE(sdf->nnz() == 2);
-
-        // Check shape after write
-        sdf = open(OpenMode::read);
-        actual = sdf->maybe_soma_joinid_shape();
-        REQUIRE(!actual.has_value());
-        sdf->close();
-
-        // Check can_upgrade_domain
-        sdf = open(OpenMode::read);
-        std::unique_ptr<ArrowSchema>
-            domain_schema = create_index_cols_info_schema(dim_infos);
-        auto domain_array = ArrowAdapter::make_arrow_array_parent(
-            dim_infos.size());
-        domain_array->children[0] = ArrowAdapter::make_arrow_array_child_string(
-            std::vector<std::string>({"a", "z"}));
-        domain_array->children[1] = ArrowAdapter::make_arrow_array_child(
-            std::vector<uint32_t>({0, 0}));
-        auto domain_table = ArrowTable(
-            std::move(domain_array), std::move(domain_schema));
-        if (!use_current_domain) {
-            StatusAndReason check = sdf->can_upgrade_domain(
-                domain_table, "testing");
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing for mystring: new lower > old lower (downsize is "
-                "unsupported)");
-        } else {
-            StatusAndReason check = sdf->can_upgrade_soma_joinid_shape(
-                1, "testing");
-            // Must fail since this is too small.
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe already has its domain set.");
-        }
-        sdf->close();
-
-        // Resize
-        auto new_shape = int64_t{SOMA_JOINID_RESIZE_DIM_MAX + 1};
-
-        if (!use_current_domain) {
-            // Domain is already set. The domain (not current domain but
-            // domain) is immutable. All we can do is check for:
-            // * throw on write beyond domain -- except here,
-            // soma_joinid is not
-            //   a dim, so no throw
-            // * throw on an attempt to resize.
-
-            sdf = open(OpenMode::write);
-            // Array not resizeable if it has not already been sized
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-        } else {
-            // Check shape after write
-            sdf = open(OpenMode::read);
-            std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(!actual.has_value());
-            sdf->close();
-
-            sdf = open(OpenMode::read);
-            REQUIRE_THROWS(sdf->resize_soma_joinid_shape(new_shape, "testing"));
-            sdf->close();
-
-            sdf = open(OpenMode::write);
-            sdf->resize_soma_joinid_shape(new_shape, "testing");
-            sdf->close();
-
-            // Check shape after resize -- noting soma_joinid is not a
-            // dim here
-            sdf = open(OpenMode::read);
-            actual = sdf->maybe_soma_joinid_shape();
-            REQUIRE(!actual.has_value());
-            sdf->close();
-
-            // Implicitly we expect no throw
-            write_sjid_u32_str_data_from(SOMA_JOINID_DIM_MAX);
-        }
-
-        // Check domainish accessors after resize
-        sdf->open(OpenMode::read, TimestampRange(0, 2));
-
-        non_empty_domain = sdf->get_non_empty_domain();
-        ned_str = ArrowAdapter::get_table_string_column_by_name(
-            non_empty_domain, "mystring");
-
-        soma_domain = sdf->get_soma_domain();
-        dom_str = ArrowAdapter::get_table_string_column_by_name(
-            soma_domain, "mystring");
-
-        soma_maxdomain = sdf->get_soma_maxdomain();
-        maxdom_str = ArrowAdapter::get_table_string_column_by_name(
-            soma_maxdomain, "mystring");
-
-        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
-
-        if (!use_current_domain) {
-            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-            REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-        } else {
-            if (specify_domain) {
-                REQUIRE(dom_str[0] == dim_infos[0].string_lo);
-                REQUIRE(dom_str[1] == dim_infos[0].string_hi);
-            } else {
-                REQUIRE(dom_str == std::vector<std::string>({"", ""}));
-            }
-            REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
-        }
-
-        // Check can_resize_soma_joinid_shape
-        StatusAndReason check = sdf->can_resize_soma_joinid_shape(0, "testing");
-        if (!use_current_domain) {
-            REQUIRE(check.first == false);
-            REQUIRE(
-                check.second ==
-                "testing: dataframe currently has no domain set.");
-        } else {
-            // Must pass since soma_joinid isn't a dim in this case.
-            REQUIRE(check.first == true);
-            REQUIRE(check.second == "");
-        }
-
-        sdf->close();
     }
 }


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Resolve discrepancies between function names and #2407.

**Notes for Reviewer:**
