### PR TITLE
[packaging] More failure info in `update-tiledb-versions.py`

### DIFF
--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -50,6 +50,7 @@ def update_version(filepath, new_version, new_hash, update_sha=True):
     old_version = None
     old_hash = None
     sha1 = None
+    error = False
 
     filepath = os.path.realpath(filepath)
     print(f"Updating {filepath}")
@@ -88,11 +89,17 @@ def update_version(filepath, new_version, new_hash, update_sha=True):
                         m = re.search(r'"(https://.*)"', line)
                         if m:
                             sha1 = hash_url_file(m.group(1))
+                            if sha1 is None:
+                                error = True
 
             # print line to file
             print(line)
 
     print(f"  old version = {old_version}-{old_hash}")
+
+    if error:
+        print("Not all artifacts were found.")
+        exit(1)
 
 
 def main(args):

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import re
 import sys
+import urllib.error
 from fileinput import FileInput
 from subprocess import run
 from urllib.request import urlopen
@@ -13,15 +14,19 @@ from urllib.request import urlopen
 def hash_url_file(url):
     """Return SHA1 hash of the file located at the provided url."""
 
-    print(f"URL {url}", file=sys.stderr)
     BLOCK_SIZE = 65536
     hash = hashlib.sha1()
-    with urlopen(url) as fp:
-        while True:
-            data = fp.read(BLOCK_SIZE)
-            if not data:
-                return hash.hexdigest()
-            hash.update(data)
+    try:
+        with urlopen(url) as fp:
+            print(f"URL  {url}", file=sys.stderr)
+            while True:
+                data = fp.read(BLOCK_SIZE)
+                if not data:
+                    return hash.hexdigest()
+                hash.update(data)
+    except urllib.error.HTTPError:
+        print(f"FAIL {url}", file=sys.stderr)
+        return None
 
 
 def get_version_hash(version):


### PR DESCRIPTION
When core releases are missing artifacts for one or more platforms (e.g. [2.27.0-rc1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.27.0-rc1), [2.27.0-rc2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.27.0-rc2)), have our one-stop artifact updater print more easily accessible information about what's missing.

Tracking issue: #3364.
