### PR TITLE
ExperimentAxisQuery - to_anndata obsp/varp as sparse matrices

### DIFF
--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -108,9 +108,10 @@ def _read_partitioned_sparse(X: SparseNDArray, d0_size: int) -> pa.Table:
     # density of matrix. Magic number determined empirically, as a tradeoff
     # between concurrency and fixed query overhead.
     tgt_point_count = 96 * 1024**2
+    nnz = X.nnz
     partition_sz = (
-        max(1024 * round(d0_size * tgt_point_count / X.nnz / 1024), 1024)
-        if X.nnz > 0
+        max(1024 * round(d0_size * tgt_point_count / nnz / 1024), 1024)
+        if nnz > 0
         else d0_size
     )
     partitions = [

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -637,19 +637,23 @@ def test_experiment_query_to_anndata_obsp_varp(soma_experiment):
         ad = query.to_anndata("raw", obsp_layers=["foo"], varp_layers=["bar"])
         assert set(ad.obsp.keys()) == {"foo"}
         obsp = ad.obsp["foo"]
-        assert isinstance(obsp, np.ndarray)
+        assert isinstance(obsp, sparse.spmatrix)
+        assert sparse.isspmatrix_csr(obsp)
         assert obsp.shape == (query.n_obs, query.n_obs)
 
+        assert (query.obsp("foo").coos().concat().to_scipy() != obsp).nnz == 0
         assert np.array_equal(
-            query.obsp("foo").coos().concat().to_scipy().todense(), obsp
+            query.obsp("foo").coos().concat().to_scipy().todense(), obsp.todense()
         )
 
         assert set(ad.varp.keys()) == {"bar"}
         varp = ad.varp["bar"]
-        assert isinstance(varp, np.ndarray)
+        assert isinstance(varp, sparse.spmatrix)
+        assert sparse.isspmatrix_csr(varp)
         assert varp.shape == (query.n_vars, query.n_vars)
+        assert (query.varp("bar").coos().concat().to_scipy() != varp).nnz == 0
         assert np.array_equal(
-            query.varp("bar").coos().concat().to_scipy().todense(), varp
+            query.varp("bar").coos().concat().to_scipy().todense(), varp.todense()
         )
 
 


### PR DESCRIPTION
**Issue and/or context:**

Fixes #3360 

**Changes:**

obsp/varp slots in the AnnData returned by ExperimentAxisQuery.to_anndata will be sparse matrices.  Previously they were dense NDArray.

**Notes for Reviewer:**
1. this required a bit of refactoring
2. as part of this, obsp/varp will be read using the partitioned reader (same as X layers)
