### PR TITLE
[python] Centralize sparse/dense `pybind11` shape methods

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -20,7 +20,7 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
-from ._flags import NEW_SHAPE_FEATURE_FLAG_ENABLED
+from ._flags import DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN, NEW_SHAPE_FEATURE_FLAG_ENABLED
 from ._tdb_handles import DenseNDArrayWrapper
 from ._types import OpenTimestamp, Slice
 from ._util import dense_indices_to_shape
@@ -105,11 +105,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             dim_name = f"soma_dim_{dim_idx}"
             pa_field = pa.field(dim_name, pa.int64())
 
-            if NEW_SHAPE_FEATURE_FLAG_ENABLED and clib.embedded_version_triple() >= (
-                2,
-                27,
-                0,
-            ):
+            if NEW_SHAPE_FEATURE_FLAG_ENABLED and DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
                 dim_capacity, dim_extent = cls._dim_capacity_and_extent(
                     dim_name,
                     # The user specifies current domain -- this is the max domain
@@ -341,7 +337,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         """Supported for ``SparseNDArray``; scheduled for implementation for
         ``DenseNDArray`` in TileDB-SOMA 1.15
         """
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             self._handle.resize(newshape)
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")

--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -5,9 +5,13 @@
 
 import os
 
+import tiledbsoma.pytiledbsoma as clib
+
 # This is temporary for
 # https://github.com/single-cell-data/TileDB-SOMA/issues/2407.  It will be
 # removed once https://github.com/single-cell-data/TileDB-SOMA/issues/2407 is
 # complete.
 
 NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"
+
+DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -35,6 +35,7 @@ from typing_extensions import Literal, Self
 
 from . import pytiledbsoma as clib
 from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
+from ._flags import DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import SOMATileDBContext
 
@@ -643,7 +644,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     def resize(self, newshape: Sequence[Union[int, None]]) -> None:
         """Wrapper-class internals"""
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             self._handle.resize(newshape)
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")
@@ -652,7 +653,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
         self, newshape: Sequence[Union[int, None]]
     ) -> StatusAndReason:
         """Wrapper-class internals"""
-        if clib.embedded_version_triple() >= (2, 27, 0):
+        if DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
         else:
             raise NotImplementedError("Not implemented for libtiledbsoma < 2.27.0")

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -977,6 +977,61 @@ void load_soma_array(py::module& m) {
 
         .def("has_metadata", &SOMAArray::has_metadata)
 
-        .def("metadata_num", &SOMAArray::metadata_num);
+        .def("metadata_num", &SOMAArray::metadata_num)
+
+        // These are for SparseNDArray and DenseNDArray both:
+        // * tiledbsoma_has_upgraded_shape
+        // * resize
+        // * can_resize
+        // * tiledbsoma_upgrade_shape
+        // * tiledbsoma_can_upgrade_shape
+        // We don't have CommonNDArray base class in pybind11, and it's probably
+        // not worth it.  These are exposed to the user-facing API only for
+        // SparseNDArray and DenseNDArray and not for DataFrame.
+        .def_property_readonly(
+            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain)
+
+        .def(
+            "resize",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    array.resize(newshape, "resize");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+        .def(
+            "can_resize",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    return array.can_resize(newshape, "can_resize");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+
+        .def(
+            "tiledbsoma_upgrade_shape",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a)
+        .def(
+            "tiledbsoma_can_upgrade_shape",
+            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
+                try {
+                    return array.can_upgrade_shape(
+                        newshape, "tiledbsoma_can_upgrade_shape");
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "newshape"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -128,8 +128,6 @@ void load_soma_dense_ndarray(py::module& m) {
         .def("write", write)
 
         .def_property_readonly("shape", &SOMADenseNDArray::shape)
-        .def_property_readonly("maxshape", &SOMADenseNDArray::maxshape)
-        .def_property_readonly(
-            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain);
+        .def_property_readonly("maxshape", &SOMADenseNDArray::maxshape);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -114,51 +114,6 @@ void load_soma_sparse_ndarray(py::module& m) {
         .def_static("exists", &SOMASparseNDArray::exists)
 
         .def_property_readonly("shape", &SOMASparseNDArray::shape)
-        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape)
-        .def_property_readonly(
-            "tiledbsoma_has_upgraded_shape", &SOMAArray::has_current_domain)
-
-        .def(
-            "resize",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    array.resize(newshape, "resize");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-        .def(
-            "can_resize",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    return array.can_resize(newshape, "can_resize");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-
-        .def(
-            "tiledbsoma_upgrade_shape",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    array.upgrade_shape(newshape, "tiledbsoma_upgrade_shape");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a)
-        .def(
-            "tiledbsoma_can_upgrade_shape",
-            [](SOMAArray& array, const std::vector<int64_t>& newshape) {
-                try {
-                    return array.can_upgrade_shape(
-                        newshape, "tiledbsoma_can_upgrade_shape");
-                } catch (const std::exception& e) {
-                    throw TileDBSOMAError(e.what());
-                }
-            },
-            "newshape"_a);
+        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -210,7 +210,7 @@ def test_dense_nd_array_basics(tmp_path):
         assert dnda.non_empty_domain() == ((0, 0), (0, 0))
 
     with tiledbsoma.DenseNDArray.open(uri, "w") as dnda:
-        if tiledbsoma.pytiledbsoma.embedded_version_triple() >= (2, 27, 0):
+        if tiledbsoma._flags.DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             dnda.resize((300, 400))
         else:
             with pytest.raises(NotImplementedError):
@@ -218,7 +218,7 @@ def test_dense_nd_array_basics(tmp_path):
 
     with tiledbsoma.DenseNDArray.open(uri) as dnda:
         assert dnda.non_empty_domain() == ((0, 0), (0, 0))
-        if tiledbsoma.pytiledbsoma.embedded_version_triple() >= (2, 27, 0):
+        if tiledbsoma._flags.DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN:
             assert dnda.shape == (300, 400)
         else:
             assert dnda.shape == (100, 200)


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

This is a split-out to simplify #3244 which turns out to be multi-faceted

**Notes for Reviewer:**

No new unit tests -- proof of success here is that all existing unit-test cases contiunue to pass.