### PR TITLE
[python] Unbreak CI with `anndata==0.11`

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2257,7 +2257,7 @@ def _write_matrix_to_sparseNDArray(
     if sp.isspmatrix_csc(matrix):
         # E.g. if we used anndata.X[:]
         stride_axis = 1
-    if isinstance(matrix, CSCDataset) and matrix.format_str == "csc":
+    if isinstance(matrix, CSCDataset):
         # E.g. if we used anndata.X without the [:]
         stride_axis = 1
 


### PR DESCRIPTION
**Issue and/or context:** As for example
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11727945417/job/32670239706?pr=3300

Note that `anndata` 0.11 just dropped, and I had failed to run any pre-assess checks using the RC series.