### PR TITLE
[r] Bindings for `upgrade_domain`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -547,8 +547,9 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         ``DataFrame`` does not have a domain set yet.  The argument must be a
         tuple of pairs of low/high values for the desired domain, one pair per
         index column. For string index columns, you must offer the low/high pair
-        as `("", "")`.  If ``check_only`` is ``True``, returns whether the
-        operation would succeed if attempted, and a reason why it would not.
+        as `("", "")`, or as `None`.  If ``check_only`` is ``True``, returns
+        whether the operation would succeed if attempted, and a reason why it
+        would not.
         """
         pyarrow_domain_table = self._upgrade_or_change_domain_helper(
             newdomain, "tiledbsoma_upgrade_domain"
@@ -574,8 +575,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         the ``DataFrame`` already has a domain.  The argument must be a tuple of
         pairs of low/high values for the desired domain, one pair per index
         column. For string index columns, you must offer the low/high pair as
-        `("", "")`.  If ``check_only`` is ``True``, returns whether the
-        operation would succeed if attempted, and a reason why it would not.
+        `("", "")`, or as `None`.  If ``check_only`` is ``True``, returns whether
+        the operation would succeed if attempted, and a reason why it would not.
         """
         pyarrow_domain_table = self._upgrade_or_change_domain_helper(
             newdomain, "change_domain"

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.99.10
+Version: 1.15.99.11
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -18,6 +18,32 @@
 * Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
 * Min-sizing for dataframes/arrays with new shape feature [#3208](https://github.com/single-cell-data/TileDB-SOMA/pull/3208)
 * Proper prefixing for shape-related methods [#3237](https://github.com/single-cell-data/TileDB-SOMA/pull/3237)
+* Bindings for `upgrade_domain` [#3238](https://github.com/single-cell-data/TileDB-SOMA/pull/3238)
+
+# tiledbsoma 1.14.5
+
+## Changes
+
+* Fixes a Python-only bug [#3225](https://github.com/single-cell-data/TileDB-SOMA/pull/3225)
+
+# tiledbsoma 1.14.4
+
+## Changes
+
+* Add new Arrow-to-R type mapper [#3161](https://github.com/single-cell-data/TileDB-SOMA/pull/3161)
+* Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
+
+# tiledbsoma 1.14.3
+
+## Changes
+
+* Handle `numeric` coords properly when reading arrays [3145](https://github.com/single-cell-data/TileDB-SOMA/pull/3145)
+
+# tiledbsoma 1.14.2
+
+## Changes
+
+* Fixes a Python-only bug [#3074](https://github.com/single-cell-data/TileDB-SOMA/pull/3074)
 
 # tiledbsoma 1.14.1
 

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -250,6 +250,10 @@ tiledbsoma_upgrade_shape <- function(uri, new_shape, function_name_for_messages,
     invisible(.Call(`_tiledbsoma_tiledbsoma_upgrade_shape`, uri, new_shape, function_name_for_messages, ctxxp))
 }
 
+upgrade_or_change_domain <- function(uri, is_change_domain, nadimap, nadimsp, function_name_for_messages, ctxxp) {
+    invisible(.Call(`_tiledbsoma_upgrade_or_change_domain`, uri, is_change_domain, nadimap, nadimsp, function_name_for_messages, ctxxp))
+}
+
 c_update_dataframe_schema <- function(uri, ctxxp, column_names_to_drop, add_cols_types, add_cols_enum_value_types, add_cols_enum_ordered) {
     invisible(.Call(`_tiledbsoma_c_update_dataframe_schema`, uri, ctxxp, column_names_to_drop, add_cols_types, add_cols_enum_value_types, add_cols_enum_ordered))
 }

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -557,7 +557,15 @@ SOMADataFrame <- R6::R6Class(
       # Get the user's new_domain list with keys in the same order as dim_names.
       ordered_new_domain = list()
       for (dimname in dimnames) {
-        ordered_new_domain[[dimname]] <- new_domain[[dimname]]
+        # * Domain cannot be specified for string-type index columns.
+        # * So we let them say `NULL` rather than `c("", "")`.
+        # * But R list semantics are `mylist[[key]] <- NULL` results in nothing
+        #   being set at that key.
+        if (is.null(new_domain[[dimname]]) && full_schema[[dimname]]$type$ToString() %in% c("string", "large_string", "utf8", "large_utf8")) {
+          ordered_new_domain[[dimname]] <- c("", "")
+        } else {
+          ordered_new_domain[[dimname]] <- new_domain[[dimname]]
+        }
       }
 
       pyarrow_table <- arrow::arrow_table(as.data.frame(ordered_new_domain), schema=dim_schema)

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -591,6 +591,21 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// upgrade_or_change_domain
+void upgrade_or_change_domain(const std::string& uri, bool is_change_domain, naxpArray nadimap, naxpSchema nadimsp, std::string function_name_for_messages, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_upgrade_or_change_domain(SEXP uriSEXP, SEXP is_change_domainSEXP, SEXP nadimapSEXP, SEXP nadimspSEXP, SEXP function_name_for_messagesSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_change_domain(is_change_domainSEXP);
+    Rcpp::traits::input_parameter< naxpArray >::type nadimap(nadimapSEXP);
+    Rcpp::traits::input_parameter< naxpSchema >::type nadimsp(nadimspSEXP);
+    Rcpp::traits::input_parameter< std::string >::type function_name_for_messages(function_name_for_messagesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    upgrade_or_change_domain(uri, is_change_domain, nadimap, nadimsp, function_name_for_messages, ctxxp);
+    return R_NilValue;
+END_RCPP
+}
 // c_update_dataframe_schema
 void c_update_dataframe_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::CharacterVector column_names_to_drop, Rcpp::List add_cols_types, Rcpp::List add_cols_enum_value_types, Rcpp::List add_cols_enum_ordered);
 RcppExport SEXP _tiledbsoma_c_update_dataframe_schema(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP column_names_to_dropSEXP, SEXP add_cols_typesSEXP, SEXP add_cols_enum_value_typesSEXP, SEXP add_cols_enum_orderedSEXP) {
@@ -822,6 +837,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 4},
     {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 4},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 4},
+    {"_tiledbsoma_upgrade_or_change_domain", (DL_FUNC) &_tiledbsoma_upgrade_or_change_domain, 6},
     {"_tiledbsoma_c_update_dataframe_schema", (DL_FUNC) &_tiledbsoma_c_update_dataframe_schema, 6},
     {"_tiledbsoma_sr_setup", (DL_FUNC) &_tiledbsoma_sr_setup, 10},
     {"_tiledbsoma_sr_complete", (DL_FUNC) &_tiledbsoma_sr_complete, 1},


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Straight-across port of #3235 from Python to R

**Notes for Reviewer:**

The Python side has an optarg `check_only` defaultingi to `False`. I'll add that on the R side too -- on a PR after this.

