### PR TITLE
[c++] Remove use of deprecated schema-display function

### DIFF
--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -100,7 +100,7 @@ std::tuple<std::string, uint64_t> create_array(
     // Open array for writing
     Array array(ctx, uri, TILEDB_WRITE, TemporalPolicy(TimeTravel, timestamp));
     if (LOG_DEBUG_ENABLED()) {
-        array.schema().dump();
+        std::cout << array.schema();
     }
 
     // Generate fragments in random order


### PR DESCRIPTION
Remove usage of deprecated `dump` function with stream operator.
