### PR TITLE
[c++] Add `ManagedQuery` constructor that takes `SOMAArray`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -34,6 +34,7 @@
 
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>
+#include "soma_array.h"
 #include "utils/common.h"
 #include "utils/logger.h"
 #include "utils/util.h"
@@ -53,6 +54,17 @@ ManagedQuery::ManagedQuery(
     , ctx_(ctx)
     , name_(name)
     , schema_(std::make_shared<ArraySchema>(array->schema())) {
+    reset();
+}
+
+ManagedQuery::ManagedQuery(
+    std::unique_ptr<SOMAArray> array,
+    std::shared_ptr<Context> ctx,
+    std::string_view name)
+    : array_(array->arr_)
+    , ctx_(ctx)
+    , name_(name)
+    , schema_(std::make_shared<ArraySchema>(array->arr_->schema())) {
     reset();
 }
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -48,6 +48,7 @@
 namespace tiledbsoma {
 
 using namespace tiledb;
+class SOMAArray;
 
 // Probably we should just use a std::tuple here
 class StatusAndException {
@@ -83,6 +84,11 @@ class ManagedQuery {
      */
     ManagedQuery(
         std::shared_ptr<Array> array,
+        std::shared_ptr<Context> ctx,
+        std::string_view name = "unnamed");
+
+    ManagedQuery(
+        std::unique_ptr<SOMAArray> array,
         std::shared_ptr<Context> ctx,
         std::string_view name = "unnamed");
 
@@ -404,6 +410,16 @@ class ManagedQuery {
      */
     tiledb_query_type_t query_type() const {
         return query_->query_type();
+    }
+
+    /**
+     * @brief Return the query status.
+     *
+     * @return tiledb::Query::Status INCOMPLETE, COMPLETE, INPROGRESS, FAILED,
+     * UNINITIALIZED, or INITIALIZED
+     */
+    Query::Status query_status() const {
+        return query_->query_status();
     }
 
    private:

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -98,6 +98,8 @@ enum class Domainish {
 
 class SOMAArray : public SOMAObject {
    public:
+    friend class ManagedQuery;
+
     //===================================================================
     //= public static
     //===================================================================


### PR DESCRIPTION
**Issue and/or context:**

As part of work for https://github.com/single-cell-data/TileDB-SOMA/issues/3053.

**Changes:**

- Add a new constructor that takes in a `SOMAArray` argument
- Add method `ManagedQuery::query_status`