### PR TITLE
[c++] Fix heap corruption in `fastercsx`

### DIFF
--- a/libtiledbsoma/src/external/include/thread_pool/status.h
+++ b/libtiledbsoma/src/external/include/thread_pool/status.h
@@ -59,7 +59,7 @@
 
 #define tdb_delete_array(p) \
   if (p) {                  \
-    delete[] p;             \
+    free((void *)p);        \
   }
 #define tdb_new_array(T, size) (T*)malloc(size * sizeof(T))
 


### PR DESCRIPTION
**Issue and/or context:** Found while debugging 

Issue: #3304.

**Changes:**

We have a pair of macros `tdb_new_array` and `tdb_delete_array`. As written, these are pairing `malloc` with `delete []`. This is incorrect behavior.

Also note that this defect is new to our modified vendoring of `threadpool/status.h`:

* Source:
  * https://github.com/TileDB-Inc/TileDB/blob/a34830c2b9fe4c00526e497630f251263b5e468b/tiledb/common/heap_memory.h#L165-L168
  * https://github.com/TileDB-Inc/TileDB/blob/a34830c2b9fe4c00526e497630f251263b5e468b/tiledb/common/heap_memory.h#L96-L113
  * https://github.com/TileDB-Inc/TileDB/blob/a34830c2b9fe4c00526e497630f251263b5e468b/tiledb/common/heap_memory.h#L115-L121
* Modified vendoring:
  * https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/libtiledbsoma/src/external/include/thread_pool/status.h#L60-L64

Given the narrative at https://github.com/single-cell-data/TileDB-SOMA/pull/3304#discussion_r1844572426 I did not review these files on my review of #3304; I'll take another look now including a diff against the core vendoring-source files.


Also note that on #3304

**Notes for Reviewer:**

I found this while debugging an issue: on my laptop (but not in CI) there is a segfault here:
https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/apis/python/tests/test_fastercsx.py#L352-L363

This intends to catch an exception thrown through this callchain, as revealed by source-level debugging this morning:

* https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/apis/python/src/tiledbsoma/_fastercsx.py#L86-L88
* https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/libtiledbsoma/src/utils/fastercsx.h#L310-L320
* https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/libtiledbsoma/src/utils/fastercsx.h#L389-L398
* https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/libtiledbsoma/src/utils/fastercsx.h#L286

Here is a standalone repro which crashes for me, taken from https://github.com/single-cell-data/TileDB-SOMA/blob/ca00d5bdc15bdea21a5139f9e5815828ffddd0d0/apis/python/tests/test_fastercsx.py#L352-L363: 

```
#!/usr/bin/env python

import tiledbsoma
import tiledbsoma._fastercsx as fastercsx

import scipy.sparse
import numpy as np

context = tiledbsoma.SOMATileDBContext()

sp = scipy.sparse.identity(32, dtype=np.int8).tocoo()
for shp in [
    (sp.shape[0] - 1, sp.shape[1]),
    (sp.shape[0], sp.shape[1] - 1),
]:
    try:
        fastercsx.CompressedMatrix.from_ijd(
            sp.row, sp.col, sp.data, shp, "csr", True, context,
        )
    except IndexError:
        print("Caught IndexError as expected")
```

This does crash for me on my laptop; I does not crash for me on an Ubuntu system. Nonetheless I ran `valgrind` on an Ubuntu system. I found the following:

* Before: https://gist.github.com/johnkerl/59c71f2928e6fdc6b991a19beed47e93 (double-spaced for convenience)
* After applying this patch: https://gist.github.com/johnkerl/71755befa2d8e82be151b4140668a89a (double-spaced for convenience)

The `valgrind` output

```
apis/python/tests/test_fastercsx.py ==9085== Mismatched free() / delete / delete []
```

led me directly to the codemod addressed on this PR.

Do note however that even after a clean and rebuild I do still experience the segfault with the above scenario. This means that I've found a heap-corruption issue on this PR, but there appears to be something else going on as well.