### PR TITLE
[c++] Column abstraction: `SOMAAttribute`, part 2

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_attribute.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_experiment.cc
@@ -209,6 +210,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_attribute.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dataframe.h

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -1,0 +1,66 @@
+#include "soma_attribute.h"
+
+namespace tiledbsoma {
+std::shared_ptr<SOMAAttribute> SOMAAttribute::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(
+        ctx, schema, type_metadata, platform_config);
+
+    return std::make_shared<SOMAAttribute>(
+        SOMAAttribute(attribute.first, attribute.second));
+}
+
+void SOMAAttribute::_set_dim_points(
+    const std::unique_ptr<ManagedQuery>&,
+    const SOMAContext&,
+    const std::any&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+void SOMAAttribute::_set_dim_ranges(
+    const std::unique_ptr<ManagedQuery>&,
+    const SOMAContext&,
+    const std::any&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+void SOMAAttribute::_set_current_domain_slot(
+    NDRectangle&, const std::vector<const void*>&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+std::any SOMAAttribute::_core_domain_slot() const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+std::any SOMAAttribute::_non_empty_domain_slot(Array&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+std::any SOMAAttribute::_core_current_domain_slot(
+    const SOMAContext&, Array&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+ArrowArray* SOMAAttribute::arrow_domain_slot(
+    const SOMAContext&, Array&, enum Domainish) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute] Column with name {} is not an index column", name()));
+}
+
+ArrowSchema* SOMAAttribute::arrow_schema_slot(
+    const SOMAContext& ctx, Array& array) {
+    return ArrowAdapter::arrow_schema_from_tiledb_attribute(
+               attribute, *ctx.tiledb_ctx(), array)
+        .release();
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -18,7 +18,9 @@ void SOMAAttribute::_set_dim_points(
     const SOMAContext&,
     const std::any&) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_set_dim_points] Column with name {} is not an index "
+        "column",
+        name()));
 }
 
 void SOMAAttribute::_set_dim_ranges(
@@ -26,35 +28,62 @@ void SOMAAttribute::_set_dim_ranges(
     const SOMAContext&,
     const std::any&) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_set_dim_ranges] Column with name {} is not an index "
+        "column",
+        name()));
 }
 
 void SOMAAttribute::_set_current_domain_slot(
-    NDRectangle&, const std::vector<const void*>&) const {
+    NDRectangle&, std::span<const std::any>) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
 }
+
+std::pair<bool, std::string> SOMAAttribute::_can_set_current_domain_slot(
+    std::optional<NDRectangle>&, std::span<const std::any>) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+};
 
 std::any SOMAAttribute::_core_domain_slot() const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_core_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
 }
 
 std::any SOMAAttribute::_non_empty_domain_slot(Array&) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
 }
 
 std::any SOMAAttribute::_core_current_domain_slot(
     const SOMAContext&, Array&) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+}
+
+std::any SOMAAttribute::_core_current_domain_slot(NDRectangle&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
 }
 
 ArrowArray* SOMAAttribute::arrow_domain_slot(
     const SOMAContext&, Array&, enum Domainish) const {
     throw TileDBSOMAError(std::format(
-        "[SOMAAttribute] Column with name {} is not an index column", name()));
+        "[SOMAAttribute][arrow_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
 }
 
 ArrowSchema* SOMAAttribute::arrow_schema_slot(

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2024 TileDB, Inc.
+ * @copyright Copyright (c) 2024-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -1,3 +1,35 @@
+/**
+ * @file   soma_attribute.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAAttribute class.
+ */
+
 #include "soma_attribute.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -95,7 +95,11 @@ class SOMAAttribute : public virtual SOMAColumn {
 
     virtual void _set_current_domain_slot(
         NDRectangle& rectangle,
-        const std::vector<const void*>& domain) const override;
+        std::span<const std::any> domain) const override;
+
+    virtual std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const override;
 
     virtual std::any _core_domain_slot() const override;
 
@@ -103,6 +107,9 @@ class SOMAAttribute : public virtual SOMAColumn {
 
     virtual std::any _core_current_domain_slot(
         const SOMAContext& ctx, Array& array) const override;
+
+    virtual std::any _core_current_domain_slot(
+        NDRectangle& ndrect) const override;
 
     Attribute attribute;
     std::optional<Enumeration> enumeration;

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -28,11 +28,11 @@ class SOMAAttribute : public virtual SOMAColumn {
         , enumeration(enumeration) {
     }
 
-    virtual inline std::string name() const {
+    virtual inline std::string name() const override {
         return attribute.name();
     }
 
-    virtual inline bool isIndexColumn() const {
+    virtual inline bool isIndexColumn() const override {
         return false;
     }
 
@@ -42,28 +42,31 @@ class SOMAAttribute : public virtual SOMAColumn {
         query->select_columns(std::vector({attribute.name()}), if_not_empty);
     };
 
-    inline soma_column_datatype_t type() const {
+    virtual inline soma_column_datatype_t type() const override {
         return soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE;
     }
 
-    inline std::optional<tiledb_datatype_t> domain_type() const {
+    virtual inline std::optional<tiledb_datatype_t> domain_type()
+        const override {
         return std::nullopt;
     }
 
-    inline std::optional<tiledb_datatype_t> data_type() const {
+    virtual inline std::optional<tiledb_datatype_t> data_type() const override {
         return attribute.type();
     }
 
-    inline std::optional<std::vector<Dimension>> tiledb_dimensions() {
+    virtual inline std::optional<std::vector<Dimension>> tiledb_dimensions()
+        override {
         return std::nullopt;
     }
 
-    inline std::optional<std::vector<Attribute>> tiledb_attributes() {
+    virtual inline std::optional<std::vector<Attribute>> tiledb_attributes()
+        override {
         return std::vector({attribute});
     }
 
-    inline virtual std::optional<std::vector<Enumeration>>
-    tiledb_enumerations() {
+    virtual inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
         if (!enumeration.has_value()) {
             return std::nullopt;
         }
@@ -83,22 +86,23 @@ class SOMAAttribute : public virtual SOMAColumn {
     virtual void _set_dim_points(
         const std::unique_ptr<ManagedQuery>& query,
         const SOMAContext& ctx,
-        const std::any& points) const;
+        const std::any& points) const override;
 
     virtual void _set_dim_ranges(
         const std::unique_ptr<ManagedQuery>& query,
         const SOMAContext& ctx,
-        const std::any& ranges) const;
+        const std::any& ranges) const override;
 
     virtual void _set_current_domain_slot(
-        NDRectangle& rectangle, const std::vector<const void*>& domain) const;
+        NDRectangle& rectangle,
+        const std::vector<const void*>& domain) const override;
 
-    virtual std::any _core_domain_slot() const;
+    virtual std::any _core_domain_slot() const override;
 
-    virtual std::any _non_empty_domain_slot(Array& array) const;
+    virtual std::any _non_empty_domain_slot(Array& array) const override;
 
     virtual std::any _core_current_domain_slot(
-        const SOMAContext& ctx, Array& array) const;
+        const SOMAContext& ctx, Array& array) const override;
 
     Attribute attribute;
     std::optional<Enumeration> enumeration;

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -1,3 +1,38 @@
+/**
+ * @file   soma_attribute.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAAttribute class. SOMAAttribute extends SOMAColumn
+ * and wraps a TileDB Attribute and optionally an enumeration associated with
+ * the attribute. The purpose of this class is to provide a common interface
+ * identical to TileDB dimensions and composite columns.
+ */
+
 #ifndef SOMA_ATTRIBUTE_H
 #define SOMA_ATTRIBUTE_H
 

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -1,0 +1,108 @@
+#ifndef SOMA_ATTRIBUTE_H
+#define SOMA_ATTRIBUTE_H
+
+#include <algorithm>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+class SOMAAttribute : public virtual SOMAColumn {
+   public:
+    /**
+     * Create a ``SOMAAttribute`` shared pointer from an arrow schema
+     */
+    static std::shared_ptr<SOMAAttribute> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMAAttribute(
+        Attribute attribute,
+        std::optional<Enumeration> enumeration = std::nullopt)
+        : attribute(attribute)
+        , enumeration(enumeration) {
+    }
+
+    virtual inline std::string name() const {
+        return attribute.name();
+    }
+
+    virtual inline bool isIndexColumn() const {
+        return false;
+    }
+
+    inline virtual void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const override {
+        query->select_columns(std::vector({attribute.name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const {
+        return soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const {
+        return std::nullopt;
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const {
+        return attribute.type();
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() {
+        return std::vector({attribute});
+    }
+
+    inline virtual std::optional<std::vector<Enumeration>>
+    tiledb_enumerations() {
+        if (!enumeration.has_value()) {
+            return std::nullopt;
+        }
+
+        return std::vector({enumeration.value()});
+    }
+
+    virtual ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    virtual ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) override;
+
+   private:
+    virtual void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& points) const;
+
+    virtual void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const;
+
+    virtual void _set_current_domain_slot(
+        NDRectangle& rectangle, const std::vector<const void*>& domain) const;
+
+    virtual std::any _core_domain_slot() const;
+
+    virtual std::any _non_empty_domain_slot(Array& array) const;
+
+    virtual std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const;
+
+    Attribute attribute;
+    std::optional<Enumeration> enumeration;
+};
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -63,44 +63,41 @@ class SOMAAttribute : public SOMAColumn {
         , enumeration(enumeration) {
     }
 
-    virtual inline std::string name() const override {
+    inline std::string name() const override {
         return attribute.name();
     }
 
-    virtual inline bool isIndexColumn() const override {
+    inline bool isIndexColumn() const override {
         return false;
     }
 
-    virtual inline void select_columns(
+    inline void select_columns(
         const std::unique_ptr<ManagedQuery>& query,
         bool if_not_empty = false) const override {
         query->select_columns(std::vector({attribute.name()}), if_not_empty);
     };
 
-    virtual inline soma_column_datatype_t type() const override {
+    inline soma_column_datatype_t type() const override {
         return soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE;
     }
 
-    virtual inline std::optional<tiledb_datatype_t> domain_type()
-        const override {
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
         return std::nullopt;
     }
 
-    virtual inline std::optional<tiledb_datatype_t> data_type() const override {
+    inline std::optional<tiledb_datatype_t> data_type() const override {
         return attribute.type();
     }
 
-    virtual inline std::optional<std::vector<Dimension>> tiledb_dimensions()
-        override {
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
         return std::nullopt;
     }
 
-    virtual inline std::optional<std::vector<Attribute>> tiledb_attributes()
-        override {
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
         return std::vector({attribute});
     }
 
-    virtual inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
         override {
         if (!enumeration.has_value()) {
             return std::nullopt;
@@ -109,42 +106,41 @@ class SOMAAttribute : public SOMAColumn {
         return std::vector({enumeration.value()});
     }
 
-    virtual ArrowArray* arrow_domain_slot(
+    ArrowArray* arrow_domain_slot(
         const SOMAContext& ctx,
         Array& array,
         enum Domainish kind) const override;
 
-    virtual ArrowSchema* arrow_schema_slot(
+    ArrowSchema* arrow_schema_slot(
         const SOMAContext& ctx, Array& array) override;
 
    private:
-    virtual void _set_dim_points(
+    void _set_dim_points(
         const std::unique_ptr<ManagedQuery>& query,
         const SOMAContext& ctx,
         const std::any& points) const override;
 
-    virtual void _set_dim_ranges(
+    void _set_dim_ranges(
         const std::unique_ptr<ManagedQuery>& query,
         const SOMAContext& ctx,
         const std::any& ranges) const override;
 
-    virtual void _set_current_domain_slot(
+    void _set_current_domain_slot(
         NDRectangle& rectangle,
         std::span<const std::any> domain) const override;
 
-    virtual std::pair<bool, std::string> _can_set_current_domain_slot(
+    std::pair<bool, std::string> _can_set_current_domain_slot(
         std::optional<NDRectangle>& rectangle,
         std::span<const std::any> new_domain) const override;
 
-    virtual std::any _core_domain_slot() const override;
+    std::any _core_domain_slot() const override;
 
-    virtual std::any _non_empty_domain_slot(Array& array) const override;
+    std::any _non_empty_domain_slot(Array& array) const override;
 
-    virtual std::any _core_current_domain_slot(
+    std::any _core_current_domain_slot(
         const SOMAContext& ctx, Array& array) const override;
 
-    virtual std::any _core_current_domain_slot(
-        NDRectangle& ndrect) const override;
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
 
     Attribute attribute;
     std::optional<Enumeration> enumeration;

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -45,10 +45,10 @@
 namespace tiledbsoma {
 using namespace tiledb;
 
-class SOMAAttribute : public virtual SOMAColumn {
+class SOMAAttribute : public SOMAColumn {
    public:
     /**
-     * Create a ``SOMAAttribute`` shared pointer from an arrow schema
+     * Create a ``SOMAAttribute`` shared pointer from an Arrow schema
      */
     static std::shared_ptr<SOMAAttribute> create(
         std::shared_ptr<Context> ctx,

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2024 TileDB, Inc.
+ * @copyright Copyright (c) 2024-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -36,7 +36,7 @@ class SOMAAttribute : public virtual SOMAColumn {
         return false;
     }
 
-    inline virtual void select_columns(
+    virtual inline void select_columns(
         const std::unique_ptr<ManagedQuery>& query,
         bool if_not_empty = false) const override {
         query->select_columns(std::vector({attribute.name()}), if_not_empty);

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -50,6 +50,7 @@
 #include "soma/soma_array.h"
 #include "soma/soma_collection.h"
 #include "soma/soma_column.h"
+#include "soma/soma_attribute.h"
 #include "soma/soma_dimension.h"
 #include "soma/soma_dataframe.h"
 #include "soma/soma_group.h"

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -314,6 +314,11 @@ TEST_CASE_METHOD(
                 std::make_shared<SOMADimension>(SOMADimension(dimension)));
         }
 
+        for (size_t i = 0; i < sdf->tiledb_schema()->attribute_num(); ++i) {
+            columns.push_back(std::make_shared<SOMAAttribute>(
+                SOMAAttribute(sdf->tiledb_schema()->attribute(i))));
+        }
+
         CurrentDomain current_domain = sdf->get_current_domain_for_test();
 
         REQUIRE(!current_domain.is_empty());


### PR DESCRIPTION
This PR introduce the `SOMAAttribute` concrete class to wrap TileDB `Attribute` and `Enumeration` pairs.

