### PR TITLE
[c++] Use core 2.27.0.rc5

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-linux-x86_64-2.27.0-rc3-8d581f2.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-linux-x86_64-2.27.0.rc5-2862c30.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -178,10 +178,10 @@ jobs:
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
           if [ `uname -m` == "arm64" ]; then
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-arm64-2.27.0-rc3-8d581f2.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-arm64-2.27.0.rc5-2862c30.tar.gz
             tar -C external -xzf tiledb-macos-arm64-*.tar.gz
           else
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-x86_64-2.27.0-rc3-8d581f2.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-x86_64-2.27.0.rc5-2862c30.tar.gz
             tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
           fi
           ls external/lib/
@@ -274,14 +274,14 @@ jobs:
           if [ `uname -s` == "Darwin" ]; then
             if [ `uname -m` == "arm64" ]; then
                 # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-arm64-2.27.0-rc3-8d581f2.tar.gz
+                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-arm64-2.27.0.rc5-2862c30.tar.gz
             else
                 # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-x86_64-2.27.0-rc3-8d581f2.tar.gz
+                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-x86_64-2.27.0.rc5-2862c30.tar.gz
             fi
           else
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-linux-x86_64-2.27.0-rc3-8d581f2.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-linux-x86_64-2.27.0.rc5-2862c30.tar.gz
           fi
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-x86_64-2.27.0-rc3-8d581f2.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-x86_64-2.27.0.rc5-2862c30.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-arm64-2.27.0-rc3-8d581f2.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-arm64-2.27.0.rc5-2862c30.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-linux-x86_64-2.27.0-rc3-8d581f2.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-linux-x86_64-2.27.0.rc5-2862c30.tar.gz"
 } else {
     message("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
     q(save = "no", status = 1)

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -58,8 +58,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-windows-x86_64-2.27.0-rc3-8d581f2.zip")
-          SET(DOWNLOAD_SHA1 "db13fe37a28f25962655e70854ca50435121287d")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-windows-x86_64-2.27.0.rc5-2862c30.zip")
+          SET(DOWNLOAD_SHA1 "c23d84a55dac572c767d461e7b2a697edce88512")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -76,22 +76,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-x86_64-2.27.0-rc3-8d581f2.tar.gz")
-            SET(DOWNLOAD_SHA1 "470c236763f731c018badf7033e0bdd376d98db0")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-x86_64-2.27.0.rc5-2862c30.tar.gz")
+            SET(DOWNLOAD_SHA1 "586020a2ee2c93eda3013cad17b4dd20e6b0b8be")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-arm64-2.27.0-rc3-8d581f2.tar.gz")
-            SET(DOWNLOAD_SHA1 "4f6929cb9e1631989b0e45fb5933022bd387db31")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-arm64-2.27.0.rc5-2862c30.tar.gz")
+            SET(DOWNLOAD_SHA1 "ebcf68fbd5ba6369123d5cc4adaa37aec9440768")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-x86_64-2.27.0-rc3-8d581f2.tar.gz")
-            SET(DOWNLOAD_SHA1 "470c236763f731c018badf7033e0bdd376d98db0")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-x86_64-2.27.0.rc5-2862c30.tar.gz")
+            SET(DOWNLOAD_SHA1 "586020a2ee2c93eda3013cad17b4dd20e6b0b8be")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-macos-arm64-2.27.0-rc3-8d581f2.tar.gz")
-            SET(DOWNLOAD_SHA1 "4f6929cb9e1631989b0e45fb5933022bd387db31")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-macos-arm64-2.27.0.rc5-2862c30.tar.gz")
+            SET(DOWNLOAD_SHA1 "ebcf68fbd5ba6369123d5cc4adaa37aec9440768")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-linux-x86_64-2.27.0-rc3-8d581f2.tar.gz")
-          SET(DOWNLOAD_SHA1 "750e5629fcab223de947f395a8148fe0ba163af8")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0.rc5/tiledb-linux-x86_64-2.27.0.rc5-2862c30.tar.gz")
+          SET(DOWNLOAD_SHA1 "9c1b1810cedd18bf30d9470d4569c9273e7f0dc3")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -113,8 +113,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.27.0-rc3.zip"
-          URL_HASH SHA1=ecfb3121208715b3099e101af0b1460c5cda7510
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.27.0.rc5.zip"
+          URL_HASH SHA1=a7fae38918f268e6efbcc688d51800b93cfe3f5d
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

FYI, intentionally (per @ihnorton ) we had core `2.27.0-rc4` but `2.27.0.rc5` (i.e. `-` -> `.`).