### PR TITLE
[python] Update Scene create method in the Python API

### DIFF
--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -76,8 +76,22 @@ void load_soma_collection(py::module& m) {
     py::class_<SOMAMeasurement, SOMACollection, SOMAGroup, SOMAObject>(
         m, "SOMAMeasurement");
 
-    py::class_<SOMAScene, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAScene");
+    py::class_<SOMAScene, SOMACollection, SOMAGroup, SOMAObject>(m, "SOMAScene")
+        .def_static(
+            "create",
+            [](std::shared_ptr<SOMAContext> ctx,
+               std::string_view uri,
+               std::optional<TimestampRange> timestamp) {
+                try {
+                    SOMAScene::create(uri, ctx, timestamp);
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
+            py::kw_only(),
+            "ctx"_a,
+            "uri"_a,
+            "timestamp"_a = py::none());
 
     py::class_<SOMAMultiscaleImage, SOMACollection, SOMAGroup, SOMAObject>(
         m, "SOMAMultiscaleImage");

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -111,7 +111,39 @@ def test_measurement_with_var_scene(tmp_path):
     assert soma.DataFrame.exists(obs_scene_uri)
 
 
-def test_scene_coord_space(tmp_path):
+def test_scene_coord_space_at_create(tmp_path):
+    uri = tmp_path.as_uri()
+
+    coord_space = soma.CoordinateSpace(
+        [
+            soma.Axis(name="x"),
+            soma.Axis(name="y"),
+        ]
+    )
+    coord_space_json = """
+    [
+        {"name": "x", "unit": null},
+        {"name": "y", "unit": null}
+    ]
+    """
+
+    with soma.Scene.create(uri, coordinate_space=("x", "y")) as scene:
+
+        # Reserved metadata key should not be settable?
+        # with pytest.raises(soma.SOMAError):
+        #     scene.metadata["soma_coordinate_space"] = coord_space_json
+
+        scene.coordinate_space = coord_space
+        assert scene.coordinate_space == coord_space
+        assert json.loads(scene.metadata["soma_coordinate_space"]) == json.loads(
+            coord_space_json
+        )
+
+    with soma.Scene.open(uri) as scene:
+        assert scene.coordinate_space == coord_space
+
+
+def test_scene_coord_space_after_create(tmp_path):
     uri = tmp_path.as_uri()
 
     coord_space = soma.CoordinateSpace(

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -49,6 +49,7 @@ void SOMAScene::create(
         auto group = SOMAGroup::create(
             ctx, scene_uri.string(), "SOMAScene", timestamp);
         // TODO: Set extra metadata.
+        // (See story: https://app.shortcut.com/tiledb-inc/story/59915)
         group->close();
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -46,30 +46,9 @@ void SOMAScene::create(
     std::optional<TimestampRange> timestamp) {
     try {
         std::filesystem::path scene_uri(uri);
-
-        SOMAGroup::create(ctx, scene_uri.string(), "SOMAScene", timestamp);
-        SOMACollection::create((scene_uri / "img").string(), ctx, timestamp);
-        SOMACollection::create((scene_uri / "obsl").string(), ctx, timestamp);
-        SOMACollection::create((scene_uri / "varl").string(), ctx, timestamp);
-
-        auto name = std::string(std::filesystem::path(uri).filename());
-        auto group = SOMAGroup::open(
-            OpenMode::write, scene_uri.string(), ctx, name, timestamp);
-        group->set(
-            (scene_uri / "img").string(),
-            URIType::absolute,
-            "img",
-            "SOMACollection");
-        group->set(
-            (scene_uri / "obsl").string(),
-            URIType::absolute,
-            "obsl",
-            "SOMACollection");
-        group->set(
-            (scene_uri / "varl").string(),
-            URIType::absolute,
-            "varl",
-            "SOMAColelction");
+        auto group = SOMAGroup::create(
+            ctx, scene_uri.string(), "SOMAScene", timestamp);
+        // TODO: Set extra metadata.
         group->close();
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());

--- a/libtiledbsoma/src/soma/soma_scene.h
+++ b/libtiledbsoma/src/soma/soma_scene.h
@@ -51,7 +51,7 @@ class SOMAScene : public SOMACollection {
      *
      * @param uri URI to create the SOMAScene
      * @param schema TileDB ArraySchema
-     * @param platform_config Optional config parameter dictionary
+     * @param timestamp Optional pair indicating timestamp start and end
      */
     static void create(
         std::string_view uri,


### PR DESCRIPTION
1. Add spatial disclaimer as warning.
2. Implement writing the coordinate space at create.
3. Use Scene C++ code instead of going through Python superclass.
   * Requires updating Scene C++ create method to match behavior of existing code (do not create `obsl`/`varl`/`img` at create).

