### PR TITLE
[python] Use new shape in one more spot

### DIFF
--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -443,11 +443,14 @@ def _extract_obsm_or_varm(
     num_cols = width_configs.get(element_name, None)
 
     if num_cols is None:
-        try:
-            used_shape = soma_nd_array.used_shape()
-            num_cols = used_shape[1][1] + 1
-        except SOMAError:
-            pass  # We tried; moving on to next option
+        if soma_nd_array.tiledbsoma_has_upgraded_shape:
+            num_cols = soma_nd_array.shape[1]
+        else:
+            try:
+                used_shape = soma_nd_array.used_shape()
+                num_cols = used_shape[1][1] + 1
+            except SOMAError:
+                pass  # We tried; moving on to next option
 
     if num_cols is None:
         num_rows_times_width, coo_column_count = matrix_tbl.shape

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -822,14 +822,14 @@ def test_export_obsm_with_holes(h5ad_file_with_obsm_holes, tmp_path):
             meta["soma_dim_1_domain_upper"]
         assert meta["soma_object_type"] == "SOMASparseNDArray"
 
-        # Now try the remaining options for outgest.
-        with pytest.raises(tiledbsoma.SOMAError):
-            tiledbsoma.io.to_anndata(exp, "RNA")
+        # No longer throws as of new-shape feature in TileDB-SOMA 1.15.
+        try3 = tiledbsoma.io.to_anndata(exp, "RNA")
+        assert try3.obsm["X_pca"].shape == (2638, 50)
 
-        try3 = tiledbsoma.io.to_anndata(
+        try4 = tiledbsoma.io.to_anndata(
             exp, "RNA", obsm_varm_width_hints={"obsm": {"X_pca": 50}}
         )
-        assert try3.obsm["X_pca"].shape == (2638, 50)
+        assert try4.obsm["X_pca"].shape == (2638, 50)
 
 
 def test_X_empty(h5ad_file_X_empty):


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Found a spot in one-off/ad-hoc testing in my laptop on a particular old dataset.

**Notes for Reviewer:**