### PR TITLE
[c++] Add `ManagedQuery::set_layout`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -73,6 +73,27 @@ void ManagedQuery::reset() {
     query_submitted_ = false;
 }
 
+void ManagedQuery::set_layout(ResultOrder layout) {
+    switch (layout) {
+        case ResultOrder::automatic:
+            if (schema_->array_type() == TILEDB_SPARSE)
+                query_->set_layout(TILEDB_UNORDERED);
+            else
+                query_->set_layout(TILEDB_ROW_MAJOR);
+            break;
+        case ResultOrder::rowmajor:
+            query_->set_layout(TILEDB_ROW_MAJOR);
+            break;
+        case ResultOrder::colmajor:
+            query_->set_layout(TILEDB_COL_MAJOR);
+            break;
+        default:
+            throw std::invalid_argument(fmt::format(
+                "[ManagedQuery] invalid ResultOrder({}) passed",
+                static_cast<int>(layout)));
+    }
+}
+
 void ManagedQuery::select_columns(
     const std::vector<std::string>& names, bool if_not_empty) {
     // Return if we are selecting all columns (columns_ is empty) and we want to

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -221,11 +221,9 @@ class ManagedQuery {
     /**
      * @brief Set query result order (layout).
      *
-     * @param layout A tiledb_layout_t constant
+     * @param layout A ResultOrder constant
      */
-    void set_layout(tiledb_layout_t layout) {
-        query_->set_layout(layout);
-    }
+    void set_layout(ResultOrder layout);
 
     /**
      * @brief Set column data for write query.

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -253,24 +253,7 @@ void SOMAArray::reset(
         mq_->select_columns(column_names);
     }
 
-    switch (result_order) {
-        case ResultOrder::automatic:
-            if (arr_->schema().array_type() == TILEDB_SPARSE)
-                mq_->set_layout(TILEDB_UNORDERED);
-            else
-                mq_->set_layout(TILEDB_ROW_MAJOR);
-            break;
-        case ResultOrder::rowmajor:
-            mq_->set_layout(TILEDB_ROW_MAJOR);
-            break;
-        case ResultOrder::colmajor:
-            mq_->set_layout(TILEDB_COL_MAJOR);
-            break;
-        default:
-            throw std::invalid_argument(fmt::format(
-                "[SOMAArray] invalid ResultOrder({}) passed",
-                static_cast<int>(result_order)));
-    }
+    mq_->set_layout(result_order);
 
     batch_size_ = batch_size;
     result_order_ = result_order;


### PR DESCRIPTION
**Issue and/or context:**

As part of work for https://github.com/single-cell-data/TileDB-SOMA/issues/3053.

**Changes:**

This is some minor clean up that replaces the switch-case setting in `SOMAArray` into a separate `ManagedQuery::set_layout`.