### PR TITLE
Save new-shape feature-flag enable for 1.15.0

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -133,14 +133,14 @@ jobs:
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: export SOMA_PY_NEW_SHAPE=false; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
+      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Run pytests for Python with new shape
       shell: bash
       # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
       # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
       # coverage analysis to work.
-      run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
+      run: export SOMA_PY_NEW_SHAPE=true; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
 
     - name: Report coverage to Codecov
       if: inputs.report_codecov

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -150,12 +150,12 @@ jobs:
 
       - name: Test without new shape
         if: ${{ matrix.covr == 'no' }}
-        run: export SOMA_R_NEW_SHAPE=false && cd apis/r/tests && Rscript testthat.R
+        run: cd apis/r/tests && Rscript testthat.R
 
       # https://github.com/single-cell-data/TileDB-SOMA/issues/2407
       - name: Test with new shape
         if: ${{ matrix.covr == 'no' }}
-        run: cd apis/r/tests && Rscript testthat.R
+        run: export SOMA_R_NEW_SHAPE=true && cd apis/r/tests && Rscript testthat.R
 
       - name: Coverage
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}

--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -10,4 +10,4 @@ import os
 # removed once https://github.com/single-cell-data/TileDB-SOMA/issues/2407 is
 # complete.
 
-NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"
+NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") is not None

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -22,10 +22,10 @@
 
   # This is temporary for https://github.com/single-cell-data/TileDB-SOMA/issues/2407
   # It will be removed once 2407 is complete.
-  if (Sys.getenv("SOMA_R_NEW_SHAPE") == "false") {
-    .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
-  } else {
+  if (Sys.getenv("SOMA_R_NEW_SHAPE") != "") {
     .pkgenv[["use_current_domain_transitional_internal_only"]] <- TRUE
+  } else {
+    .pkgenv[["use_current_domain_transitional_internal_only"]] <- FALSE
   }
 }
 


### PR DESCRIPTION
While recent PRs have put the `release-1.15` branch in sync with current `main`, we shiould stop short of releasing the new-shape feature pending more documentation work as tracked on #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).