### PR TITLE
[r/ci] Try to unbreak `r-valgrind` CI

### DIFF
--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   _R_CHECK_TESTS_NLINES_: 0
+  TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
 
 jobs:
   r-valgrind:


### PR DESCRIPTION
**Issue and/or context:** #3315 [[sc-59088]](https://app.shortcut.com/tiledb-inc/story/59088/recent-failures-in-tiledb-soma-s-r-valgrind-ci)

**Changes:** With #3313 in place to avoid the problematic (default) truncation to 13 lines of output, I ran https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11744677785/job/32720341469 and saw

```
2024-11-08T15:36:21.1886016Z   **4849** new/new[] failed and should throw an exception, but Valgrind
2024-11-08T15:36:21.1887203Z   **4849**    cannot throw exceptions and so is aborting instead.  Sorry.
```

I'm imitating a memory config from other R CI YAMLs in our project in hopes this will help.

**Notes for Reviewer:**

Manual `r-valgrind` run (since that CI doesn't run on every PR):
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11745362897

Note we have another active R CI failure (unrelated) #3314 which is muddying the waters.