### PR TITLE
[python] Pre-emptively avoid SciPy 1.15, pending a bugfix

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -339,7 +339,9 @@ setuptools.setup(
         "pandas",
         "pyarrow",
         "scanpy>=1.9.2",
-        "scipy",
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/3444
+        # https://github.com/scverse/anndata/issues/1802
+        "scipy<1.15.0",
         # Note: the somacore version is also in .pre-commit-config.yaml
         "somacore==1.0.24",
         "typing-extensions",  # Note "-" even though `import typing_extensions`

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2152,17 +2152,6 @@ def _find_mean_nnz(matrix: Matrix, axis: int) -> int:
     for lo in range(0, extent, bsz):
         hi = min(extent, lo + bsz)
         coords[axis] = slice(lo, hi)
-        print()
-        print()
-        print("HEY")
-        foo1 = tuple(coords)
-        print(f"TUPLE COORDS <<{foo1}>>")
-        foo2 = matrix[tuple(coords)]
-        print(f"MATRIX TUPLE COORDS <<{foo2}>>")
-        foo3 = matrix[tuple(coords)].nnz
-        print(f"MATRIX TUPLE COORDS NNZ <<{foo3}>>")
-        print()
-        print()
         total_nnz += matrix[tuple(coords)].nnz
     return int(math.ceil(total_nnz / extent))
 
@@ -2397,12 +2386,6 @@ def _write_matrix_to_sparseNDArray(
         stride_axis = 1
 
     dim_max_size = matrix.shape[stride_axis]
-
-    print()
-    print()
-    print("HEYY SNDA URI", soma_ndarray.uri)
-    print()
-    print()
 
     eta_tracker = eta.Tracker()
     goal_chunk_nnz = tiledb_create_options.goal_chunk_nnz

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2152,6 +2152,17 @@ def _find_mean_nnz(matrix: Matrix, axis: int) -> int:
     for lo in range(0, extent, bsz):
         hi = min(extent, lo + bsz)
         coords[axis] = slice(lo, hi)
+        print()
+        print()
+        print("HEY")
+        foo1 = tuple(coords)
+        print(f"TUPLE COORDS <<{foo1}>>")
+        foo2 = matrix[tuple(coords)]
+        print(f"MATRIX TUPLE COORDS <<{foo2}>>")
+        foo3 = matrix[tuple(coords)].nnz
+        print(f"MATRIX TUPLE COORDS NNZ <<{foo3}>>")
+        print()
+        print()
         total_nnz += matrix[tuple(coords)].nnz
     return int(math.ceil(total_nnz / extent))
 
@@ -2386,6 +2397,12 @@ def _write_matrix_to_sparseNDArray(
         stride_axis = 1
 
     dim_max_size = matrix.shape[stride_axis]
+
+    print()
+    print()
+    print("HEYY SNDA URI", soma_ndarray.uri)
+    print()
+    print()
 
     eta_tracker = eta.Tracker()
     goal_chunk_nnz = tiledb_create_options.goal_chunk_nnz


### PR DESCRIPTION
**Issue and/or context:**

Pre-emptively avoids https://github.com/single-cell-data/TileDB-SOMA/pull/new/kerl/pin-scipy-less-than-1.15. Tracking: https://github.com/single-cell-data/TileDB-SOMA/issues/3444.

Note that scipy 1.15.0 is not released yet, but, its 1.15.0rc1 is out, and our next tiledbsoma release (coincidentally also named 1.15.0) is coming out soon, and we want to pre-emptively protect against any time window in which we could suffer from this bug. Once https://github.com/scverse/anndata/issues/1802 is addressed (be it by a bugfix in SciPy or AnnData), we can remove this pin.

**Changes:**

**Notes for Reviewer:**

