### PR TITLE
[c++/python] Fixes for dense arrays and core 2.27/`dev`

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -20,7 +20,7 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
-from ._flags import NEW_SHAPE_FEATURE_FLAG_ENABLED
+from ._flags import DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN, NEW_SHAPE_FEATURE_FLAG_ENABLED
 from ._tdb_handles import DenseNDArrayWrapper
 from ._types import OpenTimestamp, Slice
 from ._util import dense_indices_to_shape
@@ -105,11 +105,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             dim_name = f"soma_dim_{dim_idx}"
             pa_field = pa.field(dim_name, pa.int64())
 
-            if NEW_SHAPE_FEATURE_FLAG_ENABLED and clib.embedded_version_triple() >= (
-                2,
-                27,
-                0,
-            ):
+            if NEW_SHAPE_FEATURE_FLAG_ENABLED and DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
                 dim_capacity, dim_extent = cls._dim_capacity_and_extent(
                     dim_name,
                     # The user specifies current domain -- this is the max domain
@@ -341,7 +337,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         """Supported for ``SparseNDArray``; scheduled for implementation for
         ``DenseNDArray`` in TileDB-SOMA 1.15
         """
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             self._handle.resize(newshape)
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -258,6 +258,10 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
+        # TODO: more on #2407, including the slotwise-none case
+        if coords == ():
+            coords = tuple(slice(0, e - 1) for e in data_shape)
+
         self._set_coords(sr, coords)
 
         arrow_tables = []

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -258,7 +258,20 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
-        # TODO: more on #2407, including the slotwise-none case
+        # Scenario to avoid:
+        # * Query dense array with coords not provided
+        # * When coords not provided, core uses the core domain
+        # For old shape:
+        # * Core current domain did not exist
+        # * Core max domain may be small; .shape returns this
+        # For new shape (core 2.27 and tiledbsoma 1.15):
+        # * Core current domain exists and will be small; .shape returns this
+        # * Core max domain will be huge
+        # In either case, applying these coords is the right thing to do
+        #
+        # TODO: more on #2407, including the case where the coords
+        # is not the empty tuple but has None or slice-of-None
+        # in one or more slots
         if coords == ():
             coords = tuple(slice(0, e - 1) for e in data_shape)
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -101,9 +101,22 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
 
         index_column_schema = []
         index_column_data = {}
+
         for dim_idx, dim_shape in enumerate(shape):
             dim_name = f"soma_dim_{dim_idx}"
+
             pa_field = pa.field(dim_name, pa.int64())
+            index_column_schema.append(pa_field)
+
+            # Here is our Arrow data API for communicating schema info between
+            # Python/R and C++ libtiledbsoma:
+            #
+            # [0] core max domain lo
+            # [1] core max domain hi
+            # [2] core extent parameter
+            # If present, these next two signal to use the current-domain feature:
+            # [3] core current domain lo
+            # [4] core current domain hi
 
             if NEW_SHAPE_FEATURE_FLAG_ENABLED and DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
                 dim_capacity, dim_extent = cls._dim_capacity_and_extent(
@@ -138,8 +151,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                     TileDBCreateOptions.from_platform_config(platform_config),
                 )
 
-            index_column_data[pa_field.name] = [0, dim_capacity - 1, dim_extent]
-            index_column_schema.append(pa_field)
+                index_column_data[pa_field.name] = [0, dim_capacity - 1, dim_extent]
 
         index_column_info = pa.RecordBatch.from_pydict(
             index_column_data, schema=pa.schema(index_column_schema)
@@ -349,16 +361,25 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         dim_shape: Optional[int],
         create_options: TileDBCreateOptions,
     ) -> Tuple[int, int]:
-        """Given a user-specified shape along a particular dimension, returns a tuple of
-        the TileDB capacity and extent for that dimension, suitable for schema creation.
-        The user-specified shape cannot be ``None`` for :class:`DenseNDArray`.
+        """Given a user-specified shape (maybe ``None``) along a particular dimension,
+        returns a tuple of the TileDB capacity and extent for that dimension, suitable
+        for schema creation. If the user-specified shape is None, the largest possible
+        int64 is returned for the capacity -- which is particularly suitable for
+        maxdomain.
         """
-        if dim_shape is None or dim_shape <= 0:
-            raise ValueError(
-                "SOMADenseNDArray shape must be a non-zero-length tuple of positive ints"
-            )
-
-        dim_capacity = dim_shape
-        dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
+        if dim_shape is None:
+            dim_capacity = 2**63 - 1
+            dim_extent = min(dim_capacity, create_options.dim_tile(dim_name, 2048))
+            # For core: "domain max expanded to multiple of tile extent exceeds max value
+            # representable by domain type. Reduce domain max by 1 tile extent to allow for
+            # expansion."
+            dim_capacity -= dim_extent
+        else:
+            if dim_shape <= 0:
+                raise ValueError(
+                    "SOMADenseNDArray shape must be a non-zero-length tuple of positive ints or Nones"
+                )
+            dim_capacity = dim_shape
+            dim_extent = min(dim_shape, create_options.dim_tile(dim_name, 2048))
 
         return (dim_capacity, dim_extent)

--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -5,9 +5,13 @@
 
 import os
 
+import tiledbsoma.pytiledbsoma as clib
+
 # This is temporary for
 # https://github.com/single-cell-data/TileDB-SOMA/issues/2407.  It will be
 # removed once https://github.com/single-cell-data/TileDB-SOMA/issues/2407 is
 # complete.
 
 NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"
+
+DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -150,7 +150,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             dim_name = f"soma_dim_{dim_idx}"
 
             pa_field = pa.field(dim_name, pa.int64())
-
             index_column_schema.append(pa_field)
 
             # Here is our Arrow data API for communicating schema info between
@@ -504,7 +503,8 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         """Given a user-specified shape (maybe ``None``) along a particular dimension,
         returns a tuple of the TileDB capacity and extent for that dimension, suitable
         for schema creation. If the user-specified shape is None, the largest possible
-        int64 is returned for the capacity.
+        int64 is returned for the capacity -- which is particularly suitable for
+        maxdomain.
         """
         if dim_shape is None:
             dim_capacity = 2**63 - 1

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -35,6 +35,7 @@ from typing_extensions import Literal, Self
 
 from . import pytiledbsoma as clib
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
+from ._flags import DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import SOMATileDBContext
 
@@ -643,7 +644,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     def resize(self, newshape: Sequence[Union[int, None]]) -> None:
         """Wrapper-class internals"""
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             self._handle.resize(newshape)
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")
@@ -652,7 +653,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
         self, newshape: Sequence[Union[int, None]]
     ) -> StatusAndReason:
         """Wrapper-class internals"""
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1854,14 +1854,12 @@ def _write_matrix_to_denseNDArray(
     # * Compute chunk sizes for both and take the minimum.
     chunk_size_using_nnz = int(math.ceil(tiledb_create_options.goal_chunk_nnz / ncol))
 
-    # try:
-    ## not scipy csr/csc
-    # itemsize = matrix.itemsize
-    # except AttributeError:
-    ## scipy csr/csc
-    # except AttributeError:
-    # XXX TEMP
-    itemsize = 8
+    try:
+        # not scipy csr/csc
+        itemsize = matrix.itemsize
+    except AttributeError:
+        # scipy csr/csc
+        itemsize = matrix.data.itemsize
 
     total_nbytes = matrix.size * itemsize
     nbytes_num_chunks = math.ceil(
@@ -1911,8 +1909,6 @@ def _write_matrix_to_denseNDArray(
         else:
             tensor = pa.Tensor.from_numpy(chunk.toarray())
         if matrix.ndim == 2:
-            ### XXX BUG soma_ndarray.write((slice(i, i2), slice(None)), tensor)
-            ### soma_ndarray.write((slice(i, i2), slice(0, ncol - 1)), tensor)
             soma_ndarray.write((slice(i, i2), slice(0, ncol)), tensor)
         else:
             soma_ndarray.write((slice(i, i2),), tensor)

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1854,12 +1854,14 @@ def _write_matrix_to_denseNDArray(
     # * Compute chunk sizes for both and take the minimum.
     chunk_size_using_nnz = int(math.ceil(tiledb_create_options.goal_chunk_nnz / ncol))
 
-    try:
-        # not scipy csr/csc
-        itemsize = matrix.itemsize
-    except AttributeError:
-        # scipy csr/csc
-        itemsize = matrix.data.itemsize
+    #try:
+        ## not scipy csr/csc
+        #itemsize = matrix.itemsize
+    #except AttributeError:
+        ## scipy csr/csc
+    #except AttributeError:
+    # XXX TEMP
+    itemsize = 8
 
     total_nbytes = matrix.size * itemsize
     nbytes_num_chunks = math.ceil(

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1854,12 +1854,12 @@ def _write_matrix_to_denseNDArray(
     # * Compute chunk sizes for both and take the minimum.
     chunk_size_using_nnz = int(math.ceil(tiledb_create_options.goal_chunk_nnz / ncol))
 
-    #try:
-        ## not scipy csr/csc
-        #itemsize = matrix.itemsize
-    #except AttributeError:
-        ## scipy csr/csc
-    #except AttributeError:
+    # try:
+    ## not scipy csr/csc
+    # itemsize = matrix.itemsize
+    # except AttributeError:
+    ## scipy csr/csc
+    # except AttributeError:
     # XXX TEMP
     itemsize = 8
 
@@ -1911,7 +1911,9 @@ def _write_matrix_to_denseNDArray(
         else:
             tensor = pa.Tensor.from_numpy(chunk.toarray())
         if matrix.ndim == 2:
-            soma_ndarray.write((slice(i, i2), slice(None)), tensor)
+            ### XXX BUG soma_ndarray.write((slice(i, i2), slice(None)), tensor)
+            ### soma_ndarray.write((slice(i, i2), slice(0, ncol - 1)), tensor)
+            soma_ndarray.write((slice(i, i2), slice(0, ncol)), tensor)
         else:
             soma_ndarray.write((slice(i, i2),), tensor)
 

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -977,6 +977,61 @@ void load_soma_array(py::module& m) {
 
         .def("has_metadata", &SOMAArray::has_metadata)
 
-        .def("metadata_num", &SOMAArray::metadata_num);
+        .def("metadata_num", &SOMAArray::metadata_num)
+
+        // These are for SparseNDArray and DenseNDArray both:
+        // * tiledbsoma_has_upgraded_shape
+        // * resize
+        // * can_resize
+        // * tiledbsoma_upgrade_shape
+        // * tiledbsoma_can_upgrade_shape
+        // We don't have CommonNDArray base class in pybind11, and it's probably
+        // not worth it.  These are exposed to the user-facing API only for
+        // SparseNDArray and DenseNDArray and not for DataFrame.
+        .def_property_readonly(
+            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain)
+
+        .def(
+            "resize",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    array.resize(newshape, "resize");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+        .def(
+            "can_resize",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    return array.can_resize(newshape, "can_resize");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+
+        .def(
+            "tiledbsoma_upgrade_shape",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+        .def(
+            "tiledbsoma_can_upgrade_shape",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    return array.can_upgrade_shape(
+                        newshape, "tiledbsoma_can_upgrade_shape");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -128,8 +128,6 @@ void load_soma_dense_ndarray(py::module& m) {
         .def("write", write)
 
         .def_property_readonly("shape", &SOMADenseNDArray::shape)
-        .def_property_readonly("maxshape", &SOMADenseNDArray::maxshape)
-        .def_property_readonly(
-            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain);
+        .def_property_readonly("maxshape", &SOMADenseNDArray::maxshape);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -114,51 +114,6 @@ void load_soma_sparse_ndarray(py::module& m) {
         .def_static("exists", &SOMASparseNDArray::exists)
 
         .def_property_readonly("shape", &SOMASparseNDArray::shape)
-        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape)
-        .def_property_readonly(
-            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain)
-
-        .def(
-            "resize",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    array.resize(newshape, "resize");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-        .def(
-            "can_resize",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    return array.can_resize(newshape, "can_resize");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-
-        .def(
-            "tiledbsoma_upgrade_shape",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-        .def(
-            "tiledbsoma_can_upgrade_shape",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    return array.can_upgrade_shape(
-                        newshape, "tiledbsoma_can_upgrade_shape");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a);
+        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -180,8 +180,13 @@ def test_dense_nd_array_requires_shape(tmp_path, shape_is_numeric):
         with soma.DenseNDArray.open(uri) as dnda:
             assert dnda.shape == (2, 3)
     else:
-        with pytest.raises(ValueError):
-            soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
+        soma.DenseNDArray.create(uri, type=pa.float32(), shape=(None, None)).close()
+        with soma.DenseNDArray.open(uri) as dnda:
+            if (
+                soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED
+                and soma._flags.DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN
+            ):
+                assert dnda.shape == (1, 1)
 
 
 def test_dense_nd_array_ned_write(tmp_path):

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -210,7 +210,7 @@ def test_dense_nd_array_basics(tmp_path):
         assert dnda.non_empty_domain() == ((0, 0), (0, 0))
 
     with tiledbsoma.DenseNDArray.open(uri, "w") as dnda:
-        if tiledbsoma.pytiledbsoma.embedded_version_triple() >= (2, 27, 0):
+        if tiledbsoma._flags.DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             dnda.resize((300, 400))
         else:
             with pytest.raises(NotImplementedError):
@@ -218,7 +218,7 @@ def test_dense_nd_array_basics(tmp_path):
 
     with tiledbsoma.DenseNDArray.open(uri) as dnda:
         assert dnda.non_empty_domain() == ((0, 0), (0, 0))
-        if tiledbsoma.pytiledbsoma.embedded_version_triple() >= (2, 27, 0):
+        if tiledbsoma._flags.DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             assert dnda.shape == (300, 400)
         else:
             assert dnda.shape == (100, 200)

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -9,8 +9,8 @@ createSchemaFromArrow <- function(uri, nasp, nadimap, nadimsp, sparse, datatype,
     invisible(.Call(`_tiledbsoma_createSchemaFromArrow`, uri, nasp, nadimap, nadimsp, sparse, datatype, pclst, ctxxp, tsvec))
 }
 
-writeArrayFromArrow <- function(uri, naap, nasp, ctxxp, arraytype = "", config = NULL, tsvec = NULL) {
-    invisible(.Call(`_tiledbsoma_writeArrayFromArrow`, uri, naap, nasp, ctxxp, arraytype, config, tsvec))
+writeArrayFromArrow <- function(uri, naap, nasp, coords_list, ctxxp, arraytype = "", config = NULL, tsvec = NULL) {
+    invisible(.Call(`_tiledbsoma_writeArrayFromArrow`, uri, naap, nasp, coords_list, ctxxp, arraytype, config, tsvec))
 }
 
 #' @noRd

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -148,6 +148,7 @@ SOMADataFrame <- R6::R6Class(
         uri = self$uri,
         naap = naap,
         nasp = nasp,
+        coords_list = list(), # only used for SOMADenseNDArray
         ctxxp = private$.soma_context,
         arraytype = "SOMADataFrame",
         config = NULL,

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -154,6 +154,7 @@ SOMADenseNDArray <- R6::R6Class(
       # arr[] <- values
       writeArrayFromArrow(
         uri = self$uri,
+        coords,
         naap = naap,
         nasp = nasp,
         ctxxp = private$.soma_context,

--- a/apis/r/R/SOMADenseNDArray.R
+++ b/apis/r/R/SOMADenseNDArray.R
@@ -154,9 +154,9 @@ SOMADenseNDArray <- R6::R6Class(
       # arr[] <- values
       writeArrayFromArrow(
         uri = self$uri,
-        coords,
         naap = naap,
         nasp = nasp,
+        coords_list = coords,
         ctxxp = private$.soma_context,
         arraytype = "SOMADenseNDArray",
         config = NULL,

--- a/apis/r/R/SOMASparseNDArray.R
+++ b/apis/r/R/SOMASparseNDArray.R
@@ -277,6 +277,7 @@ SOMASparseNDArray <- R6::R6Class(
         uri = self$uri,
         naap = naap,
         nasp = nasp,
+        coords_list = list(), # only used for SOMADenseNDArray
         ctxxp = private$.soma_context,
         arraytype = "SOMASparseNDArray",
         config = NULL,

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -41,18 +41,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // writeArrayFromArrow
-void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp, Rcpp::XPtr<somactx_wrap_t> ctxxp, const std::string arraytype, Rcpp::Nullable<Rcpp::CharacterVector> config, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
-RcppExport SEXP _tiledbsoma_writeArrayFromArrow(SEXP uriSEXP, SEXP naapSEXP, SEXP naspSEXP, SEXP ctxxpSEXP, SEXP arraytypeSEXP, SEXP configSEXP, SEXP tsvecSEXP) {
+void writeArrayFromArrow(const std::string& uri, naxpArray naap, naxpSchema nasp, Rcpp::List coords_list, Rcpp::XPtr<somactx_wrap_t> ctxxp, const std::string arraytype, Rcpp::Nullable<Rcpp::CharacterVector> config, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
+RcppExport SEXP _tiledbsoma_writeArrayFromArrow(SEXP uriSEXP, SEXP naapSEXP, SEXP naspSEXP, SEXP coords_listSEXP, SEXP ctxxpSEXP, SEXP arraytypeSEXP, SEXP configSEXP, SEXP tsvecSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< naxpArray >::type naap(naapSEXP);
     Rcpp::traits::input_parameter< naxpSchema >::type nasp(naspSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type coords_list(coords_listSEXP);
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< const std::string >::type arraytype(arraytypeSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type config(configSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type tsvec(tsvecSEXP);
-    writeArrayFromArrow(uri, naap, nasp, ctxxp, arraytype, config, tsvec);
+    writeArrayFromArrow(uri, naap, nasp, coords_list, ctxxp, arraytype, config, tsvec);
     return R_NilValue;
 END_RCPP
 }
@@ -793,7 +794,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_createSOMAContext", (DL_FUNC) &_tiledbsoma_createSOMAContext, 1},
     {"_tiledbsoma_createSchemaFromArrow", (DL_FUNC) &_tiledbsoma_createSchemaFromArrow, 9},
-    {"_tiledbsoma_writeArrayFromArrow", (DL_FUNC) &_tiledbsoma_writeArrayFromArrow, 7},
+    {"_tiledbsoma_writeArrayFromArrow", (DL_FUNC) &_tiledbsoma_writeArrayFromArrow, 8},
     {"_tiledbsoma_c_group_create", (DL_FUNC) &_tiledbsoma_c_group_create, 4},
     {"_tiledbsoma_c_group_open", (DL_FUNC) &_tiledbsoma_c_group_open, 4},
     {"_tiledbsoma_c_group_member_count", (DL_FUNC) &_tiledbsoma_c_group_member_count, 1},

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -273,7 +273,20 @@ void writeArrayFromArrow(
             int lo = *std::min_element(slot_values.begin(), slot_values.end());
             int hi = *std::max_element(slot_values.begin(), slot_values.end());
             spdl::debug(
-                "dense array write: dim {} set range lo {} hi {}", dim_name, lo, hi);
+                "dense array write: dim {} set 1-up range lo {} hi {}",
+                dim_name,
+                lo,
+                hi);
+            // These are 1-up indices from R. Convert to 0-up for C++.
+            if (lo < 1) {
+                Rcpp::stop(tfm::format(
+                    "dense array write: expected lower bound %d >= 1 for dim "
+                    "name %s",
+                    lo,
+                    dim_name));
+            }
+            lo--;
+            hi--;
             std::pair<int64_t, int64_t> lo_hi(int64_t{lo}, int64_t{hi});
             std::vector<std::pair<int64_t, int64_t>> range({lo_hi});
             arrup.get()->set_dim_ranges(dim_name, range);

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -30,10 +30,10 @@
  * This file defines the performing TileDB queries.
  */
 
+#include "managed_query.h"
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>
 #include "../utils/logger.h"
-#include "managed_query.h"
 #include "utils/common.h"
 namespace tiledbsoma {
 


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Some findings from https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/25. There is more to do though.

**Notes for Reviewer:**

## Python read-OOM repro
```
#!/usr/bin/env python

import tiledbsoma
import pyarrow as pa
import sys
import os, shutil

# Any dense 2D array with small current domain but huge (~ 2**63) core domain
uri = 'dense-dnda-227'

print("RD-DNDA URI", uri)

dnda = tiledbsoma.open(uri)
# This next line will slowly OOM -- watch htop
o = dnda.read()
```

Fixed as of this commit: https://github.com/single-cell-data/TileDB-SOMA/pull/3244/commits/0e6493a05ea64c58935c6216d579a671b3d95059

## R write-fail repro

```
$ cat wr-lldb.r
#!/usr/bin/env Rscript

library(tiledbsoma)
library(arrow)

uri <- "data-dnda-r"
element_type = arrow::float32()
shape = c(10, 20)

cat("CR-DNDA URI     ", uri, "\n")
cat("CR-DNDA SHAPE   ", shape, "\n")

if (dir.exists(uri)) unlink(uri, recursive=TRUE)
dnda <- tiledbsoma::SOMADenseNDArrayCreate(uri, type=element_type, shape=shape)

cat("WR-DNDA URI", uri, "\n")
dnda$write(matrix(1:12, nrow=3,ncol=4))

dnda$close()
```

```
$ ./wr-lldb.r
CR-DNDA URI      data-dnda-r
CR-DNDA SHAPE    10 20
WR-DNDA URI data-dnda-r
Error: WriterBase: Buffer sizes check failed; Invalid number of cells given for attribute 'soma_data' (12 != 18446744073709551615)
Execution halted
```

Fixed as of this commit: https://github.com/single-cell-data/TileDB-SOMA/pull/3244/commits/0e6493a05ea64c58935c6216d579a671b3d95059
