### PR TITLE
[c++] Some `use_current_domain` unit-test/feature-flag teardown, part 1 of 4

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1188,13 +1188,9 @@ std::pair<Dimension, bool> ArrowAdapter::tiledb_dimension_from_arrow_schema(
     FilterList filter_list = ArrowAdapter::_create_dim_filter_list(
         col_name, platform_config, soma_type, ctx);
 
-    if (array->length == 3) {
-        use_current_domain = false;
-    } else if (array->length == 5) {
-        // This is fine
-    } else {
+    if (array->length != 5) {
         throw TileDBSOMAError(std::format(
-            "ArrowAdapter: unexpected length {} for name "
+            "ArrowAdapter: unexpected length {} != 5 for name "
             "{}",
             array->length,
             col_name));

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -187,64 +187,40 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
         // SOMADataFrame objects baseline-tested in C++, then defer exhaustive
         // loop-over-all-datatypes handling to Python and R.
         if (info.tiledb_datatype == TILEDB_INT64) {
-            if (info.use_current_domain) {
-                // domain big; current_domain small
-                std::vector<int64_t> dom(
-                    {0, CORE_DOMAIN_MAX, 1, 0, info.dim_max});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            } else {
-                // domain small; current_domain feature not being used
-                std::vector<int64_t> dom({0, info.dim_max, 1});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            }
-
+              // domain big; current_domain small
+              std::vector<int64_t> dom(
+                  {0, CORE_DOMAIN_MAX, 1, 0, info.dim_max});
+              dim_array = ArrowAdapter::make_arrow_array_child(dom);
         } else if (info.tiledb_datatype == TILEDB_UINT32) {
-            if (info.use_current_domain) {
-                // domain big; current_domain small
-                std::vector<uint32_t> dom(
-                    {0,
-                     (uint32_t)CORE_DOMAIN_MAX,
-                     1,
-                     0,
-                     (uint32_t)info.dim_max});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            } else {
-                // domain small; current_domain feature not being used
-                std::vector<uint32_t> dom({0, (uint32_t)info.dim_max, 1});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            }
+              // domain big; current_domain small
+              std::vector<uint32_t> dom(
+                  {0,
+                   (uint32_t)CORE_DOMAIN_MAX,
+                   1,
+                   0,
+                   (uint32_t)info.dim_max});
+              dim_array = ArrowAdapter::make_arrow_array_child(dom);
 
         } else if (info.tiledb_datatype == TILEDB_STRING_ASCII) {
             // Domain specification for strings is not supported in core. See
             // arrow_adapter for more info. We rely on arrow_adapter to also
             // handle this case.
-            if (info.use_current_domain) {
-                std::vector<std::string> dom(
-                    {"", "", "", info.string_lo, info.string_hi});
-                dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
-            } else {
-                std::vector<std::string> dom({"", "", ""});
-                dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
-            }
+              std::vector<std::string> dom(
+                  {"", "", "", info.string_lo, info.string_hi});
+              dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
         } else if (info.tiledb_datatype == TILEDB_GEOM_WKB) {
             // No domain can be set for WKB. The domain will be set to the
             // individual spatial axes.
             dim_array = ArrowAdapter::make_arrow_array_child_binary();
         } else if (info.tiledb_datatype == TILEDB_FLOAT64) {
-            if (info.use_current_domain) {
-                // domain big; current_domain small
-                std::vector<double_t> dom(
-                    {0,
-                     (double_t)CORE_DOMAIN_MAX,
-                     1,
-                     0,
-                     (double_t)info.dim_max});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            } else {
-                // domain small; current_domain feature not being used
-                std::vector<double_t> dom({0, (double_t)info.dim_max, 1});
-                dim_array = ArrowAdapter::make_arrow_array_child(dom);
-            }
+              // domain big; current_domain small
+              std::vector<double_t> dom(
+                  {0,
+                   (double_t)CORE_DOMAIN_MAX,
+                   1,
+                   0,
+                   (double_t)info.dim_max});
+              dim_array = ArrowAdapter::make_arrow_array_child(dom);
         }
 
         if (dim_array == nullptr) {

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -187,40 +187,31 @@ static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
         // SOMADataFrame objects baseline-tested in C++, then defer exhaustive
         // loop-over-all-datatypes handling to Python and R.
         if (info.tiledb_datatype == TILEDB_INT64) {
-              // domain big; current_domain small
-              std::vector<int64_t> dom(
-                  {0, CORE_DOMAIN_MAX, 1, 0, info.dim_max});
-              dim_array = ArrowAdapter::make_arrow_array_child(dom);
+            // domain big; current_domain small
+            std::vector<int64_t> dom({0, CORE_DOMAIN_MAX, 1, 0, info.dim_max});
+            dim_array = ArrowAdapter::make_arrow_array_child(dom);
         } else if (info.tiledb_datatype == TILEDB_UINT32) {
-              // domain big; current_domain small
-              std::vector<uint32_t> dom(
-                  {0,
-                   (uint32_t)CORE_DOMAIN_MAX,
-                   1,
-                   0,
-                   (uint32_t)info.dim_max});
-              dim_array = ArrowAdapter::make_arrow_array_child(dom);
+            // domain big; current_domain small
+            std::vector<uint32_t> dom(
+                {0, (uint32_t)CORE_DOMAIN_MAX, 1, 0, (uint32_t)info.dim_max});
+            dim_array = ArrowAdapter::make_arrow_array_child(dom);
 
         } else if (info.tiledb_datatype == TILEDB_STRING_ASCII) {
             // Domain specification for strings is not supported in core. See
             // arrow_adapter for more info. We rely on arrow_adapter to also
             // handle this case.
-              std::vector<std::string> dom(
-                  {"", "", "", info.string_lo, info.string_hi});
-              dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
+            std::vector<std::string> dom(
+                {"", "", "", info.string_lo, info.string_hi});
+            dim_array = ArrowAdapter::make_arrow_array_child_string(dom);
         } else if (info.tiledb_datatype == TILEDB_GEOM_WKB) {
             // No domain can be set for WKB. The domain will be set to the
             // individual spatial axes.
             dim_array = ArrowAdapter::make_arrow_array_child_binary();
         } else if (info.tiledb_datatype == TILEDB_FLOAT64) {
-              // domain big; current_domain small
-              std::vector<double_t> dom(
-                  {0,
-                   (double_t)CORE_DOMAIN_MAX,
-                   1,
-                   0,
-                   (double_t)info.dim_max});
-              dim_array = ArrowAdapter::make_arrow_array_child(dom);
+            // domain big; current_domain small
+            std::vector<double_t> dom(
+                {0, (double_t)CORE_DOMAIN_MAX, 1, 0, (double_t)info.dim_max});
+            dim_array = ArrowAdapter::make_arrow_array_child(dom);
         }
 
         if (dim_array == nullptr) {

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -51,7 +51,7 @@ TEST_CASE("SOMACollection: basic") {
 }
 
 TEST_CASE("SOMACollection: add SOMASparseNDArray") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         TimestampRange ts(0, 2);
@@ -109,7 +109,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
 }
 
 TEST_CASE("SOMACollection: add SOMADenseNDArray") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         TimestampRange ts(0, 2);
@@ -167,7 +167,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
 }
 
 TEST_CASE("SOMACollection: add SOMADataFrame") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -231,7 +231,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
 }
 
 TEST_CASE("SOMACollection: add SOMACollection") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -264,7 +264,7 @@ TEST_CASE("SOMACollection: add SOMACollection") {
 }
 
 TEST_CASE("SOMACollection: add SOMAExperiment") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -320,7 +320,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
 }
 
 TEST_CASE("SOMACollection: add SOMAMeasurement") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -376,7 +376,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
 }
 
 TEST_CASE("SOMACollection: metadata") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -437,7 +437,7 @@ TEST_CASE("SOMACollection: metadata") {
 }
 
 TEST_CASE("SOMAExperiment: metadata") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -532,7 +532,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 }
 
 TEST_CASE("SOMAMeasurement: metadata") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -205,7 +205,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: basic",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         set_up(
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(
         std::make_pair(R"("NOOP")", TILEDB_FILTER_NONE));
 
     SECTION(std::format("- filter={}", filter.first)) {
-        auto use_current_domain = GENERATE(false, true);
+        auto use_current_domain = GENERATE(true);
         std::ostringstream section2;
         section2 << "- use_current_domain=" << use_current_domain;
         SECTION(section2.str()) {
@@ -389,7 +389,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: metadata",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         set_up(std::make_shared<SOMAContext>(), "mem://unit-test-collection");
@@ -498,7 +498,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: standard-indexed dataframe dim-sjid attr-str-u32",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -838,7 +838,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: variant-indexed dataframe dim-u32-sjid attr-str",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -1182,7 +1182,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: variant-indexed dataframe dim-sjid-str attr-u32",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {
@@ -1532,7 +1532,7 @@ TEST_CASE_METHOD(
     VariouslyIndexedDataFrameFixture,
     "SOMADataFrame: variant-indexed dataframe dim-str-u32 attr-sjid",
     "[SOMADataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
     std::ostringstream section;
     section << "- use_current_domain=" << use_current_domain;
     SECTION(section.str()) {

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -40,7 +40,7 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
     int64_t dim_max = 999;
     int64_t shape = 1000;
 
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
@@ -154,7 +154,7 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
 
 TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
     int64_t dim_max = 999;
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
@@ -239,7 +239,7 @@ TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
 
 TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     int64_t dim_max = 999;
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -40,7 +40,7 @@
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 
 TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();
@@ -151,7 +151,7 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
 }
 
 TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -36,7 +36,7 @@
 const int64_t SOMA_JOINID_DIM_MAX = 99;
 
 TEST_CASE("SOMAPointCloudDataFrame: basic", "[SOMAPointCloudDataFrame]") {
-    auto use_current_domain = GENERATE(false, true);
+    auto use_current_domain = GENERATE(true);
 
     SECTION(std::format("- use_current_domain={}", use_current_domain)) {
         auto ctx = std::make_shared<SOMAContext>();


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). Also #3273.

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

The `use_current_domain` logic was solely transitional while awaiting core 2.27.0rc3, which we now have in place. It's time to dismantle this code which is now needlessly complicating our unit-test framework.

**Notes for Reviewer:**

This is first in a series of PRs. While the changes are trivial, the line-count can be intimidating when it's attempted all at once.

Stacked on #3368