### PR TITLE
[python] Fix typos and import order in the spatial outgest

### DIFF
--- a/apis/python/src/tiledbsoma/experimental/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/experimental/_xarray_backend.py
@@ -15,12 +15,12 @@ try:
     import spatialdata as sd
     from spatialdata.models.models import DataTree
 except ImportError as err:
-    warnings.warn("Experimental spatial exporter requires the spatialdatda package.")
+    warnings.warn("Experimental spatial exporter requires the spatialdata package.")
     raise err
 try:
     import xarray as xr
 except ImportError as err:
-    warnings.warn("Experimental spatial exporter requires the spatialdatda package.")
+    warnings.warn("Experimental spatial exporter requires the xarray package.")
     raise err
 
 from .. import DenseNDArray

--- a/apis/python/src/tiledbsoma/experimental/outgest.py
+++ b/apis/python/src/tiledbsoma/experimental/outgest.py
@@ -5,11 +5,6 @@
 import warnings
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
-try:
-    import geopandas as gpd
-except ImportError as err:
-    warnings.warn("Experimental spatial outgestor requires the geopandas package.")
-    raise err
 import pandas as pd
 import somacore
 
@@ -17,6 +12,11 @@ try:
     import spatialdata as sd
 except ImportError as err:
     warnings.warn("Experimental spatial outgestor requires the spatialdata package.")
+    raise err
+try:
+    import geopandas as gpd
+except ImportError as err:
+    warnings.warn("Experimental spatial outgestor requires the geopandas package.")
     raise err
 
 from .. import MultiscaleImage, PointCloudDataFrame


### PR DESCRIPTION
Fix two typos in warnings and try importing geopandas after spatialdata.
