### PR TITLE
[r] Adjust blockwise + re-indexer to return condensed matrix, not full domain

### DIFF
--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -352,7 +352,7 @@ BlockwiseSparseReadIter <- R6::R6Class(
       stride <- self$coords[[axname]]$stride
       # For re-indexed blockwise iterators, shape should reflect the re-indexed
       # axes; this can generally be the stride of the iterator, but for the end
-      # of each iterator this needs to the remainder (see ?`%%`).
+      # of each iterator this needs to be the remainder (see ?`%%`).
       # Note: this only applies to the major axis, minor axes always return
       # the full domain.
       if (self$reindexable && shape[axis + 1L] > stride) {

--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -361,32 +361,6 @@ BlockwiseSparseReadIter <- R6::R6Class(
         } else {
           as.numeric(self$coords[[axname]]$end %% stride) + 1L
         }
-        # axes_to_reindex <- c(
-        #   if (self$axis %in% self$reindex_disable_on_axis) {
-        #     bit64::integer64()
-        #   } else {
-        #     bit64::as.integer64(self$axis)
-        #   },
-        #   self$axes_to_reindex
-        # )
-        # for (i in seq_along(axes_to_reindex)) {
-        #   ax <- axes_to_reindex[i]
-        #   axname <- sprintf("soma_dim_%i", as.integer(ax))
-        #   # self$axes_to_reindex does not contain self$axis,
-        #   # so this is the equivalent of
-        #   # ax == self$axis
-        #   # but `ax` and `self$axes_to_reindex` are integers
-        #   # while `self$axis` is an int64
-        #   if (!ax %in% self$axes_to_reindex) {
-        #     shape[axname] <- if (self$coords[[axname]]$has_next()) {
-        #       self$coords[[axname]]$stride
-        #     } else {
-        #       self$coords[[axname]]$end %% self$coords[[axname]]$stride
-        #     }
-        #     next
-        #   }
-        #   # TODO: Handle cases where minor axes are indexed
-        # }
       }
       mat <- arrow_table_to_sparse(
         tbl,

--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -352,9 +352,9 @@ BlockwiseSparseReadIter <- R6::R6Class(
       stride <- self$coords[[axname]]$stride
       # For re-indexed blockwise iterators, shape should reflect the re-indexed
       # axes; this can generally be the stride of the iterator, but for the end
-      # of each iterator this needs to the remainder (see ?`%%`)
+      # of each iterator this needs to the remainder (see ?`%%`).
       # Note: this only applies to the major axis, minor axes always return
-      # the full domain
+      # the full domain.
       if (self$reindexable && shape[axis + 1L] > stride) {
         shape[axis + 1L] <- if (self$coords[[axname]]$has_next()) {
           as.numeric(stride)

--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -346,10 +346,40 @@ BlockwiseSparseReadIter <- R6::R6Class(
     .zero_based = FALSE,
     soma_reader_transform = function(x) {
       tbl <- private$reindex_arrow_table(soma_array_to_arrow_table(x))
+      print(names(tbl))
+      shape <- private$.shape
+      names(shape) <- names(self$coords)
+      # For re-indexed blockwise iterators, shape should reflect the re-indexed axes
+      # this can generally be the stride of the iterator, but for the end of each iterator
+      # this needs to be smaller (see ?`%%`)
+      if (self$reindexable) {
+        axes_to_reindex <- c(
+          if (self$axis %in% self$reindex_disable_on_axis) {
+            bit64::integer64()
+          } else {
+            bit64::as.integer64(self$axis)
+          },
+          self$axes_to_reindex
+        )
+        for (i in seq_along(axes_to_reindex)) {
+          ax <- axes_to_reindex[i]
+          axname <- sprintf("soma_dim_%i", as.integer(ax))
+          # self$axes_to_reindex does not contain self$axis, so this is the equivalent of
+          # ax == self$axis
+          if (!ax %in% self$axes_to_reindex) {
+            shape[axname] <- if (self$coords[[axname]]$has_next()) {
+              self$coords[[axname]]$stride
+            } else {
+              self$coords[[axname]]$end %% self$coords[[axname]]$stride
+            }
+          }
+          # TODO: Handle cases where minor axes are indexed
+        }
+      }
       mat <- arrow_table_to_sparse(
         tbl,
         repr = self$repr,
-        shape = private$.shape,
+        shape = shape,
         zero_based = private$.zero_based
       )
       attr(mat, "coords") <- attr(tbl, "coords", exact = TRUE)


### PR DESCRIPTION
The blockwise iterator + re-indexer in the R API currently return a matrix with the full domain of the array, not the re-indexed shape. This PR adjusts the behavior to return the matrix with the re-indexed shape

The new behavior mimics the Python API demonstrated [here](https://gist.github.com/mojaveazure/beb4ecda9d37dc67140ba494e4ec43a5#file-soma-blockwise-reindexer-py-rmd)

Modified SOMA methods:
 - `BlockwiseSparseReadIter$private$soma_reader_transform()`: if re-indexing is enabled, adjust the shape for each re-indexed axis to the re-indexed shape

#3385 [SC-59743](https://app.shortcut.com/tiledb-inc/story/59743)