### PR TITLE
[python] Add `MultiscaleImage` methods to access level URI

### DIFF
--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -9,7 +9,7 @@ Implementation of a SOMA MultiscaleImage.
 
 import json
 import warnings
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import attrs
 import pyarrow as pa
@@ -669,6 +669,13 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             Experimental.
         """
         return self._has_channel_axis
+
+    def levels(self) -> Dict[str, Tuple[str, Tuple[int, ...]]]:
+        """Returns a mapping of {member_name: (uri, shape)}."""
+        return {
+            level.name: (self._contents[level.name].entry.uri, level.shape)
+            for level in self._levels
+        }
 
     @property
     def level_count(self) -> int:

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -687,11 +687,10 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         return len(self._levels)
 
     def level_shape(self, level: Union[int, str]) -> Tuple[int, ...]:
-        """The shape of the image at the specified level.
+        """The shape of the image at the specified resolution level.
 
         Lifecycle: experimental
         """
-
         if isinstance(level, str):
             for val in self._levels:
                 if val.name == level:
@@ -701,6 +700,15 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
         # by index
         return self._levels[level].shape
+
+    def level_uri(self, level: Union[int, str]) -> str:
+        """The URI of the image at the specified resolution level.
+
+        Lifecycle: experimental
+        """
+        if isinstance(level, int):
+            level = self._levels[level].name
+        return self._contents[level].entry.uri
 
     @property
     def nchannels(self) -> int:

--- a/apis/python/tests/test_multiscale_image.py
+++ b/apis/python/tests/test_multiscale_image.py
@@ -102,9 +102,17 @@ def test_multiscale_basic(tmp_path):
         assert coord_space.axis_names == ("x", "y")
 
         # Check the number of levels and level properties.
+        expected_shapes = [(128, 64), (64, 32), (8, 4)]
         assert image.level_count == 3
-        for index, shape in enumerate([(128, 64), (64, 32), (8, 4)]):
+        for index, shape in enumerate(expected_shapes):
             assert image.level_shape(index) == shape
+
+        # Check the levels mapping.
+        levels = image.levels()
+        assert len(levels) == 3
+        for key, val in levels.items():
+            assert soma.DenseNDArray.exists(val[0])
+            assert image.level_shape(key) == val[1]
 
         # Check a basic read
         assert level2_data == image.read_spatial_region(2).data


### PR DESCRIPTION
This adds two new methods to access the URIs of resolution levels in the MultiscaleImage.

1. `levels` - a method similar to the `Collection.members` method. Returns shape instead of element types as all levels have type `DenseNDArray`.
2. `level_uri` - returns just the URI for a level specified by either index or name.

This addition is needed for exporting a `MultiscaleImage` level to SpatialData.
