### PR TITLE
[docs] Fix Sphinx issue with linkless summaries

### DIFF
--- a/doc/source/python-tiledbsoma-axis.rst
+++ b/doc/source/python-tiledbsoma-axis.rst
@@ -1,0 +1,24 @@
+﻿tiledbsoma.Axis
+===============
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: Axis
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Axis.__init__
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Axis.name
+      ~Axis.unit
+

--- a/doc/source/python-tiledbsoma-axiscolumnnames.rst
+++ b/doc/source/python-tiledbsoma-axiscolumnnames.rst
@@ -1,0 +1,35 @@
+﻿tiledbsoma.AxisColumnNames
+==========================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: AxisColumnNames
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~AxisColumnNames.__init__
+      ~AxisColumnNames.clear
+      ~AxisColumnNames.copy
+      ~AxisColumnNames.fromkeys
+      ~AxisColumnNames.get
+      ~AxisColumnNames.items
+      ~AxisColumnNames.keys
+      ~AxisColumnNames.pop
+      ~AxisColumnNames.popitem
+      ~AxisColumnNames.setdefault
+      ~AxisColumnNames.update
+      ~AxisColumnNames.values
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~AxisColumnNames.obs
+      ~AxisColumnNames.var
+

--- a/doc/source/python-tiledbsoma-axisquery.rst
+++ b/doc/source/python-tiledbsoma-axisquery.rst
@@ -1,0 +1,24 @@
+﻿tiledbsoma.AxisQuery
+====================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: AxisQuery
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~AxisQuery.__init__
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~AxisQuery.value_filter
+      ~AxisQuery.coords
+

--- a/doc/source/python-tiledbsoma-collection.rst
+++ b/doc/source/python-tiledbsoma-collection.rst
@@ -13,27 +13,29 @@
       :toctree: _generated
 
       ~Collection.__init__
+      ~Collection.exists
+      ~Collection.create
+      ~Collection.open
+      ~Collection.reopen
+      ~Collection.close
+      ~Collection.verify_open_for_writing
+
+      ~Collection.items
+      ~Collection.keys
+      ~Collection.values
+      ~Collection.members
+      ~Collection.get
+      ~Collection.set
+      ~Collection.update
+      ~Collection.clear
+      ~Collection.pop
+      ~Collection.popitem
+      ~Collection.setdefault
+
       ~Collection.add_new_collection
       ~Collection.add_new_dataframe
       ~Collection.add_new_dense_ndarray
       ~Collection.add_new_sparse_ndarray
-      ~Collection.clear
-      ~Collection.close
-      ~Collection.create
-      ~Collection.exists
-      ~Collection.get
-      ~Collection.items
-      ~Collection.keys
-      ~Collection.members
-      ~Collection.open
-      ~Collection.pop
-      ~Collection.popitem
-      ~Collection.reopen
-      ~Collection.set
-      ~Collection.setdefault
-      ~Collection.update
-      ~Collection.values
-      ~Collection.verify_open_for_writing
 
    .. rubric:: Attributes
 

--- a/doc/source/python-tiledbsoma-collection.rst
+++ b/doc/source/python-tiledbsoma-collection.rst
@@ -1,0 +1,51 @@
+﻿tiledbsoma.Collection
+=====================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: Collection
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Collection.__init__
+      ~Collection.add_new_collection
+      ~Collection.add_new_dataframe
+      ~Collection.add_new_dense_ndarray
+      ~Collection.add_new_sparse_ndarray
+      ~Collection.clear
+      ~Collection.close
+      ~Collection.create
+      ~Collection.exists
+      ~Collection.get
+      ~Collection.items
+      ~Collection.keys
+      ~Collection.members
+      ~Collection.open
+      ~Collection.pop
+      ~Collection.popitem
+      ~Collection.reopen
+      ~Collection.set
+      ~Collection.setdefault
+      ~Collection.update
+      ~Collection.values
+      ~Collection.verify_open_for_writing
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Collection.closed
+      ~Collection.context
+      ~Collection.metadata
+      ~Collection.mode
+      ~Collection.soma_type
+      ~Collection.tiledb_timestamp
+      ~Collection.tiledb_timestamp_ms
+      ~Collection.uri
+

--- a/doc/source/python-tiledbsoma-collection.rst
+++ b/doc/source/python-tiledbsoma-collection.rst
@@ -26,11 +26,11 @@
       ~Collection.members
       ~Collection.get
       ~Collection.set
+      ~Collection.setdefault
       ~Collection.update
       ~Collection.clear
       ~Collection.pop
       ~Collection.popitem
-      ~Collection.setdefault
 
       ~Collection.add_new_collection
       ~Collection.add_new_dataframe
@@ -42,12 +42,13 @@
    .. autosummary::
       :toctree: _generated
 
+      ~Collection.uri
       ~Collection.closed
       ~Collection.context
       ~Collection.metadata
+
       ~Collection.mode
       ~Collection.soma_type
       ~Collection.tiledb_timestamp
       ~Collection.tiledb_timestamp_ms
-      ~Collection.uri
 

--- a/doc/source/python-tiledbsoma-coordinatespace.rst
+++ b/doc/source/python-tiledbsoma-coordinatespace.rst
@@ -1,0 +1,27 @@
+﻿tiledbsoma.CoordinateSpace
+==========================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: CoordinateSpace
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~CoordinateSpace.__init__
+      ~CoordinateSpace.count
+      ~CoordinateSpace.from_axis_names
+      ~CoordinateSpace.index
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~CoordinateSpace.axes
+      ~CoordinateSpace.axis_names
+

--- a/doc/source/python-tiledbsoma-dataframe.rst
+++ b/doc/source/python-tiledbsoma-dataframe.rst
@@ -13,39 +13,46 @@
       :toctree: _generated
 
       ~DataFrame.__init__
-      ~DataFrame.change_domain
-      ~DataFrame.close
-      ~DataFrame.config_options_from_schema
-      ~DataFrame.create
       ~DataFrame.exists
-      ~DataFrame.keys
-      ~DataFrame.non_empty_domain
+      ~DataFrame.create
       ~DataFrame.open
-      ~DataFrame.read
       ~DataFrame.reopen
-      ~DataFrame.tiledbsoma_resize_soma_joinid_shape
-      ~DataFrame.tiledbsoma_upgrade_domain
-      ~DataFrame.tiledbsoma_upgrade_soma_joinid_shape
-      ~DataFrame.verify_open_for_writing
+      ~DataFrame.close
+      ~DataFrame.read
       ~DataFrame.write
+      ~DataFrame.verify_open_for_writing
+
+      ~DataFrame.keys
+
+      ~DataFrame.tiledbsoma_upgrade_domain
+      ~DataFrame.change_domain
+      ~DataFrame.tiledbsoma_resize_soma_joinid_shape
+      ~DataFrame.tiledbsoma_upgrade_soma_joinid_shape
+      ~DataFrame.non_empty_domain
+
+      ~DataFrame.config_options_from_schema
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~DataFrame.closed
-      ~DataFrame.context
+      ~DataFrame.uri
+      ~DataFrame.soma_type
+      ~DataFrame.schema
+      ~DataFrame.index_column_names
+
       ~DataFrame.count
       ~DataFrame.domain
-      ~DataFrame.index_column_names
       ~DataFrame.maxdomain
-      ~DataFrame.metadata
+      ~DataFrame.tiledbsoma_has_upgraded_domain
+
       ~DataFrame.mode
-      ~DataFrame.schema
-      ~DataFrame.soma_type
+      ~DataFrame.closed
+
+      ~DataFrame.context
       ~DataFrame.tiledb_timestamp
       ~DataFrame.tiledb_timestamp_ms
-      ~DataFrame.tiledbsoma_has_upgraded_domain
-      ~DataFrame.uri
+
+      ~DataFrame.metadata
 

--- a/doc/source/python-tiledbsoma-dataframe.rst
+++ b/doc/source/python-tiledbsoma-dataframe.rst
@@ -1,0 +1,51 @@
+﻿tiledbsoma.DataFrame
+====================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: DataFrame
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~DataFrame.__init__
+      ~DataFrame.change_domain
+      ~DataFrame.close
+      ~DataFrame.config_options_from_schema
+      ~DataFrame.create
+      ~DataFrame.exists
+      ~DataFrame.keys
+      ~DataFrame.non_empty_domain
+      ~DataFrame.open
+      ~DataFrame.read
+      ~DataFrame.reopen
+      ~DataFrame.tiledbsoma_resize_soma_joinid_shape
+      ~DataFrame.tiledbsoma_upgrade_domain
+      ~DataFrame.tiledbsoma_upgrade_soma_joinid_shape
+      ~DataFrame.verify_open_for_writing
+      ~DataFrame.write
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~DataFrame.closed
+      ~DataFrame.context
+      ~DataFrame.count
+      ~DataFrame.domain
+      ~DataFrame.index_column_names
+      ~DataFrame.maxdomain
+      ~DataFrame.metadata
+      ~DataFrame.mode
+      ~DataFrame.schema
+      ~DataFrame.soma_type
+      ~DataFrame.tiledb_timestamp
+      ~DataFrame.tiledb_timestamp_ms
+      ~DataFrame.tiledbsoma_has_upgraded_domain
+      ~DataFrame.uri
+

--- a/doc/source/python-tiledbsoma-densendarray.rst
+++ b/doc/source/python-tiledbsoma-densendarray.rst
@@ -13,35 +13,41 @@
       :toctree: _generated
 
       ~DenseNDArray.__init__
-      ~DenseNDArray.close
-      ~DenseNDArray.config_options_from_schema
-      ~DenseNDArray.create
       ~DenseNDArray.exists
-      ~DenseNDArray.non_empty_domain
+      ~DenseNDArray.create
       ~DenseNDArray.open
-      ~DenseNDArray.read
       ~DenseNDArray.reopen
-      ~DenseNDArray.resize
-      ~DenseNDArray.verify_open_for_writing
+      ~DenseNDArray.close
+      ~DenseNDArray.read
       ~DenseNDArray.write
+      ~DenseNDArray.verify_open_for_writing
+
+      ~DenseNDArray.non_empty_domain
+      ~DenseNDArray.resize
+
+      ~DenseNDArray.config_options_from_schema
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~DenseNDArray.closed
-      ~DenseNDArray.context
-      ~DenseNDArray.is_sparse
-      ~DenseNDArray.maxshape
-      ~DenseNDArray.metadata
-      ~DenseNDArray.mode
-      ~DenseNDArray.ndim
-      ~DenseNDArray.schema
-      ~DenseNDArray.shape
+      ~DenseNDArray.uri
       ~DenseNDArray.soma_type
+      ~DenseNDArray.schema
+      ~DenseNDArray.is_sparse
+
+      ~DenseNDArray.ndim
+      ~DenseNDArray.nnz
+      ~DenseNDArray.shape
+      ~DenseNDArray.maxshape
+      ~DenseNDArray.tiledbsoma_has_upgraded_shape
+
+      ~DenseNDArray.mode
+      ~DenseNDArray.closed
+
+      ~DenseNDArray.context
       ~DenseNDArray.tiledb_timestamp
       ~DenseNDArray.tiledb_timestamp_ms
-      ~DenseNDArray.tiledbsoma_has_upgraded_shape
-      ~DenseNDArray.uri
 
+      ~DenseNDArray.metadata

--- a/doc/source/python-tiledbsoma-densendarray.rst
+++ b/doc/source/python-tiledbsoma-densendarray.rst
@@ -1,0 +1,47 @@
+﻿tiledbsoma.DenseNDArray
+=======================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: DenseNDArray
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~DenseNDArray.__init__
+      ~DenseNDArray.close
+      ~DenseNDArray.config_options_from_schema
+      ~DenseNDArray.create
+      ~DenseNDArray.exists
+      ~DenseNDArray.non_empty_domain
+      ~DenseNDArray.open
+      ~DenseNDArray.read
+      ~DenseNDArray.reopen
+      ~DenseNDArray.resize
+      ~DenseNDArray.verify_open_for_writing
+      ~DenseNDArray.write
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~DenseNDArray.closed
+      ~DenseNDArray.context
+      ~DenseNDArray.is_sparse
+      ~DenseNDArray.maxshape
+      ~DenseNDArray.metadata
+      ~DenseNDArray.mode
+      ~DenseNDArray.ndim
+      ~DenseNDArray.schema
+      ~DenseNDArray.shape
+      ~DenseNDArray.soma_type
+      ~DenseNDArray.tiledb_timestamp
+      ~DenseNDArray.tiledb_timestamp_ms
+      ~DenseNDArray.tiledbsoma_has_upgraded_shape
+      ~DenseNDArray.uri
+

--- a/doc/source/python-tiledbsoma-experiment.rst
+++ b/doc/source/python-tiledbsoma-experiment.rst
@@ -13,28 +13,31 @@
       :toctree: _generated
 
       ~Experiment.__init__
+      ~Experiment.exists
+      ~Experiment.create
+      ~Experiment.open
+      ~Experiment.reopen
+      ~Experiment.close
+      ~Experiment.verify_open_for_writing
+
+      ~Experiment.items
+      ~Experiment.keys
+      ~Experiment.values
+      ~Experiment.members
+      ~Experiment.get
+      ~Experiment.set
+      ~Experiment.update
+      ~Experiment.clear
+      ~Experiment.pop
+      ~Experiment.popitem
+      ~Experiment.setdefault
+
       ~Experiment.add_new_collection
       ~Experiment.add_new_dataframe
       ~Experiment.add_new_dense_ndarray
       ~Experiment.add_new_sparse_ndarray
+
       ~Experiment.axis_query
-      ~Experiment.clear
-      ~Experiment.close
-      ~Experiment.create
-      ~Experiment.exists
-      ~Experiment.get
-      ~Experiment.items
-      ~Experiment.keys
-      ~Experiment.members
-      ~Experiment.open
-      ~Experiment.pop
-      ~Experiment.popitem
-      ~Experiment.reopen
-      ~Experiment.set
-      ~Experiment.setdefault
-      ~Experiment.update
-      ~Experiment.values
-      ~Experiment.verify_open_for_writing
 
    .. rubric:: Attributes
 

--- a/doc/source/python-tiledbsoma-experiment.rst
+++ b/doc/source/python-tiledbsoma-experiment.rst
@@ -1,0 +1,56 @@
+﻿tiledbsoma.Experiment
+=====================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: Experiment
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Experiment.__init__
+      ~Experiment.add_new_collection
+      ~Experiment.add_new_dataframe
+      ~Experiment.add_new_dense_ndarray
+      ~Experiment.add_new_sparse_ndarray
+      ~Experiment.axis_query
+      ~Experiment.clear
+      ~Experiment.close
+      ~Experiment.create
+      ~Experiment.exists
+      ~Experiment.get
+      ~Experiment.items
+      ~Experiment.keys
+      ~Experiment.members
+      ~Experiment.open
+      ~Experiment.pop
+      ~Experiment.popitem
+      ~Experiment.reopen
+      ~Experiment.set
+      ~Experiment.setdefault
+      ~Experiment.update
+      ~Experiment.values
+      ~Experiment.verify_open_for_writing
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Experiment.closed
+      ~Experiment.context
+      ~Experiment.metadata
+      ~Experiment.mode
+      ~Experiment.ms
+      ~Experiment.obs
+      ~Experiment.obs_spatial_presence
+      ~Experiment.soma_type
+      ~Experiment.spatial
+      ~Experiment.tiledb_timestamp
+      ~Experiment.tiledb_timestamp_ms
+      ~Experiment.uri
+

--- a/doc/source/python-tiledbsoma-experimentaxisquery.rst
+++ b/doc/source/python-tiledbsoma-experimentaxisquery.rst
@@ -1,0 +1,38 @@
+﻿tiledbsoma.ExperimentAxisQuery
+==============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: ExperimentAxisQuery
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~ExperimentAxisQuery.X
+      ~ExperimentAxisQuery.__init__
+      ~ExperimentAxisQuery.close
+      ~ExperimentAxisQuery.obs
+      ~ExperimentAxisQuery.obs_joinids
+      ~ExperimentAxisQuery.obs_scene_ids
+      ~ExperimentAxisQuery.obsm
+      ~ExperimentAxisQuery.obsp
+      ~ExperimentAxisQuery.to_anndata
+      ~ExperimentAxisQuery.var
+      ~ExperimentAxisQuery.var_joinids
+      ~ExperimentAxisQuery.var_scene_ids
+      ~ExperimentAxisQuery.varm
+      ~ExperimentAxisQuery.varp
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~ExperimentAxisQuery.indexer
+      ~ExperimentAxisQuery.n_obs
+      ~ExperimentAxisQuery.n_vars
+

--- a/doc/source/python-tiledbsoma-intindexer.rst
+++ b/doc/source/python-tiledbsoma-intindexer.rst
@@ -1,0 +1,17 @@
+﻿tiledbsoma.IntIndexer
+=====================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: IntIndexer
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~IntIndexer.__init__
+      ~IntIndexer.get_indexer
+

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -9,6 +9,8 @@ The tiledbsoma.io module
 Functions
 ---------
 
+.. rubric:: Data conversion to/from TileDB-SOMA
+
 .. autosummary::
     :toctree: _autosummary/
     :nosignatures:
@@ -17,8 +19,12 @@ Functions
     tiledbsoma.io.from_anndata
     tiledbsoma.io.to_h5ad
     tiledbsoma.io.to_anndata
-    tiledbsoma.io.register_anndatas
-    tiledbsoma.io.register_h5ads
+
+.. rubric:: Updating values within a TileDB-SOMA Experiment
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
 
     tiledbsoma.io.add_X_layer
     tiledbsoma.io.add_matrix_to_collection
@@ -26,9 +32,18 @@ Functions
     tiledbsoma.io.update_obs
     tiledbsoma.io.update_var
     tiledbsoma.io.update_matrix
+
+.. rubric:: Growing a TileDB-SOMA Experiment
+
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    tiledbsoma.io.register_anndatas
+    tiledbsoma.io.register_h5ads
     tiledbsoma.io.append_X
     tiledbsoma.io.append_obs
     tiledbsoma.io.append_var
+    tiledbsoma.io.show_experiment_shapes
     tiledbsoma.io.upgrade_experiment_shapes
     tiledbsoma.io.resize_experiment
-    tiledbsoma.io.show_experiment_shapes

--- a/doc/source/python-tiledbsoma-measurement.rst
+++ b/doc/source/python-tiledbsoma-measurement.rst
@@ -13,46 +13,48 @@
       :toctree: _generated
 
       ~Measurement.__init__
+      ~Measurement.exists
+      ~Measurement.create
+      ~Measurement.open
+      ~Measurement.reopen
+      ~Measurement.close
+      ~Measurement.verify_open_for_writing
+
+      ~Measurement.items
+      ~Measurement.keys
+      ~Measurement.values
+      ~Measurement.members
+      ~Measurement.get
+      ~Measurement.set
+      ~Measurement.update
+      ~Measurement.clear
+      ~Measurement.pop
+      ~Measurement.popitem
+      ~Measurement.setdefault
+
       ~Measurement.add_new_collection
       ~Measurement.add_new_dataframe
       ~Measurement.add_new_dense_ndarray
       ~Measurement.add_new_sparse_ndarray
-      ~Measurement.clear
-      ~Measurement.close
-      ~Measurement.create
-      ~Measurement.exists
-      ~Measurement.get
-      ~Measurement.items
-      ~Measurement.keys
-      ~Measurement.members
-      ~Measurement.open
-      ~Measurement.pop
-      ~Measurement.popitem
-      ~Measurement.reopen
-      ~Measurement.set
-      ~Measurement.setdefault
-      ~Measurement.update
-      ~Measurement.values
-      ~Measurement.verify_open_for_writing
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~Measurement.X
+      ~Measurement.uri
+      ~Measurement.soma_type
+      ~Measurement.mode
       ~Measurement.closed
       ~Measurement.context
       ~Measurement.metadata
-      ~Measurement.mode
-      ~Measurement.obsm
-      ~Measurement.obsp
-      ~Measurement.soma_type
       ~Measurement.tiledb_timestamp
       ~Measurement.tiledb_timestamp_ms
-      ~Measurement.uri
       ~Measurement.var
       ~Measurement.var_spatial_presence
+      ~Measurement.obsm
+      ~Measurement.obsp
       ~Measurement.varm
       ~Measurement.varp
+      ~Measurement.X
 

--- a/doc/source/python-tiledbsoma-measurement.rst
+++ b/doc/source/python-tiledbsoma-measurement.rst
@@ -1,0 +1,58 @@
+﻿tiledbsoma.Measurement
+======================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: Measurement
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Measurement.__init__
+      ~Measurement.add_new_collection
+      ~Measurement.add_new_dataframe
+      ~Measurement.add_new_dense_ndarray
+      ~Measurement.add_new_sparse_ndarray
+      ~Measurement.clear
+      ~Measurement.close
+      ~Measurement.create
+      ~Measurement.exists
+      ~Measurement.get
+      ~Measurement.items
+      ~Measurement.keys
+      ~Measurement.members
+      ~Measurement.open
+      ~Measurement.pop
+      ~Measurement.popitem
+      ~Measurement.reopen
+      ~Measurement.set
+      ~Measurement.setdefault
+      ~Measurement.update
+      ~Measurement.values
+      ~Measurement.verify_open_for_writing
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Measurement.X
+      ~Measurement.closed
+      ~Measurement.context
+      ~Measurement.metadata
+      ~Measurement.mode
+      ~Measurement.obsm
+      ~Measurement.obsp
+      ~Measurement.soma_type
+      ~Measurement.tiledb_timestamp
+      ~Measurement.tiledb_timestamp_ms
+      ~Measurement.uri
+      ~Measurement.var
+      ~Measurement.var_spatial_presence
+      ~Measurement.varm
+      ~Measurement.varp
+

--- a/doc/source/python-tiledbsoma-multiscaleimage.rst
+++ b/doc/source/python-tiledbsoma-multiscaleimage.rst
@@ -13,44 +13,49 @@
       :toctree: _generated
 
       ~MultiscaleImage.__init__
-      ~MultiscaleImage.add_new_level
-      ~MultiscaleImage.clear
-      ~MultiscaleImage.close
-      ~MultiscaleImage.create
       ~MultiscaleImage.exists
-      ~MultiscaleImage.get
-      ~MultiscaleImage.get_transform_from_level
-      ~MultiscaleImage.get_transform_to_level
+      ~MultiscaleImage.create
+      ~MultiscaleImage.open
+      ~MultiscaleImage.reopen
+      ~MultiscaleImage.close
+      ~MultiscaleImage.verify_open_for_writing
+
       ~MultiscaleImage.items
       ~MultiscaleImage.keys
-      ~MultiscaleImage.level_shape
-      ~MultiscaleImage.open
-      ~MultiscaleImage.pop
-      ~MultiscaleImage.popitem
-      ~MultiscaleImage.read_spatial_region
-      ~MultiscaleImage.reopen
+      ~MultiscaleImage.values
+
+      ~MultiscaleImage.get
       ~MultiscaleImage.set
       ~MultiscaleImage.setdefault
       ~MultiscaleImage.update
-      ~MultiscaleImage.values
-      ~MultiscaleImage.verify_open_for_writing
+      ~MultiscaleImage.clear
+      ~MultiscaleImage.pop
+      ~MultiscaleImage.popitem
+
+      ~MultiscaleImage.add_new_level
+      ~MultiscaleImage.get_transform_from_level
+      ~MultiscaleImage.get_transform_to_level
+      ~MultiscaleImage.level_shape
+      ~MultiscaleImage.read_spatial_region
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~MultiscaleImage.closed
+      ~MultiscaleImage.uri
       ~MultiscaleImage.context
+      ~MultiscaleImage.metadata
+
+      ~MultiscaleImage.mode
+      ~MultiscaleImage.closed
+      ~MultiscaleImage.soma_type
+      ~MultiscaleImage.tiledb_timestamp
+      ~MultiscaleImage.tiledb_timestamp_ms
+
       ~MultiscaleImage.coordinate_space
       ~MultiscaleImage.data_axis_order
       ~MultiscaleImage.has_channel_axis
       ~MultiscaleImage.level_count
-      ~MultiscaleImage.metadata
-      ~MultiscaleImage.mode
       ~MultiscaleImage.nchannels
-      ~MultiscaleImage.soma_type
-      ~MultiscaleImage.tiledb_timestamp
-      ~MultiscaleImage.tiledb_timestamp_ms
-      ~MultiscaleImage.uri
 

--- a/doc/source/python-tiledbsoma-multiscaleimage.rst
+++ b/doc/source/python-tiledbsoma-multiscaleimage.rst
@@ -1,0 +1,56 @@
+﻿tiledbsoma.MultiscaleImage
+==========================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: MultiscaleImage
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~MultiscaleImage.__init__
+      ~MultiscaleImage.add_new_level
+      ~MultiscaleImage.clear
+      ~MultiscaleImage.close
+      ~MultiscaleImage.create
+      ~MultiscaleImage.exists
+      ~MultiscaleImage.get
+      ~MultiscaleImage.get_transform_from_level
+      ~MultiscaleImage.get_transform_to_level
+      ~MultiscaleImage.items
+      ~MultiscaleImage.keys
+      ~MultiscaleImage.level_shape
+      ~MultiscaleImage.open
+      ~MultiscaleImage.pop
+      ~MultiscaleImage.popitem
+      ~MultiscaleImage.read_spatial_region
+      ~MultiscaleImage.reopen
+      ~MultiscaleImage.set
+      ~MultiscaleImage.setdefault
+      ~MultiscaleImage.update
+      ~MultiscaleImage.values
+      ~MultiscaleImage.verify_open_for_writing
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~MultiscaleImage.closed
+      ~MultiscaleImage.context
+      ~MultiscaleImage.coordinate_space
+      ~MultiscaleImage.data_axis_order
+      ~MultiscaleImage.has_channel_axis
+      ~MultiscaleImage.level_count
+      ~MultiscaleImage.metadata
+      ~MultiscaleImage.mode
+      ~MultiscaleImage.nchannels
+      ~MultiscaleImage.soma_type
+      ~MultiscaleImage.tiledb_timestamp
+      ~MultiscaleImage.tiledb_timestamp_ms
+      ~MultiscaleImage.uri
+

--- a/doc/source/python-tiledbsoma-pointclouddataframe.rst
+++ b/doc/source/python-tiledbsoma-pointclouddataframe.rst
@@ -13,36 +13,40 @@
       :toctree: _generated
 
       ~PointCloudDataFrame.__init__
-      ~PointCloudDataFrame.close
-      ~PointCloudDataFrame.config_options_from_schema
-      ~PointCloudDataFrame.create
       ~PointCloudDataFrame.exists
-      ~PointCloudDataFrame.keys
-      ~PointCloudDataFrame.non_empty_domain
+      ~PointCloudDataFrame.create
       ~PointCloudDataFrame.open
-      ~PointCloudDataFrame.read
-      ~PointCloudDataFrame.read_spatial_region
       ~PointCloudDataFrame.reopen
+      ~PointCloudDataFrame.close
       ~PointCloudDataFrame.verify_open_for_writing
+
+      ~PointCloudDataFrame.keys
+      ~PointCloudDataFrame.read
       ~PointCloudDataFrame.write
+
+      ~PointCloudDataFrame.config_options_from_schema
+      ~PointCloudDataFrame.non_empty_domain
+      ~PointCloudDataFrame.read_spatial_region
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~PointCloudDataFrame.axis_names
+      ~PointCloudDataFrame.uri
       ~PointCloudDataFrame.closed
       ~PointCloudDataFrame.context
+      ~PointCloudDataFrame.metadata
+
+      ~PointCloudDataFrame.mode
+      ~PointCloudDataFrame.soma_type
+      ~PointCloudDataFrame.tiledb_timestamp
+      ~PointCloudDataFrame.tiledb_timestamp_ms
+
+      ~PointCloudDataFrame.axis_names
       ~PointCloudDataFrame.coordinate_space
       ~PointCloudDataFrame.count
       ~PointCloudDataFrame.domain
       ~PointCloudDataFrame.index_column_names
-      ~PointCloudDataFrame.metadata
-      ~PointCloudDataFrame.mode
       ~PointCloudDataFrame.schema
-      ~PointCloudDataFrame.soma_type
-      ~PointCloudDataFrame.tiledb_timestamp
-      ~PointCloudDataFrame.tiledb_timestamp_ms
-      ~PointCloudDataFrame.uri
 

--- a/doc/source/python-tiledbsoma-pointclouddataframe.rst
+++ b/doc/source/python-tiledbsoma-pointclouddataframe.rst
@@ -1,0 +1,48 @@
+﻿tiledbsoma.PointCloudDataFrame
+==============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: PointCloudDataFrame
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~PointCloudDataFrame.__init__
+      ~PointCloudDataFrame.close
+      ~PointCloudDataFrame.config_options_from_schema
+      ~PointCloudDataFrame.create
+      ~PointCloudDataFrame.exists
+      ~PointCloudDataFrame.keys
+      ~PointCloudDataFrame.non_empty_domain
+      ~PointCloudDataFrame.open
+      ~PointCloudDataFrame.read
+      ~PointCloudDataFrame.read_spatial_region
+      ~PointCloudDataFrame.reopen
+      ~PointCloudDataFrame.verify_open_for_writing
+      ~PointCloudDataFrame.write
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~PointCloudDataFrame.axis_names
+      ~PointCloudDataFrame.closed
+      ~PointCloudDataFrame.context
+      ~PointCloudDataFrame.coordinate_space
+      ~PointCloudDataFrame.count
+      ~PointCloudDataFrame.domain
+      ~PointCloudDataFrame.index_column_names
+      ~PointCloudDataFrame.metadata
+      ~PointCloudDataFrame.mode
+      ~PointCloudDataFrame.schema
+      ~PointCloudDataFrame.soma_type
+      ~PointCloudDataFrame.tiledb_timestamp
+      ~PointCloudDataFrame.tiledb_timestamp_ms
+      ~PointCloudDataFrame.uri
+

--- a/doc/source/python-tiledbsoma-resultorder.rst
+++ b/doc/source/python-tiledbsoma-resultorder.rst
@@ -1,0 +1,18 @@
+﻿tiledbsoma.ResultOrder
+======================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: ResultOrder
+
+   .. automethod:: __init__
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~ResultOrder.AUTO
+      ~ResultOrder.ROW_MAJOR
+      ~ResultOrder.COLUMN_MAJOR
+

--- a/doc/source/python-tiledbsoma-scene.rst
+++ b/doc/source/python-tiledbsoma-scene.rst
@@ -1,0 +1,67 @@
+﻿tiledbsoma.Scene
+================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: Scene
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Scene.__init__
+      ~Scene.add_new_collection
+      ~Scene.add_new_dataframe
+      ~Scene.add_new_dense_ndarray
+      ~Scene.add_new_geometry_dataframe
+      ~Scene.add_new_multiscale_image
+      ~Scene.add_new_point_cloud_dataframe
+      ~Scene.add_new_sparse_ndarray
+      ~Scene.clear
+      ~Scene.close
+      ~Scene.create
+      ~Scene.exists
+      ~Scene.get
+      ~Scene.get_transform_from_geometry_dataframe
+      ~Scene.get_transform_from_multiscale_image
+      ~Scene.get_transform_from_point_cloud_dataframe
+      ~Scene.get_transform_to_geometry_dataframe
+      ~Scene.get_transform_to_multiscale_image
+      ~Scene.get_transform_to_point_cloud_dataframe
+      ~Scene.items
+      ~Scene.keys
+      ~Scene.members
+      ~Scene.open
+      ~Scene.pop
+      ~Scene.popitem
+      ~Scene.reopen
+      ~Scene.set
+      ~Scene.set_transform_to_geometry_dataframe
+      ~Scene.set_transform_to_multiscale_image
+      ~Scene.set_transform_to_point_cloud_dataframe
+      ~Scene.setdefault
+      ~Scene.update
+      ~Scene.values
+      ~Scene.verify_open_for_writing
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~Scene.closed
+      ~Scene.context
+      ~Scene.coordinate_space
+      ~Scene.img
+      ~Scene.metadata
+      ~Scene.mode
+      ~Scene.obsl
+      ~Scene.soma_type
+      ~Scene.tiledb_timestamp
+      ~Scene.tiledb_timestamp_ms
+      ~Scene.uri
+      ~Scene.varl
+

--- a/doc/source/python-tiledbsoma-scene.rst
+++ b/doc/source/python-tiledbsoma-scene.rst
@@ -13,6 +13,25 @@
       :toctree: _generated
 
       ~Scene.__init__
+      ~Scene.exists
+      ~Scene.create
+      ~Scene.open
+      ~Scene.reopen
+      ~Scene.close
+      ~Scene.verify_open_for_writing
+
+      ~Scene.items
+      ~Scene.keys
+      ~Scene.values
+      ~Scene.members
+      ~Scene.get
+      ~Scene.set
+      ~Scene.setdefault
+      ~Scene.update
+      ~Scene.clear
+      ~Scene.pop
+      ~Scene.popitem
+
       ~Scene.add_new_collection
       ~Scene.add_new_dataframe
       ~Scene.add_new_dense_ndarray
@@ -20,48 +39,34 @@
       ~Scene.add_new_multiscale_image
       ~Scene.add_new_point_cloud_dataframe
       ~Scene.add_new_sparse_ndarray
-      ~Scene.clear
-      ~Scene.close
-      ~Scene.create
-      ~Scene.exists
-      ~Scene.get
+
       ~Scene.get_transform_from_geometry_dataframe
       ~Scene.get_transform_from_multiscale_image
       ~Scene.get_transform_from_point_cloud_dataframe
       ~Scene.get_transform_to_geometry_dataframe
       ~Scene.get_transform_to_multiscale_image
       ~Scene.get_transform_to_point_cloud_dataframe
-      ~Scene.items
-      ~Scene.keys
-      ~Scene.members
-      ~Scene.open
-      ~Scene.pop
-      ~Scene.popitem
-      ~Scene.reopen
-      ~Scene.set
       ~Scene.set_transform_to_geometry_dataframe
       ~Scene.set_transform_to_multiscale_image
       ~Scene.set_transform_to_point_cloud_dataframe
-      ~Scene.setdefault
-      ~Scene.update
-      ~Scene.values
-      ~Scene.verify_open_for_writing
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~Scene.closed
+      ~Scene.uri
       ~Scene.context
-      ~Scene.coordinate_space
-      ~Scene.img
       ~Scene.metadata
+
       ~Scene.mode
-      ~Scene.obsl
+      ~Scene.closed
       ~Scene.soma_type
       ~Scene.tiledb_timestamp
       ~Scene.tiledb_timestamp_ms
-      ~Scene.uri
+
+      ~Scene.coordinate_space
+      ~Scene.img
+      ~Scene.obsl
       ~Scene.varl
 

--- a/doc/source/python-tiledbsoma-somatiledbcontext.rst
+++ b/doc/source/python-tiledbsoma-somatiledbcontext.rst
@@ -1,0 +1,28 @@
+﻿tiledbsoma.SOMATileDBContext
+============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: SOMATileDBContext
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~SOMATileDBContext.__init__
+      ~SOMATileDBContext.replace
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~SOMATileDBContext.native_context
+      ~SOMATileDBContext.tiledb_config
+      ~SOMATileDBContext.timestamp
+      ~SOMATileDBContext.timestamp_ms
+      ~SOMATileDBContext.threadpool
+

--- a/doc/source/python-tiledbsoma-sparsendarray.rst
+++ b/doc/source/python-tiledbsoma-sparsendarray.rst
@@ -13,38 +13,44 @@
       :toctree: _generated
 
       ~SparseNDArray.__init__
-      ~SparseNDArray.close
-      ~SparseNDArray.config_options_from_schema
-      ~SparseNDArray.create
       ~SparseNDArray.exists
-      ~SparseNDArray.non_empty_domain
+      ~SparseNDArray.create
       ~SparseNDArray.open
-      ~SparseNDArray.read
       ~SparseNDArray.reopen
-      ~SparseNDArray.resize
-      ~SparseNDArray.tiledbsoma_upgrade_shape
-      ~SparseNDArray.used_shape
-      ~SparseNDArray.verify_open_for_writing
+      ~SparseNDArray.close
+      ~SparseNDArray.read
       ~SparseNDArray.write
+      ~SparseNDArray.verify_open_for_writing
+
+      ~SparseNDArray.non_empty_domain
+      ~SparseNDArray.tiledbsoma_upgrade_shape
+      ~SparseNDArray.resize
+      ~SparseNDArray.used_shape
+
+      ~SparseNDArray.config_options_from_schema
 
    .. rubric:: Attributes
 
    .. autosummary::
       :toctree: _generated
 
-      ~SparseNDArray.closed
-      ~SparseNDArray.context
+      ~SparseNDArray.uri
+      ~SparseNDArray.soma_type
+      ~SparseNDArray.schema
       ~SparseNDArray.is_sparse
-      ~SparseNDArray.maxshape
-      ~SparseNDArray.metadata
-      ~SparseNDArray.mode
+
       ~SparseNDArray.ndim
       ~SparseNDArray.nnz
-      ~SparseNDArray.schema
       ~SparseNDArray.shape
-      ~SparseNDArray.soma_type
+      ~SparseNDArray.maxshape
+      ~SparseNDArray.tiledbsoma_has_upgraded_shape
+
+      ~SparseNDArray.mode
+      ~SparseNDArray.closed
+
+      ~SparseNDArray.context
       ~SparseNDArray.tiledb_timestamp
       ~SparseNDArray.tiledb_timestamp_ms
-      ~SparseNDArray.tiledbsoma_has_upgraded_shape
-      ~SparseNDArray.uri
+
+      ~SparseNDArray.metadata
 

--- a/doc/source/python-tiledbsoma-sparsendarray.rst
+++ b/doc/source/python-tiledbsoma-sparsendarray.rst
@@ -1,0 +1,50 @@
+﻿tiledbsoma.SparseNDArray
+========================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: SparseNDArray
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~SparseNDArray.__init__
+      ~SparseNDArray.close
+      ~SparseNDArray.config_options_from_schema
+      ~SparseNDArray.create
+      ~SparseNDArray.exists
+      ~SparseNDArray.non_empty_domain
+      ~SparseNDArray.open
+      ~SparseNDArray.read
+      ~SparseNDArray.reopen
+      ~SparseNDArray.resize
+      ~SparseNDArray.tiledbsoma_upgrade_shape
+      ~SparseNDArray.used_shape
+      ~SparseNDArray.verify_open_for_writing
+      ~SparseNDArray.write
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~SparseNDArray.closed
+      ~SparseNDArray.context
+      ~SparseNDArray.is_sparse
+      ~SparseNDArray.maxshape
+      ~SparseNDArray.metadata
+      ~SparseNDArray.mode
+      ~SparseNDArray.ndim
+      ~SparseNDArray.nnz
+      ~SparseNDArray.schema
+      ~SparseNDArray.shape
+      ~SparseNDArray.soma_type
+      ~SparseNDArray.tiledb_timestamp
+      ~SparseNDArray.tiledb_timestamp_ms
+      ~SparseNDArray.tiledbsoma_has_upgraded_shape
+      ~SparseNDArray.uri
+

--- a/doc/source/python-tiledbsoma-sparsendarrayread.rst
+++ b/doc/source/python-tiledbsoma-sparsendarrayread.rst
@@ -1,0 +1,21 @@
+﻿tiledbsoma.SparseNDArrayRead
+============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: SparseNDArrayRead
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~SparseNDArrayRead.__init__
+      ~SparseNDArrayRead.blockwise
+      ~SparseNDArrayRead.coos
+      ~SparseNDArrayRead.dense_tensors
+      ~SparseNDArrayRead.record_batches
+      ~SparseNDArrayRead.tables
+

--- a/doc/source/python-tiledbsoma-tiledbcreateoptions.rst
+++ b/doc/source/python-tiledbsoma-tiledbcreateoptions.rst
@@ -1,0 +1,39 @@
+﻿tiledbsoma.TileDBCreateOptions
+==============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: TileDBCreateOptions
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~TileDBCreateOptions.__init__
+      ~TileDBCreateOptions.cell_tile_orders
+      ~TileDBCreateOptions.dim_tile
+      ~TileDBCreateOptions.from_platform_config
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~TileDBCreateOptions.dataframe_dim_zstd_level
+      ~TileDBCreateOptions.sparse_nd_array_dim_zstd_level
+      ~TileDBCreateOptions.dense_nd_array_dim_zstd_level
+      ~TileDBCreateOptions.write_X_chunked
+      ~TileDBCreateOptions.goal_chunk_nnz
+      ~TileDBCreateOptions.remote_cap_nbytes
+      ~TileDBCreateOptions.capacity
+      ~TileDBCreateOptions.offsets_filters
+      ~TileDBCreateOptions.validity_filters
+      ~TileDBCreateOptions.allows_duplicates
+      ~TileDBCreateOptions.tile_order
+      ~TileDBCreateOptions.cell_order
+      ~TileDBCreateOptions.dims
+      ~TileDBCreateOptions.attrs
+

--- a/doc/source/python-tiledbsoma-tiledbwriteoptions.rst
+++ b/doc/source/python-tiledbsoma-tiledbwriteoptions.rst
@@ -1,0 +1,25 @@
+﻿tiledbsoma.TileDBWriteOptions
+=============================
+
+.. currentmodule:: tiledbsoma
+
+.. autoclass:: TileDBWriteOptions
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~TileDBWriteOptions.__init__
+      ~TileDBWriteOptions.from_platform_config
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~TileDBWriteOptions.sort_coords
+      ~TileDBWriteOptions.consolidate_and_vacuum
+

--- a/doc/source/python-tiledbsoma.rst
+++ b/doc/source/python-tiledbsoma.rst
@@ -8,37 +8,35 @@ The tiledbsoma module
 Classes
 -------
 
-.. autosummary::
-    :toctree: _autosummary/
-    :nosignatures:
+.. toctree::
+    :maxdepth: 1
 
-    tiledbsoma.Collection
-    tiledbsoma.Experiment
-    tiledbsoma.Measurement
+    python-tiledbsoma-collection
+    python-tiledbsoma-experiment
+    python-tiledbsoma-measurement
 
-    tiledbsoma.DataFrame
-    tiledbsoma.SparseNDArray
-    tiledbsoma.SparseNDArrayRead
-    tiledbsoma.DenseNDArray
+    python-tiledbsoma-dataframe
+    python-tiledbsoma-sparsendarray
+    python-tiledbsoma-sparsendarrayread
+    python-tiledbsoma-densendarray
 
-    tiledbsoma.Axis
-    tiledbsoma.CoordinateSpace
-    tiledbsoma.MultiscaleImage
-    tiledbsoma.PointCloudDataFrame
-    tiledbsoma.Scene
+    python-tiledbsoma-axis
+    python-tiledbsoma-coordinatespace
+    python-tiledbsoma-multiscaleimage
+    python-tiledbsoma-pointclouddataframe
+    python-tiledbsoma-scene
 
-    tiledbsoma.ResultOrder
+    python-tiledbsoma-resultorder
 
-    tiledbsoma.AxisColumnNames
-    tiledbsoma.AxisQuery
-    tiledbsoma.ExperimentAxisQuery
+    python-tiledbsoma-axiscolumnnames
+    python-tiledbsoma-axisquery
+    python-tiledbsoma-experimentaxisquery
 
-    tiledbsoma.SOMATileDBContext
-    tiledbsoma.TileDBCreateOptions
-    tiledbsoma.TileDBWriteOptions
+    python-tiledbsoma-somatiledbcontext
+    python-tiledbsoma-tiledbcreateoptions
+    python-tiledbsoma-tiledbwriteoptions
 
-    tiledbsoma.IntIndexer
-    tiledbsoma.tiledbsoma_build_index
+    python-tiledbsoma-intindexer
 
 Exceptions
 ----------
@@ -74,3 +72,5 @@ Functions
     tiledbsoma.tiledbsoma_stats_dump
     tiledbsoma.tiledbsoma_stats_as_py
     tiledbsoma.tiledbsoma_stats_json
+
+    tiledbsoma.tiledbsoma_build_index


### PR DESCRIPTION
**Issue and/or context:** Ongoing work as part of #3282. Also fixes #3227.

## Problem

**What's right**

* Go here: https://tiledbsoma.readthedocs.io/en/stable/python-tiledbsoma.html
* Scroll to "Classes"
* Pick one like `tiledbsoma.Measurement`
* Hover over that:

![Screenshot 2024-11-02 at 1 21 16 PM](https://github.com/user-attachments/assets/7d495599-4d85-463a-99bb-b8eb85db3a32)

* This is a link; click it and you get here: https://tiledbsoma.readthedocs.io/en/stable/_autosummary/tiledbsoma.Measurement.html#tiledbsoma.Measurement

* Docstrings are present for the class -- _full_ docstrings and not just the first summary sentence

![Screenshot 2024-11-02 at 1 21 32 PM](https://github.com/user-attachments/assets/3ed226b7-971b-4a25-95e0-384f0d352b2b)

**What's wrong**

* Simply go one level deeper: scroll down to "Methods"
* Hover over a method, e.g. `add_new_collection`
* This is _not_ a hyperlink
* What you see is the _first sentence_ of its docstring
* Nothing you can click on will show you the rest of the docstring

![Screenshot 2024-11-02 at 1 24 04 PM](https://github.com/user-attachments/assets/79be9b33-e5f0-4e83-94fc-2623133656eb)

## Analysis

At the first level we have hand-written `.rst` like this:

* https://tiledbsoma.readthedocs.io/en/stable/python-tiledbsoma.html
* https://github.com/single-cell-data/TileDB-SOMA/blob/1.15.0rc3/doc/source/python-tiledbsoma.rst

We keystroke out
```
.. autosummary::
    :toctree: _autosummary/
```

At the next level, we're letting autogen recurse for us and create `.rst` files. The `.rst` files that are auto-generated are missing this line:

```
    :toctree: _autosummary/
```

I spent the morning debugging, experimenting with `sphinx-autogen` and `sphinx-apidoc`, copy/pasting examples out of the Sphinx docs, playing with the `:recursive:` tag, doing `pip install -U` of every Sphinx package on my system, etc. -- and I came to the following conclusions:

* I could not find any syntax that would make the autogenerator emit the `:toctree: dirnamegoeshere` line on the `.rst` files it generates.
* Therefore I autogenerated the "next level in", manually edited those to include the `:toctree: dirnamegoeshere` lines, and am adding them to source control.

**Changes:**

As above.

**Notes for Reviewer:**

This means more manual editng when we create new classes/methods. However, there is already a non-zero amount of manual edits necessary: #3283 is a case in point. I would love to have _fully_ automated/hands-off code -> doc generation but we simply do not have that at present. I will take a method with one more manual step, that produces correct and useful documentation, over a method one with one fewer manual step that produces incomplete and misleading documentation.

To view the docs: please compare

* https://tiledbsoma.readthedocs.io/en/stable/python-api.html# (old)
* https://tiledbsoma.readthedocs.io/en/kerl-fix-sphinx-linkless-summaries/python-api.html (new)

Note this second link is on what readthedocs calls a "hidden branch" which I created as a manual one-off for this PR review.

PR stacking as of today:

* `main`
* #3283
* #3284
* #3285
