### PR TITLE
Pin typeguard@afad2c7

### DIFF
--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -3,8 +3,9 @@ ruff
 pytest
 pytest-cov
 sparse
-# Python 3.12 support requires https://github.com/agronholm/typeguard/pull/490;
-# use Typeguard @ HEAD until that PR is included in a release. See also:
-# https://github.com/single-cell-data/TileDB-SOMA/issues/3216
-typeguard @ git+https://github.com/agronholm/typeguard
+# Python 3.12 support requires https://github.com/agronholm/typeguard/pull/490, which landed between 4.3.0 and 4.4.0.
+# However, 4.4.0 also included https://github.com/agronholm/typeguard/pull/496, which causes errors in Python 3.9 (e.g.
+# https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11545217103/job/32131849817), so we are pinning to the
+# last useful commit here. See also: https://github.com/single-cell-data/TileDB-SOMA/issues/3216.
+typeguard @ git+https://github.com/agronholm/typeguard@afad2c7
 types-setuptools


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SOMA/issues/3246

https://github.com/agronholm/typeguard/pull/496 caused CI to begin failing on Python 3.9 ([example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11522767244/job/32157898699)).

This pins Typeguard to https://github.com/agronholm/typeguard/commit/afad2c7b6be830900776922bb39f9346c2e77f6f (the last commit that works with our build), while we try to root-cause or work around more durably.
