### PR TITLE
[python/c++] Fix invalid memory read in `fastercsx`

### DIFF
--- a/apis/python/src/tiledbsoma/fastercsx.cc
+++ b/apis/python/src/tiledbsoma/fastercsx.cc
@@ -264,8 +264,8 @@ void compress_coo_validate_args_(
         }
     }
     for (uint64_t chunk_idx = 0; chunk_idx < n_chunks; chunk_idx++) {
-        if (Ai[chunk_idx].size() != Aj[chunk_idx].size() ||
-            Ai[chunk_idx].size() != Ad[chunk_idx].size())
+        if ((Ai[chunk_idx].size() != Aj[chunk_idx].size()) ||
+            (Ai[chunk_idx].size() != Ad[chunk_idx].size()))
             throw std::length_error(
                 "All COO array tuple elements must be of the same size.");
     }

--- a/apis/python/src/tiledbsoma/fastercsx.cc
+++ b/apis/python/src/tiledbsoma/fastercsx.cc
@@ -240,6 +240,7 @@ void compress_coo_validate_args_(
     4. num chunks/items in Ai/Aj/Ad is same size and type
     5. ensure B* are writeable
     6. Ensure each element in A* tuples are same type
+    7. Ensure each element in the A* tuples are the same length
     etc...
 
     Not checked:
@@ -261,6 +262,12 @@ void compress_coo_validate_args_(
                 throw pybind11::type_error(
                     "All chunks of COO arrays must be of same type.");
         }
+    }
+    for (uint64_t chunk_idx = 0; chunk_idx < n_chunks; chunk_idx++) {
+        if (Ai[chunk_idx].size() != Aj[chunk_idx].size() ||
+            Ai[chunk_idx].size() != Ad[chunk_idx].size())
+            throw std::length_error(
+                "All COO array tuple elements must be of the same size.");
     }
     if (Bp.ndim() != 1 || Bj.ndim() != 1 || Bd.ndim() != 1)
         throw std::length_error("All arrays must be of dimension rank 1.");

--- a/apis/python/tests/test_libfastercsx.py
+++ b/apis/python/tests/test_libfastercsx.py
@@ -311,3 +311,26 @@ def test_compress_coo_bad_args(
         fastercsx.compress_coo(
             context, sp.shape, (i,), (j,), (d[1:],), indptr, indices, data
         )
+
+
+def test_ragged_chunk_error(
+    rng: np.random.Generator, context: clib.SOMAContext
+) -> None:
+    # module assumes all chunks are regular across all input arrays. Check that this
+    # is enforced.
+    nnz = 3
+    shape = (100, 20)
+    indptr = np.empty(shape[0] + 1, dtype=np.int32)
+    indices = np.empty(nnz, dtype=np.int32)
+    data = np.empty(nnz, dtype=np.int8)
+    with pytest.raises(ValueError):
+        fastercsx.compress_coo(
+            context,
+            shape,
+            (np.array([0]), np.array([1, 2])),
+            (np.array([0]), np.array([1, 2])),
+            (np.array([0, 1], dtype=np.int8), np.array([2], dtype=np.int8)),
+            indptr,
+            indices,
+            data,
+        )

--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -78,6 +78,25 @@ size_t sum_over_size_(const std::vector<std::span<const T>>& v) noexcept {
             return a.size();
         });
 }
+
+/**
+ * @brief Return true if any of the tuple sub-arrays are not equal in size,
+ * false otherwise.  Used only in asserts.
+ */
+template <typename Ti, typename Tj, typename Td>
+std::bool no_ragged_chunks(
+    const std::vector<std::span<const Ti>>& Ai,
+    const std::vector<std::span<const Tj>>& Aj,
+    const std::vector<std::span<const Td>>& Ad) {
+    if (Ai.size() != Aj.size())
+        || (Ai.size() != Ad.size()) return false;
+
+    for (uint64_t chunk_idx = 0; chunk_idx < Ai.size(); chunk_idx++) {
+        if (Ai[chunk_idx].size() != Aj[chunk_idx].size() ||
+            Ai[chunk_idx].size() != Ad[chunk_idx].size())
+            return False;
+    }
+}
 #endif
 
 /**
@@ -324,6 +343,7 @@ void compress_coo(
     assert(sum_over_size_(Ai) == nnz);
     assert(sum_over_size_(Aj) == nnz);
     assert(sum_over_size_(Ad) == nnz);
+    assert(no_ragged_chunks(Ai, Aj, Ad));
     assert(Bp.size() == n_row + 1);
     assert(Bj.size() == nnz);
     assert(Bd.size() == nnz);

--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -84,18 +84,19 @@ size_t sum_over_size_(const std::vector<std::span<const T>>& v) noexcept {
  * false otherwise.  Used only in asserts.
  */
 template <typename Ti, typename Tj, typename Td>
-std::bool no_ragged_chunks(
+bool no_ragged_chunks(
     const std::vector<std::span<const Ti>>& Ai,
     const std::vector<std::span<const Tj>>& Aj,
     const std::vector<std::span<const Td>>& Ad) {
-    if (Ai.size() != Aj.size())
-        || (Ai.size() != Ad.size()) return false;
+    if ((Ai.size() != Aj.size()) || (Ai.size() != Ad.size()))
+        return false;
 
     for (uint64_t chunk_idx = 0; chunk_idx < Ai.size(); chunk_idx++) {
-        if (Ai[chunk_idx].size() != Aj[chunk_idx].size() ||
-            Ai[chunk_idx].size() != Ad[chunk_idx].size())
-            return False;
+        if ((Ai[chunk_idx].size() != Aj[chunk_idx].size()) ||
+            (Ai[chunk_idx].size() != Ad[chunk_idx].size()))
+            return false;
     }
+    return true;
 }
 #endif
 


### PR DESCRIPTION
**Issue and/or context:**

The C++ `fastercsx` layer assumes all COO data "chunks" are of the same size.  However, the Python bindings failed to perform this check, which in some circumstances can lead to reads off the end of an array buffer.

**Changes:**

1. added explicit check in the Python binding
2. added `NDEBUG` assertion in the core package
3. added a test that the error is caught
