### PR TITLE
[r] Write group-level string metadata as `TILEDB_STRING_UTF8`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.16.99
+Version: 1.16.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII`
+
 # tiledbsoma 1.15.0
 
 ## Changes

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -254,7 +254,7 @@ void c_group_put_metadata(
             std::string s(v[0]);
             // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
             // this best string type?
-	    // Use TILEDB_STRING_UTF8 for compatibility with Python API
+            // Use TILEDB_STRING_UTF8 for compatibility with Python API
             xp->grpptr->set_metadata(
                 key, TILEDB_STRING_UTF8, s.length(), s.c_str());
             break;

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -254,8 +254,9 @@ void c_group_put_metadata(
             std::string s(v[0]);
             // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
             // this best string type?
+	    // Use TILEDB_STRING_UTF8 for compatibility with Python API
             xp->grpptr->set_metadata(
-                key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+                key, TILEDB_STRING_UTF8, s.length(), s.c_str());
             break;
         }
         case LGLSXP: {  // experimental: map R logical (ie TRUE, FALSE, NA) to

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import pytest
+
+import tiledbsoma
+
+from .common import TestWritePythonReadR
+
+
+class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
+
+    @pytest.fixture(scope="class")
+    def experiment(self):
+        exp = tiledbsoma.Experiment.create(self.uri)
+        exp.close()
+
+    def base_R_script(self):
+        return (
+            """
+        library(tiledbsoma)
+
+        exp <- SOMAExperimentOpen("%s")
+        md <- exp$get_metadata()
+        for (i in seq_along(md)) {
+          stopifnot(is.character(md[[i]]$name))
+        }
+        exp$close()
+        """
+            % self.uri
+        )
+
+    def test_r_character(self):
+        self.r_assert("")

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -11,7 +11,8 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
 
     @pytest.fixture(scope="class")
     def experiment(self):
-        _ = tiledbsoma.Experiment.create(self.uri)
+        exp = tiledbsoma.Experiment.create(self.uri)
+        exp.close
 
     def base_R_script(self):
         return f"""
@@ -21,7 +22,7 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
         md <- exp$get_metadata()
         """
 
-    def test_r_character(self):
+    def test_r_character(self, experiment):
         self.r_assert(
             "stopifnot(all(vapply(md, \(x) is.character(x$name), logical(1L))))"
         )

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -11,8 +11,7 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
 
     @pytest.fixture(scope="class")
     def experiment(self):
-        exp = tiledbsoma.Experiment.create(self.uri)
-        exp.close()
+        _ = tiledbsoma.Experiment.create(self.uri)
 
     def base_R_script(self):
         return f"""

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -15,19 +15,14 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
         exp.close()
 
     def base_R_script(self):
-        return (
-            """
+        return f"""
         library(tiledbsoma)
 
-        exp <- SOMAExperimentOpen("%s")
+        exp <- SOMAExperimentOpen("{self.uri}")
         md <- exp$get_metadata()
-        for (i in seq_along(md)) {
-          stopifnot(is.character(md[[i]]$name))
-        }
-        exp$close()
         """
-            % self.uri
-        )
 
     def test_r_character(self):
-        self.r_assert("")
+        self.r_assert(
+            "stopifnot(all(vapply(md, \(x) is.character(x$name), logical(1L))))"
+        )

--- a/apis/system/tests/test_character_write_r_read_python.py
+++ b/apis/system/tests/test_character_write_r_read_python.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import pytest
+
+import tiledbsoma
+
+from .common import TestReadPythonWriteR
+
+
+class TestCharacterMetadataWriteRReadPython(TestReadPythonWriteR):
+    @pytest.fixture(scope="class")
+    def R_character(self):
+        base_script = f"""
+        library(tiledbsoma)
+
+        exp <- SOMAExperimentCreate("{self.uri}")
+        exp$close()
+        """
+        self.execute_R_script(base_script)
+
+    def test_py_character(self, R_character):
+        with tiledbsoma.open(self.uri) as exp:
+            for key in exp.metadata.keys():
+                assert isinstance(exp.metadata.get(key), str)


### PR DESCRIPTION
String group-level metadata was previously encoded using `TILEDB_CHAR` or `TILEDB_STRING_ASCII`; however, this resulting in the metadata being read in as `bytes` in the Python API instead of as `str`. The Python API already [encodes all strings (`str`) as `TILEDB_STRING_UTF8`](https://github.com/single-cell-data/TileDB-SOMA/blob/884342a1ceb994d677c52c74ba2d789fc4e208d4/apis/python/src/tiledbsoma/common.cc#L211-L223) so this PR brings the R API in-line with the Python API

[SC-61001](https://app.shortcut.com/tiledb-inc/story/61001)

adresses #2698