### PR TITLE
[c++] Fix a compiler warning

### DIFF
--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -153,7 +153,7 @@ std::unique_ptr<ArrowSchema> create_index_cols_info_schema(
 
     auto schema = ArrowAdapter::make_arrow_schema(names, tiledb_datatypes);
 
-    for (size_t i = 0; i < schema->n_children; ++i) {
+    for (size_t i = 0; i < (size_t)schema->n_children; ++i) {
         if (strcmp(schema->children[i]->name, "soma_geometry")) {
             nanoarrow::UniqueBuffer buffer;
             ArrowMetadataBuilderInit(buffer.get(), nullptr);


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

**Changes:**

Fix a compiler warning:

```
/home/ubuntu/git/single-cell-data/TileDB-SOMA/libtiledbsoma/test/common.cc: In function ‘std::unique_ptr<ArrowSchema> helper::create_index_cols_info_schema(const std::vector<DimInfo>&)’:
/home/ubuntu/git/single-cell-data/TileDB-SOMA/libtiledbsoma/test/common.cc:156:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
  156 |     for (size_t i = 0; i < schema->n_children; ++i) {
```

**Notes for Reviewer:**
