### PR TITLE
[c++] Hide internal dimensions

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -157,6 +157,14 @@ void ManagedQuery::setup_read() {
         for (int i = 0; i < attribute_num; i++) {
             columns_.push_back(schema.attribute(i).name());
         }
+
+        auto is_internal = [](std::string name) {
+            return name.rfind(SOMA_GEOMETRY_DIMENSION_PREFIX, 0) == 0;
+        };
+
+        auto internal_end = std::remove_if(
+            columns_.begin(), columns_.end(), is_internal);
+        columns_.erase(internal_end, columns_.end());
     }
 
     // Allocate and attach buffers

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -254,12 +254,12 @@ void SOMAArray::reset(
     } else {
         // Hide internal columns if any
         std::vector<std::string> columns;
-        for (const auto& dim : this->tiledb_schema()->domain().dimensions()) {
+        for (const auto& dim : arr_->schema().domain().dimensions()) {
             columns.push_back(dim.name());
         }
 
-        for (size_t i = 0; i < this->tiledb_schema()->attribute_num(); ++i) {
-            columns.push_back(this->tiledb_schema()->attribute(i).name());
+        for (size_t i = 0; i < arr_->schema().attribute_num(); ++i) {
+            columns.push_back(arr_->schema().attribute(i).name());
         }
         auto is_internal = [](std::string name) {
             return name.rfind(SOMA_GEOMETRY_DIMENSION_PREFIX, 0) == 0;

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -251,25 +251,6 @@ void SOMAArray::reset(
 
     if (!column_names.empty()) {
         mq_->select_columns(column_names);
-    } else {
-        // Hide internal columns if any
-        std::vector<std::string> columns;
-        for (const auto& dim : arr_->schema().domain().dimensions()) {
-            columns.push_back(dim.name());
-        }
-
-        for (size_t i = 0; i < arr_->schema().attribute_num(); ++i) {
-            columns.push_back(arr_->schema().attribute(i).name());
-        }
-        auto is_internal = [](std::string name) {
-            return name.rfind(SOMA_GEOMETRY_DIMENSION_PREFIX, 0) == 0;
-        };
-
-        auto internal_end = std::remove_if(
-            columns.begin(), columns.end(), is_internal);
-        columns.erase(internal_end, columns.end());
-
-        mq_->select_columns(columns);
     }
 
     mq_->set_layout(result_order);

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -251,6 +251,25 @@ void SOMAArray::reset(
 
     if (!column_names.empty()) {
         mq_->select_columns(column_names);
+    } else {
+        // Hide internal columns if any
+        std::vector<std::string> columns;
+        for (const auto& dim : this->tiledb_schema()->domain().dimensions()) {
+            columns.push_back(dim.name());
+        }
+
+        for (size_t i = 0; i < this->tiledb_schema()->attribute_num(); ++i) {
+            columns.push_back(this->tiledb_schema()->attribute(i).name());
+        }
+        auto is_internal = [](std::string name) {
+            return name.rfind(SOMA_GEOMETRY_DIMENSION_PREFIX, 0) == 0;
+        };
+
+        auto internal_end = std::remove_if(
+            columns.begin(), columns.end(), is_internal);
+        columns.erase(internal_end, columns.end());
+
+        mq_->select_columns(columns);
     }
 
     mq_->set_layout(result_order);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -33,9 +33,8 @@
 #ifndef SOMA_ARRAY
 #define SOMA_ARRAY
 
-#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
-
 #include <future>
+#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 
 #include <tiledb/tiledb>
 #include <tiledb/tiledb_experimental>
@@ -997,7 +996,7 @@ class SOMAArray : public SOMAObject {
      * @tparam T Domain datatype
      * @return Pair of [lower, upper] inclusive bounds.
      */
-    ArrowTable get_soma_domain() {
+    virtual ArrowTable get_soma_domain() {
         if (has_current_domain()) {
             return _get_core_current_domain();
         } else {
@@ -1020,7 +1019,7 @@ class SOMAArray : public SOMAObject {
      * @tparam T Domain datatype
      * @return Pair of [lower, upper] inclusive bounds.
      */
-    ArrowTable get_soma_maxdomain() {
+    virtual ArrowTable get_soma_maxdomain() {
         return _get_core_domain();
     }
 
@@ -1028,7 +1027,7 @@ class SOMAArray : public SOMAObject {
      * Returns the core non-empty domain in its entirety, as an Arrow
      * table for return to Python/R.
      */
-    ArrowTable get_non_empty_domain() {
+    virtual ArrowTable get_non_empty_domain() {
         return _get_core_domainish(Domainish::kind_non_empty_domain);
     }
 

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -54,7 +54,6 @@ void SOMAGeometryDataFrame::create(
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    std::vector<std::string> spatial_axes;
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
         schema,
@@ -98,7 +97,20 @@ std::unique_ptr<ArrowSchema> SOMAGeometryDataFrame::schema() const {
 
 const std::vector<std::string> SOMAGeometryDataFrame::index_column_names()
     const {
-    return this->dimension_names();
+    std::vector<std::string> dim_names = this->dimension_names();
+
+    auto is_internal = [](std::string name) {
+        return name.rfind(SOMA_GEOMETRY_DIMENSION_PREFIX, 0) == 0;
+    };
+
+    auto first_dim = std::find_if(
+        begin(dim_names), end(dim_names), is_internal);
+    dim_names.insert(first_dim, SOMA_GEOMETRY_COLUMN_NAME);
+    auto internal_end = std::remove_if(
+        begin(dim_names), end(dim_names), is_internal);
+    dim_names.erase(internal_end, dim_names.end());
+
+    return dim_names;
 }
 
 const std::vector<std::string> SOMAGeometryDataFrame::spatial_column_names()

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -239,6 +239,12 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
         std::unique_ptr<ArrowSchema> arrow_schema,
         std::unique_ptr<ArrowArray> arrow_array) override;
 
+    ArrowTable get_soma_domain() override;
+
+    ArrowTable get_soma_maxdomain() override;
+
+    ArrowTable get_non_empty_domain() override;
+
    private:
     //===================================================================
     //= private non-static
@@ -260,6 +266,13 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
      */
     ArrowTable _reconstruct_geometry_data_table(
         ArrowTable original_data, const std::vector<ArrowTable>& wkb_data);
+
+    /**
+     * @brief Create a new ArrowTable by merging the internal spatial dimensions
+     * and setting the ``soma_geometry`` domain as the stacked domain of each
+     * spatial axis.
+     */
+    ArrowTable _reconstruct_geometry_domain(const ArrowTable& domain);
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -354,12 +354,13 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
         columns.push_back(dimensions[i]);
     }
 
-    for (const auto& attr : tiledb_schema.attributes()) {
-        if (strcmp(attr.first.c_str(), SOMA_GEOMETRY_COLUMN_NAME.c_str()) ==
+    for (size_t i = 0; i < tiledb_schema.attribute_num(); ++i) {
+        auto attr = tiledb_schema.attribute(i);
+        if (strcmp(attr.name().c_str(), SOMA_GEOMETRY_COLUMN_NAME.c_str()) ==
             0) {
-            columns.insert(columns.begin() + internal_dim_idx, attr.second);
+            columns.insert(columns.begin() + internal_dim_idx, attr);
         } else {
-            columns.push_back(attr.second);
+            columns.push_back(attr);
         }
     }
 

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -392,7 +392,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
                 } else if constexpr (std::is_same_v<T, Attribute>) {
                     child = arrow_schema->children[i] =
                         arrow_schema_from_tiledb_attribute(
-                            arg, ctx, tiledb_array)
+                            arg, *ctx, *tiledb_array)
                             .release();
                 }
             },
@@ -425,9 +425,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_dimension(
 }
 
 std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
-    Attribute& attribute,
-    std::shared_ptr<Context> ctx,
-    std::shared_ptr<Array> tiledb_array) {
+    Attribute& attribute, const Context& ctx, const Array& tiledb_array) {
     std::unique_ptr<ArrowSchema> arrow_schema = std::make_unique<ArrowSchema>();
     arrow_schema->format = strdup(
         ArrowAdapter::to_arrow_format(attribute.type()).data());
@@ -454,10 +452,10 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
         arrow_schema->name));
 
     auto enmr_name = AttributeExperimental::get_enumeration_name(
-        *ctx, attribute);
+        ctx, attribute);
     if (enmr_name.has_value()) {
         auto enmr = ArrayExperimental::get_enumeration(
-            *ctx, *tiledb_array, attribute.name());
+            ctx, tiledb_array, attribute.name());
         auto dict = (ArrowSchema*)malloc(sizeof(ArrowSchema));
         dict->format = strdup(
             ArrowAdapter::to_arrow_format(enmr.type(), false).data());

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -230,7 +230,7 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx, std::shared_ptr<Array> tiledb_array);
 
     /**
-     * @brief Create a an ArrowSchema from TileDB Dimension
+     * @brief Create an ArrowSchema from TileDB Dimension
      *
      * @return ArrowSchema
      */

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -243,9 +243,7 @@ class ArrowAdapter {
      * @return ArrowSchema
      */
     static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_attribute(
-        Attribute& attribute,
-        std::shared_ptr<Context> ctx,
-        std::shared_ptr<Array> tiledb_array);
+        Attribute& attribute, const Context& ctx, const Array& tiledb_array);
 
     /**
      * @brief Get members of the TileDB Schema in the form of a PlatformConfig

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -238,7 +238,7 @@ class ArrowAdapter {
         const Dimension& dimension);
 
     /**
-     * @brief Create a an ArrowSchema from TileDB Attribute
+     * @brief Create an ArrowSchema from TileDB Attribute
      *
      * @return ArrowSchema
      */

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -230,6 +230,24 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx, std::shared_ptr<Array> tiledb_array);
 
     /**
+     * @brief Create a an ArrowSchema from TileDB Dimension
+     *
+     * @return ArrowSchema
+     */
+    static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_dimension(
+        const Dimension& dimension);
+
+    /**
+     * @brief Create a an ArrowSchema from TileDB Attribute
+     *
+     * @return ArrowSchema
+     */
+    static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_attribute(
+        Attribute& attribute,
+        std::shared_ptr<Context> ctx,
+        std::shared_ptr<Array> tiledb_array);
+
+    /**
      * @brief Get members of the TileDB Schema in the form of a PlatformConfig
      *
      * @return PlatformConfig

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -153,7 +153,7 @@ std::unique_ptr<ArrowSchema> create_index_cols_info_schema(
 
     auto schema = ArrowAdapter::make_arrow_schema(names, tiledb_datatypes);
 
-    for (size_t i = 0; i < static_cast<size_t>(schema->n_children); ++i) {
+    for (int64_t i = 0; i < schema->n_children; ++i) {
         if (strcmp(schema->children[i]->name, "soma_geometry")) {
             nanoarrow::UniqueBuffer buffer;
             ArrowMetadataBuilderInit(buffer.get(), nullptr);

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -313,43 +313,11 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
         while (auto batch = soma_geometry->read_next()) {
             auto arrbuf = batch.value();
             auto d0span = arrbuf->at(dim_infos[0].name)->data<int64_t>();
-            auto d1span = arrbuf
-                              ->at(
-                                  SOMA_GEOMETRY_DIMENSION_PREFIX +
-                                  spatial_dim_infos[0].name + "__min")
-                              ->data<double_t>();
-            auto d2span = arrbuf
-                              ->at(
-                                  SOMA_GEOMETRY_DIMENSION_PREFIX +
-                                  spatial_dim_infos[0].name + "__max")
-                              ->data<double_t>();
-            auto d3span = arrbuf
-                              ->at(
-                                  SOMA_GEOMETRY_DIMENSION_PREFIX +
-                                  spatial_dim_infos[1].name + "__min")
-                              ->data<double_t>();
-            auto d4span = arrbuf
-                              ->at(
-                                  SOMA_GEOMETRY_DIMENSION_PREFIX +
-                                  spatial_dim_infos[1].name + "__max")
-                              ->data<double_t>();
             auto wkbs = arrbuf->at(dim_infos[1].name)->binaries();
             auto a0span = arrbuf->at(attr_infos[0].name)->data<double>();
             CHECK(
                 std::vector<int64_t>({1}) ==
                 std::vector<int64_t>(d0span.begin(), d0span.end()));
-            CHECK(
-                std::vector<double_t>({0}) ==
-                std::vector<double_t>(d1span.begin(), d1span.end()));
-            CHECK(
-                std::vector<double_t>({1}) ==
-                std::vector<double_t>(d2span.begin(), d2span.end()));
-            CHECK(
-                std::vector<double_t>({0}) ==
-                std::vector<double_t>(d3span.begin(), d3span.end()));
-            CHECK(
-                std::vector<double_t>({1}) ==
-                std::vector<double_t>(d4span.begin(), d4span.end()));
             CHECK(geometry::to_wkb(polygon) == wkbs[0]);
             CHECK(
                 std::vector<double_t>({63}) ==

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -126,15 +126,7 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
         REQUIRE(soma_geometry->ctx() == ctx);
         REQUIRE(soma_geometry->type() == "SOMAGeometryDataFrame");
         std::vector<std::string> expected_index_column_names = {
-            dim_infos[0].name,
-            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[0].name +
-                "__min",
-            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[1].name +
-                "__min",
-            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[0].name +
-                "__max",
-            SOMA_GEOMETRY_DIMENSION_PREFIX + spatial_dim_infos[1].name +
-                "__max"};
+            dim_infos[0].name, dim_infos[1].name};
 
         std::vector<std::string> expected_spatial_column_names = {
             spatial_dim_infos[0].name, spatial_dim_infos[1].name};


### PR DESCRIPTION
Geometry dataframe creates some extra internal dimensions to support spatial indexing. When returning back the index column names and arrow schema these dimensions (being implementation-specific) should be hidden and replaces with `soma_geometry` as index column.

Additionally setting a range for spatial axes should only need the axis name and not the internal index names. 