### PR TITLE
[python] Return identity for `MultiscaleImage` transform to/from level 0

### DIFF
--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -17,6 +17,7 @@ import somacore
 from somacore import (
     CoordinateSpace,
     CoordinateTransform,
+    IdentityTransform,
     ScaleTransform,
     options,
 )
@@ -630,6 +631,11 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
+        if level == 0 or level == self._level_properties(0).name:
+            return IdentityTransform(
+                input_axes=self._coord_space.axis_names,
+                output_axes=self._coord_space.axis_names,
+            )
         level_shape = self._level_properties(level).shape
         base_shape = self._levels[0].shape
         axis_indexer = self._axis_order()
@@ -649,6 +655,11 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle:
             Experimental.
         """
+        if level == 0 or level == self._level_properties(0).name:
+            return IdentityTransform(
+                input_axes=self._coord_space.axis_names,
+                output_axes=self._coord_space.axis_names,
+            )
         level_shape = self._level_properties(level).shape
         base_shape = self._levels[0].shape
         axis_indexer = self._axis_order()

--- a/apis/python/tests/test_multiscale_image.py
+++ b/apis/python/tests/test_multiscale_image.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
-from tiledbsoma import ScaleTransform
+from tiledbsoma import IdentityTransform, ScaleTransform
 
 
 def test_multiscale_image_bad_create(tmp_path):
@@ -113,6 +113,8 @@ def test_multiscale_basic(tmp_path):
         to_level = image.get_transform_to_level
         from_level = image.get_transform_from_level
 
+        assert isinstance(to_level(0), IdentityTransform)
+        assert isinstance(from_level(0), IdentityTransform)
         assert np.array_equal(to_level(0).scale_factors, [1, 1])
         assert np.array_equal(to_level(1).scale_factors, [0.5, 0.5])
         assert np.array_equal(to_level(2).scale_factors, [0.0625, 0.0625])


### PR DESCRIPTION
The to/from level 0 transform is always the identity transform. Return the `IdentityTransform` class instead of the more generic `ScaleTransform` with ones for the scale factors.



