### PR TITLE
[python] Fix last 2.27+Python+dense failing test case

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -285,11 +285,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         # bound but not its lower bound. That works fine if data are written at
         # the start: e.g. domain (0, 99) and data written at 0,1,2,3,4. It
         # doesn't work fine if data are written at say (40,41,42,43,44).
-        # Everything is fine in core and in libtiledbsoma except this very spot
-        # right here where we resize to (0,44) rather than (40,44). The fix is
-        # easy (and coming soon!): the target_shape business above in this file
-        # needs to be modified to handle lower and upper slots of non-empty
-        # domain, rather than discarding the lower slot as it now does.
+        #
+        # This is tracked on kerl/python-227-dense-ned-read.
         reshaped = npval.reshape(target_shape)
         return pa.Tensor.from_numpy(reshaped)
 

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -280,9 +280,18 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             )
 
         arrow_table = pa.concat_tables(arrow_tables)
-        return pa.Tensor.from_numpy(
-            arrow_table.column("soma_data").to_numpy().reshape(target_shape)
-        )
+        npval = arrow_table.column("soma_data").to_numpy()
+        # TODO: as currently coded we're looking at the non-empty domain upper
+        # bound but not its lower bound. That works fine if data are written at
+        # the start: e.g. domain (0, 99) and data written at 0,1,2,3,4. It
+        # doesn't work fine if data are written at say (40,41,42,43,44).
+        # Everything is fine in core and in libtiledbsoma except this very spot
+        # right here where we resize to (0,44) rather than (40,44). The fix is
+        # easy (and coming soon!): the target_shape business above in this file
+        # needs to be modified to handle lower and upper slots of non-empty
+        # domain, rather than discarding the lower slot as it now does.
+        reshaped = npval.reshape(target_shape)
+        return pa.Tensor.from_numpy(reshaped)
 
     def write(
         self,

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -286,7 +286,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         # the start: e.g. domain (0, 99) and data written at 0,1,2,3,4. It
         # doesn't work fine if data are written at say (40,41,42,43,44).
         #
-        # This is tracked on kerl/python-227-dense-ned-read.
+        # This is tracked on https://github.com/single-cell-data/TileDB-SOMA/issues/3271
         reshaped = npval.reshape(target_shape)
         return pa.Tensor.from_numpy(reshaped)
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -451,7 +451,7 @@ class ManagedQuery {
      */
     void _fill_in_subarrays_if_dense(bool is_read);
     void _fill_in_subarrays_if_dense_with_new_shape(
-        const CurrentDomain& current_domain);
+        const CurrentDomain& current_domain, bool is_read);
     void _fill_in_subarrays_if_dense_without_new_shape(bool is_read);
 
     // TileDB array being queried.


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Following on #3263 and #3268 which deal with issues with core 2.27 and dense arrays. See also https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/25.

There is more work to be done for R tests at 2.27 (#3270) but this resolves the final issue with the Python side.

There is a TODO marked in the code on this PR: there are other cases which _would have failed_ even at 2.26 and below, _had they been written_. This is addressed on #3271.

**Notes for Reviewer:**