### PR TITLE
[c++] Some `use_current_domain` unit-test/feature-flag teardown, part 3 of 4

### DIFF
--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1387,7 +1387,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     array->release = &release_array;
     if (array->private_data != nullptr) {  // as we use nanoarrow's init
         free(array->private_data);         // free what was allocated before
-    }                                      // assigning our ArrowBuffer pointer
+    }  // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(std::format(

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -954,8 +954,6 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
 
     std::map<std::string, Dimension> dims;
 
-    bool use_current_domain = true;
-
     for (int64_t sch_idx = 0; sch_idx < arrow_schema->n_children; ++sch_idx) {
         auto child = arrow_schema->children[sch_idx];
         std::string_view type_metadata;
@@ -1059,105 +1057,95 @@ ArraySchema ArrowAdapter::tiledb_schema_from_arrow_schema(
 
     // Note: this must be done after we've got the core domain, since the
     // NDRectangle constructor requires access to the core domain.
-    if (use_current_domain) {
-        CurrentDomain current_domain(*ctx);
-        NDRectangle ndrect(*ctx, domain);
 
-        for (int64_t sch_idx = 0; sch_idx < arrow_schema->n_children;
-             ++sch_idx) {
-            auto child = arrow_schema->children[sch_idx];
-            auto type = ArrowAdapter::to_tiledb_format(child->format);
+    CurrentDomain current_domain(*ctx);
+    NDRectangle ndrect(*ctx, domain);
 
-            for (int64_t i = 0; i < index_column_schema->n_children; ++i) {
-                auto col_name = index_column_schema->children[i]->name;
-                if (strcmp(child->name, col_name) != 0) {
-                    continue;
-                }
+    for (int64_t sch_idx = 0; sch_idx < arrow_schema->n_children; ++sch_idx) {
+        auto child = arrow_schema->children[sch_idx];
+        auto type = ArrowAdapter::to_tiledb_format(child->format);
 
-                if (strcmp(child->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) ==
-                        0 &&
-                    spatial_column_info.first.get() != nullptr) {
-                    for (int64_t j = 0;
-                         j < spatial_column_info.first->n_children;
-                         ++j) {
-                        auto col_name = SOMA_GEOMETRY_DIMENSION_PREFIX +
-                                        std::string(spatial_column_info.second
-                                                        ->children[j]
-                                                        ->name);
-                        const void* buff = spatial_column_info.first
-                                               ->children[j]
-                                               ->buffers[1];
-                        auto type = ArrowAdapter::to_tiledb_format(
-                            spatial_column_info.second->children[j]->format);
-
-                        _set_current_domain_slot(
-                            type, buff, ndrect, col_name + "__min");
-                        _set_current_domain_slot(
-                            type, buff, ndrect, col_name + "__max");
-                    }
-                } else if (ArrowAdapter::arrow_is_var_length_type(
-                               child->format)) {
-                    // In the core API:
-                    //
-                    // * domain for strings must be set as (nullptr, nullptr)
-                    // * current_domain for strings cannot be set as (nullptr,
-                    //   nullptr)
-                    //
-                    // Fortunately, these are ASCII dims and we can range
-                    // these accordingly.
-
-                    ArrowArray* child_array = index_column_array->children[i];
-                    ArrowSchema* child_schema = index_column_schema
-                                                    ->children[i];
-
-                    std::vector<std::string>
-                        strings = ArrowAdapter::get_array_string_column(
-                            child_array, child_schema);
-                    if (strings.size() != 5) {
-                        throw TileDBSOMAError(std::format(
-                            "ArrowAdapter::tiledb_schema_from_arrow_schema: "
-                            "internal error: "
-                            "expected 5 strings, got {}",
-                            strings.size()));
-                    }
-
-                    std::string lo = strings[3];
-                    std::string hi = strings[4];
-                    if (lo == "" && hi == "") {
-                        // These mean "I the caller don't care, you
-                        // libtiledbsoma make it as big as possible".
-                        // See also comments in soma_array.h.
-                        ndrect.set_range(col_name, "", "\x7f");
-                    } else {
-                        ndrect.set_range(col_name, lo, hi);
-                        LOG_DEBUG(std::format(
-                            "[ArrowAdapter] index_column_info nbuf {}",
-                            index_column_array->children[i]->n_buffers));
-                    }
-
-                    LOG_DEBUG(std::format(
-                        "[ArrowAdapter] current domain {} \"{}\"-\"{}\"",
-                        child_schema->name,
-                        lo,
-                        hi));
-                } else {
-                    const void* buff = index_column_array->children[i]
-                                           ->buffers[1];
-                    _set_current_domain_slot(type, buff, ndrect, col_name);
-                }
-                break;
+        for (int64_t i = 0; i < index_column_schema->n_children; ++i) {
+            auto col_name = index_column_schema->children[i]->name;
+            if (strcmp(child->name, col_name) != 0) {
+                continue;
             }
+
+            if (strcmp(child->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) == 0 &&
+                spatial_column_info.first.get() != nullptr) {
+                for (int64_t j = 0; j < spatial_column_info.first->n_children;
+                     ++j) {
+                    auto col_name = SOMA_GEOMETRY_DIMENSION_PREFIX +
+                                    std::string(
+                                        spatial_column_info.second->children[j]
+                                            ->name);
+                    const void* buff = spatial_column_info.first->children[j]
+                                           ->buffers[1];
+                    auto type = ArrowAdapter::to_tiledb_format(
+                        spatial_column_info.second->children[j]->format);
+
+                    _set_current_domain_slot(
+                        type, buff, ndrect, col_name + "__min");
+                    _set_current_domain_slot(
+                        type, buff, ndrect, col_name + "__max");
+                }
+            } else if (ArrowAdapter::arrow_is_var_length_type(child->format)) {
+                // In the core API:
+                //
+                // * domain for strings must be set as (nullptr, nullptr)
+                // * current_domain for strings cannot be set as (nullptr,
+                //   nullptr)
+                //
+                // Fortunately, these are ASCII dims and we can range
+                // these accordingly.
+
+                ArrowArray* child_array = index_column_array->children[i];
+                ArrowSchema* child_schema = index_column_schema->children[i];
+
+                std::vector<std::string>
+                    strings = ArrowAdapter::get_array_string_column(
+                        child_array, child_schema);
+                if (strings.size() != 5) {
+                    throw TileDBSOMAError(std::format(
+                        "ArrowAdapter::tiledb_schema_from_arrow_schema: "
+                        "internal error: "
+                        "expected 5 strings, got {}",
+                        strings.size()));
+                }
+
+                std::string lo = strings[3];
+                std::string hi = strings[4];
+                if (lo == "" && hi == "") {
+                    // These mean "I the caller don't care, you
+                    // libtiledbsoma make it as big as possible"
+                    ndrect.set_range(col_name, "", "\x7f");
+                } else {
+                    ndrect.set_range(col_name, lo, hi);
+                    LOG_DEBUG(std::format(
+                        "[ArrowAdapter] index_column_info nbuf {}",
+                        index_column_array->children[i]->n_buffers));
+                }
+
+                LOG_DEBUG(std::format(
+                    "[ArrowAdapter] current domain {} \"{}\"-\"{}\"",
+                    child_schema->name,
+                    lo,
+                    hi));
+            } else {
+                const void* buff = index_column_array->children[i]->buffers[1];
+                _set_current_domain_slot(type, buff, ndrect, col_name);
+            }
+            break;
         }
-
-        current_domain.set_ndrectangle(ndrect);
-
-        LOG_DEBUG(std::format(
-            "[ArrowAdapter] before setting current_domain from ndrect"));
-        ArraySchemaExperimental::set_current_domain(
-            *ctx, schema, current_domain);
-        LOG_DEBUG(std::format(
-            "[ArrowAdapter] after setting current_domain from ndrect"));
     }
+
+    current_domain.set_ndrectangle(ndrect);
+
+    LOG_DEBUG(std::format(
+        "[ArrowAdapter] before setting current_domain from ndrect"));
+    ArraySchemaExperimental::set_current_domain(*ctx, schema, current_domain);
+    LOG_DEBUG(
+        std::format("[ArrowAdapter] after setting current_domain from ndrect"));
 
     LOG_DEBUG(std::format("[ArrowAdapter] check"));
     schema.check();
@@ -1399,7 +1387,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     array->release = &release_array;
     if (array->private_data != nullptr) {  // as we use nanoarrow's init
         free(array->private_data);         // free what was allocated before
-    }  // assigning our ArrowBuffer pointer
+    }                                      // assigning our ArrowBuffer pointer
     array->private_data = (void*)arrow_buffer;
 
     LOG_TRACE(std::format(

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -124,11 +124,10 @@ create_arrow_schema_and_index_columns(
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
     for (auto info : dim_infos) {
         LOG_DEBUG(std::format(
-            "create_column_index_info name={} type={} dim_max={} ucd={}",
+            "create_column_index_info name={} type={} dim_max={}",
             info.name,
             tiledb::impl::to_str(info.tiledb_datatype),
-            info.dim_max,
-            info.use_current_domain));
+            info.dim_max));
     }
 
     auto index_cols_info_schema = create_index_cols_info_schema(dim_infos);

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -69,7 +69,6 @@ struct DimInfo {
     int64_t dim_max;
     std::string string_lo;  // For custom/restricted DataFrame domains
     std::string string_hi;  // For custom/restricted DataFrame domains
-    bool use_current_domain;
 };
 
 // E.g. "a0" is of type TILEDB_FLOAT64

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -70,8 +70,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -127,8 +126,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         auto index_columns = helper::create_column_index_info(dim_infos);
 
         std::map<std::string, SOMAGroupEntry> expected_map{
@@ -188,8 +186,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
         auto [schema, index_columns] =
@@ -284,8 +281,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
         auto [schema, index_columns] =
@@ -340,8 +336,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
         auto [schema, index_columns] =
@@ -455,8 +450,7 @@ TEST_CASE("SOMAExperiment: metadata") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
         auto [schema, index_columns] =
@@ -549,8 +543,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
               .tiledb_datatype = tiledb_datatype,
               .dim_max = DIM_MAX,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
         std::vector<helper::AttrInfo> attr_infos(
             {{.name = attr_name, .tiledb_datatype = tiledb_datatype}});
         auto [schema, index_columns] =

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -53,15 +53,13 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
                   .tiledb_datatype = TILEDB_INT64,
                   .dim_max = SOMA_JOINID_DIM_MAX,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain}),
+                  .string_hi = "N/A"}),
              helper::DimInfo(
                  {.name = "soma_geometry",
                   .tiledb_datatype = TILEDB_GEOM_WKB,
                   .dim_max = 100,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain})});
+                  .string_hi = "N/A"})});
 
         std::vector<helper::DimInfo> spatial_dim_infos(
             {helper::DimInfo(
@@ -69,15 +67,13 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
                   .tiledb_datatype = TILEDB_FLOAT64,
                   .dim_max = 200,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain}),
+                  .string_hi = "N/A"}),
              helper::DimInfo(
                  {.name = "y",
                   .tiledb_datatype = TILEDB_FLOAT64,
                   .dim_max = 100,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain})});
+                  .string_hi = "N/A"})});
 
         std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
             {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});
@@ -164,15 +160,13 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
                   .tiledb_datatype = TILEDB_INT64,
                   .dim_max = SOMA_JOINID_DIM_MAX,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain}),
+                  .string_hi = "N/A"}),
              helper::DimInfo(
                  {.name = "soma_geometry",
                   .tiledb_datatype = TILEDB_GEOM_WKB,
                   .dim_max = 100,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain})});
+                  .string_hi = "N/A"})});
 
         std::vector<helper::DimInfo> spatial_dim_infos(
             {helper::DimInfo(
@@ -180,15 +174,13 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
                   .tiledb_datatype = TILEDB_FLOAT64,
                   .dim_max = 200,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain}),
+                  .string_hi = "N/A"}),
              helper::DimInfo(
                  {.name = "y",
                   .tiledb_datatype = TILEDB_FLOAT64,
                   .dim_max = 100,
                   .string_lo = "N/A",
-                  .string_hi = "N/A",
-                  .use_current_domain = use_current_domain})});
+                  .string_hi = "N/A"})});
 
         std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
             {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -49,22 +49,19 @@ TEST_CASE("SOMAPointCloudDataFrame: basic", "[SOMAPointCloudDataFrame]") {
                  .tiledb_datatype = TILEDB_INT64,
                  .dim_max = SOMA_JOINID_DIM_MAX,
                  .string_lo = "N/A",
-                 .string_hi = "N/A",
-                 .use_current_domain = use_current_domain}),
+                 .string_hi = "N/A"}),
             helper::DimInfo(
                 {.name = "x",
                  .tiledb_datatype = TILEDB_UINT32,
                  .dim_max = 100,
                  .string_lo = "N/A",
-                 .string_hi = "N/A",
-                 .use_current_domain = use_current_domain}),
+                 .string_hi = "N/A"}),
             helper::DimInfo(
                 {.name = "y",
                  .tiledb_datatype = TILEDB_UINT32,
                  .dim_max = 100,
                  .string_lo = "N/A",
-                 .string_hi = "N/A",
-                 .use_current_domain = use_current_domain}),
+                 .string_hi = "N/A"}),
         });
 
         std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -61,8 +61,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -95,9 +94,6 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
 
         auto expect = std::vector<int64_t>({shape});
         REQUIRE(snda->shape() == expect);
-        if (!use_current_domain) {
-            REQUIRE(snda->maxshape() == expect);
-        }
 
         snda->close();
 
@@ -136,54 +132,26 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
         REQUIRE_THROWS(snda->write());
         snda->close();
 
-        if (!use_current_domain) {
-            auto new_shape = std::vector<int64_t>({shape});
+        auto new_shape = std::vector<int64_t>({shape * 2});
 
-            snda = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
-            // Without current-domain support: this should throw since
-            // one cannot resize what has not been sized.
-            REQUIRE(!snda->has_current_domain());
-            REQUIRE_THROWS(snda->resize(new_shape, "testing"));
-            // Now set the shape
-            snda->upgrade_shape(new_shape, "testing");
-            snda->close();
+        snda = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
+        // Should throw since this already has a shape (core current
+        // domain).
+        REQUIRE_THROWS(snda->upgrade_shape(new_shape, "testing"));
+        snda->resize(new_shape, "testing");
+        snda->close();
 
-            snda->open(OpenMode::read);
-            REQUIRE(snda->has_current_domain());
-            snda->close();
+        // Try out-of-bounds write after resize.
+        snda->open(OpenMode::write);
+        snda->set_column_data(dim_name, d0b.size(), d0b.data());
+        snda->set_column_data(attr_name, a0b.size(), a0b.data());
+        // Implicitly checking for no throw
+        snda->write();
+        snda->close();
 
-            snda->open(OpenMode::write);
-            REQUIRE(snda->has_current_domain());
-            // Should not fail since we're setting it to what it already is.
-            snda->resize(new_shape, "testing");
-            snda->close();
-
-            snda->open(OpenMode::read);
-            REQUIRE(snda->shape() == new_shape);
-            snda->close();
-
-        } else {
-            auto new_shape = std::vector<int64_t>({shape * 2});
-
-            snda = SOMASparseNDArray::open(uri, OpenMode::write, ctx);
-            // Should throw since this already has a shape (core current
-            // domain).
-            REQUIRE_THROWS(snda->upgrade_shape(new_shape, "testing"));
-            snda->resize(new_shape, "testing");
-            snda->close();
-
-            // Try out-of-bounds write after resize.
-            snda->open(OpenMode::write);
-            snda->set_column_data(dim_name, d0b.size(), d0b.data());
-            snda->set_column_data(attr_name, a0b.size(), a0b.data());
-            // Implicitly checking for no throw
-            snda->write();
-            snda->close();
-
-            snda->open(OpenMode::read);
-            REQUIRE(snda->shape() == new_shape);
-            snda->close();
-        }
+        snda->open(OpenMode::read);
+        REQUIRE(snda->shape() == new_shape);
+        snda->close();
     }
 }
 
@@ -210,8 +178,7 @@ TEST_CASE("SOMASparseNDArray: platform_config", "[SOMASparseNDArray]") {
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -258,8 +225,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
               .tiledb_datatype = dim_tiledb_datatype,
               .dim_max = dim_max,
               .string_lo = "N/A",
-              .string_hi = "N/A",
-              .use_current_domain = use_current_domain}});
+              .string_hi = "N/A"}});
 
         auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -350,8 +316,7 @@ TEST_CASE(
           .tiledb_datatype = dim_tiledb_datatype,
           .dim_max = dim_max,
           .string_lo = "N/A",
-          .string_hi = "N/A",
-          .use_current_domain = true}});
+          .string_hi = "N/A"}});
 
     auto index_columns = helper::create_column_index_info(dim_infos);
 
@@ -412,8 +377,7 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
           .tiledb_datatype = dim_tiledb_datatype,
           .dim_max = dim_max,
           .string_lo = "N/A",
-          .string_hi = "N/A",
-          .use_current_domain = true}});
+          .string_hi = "N/A"}});
 
     auto index_columns = helper::create_column_index_info(dim_infos);
 


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue #2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048). Also #3273.

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

**Notes for Reviewer:**

This is third in a series of PRs. While the changes are trivial, the line-count can be intimidating when it's attempted all at once.

Stacked on https://github.com/single-cell-data/TileDB-SOMA/pull/3370

The line count is big but mostly whitespace. Suggestion: hide whitespace when reviewing:
https://github.com/single-cell-data/TileDB-SOMA/pull/3371/files?diff=split&w=1