### PR TITLE
[c++] Some `use_current_domain` unit-test/feature-flag teardown, part 2 of 4

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -265,10 +265,9 @@ class ArrowAdapter {
     /**
      * @brief Get a TileDB dimension from an Arrow schema.
      *
-     * @return std::pair<Dimension, bool> The TileDB dimension with a boolean
-     * flag indicating whether or not the dimension uses `current domain`.
+     * @return std::pair<Dimension, bool> The TileDB dimension.
      */
-    static std::pair<Dimension, bool> tiledb_dimension_from_arrow_schema(
+    static Dimension tiledb_dimension_from_arrow_schema(
         std::shared_ptr<Context> ctx,
         ArrowSchema* schema,
         ArrowArray* array,
@@ -780,7 +779,7 @@ class ArrowAdapter {
         int64_t column_index,
         int64_t expected_n_buffers);
 
-    static bool _set_spatial_dimensions(
+    static void _set_spatial_dimensions(
         std::map<std::string, Dimension>& dims,
         const ArrowTable& spatial_column_info,
         std::string_view type_metadata,


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). Also #3273.

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

**Notes for Reviewer:**

This is second in a series of PRs. While the changes are trivial, the line-count can be intimidating when it's attempted all at once.

Stacked on https://github.com/single-cell-data/TileDB-SOMA/pull/3369