### PR TITLE
[python] Add extra asserts for SpatialData tests

### DIFF
--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -300,6 +300,13 @@ def test_spatial_experiment_query_obs_slice(
         assert query.n_obs == obs_slice.stop - obs_slice.start + 1
         assert query.n_vars == 100
 
+        # Check the expected scenes are included.
+        scene_ids = set(str(val) for val in query.obs_scene_ids())
+        expected_scene_ids = set(
+            f"scene{index}" for index, val in enumerate(has_scene) if val
+        )
+        assert scene_ids == expected_scene_ids
+
         # Read to SpatialData.
         sdata = query.to_spatialdata("data")
 
@@ -328,6 +335,13 @@ def test_spatial_experiment_query_var_slice(
     ) as query:
         assert query.n_obs == 64
         assert query.n_vars == var_slice.stop - var_slice.start + 1
+
+        # Check the expected scenes are included.
+        scene_ids = set(str(val) for val in query.var_scene_ids())
+        expected_scene_ids = set(
+            f"scene{index}" for index, val in enumerate(has_scene) if val
+        )
+        assert scene_ids == expected_scene_ids
 
         # Read to SpatialData.
         sdata = query.to_spatialdata("data", scene_presence_mode="var")

--- a/scripts/show-versions.py
+++ b/scripts/show-versions.py
@@ -9,6 +9,15 @@ import pyarrow as pa
 import scanpy as sc
 import scipy as sp
 
+try:
+    import spatialdata as sd
+
+    HAS_SPATIALDATA = True
+except ImportError:
+
+    HAS_SPATIALDATA = False
+
+
 import tiledbsoma
 
 print("tiledbsoma.__version__   ", tiledbsoma.__version__)
@@ -19,5 +28,9 @@ print("pandas.__version__   (pd)", pd.__version__)
 print("pyarrow.__version__  (pa)", pa.__version__)
 print("scanpy.__version__   (sc)", sc.__version__)
 print("scipy.__version__    (sp)", sp.__version__)
+if HAS_SPATIALDATA:
+    print("spatialdata.__version__ (sd)", sd.__version__)
+else:
+    print("spatialdata not installed")
 v = sys.version_info
 print("python__version__        ", ".".join(map(str, (v.major, v.minor, v.micro))))


### PR DESCRIPTION
Extra tests to help with debugging sporadic failures in the Python 3.12 tests for exporting to SpatialData from an `ExperimentAxisQuery`.

Issue #3471