### PR TITLE
[c++] Add helper methods to convert to ArrowSchema

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -254,7 +254,7 @@ if os.name != "nt":
     CXX_FLAGS.append(f'-Wl,-rpath,{str(tiledb_dir / "lib")}')
 
 if sys.platform == "darwin":
-    CXX_FLAGS.append("-mmacosx-version-min=11.0")
+    CXX_FLAGS.append("-mmacosx-version-min=13.3")
 
 if os.name == "posix" and sys.platform != "darwin":
     LIB_DIRS.append(str(tiledbsoma_dir / "lib" / "x86_64-linux-gnu"))

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_measurement.cc
@@ -206,6 +208,8 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dense_ndarray.h

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -43,4 +43,18 @@ enum class ResultOrder { automatic = 0, rowmajor, colmajor };
 /** Defines whether the SOMAGroup URI is absolute or relative */
 enum class URIType { automatic = 0, absolute, relative };
 
+typedef enum {
+    SOMA_COLUMN_DIMENSION = 0,
+    SOMA_COLUMN_ATTRIBUTE = 1,
+    SOMA_COLUMN_GEOMETRY = 2
+} soma_column_datatype_t;
+
+// This enables some code deduplication between core domain, core current
+// domain, and core non-empty domain.
+enum class Domainish {
+    kind_core_domain = 0,
+    kind_core_current_domain = 1,
+    kind_non_empty_domain = 2
+};
+
 #endif  // SOMA_ENUMS

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -90,14 +90,6 @@ using namespace tiledb;
 
 using StatusAndReason = std::pair<bool, std::string>;
 
-// This enables some code deduplication between core domain, core current
-// domain, and core non-empty domain.
-enum class Domainish {
-    kind_core_domain = 0,
-    kind_core_current_domain = 1,
-    kind_non_empty_domain = 2
-};
-
 class SOMAArray : public SOMAObject {
    public:
     friend class ManagedQuery;

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -1,0 +1,81 @@
+/**
+ * @file   soma_column.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAColumn class.
+ */
+
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+template <>
+std::pair<std::string, std::string> SOMAColumn::core_domain_slot<std::string>()
+    const {
+    return std::pair<std::string, std::string>("", "");
+}
+
+template <>
+std::pair<std::string, std::string>
+SOMAColumn::core_current_domain_slot<std::string>(
+    const SOMAContext& ctx, Array& array) const {
+    // Here is an intersection of a few oddities:
+    //
+    // * Core domain for string dims must be a nullptr pair; it cannot
+    // be
+    //   anything else.
+    // * TileDB-Py shows this by using an empty-string pair, which we
+    //   imitate.
+    // * Core current domain for string dims must _not_ be a nullptr
+    // pair.
+    // * In TileDB-SOMA, unless the user specifies otherwise, we use ""
+    // for
+    //   min and "\x7f" for max. (We could use "\x7f" but that causes
+    //   display problems in Python.)
+    //
+    // To work with all these factors, if the current domain is the
+    // default
+    // "" to "\x7f", return an empty-string pair just as we do for
+    // domain. (There was some pre-1.15 software using "\xff" and it's
+    // super-cheap to check for that as well.)
+    try {
+        std::pair<std::string, std::string>
+            current_domain = std::any_cast<std::pair<std::string, std::string>>(
+                _core_current_domain_slot(ctx, array));
+
+        if (current_domain.first == "" && (current_domain.second == "\x7f" ||
+                                           current_domain.second == "\xff")) {
+            return std::pair<std::string, std::string>("", "");
+        }
+
+        return current_domain;
+    } catch (const std::exception& e) {
+        throw TileDBSOMAError(e.what());
+    }
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -1,0 +1,515 @@
+/**
+ * @file   soma_column.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAColumn class. SOMAColumn is an abstraction over
+ * TileDB dimensions, attributes and combinations of them. It is designed to add
+ * indexing capabilities to any datatype utilizing native TileDB dimensions
+ * without exposing the internal indexing to the end user.
+ */
+
+#ifndef SOMA_COLUMN_H
+#define SOMA_COLUMN_H
+
+#include <any>
+#include <format>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "enums.h"
+#include "managed_query.h"
+#include "nanoarrow/nanoarrow.hpp"
+#include "utils/common.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+class SOMAColumn {
+   public:
+    //===================================================================
+    //= public non-static
+    //===================================================================
+    SOMAColumn() = default;
+    SOMAColumn(const SOMAColumn&) = default;
+    SOMAColumn(SOMAColumn&&) = default;
+    SOMAColumn& operator=(const SOMAColumn&) = default;
+    SOMAColumn& operator=(SOMAColumn&&) = default;
+
+    virtual ~SOMAColumn() = default;
+
+    /**
+     * Get the SOMAColumn name as defined in schema.
+     */
+    virtual std::string name() const = 0;
+
+    /**
+     * If true, this column is used as index.
+     *
+     * @remark SOMAColumns used as indexes should define at least one TileDB
+     * Dimension
+     */
+    virtual bool isIndexColumn() const = 0;
+
+    /**
+     * Get the TileDB Dimensions defined by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Dimension>> tiledb_dimensions() = 0;
+
+    /**
+     * Get the TileDB Attributes defined by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Attribute>> tiledb_attributes() = 0;
+
+    /**
+     * Get the TileDB Enumerations used by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Enumeration>> tiledb_enumerations() = 0;
+
+    /**
+     * Get the SOMAColumn type. Each subclass should define its own type.
+     */
+    virtual soma_column_datatype_t type() const = 0;
+
+    /**
+     * Get the datatype of the TileDB Dimensions if any. All dimensions must
+     * have the same type.
+     */
+    virtual std::optional<tiledb_datatype_t> domain_type() const = 0;
+
+    /**
+     * Get the datatype of the TileDB Attributes if any. All attributes must
+     * have the same type.
+     */
+    virtual std::optional<tiledb_datatype_t> data_type() const = 0;
+
+    /**
+     * @brief Select columns names to query (dim and attr). If the
+     * `if_not_empty` parameter is `true`, the column will be selected iff the
+     * list of selected columns is empty. This prevents a `select_columns` call
+     * from changing an empty list (all columns) to a subset of columns.
+     *
+     * @param query the ManagedQuery object to modify
+     * @param if_not_empty Prevent changing an "empty" selection of all columns
+     */
+    virtual void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const = 0;
+
+    /**
+     * Get the domain kind of the SOMAColumn as an ArrowArray for use with
+     * R/Python API.
+     *
+     * @param ctx
+     * @param array
+     * @param which_kind
+     */
+    virtual ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish which_kind) const = 0;
+
+    /**
+     * Get the SOMAColumn encoded as an ArrowSchema for use with R/Python API.
+     *
+     * @param ctx
+     * @param array
+     */
+    virtual ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) = 0;
+
+    /**
+     * Get the domain kind of the SOMAColumn.
+     *
+     * @tparam T
+     * @param ctx
+     * @param array
+     * @param which_kind
+     */
+    template <typename T>
+    std::pair<T, T> domain_slot(
+        const SOMAContext& ctx, Array& array, enum Domainish which_kind) const {
+        switch (which_kind) {
+            case Domainish::kind_core_domain:
+                return core_domain_slot<T>();
+            case Domainish::kind_core_current_domain:
+                return core_current_domain_slot<T>(ctx, array);
+            case Domainish::kind_non_empty_domain:
+                return non_empty_domain_slot<T>(array);
+            default:
+                throw std::runtime_error(
+                    "internal coding error in SOMAArray::_core_domainish_slot: "
+                    "unknown kind");
+        }
+    }
+
+    /**
+     * Set the current domain of this SOMAColumn.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector of the n-dimensional domain in the form
+     * [dim_0_min, dim_1_min, ..., dim_n_max]
+     */
+    template <typename T>
+    void set_current_domain_slot(
+        NDRectangle& rectangle, const std::vector<T>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        if (domain.size() % 2 != 0) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Provided domain for "
+                "column {} has missing values",
+                name()));
+        }
+
+        std::vector<std::any> transformed_domain;
+        size_t dim_count = domain.size() / 2;
+        for (size_t i = 0; i < dim_count; ++i) {
+            transformed_domain.push_back(std::make_any<std::array<T, 2>>(
+                std::array<T, 2>({domain[i], domain[i + dim_count]})));
+        }
+
+        try {
+            _set_current_domain_slot(rectangle, transformed_domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Set the multi-type current domain of this SOMAColumn.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector holding std::arrays with 2 elements each [min,
+     * max], casted as std::any
+     */
+    void set_current_domain_slot(
+        NDRectangle& rectangle, const std::vector<std::any>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        try {
+            _set_current_domain_slot(rectangle, domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Test if the multi-type current domain of this SOMAColumn can be set with
+     * the supplied new current domain.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector holding std::arrays with 2 elements each [min,
+     * max], casted as std::any
+     */
+    std::pair<bool, std::string> can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        const std::vector<std::any>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        try {
+            return _can_set_current_domain_slot(rectangle, domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][can_set_current_domain_slot] Failed on \"{}\" "
+                "with error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using one point
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ctx
+     * @param point
+     */
+    template <typename T>
+    void set_dim_point(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const T& point) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        T points[] = {point};
+
+        try {
+            this->_set_dim_points(
+                query,
+                ctx,
+                std::make_any<std::span<const T>>(std::span<const T>(points)));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_point] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using multiple points
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ctx
+     * @param points
+     */
+    template <typename T>
+    void set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        std::span<const T> points) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        try {
+            this->_set_dim_points(
+                query, ctx, std::make_any<std::span<const T>>(points));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_points] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using multiple ranges
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ranges
+     */
+    template <typename T>
+    void set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::vector<std::pair<T, T>>& ranges) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        try {
+            this->_set_dim_ranges(
+                query,
+                ctx,
+                std::make_any<std::vector<std::pair<T, T>>>(ranges));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_ranges] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core domain of this column.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_domain_slot() const {
+        try {
+            return std::any_cast<std::pair<T, T>>(_core_domain_slot());
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][core_domain_slot] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Retrieves the non-empty domain from the array. This is the union of the
+     * non-empty domains of the array fragments. Returns (0, 0) for empty
+     * domains.
+     */
+    template <typename T>
+    std::pair<T, T> non_empty_domain_slot(Array& array) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _non_empty_domain_slot(array));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][non_empty_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core current domain of this column.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _core_current_domain_slot(ctx, array));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][core_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core current domain of this column from the supplied
+     * NDRectangle.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_current_domain_slot(NDRectangle& ndrect) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _core_current_domain_slot(ndrect));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(e.what());
+        }
+    }
+
+   protected:
+    virtual void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& points) const = 0;
+
+    virtual void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const = 0;
+
+    virtual void _set_current_domain_slot(
+        NDRectangle& rectangle, std::span<const std::any> domain) const = 0;
+
+    virtual std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const = 0;
+
+    virtual std::any _core_domain_slot() const = 0;
+
+    virtual std::any _non_empty_domain_slot(Array& array) const = 0;
+
+    virtual std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const = 0;
+
+    virtual std::any _core_current_domain_slot(NDRectangle& ndrect) const = 0;
+};
+
+template <>
+std::pair<std::string, std::string> SOMAColumn::core_domain_slot<std::string>()
+    const;
+
+template <>
+std::pair<std::string, std::string>
+SOMAColumn::core_current_domain_slot<std::string>(
+    const SOMAContext& ctx, Array& array) const;
+
+}  // namespace tiledbsoma
+#endif

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -1,0 +1,767 @@
+/**
+ * @file   soma_dimension.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMADimension class.
+ */
+
+#include "soma_dimension.h"
+#include "utils/arrow_adapter.h"
+
+namespace tiledbsoma {
+
+std::shared_ptr<SOMADimension> SOMADimension::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    ArrowArray* array,
+    const std::string& soma_type,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    auto dimension = ArrowAdapter::tiledb_dimension_from_arrow_schema(
+        ctx, schema, array, soma_type, type_metadata, "", "", platform_config);
+
+    return std::make_shared<SOMADimension>(SOMADimension(dimension));
+}
+
+void SOMADimension::_set_dim_points(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext&,
+    const std::any& points) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint8_t>>(points));
+            break;
+        case TILEDB_UINT16:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint16_t>>(points));
+            break;
+        case TILEDB_UINT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint32_t>>(points));
+            break;
+        case TILEDB_UINT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint64_t>>(points));
+            break;
+        case TILEDB_INT8:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int8_t>>(points));
+            break;
+        case TILEDB_INT16:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int16_t>>(points));
+            break;
+        case TILEDB_INT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int32_t>>(points));
+            break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int64_t>>(points));
+            break;
+        case TILEDB_FLOAT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const float_t>>(points));
+            break;
+        case TILEDB_FLOAT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const double_t>>(points));
+            break;
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const std::string>>(points));
+            break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+void SOMADimension::_set_dim_ranges(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext&,
+    const std::any& ranges) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint8_t, uint8_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT16:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint16_t, uint16_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint32_t, uint32_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint64_t, uint64_t>>>(
+                    ranges));
+            break;
+        case TILEDB_INT8:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int8_t, int8_t>>>(ranges));
+            break;
+        case TILEDB_INT16:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int16_t, int16_t>>>(
+                    ranges));
+            break;
+        case TILEDB_INT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int32_t, int32_t>>>(
+                    ranges));
+            break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int64_t, int64_t>>>(
+                    ranges));
+            break;
+        case TILEDB_FLOAT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<float_t, float_t>>>(
+                    ranges));
+            break;
+        case TILEDB_FLOAT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<double_t, double_t>>>(
+                    ranges));
+            break;
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<std::string, std::string>>>(
+                    ranges));
+            break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+void SOMADimension::_set_current_domain_slot(
+    NDRectangle& rectangle, std::span<const std::any> domain) const {
+    if (domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMADimension][_set_current_domain_slot] Invalid domain size. "
+            "Expected 1, got {}",
+            domain.size()));
+    }
+
+    switch (dimension.type()) {
+        case TILEDB_UINT8: {
+            auto dom = std::any_cast<std::array<uint8_t, 2>>(domain[0]);
+            rectangle.set_range<uint8_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT16: {
+            auto dom = std::any_cast<std::array<uint16_t, 2>>(domain[0]);
+            rectangle.set_range<uint16_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT32: {
+            auto dom = std::any_cast<std::array<uint32_t, 2>>(domain[0]);
+            rectangle.set_range<uint32_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT64: {
+            auto dom = std::any_cast<std::array<uint64_t, 2>>(domain[0]);
+            rectangle.set_range<uint64_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT8: {
+            auto dom = std::any_cast<std::array<int8_t, 2>>(domain[0]);
+            rectangle.set_range<int8_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT16: {
+            auto dom = std::any_cast<std::array<int16_t, 2>>(domain[0]);
+            rectangle.set_range<int16_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT32: {
+            auto dom = std::any_cast<std::array<int32_t, 2>>(domain[0]);
+            rectangle.set_range<int32_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64: {
+            auto dom = std::any_cast<std::array<int64_t, 2>>(domain[0]);
+            rectangle.set_range<int64_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_FLOAT32: {
+            auto dom = std::any_cast<std::array<float_t, 2>>(domain[0]);
+            rectangle.set_range<float_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_FLOAT64: {
+            auto dom = std::any_cast<std::array<double_t, 2>>(domain[0]);
+            rectangle.set_range<double_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            // Here is an intersection of a few oddities:
+            //
+            // * Core domain for string dims must be a nullptr pair; it cannot
+            // be
+            //   anything else.
+            // * TileDB-Py shows this by using an empty-string pair, which we
+            //   imitate.
+            // * Core current domain for string dims must _not_ be a nullptr
+            // pair.
+            // * In TileDB-SOMA, unless the user specifies otherwise, we use ""
+            // for
+            //   min and "\x7f" for max. (We could use "\x7f" but that causes
+            //   display problems in Python.)
+            //
+            // To work with all these factors, if the current domain is the
+            // default
+            // "" to "\7f", return an empty-string pair just as we do for
+            // domain. (There was some pre-1.15 software using "\xff" and it's
+            // super-cheap to check for that as well.)
+            auto dom = std::any_cast<std::array<std::string, 2>>(domain[0]);
+            if (dom[0] == "" && dom[1] == "") {
+                rectangle.set_range(dimension.name(), "", "\x7f");
+            } else {
+                throw TileDBSOMAError(std::format(
+                    "[SOMADimension][_set_current_domain_slot] domain (\"{}\", "
+                    "\"{}\") cannot be set for "
+                    "string index columns: please use "
+                    "(\"\", \"\")",
+                    dom[0],
+                    dom[1]));
+            }
+
+        } break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_set_current_domain_slot] Unknown datatype {}",
+                tiledb::impl::type_to_str(dimension.type())));
+    }
+}
+
+std::pair<bool, std::string> SOMADimension::_can_set_current_domain_slot(
+    std::optional<NDRectangle>& rectangle,
+    std::span<const std::any> new_domain) const {
+    if (new_domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMADimension][_can_set_current_domain_slot] Expected domain "
+            "size is 1, found {}",
+            new_domain.size()));
+    }
+
+    auto comparator =
+        [&]<typename T>(
+            const std::array<T, 2>& new_dom) -> std::pair<bool, std::string> {
+        if (new_dom[0] > new_dom[1]) {
+            return std::pair(
+                false,
+                std::format(
+                    "index-column name {}: new lower > new upper",
+                    dimension.name()));
+        }
+
+        // If we're checking against the core current domain: the user-provided
+        // domain must contain the core current domain.
+        //
+        // If we're checking against the core (max) domain: the user-provided
+        // domain must be contained within the core (max) domain.
+
+        if (rectangle.has_value()) {
+            auto dom = rectangle.value().range<T>(dimension.name());
+
+            if (new_dom[0] > dom[0]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower > old lower (downsize "
+                        "is unsupported)",
+                        dimension.name()));
+            }
+            if (new_dom[1] < dom[1]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper < old upper (downsize "
+                        "is unsupported)",
+                        dimension.name()));
+            }
+        } else {
+            auto dom = std::any_cast<std::pair<T, T>>(_core_domain_slot());
+
+            if (new_dom[0] < dom.first) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower < limit lower",
+                        dimension.name()));
+            }
+            if (new_dom[1] > dom.second) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper > limit upper",
+                        dimension.name()));
+            }
+        }
+
+        return std::pair(true, "");
+    };
+
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return comparator(
+                std::any_cast<std::array<uint8_t, 2>>(new_domain[0]));
+        case TILEDB_UINT16:
+            return comparator(
+                std::any_cast<std::array<uint16_t, 2>>(new_domain[0]));
+        case TILEDB_UINT32:
+            return comparator(
+                std::any_cast<std::array<uint32_t, 2>>(new_domain[0]));
+        case TILEDB_UINT64:
+            return comparator(
+                std::any_cast<std::array<uint64_t, 2>>(new_domain[0]));
+        case TILEDB_INT8:
+            return comparator(
+                std::any_cast<std::array<int8_t, 2>>(new_domain[0]));
+        case TILEDB_INT16:
+            return comparator(
+                std::any_cast<std::array<int16_t, 2>>(new_domain[0]));
+        case TILEDB_INT32:
+            return comparator(
+                std::any_cast<std::array<int32_t, 2>>(new_domain[0]));
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return comparator(
+                std::any_cast<std::array<int64_t, 2>>(new_domain[0]));
+        case TILEDB_FLOAT32:
+            return comparator(
+                std::any_cast<std::array<float_t, 2>>(new_domain[0]));
+        case TILEDB_FLOAT64:
+            return comparator(
+                std::any_cast<std::array<double_t, 2>>(new_domain[0]));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            auto dom = std::any_cast<std::array<std::string, 2>>(new_domain[0]);
+            if (dom[0] != "" || dom[1] != "") {
+                return std::pair(
+                    false,
+                    "domain cannot be set for string index columns: please use "
+                    "(\"\", \"\")");
+            }
+
+            return std::pair(true, "");
+        }
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_can_set_current_domain_slot] Unknown dataype "
+                "{}",
+                tiledb::impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_core_domain_slot() const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                dimension.domain<uint8_t>());
+        case TILEDB_UINT16:
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                dimension.domain<uint16_t>());
+        case TILEDB_UINT32:
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                dimension.domain<uint32_t>());
+        case TILEDB_UINT64:
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                dimension.domain<uint64_t>());
+        case TILEDB_INT8:
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                dimension.domain<int8_t>());
+        case TILEDB_INT16:
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                dimension.domain<int16_t>());
+        case TILEDB_INT32:
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                dimension.domain<int32_t>());
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                dimension.domain<int64_t>());
+        case TILEDB_FLOAT32:
+            return std::make_any<std::pair<float_t, float_t>>(
+                dimension.domain<float_t>());
+        case TILEDB_FLOAT64:
+            return std::make_any<std::pair<double_t, double_t>>(
+                dimension.domain<double_t>());
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_core_domain_slot] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_non_empty_domain_slot(Array& array) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                array.non_empty_domain<uint8_t>(dimension.name()));
+        case TILEDB_UINT16:
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                array.non_empty_domain<uint16_t>(dimension.name()));
+        case TILEDB_UINT32:
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                array.non_empty_domain<uint32_t>(dimension.name()));
+        case TILEDB_UINT64:
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                array.non_empty_domain<uint64_t>(dimension.name()));
+        case TILEDB_INT8:
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                array.non_empty_domain<int8_t>(dimension.name()));
+        case TILEDB_INT16:
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                array.non_empty_domain<int16_t>(dimension.name()));
+        case TILEDB_INT32:
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                array.non_empty_domain<int32_t>(dimension.name()));
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                array.non_empty_domain<int64_t>(dimension.name()));
+        case TILEDB_FLOAT32:
+            return std::make_any<std::pair<float_t, float_t>>(
+                array.non_empty_domain<float_t>(dimension.name()));
+        case TILEDB_FLOAT64:
+            return std::make_any<std::pair<double_t, double_t>>(
+                array.non_empty_domain<double_t>(dimension.name()));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_BLOB:
+        case TILEDB_CHAR:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
+            return std::make_any<std::pair<std::string, std::string>>(
+                array.non_empty_domain_var(dimension.name()));
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_non_empty_domain_slot] Unknown dimension "
+                "type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_core_current_domain_slot(
+    const SOMAContext& ctx, Array& array) const {
+    CurrentDomain
+        current_domain = tiledb::ArraySchemaExperimental::current_domain(
+            *ctx.tiledb_ctx(), array.schema());
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    return _core_current_domain_slot(ndrect);
+}
+
+std::any SOMADimension::_core_current_domain_slot(NDRectangle& ndrect) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8: {
+            std::array<uint8_t, 2> domain = ndrect.range<uint8_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT16: {
+            std::array<uint16_t, 2> domain = ndrect.range<uint16_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT32: {
+            std::array<uint32_t, 2> domain = ndrect.range<uint32_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT64: {
+            std::array<uint64_t, 2> domain = ndrect.range<uint64_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT8: {
+            std::array<int8_t, 2> domain = ndrect.range<int8_t>(
+                dimension.name());
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT16: {
+            std::array<int16_t, 2> domain = ndrect.range<int16_t>(
+                dimension.name());
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT32: {
+            std::array<int32_t, 2> domain = ndrect.range<int32_t>(
+                dimension.name());
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64: {
+            std::array<int64_t, 2> domain = ndrect.range<int64_t>(
+                dimension.name());
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_FLOAT32: {
+            std::array<float_t, 2> domain = ndrect.range<float_t>(
+                dimension.name());
+            return std::make_any<std::pair<float_t, float_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_FLOAT64: {
+            std::array<double_t, 2> domain = ndrect.range<double_t>(
+                dimension.name());
+            return std::make_any<std::pair<double_t, double_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            std::array<std::string, 2> domain = ndrect.range<std::string>(
+                dimension.name());
+            return std::make_any<std::pair<std::string, std::string>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+ArrowArray* SOMADimension::arrow_domain_slot(
+    const SOMAContext& ctx, Array& array, enum Domainish kind) const {
+    switch (domain_type().value()) {
+        case TILEDB_INT64:
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_TIME_HR:
+        case TILEDB_TIME_MIN:
+        case TILEDB_TIME_SEC:
+        case TILEDB_TIME_MS:
+        case TILEDB_TIME_US:
+        case TILEDB_TIME_NS:
+        case TILEDB_TIME_PS:
+        case TILEDB_TIME_FS:
+        case TILEDB_TIME_AS:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int64_t>(ctx, array, kind));
+        case TILEDB_UINT64:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint64_t>(ctx, array, kind));
+        case TILEDB_INT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int32_t>(ctx, array, kind));
+        case TILEDB_UINT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint32_t>(ctx, array, kind));
+        case TILEDB_INT16:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int16_t>(ctx, array, kind));
+        case TILEDB_UINT16:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint16_t>(ctx, array, kind));
+        case TILEDB_INT8:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int8_t>(ctx, array, kind));
+        case TILEDB_UINT8:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint8_t>(ctx, array, kind));
+        case TILEDB_FLOAT64:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<double>(ctx, array, kind));
+        case TILEDB_FLOAT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<float>(ctx, array, kind));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
+            return ArrowAdapter::make_arrow_array_child_string(
+                domain_slot<std::string>(ctx, array, kind));
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][arrow_domain_slot] dim {} has unhandled "
+                "type "
+                "{}",
+                name(),
+                tiledb::impl::type_to_str(domain_type().value())));
+    }
+}
+
+ArrowSchema* SOMADimension::arrow_schema_slot(const SOMAContext&, Array&) {
+    return ArrowAdapter::arrow_schema_from_tiledb_dimension(dimension)
+        .release();
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -1,0 +1,143 @@
+/**
+ * @file   soma_dimension.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMADimension class. SOMADimension acts as a wrapper
+ * to a TileDB Dimension and implements function to perform queries as well as
+ * core domain and current domain operations. It provides a common interface
+ * identical to TileDB attributes and composite columns.
+ */
+
+#ifndef SOMA_DIMENSION_H
+#define SOMA_DIMENSION_H
+
+#include <algorithm>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+
+class SOMADimension : public SOMAColumn {
+   public:
+    static std::shared_ptr<SOMADimension> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        ArrowArray* array,
+        const std::string& soma_type,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMADimension(Dimension dimension)
+        : dimension(dimension) {
+    }
+
+    inline std::string name() const override {
+        return dimension.name();
+    }
+
+    inline bool isIndexColumn() const override {
+        return true;
+    }
+
+    inline void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const override {
+        query->select_columns(std::vector({dimension.name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const override {
+        return soma_column_datatype_t::SOMA_COLUMN_DIMENSION;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
+        return dimension.type();
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const override {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
+        return std::vector({dimension});
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
+        return std::nullopt;
+    }
+
+    ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) override;
+
+   protected:
+    void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_current_domain_slot(
+        NDRectangle& rectangle,
+        std::span<const std::any> domain) const override;
+
+    std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const override;
+
+    std::any _core_domain_slot() const override;
+
+    std::any _non_empty_domain_slot(Array& array) const override;
+
+    std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
+
+   private:
+    Dimension dimension;
+};
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -49,6 +49,8 @@
 #include "soma/column_buffer.h"
 #include "soma/soma_array.h"
 #include "soma/soma_collection.h"
+#include "soma/soma_column.h"
+#include "soma/soma_dimension.h"
 #include "soma/soma_dataframe.h"
 #include "soma/soma_group.h"
 #include "soma/soma_experiment.h"

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1612,6 +1612,7 @@ void ArrowAdapter::set_current_domain_slot(
     NDRectangle& ndrect,
     std::string name) {
     switch (type) {
+        case TILEDB_STRING_UTF8:
         case TILEDB_STRING_ASCII:
             // Core domain must not be set for string dims.
             // Core current_domain can't _not_ be set for string dims.
@@ -1632,8 +1633,9 @@ void ArrowAdapter::set_current_domain_slot(
         case TILEDB_DATETIME_MS:
         case TILEDB_DATETIME_US:
         case TILEDB_DATETIME_NS: {
-            uint64_t lo = ((uint64_t*)buff)[3];
-            uint64_t hi = ((uint64_t*)buff)[4];
+            auto typed_buf = static_cast<const uint64_t*>(buff);
+            uint64_t lo = typed_buf[3];
+            uint64_t hi = typed_buf[4];
             ndrect.set_range<uint64_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint64_t {} to {}",
@@ -1642,8 +1644,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_INT8: {
-            int8_t lo = ((int8_t*)buff)[3];
-            int8_t hi = ((int8_t*)buff)[4];
+            auto typed_buf = static_cast<const int8_t*>(buff);
+            int8_t lo = typed_buf[3];
+            int8_t hi = typed_buf[4];
             ndrect.set_range<int8_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int8_t {} to {}",
@@ -1652,8 +1655,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_UINT8: {
-            uint8_t lo = ((uint8_t*)buff)[3];
-            uint8_t hi = ((uint8_t*)buff)[4];
+            auto typed_buf = static_cast<const uint8_t*>(buff);
+            uint8_t lo = typed_buf[3];
+            uint8_t hi = typed_buf[4];
             ndrect.set_range<uint8_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint8_t {} to {}",
@@ -1662,8 +1666,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_INT16: {
-            int16_t lo = ((int16_t*)buff)[3];
-            int16_t hi = ((int16_t*)buff)[4];
+            auto typed_buf = static_cast<const int16_t*>(buff);
+            int16_t lo = typed_buf[3];
+            int16_t hi = typed_buf[4];
             ndrect.set_range<int16_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int16_t {} to {}",
@@ -1672,8 +1677,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_UINT16: {
-            uint16_t lo = ((uint16_t*)buff)[3];
-            uint16_t hi = ((uint16_t*)buff)[4];
+            auto typed_buf = static_cast<const uint16_t*>(buff);
+            uint16_t lo = typed_buf[3];
+            uint16_t hi = typed_buf[4];
             ndrect.set_range<uint16_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint16_t {} to {}",
@@ -1682,8 +1688,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_INT32: {
-            int32_t lo = ((int32_t*)buff)[3];
-            int32_t hi = ((int32_t*)buff)[4];
+            auto typed_buf = static_cast<const int32_t*>(buff);
+            int32_t lo = typed_buf[3];
+            int32_t hi = typed_buf[4];
             ndrect.set_range<int32_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int32_t {} to {}",
@@ -1692,8 +1699,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_UINT32: {
-            uint32_t lo = ((uint32_t*)buff)[3];
-            uint32_t hi = ((uint32_t*)buff)[4];
+            auto typed_buf = static_cast<const uint32_t*>(buff);
+            uint32_t lo = typed_buf[3];
+            uint32_t hi = typed_buf[4];
             ndrect.set_range<uint32_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint32_t {} to {}",
@@ -1702,8 +1710,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_INT64: {
-            int64_t lo = ((int64_t*)buff)[3];
-            int64_t hi = ((int64_t*)buff)[4];
+            auto typed_buf = static_cast<const int64_t*>(buff);
+            int64_t lo = typed_buf[3];
+            int64_t hi = typed_buf[4];
             ndrect.set_range<int64_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain int64_t {} to {}",
@@ -1712,8 +1721,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_UINT64: {
-            uint64_t lo = ((uint64_t*)buff)[3];
-            uint64_t hi = ((uint64_t*)buff)[4];
+            auto typed_buf = static_cast<const uint64_t*>(buff);
+            uint64_t lo = typed_buf[3];
+            uint64_t hi = typed_buf[4];
             ndrect.set_range<uint64_t>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain uint64_t {} to {}",
@@ -1722,8 +1732,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_FLOAT32: {
-            float lo = ((float*)buff)[3];
-            float hi = ((float*)buff)[4];
+            auto typed_buf = static_cast<const float_t*>(buff);
+            float lo = typed_buf[3];
+            float hi = typed_buf[4];
             ndrect.set_range<float>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain float {} to {}",
@@ -1732,8 +1743,9 @@ void ArrowAdapter::set_current_domain_slot(
                 hi));
         } break;
         case TILEDB_FLOAT64: {
-            double lo = ((double*)buff)[3];
-            double hi = ((double*)buff)[4];
+            auto typed_buf = static_cast<const double_t*>(buff);
+            double lo = typed_buf[3];
+            double hi = typed_buf[4];
             ndrect.set_range<double>(name, lo, hi);
             LOG_DEBUG(std::format(
                 "[ArrowAdapter] {} current_domain double {} to {}",

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -494,8 +494,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
     arrow_schema->name = strdup(attribute.name().c_str());
     arrow_schema->metadata = nullptr;
     arrow_schema->flags = 0;
-    if (attribute.nullable() &&
-        attribute.name() != SOMA_GEOMETRY_COLUMN_NAME) {
+    if (attribute.nullable() && attribute.name() != SOMA_GEOMETRY_COLUMN_NAME) {
         arrow_schema->flags |= ARROW_FLAG_NULLABLE;
     } else {
         arrow_schema->flags &= ~ARROW_FLAG_NULLABLE;

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -464,6 +464,87 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
     return arrow_schema;
 }
 
+std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_dimension(
+    const Dimension& dimension) {
+    std::unique_ptr<ArrowSchema> arrow_schema = std::make_unique<ArrowSchema>();
+    arrow_schema->format = strdup(
+        ArrowAdapter::to_arrow_format(dimension.type()).data());
+    arrow_schema->name = strdup(dimension.name().c_str());
+    arrow_schema->metadata = nullptr;
+    arrow_schema->flags = 0;
+    arrow_schema->n_children = 0;
+    arrow_schema->children = nullptr;
+    arrow_schema->dictionary = nullptr;
+    arrow_schema->release = &ArrowAdapter::release_schema;
+    arrow_schema->private_data = nullptr;
+    LOG_TRACE(std::format(
+        "[ArrowAdapter] arrow_schema_from_tiledb_dimension format {} "
+        "name {}",
+        arrow_schema->format,
+        arrow_schema->name));
+
+    return arrow_schema;
+}
+
+std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
+    Attribute& attribute, const Context& ctx, const Array& tiledb_array) {
+    std::unique_ptr<ArrowSchema> arrow_schema = std::make_unique<ArrowSchema>();
+    arrow_schema->format = strdup(
+        ArrowAdapter::to_arrow_format(attribute.type()).data());
+    arrow_schema->name = strdup(attribute.name().c_str());
+    arrow_schema->metadata = nullptr;
+    arrow_schema->flags = 0;
+    if (attribute.nullable() &&
+        strcmp(attribute.name().c_str(), SOMA_GEOMETRY_COLUMN_NAME.c_str()) !=
+            0) {
+        arrow_schema->flags |= ARROW_FLAG_NULLABLE;
+    } else {
+        arrow_schema->flags &= ~ARROW_FLAG_NULLABLE;
+    }
+    arrow_schema->n_children = 0;
+    arrow_schema->children = nullptr;
+    arrow_schema->dictionary = nullptr;
+    arrow_schema->release = &ArrowAdapter::release_schema;
+    arrow_schema->private_data = nullptr;
+
+    LOG_TRACE(std::format(
+        "[ArrowAdapter] arrow_schema_from_tiledb_array format {} "
+        "name {}",
+        arrow_schema->format,
+        arrow_schema->name));
+
+    auto enmr_name = AttributeExperimental::get_enumeration_name(
+        ctx, attribute);
+    if (enmr_name.has_value()) {
+        auto enmr = ArrayExperimental::get_enumeration(
+            ctx, tiledb_array, attribute.name());
+        auto dict = (ArrowSchema*)malloc(sizeof(ArrowSchema));
+        dict->format = strdup(
+            ArrowAdapter::to_arrow_format(enmr.type(), false).data());
+        if (enmr.type() == TILEDB_STRING_ASCII || enmr.type() == TILEDB_CHAR) {
+            dict->format = strdup("z");
+        } else {
+            dict->format = strdup(
+                ArrowAdapter::to_arrow_format(enmr.type(), false).data());
+        }
+        dict->name = strdup(enmr.name().c_str());
+        dict->metadata = nullptr;
+        if (enmr.ordered()) {
+            arrow_schema->flags |= ARROW_FLAG_DICTIONARY_ORDERED;
+        } else {
+            arrow_schema->flags &= ~ARROW_FLAG_DICTIONARY_ORDERED;
+        }
+        dict->n_children = 0;
+        dict->children = nullptr;
+        dict->dictionary = nullptr;
+        dict->release = &ArrowAdapter::release_schema;
+        dict->private_data = nullptr;
+        arrow_schema->dictionary = dict;
+    }
+    arrow_schema->release = &ArrowAdapter::release_schema;
+    return arrow_schema;
+}
+
 FilterList ArrowAdapter::_create_filter_list(
     std::string filters, std::shared_ptr<Context> ctx) {
     return ArrowAdapter::_create_filter_list(json::parse(filters), ctx);
@@ -1224,19 +1305,8 @@ ArrowAdapter::tiledb_attribute_from_arrow_schema(
     ArrowSchema* arrow_schema,
     std::string_view type_metadata,
     PlatformConfig platform_config) {
-    auto type = ArrowAdapter::to_tiledb_format(arrow_schema->format);
-    if (strcmp(arrow_schema->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) == 0) {
-        if (type_metadata.compare("WKB") == 0) {
-            type = TILEDB_GEOM_WKB;
-        } else {
-            throw TileDBSOMAError(std::format(
-                "ArrowAdapter::tiledb_attribute_from_arrow_schema: "
-                "Unkwown type metadata for `{}`: "
-                "Expected 'WKB', got {}",
-                SOMA_GEOMETRY_COLUMN_NAME,
-                type_metadata));
-        }
-    }
+    auto type = ArrowAdapter::to_tiledb_format(
+        arrow_schema->format, type_metadata);
 
     Attribute attr(*ctx, arrow_schema->name, type);
 
@@ -1536,6 +1606,148 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
     }
 
     return std::pair(std::move(array), std::move(schema));
+}
+
+void ArrowAdapter::set_current_domain_slot(
+    tiledb_datatype_t type,
+    const void* buff,
+    NDRectangle& ndrect,
+    std::string name) {
+    switch (type) {
+        case TILEDB_STRING_ASCII:
+            // Core domain must not be set for string dims.
+            // Core current_domain can't _not_ be set for string dims.
+            // For TileDB-SOMA, we set a broad initial range for string
+            // dims (because we have to) but there has never been support
+            // for user specification of domain for string dims, and we do not
+            // introduce support for user specification of current domain for
+            // string dims.
+            throw TileDBSOMAError(
+                "Internal error: _set_current_domain_slot must not be called "
+                "for string dimensions.");
+            break;
+        case TILEDB_TIME_SEC:
+        case TILEDB_TIME_MS:
+        case TILEDB_TIME_US:
+        case TILEDB_TIME_NS:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS: {
+            uint64_t lo = ((uint64_t*)buff)[3];
+            uint64_t hi = ((uint64_t*)buff)[4];
+            ndrect.set_range<uint64_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain uint64_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_INT8: {
+            int8_t lo = ((int8_t*)buff)[3];
+            int8_t hi = ((int8_t*)buff)[4];
+            ndrect.set_range<int8_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain int8_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_UINT8: {
+            uint8_t lo = ((uint8_t*)buff)[3];
+            uint8_t hi = ((uint8_t*)buff)[4];
+            ndrect.set_range<uint8_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain uint8_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_INT16: {
+            int16_t lo = ((int16_t*)buff)[3];
+            int16_t hi = ((int16_t*)buff)[4];
+            ndrect.set_range<int16_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain int16_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_UINT16: {
+            uint16_t lo = ((uint16_t*)buff)[3];
+            uint16_t hi = ((uint16_t*)buff)[4];
+            ndrect.set_range<uint16_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain uint16_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_INT32: {
+            int32_t lo = ((int32_t*)buff)[3];
+            int32_t hi = ((int32_t*)buff)[4];
+            ndrect.set_range<int32_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain int32_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_UINT32: {
+            uint32_t lo = ((uint32_t*)buff)[3];
+            uint32_t hi = ((uint32_t*)buff)[4];
+            ndrect.set_range<uint32_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain uint32_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_INT64: {
+            int64_t lo = ((int64_t*)buff)[3];
+            int64_t hi = ((int64_t*)buff)[4];
+            ndrect.set_range<int64_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain int64_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_UINT64: {
+            uint64_t lo = ((uint64_t*)buff)[3];
+            uint64_t hi = ((uint64_t*)buff)[4];
+            ndrect.set_range<uint64_t>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain uint64_t {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_FLOAT32: {
+            float lo = ((float*)buff)[3];
+            float hi = ((float*)buff)[4];
+            ndrect.set_range<float>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain float {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        case TILEDB_FLOAT64: {
+            double lo = ((double*)buff)[3];
+            double hi = ((double*)buff)[4];
+            ndrect.set_range<double>(name, lo, hi);
+            LOG_DEBUG(std::format(
+                "[ArrowAdapter] {} current_domain double {} to {}",
+                name,
+                lo,
+                hi));
+        } break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "ArrowAdapter: Unsupported TileDB dimension: {} ",
+                tiledb::impl::type_to_str(type)));
+    }
 }
 
 bool ArrowAdapter::arrow_is_var_length_type(const char* format) {

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -495,8 +495,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
     arrow_schema->metadata = nullptr;
     arrow_schema->flags = 0;
     if (attribute.nullable() &&
-        strcmp(attribute.name().c_str(), SOMA_GEOMETRY_COLUMN_NAME.c_str()) !=
-            0) {
+        attribute.name() != SOMA_GEOMETRY_COLUMN_NAME) {
         arrow_schema->flags |= ARROW_FLAG_NULLABLE;
     } else {
         arrow_schema->flags &= ~ARROW_FLAG_NULLABLE;

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -338,6 +338,21 @@ class ArrowAdapter {
     static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_array(
         std::shared_ptr<Context> ctx, std::shared_ptr<Array> tiledb_array);
 
+    /** @brief Create a an ArrowSchema from TileDB Dimension
+     *
+     * @return ArrowSchema
+     */
+    static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_dimension(
+        const Dimension& dimension);
+
+    /**
+     * @brief Create a an ArrowSchema from TileDB Attribute
+     *
+     * @return ArrowSchema
+     */
+    static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_attribute(
+        Attribute& attribute, const Context& ctx, const Array& tiledb_array);
+
     /**
      * @brief Get members of the TileDB Schema in the form of a
      * PlatformSchemaConfig
@@ -480,6 +495,15 @@ class ArrowAdapter {
     }
 
     static void log_make_arrow_array_child(ArrowArray* child);
+
+    template <typename T>
+    static ArrowArray* make_arrow_array_child_var(
+        const std::pair<std::vector<T>, std::vector<T>>& pair) {
+        std::vector<T> v = pair.first;
+        v.insert(v.end(), pair.second.begin(), pair.second.end());
+        ArrowArray* child = make_arrow_array_child<T>(v);
+        return child;
+    }
 
     static ArrowArray* make_arrow_array_child_string(
         const std::pair<std::string, std::string>& pair) {
@@ -816,6 +840,12 @@ class ArrowAdapter {
                 "Arrow string, large_string, binary, or large_binary");
         }
     }
+
+    static void set_current_domain_slot(
+        tiledb_datatype_t type,
+        const void* buff,
+        NDRectangle& ndrect,
+        std::string name);
 
    private:
     static std::pair<const void*, std::size_t> _get_data_and_length(

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(unit_soma
     unit_soma_dense_ndarray.cc
     unit_soma_sparse_ndarray.cc
     unit_soma_collection.cc
+    unit_soma_column.cc
     unit_soma_scene.cc
     unit_soma_geometry_dataframe.cc
     unit_soma_point_cloud_dataframe.cc

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -35,13 +35,6 @@
 
 namespace helper {
 
-// This non-obvious number is:
-// * Something that fits into signed 32-bit integer for R-friendliness;
-// * Is a comfortable tile-extent distance away from 2^31-1 for default
-//   core tile extent. (Using 2^31-1 exactly would result in a core
-//   array-creation error.)
-const int CORE_DOMAIN_MAX = 2147483646;
-
 static std::unique_ptr<ArrowArray> _create_index_cols_info_array(
     const std::vector<DimInfo>& dim_infos);
 

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -61,6 +61,13 @@ static const std::string src_path = TILEDBSOMA_SOURCE_ROOT;
 
 namespace helper {
 
+// This non-obvious number is:
+// * Something that fits into signed 32-bit integer for R-friendliness;
+// * Is a comfortable tile-extent distance away from 2^31-1 for default
+//   core tile extent. (Using 2^31-1 exactly would result in a core
+//   array-creation error.)
+const int CORE_DOMAIN_MAX = 2147483646;
+
 // E.g. "d0" is of type TILEDB_INT64 with dim_max 1000 and current-domain
 // feature enabled
 struct DimInfo {

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -1,0 +1,437 @@
+/**
+ * @file   unit_soma_column.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for implementation of SOMAColumn class. This is
+ * temparary and to be removed once SOMAColumn is fully integrated.
+ */
+
+#include <format>
+#include <tiledb/tiledb>
+#include <tiledbsoma/tiledbsoma>
+#include "common.h"
+
+const int64_t SOMA_JOINID_DIM_MAX = 99;
+const int64_t SOMA_JOINID_RESIZE_DIM_MAX = 199;
+
+// This is a keystroke-reduction fixture for some similar unit-test cases For
+// convenience there are dims/attrs of type int64, uint32, and string. (Feel
+// free to add more types.) The main value-adds of this fixture are (a) simple
+// keystroke-reduction; (b) you get to pick which ones are the dim(s) and which
+// are the attr(s).
+struct VariouslyIndexedDataFrameFixture {
+    std::shared_ptr<SOMAContext> ctx_;
+    std::string uri_;
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Using Catch2's TEST_CASE_METHOD we can't pass constructor args.
+    // This is a call-after-construction method.
+    void set_up(std::shared_ptr<SOMAContext> ctx, std::string uri) {
+        ctx_ = ctx;
+        uri_ = uri;
+    }
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Helpers for setting up dim/attr configs and data
+    static const inline int64_t i64_dim_max = SOMA_JOINID_DIM_MAX;
+    static const inline int64_t u32_dim_max = 9999;
+    static const inline int64_t str_dim_max = 0;  // not used for string dims
+
+    static const inline std::string i64_name = "soma_joinid";
+    static const inline std::string u32_name = "myuint32";
+    static const inline std::string str_name = "mystring";
+
+    tiledb_datatype_t i64_datatype = TILEDB_INT64;
+    tiledb_datatype_t u32_datatype = TILEDB_UINT32;
+    tiledb_datatype_t str_datatype = TILEDB_STRING_ASCII;
+
+    std::string i64_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        i64_datatype);
+    std::string u32_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        u32_datatype);
+    std::string attr_1_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        str_datatype);
+
+    helper::DimInfo i64_dim_info() {
+        return helper::DimInfo(
+            {.name = i64_name,
+             .tiledb_datatype = i64_datatype,
+             .dim_max = i64_dim_max,
+             .string_lo = "N/A",
+             .string_hi = "N/A"});
+    }
+    helper::DimInfo u32_dim_info() {
+        return helper::DimInfo(
+            {.name = u32_name,
+             .tiledb_datatype = u32_datatype,
+             .dim_max = u32_dim_max,
+             .string_lo = "N/A",
+             .string_hi = "N/A"});
+    }
+    helper::DimInfo str_dim_info(std::string string_lo, std::string string_hi) {
+        return helper::DimInfo(
+            {.name = str_name,
+             .tiledb_datatype = str_datatype,
+             .dim_max = str_dim_max,
+             .string_lo = string_lo,
+             .string_hi = string_hi});
+    }
+
+    helper::AttrInfo i64_attr_info(std::string name = i64_name) {
+        return helper::AttrInfo(
+            {.name = name, .tiledb_datatype = i64_datatype});
+    }
+    helper::AttrInfo u32_attr_info() {
+        return helper::AttrInfo(
+            {.name = u32_name, .tiledb_datatype = u32_datatype});
+    }
+    helper::AttrInfo str_attr_info() {
+        return helper::AttrInfo(
+            {.name = str_name, .tiledb_datatype = str_datatype});
+    }
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Helper methods for create/open/write/etc.
+
+    void create(
+        const std::vector<helper::DimInfo>& dim_infos,
+        const std::vector<helper::AttrInfo>& attr_infos) {
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        SOMADataFrame::create(
+            uri_,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx_);
+    }
+
+    void create(
+        const std::vector<helper::DimInfo>& dim_infos,
+        const std::vector<helper::AttrInfo>& attr_infos,
+        const PlatformConfig& platform_config,
+        std::optional<TimestampRange> timestamp_range = std::nullopt) {
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        SOMADataFrame::create(
+            uri_,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx_,
+            platform_config,
+            timestamp_range);
+    }
+
+    std::unique_ptr<SOMADataFrame> open(
+        OpenMode mode,
+        ResultOrder result_order = ResultOrder::automatic,
+        std::optional<TimestampRange> timestamp_range = std::nullopt) {
+        return SOMADataFrame::open(
+            uri_,
+            mode,
+            ctx_,
+            {},  // column_names
+            result_order,
+            timestamp_range);
+    }
+
+    void write_sjid_u32_str_data_from(int64_t sjid_base) {
+        auto sdf = SOMADataFrame::open(uri_, OpenMode::write, ctx_);
+
+        auto i64_data = std::vector<int64_t>({sjid_base + 1, sjid_base + 2});
+
+        auto u32_data = std::vector<uint32_t>({1234, 5678});
+
+        // We like to think we're writing an array of strings ...
+        auto strings = std::vector<std::string>({"apple", "bat"});
+        // ... but really we're writing an array of characters along
+        // with offsets data.
+        //
+        // It would be possible here to just hard-code a string "applebat" and
+        // an offsets array {0, 5, 8}. The following bits simply automate that.
+        std::string char_data("");
+        std::vector<uint64_t> char_offsets(0);
+        uint64_t offset = 0;
+        for (auto e : strings) {
+            char_data += e;
+            char_offsets.push_back(offset);
+            offset += e.size();
+        }
+        char_offsets.push_back(offset);
+
+        sdf->set_column_data(i64_name, i64_data.size(), i64_data.data());
+        sdf->set_column_data(
+            str_name, strings.size(), char_data.data(), char_offsets.data());
+        sdf->set_column_data(u32_name, u32_data.size(), u32_data.data());
+        sdf->write();
+
+        sdf->close();
+    }
+};
+
+TEST_CASE("SOMAColumn: SOMADimension") {
+    auto ctx = std::make_shared<SOMAContext>();
+    PlatformConfig platform_config{};
+
+    std::vector<helper::DimInfo> dim_infos(
+        {helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_UINT32,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_INT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_STRING_ASCII,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"})});
+
+    std::vector<helper::DimInfo> geom_dim_infos({helper::DimInfo(
+        {.name = "dimension",
+         .tiledb_datatype = TILEDB_GEOM_WKB,
+         .dim_max = 100,
+         .string_lo = "N/A",
+         .string_hi = "N/A"})});
+
+    std::vector<helper::DimInfo> spatial_dim_infos(
+        {helper::DimInfo(
+             {.name = "x",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 200,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "y",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"})});
+
+    auto index_columns = helper::create_column_index_info(dim_infos);
+
+    std::vector<std::shared_ptr<SOMAColumn>> columns;
+
+    for (int64_t i = 0; i < index_columns.second->n_children; ++i) {
+        columns.push_back(SOMADimension::create(
+            ctx->tiledb_ctx(),
+            index_columns.second->children[i],
+            index_columns.first->children[i],
+            "SOMAGeometryDataFrame",
+            "",
+            platform_config));
+
+        REQUIRE(
+            columns.back()->tiledb_dimensions().value()[0].type() ==
+            dim_infos[i].tiledb_datatype);
+    }
+
+    REQUIRE(
+        columns[1]->core_domain_slot<double_t>() ==
+        std::make_pair<double_t, double_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[1]->core_domain_slot<double_t>() ==
+        std::make_pair<double_t, double_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[2]->core_domain_slot<int64_t>() ==
+        std::make_pair<int64_t, int64_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[3]->core_domain_slot<std::string>() ==
+        std::make_pair<std::string, std::string>("", ""));
+}
+
+TEST_CASE_METHOD(
+    VariouslyIndexedDataFrameFixture,
+    "SOMAColumn: query variant-indexed dataframe dim-str-u32 attr-sjid",
+    "[SOMADataFrame]") {
+    auto specify_domain = GENERATE(false, true);
+    SECTION(std::format("- specify_domain={}", specify_domain)) {
+        std::string suffix1 = specify_domain ? "true" : "false";
+        set_up(
+            std::make_shared<SOMAContext>(),
+            "mem://unit-test-column-variant-indexed-dataframe-4-" + suffix1);
+
+        std::string string_lo = "";
+        std::string string_hi = "";
+        std::vector<helper::DimInfo> dim_infos(
+            {str_dim_info(string_lo, string_hi), u32_dim_info()});
+        std::vector<helper::AttrInfo> attr_infos({i64_attr_info()});
+
+        // Create
+        create(dim_infos, attr_infos);
+
+        // Check current domain
+        auto sdf = open(OpenMode::read);
+
+        // External column initialization
+        auto raw_array = tiledb::Array(*ctx_->tiledb_ctx(), uri_, TILEDB_READ);
+        std::vector<std::shared_ptr<SOMAColumn>> columns;
+
+        for (auto dimension : sdf->tiledb_schema()->domain().dimensions()) {
+            columns.push_back(
+                std::make_shared<SOMADimension>(SOMADimension(dimension)));
+        }
+
+        CurrentDomain current_domain = sdf->get_current_domain_for_test();
+
+        REQUIRE(!current_domain.is_empty());
+        REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+        NDRectangle ndrect = current_domain.ndrectangle();
+
+        std::array<std::string, 2> str_range = ndrect.range<std::string>(
+            dim_infos[0].name);
+        std::pair<std::string, std::string>
+            str_external = columns[0]->core_current_domain_slot<std::string>(
+                *ctx_, raw_array);
+
+        // Can we write empty strings in this range?
+        REQUIRE(str_range[0] <= "");
+        REQUIRE(str_external.first <= "");
+        REQUIRE(str_range[1] >= "");
+        REQUIRE(str_external.second >= "");
+        // Can we write ASCII values in this range?
+        REQUIRE(str_range[0] < " ");
+        REQUIRE(str_external.first <= " ");
+        REQUIRE(str_range[1] > "~");
+        // REQUIRE(str_external.second >= "~");
+
+        std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
+            dim_infos[1].name);
+        std::pair<uint32_t, uint32_t>
+            u32_external = columns[1]->core_current_domain_slot<uint32_t>(
+                *ctx_, raw_array);
+        REQUIRE(u32_range[0] == u32_external.first);
+        REQUIRE(u32_range[1] == u32_external.second);
+
+        // Check shape before write
+        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+        REQUIRE(!actual.has_value());
+
+        // Check domainish accessors before resize
+        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+        std::vector<std::string>
+            ned_str = ArrowAdapter::get_table_string_column_by_name(
+                non_empty_domain, "mystring");
+
+        std::vector<std::string>
+            ned_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_non_empty_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        ArrowTable soma_domain = sdf->get_soma_domain();
+        std::vector<std::string>
+            dom_str = ArrowAdapter::get_table_string_column_by_name(
+                soma_domain, "mystring");
+
+        std::vector<std::string>
+            dom_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_core_current_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+        std::vector<std::string>
+            maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                soma_maxdomain, "mystring");
+
+        std::vector<std::string>
+            maxdom_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_core_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+        REQUIRE(ned_str == ned_str_col);
+        REQUIRE(dom_str == dom_str_col);
+        REQUIRE(maxdom_str == maxdom_str_col);
+
+        if (specify_domain) {
+            REQUIRE(dom_str[0] == dim_infos[0].string_lo);
+            REQUIRE(dom_str[1] == dim_infos[0].string_hi);
+        } else {
+            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+        }
+        REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+
+        sdf->close();
+
+        sdf = open(OpenMode::write);
+        write_sjid_u32_str_data_from(0);
+
+        sdf->close();
+
+        sdf = open(OpenMode::read);
+        REQUIRE(sdf->nnz() == 2);
+
+        sdf->close();
+
+        auto external_query = std::make_unique<ManagedQuery>(
+            open(OpenMode::read), ctx_->tiledb_ctx());
+
+        columns[1]->select_columns(external_query);
+        columns[1]->set_dim_point<uint32_t>(external_query, *ctx_, 1234);
+
+        // Configure query and allocate result buffers
+        auto ext_res = external_query->read_next().value();
+
+        REQUIRE(ext_res->num_rows() == 1);
+
+        external_query->reset();
+
+        columns[0]->select_columns(external_query);
+        columns[0]->set_dim_ranges<std::string>(
+            external_query,
+            *ctx_,
+            std::vector(
+                {std::make_pair<std::string, std::string>("apple", "b")}));
+
+        // Configure query and allocate result buffers
+        ext_res = external_query->read_next().value();
+
+        REQUIRE(ext_res->num_rows() == 1);
+    }
+}


### PR DESCRIPTION
Add helpers methods to convert from TileDB dimension and attribute to arrow schema and set current domain.

Issues: [sc-59427](https://app.shortcut.com/tiledb-inc/story/59427/create-an-abstraction-layer-for-soma-columns)

**Notes for Reviewer:**
These methods will be used and tested in the following PR chained of this.