### PR TITLE
[python, c++] Fix misleading `DoesNotExistErrors` in `open` factory

### DIFF
--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -110,7 +110,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
             clib.SOMAGroup.create(
                 uri=uri,
-                soma_type=wrapper._GROUP_WRAPPED_TYPE.__name__,
+                soma_type=wrapper._WRAPPED_TYPE.__name__,
                 ctx=context.native_context,
                 timestamp=(0, timestamp_ms),
             )
@@ -121,27 +121,6 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             )
         except SOMAError as e:
             raise map_exception_for_create(e, uri) from None
-
-    @classmethod
-    def open(
-        cls,
-        uri: str,
-        mode: options.OpenMode = "r",
-        *,
-        tiledb_timestamp: Optional[OpenTimestamp] = None,
-        context: Optional[SOMATileDBContext] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-        clib_type: Optional[str] = None,
-    ) -> Self:
-        """Opens this specific type of SOMA object."""
-        return super().open(
-            uri,
-            mode,
-            tiledb_timestamp=tiledb_timestamp,
-            context=context,
-            platform_config=platform_config,
-            clib_type="SOMAGroup",
-        )
 
     # Subclass protocol to constrain which SOMA objects types  may be set on a
     # particular collection key. Used by Experiment and Measurement.

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -6,6 +6,8 @@
 """Exceptions.
 """
 
+from typing import Union
+
 
 class SOMAError(Exception):
     """Base error type for SOMA-specific exceptions.
@@ -25,8 +27,9 @@ class DoesNotExistError(SOMAError):
     pass
 
 
-def is_does_not_exist_error(e: RuntimeError) -> bool:
-    """Given a RuntimeError, return true if it indicates the object does not exist
+def is_does_not_exist_error(e: Union[RuntimeError, SOMAError]) -> bool:
+    """Given a RuntimeError or SOMAError, return true if it indicates the object
+    does not exist
 
     Lifecycle: Maturing.
 
@@ -34,7 +37,7 @@ def is_does_not_exist_error(e: RuntimeError) -> bool:
         try:
             with tiledbsoma.open(uri):
                 ...
-        except RuntimeError as e:
+        except (RuntimeError, SOMAError) as e:
             if is_does_not_exist_error(e):
                 ...
             raise e
@@ -47,6 +50,7 @@ def is_does_not_exist_error(e: RuntimeError) -> bool:
         or "Unrecognized array" in stre
         or "HTTP code 401" in stre
         or "HTTP code 404" in stre
+        or "[SOMAObject::open] " in stre
     ):
         return True
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -3,19 +3,15 @@
 #
 # Licensed under the MIT License.
 
-from typing import Any, Optional, Tuple
+from typing import Any, Tuple
 
 import pyarrow as pa
-from somacore import options
-from typing_extensions import Self
 
 from . import _tdb_handles
 
 # This package's pybind11 code
 from . import pytiledbsoma as clib  # noqa: E402
 from ._soma_object import SOMAObject
-from ._types import OpenTimestamp
-from .options._soma_tiledb_context import SOMATileDBContext
 
 
 class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
@@ -26,27 +22,6 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
     """
 
     __slots__ = ()
-
-    @classmethod
-    def open(
-        cls,
-        uri: str,
-        mode: options.OpenMode = "r",
-        *,
-        tiledb_timestamp: Optional[OpenTimestamp] = None,
-        context: Optional[SOMATileDBContext] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-        clib_type: Optional[str] = None,
-    ) -> Self:
-        """Opens this specific type of SOMA object."""
-        return super().open(
-            uri,
-            mode,
-            tiledb_timestamp=tiledb_timestamp,
-            context=context,
-            platform_config=platform_config,
-            clib_type="SOMAArray",
-        )
 
     @property
     def schema(self) -> pa.Schema:

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -97,7 +97,11 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         del platform_config  # unused
         context = _validate_soma_tiledb_context(context)
         handle = _tdb_handles.open(
-            uri, mode, context, tiledb_timestamp, clib_type=clib_type
+            uri,
+            mode,
+            context,
+            tiledb_timestamp,
+            clib_type=cls._wrapper_type._WRAPPED_TYPE.__name__,
         )
         if not isinstance(handle, cls._wrapper_type):
             handle = cls._wrapper_type.open(uri, mode, context, tiledb_timestamp)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -70,16 +70,18 @@ def open(
 
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
-    soma_object = clib.SOMAObject.open(
-        uri=uri,
-        mode=open_mode,
-        context=context.native_context,
-        timestamp=(0, timestamp_ms),
-        clib_type=clib_type,
-    )
-
-    if not soma_object:
-        raise DoesNotExistError(f"{uri!r} does not exist")
+    try:
+        soma_object = clib.SOMAObject.open(
+            uri=uri,
+            mode=open_mode,
+            context=context.native_context,
+            timestamp=(0, timestamp_ms),
+            clib_type=clib_type,
+        )
+    except (RuntimeError, SOMAError) as tdbe:
+        if is_does_not_exist_error(tdbe):
+            raise DoesNotExistError(tdbe) from tdbe
+        raise
 
     _type_to_class = {
         "somadataframe": DataFrameWrapper,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -57,6 +57,8 @@ RawHandle = Union[
 _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 """A raw TileDB object. Covariant because Handles are immutable enough."""
 
+_SOMAObjectType = TypeVar("_SOMAObjectType", bound=clib.SOMAObject)
+
 
 def open(
     uri: str,
@@ -70,13 +72,30 @@ def open(
 
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
+    _type_to_open = {
+        "somaarray": clib.SOMAArray.open,
+        "somagroup": clib.SOMAGroup.open,
+        "somadataframe": clib.SOMADataFrame.open,
+        "somapointclouddataframe": clib.SOMAPointCloudDataFrame.open,
+        "somadensendarray": clib.SOMADenseNDArray.open,
+        "somasparsendarray": clib.SOMASparseNDArray.open,
+        "somacollection": clib.SOMACollection.open,
+        "somaexperiment": clib.SOMAExperiment.open,
+        "somameasurement": clib.SOMAMeasurement.open,
+        "somascene": clib.SOMAScene.open,
+        "somamultiscaleimage": clib.SOMAMultiscaleImage.open,
+        None: clib.SOMAObject.open,
+    }
+
+    if clib_type is not None:
+        clib_type = clib_type.lower()
+
     try:
-        soma_object = clib.SOMAObject.open(
+        soma_object = _type_to_open[clib_type](
             uri=uri,
             mode=open_mode,
             context=context.native_context,
             timestamp=(0, timestamp_ms),
-            clib_type=clib_type,
         )
     except (RuntimeError, SOMAError) as tdbe:
         if is_does_not_exist_error(tdbe):
@@ -267,13 +286,10 @@ class GroupEntry:
         raise SOMAError(f"internal error: unknown object type {uri}")
 
 
-_GrpType = TypeVar("_GrpType", bound=clib.SOMAGroup)
-
-
-class SOMAGroupWrapper(Wrapper[_GrpType]):
+class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
     """Base class for Pybind11 SOMAGroupWrapper handles."""
 
-    _GROUP_WRAPPED_TYPE: Type[_GrpType]
+    _WRAPPED_TYPE: Type[_SOMAObjectType]
 
     clib_type = "SOMAGroup"
 
@@ -286,7 +302,7 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
         timestamp: int,
     ) -> clib.SOMAGroup:
         open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
-        return cls._GROUP_WRAPPED_TYPE.open(
+        return cls._WRAPPED_TYPE.open(
             uri,
             mode=open_mode,
             context=context.native_context,
@@ -312,40 +328,37 @@ class SOMAGroupWrapper(Wrapper[_GrpType]):
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
     """Wrapper around a Pybind11 CollectionWrapper handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMACollection
+    _WRAPPED_TYPE = clib.SOMACollection
 
 
 class ExperimentWrapper(SOMAGroupWrapper[clib.SOMAExperiment]):
     """Wrapper around a Pybind11 ExperimentWrapper handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMAExperiment
+    _WRAPPED_TYPE = clib.SOMAExperiment
 
 
 class MeasurementWrapper(SOMAGroupWrapper[clib.SOMAMeasurement]):
     """Wrapper around a Pybind11 MeasurementWrapper handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMAMeasurement
+    _WRAPPED_TYPE = clib.SOMAMeasurement
 
 
 class MultiscaleImageWrapper(SOMAGroupWrapper[clib.SOMAMultiscaleImage]):
     """Wrapper around a Pybind11 MultiscaleImage handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMAMultiscaleImage
+    _WRAPPED_TYPE = clib.SOMAMultiscaleImage
 
 
 class SceneWrapper(SOMAGroupWrapper[clib.SOMAScene]):
     """Wrapper around a Pybind11 SceneWrapper handle."""
 
-    _GROUP_WRAPPED_TYPE = clib.SOMAScene
+    _WRAPPED_TYPE = clib.SOMAScene
 
 
-_ArrType = TypeVar("_ArrType", bound=clib.SOMAArray)
-
-
-class SOMAArrayWrapper(Wrapper[_ArrType]):
+class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
     """Base class for Pybind11 SOMAArrayWrapper handles."""
 
-    _ARRAY_WRAPPED_TYPE: Type[_ArrType]
+    _WRAPPED_TYPE: Type[_SOMAObjectType]
 
     clib_type = "SOMAArray"
 
@@ -359,7 +372,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
     ) -> clib.SOMAArray:
         open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
 
-        return cls._ARRAY_WRAPPED_TYPE.open(
+        return cls._WRAPPED_TYPE.open(
             uri,
             mode=open_mode,
             context=context.native_context,
@@ -519,7 +532,7 @@ class SOMAArrayWrapper(Wrapper[_ArrType]):
 class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     """Wrapper around a Pybind11 SOMADataFrame handle."""
 
-    _ARRAY_WRAPPED_TYPE = clib.SOMADataFrame
+    _WRAPPED_TYPE = clib.SOMADataFrame
 
     @property
     def count(self) -> int:
@@ -609,7 +622,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
 class PointCloudDataFrameWrapper(SOMAArrayWrapper[clib.SOMAPointCloudDataFrame]):
     """Wrapper around a Pybind11 SOMAPointCloudDataFrame handle."""
 
-    _ARRAY_WRAPPED_TYPE = clib.SOMAPointCloudDataFrame
+    _WRAPPED_TYPE = clib.SOMAPointCloudDataFrame
 
     @property
     def count(self) -> int:
@@ -622,7 +635,7 @@ class PointCloudDataFrameWrapper(SOMAArrayWrapper[clib.SOMAPointCloudDataFrame])
 class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     """Wrapper around a Pybind11 DenseNDArrayWrapper handle."""
 
-    _ARRAY_WRAPPED_TYPE = clib.SOMADenseNDArray
+    _WRAPPED_TYPE = clib.SOMADenseNDArray
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
@@ -655,7 +668,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
     """Wrapper around a Pybind11 SparseNDArrayWrapper handle."""
 
-    _ARRAY_WRAPPED_TYPE = clib.SOMASparseNDArray
+    _WRAPPED_TYPE = clib.SOMASparseNDArray
 
     @property
     def nnz(self) -> int:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -100,7 +100,7 @@ def open(
     except (RuntimeError, SOMAError) as tdbe:
         if is_does_not_exist_error(tdbe):
             raise DoesNotExistError(tdbe) from tdbe
-        raise
+        raise SOMAError(tdbe) from tdbe
 
     _type_to_class = {
         "somadataframe": DataFrameWrapper,

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -71,10 +71,28 @@ void load_soma_collection(py::module& m) {
         .def("get", &SOMACollection::get);
 
     py::class_<SOMAExperiment, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAExperiment");
+        m, "SOMAExperiment")
+        .def_static(
+            "open",
+            &SOMAExperiment::open,
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>());
 
     py::class_<SOMAMeasurement, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAMeasurement");
+        m, "SOMAMeasurement")
+        .def_static(
+            "open",
+            &SOMAMeasurement::open,
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>());
 
     py::class_<SOMAScene, SOMACollection, SOMAGroup, SOMAObject>(m, "SOMAScene")
         .def_static(
@@ -91,9 +109,27 @@ void load_soma_collection(py::module& m) {
             py::kw_only(),
             "ctx"_a,
             "uri"_a,
-            "timestamp"_a = py::none());
+            "timestamp"_a = py::none())
+        .def_static(
+            "open",
+            &SOMAScene::open,
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>());
 
     py::class_<SOMAMultiscaleImage, SOMACollection, SOMAGroup, SOMAObject>(
-        m, "SOMAMultiscaleImage");
+        m, "SOMAMultiscaleImage")
+        .def_static(
+            "open",
+            &SOMAMultiscaleImage::open,
+            "uri"_a,
+            py::kw_only(),
+            "mode"_a,
+            "context"_a,
+            "timestamp"_a = py::none(),
+            py::call_guard<py::gil_scoped_release>());
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -57,52 +57,41 @@ void load_soma_object(py::module& m) {
                std::shared_ptr<SOMAContext> context,
                std::optional<std::pair<uint64_t, uint64_t>> timestamp,
                std::optional<std::string> clib_type) -> py::object {
-                try {
-                    auto soma_obj = ([&]() {
-                        py::gil_scoped_release release;
-                        return SOMAObject::open(
-                            uri, mode, context, timestamp, clib_type);
-                    })();
-                    auto soma_obj_type = soma_obj->type();
+                auto soma_obj = ([&]() {
+                    py::gil_scoped_release release;
+                    return SOMAObject::open(
+                        uri, mode, context, timestamp, clib_type);
+                })();
 
-                    if (soma_obj_type.has_value()) {
-                        std::transform(
-                            soma_obj_type->begin(),
-                            soma_obj_type->end(),
-                            soma_obj_type->begin(),
-                            [](unsigned char c) { return std::tolower(c); });
-                    }
+                auto soma_obj_type = soma_obj->type();
 
-                    if (soma_obj_type == "somadataframe")
-                        return py::cast(
-                            dynamic_cast<SOMADataFrame&>(*soma_obj));
-                    if (soma_obj_type == "somapointclouddataframe")
-                        return py::cast(
-                            dynamic_cast<SOMAPointCloudDataFrame&>(*soma_obj));
-                    else if (soma_obj_type == "somasparsendarray")
-                        return py::cast(
-                            dynamic_cast<SOMASparseNDArray&>(*soma_obj));
-                    else if (soma_obj_type == "somadensendarray")
-                        return py::cast(
-                            dynamic_cast<SOMADenseNDArray&>(*soma_obj));
-                    else if (soma_obj_type == "somacollection")
-                        return py::cast(
-                            dynamic_cast<SOMACollection&>(*soma_obj));
-                    else if (soma_obj_type == "somaexperiment")
-                        return py::cast(
-                            dynamic_cast<SOMAExperiment&>(*soma_obj));
-                    else if (soma_obj_type == "somameasurement")
-                        return py::cast(
-                            dynamic_cast<SOMAMeasurement&>(*soma_obj));
-                    else if (soma_obj_type == "somascene")
-                        return py::cast(dynamic_cast<SOMAScene&>(*soma_obj));
-                    else if (soma_obj_type == "somamultiscaleimage")
-                        return py::cast(
-                            dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
-                    return py::none();
-                } catch (...) {
-                    return py::none();
-                }
+                std::transform(
+                    soma_obj_type->begin(),
+                    soma_obj_type->end(),
+                    soma_obj_type->begin(),
+                    [](unsigned char c) { return std::tolower(c); });
+
+                if (soma_obj_type == "somadataframe")
+                    return py::cast(dynamic_cast<SOMADataFrame&>(*soma_obj));
+                if (soma_obj_type == "somapointclouddataframe")
+                    return py::cast(
+                        dynamic_cast<SOMAPointCloudDataFrame&>(*soma_obj));
+                else if (soma_obj_type == "somasparsendarray")
+                    return py::cast(
+                        dynamic_cast<SOMASparseNDArray&>(*soma_obj));
+                else if (soma_obj_type == "somadensendarray")
+                    return py::cast(dynamic_cast<SOMADenseNDArray&>(*soma_obj));
+                else if (soma_obj_type == "somacollection")
+                    return py::cast(dynamic_cast<SOMACollection&>(*soma_obj));
+                else if (soma_obj_type == "somaexperiment")
+                    return py::cast(dynamic_cast<SOMAExperiment&>(*soma_obj));
+                else if (soma_obj_type == "somameasurement")
+                    return py::cast(dynamic_cast<SOMAMeasurement&>(*soma_obj));
+                else if (soma_obj_type == "somascene")
+                    return py::cast(dynamic_cast<SOMAScene&>(*soma_obj));
+                else if (soma_obj_type == "somamultiscaleimage")
+                    return py::cast(
+                        dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
             },
             "uri"_a,
             "mode"_a,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -87,6 +87,31 @@ def test_collection_basic(tmp_path):
     with readback_collection["snda"] as snda:
         assert len(snda.read().tables().concat()) == 3
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(collection.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(collection.uri)
+
 
 @pytest.fixture(
     scope="function",

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -160,6 +160,31 @@ def test_dataframe(tmp_path, arrow_schema):
     with soma.DataFrame.open(tmp_path.as_posix(), "w") as A:
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADataFrame)
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(tmp_path.as_posix())
+
 
 def test_dataframe_reopen(tmp_path, arrow_schema):
     soma.DataFrame.create(

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -57,6 +57,31 @@ def test_dense_nd_array_create_ok(
     with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A:
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMADenseNDArray)
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(tmp_path.as_posix())
+
 
 def test_dense_nd_array_reopen(tmp_path):
     soma.DenseNDArray.create(

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -162,6 +162,54 @@ def test_experiment_basic(tmp_path):
     with pytest.raises(soma.DoesNotExistError):
         soma.DataFrame.open("/nonesuch/no/nope/nope/never")
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(experiment.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(measurement.uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(measurement.uri)
     # ----------------------------------------------------------------
     # TODO: check more things
 

--- a/apis/python/tests/test_multiscale_image.py
+++ b/apis/python/tests/test_multiscale_image.py
@@ -159,6 +159,31 @@ def test_multiscale_basic(tmp_path):
         assert np.array_equal(from_level(1).scale_factors, [2, 2])
         assert np.array_equal(from_level(2).scale_factors, [16, 16])
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(image_uri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(image_uri)
+
 
 class TestSimpleMultiscale2D:
 
@@ -461,7 +486,7 @@ def test_multiscale_2d_read_region_with_channel(
     baseuri = urljoin(f"{tmp_path.as_uri()}/", "test_multiscale_read_region")
     image_uri = create_multiscale(baseuri, ("x", "y"), data_axis_order, True, shapes)
 
-    with soma.Collection.open(image_uri, mode="w") as image:
+    with soma.MultiscaleImage.open(image_uri, mode="w") as image:
         for i, shape in enumerate(shapes):
             data = np.arange(shape[0] * shape[1] * shape[2], dtype=np.uint8).reshape(
                 shape
@@ -526,7 +551,7 @@ def test_multiscale_2d_read_region_no_channel(tmp_path, shapes, region, scale_fa
     baseuri = urljoin(f"{tmp_path.as_uri()}/", "test_multiscale_read_region")
     image_uri = create_multiscale(baseuri, ("x", "y"), ("y", "x"), False, shapes)
 
-    with soma.Collection.open(image_uri, mode="w") as image:
+    with soma.MultiscaleImage.open(image_uri, mode="w") as image:
         for i, shape in enumerate(shapes):
             data = np.arange(shape[0] * shape[1], dtype=np.uint8).reshape(shape)
             image[f"level{i}"].write(

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -69,7 +69,7 @@ def test_platform_config(conftest_pbmc_small):
             ]
 
         var_arr_uri = str(Path(output_path) / "ms" / "RNA" / "var")
-        with tiledbsoma.SparseNDArray.open(var_arr_uri) as var_arr:
+        with tiledbsoma.DataFrame.open(var_arr_uri) as var_arr:
             cfg = var_arr.config_options_from_schema()
             assert json.loads(cfg.dims)["soma_joinid"]["filters"] == [
                 {"COMPRESSION_LEVEL": 1, "name": "ZSTD"}

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -88,6 +88,31 @@ def test_point_cloud_basic_read(tmp_path):
         assert [e.as_py() for e in table["x"]] == pydict["x"]
         assert [e.as_py() for e in table["y"]] == pydict["y"]
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(urljoin(baseuri, "default"))
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(urljoin(baseuri, "default"))
+
 
 def test_point_cloud_coordinate_space(tmp_path):
     uri = tmp_path.as_uri()

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -97,6 +97,31 @@ def test_scene_basic(tmp_path):
     with pytest.raises(soma.DoesNotExistError):
         soma.Scene.open("bad uri")
 
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.SparseNDArray.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(baseuri)
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(baseuri)
+
 
 def test_measurement_with_var_scene(tmp_path):
     baseuri = tmp_path.as_uri()

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -83,9 +83,34 @@ def test_sparse_nd_array_create_ok(
     with soma.SparseNDArray.open(tmp_path.as_posix(), "r") as A:
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMASparseNDArray)
 
-    # Ensure write mode uses Python object
+    # Ensure write mode uses clib object
     with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A:
         assert isinstance(A._handle._handle, soma.pytiledbsoma.SOMASparseNDArray)
+
+    # Ensure it cannot be opened by another type
+    with pytest.raises(soma.SOMAError):
+        soma.DataFrame.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.DenseNDArray.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.PointCloudDataFrame.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Collection.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Experiment.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Measurement.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.Scene.open(tmp_path.as_posix())
+
+    with pytest.raises(soma.SOMAError):
+        soma.MultiscaleImage.open(tmp_path.as_posix())
 
 
 def test_sparse_nd_array_reopen(tmp_path):

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -281,7 +281,7 @@ Rcpp::NumericVector maxshape(
 // [[Rcpp::export]]
 SEXP non_empty_domain(
     const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
-    auto sdf = tdbs::SOMADataFrame::open(uri, OpenMode::read, ctxxp->ctxptr);
+    auto sdf = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
     tdbs::ArrowTable arrow_table = sdf->get_non_empty_domain();
     SEXP retval = convert_domainish(arrow_table);
     sdf->close();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -234,7 +234,7 @@ class SOMAArray : public SOMAObject {
         , meta_cache_arr_(other.meta_cache_arr_)
         , first_read_next_(other.first_read_next_)
         , submitted_(other.submitted_) {
-        fill_metadata_cache();
+        fill_metadata_cache(timestamp_);
     }
 
     SOMAArray(
@@ -1533,7 +1533,7 @@ class SOMAArray : public SOMAObject {
     std::optional<int64_t> _maybe_soma_joinid_tiledb_current_domain();
     std::optional<int64_t> _maybe_soma_joinid_tiledb_domain();
 
-    void fill_metadata_cache();
+    void fill_metadata_cache(std::optional<TimestampRange> timestamp);
 
     // SOMAArray URI
     std::string uri_;

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -58,7 +58,15 @@ std::unique_ptr<SOMACollection> SOMACollection::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMACollection>(mode, uri, ctx, timestamp);
+        auto group = std::make_unique<SOMACollection>(
+            mode, uri, ctx, timestamp);
+
+        if (!group->check_type("SOMACollection")) {
+            throw TileDBSOMAError(
+                "[SOMACollection::open] Object is not a SOMACollection");
+        }
+
+        return group;
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -65,8 +65,15 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
-    return std::make_unique<SOMADataFrame>(
+    auto array = std::make_unique<SOMADataFrame>(
         mode, uri, ctx, column_names, result_order, timestamp);
+
+    if (!array->check_type("SOMADataFrame")) {
+        throw TileDBSOMAError(
+            "[SOMADataFrame::open] Object is not a SOMADataFrame");
+    }
+
+    return array;
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
@@ -74,7 +81,15 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     OpenMode mode,
     std::string_view name,
     std::map<std::string, std::string> platform_config) {
-    return std::make_unique<SOMADataFrame>(mode, uri, name, platform_config);
+    auto array = std::make_unique<SOMADataFrame>(
+        mode, uri, name, platform_config);
+
+    if (!array->check_type("SOMADataFrame")) {
+        throw TileDBSOMAError(
+            "[SOMADataFrame::open] Object is not a SOMADataFrame");
+    }
+
+    return array;
 }
 
 bool SOMADataFrame::exists(

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -99,8 +99,15 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
-    return std::make_unique<SOMADenseNDArray>(
+    auto array = std::make_unique<SOMADenseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
+
+    if (!array->check_type("SOMADenseNDArray")) {
+        throw TileDBSOMAError(
+            "[SOMADenseNDArray::open] Object is not a SOMADenseNDArray");
+    }
+
+    return array;
 }
 
 bool SOMADenseNDArray::exists(

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -90,7 +90,15 @@ std::unique_ptr<SOMAExperiment> SOMAExperiment::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMAExperiment>(mode, uri, ctx, timestamp);
+        auto group = std::make_unique<SOMAExperiment>(
+            mode, uri, ctx, timestamp);
+
+        if (!group->check_type("SOMAExperiment")) {
+            throw TileDBSOMAError(
+                "[SOMAExperiment::open] Object is not a SOMAExperiment");
+        }
+
+        return group;
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -118,7 +118,15 @@ std::unique_ptr<SOMAMeasurement> SOMAMeasurement::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMAMeasurement>(mode, uri, ctx, timestamp);
+        auto group = std::make_unique<SOMAMeasurement>(
+            mode, uri, ctx, timestamp);
+
+        if (!group->check_type("SOMAMeasurement")) {
+            throw TileDBSOMAError(
+                "[SOMAMeasurement::open] Object is not a SOMAMeasurement");
+        }
+
+        return group;
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -59,7 +59,16 @@ std::unique_ptr<SOMAMultiscaleImage> SOMAMultiscaleImage::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMAMultiscaleImage>(mode, uri, ctx, timestamp);
+        auto group = std::make_unique<SOMAMultiscaleImage>(
+            mode, uri, ctx, timestamp);
+
+        if (!group->check_type("SOMAMultiscaleImage")) {
+            throw TileDBSOMAError(
+                "[SOMAMultiscaleImage::open] Object is not a "
+                "SOMAMultiscaleImage");
+        }
+
+        return group;
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -45,7 +45,8 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
         auto array_type = array_->type();
 
         if (!array_type.has_value())
-            throw TileDBSOMAError("SOMAArray has no type info");
+            throw TileDBSOMAError(
+                "[SOMAObject::open] SOMAArray has no type info");
 
         std::transform(
             array_type->begin(),
@@ -64,14 +65,16 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
         } else if (array_type == "somageometrydataframe") {
             return std::make_unique<SOMAGeometryDataFrame>(*array_);
         } else {
-            throw TileDBSOMAError("Saw invalid SOMAArray type");
+            throw TileDBSOMAError(
+                "[SOMAObject::open] Saw invalid SOMAArray type");
         }
     } else if (soma_type == "SOMAGroup") {
         auto group_ = SOMAGroup::open(mode, uri, ctx, "", timestamp);
         auto group_type = group_->type();
 
         if (!group_type.has_value())
-            throw TileDBSOMAError("SOMAGroup has no type info");
+            throw TileDBSOMAError(
+                "[SOMAObject::open] SOMAGroup has no type info");
 
         std::transform(
             group_type->begin(),
@@ -90,11 +93,13 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
         } else if (group_type == "somamultiscaleimage") {
             return std::make_unique<SOMAMultiscaleImage>(*group_);
         } else {
-            throw TileDBSOMAError("Saw invalid SOMAGroup type");
+            throw TileDBSOMAError(
+                "[SOMAObject::open] Saw invalid SOMAGroup type");
         }
     }
 
-    throw TileDBSOMAError("Invalid TileDB object passed to SOMAObject::open");
+    throw TileDBSOMAError(
+        "[SOMAObject::open] Invalid TileDB object passed to SOMAObject::open");
 }
 
 const std::optional<std::string> SOMAObject::type() {

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -116,4 +116,25 @@ const std::optional<std::string> SOMAObject::type() {
     return std::string(dtype, sz);
 }
 
+bool SOMAObject::check_type(std::string expected_type) {
+    auto soma_object_type = this->type();
+
+    if (!soma_object_type.has_value())
+        return false;
+
+    std::transform(
+        soma_object_type->begin(),
+        soma_object_type->end(),
+        soma_object_type->begin(),
+        [](unsigned char c) { return std::tolower(c); });
+
+    std::transform(
+        expected_type.begin(),
+        expected_type.end(),
+        expected_type.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+
+    return soma_object_type == expected_type;
+};
+
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -35,7 +35,8 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
                 soma_type = "SOMAGroup";
                 break;
             default:
-                throw TileDBSOMAError("[SOMAObject::open] Saw invalid TileDB type");
+                throw TileDBSOMAError(
+                    "[SOMAObject::open] Saw invalid TileDB type");
         }
     }
 

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -35,7 +35,7 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
                 soma_type = "SOMAGroup";
                 break;
             default:
-                throw TileDBSOMAError("Saw invalid TileDB type");
+                throw TileDBSOMAError("[SOMAObject::open] Saw invalid TileDB type");
         }
     }
 

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -64,6 +64,8 @@ class SOMAObject {
      */
     const std::optional<std::string> type();
 
+    bool check_type(std::string expected_type);
+
     /**
      * @brief Get URI of the SOMAObject.
      *

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -65,8 +65,16 @@ std::unique_ptr<SOMAPointCloudDataFrame> SOMAPointCloudDataFrame::open(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
-    return std::make_unique<SOMAPointCloudDataFrame>(
+    auto array = std::make_unique<SOMAPointCloudDataFrame>(
         mode, uri, ctx, column_names, result_order, timestamp);
+
+    if (!array->check_type("SOMAPointCloudDataFrame")) {
+        throw TileDBSOMAError(
+            "[SOMAPointCloudDataFrame::open] Object is not a "
+            "SOMAPointCloudDataFrame");
+    }
+
+    return array;
 }
 
 bool SOMAPointCloudDataFrame::exists(

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -62,7 +62,14 @@ std::unique_ptr<SOMAScene> SOMAScene::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp) {
     try {
-        return std::make_unique<SOMAScene>(mode, uri, ctx, timestamp);
+        auto group = std::make_unique<SOMAScene>(mode, uri, ctx, timestamp);
+
+        if (!group->check_type("SOMAScene")) {
+            throw TileDBSOMAError(
+                "[SOMAScene::open] Object is not a SOMAScene");
+        }
+
+        return group;
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -100,8 +100,15 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     std::vector<std::string> column_names,
     ResultOrder result_order,
     std::optional<TimestampRange> timestamp) {
-    return std::make_unique<SOMASparseNDArray>(
+    auto array = std::make_unique<SOMASparseNDArray>(
         mode, uri, ctx, column_names, result_order, timestamp);
+
+    if (!array->check_type("SOMASparseNDArray")) {
+        throw TileDBSOMAError(
+            "[SOMASparseNDArray::open] Object is not a SOMASparseNDArray");
+    }
+
+    return array;
 }
 
 bool SOMASparseNDArray::exists(

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -377,10 +377,10 @@ TEST_CASE_METHOD(
 
     REQUIRE(!SOMADataFrame::exists(uri_, ctx_));
 
-    create(dim_infos, attr_infos, PlatformConfig(), TimestampRange(0, 2));
+    create(dim_infos, attr_infos, PlatformConfig(), TimestampRange(0, 1));
 
     auto sdf = open(
-        OpenMode::write, ResultOrder::automatic, TimestampRange(1, 1));
+        OpenMode::write, ResultOrder::automatic, TimestampRange(0, 2));
 
     int32_t val = 100;
     sdf->set_metadata("md", TILEDB_INT32, 1, &val);
@@ -398,8 +398,8 @@ TEST_CASE_METHOD(
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     sdf->close();
 
-    // md should not be available at (2, 2)
-    sdf->open(OpenMode::read, TimestampRange(2, 2));
+    // md should not be available at (0, 1)
+    sdf->open(OpenMode::read, TimestampRange(0, 1));
     REQUIRE(sdf->metadata_num() == 2);
     REQUIRE(sdf->has_metadata("soma_object_type"));
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
@@ -407,7 +407,7 @@ TEST_CASE_METHOD(
     sdf->close();
 
     // Metadata should also be retrievable in write mode
-    sdf->open(OpenMode::write, TimestampRange(0, 2));
+    sdf->open(OpenMode::write);
     REQUIRE(sdf->metadata_num() == 3);
     REQUIRE(sdf->has_metadata("soma_object_type"));
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
@@ -415,15 +415,14 @@ TEST_CASE_METHOD(
     mdval = sdf->get_metadata("md");
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
 
-    // Delete and have it reflected when reading metadata while in
-    // write mode
+    // Delete and have it reflected when reading metadata while in write mode
     sdf->delete_metadata("md");
     mdval = sdf->get_metadata("md");
     REQUIRE(!mdval.has_value());
     sdf->close();
 
     // Confirm delete in read mode
-    sdf->open(OpenMode::read, TimestampRange(0, 2));
+    sdf->open(OpenMode::read);
     REQUIRE(!sdf->has_metadata("md"));
     REQUIRE(sdf->metadata_num() == 2);
 }


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/3388

The C++ `SOMAObject::open` throws a `SOMAError` exception in the cases where:
- A file does not exist at the requested URI
- The object is not a TileDB object (`INVALID`)
- The TileDB object is not a `SOMAObject` (missing `soma_object_type` in metadata)
- The TileDB array is not a `SOMAArray` type (`soma_object_type` value is invalid)
- The TileDB group is not a `SOMAGroup` type (`soma_object_type` value is invalid)

**Changes:**

- Modify `is_does_not_exist_error` to also take in `SOMAError`
- Add additional error message string checks to catch errors from `[SOMAObject::open]` and rethrow as `DoesNotExistErrors`
- C++ metadata tests had to be rewritten with corrected timestamps
- tiledbsoma-py's `open` factory now uses dictionary to map SOMA type to concrete `clib.SOMAObject.open` method
- tiledbsoma-r's `non_empty_domain` should not use `SOMADataFrame::open` as other `SOMAArray`s may call `non_empty_domain`
