### PR TITLE
[python/r] Enforce dataframe domain lower bound == 0

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -295,6 +295,16 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 slot_core_max_domain, extent, saturated_md
             )
 
+            if index_column_name == "soma_joinid":
+                if slot_core_current_domain[0] != 0:
+                    raise ValueError(
+                        f"domain for soma_joinid must have lower bound of 0; got {slot_core_current_domain[0]}"
+                    )
+                if slot_core_max_domain[0] != 0:
+                    raise ValueError(
+                        f"maxdomain for soma_joinid must have lower bound of 0; got {slot_core_max_domain[0]}"
+                    )
+
             # Here is our Arrow data API for communicating schema info between
             # Python/R and C++ libtiledbsoma:
             #

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -296,13 +296,15 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             )
 
             if index_column_name == "soma_joinid":
-                if slot_core_current_domain[0] != 0:
+                lower = slot_core_current_domain[0]
+                upper = slot_core_current_domain[1]
+                if lower != 0:
                     raise ValueError(
-                        f"domain for soma_joinid must have lower bound of 0; got {slot_core_current_domain[0]}"
+                        f"domain for soma_joinid must have lower bound of 0; got {lower}"
                     )
-                if slot_core_max_domain[0] != 0:
+                if upper < 0:
                     raise ValueError(
-                        f"maxdomain for soma_joinid must have lower bound of 0; got {slot_core_max_domain[0]}"
+                        f"domain for soma_joinid must have upper bound >= 0; got {upper}"
                     )
 
             # Here is our Arrow data API for communicating schema info between

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1864,3 +1864,31 @@ def test_presence_matrix(tmp_path):
         actual = soma_df.read().concat().to_pandas()
 
     assert actual.equals(df)
+
+
+def test_lower_bound_on_somajoinid_domain(tmp_path):
+    uri = tmp_path.as_posix()
+
+    schema = pa.schema(
+        [
+            ("soma_joinid", pa.int64()),
+            ("mystring", pa.string()),
+            ("myint", pa.int32()),
+            ("myfloat", pa.float32()),
+        ]
+    )
+
+    with pytest.raises(ValueError):
+        soma.DataFrame.create(
+            uri,
+            schema=schema,
+            domain=[[2, 99]],
+        )
+
+    soma.DataFrame.create(
+        uri,
+        schema=schema,
+        domain=[[0, 99]],
+    )
+
+    assert soma.DataFrame.exists(uri)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1866,7 +1866,7 @@ def test_presence_matrix(tmp_path):
     assert actual.equals(df)
 
 
-def test_lower_bound_on_somajoinid_domain(tmp_path):
+def test_bounds_on_somajoinid_domain(tmp_path):
     uri = tmp_path.as_posix()
 
     schema = pa.schema(
@@ -1883,6 +1883,13 @@ def test_lower_bound_on_somajoinid_domain(tmp_path):
             uri,
             schema=schema,
             domain=[[2, 99]],
+        )
+
+    with pytest.raises(ValueError):
+        soma.DataFrame.create(
+            uri,
+            schema=schema,
+            domain=[[0, -1]],
         )
 
     soma.DataFrame.create(

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -65,6 +65,11 @@ SOMADataFrame <- R6::R6Class(
           length(attr_column_names) > 0
       )
 
+      if ("soma_joinid" %in% index_column_names && !is.null(domain)) {
+        lower <- domain[["soma_joinid"]][1]
+        stopifnot("The lower bound for soma_joinid domain must be 0" = lower == 0)
+      }
+
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
       tiledb_create_options <- TileDBCreateOptions$new(platform_config)

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -67,7 +67,11 @@ SOMADataFrame <- R6::R6Class(
 
       if ("soma_joinid" %in% index_column_names && !is.null(domain)) {
         lower <- domain[["soma_joinid"]][1]
-        stopifnot("The lower bound for soma_joinid domain must be 0" = lower == 0)
+        upper <- domain[["soma_joinid"]][2]
+        stopifnot(
+          "The lower bound for soma_joinid domain must be 0" = lower == 0,
+          "The upper bound for soma_joinid domain must be >= 0" = upper >= 0
+          )
       }
 
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -640,9 +640,9 @@ test_that("SOMADataFrame timestamped ops", {
     arrow::field("valdbl", arrow::float64(), nullable = FALSE)
   )
   if (dir.exists(uri)) unlink(uri, recursive = TRUE)
-  sdf <- SOMADataFrameCreate(uri = uri, schema = sch, domain = list(soma_joinid = c(1, 100)))
+  sdf <- SOMADataFrameCreate(uri = uri, schema = sch, domain = list(soma_joinid = c(0, 99)))
   rb1 <- arrow::record_batch(
-    soma_joinid = bit64::as.integer64(1L:3L),
+    soma_joinid = bit64::as.integer64(0L:2L),
     valint = 1L:3L,
     valdbl = 100 * (1:3),
     schema = sch
@@ -660,7 +660,7 @@ test_that("SOMADataFrame timestamped ops", {
   t20 <- Sys.time()
   sdf <- SOMADataFrameOpen(uri = uri, mode = "WRITE")
   rb2 <- arrow::record_batch(
-    soma_joinid = bit64::as.integer64(4L:6L),
+    soma_joinid = bit64::as.integer64(3L:5L),
     valint = 4L:6L,
     valdbl = 100 * (4:6),
     schema = sch

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -177,6 +177,41 @@ test_that("Basic mechanics with default index_column_names", {
   gc()
 })
 
+test_that("soma_joinid domain lower bound must be zero", {
+  uri <- withr::local_tempdir("soma-dataframe-soma-joinid-domain-lower-bound")
+
+  index_column_names <- c("soma_joinid")
+
+  asch <- arrow::schema(
+      arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+      arrow::field("mystring", arrow::large_utf8(), nullable = FALSE),
+      arrow::field("myint", arrow::int32(), nullable = FALSE),
+      arrow::field("myfloat", arrow::float32(), nullable = FALSE)
+  )
+
+  expect_error(
+    SOMADataFrameCreate(
+      uri,
+      asch,
+      index_column_names = index_column_names,
+      domain = list(soma_joinid=c(2, 99))
+    )
+  )
+
+  expect_no_condition(
+    SOMADataFrameCreate(
+      uri,
+      asch,
+      index_column_names = index_column_names,
+      domain = list(soma_joinid=c(0, 99))
+    )
+  )
+
+  sdf <- SOMADataFrameOpen(uri)
+  expect_true(sdf$exists())
+  sdf$close()
+})
+
 test_that("creation with all supported dimension data types", {
   skip_if(!extended_tests())
   sch <- arrow::schema(

--- a/apis/r/tests/testthat/test-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-SOMADataFrame.R
@@ -198,6 +198,15 @@ test_that("soma_joinid domain lower bound must be zero", {
     )
   )
 
+  expect_error(
+    SOMADataFrameCreate(
+      uri,
+      asch,
+      index_column_names = index_column_names,
+      domain = list(soma_joinid=c(0, -1))
+    )
+  )
+
   expect_no_condition(
     SOMADataFrameCreate(
       uri,

--- a/apis/r/tests/testthat/test-shape.R
+++ b/apis/r/tests/testthat/test-shape.R
@@ -327,14 +327,14 @@ test_that("SOMADataFrame domain mods", {
    index_column_names <- c("soma_joinid", "mystring", "myint", "myfloat")
 
     domain_for_create <- list(
-        soma_joinid = c(1, 4),
+        soma_joinid = c(0, 3),
         mystring = NULL,
         myint = c(20, 50),
         myfloat = c(0.0, 6.0)
     )
 
     table <- arrow::arrow_table(
-      soma_joinid = 1L:4L,
+      soma_joinid = 0L:3L,
       mystring = c("a", "b", "a", "b"),
       myint = c(20, 30, 40, 50),
       myfloat = c(1.0, 2.5, 4.0, 5.5),
@@ -355,7 +355,7 @@ test_that("SOMADataFrame domain mods", {
 
     # Check "expand" to same
     new_domain <- list(
-        soma_joinid = c(1, 4),
+        soma_joinid = c(0, 3),
         mystring = NULL,
         myint = c(20, 50),
         myfloat = c(0.0, 6.0)
@@ -364,7 +364,7 @@ test_that("SOMADataFrame domain mods", {
 
     # Shrink
     new_domain <- list(
-        soma_joinid = c(1, 3),
+        soma_joinid = c(0, 2),
         mystring = NULL,
         myint = c(20, 50),
         myfloat = c(0.0, 6.0)
@@ -372,7 +372,7 @@ test_that("SOMADataFrame domain mods", {
     expect_error(sdf$change_domain(new_domain))
 
     new_domain <- list(
-        soma_joinid = c(1, 4),
+        soma_joinid = c(0, 3),
         mystring = NULL,
         myint = c(20, 40),
         myfloat = c(0.0, 6.0)
@@ -380,7 +380,7 @@ test_that("SOMADataFrame domain mods", {
     expect_error(sdf$change_domain(new_domain))
 
     new_domain <- list(
-        soma_joinid = c(1, 4),
+        soma_joinid = c(0, 3),
         mystring = NULL,
         myint = c(20, 50),
         myfloat = c(2.0, 6.0)
@@ -389,7 +389,7 @@ test_that("SOMADataFrame domain mods", {
 
     # String domain cannot be specified
     new_domain <- list(
-        soma_joinid = c(1, 4),
+        soma_joinid = c(0, 3),
         mystring = c("a", "z"),
         myint = c(20, 50),
         myfloat = c(0.0, 6.0)
@@ -400,7 +400,7 @@ test_that("SOMADataFrame domain mods", {
 
     # String domain cannot be specified
     new_domain <- list(
-        soma_joinid = c(1, 9),
+        soma_joinid = c(0, 8),
         mystring = c("", ""),
         myint = c(20, 50),
         myfloat = c(0.0, 10.0)


### PR DESCRIPTION
Arose during discussion of #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048), but the defect here predates the new-shape work.