### PR TITLE
[docs] Fix broken tutorial-doc symlinks in `release-1.15`

### DIFF
--- a/doc/source/notebooks/tutorial_soma_shape.ipynb
+++ b/doc/source/notebooks/tutorial_soma_shape.ipynb
@@ -1,1 +1,0 @@
-../../../apis/python/notebooks/tutorial_soma_shape.ipynb

--- a/doc/source/notebooks/tutorial_soma_shape.ipynb
+++ b/doc/source/notebooks/tutorial_soma_shape.ipynb
@@ -1,0 +1,1 @@
+../../../apis/python/notebooks/tutorial_soma_shape.ipynb

--- a/doc/source/notebooks/tutorial_spatial.ipynb
+++ b/doc/source/notebooks/tutorial_spatial.ipynb
@@ -1,0 +1,1 @@
+../../../apis/python/notebooks/tutorial_spatial.ipynb

--- a/doc/source/notebooks/tutorial_spatial.ipynb
+++ b/doc/source/notebooks/tutorial_spatial.ipynb
@@ -1,1 +1,0 @@
-../../../apis/python/notebooks/tutorial_spatial.ipynb


### PR DESCRIPTION
**Issue and/or context:** Post-1.15.0 :( I realized that when I synced `main` and `release-1.15` (modulo necessary differences of course) the files that had been symlinks in `main` became plain files in `release-1.15` -- worse, files containing only the path to their referees. :(

[[sc-59686]](https://app.shortcut.com/tiledb-inc/story/59686/update-projects-to-tiledb-2-27)

**Changes:** Make these symlinks as they should be.

**Notes for Reviewer:**

