### PR TITLE
[python] Fix a test deprecation warning

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -390,7 +390,7 @@ def test_ingest_uns(
     ingest_uns_keys,
 ):
     tmp_uri = tmp_path.as_uri()
-    adata_extended2 = anndata.read(conftest_pbmc3k_h5ad_path)
+    adata_extended2 = anndata.read_h5ad(conftest_pbmc3k_h5ad_path)
     uri = tiledbsoma.io.from_anndata(
         tmp_uri,
         adata_extended2,


### PR DESCRIPTION
Observed in a cloud-images CI job:

```
/opt/conda/lib/python3.9/site-packages/anndata/__init__.py:55: FutureWarning: `anndata.read` is deprecated, use `anndata.read_h5ad` instead. `ad.read` will be removed in mid 2024.
```