### PR TITLE
[python] Update README.md to remove tiledb-py

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -38,7 +38,6 @@ If this comes up empty for your system, you'll definitely need to build from sou
 
 ## From source
 
-* This requires [`tiledb`](https://github.com/TileDB-Inc/TileDB-Py) (see [./setup.cfg](setup.cfg) for version), in addition to other dependencies in [setup.cfg](./setup.cfg).
 * Clone [this repo](https://github.com/single-cell-data/TileDB-SOMA)
 * `cd` into your checkout and then `cd apis/python`
 * `python -m pip install .`


### PR DESCRIPTION
This removes the tiledb-py requirement from the `README.md`. All other steps remain the same.