### PR TITLE
[r/ci] Avoid log truncation with "Last 13 lines of output"

### DIFF
--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -114,3 +114,4 @@ jobs:
         run: python -m pytest apis/system/tests/
         env:
           TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
+          _R_CHECK_TESTS_NLINES_: 0

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "23 4 * * *"
 
+env:
+  _R_CHECK_TESTS_NLINES_: 0
+
 jobs:
   r-valgrind:
     runs-on: ubuntu-latest


### PR DESCRIPTION
More of #1871 -- which I didn't apply to sufficiently many CI YAML files.