### PR TITLE
[python] Rename `set_reader_coords` to `set_coords`

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -683,7 +683,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if value_filter is not None:
             sr.set_condition(QueryCondition(value_filter), handle.schema)
 
-        self._set_reader_coords(sr, coords)
+        self._set_coords(sr, coords)
 
         # # TODO: batch_size
         return TableReadIter(sr)
@@ -745,7 +745,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         return self
 
-    def _set_reader_coord(
+    def _set_coord(
         self,
         sr: clib.SOMAArray,
         dim_idx: int,
@@ -766,7 +766,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             return True
 
         if isinstance(coord, (Sequence, np.ndarray)):
-            if self._set_reader_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
+            if self._set_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
                 return True
 
         if isinstance(coord, slice):
@@ -776,7 +776,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         if isinstance(coord, slice):
             _util.validate_slice(coord)
-            if self._set_reader_coord_by_numeric_slice(sr, dim_idx, dim, coord):
+            if self._set_coord_by_numeric_slice(sr, dim_idx, dim, coord):
                 return True
 
         domain = self.domain[dim_idx]
@@ -815,12 +815,12 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             sr.set_dim_ranges_int64(dim.name, [(istart, istop)])
             return True
 
-        if super()._set_reader_coord(sr, dim_idx, dim, coord):
+        if super()._set_coord(sr, dim_idx, dim, coord):
             return True
 
         return False
 
-    def _set_reader_coord_by_py_seq_or_np_array(
+    def _set_coord_by_py_seq_or_np_array(
         self,
         sr: clib.SOMAArray,
         dim_idx: int,
@@ -861,7 +861,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
 
-    def _set_reader_coord_by_numeric_slice(
+    def _set_coord_by_numeric_slice(
         self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: Slice[Any]
     ) -> bool:
         try:

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -250,7 +250,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
-        self._set_reader_coords(sr, coords)
+        self._set_coords(sr, coords)
 
         arrow_tables = []
         while True:
@@ -329,7 +329,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
         clib_dense_array.reset(result_order=order)
-        self._set_reader_coords(clib_dense_array, new_coords)
+        self._set_coords(clib_dense_array, new_coords)
         clib_dense_array.write(input)
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -342,7 +342,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         if value_filter is not None:
             sr.set_condition(QueryCondition(value_filter), handle.schema)
 
-        self._set_reader_coords(sr, coords)
+        self._set_coords(sr, coords)
 
         # # TODO: batch_size
         return TableReadIter(sr)

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -236,7 +236,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
             self.sr.reset(**kwargs)
             step_coords = list(self.coords)
             step_coords[self.major_axis] = coord_chunk
-            self.array._set_reader_coords(self.sr, step_coords)
+            self.array._set_coords(self.sr, step_coords)
 
             joinids = list(self.joinids)
             joinids[self.major_axis] = pa.array(coord_chunk)

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -147,7 +147,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.maxdomain
 
-    def _set_reader_coords(self, sr: clib.SOMAArray, coords: Sequence[object]) -> None:
+    def _set_coords(self, sr: clib.SOMAArray, coords: Sequence[object]) -> None:
         """Parses the given coords and sets them on the SOMA Reader."""
         if not is_nonstringy_sequence(coords):
             raise TypeError(
@@ -162,13 +162,13 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
             )
         for i, coord in enumerate(coords):
             dim = self.schema.field(i)
-            if not self._set_reader_coord(sr, i, dim, coord):
+            if not self._set_coord(sr, i, dim, coord):
                 raise TypeError(
                     f"coord type {type(coord)} for dimension {dim.name}"
                     f" (slot {i}) unsupported"
                 )
 
-    def _set_reader_coord(
+    def _set_coord(
         self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: object
     ) -> bool:
         """Parses a single coordinate entry.

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -461,10 +461,10 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             f"Unsupported Arrow type or non-arrow type for values argument: {type(values)}"
         )
 
-    def _set_reader_coord(
+    def _set_coord(
         self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: object
     ) -> bool:
-        if super()._set_reader_coord(sr, dim_idx, dim, coord):
+        if super()._set_coord(sr, dim_idx, dim, coord):
             return True
         if isinstance(coord, Sequence):
             if pa.types.is_int64(dim.type):
@@ -642,7 +642,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
         """
         if shape is not None and (len(shape) != len(self.shape)):
             raise ValueError(f"shape must be a tuple of size {len(self.shape)}")
-        self.array._set_reader_coords(self.sr, self.coords)
+        self.array._set_coords(self.sr, self.coords)
         return SparseCOOTensorReadIter(self.sr, shape or self.shape)
 
     def tables(self) -> TableReadIter:
@@ -653,7 +653,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
         Lifecycle:
             Maturing.
         """
-        self.array._set_reader_coords(self.sr, self.coords)
+        self.array._set_coords(self.sr, self.coords)
         return TableReadIter(self.sr)
 
     def blockwise(

--- a/apis/python/src/tiledbsoma/_spatial_dataframe.py
+++ b/apis/python/src/tiledbsoma/_spatial_dataframe.py
@@ -174,7 +174,7 @@ class SpatialDataFrame(SOMAArray):
         """
         raise NotImplementedError("must be implemented by child class")
 
-    def _set_reader_coord(
+    def _set_coord(
         self,
         sr: clib.SOMAArray,
         dim_idx: int,
@@ -195,7 +195,7 @@ class SpatialDataFrame(SOMAArray):
             return True
 
         if isinstance(coord, (Sequence, np.ndarray)):
-            if self._set_reader_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
+            if self._set_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
                 return True
 
         if isinstance(coord, slice):
@@ -205,7 +205,7 @@ class SpatialDataFrame(SOMAArray):
 
         if isinstance(coord, slice):
             _util.validate_slice(coord)
-            if self._set_reader_coord_by_numeric_slice(sr, dim_idx, dim, coord):
+            if self._set_coord_by_numeric_slice(sr, dim_idx, dim, coord):
                 return True
 
         domain = self.domain[dim_idx]
@@ -244,12 +244,12 @@ class SpatialDataFrame(SOMAArray):
             sr.set_dim_ranges_int64(dim.name, [(istart, istop)])
             return True
 
-        if super()._set_reader_coord(sr, dim_idx, dim, coord):
+        if super()._set_coord(sr, dim_idx, dim, coord):
             return True
 
         return False
 
-    def _set_reader_coord_by_py_seq_or_np_array(
+    def _set_coord_by_py_seq_or_np_array(
         self,
         sr: clib.SOMAArray,
         dim_idx: int,
@@ -290,7 +290,7 @@ class SpatialDataFrame(SOMAArray):
 
         raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
 
-    def _set_reader_coord_by_numeric_slice(
+    def _set_coord_by_numeric_slice(
         self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: Slice[Any]
     ) -> bool:
         try:


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

@nguyenv mentioned the other doing this. However while working on #3244 I realized it was a good deconfuse for me to go ahead and do this sooner than later.

**Notes for Reviewer:**