### PR TITLE
[python] Export full experiment to SpatialData

### DIFF
--- a/apis/python/src/tiledbsoma/io/spatial/__init__.py
+++ b/apis/python/src/tiledbsoma/io/spatial/__init__.py
@@ -5,5 +5,6 @@ may be dropped.
 """
 
 from .ingest import VisiumPaths, from_visium
+from .outgest import to_spatial_data
 
-__all__ = ["from_visium", "VisiumPaths"]
+__all__ = ["to_spatial_data", "from_visium", "VisiumPaths"]

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -500,7 +500,7 @@ def to_spatial_data(
                             soma_joinid_name=obs_id_name,
                         )
                     else:
-                        points[output_key] = to_spatial_data_shapes(
+                        points[output_key] = to_spatial_data_points(
                             df,
                             key=output_key,
                             scene_id=scene_id,
@@ -536,7 +536,7 @@ def to_spatial_data(
                                 soma_joinid_name=obs_id_name,
                             )
                         else:
-                            points[output_key] = to_spatial_data_shapes(
+                            points[output_key] = to_spatial_data_points(
                                 df,
                                 key=output_key,
                                 scene_id=scene_id,

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -434,7 +434,11 @@ def _add_scene_to_spatial_data(
     Args:
         sdata: SpatialData object to update.
         scene_id: Name of the scene that will be added to the SpatialData object.
-        measurement_names: Measur
+        scene: The scene that is being added to the SpatialData object.
+        obs_id_name: Name to use for the ``soma_joinid`` in ``obsl``.
+        var_id_name: Name to use fo the ``soma_joinid in ``varl``.
+        measurement_names: The names of measurements to export. If ``None``, all
+            measurements are included. Defaults to ``None``.
 
     """
     # Cannot have spatial data if no coordinate space.

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -427,10 +427,24 @@ def to_spatial_data(
     scene_names: Optional[Sequence[str]] = None,
     obs_id_name: str = "obs_id",
     var_id_name: str = "var_id",
-    default_X_layer_name: Optional[str] = "data",
-    table_kwargs: Optional[Dict[str, Any]] = None,
+    table_kwargs: Optional[Mapping[str, Dict[str, Any]]] = None,
 ) -> sd.SpatialData:
-    """TODO: Add docstring before merging"""
+    """Converts the experiment group to SpatialData format.
+
+    Args:
+        experiment:
+        measurement_names: The names of measurements to export. If ``None``, all
+            measurements are included. Defaults to ``None``.
+        scene_names: The names of the scenes to export. If ``None``, all scenes are
+            included. Defaults to ``None``.
+        obs_id_name: Column name to use for ``obs`` dataframes. Defaults to
+            ``"obs_id"``.
+        var_id_name: Column name to use for ``var`` dataframes. Defaults to
+            ``"var_id|``.
+        table_kwargs: Optional mapping from measurment name to keyword arguments to
+            pass to table conversions. See :method:`to_anndata` for possible keyword
+            arguments.
+    """
     warnings.warn(SPATIAL_DISCLAIMER)
 
     # Read non-spatial data into Anndata tables.

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -487,7 +487,7 @@ def to_spatial_data(
         # Export obsl data to SpatialData.
         if "obsl" in scene:
             for key, df in scene.obsl.items():
-                output_key = f"{scene_id}_obsl_{key}"
+                output_key = f"{scene_id}_{key}"
                 transform = _get_transform_from_collection(key, scene.obsl.metadata)
                 if isinstance(df, PointCloudDataFrame):
                     if "soma_geometry" in df.metadata:
@@ -523,8 +523,8 @@ def to_spatial_data(
                 ):
                     continue
                 for key, df in subcoll.items():
-                    output_key = f"{scene_id}_varl_{key}"
-                    transform = _get_transform_from_collection(key, scene.varl.metadata)
+                    output_key = f"{scene_id}_{measurement_name}_{key}"
+                    transform = _get_transform_from_collection(key, subcoll.metadata)
                     if isinstance(df, PointCloudDataFrame):
                         if "soma_geometry" in df.metadata:
                             shapes[output_key] = to_spatial_data_shapes(
@@ -533,7 +533,7 @@ def to_spatial_data(
                                 scene_id=scene_id,
                                 scene_dim_map=scene_dim_map,
                                 transform=transform,
-                                soma_joinid_name=obs_id_name,
+                                soma_joinid_name=var_id_name,
                             )
                         else:
                             points[output_key] = to_spatial_data_points(
@@ -542,7 +542,7 @@ def to_spatial_data(
                                 scene_id=scene_id,
                                 scene_dim_map=scene_dim_map,
                                 transform=transform,
-                                soma_joinid_name=obs_id_name,
+                                soma_joinid_name=var_id_name,
                             )
                     else:
                         warnings.warn(
@@ -553,7 +553,7 @@ def to_spatial_data(
         # Export img data to SpatialData.
         if "img" in scene:
             for key, image in scene.img.items():
-                output_key = f"{scene_id}_img_{key}"
+                output_key = f"{scene_id}_{key}"
                 transform = _get_transform_from_collection(key, scene.img.metadata)
                 if not isinstance(image, MultiscaleImage):
                     warnings.warn(  # type: ignore[unreachable]
@@ -570,7 +570,7 @@ def to_spatial_data(
                         transform=transform,
                     )
                 else:
-                    images[f"{scene_id}_img_{key}"] = to_spatial_data_multiscale_image(
+                    images[f"{scene_id}_{key}"] = to_spatial_data_multiscale_image(
                         image,
                         key=output_key,
                         scene_id=scene_id,

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -8,10 +9,23 @@ import tiledbsoma as soma
 from tiledbsoma import _factory
 
 spatial_outgest = pytest.importorskip("tiledbsoma.io.spatial.outgest")
+sd = pytest.importorskip("spatialdata")
+gpd = pytest.importorskip("geopandas")
+shapely = pytest.importorskip("shapely")
 
 
 @pytest.fixture(scope="module")
-def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
+def sample_2d_data():
+    return [
+        np.random.randint(0, 255, size=(3, 64, 64), dtype=np.uint8),
+        np.random.randint(0, 255, size=(3, 32, 32), dtype=np.uint8),
+        np.random.randint(0, 255, size=(3, 16, 16), dtype=np.uint8),
+        np.random.randint(0, 255, size=(3, 8, 8), dtype=np.uint8),
+    ]
+
+
+@pytest.fixture(scope="module")
+def experiment_with_single_scene(tmp_path_factory, sample_2d_data) -> soma.Experiment:
     uri = tmp_path_factory.mktemp("experiment_with_spatial_data").as_uri()
     with soma.Experiment.create(uri) as exp:
         assert exp.uri == uri
@@ -74,7 +88,7 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
         )
 
         # Add multiscale image with a single image.
-        scene1.add_new_multiscale_image(
+        with scene1.add_new_multiscale_image(
             "image1",
             "img",
             type=pa.uint8(),
@@ -82,11 +96,13 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
             transform=soma.UniformScaleTransform(
                 ("x_scene1", "y_scene1"), ("x", "y"), 0.5
             ),
-        )
-        # TODO: Write data.
+        ) as image1:
+            coords = (slice(None), slice(None), slice(None))
+            l0 = image1["level0"]
+            l0.write(coords, pa.Tensor.from_numpy(sample_2d_data[0]))
 
         # Add multiscale image with multiple resolutions.
-        image2 = scene1.add_new_multiscale_image(
+        with scene1.add_new_multiscale_image(
             "image2",
             "img",
             type=pa.uint8(),
@@ -95,10 +111,15 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
             transform=soma.UniformScaleTransform(
                 ("x_scene1", "y_scene1"), ("x", "y"), 0.5
             ),
-        )
-        image2.add_new_level("hires", shape=(3, 16, 16))
-        image2.add_new_level("lowres", shape=(3, 8, 8))
-        scene1.close()
+        ) as image2:
+            coords = (slice(None), slice(None), slice(None))
+            fullres = image2["fullres"]
+            fullres.write(coords, pa.Tensor.from_numpy(sample_2d_data[1]))
+            hires = image2.add_new_level("hires", shape=(3, 16, 16))
+            hires.write(coords, pa.Tensor.from_numpy(sample_2d_data[2]))
+            lowres = image2.add_new_level("lowres", shape=(3, 8, 8))
+            lowres.write(coords, pa.Tensor.from_numpy(sample_2d_data[3]))
+            scene1.close()
 
     return soma.Experiment.open(uri, mode="r")
 
@@ -139,7 +160,7 @@ def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
     assert raw.X.shape == conftest_pbmc_small.raw.shape
 
 
-def test_outgest_spatial_only(experiment_with_single_scene):
+def test_outgest_spatial_only(experiment_with_single_scene, sample_2d_data):
     # Export to SpatialData.
     sdata = spatial_outgest.to_spatial_data(experiment_with_single_scene)
 
@@ -149,5 +170,55 @@ def test_outgest_spatial_only(experiment_with_single_scene):
     assert len(sdata.shapes) == 1
     assert len(sdata.points) == 1
 
-    # Check the values of the points.
-    assert False  # TODO
+    # Check image1.
+    image1 = sdata.images["scene1_image1"]
+    assert isinstance(image1, sd.models.models.DataArray)  # Verify single scale image.
+    assert image1.attrs["transform"] == {
+        "scene1": sd.transformations.Scale([2, 2], ("x", "y"))
+    }
+    image_data = image1.data.compute()
+    np.testing.assert_equal(image_data, sample_2d_data[0])
+
+    # Check image2.
+    image2 = sdata.images["scene1_image2"]
+    assert isinstance(image2, sd.models.models.DataTree)  # Verify mulitscale image.
+    for index in range(3):
+        image_level = image2[f"scale{index}"]["image"]
+        image_data = image_level.data.compute()
+        np.testing.assert_equal(image_data, sample_2d_data[index + 1])
+        scale = 2 ** (index + 1)
+        assert image_level.attrs["transform"] == {
+            "scene1": sd.transformations.Scale([scale, scale], ("x", "y"))
+        }
+
+    # Check points1.
+    points1 = sdata.shapes["scene1_points1"]
+    points1_expected = gpd.GeoDataFrame.from_dict(
+        {
+            "obs_id": np.arange(4),
+            "radius": np.ones((4,), dtype=np.float64),
+            "geometry": shapely.points(
+                [[0, 0], [0, 0.5], [0.5, 0], [0.5, 0.5]]
+            ).tolist(),
+        }
+    )
+    assert all(points1 == points1_expected)
+    assert points1.attrs["transform"] == {
+        "scene1": sd.transformations.Scale([0.5, 0.5], ("x", "y"))
+    }
+
+    # Check points2.
+    points2 = sdata.points["scene1_RNA_points2"]
+    points2_expected = pd.DataFrame.from_dict(
+        {
+            "x": np.array([0, 0, -0.5, -0.5]),
+            "y": np.array([0, -0.5, 0, -0.5]),
+            "var_id": np.arange(4),
+        }
+    )
+    points2_data = points2.compute()
+    print(points2_data)
+    assert all(points2_data == points2_expected)
+    assert points2.attrs["transform"] == {
+        "scene1": sd.transformations.Scale([-1.0, -1.0], ("x", "y"))
+    }

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -20,18 +20,16 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
 
         # Create scene 1.
         scene1_uri = urljoin(urljoin(uri, "spatial"), "scene1")
-        obsl_uri = urljoin(scene1_uri, "obsl")
-        varl_uri = urljoin(scene1_uri, "varl")
-        img_uri = urljoin(scene1_uri, "img")
         exp.spatial["scene1"] = soma.Scene.create(scene1_uri)
         scene1 = exp.spatial["scene1"]
+        assert scene1_uri == scene1.uri
         scene1.coordinate_space = soma.CoordinateSpace.from_axis_names(
             ["x_scene1", "y_scene1"]
         )
-        scene1.obsl = soma.Collection.create(obsl_uri)
-        scene1.varl = soma.Collection.create(varl_uri)
+        scene1.add_new_collection("obsl")
+        scene1.add_new_collection("varl")
         scene1.varl.add_new_collection("RNA")
-        scene1.img = soma.Collection.create(img_uri)
+        scene1.add_new_collection("img")
 
         # Add point cloud with shape to scene 1.
         points1 = scene1.add_new_point_cloud_dataframe(
@@ -142,15 +140,14 @@ def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
 
 
 def test_outgest_spatial_only(experiment_with_single_scene):
-    print(experiment_with_single_scene)
+    # Export to SpatialData.
     sdata = spatial_outgest.to_spatial_data(experiment_with_single_scene)
 
     # Check the number assets is correct.
-    print(sdata)
     assert len(sdata.tables) == 0
-    assert len(sdata.points) == 1
-    assert len(sdata.shapes) == 1
     assert len(sdata.images) == 2
+    assert len(sdata.shapes) == 1
+    assert len(sdata.points) == 1
 
     # Check the values of the points.
     assert False  # TODO

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -164,7 +164,7 @@ def test_outgest_spatial_only(experiment_with_single_scene, sample_2d_data):
     # Export to SpatialData.
     sdata = spatial_outgest.to_spatial_data(experiment_with_single_scene)
 
-    # Check the number assets is correct.
+    # Check the number of assets is correct.
     assert len(sdata.tables) == 0
     assert len(sdata.images) == 2
     assert len(sdata.shapes) == 1

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -1,0 +1,45 @@
+from urllib.parse import urljoin
+
+import pytest
+
+import tiledbsoma
+from tiledbsoma import _factory
+
+spatial_outgest = pytest.importorskip("tiledbsoma.io.spatial.outgest")
+
+
+def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
+    # Create the SOMA Experiment.
+    output_path = urljoin(f"{tmp_path.as_uri()}/", "outgest_no_spatial")
+    tiledbsoma.io.from_anndata(output_path, conftest_pbmc_small, measurement_name="RNA")
+
+    # Read full experiment into SpatialData.
+    with _factory.open(output_path) as exp:
+        sdata = spatial_outgest.to_spatialdata(exp)
+
+    # Check the number of assets (exactly 1 table) is as expected.
+    print(sdata)
+    assert len(sdata.tables) == 2
+    assert len(sdata.points) == 0
+    assert len(sdata.shapes) == 0
+    assert len(sdata.images) == 0
+
+    # Check the values of the anndata table.
+    rna = sdata.tables["RNA"]
+    assert rna.obs.shape == conftest_pbmc_small.obs.shape
+    assert rna.var.shape == conftest_pbmc_small.var.shape
+    assert rna.X.shape == conftest_pbmc_small.X.shape
+
+    for key in conftest_pbmc_small.obsm.keys():
+        assert rna.obsm[key].shape == conftest_pbmc_small.obsm[key].shape
+    for key in conftest_pbmc_small.varm.keys():
+        assert rna.varm[key].shape == conftest_pbmc_small.varm[key].shape
+    for key in conftest_pbmc_small.obsp.keys():
+        assert rna.obsp[key].shape == conftest_pbmc_small.obsp[key].shape
+    for key in conftest_pbmc_small.varp.keys():
+        assert rna.varp[key].shape == conftest_pbmc_small.varp[key].shape
+
+    # Check the values of the anndata table.
+    raw = sdata.tables["raw"]
+    assert raw.var.shape == conftest_pbmc_small.raw.var.shape
+    assert raw.X.shape == conftest_pbmc_small.raw.shape

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -19,7 +19,7 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
         exp.add_new_collection("spatial")
 
         # Create scene 1.
-        scene1_uri = urljoin(urljoin(uri, "spatial"), "scene1")
+        scene1_uri = urljoin(exp.spatial.uri, "scene1")
         exp.spatial["scene1"] = soma.Scene.create(scene1_uri)
         scene1 = exp.spatial["scene1"]
         assert scene1_uri == scene1.uri
@@ -98,9 +98,9 @@ def experiment_with_single_scene(tmp_path_factory) -> soma.Experiment:
         )
         image2.add_new_level("hires", shape=(3, 16, 16))
         image2.add_new_level("lowres", shape=(3, 8, 8))
+        scene1.close()
 
-    exp = soma.Experiment.open(uri, mode="r")
-    return exp
+    return soma.Experiment.open(uri, mode="r")
 
 
 def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):


### PR DESCRIPTION
Add `to_spatial_data` exporter that exports a full SOMA `Experiment` to a `SpatialData` object. 
