### PR TITLE
[python] Change import `experimental` -> `io.spatial` in test

### DIFF
--- a/apis/python/tests/test_spatial_outgest_util.py
+++ b/apis/python/tests/test_spatial_outgest_util.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import somacore
 
-soma_outgest = pytest.importorskip("tiledbsoma.experimental.outgest")
+soma_outgest = pytest.importorskip("tiledbsoma.io.spatial.outgest")
 sd = pytest.importorskip("spatialdata")
 
 


### PR DESCRIPTION
One instance of renaming the `experimental` module was missed in PR #3384.