### PR TITLE
Expose `shape` accessor for `DataFrame` [RFC]

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -402,11 +402,9 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         return cast(DataFrameWrapper, self._handle).count
 
     @property
-    def _maybe_soma_joinid_shape(self) -> Optional[int]:
-        """An internal helper method that returns the shape
-        value along the ``soma_joinid`` index column, if the ``DataFrame
-        has one, else ``None``.
-
+    def shape(self) -> Optional[int]:
+        """Returns the shape for the ``soma_joinid`` index column, if it
+        is an index column in the dataframe; otherwise, returns ``None``.
 
         Lifecycle:
             Experimental.
@@ -414,10 +412,9 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         return self._handle.maybe_soma_joinid_shape
 
     @property
-    def _maybe_soma_joinid_maxshape(self) -> Optional[int]:
-        """An internal helper method that returns the maxshape
-        value along the ``soma_joinid`` index column, if the ``DataFrame
-        has one, else ``None``.
+    def maxshape(self) -> Optional[int]:
+        """Returns the maxshape for the ``soma_joinid`` index column, if it
+        is an index column in the dataframe; otherwise, returns ``None``.
 
         Lifecycle:
             Experimental.

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -172,7 +172,7 @@ def resize_experiment(
     with tiledbsoma.Experiment.open(uri) as exp:
         for ms_key in exp.ms.keys():
             if ms_key not in nvars.keys():
-                nvars[ms_key] = exp.ms[ms_key].var._maybe_soma_joinid_shape or 1
+                nvars[ms_key] = exp.ms[ms_key].var.shape or 1
 
     ok = _treewalk(
         uri,
@@ -251,6 +251,8 @@ def _leaf_visitor_show_shapes(
     if isinstance(item, tiledbsoma.DataFrame):
         _print_leaf_node_banner("DataFrame", node_name, item.uri, args)
         _bannerize(args, "count", item.count)
+        _bannerize(args, "shape", item.shape)
+        _bannerize(args, "maxshape", item.maxshape)
         _bannerize(args, "domain", item.domain)
         _bannerize(args, "maxdomain", item.maxdomain)
         _bannerize(args, "upgraded", item.tiledbsoma_has_upgraded_domain)

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -259,7 +259,6 @@ def _leaf_visitor_show_shapes(
 
     elif isinstance(item, tiledbsoma.SparseNDArray):
         _print_leaf_node_banner("SparseNDArray", node_name, item.uri, args)
-        _bannerize(args, "used_shape", item.used_shape())
         _bannerize(args, "shape", item.shape)
         _bannerize(args, "maxshape", item.maxshape)
         _bannerize(args, "upgraded", item.tiledbsoma_has_upgraded_shape)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -101,12 +101,9 @@ def test_dataframe(tmp_path, arrow_schema):
             == soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED
         )
 
-        with pytest.raises(AttributeError):
-            assert sdf.shape is None
-
         # soma_joinid is not a dim here
-        assert sdf._maybe_soma_joinid_shape is None
-        assert sdf._maybe_soma_joinid_maxshape is None
+        assert sdf.shape is None
+        assert sdf.maxshape is None
 
         # Read all
         table = sdf.read().concat()

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -302,18 +302,18 @@ def test_dataframe_basics(tmp_path, soma_joinid_domain, index_column_names):
     with tiledbsoma.DataFrame.open(uri) as sdf:
         has_sjid_dim = "soma_joinid" in index_column_names
         if has_sjid_dim:
-            assert sdf._maybe_soma_joinid_shape == 1 + soma_joinid_domain[1]
+            assert sdf.shape == 1 + soma_joinid_domain[1]
             if not tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-                assert sdf._maybe_soma_joinid_maxshape == 1 + soma_joinid_domain[1]
+                assert sdf.maxshape == 1 + soma_joinid_domain[1]
         else:
-            assert sdf._maybe_soma_joinid_shape is None
+            assert sdf.shape is None
             if not tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-                assert sdf._maybe_soma_joinid_maxshape is None
+                assert sdf.maxshape is None
 
         assert len(sdf.non_empty_domain()) == len(index_column_names)
 
         # This may be None if soma_joinid is not an index column
-        shape_at_create = sdf._maybe_soma_joinid_shape
+        shape_at_create = sdf.shape
 
     if tiledbsoma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
 
@@ -339,7 +339,7 @@ def test_dataframe_basics(tmp_path, soma_joinid_domain, index_column_names):
                 sdf.tiledbsoma_resize_soma_joinid_shape(new_shape)
 
         with tiledbsoma.DataFrame.open(uri) as sdf:
-            assert sdf._maybe_soma_joinid_shape == shape_at_create
+            assert sdf.shape == shape_at_create
 
         # Test writes out of bounds, before resize
         offset = shape_at_create if has_soma_joinid_dim else 100

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -360,28 +360,16 @@ SOMADataFrame <- R6::R6Class(
       self$write(values)
     },
 
-    #' @description Retrieve the shape; as \code{SOMADataFrames} are shapeless,
-    #' simply raises an error
-    #'
-    #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
-    #'
+    #' @description Returns the shape for the `soma_joinid` index column, if it
+    #' is an index column in the dataframe; otherwise, returns `NULL`.
     shape = function() {
-      stop(errorCondition(
-        "'SOMADataFrame$shape()' is not implemented yet",
-        class = "notYetImplementedError"
-      ))
+      return(maybe_soma_joinid_shape(self$uri, private$.soma_context))
     },
 
-    #' @description Retrieve the maxshape; as \code{SOMADataFrames} are shapeless,
-    #' simply raises an error
-    #'
-    #' @return None, instead a \code{\link{.NotYetImplemented}()} error is raised
-    #'
+    #' @description Returns the maxshape for the `soma_joinid` index column, if it
+    #' is an index column in the dataframe; otherwise, returns `NULL`.
     maxshape = function() {
-      stop(errorCondition(
-        "'SOMADataFrame$maxshape()' is not implemented",
-        class = "notYetImplementedError"
-      ))
+      return(maybe_soma_joinid_maxshape(self$uri, private$.soma_context))
     },
 
     #' @description Returns a named list of minimum/maximum pairs, one per index

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -48,7 +48,7 @@ test_that("Basic mechanics", {
   sdf <- SOMADataFrameOpen(uri)
   expect_match(sdf$soma_type, "SOMADataFrame")
 
-  expect_error(sdf$shape(), class = "notYetImplementedError")
+  ### TODO: add assertions expect_error(sdf$shape(), class = "notYetImplementedError")
 
   expect_equivalent(
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -61,8 +61,8 @@ test_that("SOMADataFrame shape", {
     } else {
       expect_true(sdf$tiledbsoma_has_upgraded_domain())
     }
-    expect_error(sdf$shape(), class = "notYetImplementedError")
-    expect_error(sdf$maxshape(), class = "notYetImplementedError")
+    ## TODO: write cases expect_error(sdf$shape(), class = "notYetImplementedError")
+    ## TODO: write cases expect_error(sdf$maxshape(), class = "notYetImplementedError")
 
     # Not implemented this way per
     # https://github.com/single-cell-data/TileDB-SOMA/pull/2953#discussion_r1746125089

--- a/apis/r/tests/testthat/test-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-write-soma-objects.R
@@ -11,7 +11,7 @@ test_that("write_soma.data.frame mechanics", {
   expect_identical(sdf$uri, file.path(collection$uri, "co2"))
   expect_identical(sdf$dimnames(), "soma_joinid")
   expect_identical(sdf$attrnames(), c(names(co2), "obs_id"))
-  expect_error(sdf$shape(), class = "notYetImplementedError")
+  ### TODO: add assertions expect_error(sdf$shape(), class = "notYetImplementedError")
   schema <- sdf$schema()
   expect_s3_class(schema, "Schema")
   expect_equal(schema$num_fields - 2L, ncol(co2))


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

**Notes for Reviewer:**

This is an RFC.