### PR TITLE
[python] Fix bad merge of soma-shapes notebook

### DIFF
--- a/apis/python/notebooks/tutorial_soma_shape.ipynb
+++ b/apis/python/notebooks/tutorial_soma_shape.ipynb
@@ -618,8 +618,7 @@
     "\n",
     "Because the shapes are soft limits, reading or writing beyond which will result in an exception, you'd need to resize the experiment to accommodate new shapes for the dataframes and arrays in the experiment to allow for new `nobs` = 170,000.\n",
     "\n",
-    "Please see the [append-mode tutorial](./tutorial_soma_append_mode.ipynb) for how to do that using `tiledbsoma.io.register_anndatas` and `tiledbsoma.io.resize_experiment`.
-`.\n",
+    "Please see the [append-mode tutorial](./tutorial_soma_append_mode.ipynb) for how to do that using `tiledbsoma.io.register_anndatas` and `tiledbsoma.io.resize_experiment`\n",
     "\n",
     "While you can resize each dataframe and array in the experiment one at a time -- see \"Advanced usage\", below in this notebook -- by var the most common case is `tiledbsoma.io.resize_experiment`, which exists to make this simple and convenient."
    ]


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Fix bad merge of #3294. Looks like this commit: https://github.com/single-cell-data/TileDB-SOMA/pull/3294#discussion_r1833109086

**Notes for Reviewer:**

Review link:
https://github.com/single-cell-data/TileDB-SOMA/blob/kerl/fix-notebook-merge/apis/python/notebooks/tutorial_soma_shape.ipynb
