### PR TITLE
[python,c++] Improve error handling in `IntIndexer`

### DIFF
--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -66,9 +66,21 @@ class IntIndexer:
             Maturing.
         """
         self._context = context
-        self._reindexer = clib.IntIndexer(
-            None if self._context is None else self._context.native_context
+        self._reindexer = (
+            clib.IntIndexer()
+            if self._context is None
+            else clib.IntIndexer(self._context.native_context)
         )
+
+        # TODO: the map_locations interface does not accept chunked arrays. It would
+        # save a copy (reduce memory usage) if they were natively supported.
+        if isinstance(
+            data, (pa.Array, pa.ChunkedArray, pd.arrays.IntegerArray, pd.Series)
+        ):
+            data = data.to_numpy()
+        elif isinstance(data, list):
+            data = np.array(data, dtype=np.int64)
+
         self._reindexer.map_locations(data)
 
     def get_indexer(self, target: IndexerDataType) -> npt.NDArray[np.intp]:
@@ -79,8 +91,12 @@ class IntIndexer:
         Args:
             target: Data to return re-index data for.
         """
-        return (
-            self._reindexer.get_indexer_pyarrow(target)
-            if isinstance(target, (pa.Array, pa.ChunkedArray))
-            else self._reindexer.get_indexer_general(target)
-        )
+        if isinstance(target, (pa.ChunkedArray, pa.Array)):
+            return self._reindexer.get_indexer_pyarrow(target)
+
+        if isinstance(target, (pd.arrays.IntegerArray, pd.Series)):
+            target = target.to_numpy()
+        elif isinstance(target, list):
+            target = np.array(target, dtype=np.int64)
+
+        return self._reindexer.get_indexer_general(target)

--- a/apis/python/src/tiledbsoma/reindexer.cc
+++ b/apis/python/src/tiledbsoma/reindexer.cc
@@ -147,7 +147,7 @@ py::array_t<int64_t> get_indexer_py_arrow_aux(
         ArrowSchema arrow_schema;
         ArrowArray arrow_array;
         extract_py_array_schema(array, arrow_array, arrow_schema);
-        auto input_ptr = (int64_t*)arrow_array.buffers[1];
+        auto input_ptr = (int64_t*)arrow_array.buffers[1] + arrow_array.offset;
 
         py::gil_scoped_release release;
         indexer.lookup(

--- a/apis/python/src/tiledbsoma/reindexer.cc
+++ b/apis/python/src/tiledbsoma/reindexer.cc
@@ -65,7 +65,8 @@ py::array_t<int64_t> get_indexer_general_aux(
 py::array_t<int64_t> get_indexer_general(
     IntIndexer& indexer, py::array_t<int64_t> lookups) {
     if (lookups.ndim() != 1)
-        throw std::invalid_argument("IntIndexer only supports arrays of dimension 1");
+        throw std::invalid_argument(
+            "IntIndexer only supports arrays of dimension 1");
     if (lookups.dtype() != py::dtype::of<int64_t>())
         throw py::type_error("IntIndexer only supports array of type int64");
 

--- a/apis/python/src/tiledbsoma/reindexer.cc
+++ b/apis/python/src/tiledbsoma/reindexer.cc
@@ -65,9 +65,9 @@ py::array_t<int64_t> get_indexer_general_aux(
 py::array_t<int64_t> get_indexer_general(
     IntIndexer& indexer, py::array_t<int64_t> lookups) {
     if (lookups.ndim() != 1)
-        throw TileDBSOMAError("IntIndexer only supports arrays of dimension 1");
+        throw std::invalid_argument("IntIndexer only supports arrays of dimension 1");
     if (lookups.dtype() != py::dtype::of<int64_t>())
-        throw TileDBSOMAError("IntIndexer only supports array of type int64");
+        throw py::type_error("IntIndexer only supports array of type int64");
 
     try {
         return get_indexer_general_aux(indexer, lookups);
@@ -182,10 +182,10 @@ void load_reindexer(py::module& m) {
             "map_locations",
             [](IntIndexer& indexer, py::array keys) {
                 if (keys.ndim() != 1)
-                    throw TileDBSOMAError(
+                    throw std::invalid_argument(
                         "IntIndexer only supports arrays of dimension 1");
                 if (keys.dtype() != py::dtype::of<int64_t>())
-                    throw TileDBSOMAError(
+                    throw py::type_error(
                         "IntIndexer only supports array of type int64");
 
                 auto keys_int64 = py::cast<py::array_t<int64_t>>(keys);

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -121,15 +121,15 @@ def test_expected_errors() -> None:
     context = SOMATileDBContext()
 
     # ndim != 1
-    with pytest.raises(SOMAError):
+    with pytest.raises(ValueError):
         IntIndexer(np.array([[0, 1], [2, 3]], dtype=np.int64), context=context)
-    with pytest.raises(SOMAError):
+    with pytest.raises(ValueError):
         IntIndexer(np.array([0, 1, 2, 3], dtype=np.int64), context=context).get_indexer(
             np.array([[0, 1]], dtype=np.int64)
         )
 
     # non-native byte order (one of the two must fail)
-    with pytest.raises(SOMAError):
+    with pytest.raises(TypeError):
         IntIndexer(np.array([0, 1, 2, 3], dtype=np.dtype("<i8")), context=context)
         IntIndexer(np.array([0, 1, 2, 3], dtype=np.dtype(">i8")), context=context)
     with pytest.raises(TypeError):
@@ -141,7 +141,7 @@ def test_expected_errors() -> None:
         )
 
     # unsupported dtype
-    with pytest.raises(SOMAError):
+    with pytest.raises(TypeError):
         IntIndexer(np.array([0, 1, 2], dtype=np.uint64), context=context)
     with pytest.raises(TypeError):
         IntIndexer(np.array([0, 1, 2], dtype=np.int64), context=context).get_indexer(

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -147,3 +147,17 @@ def test_expected_errors() -> None:
         IntIndexer(np.array([0, 1, 2], dtype=np.int64), context=context).get_indexer(
             np.array([0, 1, 2], dtype=np.float64)
         )
+
+
+def test_arrow_offset_handling() -> None:
+    """Ensure accurate handling of slice offset/length"""
+    assert np.array_equal(
+        IntIndexer([0, 1]).get_indexer(pa.array([0, 1, 2]).slice(offset=1, length=1)),
+        np.array([1]),
+    )
+    assert np.array_equal(
+        IntIndexer([0, 1, 2, 3, 4, 5]).get_indexer(
+            pa.chunked_array([[0, 1], [2, 3]]).slice(offset=1, length=2)
+        ),
+        np.array([1, 2]),
+    )

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -72,7 +72,7 @@ class IntIndexer {
 
         lookup(keys.data(), results.data(), keys.size());
     }
-    IntIndexer(){};
+    IntIndexer() {};
     IntIndexer(std::shared_ptr<tiledbsoma::SOMAContext> context)
         : context_(context) {
     }

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -72,7 +72,7 @@ class IntIndexer {
 
         lookup(keys.data(), results.data(), keys.size());
     }
-    IntIndexer() {};
+    IntIndexer(){};
     IntIndexer(std::shared_ptr<tiledbsoma::SOMAContext> context)
         : context_(context) {
     }


### PR DESCRIPTION
**Issue and/or context:**

IntIndexer would do strange things when given malformed inputs.  See for example sc-60689 and sc-60690

IntIndexer also incorrectly handled any arrow array with an offset, and would return incorrect outputs.  See sc-60795

**Changes:**

1. More error checking in pybind-ings, plus tests.  The desired parts of the implicit casting are moved up into the Python code where they are more easily managed.
2. Minimal fix to correctly use array offsets (note: this code needs refactoring to use nanoarrow interfaces)
