### PR TITLE
[python/ci] Pin dask version 2024.11.2 to unblock CI

### DIFF
--- a/apis/python/requirements_spatial.txt
+++ b/apis/python/requirements_spatial.txt
@@ -3,4 +3,4 @@ tifffile
 pillow
 spatialdata>=0.2.5
 xarray
-dask
+dask<=2024.11.2


### PR DESCRIPTION
**Issue and/or context:** #3398

**Changes:** Pinning dask to 2024.11.2 version

**Notes for Reviewer:**

