### PR TITLE
[c++] Apply subarrays for dense reads and writes

### DIFF
--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -14,4 +14,5 @@ import tiledbsoma.pytiledbsoma as clib
 
 NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"
 
-DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)
+#DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)
+DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = False

--- a/apis/python/src/tiledbsoma/_flags.py
+++ b/apis/python/src/tiledbsoma/_flags.py
@@ -14,5 +14,10 @@ import tiledbsoma.pytiledbsoma as clib
 
 NEW_SHAPE_FEATURE_FLAG_ENABLED = os.getenv("SOMA_PY_NEW_SHAPE") != "false"
 
-#DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)
-DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = False
+DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = clib.embedded_version_triple() >= (2, 27, 0)
+
+# Temporary for # https://github.com/single-cell-data/TileDB-SOMA/issues/2407:
+# this allows testing dense + current domain on the same machine without
+# having to switch core builds (or switch machines).
+if os.getenv("SOMA_IGNORE_CORE_2_27") is not None:
+    DENSE_ARRAYS_CAN_HAVE_CURRENT_DOMAIN = False

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -37,8 +37,9 @@
 }
 
 .dense_arrays_can_have_current_domain <- function() {
-  triple <- tiledb_embedded_version()
-  return(triple[[1]] >= 2 && triple[[2]] >= 27)
+  #triple <- tiledb_embedded_version()
+  #return(triple[[1]] >= 2 && triple[[2]] >= 27)
+  return(FALSE)
 }
 
 ## An .onAttach() function is not allowed to use cat() etc but _must_ communicate via

--- a/apis/r/R/Init.R
+++ b/apis/r/R/Init.R
@@ -36,10 +36,17 @@
   .pkgenv[["use_current_domain_transitional_internal_only"]]
 }
 
+# Temporary for # https://github.com/single-cell-data/TileDB-SOMA/issues/2407.
+# Once core 2.27 is released and we depend on it, this can go away.
 .dense_arrays_can_have_current_domain <- function() {
-  #triple <- tiledb_embedded_version()
-  #return(triple[[1]] >= 2 && triple[[2]] >= 27)
-  return(FALSE)
+  # This allows testing dense + current domain on the same machine without
+  # having to switch core builds (or switch machines).
+  if (Sys.getenv("SOMA_IGNORE_CORE_2_27") != "") {
+    return(FALSE)
+  }
+
+  triple <- tiledb_embedded_version()
+  return(triple[[1]] >= 2 && triple[[2]] >= 27)
 }
 
 ## An .onAttach() function is not allowed to use cat() etc but _must_ communicate via

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -30,10 +30,10 @@
  * This file defines the performing TileDB queries.
  */
 
-#include "managed_query.h"
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>
 #include "../utils/logger.h"
+#include "managed_query.h"
 #include "utils/common.h"
 namespace tiledbsoma {
 
@@ -62,7 +62,7 @@ void ManagedQuery::reset() {
     query_ = std::make_unique<Query>(*ctx_, *array_);
     subarray_ = std::make_unique<Subarray>(*ctx_, *array_);
 
-    subarray_range_set_ = false;
+    subarray_range_set_ = {};
     subarray_range_empty_ = {};
     columns_.clear();
     results_complete_ = true;
@@ -109,7 +109,8 @@ void ManagedQuery::setup_read() {
         // domain on dimension 0. In the case that the non-empty domain does not
         // exist (when the array has not been written to yet), use dimension 0's
         // full domain
-        if (schema.array_type() == TILEDB_DENSE && !subarray_range_set_) {
+        if (schema.array_type() == TILEDB_DENSE &&
+            !_has_any_subarray_range_set()) {
             // Check if the array has been written to by using the C API as
             // there is no way to to check for an empty domain using the current
             // CPP API

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -265,7 +265,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
             continue;
         }
 
-        // Dense arrays are (as of this writing) all DenseNDArray.
+        // Dense arrays are (as of this writing in 1.15.0) all DenseNDArray.
         // Per the spec DenseNDArray must only have dims named
         // soma_dim_{i} with i=0,1,2,...,n-1, of type int64.
         if (dim_name.rfind("soma_dim_", 0) != 0) {

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -449,10 +449,10 @@ class ManagedQuery {
      * routine, if the array is dense, for each dim without a subarray set,
      * we set it to match the soma domain. This guarantees correct behavior.
      */
-    void _fill_in_subarrays_if_dense();
+    void _fill_in_subarrays_if_dense(bool is_read);
     void _fill_in_subarrays_if_dense_with_new_shape(
         const CurrentDomain& current_domain);
-    void _fill_in_subarrays_if_dense_without_new_shape();
+    void _fill_in_subarrays_if_dense_without_new_shape(bool is_read);
 
     // TileDB array being queried.
     std::shared_ptr<Array> array_;

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -430,20 +430,20 @@ class ManagedQuery {
     /**
      * This handles a few internals.
      *
-     * One is that (for a long time now) a dense array must have _at least one_
+     * One is that a dense array must have _at least one_
      * dim's subarray set for a read query. Without that, reads fail immediately
      * with the unambiguous
      *
      *   DenseReader: Cannot initialize reader; Dense reads must have a subarray
      *   set
      *
-     * The other is a combination of several things. One thing is current-domain
+     * The other is a combination of several things. Firstly, is current-domain
      * support which we have for sparse arrays as of core 2.26, and for dense as
-     * of 2.27. Also, without current-domain support, we had small domains; with
-     * it, we have huge core domains (2^63-ish) since they are immutable, and
-     * small current domains as they are upward-mutable. (The soma domain and
+     * of 2.27. Secondly, without current-domain support, we had small domains; with
+     * it, we have huge core domains (2^63-ish) which are immutable, and
+     * small current domains which are upward-mutable. (The soma domain and
      * maxdomain, respectively, are core current domain and domain.) Thirdly,
-     * for a long time now, if a query doesn't have a subarray set on any
+     * if a query doesn't have a subarray set on any
      * particular dim, core will use the core domain on that dim. That was fine
      * when core domains were small; not fine now that they are huge. In this
      * routine, if the array is dense, for each dim without a subarray set,

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -45,7 +45,7 @@ const int CORE_DOMAIN_MAX = 2147483646;
 static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
     const std::vector<DimInfo>& dim_infos);
 
-// Core PRP: https://github.com/TileDB-Inc/TileDB/pull/5303
+// Core PR: https://github.com/TileDB-Inc/TileDB/pull/5303
 bool have_dense_current_domain_support() {
     auto vers = tiledbsoma::version::embedded_version_triple();
     return std::get<0>(vers) >= 2 && std::get<1>(vers) >= 27;

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -340,8 +340,6 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
         REQUIRE(snda->metadata_num() == 2);
     }
 }
-void breakme() {
-}
 
 TEST_CASE(
     "SOMASparseNDArray: can_tiledbsoma_upgrade_shape", "[SOMASparseNDArray]") {
@@ -389,7 +387,6 @@ TEST_CASE(
     REQUIRE(dom.first == 0);
     REQUIRE(dom.second == dim_max);
 
-    breakme();
     std::vector<int64_t> newshape_wrong_dims({dim_max, 12});
     std::vector<int64_t> newshape_too_big({dim_max + 10});
     std::vector<int64_t> newshape_good({40});


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

As found on #3244:

* The main context of #3244 is:
  * For dense arrays only
  * If any dim's subarray range isn't specified, core uses the core domain
  * With new-shape feature-flag enabled, and with core 2.27 where dense arrays _can_ have current domain (they couldn't in 2.26), we are indeed using data-sized core current domain and huge core domain
  * Put those together and we get these problems
  * Note there are a few other issues on this PR, and a few _not_ yet included in this PR, other than that -- and those should be split out into separate PRs
* On this PR I've ben finding callsites, for write and for read, for Python and R, and touching up the ranges which end up being core subarrays on each dim slot
  * This is tedious and error-prone
* What we should do instead is:
  * In one place -- in `libtiledbsoma`, in `ManagedQuery`, before `submit_query`
  * If any dim's range has not been set up to this point, and if the array has a current domain, simply set the ranges on that dim to be the current domain's `(lo, hi)`
  * We know (for a fact) that core will go ahead and use the too-big domain anyway so this is safe

**Notes for Reviewer:**
