### PR TITLE
[python] Add support for exporting to SpatialData without transform

### DIFF
--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -106,6 +106,8 @@ def to_spatial_data_points(
 
     Args:
         points: The point cloud data frame to convert to SpatialData shapes.
+        key: Key for the item in the SpatialData object. Used to set a transformation
+            to the item itself if no scene transform is provided.
         scene_id: The ID of the scene this point cloud dataframe is from.
         scene_dim_map: A mapping from the axis names of the scene to the corresponding
             SpatialData dimension names.
@@ -149,6 +151,8 @@ def to_spatial_data_shapes(
 
     Args:
         points: The point cloud data frame to convert to SpatialData shapes.
+        key: Key for the item in the SpatialData object. Used to set a transformation
+            to the item itself if no scene transform is provided.
         scene_id: The ID of the scene this point cloud dataframe is from.
         scene_dim_map: A mapping from the axis names of the scene to the corresponding
             SpatialData dimension names.
@@ -219,6 +223,17 @@ def to_spatial_data_image(
 ) -> "DataArray":
     """Export a level of a :class:`MultiscaleImage` to a
     :class:`spatialdata.Image2DModel` or :class:`spatialdata.Image3DModel`.
+
+    Args:
+        image: The multiscale image to convert to a level from to a SpatialData image.
+        level: The level of the multiscale image to convert.
+        key: Key for the item in the SpatialData object. Used to set a transformation
+            to the item itself if no scene transform is provided.
+        scene_id: The ID of the scene this multiscale image is from.
+        scene_dim_map: A mapping from the axis names of the scene to the corresponding
+            SpatialData dimension names.
+        transform: The transformation from the coordinate space of the scene this
+            multiscale image is in to the coordinate space of the image itself.
     """
     if not image.has_channel_axis:
         raise NotImplementedError(
@@ -295,7 +310,18 @@ def to_spatial_data_multiscale_image(
     scene_dim_map: Dict[str, str],
     transform: Optional[somacore.CoordinateTransform],
 ) -> "DataTree":
-    """Export a MultiscaleImage to a DataTree."""
+    """Export a MultiscaleImage to a DataTree.
+
+    Args:
+        image: The multiscale image to convert to a SpatialData image.
+        key: Key for the item in the SpatialData object. Used to set a transformation
+            to the item itself if no scene transform is provided.
+        scene_id: The ID of the scene this multiscale image is from.
+        scene_dim_map: A mapping from the axis names of the scene to the corresponding
+            SpatialData dimension names.
+        transform: The transformation from the coordinate space of the scene this
+            multiscale image is in to the coordinate space of the image itself.
+    """
 
     # Check for channel axis.
     if not image.has_channel_axis:

--- a/apis/python/tests/test_export_point_cloud_dataframe.py
+++ b/apis/python/tests/test_export_point_cloud_dataframe.py
@@ -35,17 +35,30 @@ def sample_point_cloud_dataframe_2d(tmp_path_factory):
     return point_cloud
 
 
-def test_export_to_shapes_2d(sample_point_cloud_dataframe_2d):
+@pytest.mark.parametrize(
+    "transform,expected_transformation",
+    [
+        (None, {"point_cloud": spatialdata.transformations.Identity()}),
+        (
+            somacore.IdentityTransform(
+                ("x_scene", "y_scene"), ("x_points", "y_points")
+            ),
+            {"scene0": spatialdata.transformations.Identity()},
+        ),
+    ],
+)
+def test_export_to_shapes_2d(
+    sample_point_cloud_dataframe_2d, transform, expected_transformation
+):
     """Test exporting a simple point cloud to a SpatialData shape model."""
     # Export PointCloudDataFrame to shapes.
     shape = soma_outgest.to_spatial_data_shapes(
         sample_point_cloud_dataframe_2d,
         scene_id="scene0",
+        key="point_cloud",
         scene_dim_map={"x_scene": "x", "y_scene": "y"},
         soma_joinid_name="obs_id",
-        transform=somacore.IdentityTransform(
-            ("x_scene", "y_scene"), ("x_points", "y_points")
-        ),
+        transform=transform,
     )
 
     # Check this is valid storage for the SpatialData "Shapes" model.
@@ -65,23 +78,34 @@ def test_export_to_shapes_2d(sample_point_cloud_dataframe_2d):
 
     # Check the metadata.
     metadata = dict(shape.attrs)
-    for key, val in metadata.items():
-        print(f"{key}: {val}")
     assert len(metadata) == 1
-    assert metadata["transform"] == {"scene0": spatialdata.transformations.Identity()}
+    assert metadata["transform"] == expected_transformation
 
 
-def test_export_to_points_2d(sample_point_cloud_dataframe_2d):
+@pytest.mark.parametrize(
+    "transform,expected_transformation",
+    [
+        (None, {"point_cloud": spatialdata.transformations.Identity()}),
+        (
+            somacore.IdentityTransform(
+                ("x_scene", "y_scene"), ("x_points", "y_points")
+            ),
+            {"scene0": spatialdata.transformations.Identity()},
+        ),
+    ],
+)
+def test_export_to_points_2d(
+    sample_point_cloud_dataframe_2d, transform, expected_transformation
+):
     """Test exporting a simple point cloud to a SpatialData shape model."""
     # Export PointCloudDataFrame to shapes.
     points = soma_outgest.to_spatial_data_points(
         sample_point_cloud_dataframe_2d,
+        key="point_cloud",
         scene_id="scene0",
         scene_dim_map={"x_scene": "x", "y_scene": "y"},
         soma_joinid_name="obs_id",
-        transform=somacore.IdentityTransform(
-            ("x_scene", "y_scene"), ("x_points", "y_points")
-        ),
+        transform=transform,
     )
 
     # Check this is valid storage for the SpatialData "Points" model.
@@ -99,7 +123,5 @@ def test_export_to_points_2d(sample_point_cloud_dataframe_2d):
 
     # Check the metadata.
     metadata = dict(points.attrs)
-    for key, val in metadata.items():
-        print(f"{key}: {val}")
     assert len(metadata) == 1
-    assert metadata["transform"] == {"scene0": spatialdata.transformations.Identity()}
+    assert metadata["transform"] == expected_transformation


### PR DESCRIPTION
Add support for exporting a `PointCloudDataFrame` or `GeometryDataFrame` to SpatialData even if we don't have a mapping from the object to the `Scene` it is stored in.



