### PR TITLE
[c++/python/r] Migrate to C++20

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Backport
     steps:
       - name: Backport

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,7 +18,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # This is GitHub Actions magic -- there are no secrets we as package owners need to set up or manage
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -28,8 +28,8 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
           - runs-on: ubuntu-latest
-            cc: gcc-11
-            cxx: g++-11
+            cc: gcc-13
+            cxx: g++-13
           - runs-on: macos-latest
             cc: clang
             cxx: clang++

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -21,13 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: decide on Windows CI coverage
-        os: [ubuntu-latest, macos-latest]
-        # os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-24.04, macos-latest]
+        # os: [ubuntu-24.04, macos-latest, windows-2019]
         # TODO: add 3.12
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
         python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24.04
             cc: gcc-13
             cxx: g++-13
           - runs-on: macos-latest
@@ -39,6 +39,6 @@ jobs:
       python_version: ${{ matrix.python-version }}
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
-      report_codecov: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
-      run_lint: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
+      report_codecov: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' }}
+      run_lint: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' }}
     secrets: inherit

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: true
 
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
         python-version: ['3.9', '3.12']
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cc: gcc-13
             cxx: g++-13
           - os: macos-latest

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -32,8 +32,8 @@ jobs:
         python-version: ['3.9', '3.12']
         include:
           - os: ubuntu-latest
-            cc: gcc-11
-            cxx: g++-11
+            cc: gcc-13
+            cxx: g++-13
           - os: macos-latest
             cc: clang
             cxx: clang++

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -168,6 +168,10 @@ jobs:
           fetch-depth: 0  # for setuptools-scm
       - name: Check if System Integrity Protection (SIP) is enabled
         run: csrutil status
+      - name: Select XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
       - name: Install pre-built libtiledb
         if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
         run: |

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -152,7 +152,7 @@ jobs:
   # https://github.com/single-cell-data/TileDB-SOMA/pull/1937
   # Same as job above, but running on macOS instead of in a Docker container
   macos:
-    runs-on: macos-13
+    runs-on: macos-latest
     name: "SO copying (macos) TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -39,7 +39,7 @@ jobs:
   # Confirm shared object copying when building the Python package
   # https://github.com/single-cell-data/TileDB-SOMA/pull/1937
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: "SO copying (docker) TILEDB_EXISTS: ${{ matrix.TILEDB_EXISTS }} TILEDBSOMA_EXISTS: ${{ matrix.TILEDBSOMA_EXISTS }}"
     strategy:
       fail-fast: false
@@ -259,7 +259,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-24.04", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -364,7 +364,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-24.04", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -70,7 +70,7 @@ jobs:
       run: echo "inputs.os:" ${{ inputs.os }}
 
     - name: Linux CPU info
-      if: ${{ inputs.os == 'ubuntu-latest' }}
+      if: ${{ inputs.os == 'ubuntu-24.04' }}
       run: cat /proc/cpuinfo
 
     - name: MacOS CPU info

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -129,8 +129,8 @@ jobs:
           - wheel-name: manylinux2014
             os: ubuntu-latest
             arch: x86_64
-            cc: gcc-11
-            cxx: g++-11
+            cc: gcc-13
+            cxx: g++-13
           - wheel-name: macos-x86_64
             os: macos-13
             arch: x86_64

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
         include:
           - cibw_build: manylinux_x86_64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             wheel-name: manylinux2014
           - cibw_build: macosx_x86_64
             os: macos-latest
@@ -127,7 +127,7 @@ jobs:
           - macos-arm64
         include:
           - wheel-name: manylinux2014
-            os: ubuntu-latest
+            os: ubuntu-24.04
             arch: x86_64
             cc: gcc-13
             cxx: g++-13
@@ -166,7 +166,7 @@ jobs:
         run: python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.__file__); tiledbsoma.show_package_versions()'
         # TODO: more thorough local smoke test
       - name: Smoke test in docker
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           docker run -v $(pwd):/mnt python:${{ matrix.python.dotted-version }} bash -ec "
             apt-get -qq update && apt-get install -y python3-pip python3-wheel
@@ -178,7 +178,7 @@ jobs:
   publish-to-test-pypi:
     name: Publish package to TestPyPI
     needs: smoke-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Download artifacts
@@ -202,7 +202,7 @@ jobs:
   publish-to-pypi:
     name: Publish package to PyPI
     needs: smoke-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release'
     steps:
       - name: Download artifacts
@@ -223,7 +223,7 @@ jobs:
   # File a bug report if anything fails, but don't file tickets for manual runs
   # -- only for scheduled ones.
   create_issue_on_fail:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
     if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
     steps:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -137,7 +137,7 @@ jobs:
             cc: gcc-13
             cxx: g++-13
           - wheel-name: macos-x86_64
-            os: macos-13
+            os: macos-latest
             arch: x86_64
             cc: clang
             cxx: clang++

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -84,6 +84,11 @@ jobs:
           pip install setuptools
           python -c 'from distutils import util; print("distutil.util.get_platform:", util.get_platform())'
           python -c 'import platform; print("platform.platform()", platform.platform())'
+      - name: Select XCode version
+        if: startsWith(matrix.os, 'macos')
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1
         with:

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -32,13 +32,13 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
             covr: 'no'
           - name: macos
             os: macOS-latest
             covr: 'no'
           - name: coverage
-            os: ubuntu-latest
+            os: ubuntu-24.04
             covr: 'yes'
 
     runs-on: ${{ matrix.os }}
@@ -50,7 +50,7 @@ jobs:
         run: echo "matrix.os:" ${{ matrix.os }}
 
       - name: Linux CPU info
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: cat /proc/cpuinfo
 
       - name: MacOS CPU info
@@ -105,7 +105,7 @@ jobs:
       #  run: sudo scripts/bld --prefix=/usr/local
 
       #- name: Call ldconfig
-      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  if: ${{ matrix.os == 'ubuntu-24.04' }}
       #  run: sudo ldconfig
       #
       # - name: Update Packages
@@ -136,7 +136,7 @@ jobs:
         run: cd apis/r/tests && Rscript testthat.R
 
       - name: Coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.covr == 'yes' && github.event_name == 'workflow_dispatch' }}
         run: apis/r/tools/r-ci.sh coverage
 
       - name: View Logs

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-latest }
+          - { os: ubuntu-24.04 }
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   r-valgrind:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: rocker/r2u:latest
     steps:

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -320,7 +320,7 @@ setuptools.setup(
             library_dirs=LIB_DIRS,
             libraries=["tiledbsoma"] + (["tiledb"] if os.name == "nt" else []),
             extra_link_args=CXX_FLAGS,
-            extra_compile_args=["-std=c++17" if os.name != "nt" else "/std:c++17"]
+            extra_compile_args=["-std=c++20" if os.name != "nt" else "/std:c++20"]
             + CXX_FLAGS,
             language="c++",
         )

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -49,7 +49,7 @@ Imports:
     nanoarrow
 LinkingTo:
     Rcpp,
-    RcppSpdlog,
+    RcppSpdlog (>= 0.0.19),
     RcppInt64,
     nanoarrow
 Additional_repositories: https://ghrr.github.io/drat

--- a/apis/r/configure
+++ b/apis/r/configure
@@ -54,7 +54,7 @@ tools/build_libtiledbsoma.sh
 pkgincl="-I../inst/tiledb/include -I../inst/tiledbsoma/include -I../inst/tiledbsoma/include/tiledbsoma"
 pkglibs="-ltiledb -L../inst/tiledb/lib -ltiledbsoma -L../inst/tiledbsoma/lib"
 rpath="-Wl,-rpath,'\$\$ORIGIN/../tiledb/lib' -Wl,-rpath,'\$\$ORIGIN/../tiledbsoma/lib'"
-macosver=`${R_HOME}/bin/Rscript -e 'if (Sys.info()["sysname"] == "Darwin") cat("-mmacosx-version-min=11.0") else cat("")'`
+macosver=`${R_HOME}/bin/Rscript -e 'if (Sys.info()["sysname"] == "Darwin") cat("-mmacosx-version-min=13.3") else cat("")'`
 
 sed -e "s|@tiledb_include@|$pkgincl |" \
     -e "s|@tiledb_libs@|$pkglibs|" \

--- a/apis/r/configure
+++ b/apis/r/configure
@@ -18,11 +18,11 @@ if [ $? -eq 0 ]; then
         pkgcflags=`pkg-config --cflags tiledb tiledbsoma`
         pkglibs=`pkg-config --libs tiledb tiledbsoma`
 
-        ## substitute them in (leaving @tiledb_rpath@ and @cxx17_macos@ alone for now)
+        ## substitute them in (leaving @tiledb_rpath@ and @cxx20_macos@ alone for now)
         sed -e "s|@tiledb_include@|$pkgcflags |" \
             -e "s|@tiledb_libs@|$pkglibs|" \
             -e "s|@tiledb_rpath@||" \
-            -e "s|@cxx17_macos@||" \
+            -e "s|@cxx20_macos@||" \
             src/Makevars.in > src/Makevars
 
         echo "** updated src/Makevars for system library via pkg-config"
@@ -59,5 +59,5 @@ macosver=`${R_HOME}/bin/Rscript -e 'if (Sys.info()["sysname"] == "Darwin") cat("
 sed -e "s|@tiledb_include@|$pkgincl |" \
     -e "s|@tiledb_libs@|$pkglibs|" \
     -e "s|@tiledb_rpath@|$rpath|" \
-    -e "s|@cxx17_macos@|$macosver|" \
+    -e "s|@cxx20_macos@|$macosver|" \
     src/Makevars.in > src/Makevars

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -1,10 +1,10 @@
-CXX_STD = CXX17
+CXX_STD = CXX20
 
 ## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 10.14 for macOS
-PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx17_macos@
+PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx20_macos@ -D SPDLOG_USE_STD_FORMAT
 
 ## We also need the TileDB library
-PKG_LIBS = @cxx17_macos@ @tiledb_libs@ @tiledb_rpath@
+PKG_LIBS = @cxx20_macos@ @tiledb_libs@ @tiledb_rpath@
 
 all: $(SHLIB)
         # On macOS aka Darwin we call install_name_tool

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -81,8 +81,8 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif()
 
-# Set C++17 as required standard for all C++ targets (C++17 minimum is required to use the TileDB C++ API).
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 as required standard for all C++ targets (C++17 minimum is required to use the TileDB C++ API).
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Don't use GNU extensions
 

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -34,6 +34,7 @@
 #include "soma/soma_array.h"
 #include "utils/arrow_adapter.h"
 #include "utils/logger.h"
+#include <format>
 
 using namespace tiledbsoma;
 
@@ -77,8 +78,8 @@ void test_sdf(const std::string& uri) {
         total_num_rows += (*batch)->num_rows();
     }
 
-    LOG_INFO(fmt::format("X/data rows = {}", total_num_rows));
-    LOG_INFO(fmt::format("  batches = {}", batches));
+    LOG_INFO(std::format("X/data rows = {}", total_num_rows));
+    LOG_INFO(std::format("  batches = {}", batches));
 }
 
 namespace tdbs = tiledbsoma;
@@ -89,10 +90,10 @@ void test_arrow(const std::string& uri) {
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto obs_data = obs->read_next();
     if (!obs->results_complete()) {
-        tdbs::LOG_WARN(fmt::format("Read of '{}' incomplete", uri));
+        tdbs::LOG_WARN(std::format("Read of '{}' incomplete", uri));
         exit(-1);
     }
-    tdbs::LOG_INFO(fmt::format(
+    tdbs::LOG_INFO(std::format(
         "Read complete with {} obs and {} cols",
         obs_data->get()->num_rows(),
         obs_data->get()->names().size()));
@@ -101,7 +102,7 @@ void test_arrow(const std::string& uri) {
         auto buf = obs_data->get()->at(nm);
         auto pp = tdbs::ArrowAdapter::to_arrow(buf);
         ArrowSchema* schema = pp.second.get();
-        tdbs::LOG_INFO(fmt::format(
+        tdbs::LOG_INFO(std::format(
             "Accessing '{}', retrieved '{}', n_children {}",
             nm,
             schema->name,

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -30,11 +30,11 @@
  * This file is currently a sandbox for C++ API experiments
  */
 
+#include <format>
 #include "soma/enums.h"
 #include "soma/soma_array.h"
 #include "utils/arrow_adapter.h"
 #include "utils/logger.h"
-#include <format>
 
 using namespace tiledbsoma;
 

--- a/libtiledbsoma/src/reindexer/reindexer.cc
+++ b/libtiledbsoma/src/reindexer/reindexer.cc
@@ -60,7 +60,7 @@ void IntIndexer::map_locations(const int64_t* keys, size_t size) {
     int64_t counter = 0;
     // Hash map construction
     LOG_DEBUG(
-        fmt::format("[Re-indexer] Start of Map locations with {} keys", size));
+        std::format("[Re-indexer] Start of Map locations with {} keys", size));
     for (size_t i = 0; i < size; i++) {
         k = kh_put(m64, hash_, keys[i], &ret);
         assert(k != kh_end(hash_));
@@ -71,10 +71,10 @@ void IntIndexer::map_locations(const int64_t* keys, size_t size) {
         throw std::runtime_error("There are duplicate keys.");
     }
     auto hsize = kh_size(hash_);
-    LOG_DEBUG(fmt::format("[Re-indexer] khash size = {}", hsize));
+    LOG_DEBUG(std::format("[Re-indexer] khash size = {}", hsize));
 
     LOG_DEBUG(
-        fmt::format("[Re-indexer] Thread pool started and hash table created"));
+        std::format("[Re-indexer] Thread pool started and hash table created"));
 }
 
 void IntIndexer::lookup(const int64_t* keys, int64_t* results, size_t size) {
@@ -95,7 +95,7 @@ void IntIndexer::lookup(const int64_t* keys, int64_t* results, size_t size) {
         }
         return;
     }
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "Lookup with thread concurrency {} on data size {}",
         context_->thread_pool()->concurrency_level(),
         size));
@@ -114,7 +114,7 @@ void IntIndexer::lookup(const int64_t* keys, int64_t* results, size_t size) {
         if (end > size) {
             end = size;
         }
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "Creating tileDB task for the range from {} to {} ", start, end));
         tiledbsoma::ThreadPool::Task task = context_->thread_pool()->execute(
             [this, start, end, &results, &keys]() {
@@ -131,7 +131,7 @@ void IntIndexer::lookup(const int64_t* keys, int64_t* results, size_t size) {
             });
         assert(task.valid());
         tasks.emplace_back(std::move(task));
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "Task for the range from {} to {} inserted in the queue",
             start,
             end));

--- a/libtiledbsoma/src/soma/array_buffers.cc
+++ b/libtiledbsoma/src/soma/array_buffers.cc
@@ -33,6 +33,8 @@
 #include "array_buffers.h"
 #include "../utils/logger.h"
 
+#include <format>
+
 namespace tiledbsoma {
 
 using namespace tiledb;
@@ -40,7 +42,7 @@ using namespace tiledb;
 std::shared_ptr<ColumnBuffer> ArrayBuffers::at(const std::string& name) {
     if (!contains(name)) {
         throw TileDBSOMAError(
-            fmt::format("[ArrayBuffers] column '{}' does not exist", name));
+            std::format("[ArrayBuffers] column '{}' does not exist", name));
     }
     return buffers_[name];
 }
@@ -49,7 +51,7 @@ void ArrayBuffers::emplace(
     const std::string& name, std::shared_ptr<ColumnBuffer> buffer) {
     if (contains(name)) {
         throw TileDBSOMAError(
-            fmt::format("[ArrayBuffers] column '{}' already exists", name));
+            std::format("[ArrayBuffers] column '{}' already exists", name));
     }
     names_.push_back(name);
     buffers_.emplace(name, buffer);

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -33,6 +33,8 @@
 #include "column_buffer.h"
 #include "../utils/logger.h"
 
+#include <format>
+
 namespace tiledbsoma {
 
 using namespace tiledb;
@@ -141,7 +143,7 @@ ColumnBuffer::ColumnBuffer(
     , is_nullable_(is_nullable)
     , enumeration_(enumeration)
     , is_ordered_(is_ordered) {
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "[ColumnBuffer] '{}' {} bytes is_var={} is_nullable={}",
         name,
         num_bytes,
@@ -160,7 +162,7 @@ ColumnBuffer::ColumnBuffer(
 }
 
 ColumnBuffer::~ColumnBuffer() {
-    LOG_TRACE(fmt::format("[ColumnBuffer] release '{}'", name_));
+    LOG_TRACE(std::format("[ColumnBuffer] release '{}'", name_));
 }
 
 void ColumnBuffer::attach(Query& query, std::optional<Subarray> subarray) {
@@ -299,7 +301,7 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
         try {
             num_bytes = std::stoull(value_str);
         } catch (const std::exception& e) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "[ColumnBuffer] Error parsing {}: '{}' ({})",
                 CONFIG_KEY_INIT_BYTES,
                 value_str,

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -34,11 +34,11 @@
 
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>
+#include <format>
 #include "soma_array.h"
 #include "utils/common.h"
 #include "utils/logger.h"
 #include "utils/util.h"
-#include <format>
 namespace tiledbsoma {
 
 using namespace tiledb;

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -38,6 +38,7 @@
 #include "utils/common.h"
 #include "utils/logger.h"
 #include "utils/util.h"
+#include <format>
 namespace tiledbsoma {
 
 using namespace tiledb;
@@ -100,7 +101,7 @@ void ManagedQuery::set_layout(ResultOrder layout) {
             query_->set_layout(TILEDB_COL_MAJOR);
             break;
         default:
-            throw std::invalid_argument(fmt::format(
+            throw std::invalid_argument(std::format(
                 "[ManagedQuery] invalid ResultOrder({}) passed",
                 static_cast<int>(layout)));
     }
@@ -118,7 +119,7 @@ void ManagedQuery::select_columns(
         // Name is not an attribute or dimension.
         if (!schema_->has_attribute(name) &&
             !schema_->domain().has_dimension(name)) {
-            LOG_WARN(fmt::format(
+            LOG_WARN(std::format(
                 "[TileDB-SOMA::ManagedQuery] [{}] Invalid column selected: {}",
                 name_,
                 name));
@@ -163,7 +164,7 @@ void ManagedQuery::setup_read() {
     LOG_TRACE("[ManagedQuery] allocate new buffers");
     buffers_ = std::make_shared<ArrayBuffers>();
     for (auto& name : columns_) {
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ManagedQuery] [{}] Adding buffer for column '{}'", name_, name));
         buffers_->emplace(name, ColumnBuffer::create(array_, name));
         buffers_->at(name)->attach(*query_);
@@ -271,7 +272,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_without_new_shape(bool is_read) {
     }
 
     subarray_->add_range(0, array_shape.first, array_shape.second);
-    LOG_TRACE(fmt::format(
+    LOG_TRACE(std::format(
         "[ManagedQuery] Add full range to dense subarray dim0 = ({}, {})",
         array_shape.first,
         array_shape.second));
@@ -295,7 +296,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
     for (const auto& dim : schema.domain().dimensions()) {
         std::string dim_name = dim.name();
         if (subarray_range_set_[dim_name]) {
-            LOG_TRACE(fmt::format(
+            LOG_TRACE(std::format(
                 "[ManagedQuery] _fill_in_subarrays continue {}", dim_name));
             continue;
         }
@@ -304,11 +305,11 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
         // Per the spec DenseNDArray must only have dims named
         // soma_dim_{i} with i=0,1,2,...,n-1, of type int64.
         if (dim_name.rfind("soma_dim_", 0) != 0) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "found dense array with unexpected dim name {}", dim_name));
         }
         if (dim.type() != TILEDB_INT64) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "expected dense arrays to have int64 dims; got {} for {}",
                 tiledb::impl::to_str(dim.type()),
                 dim_name));
@@ -320,7 +321,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
         int64_t lo = cd_lo;
         int64_t hi = cd_hi;
 
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
             "name {} current domain ({}, {})",
             dim_name,
@@ -344,14 +345,14 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
                 &ned,
                 &is_empty));
             if (is_empty == 1) {
-                LOG_TRACE(fmt::format(
+                LOG_TRACE(std::format(
                     "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape "
                     "dim name {} non-empty domain is absent",
                     dim_name));
             } else {
                 int64_t ned_lo = ned[0];
                 int64_t ned_hi = ned[1];
-                LOG_TRACE(fmt::format(
+                LOG_TRACE(std::format(
                     "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape "
                     "dim name {} non-empty domain ({}, {})",
                     dim_name,
@@ -366,7 +367,7 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(
             }
         }
 
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
             "name {} select ({}, {})",
             dim_name,
@@ -384,14 +385,14 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
     }
 
     if (query_future_.valid()) {
-        LOG_DEBUG(fmt::format("[ManagedQuery] [{}] Waiting for query", name_));
+        LOG_DEBUG(std::format("[ManagedQuery] [{}] Waiting for query", name_));
         query_future_.wait();
         LOG_DEBUG(
-            fmt::format("[ManagedQuery] [{}] Done waiting for query", name_));
+            std::format("[ManagedQuery] [{}] Done waiting for query", name_));
 
         auto retval = query_future_.get();
         if (!retval.succeeded()) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "[ManagedQuery] [{}] Query FAILED: {}",
                 name_,
                 retval.message()));
@@ -399,14 +400,14 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
 
     } else {
         throw TileDBSOMAError(
-            fmt::format("[ManagedQuery] [{}] 'query_future_' invalid", name_));
+            std::format("[ManagedQuery] [{}] 'query_future_' invalid", name_));
     }
 
     auto status = query_->query_status();
 
     if (status == Query::Status::FAILED) {
         throw TileDBSOMAError(
-            fmt::format("[ManagedQuery] [{}] Query FAILED", name_));
+            std::format("[ManagedQuery] [{}] Query FAILED", name_));
     }
 
     // If the query was ever incomplete, the result buffers contents are not
@@ -421,7 +422,7 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
     size_t num_cells = 0;
     for (auto& name : buffers_->names()) {
         num_cells = buffers_->at(name)->update_size(*query_);
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ManagedQuery] [{}] Buffer {} cells={}", name_, name, num_cells));
     }
     total_num_cells_ += num_cells;
@@ -429,7 +430,7 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
     // TODO: retry the query with larger buffers
     if (status == Query::Status::INCOMPLETE && !num_cells) {
         throw TileDBSOMAError(
-            fmt::format("[ManagedQuery] [{}] Buffers are too small.", name_));
+            std::format("[ManagedQuery] [{}] Buffers are too small.", name_));
     }
 
     // Visit all attributes and retrieve enumeration vectors
@@ -448,7 +449,7 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
             }
             auto colbuf = buffers_->at(attrname);
             colbuf->add_enumeration(enumvec);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ManagedQuery] got Enumeration '{}' for attribute '{}'",
                 enumname.value(),
                 attrname));
@@ -459,7 +460,7 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
 
 void ManagedQuery::check_column_name(const std::string& name) {
     if (!buffers_->contains(name)) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "[ManagedQuery] Column '{}' is not available in the query "
             "results.",
             name));
@@ -594,7 +595,7 @@ bool ManagedQuery::_cast_column(
         case TILEDB_FLOAT64:
             return _cast_column_aux<double>(schema, array, se);
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "Saw invalid TileDB user type when attempting to cast table: "
                 "{}",
                 tiledb::impl::type_to_str(user_type)));
@@ -660,7 +661,7 @@ void ManagedQuery::_promote_indexes_to_values(
         case TILEDB_FLOAT64:
             return _cast_dictionary_values<double>(schema, array);
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "Saw invalid TileDB value type when attempting to promote "
                 "indexes to values: {}",
                 tiledb::impl::type_to_str(value_type)));
@@ -956,7 +957,7 @@ bool ManagedQuery::_extend_enumeration(
             return _extend_and_evolve_schema<double>(
                 value_schema, value_array, index_schema, index_array, se);
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
                 tiledb::impl::type_to_str(value_type)));
     }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -33,6 +33,9 @@
 #include <tiledb/array_experimental.h>
 #include "../utils/logger.h"
 #include "../utils/util.h"
+
+#include <format>
+
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -86,7 +89,7 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
     LOG_DEBUG(
-        fmt::format("[SOMAArray] static method 'cfg' opening array '{}'", uri));
+        std::format("[SOMAArray] static method 'cfg' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
         mode,
         uri,
@@ -108,7 +111,7 @@ std::unique_ptr<SOMAArray> SOMAArray::open(
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
     LOG_DEBUG(
-        fmt::format("[SOMAArray] static method 'ctx' opening array '{}'", uri));
+        std::format("[SOMAArray] static method 'ctx' opening array '{}'", uri));
     return std::make_unique<SOMAArray>(
         mode,
         uri,
@@ -417,7 +420,7 @@ void SOMAArray::validate(
     auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
 
     try {
-        LOG_DEBUG(fmt::format("[SOMAArray] opening array '{}'", uri_));
+        LOG_DEBUG(std::format("[SOMAArray] opening array '{}'", uri_));
         if (timestamp) {
             arr_ = std::make_shared<Array>(
                 *ctx_->tiledb_ctx(),
@@ -428,14 +431,14 @@ void SOMAArray::validate(
         } else {
             arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, tdb_mode);
         }
-        LOG_TRACE(fmt::format("[SOMAArray] loading enumerations"));
+        LOG_TRACE(std::format("[SOMAArray] loading enumerations"));
         ArrayExperimental::load_all_enumerations(
             *ctx_->tiledb_ctx(), *(arr_.get()));
         schema_ = std::make_shared<ArraySchema>(arr_->schema());
         mq_ = std::make_unique<ManagedQuery>(arr_, ctx_->tiledb_ctx(), name);
     } catch (const std::exception& e) {
         throw TileDBSOMAError(
-            fmt::format("Error opening array: '{}'\n  {}", uri_, e.what()));
+            std::format("Error opening array: '{}'\n  {}", uri_, e.what()));
     }
 }
 
@@ -551,7 +554,7 @@ ArrowTable SOMAArray::_get_core_domainish(enum Domainish which_kind) {
                 break;
 
             default:
-                throw TileDBSOMAError(fmt::format(
+                throw TileDBSOMAError(std::format(
                     "SOMAArray::_get_core_domainish:dim {} has unhandled type "
                     "{}",
                     core_dim.name(),
@@ -574,7 +577,7 @@ uint64_t SOMAArray::nnz() {
     FragmentInfo fragment_info(*ctx_->tiledb_ctx(), uri_);
     fragment_info.load();
 
-    LOG_DEBUG(fmt::format("[SOMAArray] Fragment info for array '{}'", uri_));
+    LOG_DEBUG(std::format("[SOMAArray] Fragment info for array '{}'", uri_));
     if (LOG_DEBUG_ENABLED()) {
         fragment_info.dump();
     }
@@ -638,7 +641,7 @@ uint64_t SOMAArray::nnz() {
     auto type_code = dim.type();
     if ((dim_name != "soma_joinid" && dim_name != "soma_dim_0") ||
         type_code != TILEDB_INT64) {
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[SOMAArray::nnz] dim 0 (type={} name={}) isn't int64 "
             "soma_joinid or int64 soma_dim_0: using _nnz_slow",
             tiledb::impl::type_to_str(type_code),
@@ -655,7 +658,7 @@ uint64_t SOMAArray::nnz() {
         fragment_info.get_non_empty_domain(
             relevant_fragments[i], 0, &non_empty_domains[i]);
 
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[SOMAArray] fragment {} non-empty domain = [{}, {}]",
             i,
             non_empty_domains[i][0],
@@ -669,7 +672,7 @@ uint64_t SOMAArray::nnz() {
     // the next non-empty domain, there is an overlap
     bool overlap = false;
     for (uint32_t i = 0; i < fragment_count - 1; i++) {
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[SOMAArray] Checking {} < {}",
             non_empty_domains[i][1],
             non_empty_domains[i + 1][0]));
@@ -738,7 +741,7 @@ StatusAndReason SOMAArray::_can_set_shape_helper(
     if (array_ndim != arg_ndim) {
         return std::pair(
             false,
-            fmt::format(
+            std::format(
                 "{}: provided shape has ndim {}, while the array has {}",
                 function_name_for_messages,
                 arg_ndim,
@@ -755,7 +758,7 @@ StatusAndReason SOMAArray::_can_set_shape_helper(
         if (!has_shape) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: array currently has no shape: please "
                     "upgrade the array.",
                     function_name_for_messages));
@@ -766,7 +769,7 @@ StatusAndReason SOMAArray::_can_set_shape_helper(
         if (has_shape) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: array already has a shape: please use resize",
                     function_name_for_messages));
         }
@@ -820,7 +823,7 @@ StatusAndReason SOMAArray::_can_set_shape_domainish_subhelper(
         // multi-type dims, need to go through upgrade_domain -- and this is
         // library-internal code, it's not the user's fault if we got here.
         if (dim.type() != TILEDB_INT64) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{}: internal error: expected {} dim to be {}; got {}",
                 function_name_for_messages,
                 dim_name,
@@ -836,7 +839,7 @@ StatusAndReason SOMAArray::_can_set_shape_domainish_subhelper(
             if (newshape[i] < old_dim_shape) {
                 return std::pair(
                     false,
-                    fmt::format(
+                    std::format(
                         "{} for {}: new {} < existing shape {}",
                         function_name_for_messages,
                         dim_name,
@@ -852,7 +855,7 @@ StatusAndReason SOMAArray::_can_set_shape_domainish_subhelper(
             if (newshape[i] > old_dim_shape) {
                 return std::pair(
                     false,
-                    fmt::format(
+                    std::format(
                         "{} for {}: new {} < maxshape {}",
                         function_name_for_messages,
                         dim_name,
@@ -875,7 +878,7 @@ StatusAndReason SOMAArray::_can_set_soma_joinid_shape_helper(
         if (has_current_domain()) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: dataframe already has its domain set.",
                     function_name_for_messages));
         }
@@ -886,7 +889,7 @@ StatusAndReason SOMAArray::_can_set_soma_joinid_shape_helper(
         if (!has_current_domain()) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: dataframe currently has no domain set.",
                     function_name_for_messages));
         }
@@ -904,7 +907,7 @@ StatusAndReason SOMAArray::_can_set_soma_joinid_shape_helper(
         if (newshape < cur_dom_lo_hi.second) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: new soma_joinid shape {} < existing shape {}",
                     function_name_for_messages,
                     newshape,
@@ -917,7 +920,7 @@ StatusAndReason SOMAArray::_can_set_soma_joinid_shape_helper(
     if (newshape > dom_lo_hi.second) {
         return std::pair(
             false,
-            fmt::format(
+            std::format(
                 "{}: new soma_joinid shape {} > maxshape {}",
                 function_name_for_messages,
                 newshape,
@@ -933,7 +936,7 @@ void SOMAArray::_set_shape_helper(
     bool must_already_have,
     std::string function_name_for_messages) {
     if (arr_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "{} array must be opened in write mode",
             function_name_for_messages));
     }
@@ -941,14 +944,14 @@ void SOMAArray::_set_shape_helper(
     if (!must_already_have) {
         // Upgrading an array to install a current domain
         if (!_get_current_domain().is_empty()) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{}: array must not already have a shape: please upgrade it",
                 function_name_for_messages));
         }
     } else {
         // Expanding an array's current domain
         if (_get_current_domain().is_empty()) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{} array must already have a shape: please upgrade it",
                 function_name_for_messages));
         }
@@ -967,7 +970,7 @@ void SOMAArray::_set_shape_helper(
 
     unsigned n = domain.ndim();
     if ((unsigned)newshape.size() != n) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "[SOMAArray::resize]: newshape has dimension count {}; array has "
             "{} ",
             newshape.size(),
@@ -989,7 +992,7 @@ void SOMAArray::_set_soma_joinid_shape_helper(
     bool must_already_have,
     std::string function_name_for_messages) {
     if (arr_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "{}: array must be opened in write mode",
             function_name_for_messages));
     }
@@ -997,14 +1000,14 @@ void SOMAArray::_set_soma_joinid_shape_helper(
     if (!must_already_have) {
         // Upgrading an array to install a current domain
         if (!_get_current_domain().is_empty()) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{}: array must not already have a shape",
                 function_name_for_messages));
         }
     } else {
         // Expanding an array's current domain
         if (_get_current_domain().is_empty()) {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{} array must already have a shape",
                 function_name_for_messages));
         }
@@ -1028,7 +1031,7 @@ void SOMAArray::_set_soma_joinid_shape_helper(
             const std::string dim_name = dim.name();
             if (dim_name == "soma_joinid") {
                 if (dim.type() != TILEDB_INT64) {
-                    throw TileDBSOMAError(fmt::format(
+                    throw TileDBSOMAError(std::format(
                         "{}: expected soma_joinid to be of type {}; got {}",
                         function_name_for_messages,
                         tiledb::impl::type_to_str(TILEDB_INT64),
@@ -1132,7 +1135,7 @@ void SOMAArray::_set_soma_joinid_shape_helper(
                             dim.domain<double>().second);
                         break;
                     default:
-                        throw TileDBSOMAError(fmt::format(
+                        throw TileDBSOMAError(std::format(
                             "{}: internal error: unhandled type {} for {}.",
                             function_name_for_messages,
                             tiledb::impl::type_to_str(dim.type()),
@@ -1176,7 +1179,7 @@ StatusAndReason SOMAArray::_can_set_domain_helper(
         if (!has_current_domain()) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: dataframe does not have a domain: please upgrade it",
                     function_name_for_messages));
         }
@@ -1184,7 +1187,7 @@ StatusAndReason SOMAArray::_can_set_domain_helper(
         if (has_current_domain()) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{}: dataframe already has a domain",
                     function_name_for_messages));
         }
@@ -1237,7 +1240,7 @@ StatusAndReason SOMAArray::_can_set_dataframe_domainish_subhelper(
     if (new_domain_schema->n_children != domain.ndim()) {
         return std::pair(
             false,
-            fmt::format(
+            std::format(
                 "{}: requested domain has ndim={} but the dataframe has "
                 "ndim={}",
                 function_name_for_messages,
@@ -1248,7 +1251,7 @@ StatusAndReason SOMAArray::_can_set_dataframe_domainish_subhelper(
     if (new_domain_schema->n_children != new_domain_array->n_children) {
         return std::pair(
             false,
-            fmt::format(
+            std::format(
                 "{}: internal coding error", function_name_for_messages));
     }
 
@@ -1343,7 +1346,7 @@ StatusAndReason SOMAArray::_can_set_dataframe_domainish_subhelper(
                         double>(check_current_domain, newdomain, dim.name());
                 break;
             default:
-                throw TileDBSOMAError(fmt::format(
+                throw TileDBSOMAError(std::format(
                     "{}: saw invalid TileDB type when attempting to cast "
                     "domain information: {}",
                     function_name_for_messages,
@@ -1353,7 +1356,7 @@ StatusAndReason SOMAArray::_can_set_dataframe_domainish_subhelper(
         if (status_and_reason.first == false) {
             return std::pair(
                 false,
-                fmt::format(
+                std::format(
                     "{} for {}: {}",
                     function_name_for_messages,
                     dim.name(),
@@ -1368,22 +1371,22 @@ void SOMAArray::_set_domain_helper(
     bool must_already_have,
     std::string function_name_for_messages) {
     if (arr_->query_type() != TILEDB_WRITE) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "{}: array must be opened in write mode",
             function_name_for_messages));
     }
 
     if (must_already_have) {
         if (!has_current_domain()) {
-            throw TileDBSOMAError(fmt::format(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{}: dataframe does not have a domain: please upgrade it",
-                function_name_for_messages)));
+                function_name_for_messages));
         }
     } else {
         if (has_current_domain()) {
-            throw TileDBSOMAError(fmt::format(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "{}: dataframe already has a domain",
-                function_name_for_messages)));
+                function_name_for_messages));
         }
     }
 
@@ -1393,17 +1396,17 @@ void SOMAArray::_set_domain_helper(
     ArrowSchema* new_domain_schema = newdomain.second.get();
 
     if (new_domain_schema->n_children != domain.ndim()) {
-        throw TileDBSOMAError(fmt::format(fmt::format(
+        throw TileDBSOMAError(std::format(
             "{}: requested domain has ndim={} but the dataframe has "
             "ndim={}",
             function_name_for_messages,
             new_domain_schema->n_children,
-            domain.ndim())));
+            domain.ndim()));
     }
 
     if (new_domain_schema->n_children != new_domain_array->n_children) {
-        throw TileDBSOMAError(fmt::format(fmt::format(
-            "{}: internal coding error", function_name_for_messages)));
+        throw TileDBSOMAError(std::format(
+            "{}: internal coding error", function_name_for_messages));
     }
 
     auto tctx = ctx_->tiledb_ctx();
@@ -1427,10 +1430,12 @@ void SOMAArray::_set_domain_helper(
                     // Don't care -> as big as possible
                     ndrect.set_range(dim_name, "", "\xff");
                 } else {
-                    throw TileDBSOMAError(
-                        fmt::format("domain (\"{}\", \"{}\") cannot be set for "
-                                    "string index columns: please use "
-                                    "(\"\", \"\")"));
+                    throw TileDBSOMAError(std::format(
+                        "domain (\"{}\", \"{}\") cannot be set for "
+                        "string index columns: please use "
+                        "(\"\", \"\")",
+                        lo_hi[0],
+                        lo_hi[1]));
                 }
             } break;
 
@@ -1508,7 +1513,7 @@ void SOMAArray::_set_domain_helper(
                 ndrect.set_range<double>(dim_name, lo_hi[0], lo_hi[1]);
             } break;
             default:
-                throw TileDBSOMAError(fmt::format(
+                throw TileDBSOMAError(std::format(
                     "{}: internal error: unhandled type {} for {}.",
                     function_name_for_messages,
                     tiledb::impl::type_to_str(dim.type()),
@@ -1599,7 +1604,7 @@ std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_current_domain() {
 
     auto dim = dom.dimension(dim_name);
     if (dim.type() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "expected {} dim to be {}; got {}",
             dim_name,
             tiledb::impl::type_to_str(TILEDB_INT64),
@@ -1621,7 +1626,7 @@ std::optional<int64_t> SOMAArray::_maybe_soma_joinid_tiledb_domain() {
 
     auto dim = dom.dimension(dim_name);
     if (dim.type() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "expected {} dim to be {}; got {}",
             dim_name,
             tiledb::impl::type_to_str(TILEDB_INT64),

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -35,8 +35,8 @@
 
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 
-#include <future>
 #include <format>
+#include <future>
 
 #include <tiledb/tiledb>
 #include <tiledb/tiledb_experimental>

--- a/libtiledbsoma/src/soma/soma_context.cc
+++ b/libtiledbsoma/src/soma/soma_context.cc
@@ -33,7 +33,7 @@
 
 #include <thread_pool/thread_pool.h>
 #include "../utils/common.h"
-#include "../utils/logger.h"  // for fmt::
+#include "../utils/logger.h"
 #include "soma_context.h"
 
 namespace tiledbsoma {
@@ -49,7 +49,7 @@ std::shared_ptr<ThreadPool>& SOMAContext::thread_pool() {
             try {
                 concurrency = std::stoull(value_str);
             } catch (const std::exception& e) {
-                throw TileDBSOMAError(fmt::format(
+                throw TileDBSOMAError(std::format(
                     "[SOMAContext] Error parsing {}: '{}' ({}) - must be a "
                     "postive integer.",
                     CONFIG_KEY_COMPUTE_CONCURRENCY_LEVEL,

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -95,7 +95,7 @@ void SOMADataFrame::update_dataframe_schema(
     std::map<std::string, std::pair<std::string, bool>> add_enmrs) {
     ArraySchemaEvolution se(*ctx->tiledb_ctx());
     for (auto key_name : drop_attrs) {
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[SOMADataFrame::update_dataframe_schema] drop col name {}",
             key_name));
         se.drop_attribute(key_name);
@@ -158,7 +158,7 @@ void SOMADataFrame::update_dataframe_schema(
 
         if (has_enmr) {
             auto [enmr_type, ordered] = enmr_it->second;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[SOMADataFrame::update_dataframe_schema] add col name {} "
                 "index_type "
                 "{} value_type {} ordered {}",
@@ -178,7 +178,7 @@ void SOMADataFrame::update_dataframe_schema(
             AttributeExperimental::set_enumeration_name(
                 *ctx->tiledb_ctx(), attr, attr_name);
         } else {
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[SOMADataFrame::update_dataframe_schema] add col name {} type "
                 "{}",
                 attr_name,

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1405,7 +1405,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     array->release = &release_array;
     if (array->private_data != nullptr) {  // as we use nanoarrow's init
         free(array->private_data);         // free what was allocated before
-    }                                      // assigning our ArrowBuffer pointer
+    }  // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(std::format(

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -42,17 +42,17 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
     std::string name_for_log(
         schema->name == nullptr ? "anonymous" : schema->name);
     if (schema->name != nullptr)
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ArrowAdapter] release_schema start for {}", schema->name));
 
     if (schema->name != nullptr) {
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema schema->name {}", schema->name));
         free((void*)schema->name);
         schema->name = nullptr;
     }
     if (schema->format != nullptr) {
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema name {} schema->format {}",
             name_for_log,
             schema->format));
@@ -60,7 +60,7 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
         schema->format = nullptr;
     }
     if (schema->metadata != nullptr) {
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema name {} schema->metadata",
             name_for_log));
         free((void*)schema->metadata);
@@ -68,7 +68,7 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
     }
 
     if (schema->children != nullptr) {
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema name {} n_children {} begin "
             "recurse ",
             name_for_log,
@@ -77,7 +77,7 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
         for (auto i = 0; i < schema->n_children; i++) {
             if (schema->children[i] != nullptr) {
                 if (schema->children[i]->release != nullptr) {
-                    LOG_TRACE(fmt::format(
+                    LOG_TRACE(std::format(
                         "[ArrowAdapter] release_schema name {} schema->child "
                         "{} "
                         "release",
@@ -85,7 +85,7 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
                         i));
                     release_schema(schema->children[i]);
                 }
-                LOG_TRACE(fmt::format(
+                LOG_TRACE(std::format(
                     "[ArrowAdapter] release_schema name {} schema->child {} "
                     "free",
                     name_for_log,
@@ -95,7 +95,7 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
             }
         }
 
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema name {} n_children {} end recurse ",
             name_for_log,
             schema->n_children));
@@ -106,12 +106,12 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
 
     if (schema->dictionary != nullptr) {
         if (schema->dictionary->release != nullptr) {
-            LOG_TRACE(fmt::format(
+            LOG_TRACE(std::format(
                 "[ArrowAdapter] release_schema name {} schema->dict release",
                 name_for_log));
             release_schema(schema->dictionary);
         }
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_schema name {} schema->dict free",
             name_for_log));
         free(schema->dictionary);
@@ -119,14 +119,14 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
     }
 
     schema->release = nullptr;
-    LOG_TRACE(fmt::format(
+    LOG_TRACE(std::format(
         "[ArrowAdapter] release_schema name {} done", name_for_log));
 }
 
 void ArrowAdapter::release_array(struct ArrowArray* array) {
     auto arrow_buffer = static_cast<ArrowBuffer*>(array->private_data);
     if (arrow_buffer != nullptr) {
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] release_array {} use_count={}",
             arrow_buffer->buffer_->name(),
             arrow_buffer->buffer_.use_count()));
@@ -146,12 +146,12 @@ void ArrowAdapter::release_array(struct ArrowArray* array) {
         for (auto i = 0; i < array->n_children; i++) {
             if (array->children[i] != nullptr) {
                 if (array->children[i]->release != nullptr) {
-                    LOG_TRACE(fmt::format(
+                    LOG_TRACE(std::format(
                         "[ArrowAdapter] release_schema array->child {} release",
                         i));
                     release_array(array->children[i]);
                 }
-                LOG_TRACE(fmt::format(
+                LOG_TRACE(std::format(
                     "[ArrowAdapter] release_schema array->child {} free", i));
                 free(array->children[i]);
                 array->children[i] = nullptr;
@@ -175,7 +175,7 @@ void ArrowAdapter::release_array(struct ArrowArray* array) {
     }
 
     array->release = nullptr;
-    LOG_TRACE(fmt::format("[ArrowAdapter] release_array done"));
+    LOG_TRACE(std::format("[ArrowAdapter] release_array done"));
 }
 
 PlatformConfig ArrowAdapter::platform_config_from_tiledb_schema(
@@ -345,7 +345,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
 
     arrow_schema->children = (ArrowSchema**)malloc(
         arrow_schema->n_children * sizeof(ArrowSchema*));
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "[ArrowAdapter] arrow_schema_from_tiledb_array n_children {}",
         arrow_schema->n_children));
 
@@ -365,7 +365,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
         child->dictionary = nullptr;
         child->release = &ArrowAdapter::release_schema;
         child->private_data = nullptr;
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] arrow_schema_from_tiledb_array dim {} format {} "
             "name {}",
             i,
@@ -393,7 +393,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
         child->release = &ArrowAdapter::release_schema;
         child->private_data = nullptr;
 
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] arrow_schema_from_tiledb_array attr {} format {} "
             "name {}",
             i,
@@ -553,7 +553,7 @@ void ArrowAdapter::_append_to_filter_list(
             filter_list.add_filter(filter);
         }
     } catch (std::out_of_range& e) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "Invalid filter {} passed to PlatformConfig", std::string(value)));
     }
 }
@@ -604,7 +604,7 @@ void ArrowAdapter::_set_filter_option(
             break;
         default:
             throw TileDBSOMAError(
-                fmt::format("Invalid option {} passed to filter", option_name));
+                std::format("Invalid option {} passed to filter", option_name));
     }
 }
 
@@ -631,7 +631,7 @@ Dimension ArrowAdapter::_create_dim(
             // #include arrow_adapter.h. Hence the code duplication in
             // logging statements. :(
             uint64_t* b = (uint64_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -641,7 +641,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_INT8: {
             int8_t* b = (int8_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -651,7 +651,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_UINT8: {
             uint8_t* b = (uint8_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -661,7 +661,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_INT16: {
             int16_t* b = (int16_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -671,7 +671,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_UINT16: {
             uint16_t* b = (uint16_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -681,7 +681,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_INT32: {
             int32_t* b = (int32_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -691,7 +691,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_UINT32: {
             uint32_t* b = (uint32_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -701,7 +701,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_INT64: {
             int64_t* b = (int64_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -711,7 +711,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_UINT64: {
             uint64_t* b = (uint64_t*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -721,7 +721,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_FLOAT32: {
             float* b = (float*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -731,7 +731,7 @@ Dimension ArrowAdapter::_create_dim(
         }
         case TILEDB_FLOAT64: {
             double* b = (double*)buff;
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "_create_dim name={} b={} b1={} b2={}",
                 name,
                 b[0],
@@ -740,7 +740,7 @@ Dimension ArrowAdapter::_create_dim(
             return ArrowAdapter::_create_dim_aux(ctx, name, (double*)buff);
         }
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "ArrowAdapter: Unsupported TileDB dimension: {} ",
                 tiledb::impl::type_to_str(type)));
     }
@@ -775,7 +775,7 @@ void ArrowAdapter::_set_current_domain_slot(
             uint64_t lo = ((uint64_t*)buff)[3];
             uint64_t hi = ((uint64_t*)buff)[4];
             ndrect.set_range<uint64_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint64_t {} to {}",
                 name,
                 lo,
@@ -785,7 +785,7 @@ void ArrowAdapter::_set_current_domain_slot(
             int8_t lo = ((int8_t*)buff)[3];
             int8_t hi = ((int8_t*)buff)[4];
             ndrect.set_range<int8_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int8_t {} to {}",
                 name,
                 lo,
@@ -795,7 +795,7 @@ void ArrowAdapter::_set_current_domain_slot(
             uint8_t lo = ((uint8_t*)buff)[3];
             uint8_t hi = ((uint8_t*)buff)[4];
             ndrect.set_range<uint8_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint8_t {} to {}",
                 name,
                 lo,
@@ -805,7 +805,7 @@ void ArrowAdapter::_set_current_domain_slot(
             int16_t lo = ((int16_t*)buff)[3];
             int16_t hi = ((int16_t*)buff)[4];
             ndrect.set_range<int16_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int16_t {} to {}",
                 name,
                 lo,
@@ -815,7 +815,7 @@ void ArrowAdapter::_set_current_domain_slot(
             uint16_t lo = ((uint16_t*)buff)[3];
             uint16_t hi = ((uint16_t*)buff)[4];
             ndrect.set_range<uint16_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint16_t {} to {}",
                 name,
                 lo,
@@ -825,7 +825,7 @@ void ArrowAdapter::_set_current_domain_slot(
             int32_t lo = ((int32_t*)buff)[3];
             int32_t hi = ((int32_t*)buff)[4];
             ndrect.set_range<int32_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int32_t {} to {}",
                 name,
                 lo,
@@ -835,7 +835,7 @@ void ArrowAdapter::_set_current_domain_slot(
             uint32_t lo = ((uint32_t*)buff)[3];
             uint32_t hi = ((uint32_t*)buff)[4];
             ndrect.set_range<uint32_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint32_t {} to {}",
                 name,
                 lo,
@@ -845,7 +845,7 @@ void ArrowAdapter::_set_current_domain_slot(
             int64_t lo = ((int64_t*)buff)[3];
             int64_t hi = ((int64_t*)buff)[4];
             ndrect.set_range<int64_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int64_t {} to {}",
                 name,
                 lo,
@@ -855,7 +855,7 @@ void ArrowAdapter::_set_current_domain_slot(
             uint64_t lo = ((uint64_t*)buff)[3];
             uint64_t hi = ((uint64_t*)buff)[4];
             ndrect.set_range<uint64_t>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint64_t {} to {}",
                 name,
                 lo,
@@ -865,7 +865,7 @@ void ArrowAdapter::_set_current_domain_slot(
             float lo = ((float*)buff)[3];
             float hi = ((float*)buff)[4];
             ndrect.set_range<float>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain float {} to {}",
                 name,
                 lo,
@@ -875,14 +875,14 @@ void ArrowAdapter::_set_current_domain_slot(
             double lo = ((double*)buff)[3];
             double hi = ((double*)buff)[4];
             ndrect.set_range<double>(name, lo, hi);
-            LOG_DEBUG(fmt::format(
+            LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain double {} to {}",
                 name,
                 lo,
                 hi));
         } break;
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "ArrowAdapter: Unsupported TileDB dimension: {} ",
                 tiledb::impl::type_to_str(type)));
     }
@@ -910,7 +910,7 @@ tiledb_layout_t ArrowAdapter::_get_order(std::string order) {
         return convert_order[order];
     } catch (const std::out_of_range& e) {
         throw TileDBSOMAError(
-            fmt::format("Invalid order {} passed to PlatformConfig", order));
+            std::format("Invalid order {} passed to PlatformConfig", order));
     }
 }
 
@@ -972,7 +972,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
             type_metadata = std::string_view(out.data, out.size_bytes);
         }
 
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ArrowAdapter] schema pass for child {} name {}",
             sch_idx,
             std::string(child->name)));
@@ -1023,14 +1023,14 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
             }
 
             LOG_DEBUG(
-                fmt::format("[ArrowAdapter] adding attribute {}", child->name));
+                std::format("[ArrowAdapter] adding attribute {}", child->name));
 
             schema.add_attribute(attr.first);
         }
     }
 
     for (int64_t i = 0; i < index_column_schema->n_children; ++i) {
-        LOG_DEBUG(fmt::format("[ArrowAdapter] child {}", i));
+        LOG_DEBUG(std::format("[ArrowAdapter] child {}", i));
         auto col_name = index_column_schema->children[i]->name;
         if (strcmp(col_name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) == 0) {
             for (auto& dim : dims) {
@@ -1051,10 +1051,10 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
         }
     }
 
-    LOG_DEBUG(fmt::format("[ArrowAdapter] set_domain"));
+    LOG_DEBUG(std::format("[ArrowAdapter] set_domain"));
     schema.set_domain(domain);
 
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "[ArrowAdapter] index_column_info length {}",
         index_column_array->length));
 
@@ -1115,7 +1115,7 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                         strings = ArrowAdapter::get_array_string_column(
                             child_array, child_schema);
                     if (strings.size() != 5) {
-                        throw TileDBSOMAError(fmt::format(
+                        throw TileDBSOMAError(std::format(
                             "ArrowAdapter::tiledb_schema_from_arrow_schema: "
                             "internal error: "
                             "expected 5 strings, got {}",
@@ -1130,12 +1130,12 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                         ndrect.set_range(col_name, "", "\xff");
                     } else {
                         ndrect.set_range(col_name, lo, hi);
-                        LOG_DEBUG(fmt::format(
+                        LOG_DEBUG(std::format(
                             "[ArrowAdapter] index_column_info nbuf {}",
                             index_column_array->children[i]->n_buffers));
                     }
 
-                    LOG_DEBUG(fmt::format(
+                    LOG_DEBUG(std::format(
                         "[ArrowAdapter] current domain {} \"{}\"-\"{}\"",
                         child_schema->name,
                         lo,
@@ -1151,18 +1151,18 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
 
         current_domain.set_ndrectangle(ndrect);
 
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ArrowAdapter] before setting current_domain from ndrect"));
         ArraySchemaExperimental::set_current_domain(
             *ctx, schema, current_domain);
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ArrowAdapter] after setting current_domain from ndrect"));
     }
 
-    LOG_DEBUG(fmt::format("[ArrowAdapter] check"));
+    LOG_DEBUG(std::format("[ArrowAdapter] check"));
     schema.check();
 
-    LOG_DEBUG(fmt::format("[ArrowAdapter] returning"));
+    LOG_DEBUG(std::format("[ArrowAdapter] returning"));
     return schema;
 }
 
@@ -1193,7 +1193,7 @@ std::pair<Dimension, bool> ArrowAdapter::tiledb_dimension_from_arrow_schema(
     } else if (array->length == 5) {
         // This is fine
     } else {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "ArrowAdapter: unexpected length {} for name "
             "{}",
             array->length,
@@ -1218,7 +1218,7 @@ ArrowAdapter::tiledb_attribute_from_arrow_schema(
         if (type_metadata.compare("WKB") == 0) {
             type = TILEDB_GEOM_WKB;
         } else {
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "ArrowAdapter::tiledb_attribute_from_arrow_schema: "
                 "Unkwown type metadata for `{}`: "
                 "Expected 'WKB', got {}",
@@ -1256,7 +1256,7 @@ ArrowAdapter::tiledb_attribute_from_arrow_schema(
             arrow_schema->flags & ARROW_FLAG_DICTIONARY_ORDERED);
         AttributeExperimental::set_enumeration_name(
             *ctx, attr, arrow_schema->name);
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "[ArrowAdapter] dictionary for {} as {} {}",
             std::string(arrow_schema->name),
             tiledb::impl::type_to_str(enmr_type),
@@ -1337,7 +1337,7 @@ std::pair<const void*, std::size_t> ArrowAdapter::_get_data_and_length(
                 ArrowAdapter::_fill_data_buffer(data, dst), data.size());
         }
         default:
-            throw TileDBSOMAError(fmt::format(
+            throw TileDBSOMAError(std::format(
                 "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
                 tiledb::impl::type_to_str(enmr.type())));
     }
@@ -1346,7 +1346,7 @@ std::pair<const void*, std::size_t> ArrowAdapter::_get_data_and_length(
 inline void exitIfError(const ArrowErrorCode ec, const std::string& msg) {
     if (ec != NANOARROW_OK)
         throw TileDBSOMAError(
-            fmt::format("ArrowAdapter: Arrow Error {} ", msg));
+            std::format("ArrowAdapter: Arrow Error {} ", msg));
 }
 
 std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
@@ -1384,7 +1384,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     exitIfError(ArrowArrayAllocateChildren(arr, 0), "Bad array children alloc");
     array->length = column->size();
 
-    LOG_TRACE(fmt::format(
+    LOG_TRACE(std::format(
         "[ArrowAdapter] column type {} name {} nbuf {} {} nullable {}",
         to_arrow_format(column->type()).data(),
         column->name().data(),
@@ -1393,7 +1393,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         column->is_nullable()));
 
     if (array->n_buffers != n_buffers) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "[ArrowAdapter] expected array n_buffers {} for column {}; got {}",
             n_buffers,
             column->name(),
@@ -1408,7 +1408,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     }                                      // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
-    LOG_TRACE(fmt::format(
+    LOG_TRACE(std::format(
         "[ArrowAdapter] create array name='{}' use_count={}",
         column->name(),
         column.use_count()));
@@ -1553,7 +1553,7 @@ std::string_view ArrowAdapter::to_arrow_format(
     try {
         return _to_arrow_format_map.at(tiledb_dtype);
     } catch (const std::out_of_range& e) {
-        throw std::out_of_range(fmt::format(
+        throw std::out_of_range(std::format(
             "ArrowAdapter: Unsupported TileDB type: {} ",
             tiledb::impl::type_to_str(tiledb_dtype)));
     }
@@ -1587,7 +1587,7 @@ tiledb_datatype_t ArrowAdapter::to_tiledb_format(
 
         return dtype;
     } catch (const std::out_of_range& e) {
-        throw std::out_of_range(fmt::format(
+        throw std::out_of_range(std::format(
             "ArrowAdapter: Unsupported Arrow type: {} ", arrow_dtype));
     }
 }
@@ -1636,7 +1636,7 @@ enum ArrowType ArrowAdapter::to_nanoarrow_type(std::string_view sv) {
         return NANOARROW_TYPE_LARGE_BINARY;
     else
         throw TileDBSOMAError(
-            fmt::format("ArrowAdapter: Unsupported Arrow format: {} ", sv));
+            std::format("ArrowAdapter: Unsupported Arrow format: {} ", sv));
 }
 
 std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
@@ -1646,7 +1646,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
     auto num_types = tiledb_datatypes.size();
 
     if (num_names != num_types) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "ArrowAdapter::make_arrow_schema: internal coding error: num_types "
             "{} != num_names {}",
             num_names,
@@ -1665,7 +1665,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->private_data = nullptr;
 
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "[ArrowAdapter] make_arrow_schema n_children {}",
         arrow_schema->n_children));
 
@@ -1684,7 +1684,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
         dim_schema->private_data = nullptr;
 
         arrow_schema->children[i] = dim_schema;
-        LOG_TRACE(fmt::format(
+        LOG_TRACE(std::format(
             "[ArrowAdapter] make_arrow_schema child {} format {} name {}",
             i,
             dim_schema->format,
@@ -1729,7 +1729,7 @@ std::unique_ptr<ArrowArray> ArrowAdapter::make_arrow_array_parent(
         arrow_array->children[i] = nullptr;
     }
 
-    LOG_DEBUG(fmt::format(
+    LOG_DEBUG(std::format(
         "[ArrowAdapter] make_arrow_array n_children {}",
         arrow_array->n_children));
 
@@ -1737,7 +1737,7 @@ std::unique_ptr<ArrowArray> ArrowAdapter::make_arrow_array_parent(
 }
 
 void ArrowAdapter::log_make_arrow_array_child(ArrowArray* child) {
-    LOG_TRACE(fmt::format(
+    LOG_TRACE(std::format(
         "[ArrowAdapter] make_arrow_array_child length {} n_buffers {}",
         child->length,
         child->n_buffers));
@@ -1774,7 +1774,7 @@ int64_t ArrowAdapter::_get_column_index_from_name(
         }
     }
 
-    throw std::runtime_error(fmt::format(
+    throw std::runtime_error(std::format(
         "ArrowAdapter::_check_shapes: column {} not found", column_name));
 }
 
@@ -1784,7 +1784,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     int64_t expected_n_buffers) {
     ArrowArray* arrow_array = arrow_table.first.get();
     if (column_index < 0 || column_index >= arrow_array->n_children) {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "ArrowAdapter::_get_and_check_column: column index {} out of "
             "bounds {}..{}",
             column_index,
@@ -1795,7 +1795,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     ArrowArray* child = arrow_array->children[column_index];
 
     if (child->n_children != 0) {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "ArrowAdapter::_get_and_check_column: column index {} is "
             "non-terminal",
             column_index));
@@ -1803,7 +1803,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
 
     if (expected_n_buffers == 2) {
         if (child->n_buffers != 2) {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "ArrowAdapter::_get_and_check_column: column index {} "
                 "has buffer count {}; expected 2 for non-string data",
                 column_index,
@@ -1812,7 +1812,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
 
     } else if (expected_n_buffers == 3) {
         if (child->n_buffers != 3) {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "ArrowAdapter::_get_and_check_column: column index {} is "
                 "has buffer count {}; expected 3 for string data",
                 column_index,
@@ -1820,7 +1820,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
         }
 
     } else {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "ArrowAdapter::_get_and_check_column: internal coding error: "
             "expected_n_buffers {} is "
             "neither 2 nor 3.",
@@ -1839,7 +1839,7 @@ bool ArrowAdapter::_set_spatial_dimensions(
     PlatformConfig platform_config) {
     bool use_current_domain = true;
     if (type_metadata.compare("WKB") != 0) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "ArrowAdapter::tiledb_attribute_from_arrow_schema: "
             "Unkwown type metadata for `{}`: "
             "Expected 'WKB', got {}",

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -361,12 +361,7 @@ class ArrowAdapter {
         ArrowArray* child = make_arrow_array_child<T>(v);
         return child;
     }
-    /**
-     * Helper for make_arrow_array_child. We need the templating
-     * in the header file so it's instantiated at all callsites.
-     * But fmt::format logging is hard in header files since
-     * #include <logger.h> is relative to the includer, which varies.
-     */
+
     static void log_make_arrow_array_child(ArrowArray* child);
 
     static ArrowArray* make_arrow_array_child_string(

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -76,7 +76,7 @@ std::string rstrip_uri(std::string_view uri) {
 
 std::vector<uint8_t> cast_bit_to_uint8(ArrowSchema* schema, ArrowArray* array) {
     if (strcmp(schema->format, "b") != 0) {
-        throw TileDBSOMAError(fmt::format(
+        throw TileDBSOMAError(std::format(
             "_cast_bit_to_uint8 expected column format to be 'b' but saw {}",
             schema->format));
     }

--- a/libtiledbsoma/src/utils/version.cc
+++ b/libtiledbsoma/src/utils/version.cc
@@ -38,7 +38,7 @@ namespace tiledbsoma::version {
 std::string as_string() {
     int major, minor, patch;
     tiledb_version(&major, &minor, &patch);
-    return fmt::format("libtiledb={}.{}.{}", major, minor, patch);
+    return std::format("libtiledb={}.{}.{}", major, minor, patch);
 }
 
 std::tuple<int, int, int> embedded_version_triple() {

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -123,7 +123,7 @@ create_arrow_schema_and_index_columns(
 // Create index-column info only, no schema involving the attrs
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
     for (auto info : dim_infos) {
-        LOG_DEBUG(fmt::format(
+        LOG_DEBUG(std::format(
             "create_column_index_info name={} type={} dim_max={} ucd={}",
             info.name,
             tiledb::impl::to_str(info.tiledb_datatype),

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -41,6 +41,7 @@
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include <numeric>
 #include <random>
+#include <format>
 
 #include <tiledb/tiledb>
 #include <tiledbsoma/tiledbsoma>
@@ -190,14 +191,7 @@ TEST_CASE("SOMAArray: nnz") {
     const char* dim_name = "d0";
     const char* attr_name = "a0";
 
-    // TODO this use to be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- fragments=" << num_fragments << ", overlap" << overlap
-            << ", allow_duplicates=" << allow_duplicates;
-
-    SECTION(section.str()) {
+    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array
@@ -264,14 +258,7 @@ TEST_CASE("SOMAArray: nnz with timestamp") {
     auto allow_duplicates = true;
     int num_cells_per_fragment = 128;
 
-    // TODO this use to be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- fragments=" << num_fragments << ", overlap" << overlap
-            << ", allow_duplicates=" << allow_duplicates;
-
-    SECTION(section.str()) {
+    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array
@@ -317,14 +304,7 @@ TEST_CASE("SOMAArray: nnz with consolidation") {
     auto vacuum = GENERATE(false, true);
     int num_cells_per_fragment = 128;
 
-    // TODO this use to be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- fragments=" << num_fragments << ", overlap" << overlap
-            << ", allow_duplicates=" << allow_duplicates;
-
-    SECTION(section.str()) {
+    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -39,9 +39,9 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_templated.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
+#include <format>
 #include <numeric>
 #include <random>
-#include <format>
 
 #include <tiledb/tiledb>
 #include <tiledbsoma/tiledbsoma>
@@ -191,7 +191,11 @@ TEST_CASE("SOMAArray: nnz") {
     const char* dim_name = "d0";
     const char* attr_name = "a0";
 
-    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
+    SECTION(std::format(
+        "- fragments={}, overlap={}, allow_duplicates={}",
+        num_fragments,
+        overlap,
+        allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array
@@ -258,7 +262,11 @@ TEST_CASE("SOMAArray: nnz with timestamp") {
     auto allow_duplicates = true;
     int num_cells_per_fragment = 128;
 
-    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
+    SECTION(std::format(
+        "- fragments={}, overlap={}, allow_duplicates={}",
+        num_fragments,
+        overlap,
+        allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array
@@ -304,7 +312,11 @@ TEST_CASE("SOMAArray: nnz with consolidation") {
     auto vacuum = GENERATE(false, true);
     int num_cells_per_fragment = 128;
 
-    SECTION(std::format("- fragments={}, overlap={}, allow_duplicates={}", num_fragments, overlap, allow_duplicates)) {
+    SECTION(std::format(
+        "- fragments={}, overlap={}, allow_duplicates={}",
+        num_fragments,
+        overlap,
+        allow_duplicates)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         // Create array

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -32,6 +32,8 @@
 
 #include "common.h"
 
+#include <format>
+
 static const int64_t DIM_MAX = 999;
 
 TEST_CASE("SOMACollection: basic") {
@@ -50,12 +52,8 @@ TEST_CASE("SOMACollection: basic") {
 
 TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         TimestampRange ts(0, 2);
         auto ctx = std::make_shared<SOMAContext>();
         std::string base_uri = "mem://unit-test-add-sparse-ndarray";
@@ -112,12 +110,8 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
 
 TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         TimestampRange ts(0, 2);
         auto ctx = std::make_shared<SOMAContext>();
         std::string base_uri = "mem://unit-test-add-dense-ndarray";

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -30,8 +30,8 @@
  * This file manages unit tests for the SOMADataFrame class
  */
 
-#include "common.h"
 #include <format>
+#include "common.h"
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 const int64_t SOMA_JOINID_RESIZE_DIM_MAX = 199;

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -31,6 +31,7 @@
  */
 
 #include "common.h"
+#include <format>
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 const int64_t SOMA_JOINID_RESIZE_DIM_MAX = 199;
@@ -205,12 +206,8 @@ TEST_CASE_METHOD(
     "SOMADataFrame: basic",
     "[SOMADataFrame]") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         set_up(
             std::make_shared<SOMAContext>(), "mem://unit-test-dataframe-basic");
 
@@ -309,13 +306,7 @@ TEST_CASE_METHOD(
         std::make_pair(R"("BYTESHUFFLE")", TILEDB_FILTER_BYTESHUFFLE),
         std::make_pair(R"("NOOP")", TILEDB_FILTER_NONE));
 
-    // TODO this used to be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- filter=" << filter.first;
-
-    SECTION(section.str()) {
+    SECTION(std::format("- filter={}", filter.first)) {
         auto use_current_domain = GENERATE(false, true);
         std::ostringstream section2;
         section2 << "- use_current_domain=" << use_current_domain;
@@ -399,12 +390,8 @@ TEST_CASE_METHOD(
     "SOMADataFrame: metadata",
     "[SOMADataFrame]") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of
-    // internal header spd/log/fmt/fmt.h and should not be used. In
-    // C++20, this can be replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         set_up(std::make_shared<SOMAContext>(), "mem://unit-test-collection");
 
         std::vector<helper::DimInfo> dim_infos(

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -30,8 +30,8 @@
  * This file manages unit tests for the SOMADenseNDArray class
  */
 
-#include "common.h"
 #include <format>
+#include "common.h"
 
 TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     // Core uses domain & current domain like (0, 999); SOMA uses shape like

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -31,6 +31,7 @@
  */
 
 #include "common.h"
+#include <format>
 
 TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     // Core uses domain & current domain like (0, 999); SOMA uses shape like
@@ -40,12 +41,8 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     int64_t shape = 1000;
 
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri = "mem://unit-test-dense-ndarray-basic";
         std::string dim_name = "soma_dim_0";
@@ -158,12 +155,8 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
 TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
     int64_t dim_max = 999;
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of
-    // internal header spd/log/fmt/fmt.h and should not be used. In C++20,
-    // this can be replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri = "mem://unit-test-dense-ndarray-platform-config";
         std::string dim_name = "soma_dim_0";
@@ -247,12 +240,8 @@ TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
 TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     int64_t dim_max = 999;
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of
-    // internal header spd/log/fmt/fmt.h and should not be used. In C++20,
-    // this can be replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri = "mem://unit-test-dense-ndarray";
         std::string dim_name = "soma_dim_0";

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -30,12 +30,12 @@
  * This file manages unit tests for the SOMAGeometryDataFrame class
  */
 
+#include <format>
 #include <vector>
 #include "../src/geometry/geometry.h"
 #include "../src/geometry/operators/io/write.h"
 #include "../src/utils/common.h"
 #include "common.h"
-#include <format>
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -35,17 +35,14 @@
 #include "../src/geometry/operators/io/write.h"
 #include "../src/utils/common.h"
 #include "common.h"
+#include <format>
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 
 TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri{"mem://unit-test-geometry-basic"};
         PlatformConfig platform_config{};
@@ -155,12 +152,8 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
 
 TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri{"mem://unit-test-geometry-roundtrip"};
         PlatformConfig platform_config{};

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -30,8 +30,8 @@
  * This file manages unit tests for the SOMAPointCloudDataFrame class
  */
 
-#include "common.h"
 #include <format>
+#include "common.h"
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -31,17 +31,14 @@
  */
 
 #include "common.h"
+#include <format>
 
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 
 TEST_CASE("SOMAPointCloudDataFrame: basic", "[SOMAPointCloudDataFrame]") {
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri{"mem://unit-test-point-cloud-basic"};
         PlatformConfig platform_config{};

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -30,8 +30,8 @@
  * This file manages unit tests for the SOMASparseNDArray class
  */
 
-#include "common.h"
 #include <format>
+#include "common.h"
 
 TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     // Core uses domain & current domain like (0, 999); SOMA uses shape like

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -31,6 +31,7 @@
  */
 
 #include "common.h"
+#include <format>
 
 TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     // Core uses domain & current domain like (0, 999); SOMA uses shape like
@@ -40,12 +41,8 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     int64_t shape = 1000;
 
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri = "mem://unit-test-sparse-ndarray-basic";
         std::string dim_name = "soma_dim_0";
@@ -193,12 +190,8 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
 TEST_CASE("SOMASparseNDArray: platform_config", "[SOMASparseNDArray]") {
     int64_t dim_max = 999;
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
         std::string uri = "mem://unit-test-dataframe-platform-config";
         std::string dim_name = "soma_dim_0";
@@ -247,12 +240,8 @@ TEST_CASE("SOMASparseNDArray: platform_config", "[SOMASparseNDArray]") {
 TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     int64_t dim_max = 999;
     auto use_current_domain = GENERATE(false, true);
-    // TODO this could be formatted with fmt::format which is part of internal
-    // header spd/log/fmt/fmt.h and should not be used. In C++20, this can be
-    // replaced with std::format.
-    std::ostringstream section;
-    section << "- use_current_domain=" << use_current_domain;
-    SECTION(section.str()) {
+
+    SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
 
         std::string uri = "mem://unit-test-sparse-ndarray";


### PR DESCRIPTION
This PR migrates minimum C++ version to C++20 and replaces `fmt::format` with the now available `std::format`