### PR TITLE
[python] Config type aliases

### DIFF
--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -2,11 +2,12 @@
 #
 # Licensed under the MIT License.
 
-from ._soma_tiledb_context import SOMATileDBContext
+from ._soma_tiledb_context import ConfigDict, SOMATileDBContext
 from ._tiledb_create_write_options import TileDBCreateOptions, TileDBWriteOptions
 
 __all__ = [
     "SOMATileDBContext",
+    "ConfigDict",
     "TileDBCreateOptions",
     "TileDBWriteOptions",
 ]


### PR DESCRIPTION
We use `dict[str, str | float]` in a few places, to mean "TileDB config"; this factors+names that.

#3740 was the impetus for resurrecting this; I'm referencing this type in other files there.