### PR TITLE
[c++] Use valid ASCII for wide-as-possible string current domain

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1046,9 +1046,8 @@ void SOMAArray::_set_soma_joinid_shape_helper(
                     case TILEDB_CHAR:
                     case TILEDB_GEOM_WKB:
                     case TILEDB_GEOM_WKT:
-                        // TODO: make these named constants b/c they're shared
-                        // with arrow_adapter.
-                        ndrect.set_range(dim_name, "", "\xff");
+                        // See comments in soma_array.h.
+                        ndrect.set_range(dim_name, "", "\x7f");
                         break;
 
                     case TILEDB_INT8:
@@ -1427,8 +1426,9 @@ void SOMAArray::_set_domain_helper(
                 auto lo_hi = ArrowAdapter::get_table_string_column_by_index(
                     newdomain, i);
                 if (lo_hi[0] == "" && lo_hi[1] == "") {
-                    // Don't care -> as big as possible
-                    ndrect.set_range(dim_name, "", "\xff");
+                    // Don't care -> as big as possible.
+                        // See comments in soma_array.h.
+                    ndrect.set_range(dim_name, "", "\x7f");
                 } else {
                     throw TileDBSOMAError(std::format(
                         "domain (\"{}\", \"{}\") cannot be set for "

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -906,13 +906,15 @@ class SOMAArray : public SOMAObject {
         //   imitate.
         // * Core current domain for string dims must _not_ be a nullptr pair.
         // * In TileDB-SOMA, unless the user specifies otherwise, we use "" for
-        //   min and "\xff" for max.
-        // * However, "\xff" causes display problems in Python. It's also
+        //   min and "\x7f" for max.
+        // * However, "\x7f" causes display problems in Python. It's also
         //   flat-out confusing to show to users.
         //
         // To work with all these factors, if the current domain is the default
-        // "" to "\xff", return an empty-string pair just as we do for domain.
-        if (arr[0] == "" && arr[1] == "\xff") {
+        // "" to "\7f", return an empty-string pair just as we do for domain.
+        // There was some pre-release software using "\xff" and it's super-cheap
+        // to check for that as well.
+        if (arr[0] == "" && (arr[1] == "\x7f" || arr[1] == "\xff")) {
             return std::pair<std::string, std::string>("", "");
         } else {
             return std::pair<std::string, std::string>(arr[0], arr[1]);

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1126,8 +1126,9 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
                     std::string hi = strings[4];
                     if (lo == "" && hi == "") {
                         // These mean "I the caller don't care, you
-                        // libtiledbsoma make it as big as possible"
-                        ndrect.set_range(col_name, "", "\xff");
+                        // libtiledbsoma make it as big as possible".
+                        // See also comments in soma_array.h.
+                        ndrect.set_range(col_name, "", "\x7f");
                     } else {
                         ndrect.set_range(col_name, lo, hi);
                         LOG_DEBUG(std::format(


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

Using `"\xff"` causes issues in TileDB-Py's `tiledb.schema.dump`, and is unnecessary regardless.

**Notes for Reviewer:**
