### PR TITLE
[python] Rename `to_spatial_data` -> `to_spatialdata`

### DIFF
--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -486,7 +486,7 @@ class ExperimentAxisQuery:
 
         return ad
 
-    def to_spatial_data(  # type: ignore[no-untyped-def]
+    def to_spatialdata(  # type: ignore[no-untyped-def]
         self,
         X_name: str,
         *,
@@ -524,7 +524,7 @@ class ExperimentAxisQuery:
 
         from spatialdata import SpatialData
 
-        from .io.spatial.outgest import _add_scene_to_spatial_data
+        from .io.spatial.outgest import _add_scene_to_spatialdata
 
         warnings.warn(SPATIAL_DISCLAIMER)
 
@@ -554,7 +554,7 @@ class ExperimentAxisQuery:
 
         for scene_id in scene_ids:
             scene = self.experiment.spatial[str(scene_id)]
-            _add_scene_to_spatial_data(
+            _add_scene_to_spatialdata(
                 sdata,
                 scene_id=str(scene_id),
                 scene=scene,

--- a/apis/python/src/tiledbsoma/io/spatial/__init__.py
+++ b/apis/python/src/tiledbsoma/io/spatial/__init__.py
@@ -5,6 +5,6 @@ may be dropped.
 """
 
 from .ingest import VisiumPaths, from_visium
-from .outgest import to_spatial_data
+from .outgest import to_spatialdata
 
-__all__ = ["to_spatial_data", "from_visium", "VisiumPaths"]
+__all__ = ["to_spatialdata", "from_visium", "VisiumPaths"]

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -69,7 +69,7 @@ def _convert_axis_names(
     return spatial_data_axes, soma_dim_map
 
 
-def _transform_to_spatial_data(
+def _transform_to_spatialdata(
     transform: somacore.CoordinateTransform,
     input_dim_map: Dict[str, str],
     output_dim_map: Dict[str, str],
@@ -102,7 +102,7 @@ def _transform_to_spatial_data(
     )
 
 
-def to_spatial_data_points(
+def to_spatialdata_points(
     points: PointCloudDataFrame,
     *,
     key: str,
@@ -135,7 +135,7 @@ def to_spatial_data_points(
         transforms = {key: sd.transformations.Identity()}
     else:
         transforms = {
-            scene_id: _transform_to_spatial_data(
+            scene_id: _transform_to_spatialdata(
                 transform.inverse_transform(), points_dim_map, scene_dim_map
             )
         }
@@ -146,7 +146,7 @@ def to_spatial_data_points(
     return sd.models.PointsModel.parse(df, transformations=transforms)
 
 
-def to_spatial_data_shapes(
+def to_spatialdata_shapes(
     points: PointCloudDataFrame,
     *,
     key: str,
@@ -197,7 +197,7 @@ def to_spatial_data_shapes(
         transforms = {key: sd.transformations.Identity()}
     else:
         transforms = {
-            scene_id: _transform_to_spatial_data(
+            scene_id: _transform_to_spatialdata(
                 transform.inverse_transform(), points_dim_map, scene_dim_map
             )
         }
@@ -220,7 +220,7 @@ def to_spatial_data_shapes(
     return df
 
 
-def to_spatial_data_image(
+def to_spatialdata_image(
     image: MultiscaleImage,
     level: Optional[Union[str, int]] = None,
     *,
@@ -272,7 +272,7 @@ def to_spatial_data_image(
     if transform is None:
         # Get the transformation from the image level to the highest resolution of the multiscale image.
         scale_transform = image.get_transform_from_level(level)
-        sd_transform = _transform_to_spatial_data(
+        sd_transform = _transform_to_spatialdata(
             scale_transform, image_dim_map, image_dim_map
         )
         transformations = {key: sd_transform}
@@ -287,14 +287,14 @@ def to_spatial_data_image(
             scale_transform, somacore.IdentityTransform
         ):
             # inv_transform @ scale_transform -> applies scale_transform first
-            sd_transform = _transform_to_spatial_data(
+            sd_transform = _transform_to_spatialdata(
                 inv_transform @ scale_transform, image_dim_map, scene_dim_map
             )
         else:
-            sd_transform1 = _transform_to_spatial_data(
+            sd_transform1 = _transform_to_spatialdata(
                 scale_transform, image_dim_map, image_dim_map
             )
-            sd_transform2 = _transform_to_spatial_data(
+            sd_transform2 = _transform_to_spatialdata(
                 inv_transform, image_dim_map, scene_dim_map
             )
             # Sequence([sd_transform1, sd_transform2]) -> applies sd_transform1 first
@@ -310,7 +310,7 @@ def to_spatial_data_image(
     )
 
 
-def to_spatial_data_multiscale_image(
+def to_spatialdata_multiscale_image(
     image: MultiscaleImage,
     *,
     key: str,
@@ -350,7 +350,7 @@ def to_spatial_data_multiscale_image(
 
     if transform is None:
         spatial_data_transformations = tuple(
-            _transform_to_spatial_data(
+            _transform_to_spatialdata(
                 image.get_transform_from_level(level),
                 image_dim_map,
                 image_dim_map,
@@ -366,7 +366,7 @@ def to_spatial_data_multiscale_image(
         if isinstance(transform, somacore.ScaleTransform):
             # inv_transform @ scale_transform -> applies scale_transform first
             spatial_data_transformations = tuple(
-                _transform_to_spatial_data(
+                _transform_to_spatialdata(
                     inv_transform @ image.get_transform_from_level(level),
                     image_dim_map,
                     scene_dim_map,
@@ -375,12 +375,12 @@ def to_spatial_data_multiscale_image(
             )
         else:
             sd_scale_transforms = tuple(
-                _transform_to_spatial_data(
+                _transform_to_spatialdata(
                     image.get_transform_from_level(level), image_dim_map, image_dim_map
                 )
                 for level in range(1, image.level_count)
             )
-            sd_inv_transform = _transform_to_spatial_data(
+            sd_inv_transform = _transform_to_spatialdata(
                 inv_transform, image_dim_map, scene_dim_map
             )
 
@@ -420,7 +420,7 @@ def _get_transform_from_collection(
     return None
 
 
-def _add_scene_to_spatial_data(
+def _add_scene_to_spatialdata(
     sdata: sd.SpatialData,
     scene_id: str,
     scene: Scene,
@@ -456,7 +456,7 @@ def _add_scene_to_spatial_data(
             transform = _get_transform_from_collection(key, scene.obsl.metadata)
             if isinstance(df, PointCloudDataFrame):
                 if "soma_geometry" in df.metadata:
-                    sdata.shapes[output_key] = to_spatial_data_shapes(
+                    sdata.shapes[output_key] = to_spatialdata_shapes(
                         df,
                         key=output_key,
                         scene_id=scene_id,
@@ -465,7 +465,7 @@ def _add_scene_to_spatial_data(
                         soma_joinid_name=obs_id_name,
                     )
                 else:
-                    sdata.points[output_key] = to_spatial_data_points(
+                    sdata.points[output_key] = to_spatialdata_points(
                         df,
                         key=output_key,
                         scene_id=scene_id,
@@ -492,7 +492,7 @@ def _add_scene_to_spatial_data(
                 transform = _get_transform_from_collection(key, subcoll.metadata)
                 if isinstance(df, PointCloudDataFrame):
                     if "soma_geometry" in df.metadata:
-                        sdata.shapes[output_key] = to_spatial_data_shapes(
+                        sdata.shapes[output_key] = to_spatialdata_shapes(
                             df,
                             key=output_key,
                             scene_id=scene_id,
@@ -501,7 +501,7 @@ def _add_scene_to_spatial_data(
                             soma_joinid_name=var_id_name,
                         )
                     else:
-                        sdata.points[output_key] = to_spatial_data_points(
+                        sdata.points[output_key] = to_spatialdata_points(
                             df,
                             key=output_key,
                             scene_id=scene_id,
@@ -526,7 +526,7 @@ def _add_scene_to_spatial_data(
                     f"datatype {type(image).__name__}."
                 )
             if image.level_count == 1:
-                sdata.images[output_key] = to_spatial_data_image(
+                sdata.images[output_key] = to_spatialdata_image(
                     image,
                     0,
                     key=output_key,
@@ -535,7 +535,7 @@ def _add_scene_to_spatial_data(
                     transform=transform,
                 )
             else:
-                sdata.images[f"{scene_id}_{key}"] = to_spatial_data_multiscale_image(
+                sdata.images[f"{scene_id}_{key}"] = to_spatialdata_multiscale_image(
                     image,
                     key=output_key,
                     scene_id=scene_id,
@@ -544,7 +544,7 @@ def _add_scene_to_spatial_data(
                 )
 
 
-def to_spatial_data(
+def to_spatialdata(
     experiment: Experiment,
     *,
     measurement_names: Optional[Sequence[str]] = None,
@@ -614,7 +614,7 @@ def to_spatial_data(
 
     for scene_id in scene_names:
         scene = experiment.spatial[scene_id]
-        _add_scene_to_spatial_data(
+        _add_scene_to_spatialdata(
             sdata=sdata,
             scene_id=scene_id,
             scene=scene,

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -26,7 +26,7 @@ def sample_2d_data():
 
 @pytest.fixture(scope="module")
 def experiment_with_single_scene(tmp_path_factory, sample_2d_data) -> soma.Experiment:
-    uri = tmp_path_factory.mktemp("experiment_with_spatial_data").as_uri()
+    uri = tmp_path_factory.mktemp("experiment_with_spatialdata").as_uri()
     with soma.Experiment.create(uri) as exp:
         assert exp.uri == uri
         # Create spatial folder.
@@ -173,7 +173,7 @@ def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
 
     # Read full experiment into SpatialData.
     with _factory.open(output_path) as exp:
-        sdata = spatial_outgest.to_spatial_data(exp)
+        sdata = spatial_outgest.to_spatialdata(exp)
 
     # Check the number of assets (exactly 1 table) is as expected.
     assert len(sdata.tables) == 2
@@ -204,7 +204,7 @@ def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
 
 def test_outgest_spatial_only(experiment_with_single_scene, sample_2d_data):
     # Export to SpatialData.
-    sdata = spatial_outgest.to_spatial_data(experiment_with_single_scene)
+    sdata = spatial_outgest.to_spatialdata(experiment_with_single_scene)
 
     # Check the number of assets is correct.
     assert len(sdata.tables) == 0

--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -251,7 +251,7 @@ def test_spatial_experiment_query_none(soma_spatial_experiment):
         assert query.n_vars == 0
 
         # Read to SpatialData.
-        sdata = query.to_spatial_data("data")
+        sdata = query.to_spatialdata("data")
         assert len(sdata.tables) == 1
         assert len(sdata.points) == 0
         assert len(sdata.shapes) == 0
@@ -269,7 +269,7 @@ def test_spatial_experiment_query_all(soma_spatial_experiment):
         assert query.n_vars == 100
 
         # Read to SpatialData.
-        sdata = query.to_spatial_data("data")
+        sdata = query.to_spatialdata("data")
 
         # Verify the correct number of assets.
         assert len(sdata.tables) == 1
@@ -301,7 +301,7 @@ def test_spatial_experiment_query_obs_slice(
         assert query.n_vars == 100
 
         # Read to SpatialData.
-        sdata = query.to_spatial_data("data")
+        sdata = query.to_spatialdata("data")
 
         # Verify the correct number of assets.
         assert len(sdata.tables) == 1
@@ -330,7 +330,7 @@ def test_spatial_experiment_query_var_slice(
         assert query.n_vars == var_slice.stop - var_slice.start + 1
 
         # Read to SpatialData.
-        sdata = query.to_spatial_data("data", scene_presence_mode="var")
+        sdata = query.to_spatialdata("data", scene_presence_mode="var")
 
         # Verify the correct number of assets.
         assert len(sdata.tables) == 1

--- a/apis/python/tests/test_export_multiscale_image.py
+++ b/apis/python/tests/test_export_multiscale_image.py
@@ -121,7 +121,7 @@ def sample_multiscale_image_2d(tmp_path_factory, sample_2d_data):
         ),
     ],
 )
-def test_export_image_level_to_spatial_data(
+def test_export_image_level_to_spatialdata(
     sample_multiscale_image_2d,
     sample_2d_data,
     level,
@@ -129,7 +129,7 @@ def test_export_image_level_to_spatial_data(
     expected_transformation,
     expected_transformation_key,
 ):
-    image2d = soma_outgest.to_spatial_data_image(
+    image2d = soma_outgest.to_spatialdata_image(
         sample_multiscale_image_2d,
         level=level,
         key="image",
@@ -223,14 +223,14 @@ def test_export_image_level_to_spatial_data(
         ),
     ],
 )
-def test_export_full_image_to_spatial_data(
+def test_export_full_image_to_spatialdata(
     sample_multiscale_image_2d,
     sample_2d_data,
     transform,
     expected_transformation,
     expected_transformation_key,
 ):
-    image2d = soma_outgest.to_spatial_data_multiscale_image(
+    image2d = soma_outgest.to_spatialdata_multiscale_image(
         sample_multiscale_image_2d,
         key="image",
         scene_id="scene0",

--- a/apis/python/tests/test_export_point_cloud_dataframe.py
+++ b/apis/python/tests/test_export_point_cloud_dataframe.py
@@ -52,7 +52,7 @@ def test_export_to_shapes_2d(
 ):
     """Test exporting a simple point cloud to a SpatialData shape model."""
     # Export PointCloudDataFrame to shapes.
-    shape = soma_outgest.to_spatial_data_shapes(
+    shape = soma_outgest.to_spatialdata_shapes(
         sample_point_cloud_dataframe_2d,
         scene_id="scene0",
         key="point_cloud",
@@ -100,7 +100,7 @@ def test_export_to_points_2d(
 ):
     """Test exporting a simple point cloud to a SpatialData shape model."""
     # Export PointCloudDataFrame to shapes.
-    points = soma_outgest.to_spatial_data_points(
+    points = soma_outgest.to_spatialdata_points(
         sample_point_cloud_dataframe_2d,
         key="point_cloud",
         scene_id="scene0",

--- a/apis/python/tests/test_spatial_outgest_util.py
+++ b/apis/python/tests/test_spatial_outgest_util.py
@@ -33,10 +33,10 @@ sd = pytest.importorskip("spatialdata")
         ),
     ],
 )
-def test_transform_to_spatial_data(transform, expected):
+def test_transform_to_spatialdata(transform, expected):
     input_dim_map = {"x1": "x", "y1": "y", "z1": "z"}
     output_dim_map = {"x2": "x", "y2": "y", "z2": "z"}
-    actual = soma_outgest._transform_to_spatial_data(
+    actual = soma_outgest._transform_to_spatialdata(
         transform, input_dim_map, output_dim_map
     )
     assert actual == expected


### PR DESCRIPTION
Change name of methods that contain `to_spatial_data` to `to_spatialdata`.

