### PR TITLE
[python] Consolidate all `_set_coords` methods into single `_util` function

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -14,7 +14,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -39,9 +38,7 @@ from ._types import (
     NPFloating,
     NPInteger,
     OpenTimestamp,
-    Slice,
     StatusAndReason,
-    is_slice_of,
 )
 from .options import SOMATileDBContext
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
@@ -696,7 +693,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         if value_filter is not None:
             sr.set_condition(QueryCondition(value_filter), handle.schema)
 
-        self._set_coords(sr, coords)
+        _util._set_coords(sr, coords)
 
         # TODO: batch_size
         return TableReadIter(sr)
@@ -757,140 +754,6 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             clib_dataframe.consolidate_and_vacuum()
 
         return self
-
-    def _set_coord(
-        self,
-        sr: clib.SOMAArray,
-        dim_idx: int,
-        dim: pa.Field,
-        coord: object,
-    ) -> bool:
-        if coord is None:
-            return True  # No constraint; select all in this dimension
-
-        if isinstance(coord, (str, bytes)):
-            sr.set_dim_points_string_or_bytes(dim.name, [coord])
-            return True
-
-        if isinstance(coord, (pa.Array, pa.ChunkedArray)):
-            # sr.set_dim_points_arrow does type disambiguation based on array schema -- so we do
-            # not.
-            sr.set_dim_points_arrow(dim.name, coord)
-            return True
-
-        if isinstance(coord, (Sequence, np.ndarray)):
-            if self._set_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
-                return True
-
-        if isinstance(coord, slice):
-            _util.validate_slice(coord)
-            if coord.start is None and coord.stop is None:
-                return True
-
-        if isinstance(coord, slice):
-            _util.validate_slice(coord)
-            if self._set_coord_by_numeric_slice(sr, dim_idx, dim, coord):
-                return True
-
-        domain = self.domain[dim_idx]
-
-        # Note: slice(None, None) matches the is_slice_of part, unless we also check the dim-type
-        # part.
-        if (
-            is_slice_of(coord, str) or is_slice_of(coord, bytes)
-        ) and _util.pa_types_is_string_or_bytes(dim.type):
-            _util.validate_slice(coord)
-            # Figure out which one.
-            dim_type: Union[Type[str], Type[bytes]] = type(domain[0])
-            # A ``None`` or empty start is always equivalent to empty str/bytes.
-            start = coord.start or dim_type()
-            if coord.stop is None:
-                # There's no way to specify "to infinity" for strings.
-                # We have to get the nonempty domain and use that as the end.
-                ned = self._handle.non_empty_domain()
-                _, stop = ned[dim_idx]
-            else:
-                stop = coord.stop
-            sr.set_dim_ranges_string_or_bytes(dim.name, [(start, stop)])
-            return True
-
-        # Note: slice(None, None) matches the is_slice_of part, unless we also check the dim-type
-        # part.
-        if is_slice_of(coord, np.datetime64) and pa.types.is_timestamp(dim.type):
-            _util.validate_slice(coord)
-            # These timestamp types are stored in Arrow as well as TileDB as 64-bit integers (with
-            # distinguishing metadata of course). For purposes of the query logic they're just
-            # int64.
-            istart = coord.start or domain[0]
-            istart = int(istart.astype("int64"))
-            istop = coord.stop or domain[1]
-            istop = int(istop.astype("int64"))
-            sr.set_dim_ranges_int64(dim.name, [(istart, istop)])
-            return True
-
-        if super()._set_coord(sr, dim_idx, dim, coord):
-            return True
-
-        return False
-
-    def _set_coord_by_py_seq_or_np_array(
-        self,
-        sr: clib.SOMAArray,
-        dim_idx: int,
-        dim: pa.Field,
-        coord: object,
-    ) -> bool:
-        if isinstance(coord, np.ndarray):
-            if coord.ndim != 1:
-                raise ValueError(
-                    f"only 1D numpy arrays may be used to index; got {coord.ndim}"
-                )
-
-        try:
-            set_dim_points = getattr(sr, f"set_dim_points_{dim.type}")
-        except AttributeError:
-            # We have to handle this type specially below
-            pass
-        else:
-            set_dim_points(dim.name, coord)
-            return True
-
-        if _util.pa_types_is_string_or_bytes(dim.type):
-            sr.set_dim_points_string_or_bytes(dim.name, coord)
-            return True
-        elif pa.types.is_timestamp(dim.type):
-            if not isinstance(coord, (tuple, list, np.ndarray)):
-                raise ValueError(
-                    f"unhandled coord type {type(coord)} for index column named {dim.name}"
-                )
-            icoord = [
-                int(e.astype("int64")) if isinstance(e, np.datetime64) else e
-                for e in coord
-            ]
-            sr.set_dim_points_int64(dim.name, icoord)
-            return True
-
-        # TODO: bool
-
-        raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
-
-    def _set_coord_by_numeric_slice(
-        self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: Slice[Any]
-    ) -> bool:
-        try:
-            lo_hi = _util.slice_to_numeric_range(coord, self.domain[dim_idx])
-        except _util.NonNumericDimensionError:
-            return False  # We only handle numeric dimensions here.
-
-        if not lo_hi:
-            return True
-
-        try:
-            set_dim_range = getattr(sr, f"set_dim_ranges_{dim.type}")
-            set_dim_range(dim.name, [lo_hi])
-            return True
-        except AttributeError:
-            return False
 
 
 def _canonicalize_schema(

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -259,7 +259,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             timestamp=handle.timestamp and (0, handle.timestamp),
         )
 
-        self._set_coords(sr, coords)
+        _util._set_coords(sr, coords)
 
         arrow_tables = []
         while True:
@@ -344,7 +344,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
         clib_dense_array.reset(result_order=order)
-        self._set_coords(clib_dense_array, new_coords)
+        _util._set_coords(clib_dense_array, new_coords)
         clib_dense_array.write(input)
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -342,7 +342,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         if value_filter is not None:
             sr.set_condition(QueryCondition(value_filter), handle.schema)
 
-        self._set_coords(sr, coords)
+        _util._set_coords(sr, coords)
 
         # # TODO: batch_size
         return TableReadIter(sr)

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -236,7 +236,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
             self.sr.reset(**kwargs)
             step_coords = list(self.coords)
             step_coords[self.major_axis] = coord_chunk
-            self.array._set_coords(self.sr, step_coords)
+            _util._set_coords(self.sr, step_coords)
 
             joinids = list(self.joinids)
             joinids[self.major_axis] = pa.array(coord_chunk)

--- a/apis/python/src/tiledbsoma/_spatial_dataframe.py
+++ b/apis/python/src/tiledbsoma/_spatial_dataframe.py
@@ -6,19 +6,15 @@
 """
 Implementation of a base class shared between GeometryDataFrame and PointCloudDataFrame
 """
-from typing import Any, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
-import numpy as np
 import pyarrow as pa
 import somacore
 from somacore import CoordinateSpace, CoordinateTransform, options
 from typing_extensions import Self
 
-from . import _util
-from . import pytiledbsoma as clib
 from ._read_iters import TableReadIter
 from ._soma_array import SOMAArray
-from ._types import Slice, is_slice_of
 
 _UNBATCHED = options.BatchSize()
 
@@ -173,137 +169,3 @@ class SpatialDataFrame(SOMAArray):
             Experimental.
         """
         raise NotImplementedError("must be implemented by child class")
-
-    def _set_coord(
-        self,
-        sr: clib.SOMAArray,
-        dim_idx: int,
-        dim: pa.Field,
-        coord: object,
-    ) -> bool:
-        if coord is None:
-            return True  # No constraint; select all in this dimension
-
-        if isinstance(coord, (str, bytes)):
-            sr.set_dim_points_string_or_bytes(dim.name, [coord])
-            return True
-
-        if isinstance(coord, (pa.Array, pa.ChunkedArray)):
-            # sr.set_dim_points_arrow does type disambiguation based on array schema -- so we do
-            # not.
-            sr.set_dim_points_arrow(dim.name, coord)
-            return True
-
-        if isinstance(coord, (Sequence, np.ndarray)):
-            if self._set_coord_by_py_seq_or_np_array(sr, dim_idx, dim, coord):
-                return True
-
-        if isinstance(coord, slice):
-            _util.validate_slice(coord)
-            if coord.start is None and coord.stop is None:
-                return True
-
-        if isinstance(coord, slice):
-            _util.validate_slice(coord)
-            if self._set_coord_by_numeric_slice(sr, dim_idx, dim, coord):
-                return True
-
-        domain = self.domain[dim_idx]
-
-        # Note: slice(None, None) matches the is_slice_of part, unless we also check the dim-type
-        # part.
-        if (
-            is_slice_of(coord, str) or is_slice_of(coord, bytes)
-        ) and _util.pa_types_is_string_or_bytes(dim.type):
-            _util.validate_slice(coord)
-            # Figure out which one.
-            dim_type: Union[Type[str], Type[bytes]] = type(domain[0])
-            # A ``None`` or empty start is always equivalent to empty str/bytes.
-            start = coord.start or dim_type()
-            if coord.stop is None:
-                # There's no way to specify "to infinity" for strings.
-                # We have to get the nonempty domain and use that as the end.
-                ned = self._handle.non_empty_domain()
-                _, stop = ned[dim_idx]
-            else:
-                stop = coord.stop
-            sr.set_dim_ranges_string_or_bytes(dim.name, [(start, stop)])
-            return True
-
-        # Note: slice(None, None) matches the is_slice_of part, unless we also check the dim-type
-        # part.
-        if is_slice_of(coord, np.datetime64) and pa.types.is_timestamp(dim.type):
-            _util.validate_slice(coord)
-            # These timestamp types are stored in Arrow as well as TileDB as 64-bit integers (with
-            # distinguishing metadata of course). For purposes of the query logic they're just
-            # int64.
-            istart = coord.start or domain[0]
-            istart = int(istart.astype("int64"))
-            istop = coord.stop or domain[1]
-            istop = int(istop.astype("int64"))
-            sr.set_dim_ranges_int64(dim.name, [(istart, istop)])
-            return True
-
-        if super()._set_coord(sr, dim_idx, dim, coord):
-            return True
-
-        return False
-
-    def _set_coord_by_py_seq_or_np_array(
-        self,
-        sr: clib.SOMAArray,
-        dim_idx: int,
-        dim: pa.Field,
-        coord: object,
-    ) -> bool:
-        if isinstance(coord, np.ndarray):
-            if coord.ndim != 1:
-                raise ValueError(
-                    f"only 1D numpy arrays may be used to index; got {coord.ndim}"
-                )
-
-        try:
-            set_dim_points = getattr(sr, f"set_dim_points_{dim.type}")
-        except AttributeError:
-            # We have to handle this type specially below
-            pass
-        else:
-            set_dim_points(dim.name, coord)
-            return True
-
-        if _util.pa_types_is_string_or_bytes(dim.type):
-            sr.set_dim_points_string_or_bytes(dim.name, coord)
-            return True
-        elif pa.types.is_timestamp(dim.type):
-            if not isinstance(coord, (tuple, list, np.ndarray)):
-                raise ValueError(
-                    f"unhandled coord type {type(coord)} for index column named {dim.name}"
-                )
-            icoord = [
-                int(e.astype("int64")) if isinstance(e, np.datetime64) else e
-                for e in coord
-            ]
-            sr.set_dim_points_int64(dim.name, icoord)
-            return True
-
-        # TODO: bool
-
-        raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
-
-    def _set_coord_by_numeric_slice(
-        self, sr: clib.SOMAArray, dim_idx: int, dim: pa.Field, coord: Slice[Any]
-    ) -> bool:
-        try:
-            lo_hi = _util.slice_to_numeric_range(coord, self.domain[dim_idx])
-        except _util.NonNumericDimensionError:
-            return False  # We only handle numeric dimensions here.
-
-        if not lo_hi:
-            return True
-
-        try:
-            set_dim_range = getattr(sr, f"set_dim_ranges_{dim.type}")
-            set_dim_range(dim.name, [lo_hi])
-            return True
-        except AttributeError:
-            return False

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -391,36 +391,22 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     def ndim(self) -> int:
         return len(self._handle.dimension_names)
 
-    def _cast_domainish(
-        self, domainish: List[Any]
-    ) -> Tuple[Tuple[object, object], ...]:
-        result = []
-        for i, slot in enumerate(domainish):
-
-            arrow_type = slot[0].type
-            if pa.types.is_timestamp(arrow_type):
-                pandas_type = np.dtype(arrow_type.to_pandas_dtype())
-                result.append(
-                    tuple(
-                        pandas_type.type(e.cast(pa.int64()).as_py(), arrow_type.unit)
-                        for e in slot
-                    )
-                )
-            else:
-                result.append(tuple(e.as_py() for e in slot))
-
-        return tuple(result)
-
     @property
     def domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domainish(self._handle.domain())
+        from ._util import _cast_domainish
+
+        return _cast_domainish(self._handle.domain())
 
     @property
     def maxdomain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domainish(self._handle.maxdomain())
+        from ._util import _cast_domainish
+
+        return _cast_domainish(self._handle.maxdomain())
 
     def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
-        return self._cast_domainish(self._handle.non_empty_domain())
+        from ._util import _cast_domainish
+
+        return _cast_domainish(self._handle.non_empty_domain())
 
     @property
     def attr_names(self) -> Tuple[str, ...]:

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -9,14 +9,27 @@ import pathlib
 import time
 import urllib.parse
 from itertools import zip_longest
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
+import numpy as np
 import pyarrow as pa
 import somacore
 from somacore import options
 
 from . import pytiledbsoma as clib
-from ._types import OpenTimestamp, Slice, is_slice_of
+from ._types import OpenTimestamp, Slice, is_nonstringy_sequence, is_slice_of
 from .options._tiledb_create_write_options import (
     TileDBCreateOptions,
     _ColumnConfig,
@@ -428,3 +441,169 @@ def _build_filter_list(
                     )
         filter_list.append(filter)
     return json.dumps(filter_list) if return_json else filter_list
+
+
+def _cast_domainish(domainish: List[Any]) -> Tuple[Tuple[object, object], ...]:
+    result = []
+    for slot in domainish:
+
+        arrow_type = slot[0].type
+        if pa.types.is_timestamp(arrow_type):
+            pandas_type = np.dtype(arrow_type.to_pandas_dtype())
+            result.append(
+                tuple(
+                    pandas_type.type(e.cast(pa.int64()).as_py(), arrow_type.unit)
+                    for e in slot
+                )
+            )
+        else:
+            result.append(tuple(e.as_py() for e in slot))
+
+    return tuple(result)
+
+
+def _set_coords(sr: clib.SOMAArray, coords: options.SparseNDCoords) -> None:
+    if not is_nonstringy_sequence(coords):
+        raise TypeError(
+            f"coords type {type(coords)} must be a regular sequence,"
+            " not str or bytes"
+        )
+
+    if len(coords) > len(sr.dimension_names):
+        raise ValueError(
+            f"coords ({len(coords)} elements) must be shorter than ndim"
+            f" ({len(sr.dimension_names)})"
+        )
+
+    for i, coord in enumerate(coords):
+        _set_coord(i, sr, coord)
+
+
+def _set_coord(dim_idx: int, sr: clib.SOMAArray, coord: object) -> None:
+    if coord is None:
+        return
+
+    dim = sr.schema.field(dim_idx)
+    dom = _cast_domainish(sr.domain())[dim_idx]
+
+    if isinstance(coord, (str, bytes)):
+        sr.set_dim_points_string_or_bytes(dim.name, [coord])
+        return
+
+    if isinstance(coord, (pa.Array, pa.ChunkedArray)):
+        sr.set_dim_points_arrow(dim.name, coord)
+        return
+
+    if isinstance(coord, (Sequence, np.ndarray)):
+        _set_coord_by_py_seq_or_np_array(sr, dim, coord)
+        return
+
+    if isinstance(coord, int):
+        sr.set_dim_points_int64(dim.name, [coord])
+        return
+
+    # Note: slice(None, None) matches the is_slice_of part, unless we also check
+    # the dim-type part
+    if (
+        is_slice_of(coord, str) or is_slice_of(coord, bytes)
+    ) and pa_types_is_string_or_bytes(dim.type):
+        validate_slice(coord)
+        dim_type = type(dom[0])
+        # A ``None`` or empty start is always equivalent to empty str/bytes.
+        start = coord.start or dim_type()
+        if coord.stop is None:
+            # There's no way to specify "to infinity" for strings.
+            # We have to get the nonempty domain and use that as the end.\
+            ned = _cast_domainish(sr.non_empty_domain())
+            _, stop = ned[dim_idx]
+        else:
+            stop = coord.stop
+        sr.set_dim_ranges_string_or_bytes(dim.name, [(start, stop)])
+        return
+
+    # Note: slice(None, None) matches the is_slice_of part, unless we also check
+    # the dim-type part.
+    if is_slice_of(coord, np.datetime64) and pa.types.is_timestamp(dim.type):
+        validate_slice(coord)
+
+        # These timestamp types are stored in Arrow as well as TileDB as 64-bit
+        # integers (with distinguishing metadata of course). For purposes of the
+        # query logic they're just int64.
+        ts_dom = pa.array(dom, type=dim.type).cast(pa.int64())
+
+        if coord.start is not None:
+            istart = coord.start.astype("int64")
+        else:
+            istart = ts_dom[0].as_py()
+
+        if coord.stop is not None:
+            istop = coord.stop.astype("int64")
+        else:
+            istop = ts_dom[1].as_py()
+
+        sr.set_dim_ranges_int64(dim.name, [(istart, istop)])
+        return
+
+    if isinstance(coord, slice):
+        validate_slice(coord)
+        if coord.start is None and coord.stop is None:
+            return
+        _set_coord_by_numeric_slice(sr, dim, dom, coord)
+        return
+
+    raise TypeError(f"unhandled type {dim.type} for index column named {dim.name}")
+
+
+def _set_coord_by_py_seq_or_np_array(
+    sr: clib.SOMAArray, dim: pa.Field, coord: object
+) -> None:
+    if isinstance(coord, np.ndarray):
+        if coord.ndim != 1:
+            raise ValueError(
+                f"only 1D numpy arrays may be used to index; got {coord.ndim}"
+            )
+
+    try:
+        set_dim_points = getattr(sr, f"set_dim_points_{dim.type}")
+    except AttributeError:
+        # We have to handle this type specially below
+        pass
+    else:
+        set_dim_points(dim.name, coord)
+        return
+
+    if pa_types_is_string_or_bytes(dim.type):
+        sr.set_dim_points_string_or_bytes(dim.name, coord)
+        return
+
+    if pa.types.is_timestamp(dim.type):
+        if not isinstance(coord, (tuple, list, np.ndarray)):
+            raise ValueError(
+                f"unhandled coord type {type(coord)} for index column named {dim.name}"
+            )
+        icoord = [
+            int(e.astype("int64")) if isinstance(e, np.datetime64) else e for e in coord
+        ]
+        sr.set_dim_points_int64(dim.name, icoord)
+        return
+
+    raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
+
+
+def _set_coord_by_numeric_slice(
+    sr: clib.SOMAArray, dim: pa.Field, dom: Tuple[object, object], coord: Slice[Any]
+) -> None:
+    try:
+        lo_hi = slice_to_numeric_range(coord, dom)
+    except NonNumericDimensionError:
+        return
+
+    if not lo_hi:
+        return
+
+    try:
+        set_dim_range = getattr(sr, f"set_dim_ranges_{dim.type}")
+        set_dim_range(dim.name, [lo_hi])
+        return
+    except AttributeError:
+        return


### PR DESCRIPTION
**Issue and/or context:**

As part of work for https://github.com/single-cell-data/TileDB-SOMA/issues/3053.

**Changes:**

This is clean-up work.

This takes the separate implementations of `_set_coords` from `_dataframe`, `_sparse_nd_array`,  `_spatial_dataframe`, and `_soma_array` into a single `_util._set_coords`. `_cast_domainish` was also moved out of `SOMAArrayWrapper` and into `_util` to support casting of domains and NEDs in `_set_coord`.

**Note for reviewers:**

I am unsure if `_util.py` is the appropriate place for this.