### PR TITLE
[python] Fix some warnings at `anndata==0.11`

### DIFF
--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -10,7 +10,14 @@ import h5py
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
-from anndata.experimental import CSCDataset, CSRDataset
+
+# As of anndata 0.11 we get a warning importing anndata.experimental.
+# But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
+# exist for Python 3.9. And we have not yet dropped support for Python 3.9.
+try:
+    from anndata.abc import CSCDataset, CSRDataset
+except (AttributeError, ModuleNotFoundError):
+    from anndata.experimental import CSCDataset, CSRDataset
 
 from tiledbsoma._types import Metadatum, NPNDArray
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -36,7 +36,15 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
-from anndata.experimental import CSCDataset
+
+# As of anndata 0.11 we get a warning importing anndata.experimental.
+# But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
+# exist for Python 3.9. And we have not yet dropped support for Python 3.9.
+try:
+    from anndata.abc import CSCDataset
+except (AttributeError, ModuleNotFoundError):
+    from anndata.experimental import CSCDataset
+
 from somacore.options import PlatformConfig
 from typing_extensions import get_args
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2257,7 +2257,7 @@ def _write_matrix_to_sparseNDArray(
     if sp.isspmatrix_csc(matrix):
         # E.g. if we used anndata.X[:]
         stride_axis = 1
-    if isinstance(matrix, CSCDataset) and matrix.format_str == "csc":
+    if isinstance(matrix, CSCDataset):
         # E.g. if we used anndata.X without the [:]
         stride_axis = 1
 


### PR DESCRIPTION
Follow-on to #3305

Unfortunately, I still see these which appear to be outside of our control:

```
>>> import scanpy
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_csv from `anndata` is deprecated. Import anndata.io.read_csv instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_excel from `anndata` is deprecated. Import anndata.io.read_excel instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_hdf from `anndata` is deprecated. Import anndata.io.read_hdf instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_loom from `anndata` is deprecated. Import anndata.io.read_loom instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_mtx from `anndata` is deprecated. Import anndata.io.read_mtx instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_text from `anndata` is deprecated. Import anndata.io.read_text instead.
  warnings.warn(msg, FutureWarning)
/Users/kerl/.pyenv/versions/3.11.9/lib/python3.11/site-packages/anndata/utils.py:429: FutureWarning: Importing read_umi_tools from `anndata` is deprecated. Import anndata.io.read_umi_tools instead.
```