### PR TITLE
[c++] Add ASAN run of CI to weekly CI job

### DIFF
--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -1,0 +1,17 @@
+name: libtiledbsoma ASAN
+
+on:
+  schedule:
+    - cron: 20 8 * * 0
+  workflow_dispatch:
+
+jobs:
+  asan:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout TileDB-SOMA
+      uses: actions/checkout@v4
+    - name: Build libtiledbsoma
+      run: ./scripts/bld --build=ASAN --no-tiledb-deprecated=true --werror=true
+    - name: Run libTileDB-SOMA unittests
+      run: ctest --test-dir build/libtiledbsoma -C ASAN --verbose --rerun-failed --output-on-failure

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -1,6 +1,9 @@
 name: libtiledbsoma ASAN
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/libtiledbsoma-asan-ci.yml'
   schedule:
     - cron: 20 8 * * 0
   workflow_dispatch:

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -12,9 +12,26 @@ jobs:
   asan:
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout TileDB-SOMA
-      uses: actions/checkout@v4
-    - name: Build libtiledbsoma
-      run: ./scripts/bld --build=ASAN --no-tiledb-deprecated=true --werror=true
-    - name: Run libTileDB-SOMA unittests
-      run: ctest --test-dir build/libtiledbsoma -C ASAN --verbose --rerun-failed --output-on-failure
+      - name: Checkout TileDB-SOMA
+        uses: actions/checkout@v4
+      - name: Install pre-built libtiledb
+        run: |
+          mkdir -p external
+            # Please do not edit manually -- let scripts/update-tiledb-version.py update this
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0/tiledb-linux-x86_64-2.27.0-2862c30.tar.gz
+          tar -C external -xzf tiledb-*.tar.gz
+          ls external/lib/
+      - name: Build and install libtiledbsoma
+        run: |
+          cmake -S libtiledbsoma -B build \
+            -D CMAKE_BUILD_TYPE=ASAN \
+            -D CMAKE_PREFIX_PATH=$(pwd)/external/ \
+            -D CMAKE_INSTALL_PREFIX:PATH=$(pwd)/external/ \
+            -D OVERRIDE_INSTALL_PREFIX=OFF \
+            -D DOWNLOAD_TILEDB_PREBUILT=OFF \
+            -D TILEDB_REMOVE_DEPRECATIONS=ON \
+            -D FORCE_BUILD_TILEDB=OFF
+          cmake --build build -j 2
+          ls external/lib/
+      - name: Run C++ unittests
+        run: ctest --test-dir build/libtiledbsoma -C ASAN --verbose --rerun-failed --output-on-failure

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ Rules:
   clean               Remove build artifacts
 
 Options:
-  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
+  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|ASAN|TSAN|LSAN|UBSAN|MSAN|Coverage [Release]
   prefix=PREFIX       Install location [${PWD}/dist]
   tiledb=TILEDB_DIST  Absolute path to custom TileDB build
 
@@ -118,4 +118,3 @@ export HELP
 .PHONY: help
 help:
 	@printf "$${HELP}"
-

--- a/libtiledbsoma/README.md
+++ b/libtiledbsoma/README.md
@@ -46,7 +46,7 @@ This approach leverages the build-system defined in [pyproject.toml](../apis/pyt
 
 ## Python and C++ Development
 
-Developers who plan to modify the C++ code must use these build commands: 
+Developers who plan to modify the C++ code must use these build commands:
 
 ```
 # clean, build, and install
@@ -77,9 +77,9 @@ Rules:
   clean               Remove build artifacts
 
 Options:
-  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
+  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|ASAN|TSAN|LSAN|UBSAN|MSAN|Coverage [Release]
   prefix=PREFIX       Install location [dist]
-  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
+  tiledb=TILEDB_DIST  Absolute path to custom TileDB build
 
 Examples:
   Install Release build

--- a/scripts/bld
+++ b/scripts/bld
@@ -38,7 +38,7 @@ fi
 # set extra cmake options
 # -------------------------------------------------------------------
 extra_opts=""
-if [ "${build}" == "Debug" ] && [ -z "${tiledb}" ]; then
+if [ "${build}" != "Release" ] && [ -z "${tiledb}" ]; then
   # Debug build of TileDB from source
   extra_opts+=" -DDOWNLOAD_TILEDB_PREBUILT=OFF"
 fi

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -121,6 +121,11 @@ def main(args):
     )
     update_version(filepath, new_version, new_hash)
 
+    filepath = (
+        f"{os.path.dirname(__file__)}/../.github/workflows/libtiledbsoma-asan-ci.yml"
+    )
+    update_version(filepath, new_version, new_hash)
+
 
 if __name__ == "__main__":
     description = (


### PR DESCRIPTION
1. Update `bld/script.sh` to skip downloading TileDB prebuilt for all non-`Release` configurations.
2. Add new weekly CI job that runs the CI for the ASAN configuration.
3. Update developer docs for building with sanitizers.

[[sc-34306]](https://app.shortcut.com/tiledb-inc/story/34306/soma-run-sanitizer-s-in-ci)


