### PR TITLE
[python/docs] Use `ubuntu-24.04` (C++ 20) for `readthedocs`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 sphinx:
   configuration: doc/source/conf.py
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   commands:


### PR DESCRIPTION
**Issue and/or context:**

- #3154
- [RTD build failed](https://readthedocs.org/projects/tiledbsoma/builds/26329893/) after #3331 
- Test RTD build from this branch ✅: https://readthedocs.org/projects/tiledbsoma/builds/26331078/

**Changes:**
Use Ubuntu 24.04 in RTD build
