### PR TITLE
[python] Fix 3D/4D cases with core 2.27

### DIFF
--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -122,6 +122,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         cls,
         dim_name: str,
         dim_shape: Optional[int],
+        ndim: int,
         create_options: TileDBCreateOptions,
     ) -> Tuple[int, int]:
         raise NotImplementedError("must be implemented by child class.")

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -169,6 +169,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                     # which is taken from the max ranges for the dim datatype.
                     # We pass None here to detect those.
                     None,
+                    len(shape),
                     TileDBCreateOptions.from_platform_config(platform_config),
                 )
 
@@ -192,6 +193,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 dim_capacity, dim_extent = cls._dim_capacity_and_extent(
                     dim_name,
                     dim_shape,
+                    len(shape),
                     TileDBCreateOptions.from_platform_config(platform_config),
                 )
                 index_column_data[pa_field.name] = [0, dim_capacity - 1, dim_extent]
@@ -498,6 +500,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         cls,
         dim_name: str,
         dim_shape: Optional[int],
+        ndim: int,  # not needed for sparse
         create_options: TileDBCreateOptions,
     ) -> Tuple[int, int]:
         """Given a user-specified shape (maybe ``None``) along a particular dimension,

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -439,8 +439,8 @@ class ManagedQuery {
      *
      * The other is a combination of several things. Firstly, is current-domain
      * support which we have for sparse arrays as of core 2.26, and for dense as
-     * of 2.27. Secondly, without current-domain support, we had small domains; with
-     * it, we have huge core domains (2^63-ish) which are immutable, and
+     * of 2.27. Secondly, without current-domain support, we had small domains;
+     * with it, we have huge core domains (2^63-ish) which are immutable, and
      * small current domains which are upward-mutable. (The soma domain and
      * maxdomain, respectively, are core current domain and domain.) Thirdly,
      * if a query doesn't have a subarray set on any


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Fixes another core 2.27 corner case, aside from the main case on #3263.

**Notes for Reviewer:**