### PR TITLE
[python] Remove double open For `SOMAArray` reads

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -289,7 +289,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         """
         _util.check_type("values", values, (pa.Tensor,))
 
-        sr = self._handle._handle
+        clib_handle = self._handle._handle
 
         # Compute the coordinates for the dense array.
         new_coords: List[Union[int, Slice[int], None]] = []
@@ -311,15 +311,15 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
 
-        mq = clib.ManagedQuery(sr, sr.context())
+        mq = clib.ManagedQuery(clib_handle, clib_handle.context())
         mq.set_layout(order)
-        _util._set_coords(mq, sr, new_coords)
+        _util._set_coords(mq, clib_handle, new_coords)
         mq.set_soma_data(input)
         mq.submit_write()
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)
         if tiledb_write_options.consolidate_and_vacuum:
-            sr.consolidate_and_vacuum()
+            clib_handle.consolidate_and_vacuum()
         return self
 
     @classmethod

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -20,6 +20,7 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
+from ._read_iters import TableReadIter
 from ._tdb_handles import DenseNDArrayWrapper
 from ._types import OpenTimestamp, Slice
 from ._util import dense_indices_to_shape
@@ -232,42 +233,20 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         data_shape = tuple(handle.shape if use_shape else ned)
         target_shape = dense_indices_to_shape(coords, data_shape, result_order)
 
-        context = handle.context()
-        if platform_config is not None:
-            config = context.tiledb_config.copy()
-            config.update(platform_config)
-            context = clib.SOMAContext(config)
-
-        sr = clib.SOMADenseNDArray.open(
-            uri=handle.uri,
-            mode=clib.OpenMode.read,
-            context=context,
+        arrow_table = TableReadIter(
+            array=self,
+            coords=coords,
             column_names=[],
             result_order=_util.to_clib_result_order(result_order),
-            timestamp=handle.timestamp and (0, handle.timestamp),
-        )
+            value_filter=None,
+            platform_config=platform_config,
+        ).concat()
 
-        _util._set_coords(sr, coords)
-
-        arrow_tables = []
-        while True:
-            arrow_table_piece = sr.read_next()
-            if not arrow_table_piece:
-                break
-            arrow_tables.append(arrow_table_piece)
-
-        # For dense arrays there is no zero-output case: attempting to make a test case
-        # to do that, say by indexing a 10x20 array by positions 888 and 999, results
-        # in read-time errors of the form
-        #
-        # [TileDB::Subarray] Error: Cannot add range to dimension 'soma_dim_0'; Range [888, 888] is
-        # out of domain bounds [0, 9]
-        if not arrow_tables:
+        if arrow_table is None:
             raise SOMAError(
                 "internal error: at least one table-piece should have been returned"
             )
 
-        arrow_table = pa.concat_tables(arrow_tables)
         npval = arrow_table.column("soma_data").to_numpy()
         # TODO: as currently coded we're looking at the non-empty domain upper
         # bound but not its lower bound. That works fine if data are written at
@@ -310,7 +289,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         """
         _util.check_type("values", values, (pa.Tensor,))
 
-        clib_dense_array = self._handle._handle
+        sr = self._handle._handle
 
         # Compute the coordinates for the dense array.
         new_coords: List[Union[int, Slice[int], None]] = []
@@ -331,13 +310,16 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             if not input.flags.contiguous:
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
-        clib_dense_array.reset(result_order=order)
-        _util._set_coords(clib_dense_array, new_coords)
-        clib_dense_array.write(input)
+
+        mq = clib.ManagedQuery(sr, sr.context())
+        mq.set_layout(order)
+        _util._set_coords(mq, sr, new_coords)
+        mq.set_soma_data(input)
+        mq.submit_write()
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)
         if tiledb_write_options.consolidate_and_vacuum:
-            clib_dense_array.consolidate_and_vacuum()
+            sr.consolidate_and_vacuum()
         return self
 
     @classmethod

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -368,10 +368,10 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
         if self.compress and self.major_axis in self.reindex_disable_on_axis:
             raise SOMAError(
-                "Unable to disable reindexing of coordinates on CSC/Cclib_handle major axis"
+                "Unable to disable reindexing of coordinates on CSC/CSR major axis"
             )
 
-        # Sanity check: if CSC/Cclib_handle, we _must_ be reindexing
+        # Sanity check: if CSC/CSR, we _must_ be reindexing
         assert not self.compress or self.axes_to_reindex
 
     @property

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -29,6 +29,7 @@ import pyarrow as pa
 import somacore
 from scipy import sparse
 from somacore import options
+from typing_extensions import Self
 
 # This package's pybind11 code
 import tiledbsoma.pytiledbsoma as clib
@@ -583,52 +584,53 @@ class ArrowTableRead:
 
         self.mq.setup_read()
 
-    def __iter__(self):
+    def __iter__(self) -> Self:
         return self
 
     def __next__(self) -> pa.Table:
         return self.mq.next()
 
-def _arrow_table_reader(
-    array: SOMAArray,
-    coords: Union[
-        options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
-    ],
-    column_names: Optional[Sequence[str]],
-    result_order: clib.ResultOrder,
-    value_filter: Optional[str],
-    platform_config: Optional[options.PlatformConfig],
-) -> Iterator[pa.Table]:
-    """Private. Simple Table iterator on any Array"""
 
-    sr = array._handle._handle
+# def _arrow_table_reader(
+#     array: SOMAArray,
+#     coords: Union[
+#         options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
+#     ],
+#     column_names: Optional[Sequence[str]],
+#     result_order: clib.ResultOrder,
+#     value_filter: Optional[str],
+#     platform_config: Optional[options.PlatformConfig],
+# ) -> Iterator[pa.Table]:
+#     """Private. Simple Table iterator on any Array"""
 
-    if platform_config is not None:
-        cfg = sr.context().config()
-        cfg.update(platform_config)
-        ctx = clib.SOMAContext(cfg)
-    else:
-        ctx = sr.context()
+#     sr = array._handle._handle
 
-    mq = clib.ManagedQuery(sr, ctx)
+#     if platform_config is not None:
+#         cfg = sr.context().config()
+#         cfg.update(platform_config)
+#         ctx = clib.SOMAContext(cfg)
+#     else:
+#         ctx = sr.context()
 
-    mq.set_layout(result_order)
+#     mq = clib.ManagedQuery(sr, ctx)
 
-    if column_names is not None:
-        mq.select_columns(list(column_names))
+#     mq.set_layout(result_order)
 
-    if value_filter is not None:
-        mq.set_condition(QueryCondition(value_filter), sr.schema)
+#     if column_names is not None:
+#         mq.select_columns(list(column_names))
 
-    _util._set_coords(mq, sr, coords)
+#     if value_filter is not None:
+#         mq.set_condition(QueryCondition(value_filter), sr.schema)
 
-    mq.setup_read()
-    if mq.is_empty_query():
-        yield mq.results()
-    else:
-        while not mq.is_complete(True):
-            mq.submit_read()
-            yield mq.results()
+#     _util._set_coords(mq, sr, coords)
+
+#     mq.setup_read()
+#     if mq.is_empty_query():
+#         yield mq.results()
+#     else:
+#         while not mq.is_complete(True):
+#             mq.submit_read()
+#             yield mq.results()
 
 
 def _coords_strider(

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -53,7 +53,7 @@ BlockwiseTableReadIterResult = Tuple[pa.Table, Tuple[pa.Array, ...]]
 BlockwiseSingleAxisTableIter = Iterator[BlockwiseTableReadIterResult]
 
 BlockwiseScipyReadIterResult = Tuple[
-    Union[sparse.csr_handle_matrix, sparse.csc_matrix, sparse.coo_matrix],
+    Union[sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix],
     Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
 ]
 

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -591,48 +591,6 @@ class ArrowTableRead:
         return self.mq.next()
 
 
-# def _arrow_table_reader(
-#     array: SOMAArray,
-#     coords: Union[
-#         options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
-#     ],
-#     column_names: Optional[Sequence[str]],
-#     result_order: clib.ResultOrder,
-#     value_filter: Optional[str],
-#     platform_config: Optional[options.PlatformConfig],
-# ) -> Iterator[pa.Table]:
-#     """Private. Simple Table iterator on any Array"""
-
-#     sr = array._handle._handle
-
-#     if platform_config is not None:
-#         cfg = sr.context().config()
-#         cfg.update(platform_config)
-#         ctx = clib.SOMAContext(cfg)
-#     else:
-#         ctx = sr.context()
-
-#     mq = clib.ManagedQuery(sr, ctx)
-
-#     mq.set_layout(result_order)
-
-#     if column_names is not None:
-#         mq.select_columns(list(column_names))
-
-#     if value_filter is not None:
-#         mq.set_condition(QueryCondition(value_filter), sr.schema)
-
-#     _util._set_coords(mq, sr, coords)
-
-#     mq.setup_read()
-#     if mq.is_empty_query():
-#         yield mq.results()
-#     else:
-#         while not mq.is_complete(True):
-#             mq.submit_read()
-#             yield mq.results()
-
-
 def _coords_strider(
     coords: options.SparseNDCoord, length: int, stride: int
 ) -> Iterator[npt.NDArray[np.int64]]:

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -70,12 +70,37 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
     def __init__(
         self,
         array: SOMAArray,
-        coords: options.SparseDFCoords,
+        coords: Union[options.SparseDFCoords, options.DenseNDCoords],
         column_names: Optional[Sequence[str]],
         result_order: clib.ResultOrder,
         value_filter: Optional[str],
         platform_config: Optional[options.PlatformConfig],
     ):
+        """Initalizes a new TableReadIter for SOMAArrays.
+
+        Args:
+            array (SOMAArray):
+                The NDArray, DataFrame, or SpatialDataFrame being read.
+
+            coords (Union[options.SparseDFCoords, options.DenseNDCoords]):
+                for each index dimension, which rows to read.
+                ``()`` means no constraint -- all IDs.
+
+            column_names (Optional[Sequence[str]]):
+                The named columns to read and return.
+                ``None`` means no constraint -- all column names.
+
+            result_order (clib.ResultOrder):
+                Order of read results.
+
+            value_filter (Optional[str]):
+                An optional [value filter] to apply to the results.
+                This can be one of automatic, rowmajor, or colmajor.
+
+            platform_config (Optional[options.PlatformConfig]):
+                Pass in parameters for tuning reads.
+
+        """
         self._reader = _arrow_table_reader(
             array, coords, column_names, result_order, value_filter, platform_config
         )
@@ -519,7 +544,7 @@ class SparseCOOTensorReadIter(SparseTensorReadIterBase[pa.SparseCOOTensor]):
 
 def _arrow_table_reader(
     array: SOMAArray,
-    coords: options.SparseDFCoords,
+    coords: Union[options.SparseDFCoords, options.DenseNDCoords],
     column_names: Optional[Sequence[str]],
     result_order: clib.ResultOrder,
     value_filter: Optional[str],

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -53,7 +53,7 @@ BlockwiseTableReadIterResult = Tuple[pa.Table, Tuple[pa.Array, ...]]
 BlockwiseSingleAxisTableIter = Iterator[BlockwiseTableReadIterResult]
 
 BlockwiseScipyReadIterResult = Tuple[
-    Union[sparse.cclib_handle_matrix, sparse.csc_matrix, sparse.coo_matrix],
+    Union[sparse.csr_handle_matrix, sparse.csc_matrix, sparse.coo_matrix],
     Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
 ]
 
@@ -447,9 +447,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
     def _cs_reader(
         self, _pool: Optional[ThreadPoolExecutor] = None
-    ) -> Iterator[
-        Tuple[Union[sparse.cclib_handle_matrix, sparse.csc_matrix], IndicesType],
-    ]:
+    ) -> Iterator[Tuple[Union[sparse.csr_matrix, sparse.csc_matrix], IndicesType],]:
         """Private. Compressed sparse variants"""
         assert self.compress
         assert self.major_axis not in self.reindex_disable_on_axis

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -502,18 +502,12 @@ class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
 
         _util._set_coords(self.mq, sr, coords)
 
-        self.mq.setup_read()
-
     @abc.abstractmethod
     def _from_table(self, arrow_table: pa.Table) -> _RT:
         raise NotImplementedError()
 
     def __next__(self) -> _RT:
-        if self.mq.is_empty_query():
-            raise StopIteration
-
-        self.mq.submit_read()
-        return self._from_table(self.mq.results())
+        return self._from_table(self.mq.next())
 
     def concat(self) -> _RT:
         """Returns all the requested data in a single operation.
@@ -580,8 +574,6 @@ class ArrowTableRead(Iterator[pa.Table]):
             self.mq.set_condition(QueryCondition(value_filter), sr.schema)
 
         _util._set_coords(self.mq, sr, coords)
-
-        self.mq.setup_read()
 
     def __next__(self) -> pa.Table:
         return self.mq.next()

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -29,7 +29,6 @@ import pyarrow as pa
 import somacore
 from scipy import sparse
 from somacore import options
-from typing_extensions import Self
 
 # This package's pybind11 code
 import tiledbsoma.pytiledbsoma as clib
@@ -549,7 +548,7 @@ class SparseCOOTensorReadIter(SparseTensorReadIterBase[pa.SparseCOOTensor]):
         return pa.SparseCOOTensor.from_numpy(coo_data, coo_coords, shape=self.shape)
 
 
-class ArrowTableRead:
+class ArrowTableRead(Iterator[pa.Table]):
     def __init__(
         self,
         array: SOMAArray,
@@ -583,9 +582,6 @@ class ArrowTableRead:
         _util._set_coords(self.mq, sr, coords)
 
         self.mq.setup_read()
-
-    def __iter__(self) -> Self:
-        return self
 
     def __next__(self) -> pa.Table:
         return self.mq.next()

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -70,7 +70,9 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
     def __init__(
         self,
         array: SOMAArray,
-        coords: Union[options.SparseDFCoords, options.DenseNDCoords],
+        coords: Union[
+            options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
+        ],
         column_names: Optional[Sequence[str]],
         result_order: clib.ResultOrder,
         value_filter: Optional[str],
@@ -82,7 +84,9 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
             array (SOMAArray):
                 The NDArray, DataFrame, or SpatialDataFrame being read.
 
-            coords (Union[options.SparseDFCoords, options.DenseNDCoords]):
+            coords (Union[
+                options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
+            ]):
                 for each index dimension, which rows to read.
                 ``()`` means no constraint -- all IDs.
 
@@ -544,7 +548,9 @@ class SparseCOOTensorReadIter(SparseTensorReadIterBase[pa.SparseCOOTensor]):
 
 def _arrow_table_reader(
     array: SOMAArray,
-    coords: Union[options.SparseDFCoords, options.DenseNDCoords],
+    coords: Union[
+        options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
+    ],
     column_names: Optional[Sequence[str]],
     result_order: clib.ResultOrder,
     value_filter: Optional[str],

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -490,7 +490,9 @@ class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         sr = array._handle._handle
 
         if platform_config is not None:
-            ctx = clib.SOMAContext(platform_config)
+            cfg = sr.context().config()
+            cfg.update(platform_config)
+            ctx = clib.SOMAContext(cfg)
         else:
             ctx = sr.context()
 
@@ -561,7 +563,9 @@ def _arrow_table_reader(
     sr = array._handle._handle
 
     if platform_config is not None:
-        ctx = clib.SOMAContext(platform_config)
+        cfg = sr.context().config()
+        cfg.update(platform_config)
+        ctx = clib.SOMAContext(cfg)
     else:
         ctx = sr.context()
 

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -588,11 +588,6 @@ class ArrowTableRead:
 
     def __next__(self) -> pa.Table:
         return self.mq.next()
-        # if self.mq.is_empty_query() or self.mq.is_complete(True):
-        #     raise StopIteration
-
-        # self.mq.submit_read()
-        # return self.mq.results()
 
 def _arrow_table_reader(
     array: SOMAArray,

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -487,7 +487,7 @@ class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         self.result_order = result_order
         self.platform_config = platform_config
 
-        sr = array._handle._handle
+        clib_handle = array._handle._handle
 
         if platform_config is not None:
             cfg = sr.context().config()

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -40,7 +40,7 @@ from ._read_iters import (
     TableReadIter,
 )
 from ._tdb_handles import SparseNDArrayWrapper
-from ._types import NTuple, OpenTimestamp, StatusAndReason
+from ._types import NTuple, OpenTimestamp
 from .options._soma_tiledb_context import (
     SOMATileDBContext,
     _validate_soma_tiledb_context,
@@ -275,36 +275,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             result_order=_util.to_clib_result_order(result_order),
             platform_config=platform_config,
         )
-
-    def resize(
-        self, newshape: Sequence[Union[int, None]], check_only: bool = False
-    ) -> StatusAndReason:
-        """Increases the shape of the array as specfied. Raises an error if the new
-        shape is less than the current shape in any dimension. Raises an error if
-        the new shape exceeds maxshape in any dimension. Raises an error if the
-        array doesn't already have a shape: in that case please call
-        tiledbsoma_upgrade_shape. If ``check_only`` is ``True``, returns
-        whether the operation would succeed if attempted, and a reason why it
-        would not.
-        """
-        if check_only:
-            return self._handle.tiledbsoma_can_resize(newshape)
-        else:
-            self._handle.resize(newshape)
-            return (True, "")
-
-    def tiledbsoma_upgrade_shape(
-        self, newshape: Sequence[Union[int, None]], check_only: bool = False
-    ) -> StatusAndReason:
-        """Allows the array to have a resizeable shape as described in the TileDB-SOMA
-        1.15 release notes.  Raises an error if the new shape exceeds maxshape in
-        any dimension. Raises an error if the array already has a shape.
-        """
-        if check_only:
-            return self._handle.tiledbsoma_can_upgrade_shape(newshape)
-        else:
-            self._handle.tiledbsoma_upgrade_shape(newshape)
-            return (True, "")
 
     def write(
         self,

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -40,7 +40,7 @@ from ._read_iters import (
     TableReadIter,
 )
 from ._tdb_handles import SparseNDArrayWrapper
-from ._types import NTuple, OpenTimestamp
+from ._types import NTuple, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import (
     SOMATileDBContext,
     _validate_soma_tiledb_context,

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -464,7 +464,9 @@ def _cast_domainish(domainish: List[Any]) -> Tuple[Tuple[object, object], ...]:
     return tuple(result)
 
 
-def _set_coords(sarr: clib.SOMAArray, coords: options.SparseNDCoords) -> None:
+def _set_coords(
+    mq: clib.ManagedQuery, sarr: clib.SOMAArray, coords: options.SparseNDCoords
+) -> None:
     if not is_nonstringy_sequence(coords):
         raise TypeError(
             f"coords type {type(coords)} must be a regular sequence,"
@@ -478,10 +480,12 @@ def _set_coords(sarr: clib.SOMAArray, coords: options.SparseNDCoords) -> None:
         )
 
     for i, coord in enumerate(coords):
-        _set_coord(i, sarr, coord)
+        _set_coord(i, mq, sarr, coord)
 
 
-def _set_coord(dim_idx: int, sarr: clib.SOMAArray, coord: object) -> None:
+def _set_coord(
+    dim_idx: int, mq: clib.ManagedQuery, sarr: clib.SOMAArray, coord: object
+) -> None:
     if coord is None:
         return
 
@@ -489,19 +493,19 @@ def _set_coord(dim_idx: int, sarr: clib.SOMAArray, coord: object) -> None:
     dom = _cast_domainish(sarr.domain())[dim_idx]
 
     if isinstance(coord, (str, bytes)):
-        sarr.set_dim_points_string_or_bytes(dim.name, [coord])
+        mq.set_dim_points_string_or_bytes(dim.name, [coord])
         return
 
     if isinstance(coord, (pa.Array, pa.ChunkedArray)):
-        sarr.set_dim_points_arrow(dim.name, coord)
+        mq.set_dim_points_arrow(dim.name, coord)
         return
 
     if isinstance(coord, (Sequence, np.ndarray)):
-        _set_coord_by_py_seq_or_np_array(sarr, dim, coord)
+        _set_coord_by_py_seq_or_np_array(mq, dim, coord)
         return
 
     if isinstance(coord, int):
-        sarr.set_dim_points_int64(dim.name, [coord])
+        mq.set_dim_points_int64(dim.name, [coord])
         return
 
     # Note: slice(None, None) matches the is_slice_of part, unless we also check
@@ -520,7 +524,7 @@ def _set_coord(dim_idx: int, sarr: clib.SOMAArray, coord: object) -> None:
             _, stop = ned[dim_idx]
         else:
             stop = coord.stop
-        sarr.set_dim_ranges_string_or_bytes(dim.name, [(start, stop)])
+        mq.set_dim_ranges_string_or_bytes(dim.name, [(start, stop)])
         return
 
     # Note: slice(None, None) matches the is_slice_of part, unless we also check
@@ -543,21 +547,21 @@ def _set_coord(dim_idx: int, sarr: clib.SOMAArray, coord: object) -> None:
         else:
             istop = ts_dom[1].as_py()
 
-        sarr.set_dim_ranges_int64(dim.name, [(istart, istop)])
+        mq.set_dim_ranges_int64(dim.name, [(istart, istop)])
         return
 
     if isinstance(coord, slice):
         validate_slice(coord)
         if coord.start is None and coord.stop is None:
             return
-        _set_coord_by_numeric_slice(sarr, dim, dom, coord)
+        _set_coord_by_numeric_slice(mq, dim, dom, coord)
         return
 
     raise TypeError(f"unhandled type {dim.type} for index column named {dim.name}")
 
 
 def _set_coord_by_py_seq_or_np_array(
-    sarr: clib.SOMAArray, dim: pa.Field, coord: object
+    mq: clib.ManagedQuery, dim: pa.Field, coord: object
 ) -> None:
     if isinstance(coord, np.ndarray):
         if coord.ndim != 1:
@@ -566,7 +570,7 @@ def _set_coord_by_py_seq_or_np_array(
             )
 
     try:
-        set_dim_points = getattr(sarr, f"set_dim_points_{dim.type}")
+        set_dim_points = getattr(mq, f"set_dim_points_{dim.type}")
     except AttributeError:
         # We have to handle this type specially below
         pass
@@ -575,7 +579,7 @@ def _set_coord_by_py_seq_or_np_array(
         return
 
     if pa_types_is_string_or_bytes(dim.type):
-        sarr.set_dim_points_string_or_bytes(dim.name, coord)
+        mq.set_dim_points_string_or_bytes(dim.name, coord)
         return
 
     if pa.types.is_timestamp(dim.type):
@@ -586,14 +590,14 @@ def _set_coord_by_py_seq_or_np_array(
         icoord = [
             int(e.astype("int64")) if isinstance(e, np.datetime64) else e for e in coord
         ]
-        sarr.set_dim_points_int64(dim.name, icoord)
+        mq.set_dim_points_int64(dim.name, icoord)
         return
 
     raise ValueError(f"unhandled type {dim.type} for index column named {dim.name}")
 
 
 def _set_coord_by_numeric_slice(
-    sarr: clib.SOMAArray, dim: pa.Field, dom: Tuple[object, object], coord: Slice[Any]
+    mq: clib.ManagedQuery, dim: pa.Field, dom: Tuple[object, object], coord: Slice[Any]
 ) -> None:
     try:
         lo_hi = slice_to_numeric_range(coord, dom)
@@ -604,7 +608,7 @@ def _set_coord_by_numeric_slice(
         return
 
     try:
-        set_dim_range = getattr(sarr, f"set_dim_ranges_{dim.type}")
+        set_dim_range = getattr(mq, f"set_dim_ranges_{dim.type}")
         set_dim_range(dim.name, [lo_hi])
         return
     except AttributeError:

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -117,7 +117,10 @@ void load_managed_query(py::module& m) {
             "names"_a,
             "if_not_empty"_a = false)
 
-        .def("submit_read", &ManagedQuery::submit_read)
+        .def(
+            "submit_read",
+            &ManagedQuery::submit_read,
+            py::call_guard<py::gil_scoped_release>())
         .def(
             "results",
             [](ManagedQuery& mq) -> std::optional<py::object> {
@@ -143,6 +146,7 @@ void load_managed_query(py::module& m) {
                 py_batch.attr("_export_to_c")(
                     arrow_array_ptr, arrow_schema_ptr);
 
+                py::gil_scoped_release release;
                 try {
                     mq.set_array_data(
                         std::make_unique<ArrowSchema>(arrow_schema),
@@ -150,6 +154,7 @@ void load_managed_query(py::module& m) {
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }
+                py::gil_scoped_acquire acquire;
 
                 arrow_schema.release(&arrow_schema);
                 arrow_array.release(&arrow_array);
@@ -158,17 +163,21 @@ void load_managed_query(py::module& m) {
             "set_soma_data",
             [](ManagedQuery& mq, py::array data) {
                 py::buffer_info data_info = data.request();
+
+                py::gil_scoped_release release;
                 mq.setup_write_column(
                     "soma_data",
                     data.size(),
                     (const void*)data_info.ptr,
                     static_cast<uint64_t*>(nullptr),
                     static_cast<uint8_t*>(nullptr));
+                py::gil_scoped_acquire acquire;
             })
         .def(
             "submit_write",
             &ManagedQuery::submit_write,
-            "sort_coords"_a = false)
+            "sort_coords"_a = false,
+            py::call_guard<py::gil_scoped_release>())
 
         .def("reset", &ManagedQuery::reset)
         .def("close", &ManagedQuery::close)

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -142,6 +142,8 @@ void load_managed_query(py::module& m) {
                 // Release python GIL before reading data
                 py::gil_scoped_release release;
 
+                mq.setup_read();
+
                 if (mq.is_empty_query() && mq.is_first_read()) {
                     auto tbl = mq.results();
                     // Acquire python GIL before accessing python objects

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -136,36 +136,6 @@ void load_managed_query(py::module& m) {
                 }
             })
 
-        // .def(
-        //     "next",
-        //     [](ManagedQuery& mq) -> std::optional<py::object> {
-        //         // Release python GIL before reading data
-        //         py::gil_scoped_release release;
-
-        //         mq.setup_read();
-
-        //         if (mq.is_empty_query() && mq.is_first_read()) {
-        //             auto tbl = mq.results();
-        //             // Acquire python GIL before accessing python objects
-        //             py::gil_scoped_acquire acquire;
-        //             return to_table(std::make_optional(tbl));
-        //         }
-
-        //         if (mq.is_complete(false)) {
-        //             throw py::stop_iteration();
-        //         }
-
-        //         try {
-        //             mq.submit_read();
-        //             auto tbl = mq.results();
-        //             // Acquire python GIL before accessing python objects
-        //             py::gil_scoped_acquire acquire;
-        //             return to_table(std::make_optional(tbl));
-        //         } catch (const std::exception& e) {
-        //             throw TileDBSOMAError(e.what());
-        //         }
-        //     })
-
         .def(
             "next",
             [](ManagedQuery& mq) -> std::optional<py::object> {

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -140,17 +140,24 @@ void load_managed_query(py::module& m) {
             "next",
             [](ManagedQuery& mq) -> std::optional<py::object> {
                 // Release python GIL before reading data
-                // py::gil_scoped_release release;
-                if(mq.is_empty_query() || mq.is_complete(true)){
+                py::gil_scoped_release release;
+
+                if(mq.is_empty_query() && mq.is_first_read()){
+                    auto tbl = mq.results();
+                    // Acquire python GIL before accessing python objects
+                    py::gil_scoped_acquire acquire;
+                    return to_table(std::make_optional(tbl));
+                }
+                
+                if(mq.is_complete(false)){
                     throw py::stop_iteration();
                 }
 
                 mq.submit_read();
                 try {
-
                     auto tbl = mq.results();
                     // Acquire python GIL before accessing python objects
-                    // py::gil_scoped_acquire acquire;
+                    py::gil_scoped_acquire acquire;
                     return to_table(std::make_optional(tbl));
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -142,14 +142,14 @@ void load_managed_query(py::module& m) {
                 // Release python GIL before reading data
                 py::gil_scoped_release release;
 
-                if(mq.is_empty_query() && mq.is_first_read()){
+                if (mq.is_empty_query() && mq.is_first_read()) {
                     auto tbl = mq.results();
                     // Acquire python GIL before accessing python objects
                     py::gil_scoped_acquire acquire;
                     return to_table(std::make_optional(tbl));
                 }
-                
-                if(mq.is_complete(false)){
+
+                if (mq.is_complete(false)) {
                     throw py::stop_iteration();
                 }
 
@@ -162,8 +162,7 @@ void load_managed_query(py::module& m) {
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
-            }
-        )
+            })
 
         .def(
             "set_array_data",

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -136,34 +136,55 @@ void load_managed_query(py::module& m) {
                 }
             })
 
+        // .def(
+        //     "next",
+        //     [](ManagedQuery& mq) -> std::optional<py::object> {
+        //         // Release python GIL before reading data
+        //         py::gil_scoped_release release;
+
+        //         mq.setup_read();
+
+        //         if (mq.is_empty_query() && mq.is_first_read()) {
+        //             auto tbl = mq.results();
+        //             // Acquire python GIL before accessing python objects
+        //             py::gil_scoped_acquire acquire;
+        //             return to_table(std::make_optional(tbl));
+        //         }
+
+        //         if (mq.is_complete(false)) {
+        //             throw py::stop_iteration();
+        //         }
+
+        //         try {
+        //             mq.submit_read();
+        //             auto tbl = mq.results();
+        //             // Acquire python GIL before accessing python objects
+        //             py::gil_scoped_acquire acquire;
+        //             return to_table(std::make_optional(tbl));
+        //         } catch (const std::exception& e) {
+        //             throw TileDBSOMAError(e.what());
+        //         }
+        //     })
+
         .def(
             "next",
             [](ManagedQuery& mq) -> std::optional<py::object> {
                 // Release python GIL before reading data
                 py::gil_scoped_release release;
-
-                mq.setup_read();
-
-                if (mq.is_empty_query() && mq.is_first_read()) {
-                    auto tbl = mq.results();
-                    // Acquire python GIL before accessing python objects
-                    py::gil_scoped_acquire acquire;
-                    return to_table(std::make_optional(tbl));
-                }
-
-                if (mq.is_complete(false)) {
-                    throw py::stop_iteration();
-                }
-
+                std::optional<std::shared_ptr<ArrayBuffers>> tbl;
                 try {
-                    mq.submit_read();
-                    auto tbl = mq.results();
+                    tbl = mq.read_next();
                     // Acquire python GIL before accessing python objects
-                    py::gil_scoped_acquire acquire;
-                    return to_table(std::make_optional(tbl));
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
+                py::gil_scoped_acquire acquire;
+
+                if (!tbl) {
+                    throw py::stop_iteration();
+                }
+
+                return to_table(tbl);
             })
 
         .def(

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -141,7 +141,7 @@ void load_managed_query(py::module& m) {
             [](ManagedQuery& mq) -> std::optional<py::object> {
                 // Release python GIL before reading data
                 // py::gil_scoped_release release;
-                if(mq.is_empty_query() && mq.is_complete(true)){
+                if(mq.is_empty_query() || mq.is_complete(true)){
                     throw py::stop_iteration();
                 }
 

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -153,8 +153,8 @@ void load_managed_query(py::module& m) {
                     throw py::stop_iteration();
                 }
 
-                mq.submit_read();
                 try {
+                    mq.submit_read();
                     auto tbl = mq.results();
                     // Acquire python GIL before accessing python objects
                     py::gil_scoped_acquire acquire;

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1912,10 +1912,7 @@ def test_pass_configs(tmp_path, arrow_schema):
         pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
         pydict["quux"] = [True, False, False, True, False]
         rb = pa.Table.from_pydict(pydict)
-
-        if soma._flags.NEW_SHAPE_FEATURE_FLAG_ENABLED:
-            sdf.tiledbsoma_resize_soma_joinid_shape(len(rb))
-
+        sdf.tiledbsoma_resize_soma_joinid_shape(len(rb))
         sdf.write(rb)
 
     # Pass a custom config to open

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1907,10 +1907,10 @@ def test_pass_configs(tmp_path, arrow_schema):
     with soma.DataFrame.create(uri, schema=arrow_schema()) as sdf:
         pydict = {}
         pydict["soma_joinid"] = [0, 1, 2, 3, 4]
-        pydict["foo"] = [10, 20, 30, 40, 50]
-        pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
-        pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
-        pydict["quux"] = [True, False, False, True, False]
+        pydict["myint"] = [10, 20, 30, 40, 50]
+        pydict["myfloat"] = [4.1, 5.2, 6.3, 7.4, 8.5]
+        pydict["mystring"] = ["apple", "ball", "cat", "dog", "egg"]
+        pydict["mybool"] = [True, False, False, True, False]
         rb = pa.Table.from_pydict(pydict)
         sdf.tiledbsoma_resize_soma_joinid_shape(len(rb))
         sdf.write(rb)
@@ -1924,7 +1924,7 @@ def test_pass_configs(tmp_path, arrow_schema):
         ),
     ) as sdf:
 
-        # This error out as 0 are not valid values to set the total memory
+        # This errors out as 0 is not a valid value to set the total memory
         # budget or nummber of threads
         with pytest.raises(soma.SOMAError):
             next(sdf.read())

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -21,10 +21,10 @@ def arrow_schema():
     def _schema():
         return pa.schema(
             [
-                pa.field("foo", pa.int64()),
-                pa.field("bar", pa.float64()),
-                pa.field("baz", pa.string()),
-                pa.field("quux", pa.bool_()),
+                pa.field("myint", pa.int64()),
+                pa.field("myfloat", pa.float64()),
+                pa.field("mystring", pa.string()),
+                pa.field("mybool", pa.bool_()),
             ]
         )
 
@@ -36,10 +36,10 @@ def test_dataframe(tmp_path, arrow_schema):
 
     asch = pa.schema(
         [
-            ("foo", pa.int32()),
-            ("bar", pa.float64()),
-            ("baz", pa.large_string()),
-            ("quux", pa.bool_()),
+            ("myint", pa.int32()),
+            ("myfloat", pa.float64()),
+            ("mystring", pa.large_string()),
+            ("mybool", pa.bool_()),
         ]
     )
 
@@ -55,7 +55,7 @@ def test_dataframe(tmp_path, arrow_schema):
         # nonexistent indexed column
         soma.DataFrame.create(uri, schema=asch, index_column_names=["bogus"])
     soma.DataFrame.create(
-        uri, schema=asch, index_column_names=["foo"], domain=[[0, 99]]
+        uri, schema=asch, index_column_names=["myint"], domain=[[0, 99]]
     ).close()
 
     assert soma.DataFrame.exists(uri)
@@ -67,7 +67,7 @@ def test_dataframe(tmp_path, arrow_schema):
         assert len(sdf) == 0
 
         assert sorted(sdf.schema.names) == sorted(
-            ["foo", "bar", "baz", "soma_joinid", "quux"]
+            ["myint", "myfloat", "mystring", "soma_joinid", "mybool"]
         )
         assert sorted(sdf.keys()) == sorted(sdf.schema.names)
 
@@ -76,10 +76,10 @@ def test_dataframe(tmp_path, arrow_schema):
         for _ in range(3):
             pydict = {}
             pydict["soma_joinid"] = [0, 1, 2, 3, 4]
-            pydict["foo"] = [10, 20, 30, 40, 50]
-            pydict["bar"] = [4.1, 5.2, 6.3, 7.4, 8.5]
-            pydict["baz"] = ["apple", "ball", "cat", "dog", "egg"]
-            pydict["quux"] = [True, False, False, True, False]
+            pydict["myint"] = [10, 20, 30, 40, 50]
+            pydict["myfloat"] = [4.1, 5.2, 6.3, 7.4, 8.5]
+            pydict["mystring"] = ["apple", "ball", "cat", "dog", "egg"]
+            pydict["mybool"] = [True, False, False, True, False]
             rb = pa.Table.from_pydict(pydict)
 
             sdf.tiledbsoma_resize_soma_joinid_shape(len(rb))
@@ -108,20 +108,20 @@ def test_dataframe(tmp_path, arrow_schema):
         assert table.num_rows == 5
         assert table.num_columns == 5
         assert [e.as_py() for e in table["soma_joinid"]] == pydict["soma_joinid"]
-        assert [e.as_py() for e in table["foo"]] == pydict["foo"]
-        assert [e.as_py() for e in table["bar"]] == pydict["bar"]
-        assert [e.as_py() for e in table["baz"]] == pydict["baz"]
-        assert [e.as_py() for e in table["quux"]] == pydict["quux"]
+        assert [e.as_py() for e in table["myint"]] == pydict["myint"]
+        assert [e.as_py() for e in table["myfloat"]] == pydict["myfloat"]
+        assert [e.as_py() for e in table["mystring"]] == pydict["mystring"]
+        assert [e.as_py() for e in table["mybool"]] == pydict["mybool"]
 
         # Read ids
         table = sdf.read(coords=[[30, 10]]).concat()
         assert table.num_rows == 2
         assert table.num_columns == 5
         assert sorted([e.as_py() for e in table["soma_joinid"]]) == [0, 2]
-        assert sorted([e.as_py() for e in table["foo"]]) == [10, 30]
-        assert sorted([e.as_py() for e in table["bar"]]) == [4.1, 6.3]
-        assert sorted([e.as_py() for e in table["baz"]]) == ["apple", "cat"]
-        assert [e.as_py() for e in table["quux"]] == [True, False]
+        assert sorted([e.as_py() for e in table["myint"]]) == [10, 30]
+        assert sorted([e.as_py() for e in table["myfloat"]]) == [4.1, 6.3]
+        assert sorted([e.as_py() for e in table["mystring"]]) == ["apple", "cat"]
+        assert [e.as_py() for e in table["mybool"]] == [True, False]
 
     # Open and read with bindings
     with contextlib.closing(
@@ -133,18 +133,18 @@ def test_dataframe(tmp_path, arrow_schema):
         assert table.num_rows == 5
         assert table.num_columns == 5
         assert [e.as_py() for e in table["soma_joinid"]] == pydict["soma_joinid"]
-        assert [e.as_py() for e in table["foo"]] == pydict["foo"]
-        assert [e.as_py() for e in table["bar"]] == pydict["bar"]
-        assert [e.as_py() for e in table["baz"]] == pydict["baz"]
-        assert [e.as_py() for e in table["quux"]] == pydict["quux"]
+        assert [e.as_py() for e in table["myint"]] == pydict["myint"]
+        assert [e.as_py() for e in table["myfloat"]] == pydict["myfloat"]
+        assert [e.as_py() for e in table["mystring"]] == pydict["mystring"]
+        assert [e.as_py() for e in table["mybool"]] == pydict["mybool"]
 
     with soma.DataFrame.open(uri) as A:
         cfg = A.config_options_from_schema()
         assert not cfg.allows_duplicates
-        assert json.loads(cfg.dims)["foo"]["filters"] == [
+        assert json.loads(cfg.dims)["myint"]["filters"] == [
             {"COMPRESSION_LEVEL": 3, "name": "ZSTD"}
         ]
-        assert json.loads(cfg.attrs)["bar"]["filters"] == [
+        assert json.loads(cfg.attrs)["myfloat"]["filters"] == [
             {"COMPRESSION_LEVEL": -1, "name": "ZSTD"}
         ]
 
@@ -202,16 +202,16 @@ def test_dataframe_reopen(tmp_path, arrow_schema):
 
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame.create(
-        tmp_path.as_posix(), schema=arrow_schema(), index_column_names=("bar",)
+        tmp_path.as_posix(), schema=arrow_schema(), index_column_names=("myfloat",)
     )
-    assert sdf.index_column_names == ("bar",)
+    assert sdf.index_column_names == ("myfloat",)
 
 
 def test_dataframe_with_enumeration(tmp_path):
     schema = pa.schema(
         [
-            pa.field("foo", pa.dictionary(pa.int64(), pa.large_string())),
-            pa.field("bar", pa.dictionary(pa.int64(), pa.large_string())),
+            pa.field("myint", pa.dictionary(pa.int64(), pa.large_string())),
+            pa.field("myfloat", pa.dictionary(pa.int64(), pa.large_string())),
         ]
     )
     enums = {"enmr1": ("a", "bb", "ccc"), "enmr2": ("cat", "dog")}
@@ -220,19 +220,19 @@ def test_dataframe_with_enumeration(tmp_path):
     ) as sdf:
         data = {}
         data["soma_joinid"] = [0, 1, 2, 3, 4]
-        data["foo"] = ["a", "bb", "ccc", "bb", "a"]
-        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        data["myint"] = ["a", "bb", "ccc", "bb", "a"]
+        data["myfloat"] = ["cat", "dog", "cat", "cat", "cat"]
         with pytest.raises(soma.SOMAError):
             sdf.write(pa.Table.from_pydict(data))
 
-        data["foo"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
-        data["bar"] = pd.Categorical(["cat", "dog", "cat", "cat", "cat"])
+        data["myint"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
+        data["myfloat"] = pd.Categorical(["cat", "dog", "cat", "cat", "cat"])
         sdf.write(pa.Table.from_pydict(data))
 
     with soma.DataFrame.open(tmp_path.as_posix()) as sdf:
         df = sdf.read().concat()
-        np.testing.assert_array_equal(df["foo"].chunk(0).dictionary, enums["enmr1"])
-        np.testing.assert_array_equal(df["bar"].chunk(0).dictionary, enums["enmr2"])
+        np.testing.assert_array_equal(df["myint"].chunk(0).dictionary, enums["enmr1"])
+        np.testing.assert_array_equal(df["myfloat"].chunk(0).dictionary, enums["enmr2"])
 
 
 @pytest.fixture
@@ -1749,8 +1749,8 @@ def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
 
     schema = pa.schema(
         [
-            pa.field("foo", pa.dictionary(pa.int64(), pa.large_string())),
-            pa.field("bar", pa.large_string()),
+            pa.field("myint", pa.dictionary(pa.int64(), pa.large_string())),
+            pa.field("myfloat", pa.large_string()),
         ]
     )
 
@@ -1759,32 +1759,32 @@ def test_only_evolve_schema_when_enmr_is_extended(tmp_path):
     with soma.DataFrame.create(uri, schema=schema, domain=[[0, 4]]) as sdf:
         data = {}
         data["soma_joinid"] = [0, 1, 2, 3, 4]
-        data["foo"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
-        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        data["myint"] = pd.Categorical(["a", "bb", "ccc", "bb", "a"])
+        data["myfloat"] = ["cat", "dog", "cat", "cat", "cat"]
         sdf.write(pa.Table.from_pydict(data))
 
     # +1 evolving the schema
     with soma.DataFrame.open(uri, "w") as sdf:
         data = {}
         data["soma_joinid"] = [0, 1, 2, 3, 4]
-        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
-        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        data["myint"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
+        data["myfloat"] = ["cat", "dog", "cat", "cat", "cat"]
         sdf.write(pa.Table.from_pydict(data))
 
     # +0 no changes to enumeration values
     with soma.DataFrame.open(uri, "w") as sdf:
         data = {}
         data["soma_joinid"] = [0, 1, 2, 3, 4]
-        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
-        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        data["myint"] = pd.Categorical(["a", "bb", "ccc", "d", "a"])
+        data["myfloat"] = ["cat", "dog", "cat", "cat", "cat"]
         sdf.write(pa.Table.from_pydict(data))
 
     # +0 no changes enumeration values
     with soma.DataFrame.open(uri, "w") as sdf:
         data = {}
         data["soma_joinid"] = [0, 1, 2, 3, 4]
-        data["foo"] = pd.Categorical(["a", "bb", "ccc", "d", "d"])
-        data["bar"] = ["cat", "dog", "cat", "cat", "cat"]
+        data["myint"] = pd.Categorical(["a", "bb", "ccc", "d", "d"])
+        data["myfloat"] = ["cat", "dog", "cat", "cat", "cat"]
         sdf.write(pa.Table.from_pydict(data))
 
     # total 3 fragment files

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -531,12 +531,12 @@ def test_pass_configs(tmp_path):
         # This still errors out because read still sees that the number of
         # threads is 0 and therefore invalid
         with pytest.raises(soma.SOMAError):
-            sdf.read(platform_config={"sm.mem.total_budget": "10000"})
+            sdf.read(platform_config={"sm.mem.total_budget": "300000"})
 
         # With correct values, this reads without issue
         sdf.read(
             platform_config={
-                "sm.mem.total_budget": "10000",
+                "sm.mem.total_budget": "300000",
                 "sm.io_concurrency_level": "1",
             }
         )

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -523,7 +523,7 @@ def test_pass_configs(tmp_path):
         ),
     ) as sdf:
 
-        # This error out as 0 are not valid values to set the total memory
+        # This errors out as 0 is not a valid value to set the total memory
         # budget or nummber of threads
         with pytest.raises(soma.SOMAError):
             sdf.read()

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -498,3 +498,45 @@ def test_read_to_unwritten_array(tmp_path, shape):
 
     with soma.DenseNDArray.open(uri, "r") as A:
         assert np.array_equal(np.ones(shape) * 255, A.read().to_numpy())
+
+
+def test_pass_configs(tmp_path):
+    uri = tmp_path.as_posix()
+
+    with soma.DenseNDArray.create(
+        tmp_path.as_posix(),
+        type=pa.uint8(),
+        shape=(2, 2),
+        context=SOMATileDBContext(timestamp=1),
+    ) as a:
+        a.write(
+            (slice(0, 2), slice(0, 2)),
+            pa.Tensor.from_numpy(np.zeros((2, 2), dtype=np.uint8)),
+        )
+
+    # Pass a custom config to open
+    with soma.DenseNDArray.open(
+        uri,
+        "r",
+        context=soma.SOMATileDBContext(
+            {"sm.mem.total_budget": "0", "sm.io_concurrency_level": "0"}
+        ),
+    ) as sdf:
+
+        # This error out as 0 are not valid values to set the total memory
+        # budget or nummber of threads
+        with pytest.raises(soma.SOMAError):
+            sdf.read()
+
+        # This still errors out because read still sees that the number of
+        # threads is 0 and therefore invalid
+        with pytest.raises(soma.SOMAError):
+            sdf.read(platform_config={"sm.mem.total_budget": "10000"})
+
+        # With correct values, this reads without issue
+        sdf.read(
+            platform_config={
+                "sm.mem.total_budget": "10000",
+                "sm.io_concurrency_level": "1",
+            }
+        )

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1908,7 +1908,7 @@ def test_pass_configs(tmp_path):
         ),
     ) as sdf:
 
-        # This error out as 0 are not valid values to set the total memory
+        # This errors out as 0 is not a valid value to set the total memory
         # budget or nummber of threads
         with pytest.raises(soma.SOMAError):
             next(sdf.read().tables())

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -381,6 +381,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
 
 std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
     if (is_empty_query()) {
+        query_submitted_ = true;
         return buffers_;
     }
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -281,6 +281,8 @@ class ManagedQuery {
      */
     void setup_read();
 
+    std::optional<std::shared_ptr<ArrayBuffers>> read_next();
+
     /**
      * @brief Check if the query is complete.
      *

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -423,6 +423,10 @@ class ManagedQuery {
         return query_->query_status();
     }
 
+    bool is_first_read() const {
+        return !query_submitted_;
+    }
+
    private:
     //===================================================================
     //= private non-static


### PR DESCRIPTION
**Issue and/or context:**

This finishes up https://github.com/single-cell-data/TileDB-SOMA/issues/3053 [[sc-54744]](https://app.shortcut.com/tiledb-inc/story/54744/python-soma-read-does-an-open-on-an-already-open-array)

**Changes:**

- Remove `clib.SOMAArray.open` in all `SOMAArray` derived class `read` calls
- Pass query arguments coords, column names, result order, value filter, and platform config that were formerly passed to `clib.SOMAArray.open` or `clib.SOMAArray.reset` instead to `TableReadIter` and `SparseNDArrayRead`
- `_set_coords` on the `ManagedQuery` rather than through `SOMAArray`
- `_arrow_table_reader` and `SparseTensorReadIterBase` initialize a `ManagedQuery` object and set the query arguments listed above; set up the read; and submit reads and return results until the query is complete
