### PR TITLE
[python] Fix conditional fall-through in `SOMAObject.open`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -92,8 +92,9 @@ void load_soma_object(py::module& m) {
                 else if (soma_obj_type == "somamultiscaleimage")
                     return py::cast(
                         dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
-                else{
-                    TPY_ERROR_LOC(*soma_obj_type + " SOMA object type not found");
+                else {
+                    TPY_ERROR_LOC(
+                        *soma_obj_type + " SOMA object type not found");
                 }
             },
             "uri"_a,

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -92,6 +92,9 @@ void load_soma_object(py::module& m) {
                 else if (soma_obj_type == "somamultiscaleimage")
                     return py::cast(
                         dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
+                else{
+                    TPY_ERROR_LOC(*soma_obj_type + " SOMA object type not found");
+                }
             },
             "uri"_a,
             "mode"_a,

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -63,7 +63,11 @@ void load_soma_object(py::module& m) {
                         uri, mode, context, timestamp, clib_type);
                 })();
 
-                auto soma_obj_type = soma_obj->type();
+                try {
+                    auto soma_obj_type = soma_obj->type();
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
 
                 std::transform(
                     soma_obj_type->begin(),
@@ -92,10 +96,13 @@ void load_soma_object(py::module& m) {
                 else if (soma_obj_type == "somamultiscaleimage")
                     return py::cast(
                         dynamic_cast<SOMAMultiscaleImage&>(*soma_obj));
-                else {
-                    TPY_ERROR_LOC(
-                        *soma_obj_type + " SOMA object type not found");
-                }
+
+                assert(
+                    false &&
+                    "Unreachable code: All possible SOMA object types are "
+                    "already handled. This indicates a logic error or an "
+                    "unexpected failure to catch exceptions by "
+                    "SOMAObject::open");
             },
             "uri"_a,
             "mode"_a,

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -63,10 +63,20 @@ void load_soma_object(py::module& m) {
                         uri, mode, context, timestamp, clib_type);
                 })();
 
+                std::optional<std::string> soma_obj_type;
                 try {
-                    auto soma_obj_type = soma_obj->type();
+                    soma_obj_type = soma_obj->type();
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
+                }
+
+                if (!soma_obj_type) {
+                    assert(
+                        false &&
+                        "Unreachable code: The missing soma_object_type case "
+                        "is already handled. This indicates an "
+                        "unexpected failure to catch exceptions by "
+                        "SOMAObject::open");
                 }
 
                 std::transform(


### PR DESCRIPTION
**Issue and/or context:**

As reported internally, the pybind11 implemented `SOMAObject.open` contains a conditional fall-through as of #3402.

**Changes:**

Wrap the C++ call in try-catch block where `SOMAObject::open` should already throw an exception for unknown types. In the Pybind11 code, if the conditional falls through then trigger an `assert` for unreachable code.