### PR TITLE
[python] Add export for `MultiscaleImage` to SpatialData

### DIFF
--- a/apis/python/requirements_spatial.txt
+++ b/apis/python/requirements_spatial.txt
@@ -1,5 +1,6 @@
 geopandas
 tifffile
 pillow
-spatialdata
-xarray>=2024.05.0
+spatialdata>=0.2.5
+xarray
+dask

--- a/apis/python/src/tiledbsoma/experimental/_util.py
+++ b/apis/python/src/tiledbsoma/experimental/_util.py
@@ -16,6 +16,26 @@ def _str_to_int(value: str) -> int:
     return int(value)
 
 
+def _version_less_than(version: str, upper_bound: Tuple[int, int, int]) -> bool:
+    split_version = version.split(".")
+    try:
+        major = _str_to_int(split_version[0])
+        minor = _str_to_int(split_version[1])
+        patch = _str_to_int(split_version[2])
+    except ValueError as err:
+        raise ValueError(f"Unable to parse version {version}.") from err
+    print(f"Actual: {(major, minor, patch)} and Compare: {upper_bound}")
+    return (
+        major < upper_bound[0]
+        or (major == upper_bound[0] and minor < upper_bound[1])
+        or (
+            major == upper_bound[0]
+            and minor == upper_bound[1]
+            and patch < upper_bound[2]
+        )
+    )
+
+
 def _read_visium_software_version(
     gene_expression_path: Union[str, Path]
 ) -> Tuple[int, int, int]:

--- a/apis/python/src/tiledbsoma/experimental/_util.py
+++ b/apis/python/src/tiledbsoma/experimental/_util.py
@@ -24,7 +24,6 @@ def _version_less_than(version: str, upper_bound: Tuple[int, int, int]) -> bool:
         patch = _str_to_int(split_version[2])
     except ValueError as err:
         raise ValueError(f"Unable to parse version {version}.") from err
-    print(f"Actual: {(major, minor, patch)} and Compare: {upper_bound}")
     return (
         major < upper_bound[0]
         or (major == upper_bound[0] and minor < upper_bound[1])

--- a/apis/python/src/tiledbsoma/experimental/outgest.py
+++ b/apis/python/src/tiledbsoma/experimental/outgest.py
@@ -256,3 +256,85 @@ def to_spatial_data_image(
         attrs={"transform": transformations},
         context=image.context,
     )
+
+
+def to_spatial_data_multiscale_image(
+    image: MultiscaleImage,
+    *,
+    scene_id: str,
+    scene_dim_map: Dict[str, str],
+    transform: somacore.CoordinateTransform,
+) -> xr.DataTree:
+    """Export a MultiscaleImage to a DataTree."""
+
+    # Check for channel axis.
+    if not image.has_channel_axis:
+        raise NotImplementedError(
+            "Support for exporting a MultiscaleImage to without a channel axis to "
+            "SpatialData is not yet implemented."
+        )
+
+    # Convert from SOMA axis names to SpatialData axis names.
+    orig_axis_names = image.coordinate_space.axis_names
+    if len(orig_axis_names) not in {2, 3}:
+        raise NotImplementedError(
+            f"Support for converting a '{len(orig_axis_names)}'D is not yet implemented."
+        )
+    new_axis_names, image_dim_map = _convert_axis_names(
+        orig_axis_names, image.data_axis_order
+    )
+
+    # Get the transformtion from the image level to the scene:
+    # If the result is a single scale transform (or identity transform), output a
+    # single transformation. Otherwise, convert to a SpatialData sequence of
+    # transformations.
+    inv_transform = transform.inverse_transform()
+    if isinstance(transform, somacore.ScaleTransform):
+        # inv_transform @ scale_transform -> applies scale_transform first
+        spatial_data_transformations = tuple(
+            _transform_to_spatial_data(
+                inv_transform @ image.get_transform_from_level(level),
+                image_dim_map,
+                scene_dim_map,
+            )
+            for level in range(image.level_count)
+        )
+
+    else:
+        sd_scale_transforms = tuple(
+            _transform_to_spatial_data(
+                image.get_transform_from_level(level), image_dim_map, image_dim_map
+            )
+            for level in range(1, image.level_count)
+        )
+        sd_inv_transform = _transform_to_spatial_data(
+            inv_transform, image_dim_map, scene_dim_map
+        )
+
+        # First level transform is always the identity, so just directly use
+        # inv_transform. For remaining transformations,
+        # Sequence([sd_transform1, sd_transform2]) -> applies sd_transform1 first
+        spatial_data_transformations = (sd_inv_transform,) + tuple(
+            sd.transformations.Sequence([scale_transform, sd_inv_transform])
+            for scale_transform in sd_scale_transforms
+        )
+
+    # Create the datatree
+    image_datasets = {
+        f"scale{index}": xr.Dataset(
+            {
+                "image": dense_nd_array_to_data_array(
+                    uri=image.level_uri(index),
+                    dim_names=new_axis_names,
+                    attrs={
+                        "transform": {scene_id: spatial_data_transformations[index]}
+                    },
+                    context=image.context,
+                )
+            }
+        )
+        for index, (soma_name, val) in enumerate(image.levels().items())
+    }
+    multiscale_image = xr.DataTree.from_dict(image_datasets)
+
+    return multiscale_image

--- a/apis/python/tests/test_export_multiscale_image.py
+++ b/apis/python/tests/test_export_multiscale_image.py
@@ -208,7 +208,6 @@ def test_export_full_image_to_spatial_data(
     # Check the correct data exists.
     for index in range(3):
         data_array = image2d[f"scale{index}"]["image"]
-        print(f"{index}: {data_array}")
 
         # Check data.
         result = data_array.data.compute()

--- a/apis/python/tests/test_export_multiscale_image.py
+++ b/apis/python/tests/test_export_multiscale_image.py
@@ -9,7 +9,6 @@ import tiledbsoma as soma
 
 soma_outgest = pytest.importorskip("tiledbsoma.experimental.outgest")
 sd = pytest.importorskip("spatialdata")
-xr = pytest.importorskip("xarray")
 
 
 @pytest.fixture(scope="module")
@@ -119,7 +118,7 @@ def test_export_image_level_to_spatial_data(
         transform=transform,
     )
 
-    assert isinstance(image2d, xr.DataArray)
+    assert isinstance(image2d, sd.models.models.DataArray)
 
     # Validate the model.
     schema = sd.models.get_model(image2d)
@@ -200,7 +199,7 @@ def test_export_full_image_to_spatial_data(
         transform=transform,
     )
 
-    assert isinstance(image2d, xr.DataTree)
+    assert isinstance(image2d, sd.models.models.DataTree)
 
     # Validate the model.
     schema = sd.models.get_model(image2d)

--- a/apis/python/tests/test_export_multiscale_image.py
+++ b/apis/python/tests/test_export_multiscale_image.py
@@ -133,3 +133,89 @@ def test_export_image_level_to_spatial_data(
     metadata = dict(image2d.attrs)
     assert len(metadata) == 1
     assert metadata["transform"] == {"scene0": expected_transformation}
+
+
+@pytest.mark.parametrize(
+    "transform,expected_transformation",
+    [
+        (
+            somacore.IdentityTransform(("x_scene", "y_scene"), ("x_image", "y_image")),
+            [
+                sd.transformations.Identity(),
+                sd.transformations.Scale([2, 2], ("x", "y")),
+                sd.transformations.Scale([4, 4], ("x", "y")),
+            ],
+        ),
+        (
+            somacore.ScaleTransform(
+                ("x_scene", "y_scene"), ("x_image", "y_image"), [0.25, 0.5]
+            ),
+            [
+                sd.transformations.Scale([4, 2], ("x", "y")),
+                sd.transformations.Scale([8, 4], ("x", "y")),
+                sd.transformations.Scale([16, 8], ("x", "y")),
+            ],
+        ),
+        (
+            somacore.AffineTransform(
+                ("x_scene", "y_scene"), ("x_image", "y_image"), [[1, 0, 1], [0, 1, 2]]
+            ),
+            [
+                sd.transformations.Affine(
+                    np.array([[1, 0, -1], [0, 1, -2], [0, 0, 1]]),
+                    ("x", "y"),
+                    ("x", "y"),
+                ),
+                sd.transformations.Sequence(
+                    [
+                        sd.transformations.Scale([2, 2], ("x", "y")),
+                        sd.transformations.Affine(
+                            np.array([[1, 0, -1], [0, 1, -2], [0, 0, 1]]),
+                            ("x", "y"),
+                            ("x", "y"),
+                        ),
+                    ]
+                ),
+                sd.transformations.Sequence(
+                    [
+                        sd.transformations.Scale([4, 4], ("x", "y")),
+                        sd.transformations.Affine(
+                            np.array([[1, 0, -1], [0, 1, -2], [0, 0, 1]]),
+                            ("x", "y"),
+                            ("x", "y"),
+                        ),
+                    ]
+                ),
+            ],
+        ),
+    ],
+)
+def test_export_full_image_to_spatial_data(
+    sample_multiscale_image_2d, sample_2d_data, transform, expected_transformation
+):
+    image2d = soma_outgest.to_spatial_data_multiscale_image(
+        sample_multiscale_image_2d,
+        scene_id="scene0",
+        scene_dim_map={"x_scene": "x", "y_scene": "y"},
+        transform=transform,
+    )
+
+    assert isinstance(image2d, xr.DataTree)
+
+    # Validate the model.
+    schema = sd.models.get_model(image2d)
+    assert schema == sd.models.Image2DModel
+
+    # Check the correct data exists.
+    for index in range(3):
+        data_array = image2d[f"scale{index}"]["image"]
+        print(f"{index}: {data_array}")
+
+        # Check data.
+        result = data_array.data.compute()
+        np.testing.assert_equal(result, sample_2d_data[index])
+
+        # Check the metadata.
+        metadata = dict(data_array.attrs)
+        assert len(metadata) == 1
+        assert metadata["transform"] == {"scene0": expected_transformation[index]}


### PR DESCRIPTION
Add function to export a full `MultiscaleImage` to a SpatialData `Image2DModel` or `Image3DModel`. 

Note: At the time of this PR, SpatialData is in the process of changing the multiscale image model to move from the legacy `xarray_datatree.datatree.DataTree` class to the new `xarray.DataTree` model. This PR implements both versions and checks which to use based on the SpatialData version.