### PR TITLE
Fix and test SpatialData transformation exporter

### DIFF
--- a/apis/python/tests/test_export_point_cloud_dataframe.py
+++ b/apis/python/tests/test_export_point_cloud_dataframe.py
@@ -41,8 +41,11 @@ def test_export_to_shapes_2d(sample_point_cloud_dataframe_2d):
     shape = soma_outgest.to_spatial_data_shapes(
         sample_point_cloud_dataframe_2d,
         scene_id="scene0",
+        scene_dim_map={"x_scene": "x", "y_scene": "y"},
         soma_joinid_name="obs_id",
-        transform=somacore.IdentityTransform(("x", "y"), ("x", "y")),
+        transform=somacore.IdentityTransform(
+            ("x_scene", "y_scene"), ("x_points", "y_points")
+        ),
     )
 
     # Validate that this is validate storage for the SpatialData "Shapes"

--- a/apis/python/tests/test_spatial_outgest_util.py
+++ b/apis/python/tests/test_spatial_outgest_util.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import somacore
+
+soma_outgest = pytest.importorskip("tiledbsoma.experimental.outgest")
+sd = pytest.importorskip("spatialdata")
+
+
+@pytest.mark.parametrize(
+    "transform, expected",
+    [
+        (
+            somacore.IdentityTransform(("x1", "y1"), ("x2", "y2")),
+            sd.transformations.Identity(),
+        ),
+        (
+            somacore.UniformScaleTransform(("x1", "y1"), ("x2", "y2"), 10),
+            sd.transformations.Scale([10, 10], ("x", "y")),
+        ),
+        (
+            somacore.ScaleTransform(("x1", "y1"), ("x2", "y2"), [4, 0.1]),
+            sd.transformations.Scale([4, 0.1], ("x", "y")),
+        ),
+        (
+            somacore.AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                [[2, 2, 0], [0, 3, 1]],
+            ),
+            sd.transformations.Affine(
+                np.array([[2, 2, 0], [0, 3, 1], [0, 0, 1]]), ("x", "y"), ("x", "y")
+            ),
+        ),
+    ],
+)
+def test_transform_to_spatial_data(transform, expected):
+    input_dim_map = {"x1": "x", "y1": "y", "z1": "z"}
+    output_dim_map = {"x2": "x", "y2": "y", "z2": "z"}
+    actual = soma_outgest._transform_to_spatial_data(
+        transform, input_dim_map, output_dim_map
+    )
+    assert actual == expected


### PR DESCRIPTION
Fixes:
* Fix changes from SOMA coordinate axis names to SpatialData coordinate dimension names.
* Invert SOMA scene-to-points transform to correctly store SpatialData point-to-scene transformation.
* Fix type annotation for GeoPandas `GeoDataFrame`.

Clean-up:
* Import `spatialdata` as `sd`. 
* Add tests for converting transformations.