### PR TITLE
[python] Use `somacore` 1.0.26

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore==1.0.25"
+        - "somacore==1.0.26"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
         # https://github.com/scverse/anndata/issues/1802
         "scipy<1.15.0",
         # Note: the somacore version is also in .pre-commit-config.yaml
-        "somacore==1.0.25",
+        "somacore==1.0.26",
         "typing-extensions",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={


### PR DESCRIPTION
Found on
https://github.com/single-cell-data/TileDB-SOMA/actions/runs/12364349712/job/34507422201
in light of
https://github.com/single-cell-data/TileDB-SOMA/pull/3455

[[sc-59686]](https://app.shortcut.com/tiledb-inc/story/59686/update-projects-to-tiledb-2-27)