### PR TITLE
[python] Re-enable `tiledbsoma.ExperimentAxisQuery`

### DIFF
--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -140,10 +140,10 @@ from somacore import (
     CoordinateSpace,
     IdentityTransform,
     ScaleTransform,
-    Axis,
     UniformScaleTransform,
 )
 from ._query import (
+    Axis,
     ExperimentAxisQuery,
 )
 from somacore.options import ResultOrder

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -133,16 +133,17 @@ except ImportError:
     except OSError:
         # Otherwise try loading by name only.
         ctypes.CDLL(libtiledbsoma_name)
-
 from somacore import (
-    Axis,
-    CoordinateSpace,
     AffineTransform,
-    ScaleTransform,
-    IdentityTransform,
-    UniformScaleTransform,
     AxisColumnNames,
     AxisQuery,
+    CoordinateSpace,
+    IdentityTransform,
+    ScaleTransform,
+    Axis,
+    UniformScaleTransform,
+)
+from ._query import (
     ExperimentAxisQuery,
 )
 from somacore.options import ResultOrder

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -135,6 +135,7 @@ except ImportError:
         ctypes.CDLL(libtiledbsoma_name)
 from somacore import (
     AffineTransform,
+    Axis,
     AxisColumnNames,
     AxisQuery,
     CoordinateSpace,
@@ -143,7 +144,6 @@ from somacore import (
     UniformScaleTransform,
 )
 from ._query import (
-    Axis,
     ExperimentAxisQuery,
 )
 from somacore.options import ResultOrder

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -14,10 +14,10 @@ from scipy import sparse
 from somacore import AxisQuery, options
 
 import tiledbsoma as soma
-from tiledbsoma import SOMATileDBContext, _factory, pytiledbsoma
+from tiledbsoma import ExperimentAxisQuery, SOMATileDBContext, _factory, pytiledbsoma
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma._experiment import Experiment
-from tiledbsoma._query import Axis, ExperimentAxisQuery
+from tiledbsoma._query import Axis
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -22,7 +22,7 @@ from tiledbsoma import (
 )
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma._experiment import Experiment
-from tiledbsoma._query import Axis
+from tiledbsoma._query import AxisName
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard
@@ -949,12 +949,12 @@ class IHaveObsVarStuff:
 
 def test_axis_helpers() -> None:
     thing = IHaveObsVarStuff(obs=1, var=2, the_obs_suf="observe", the_var_suf="vary")
-    assert 1 == Axis.OBS.getattr_from(thing)
-    assert 2 == Axis.VAR.getattr_from(thing)
-    assert "observe" == Axis.OBS.getattr_from(thing, pre="the_", suf="_suf")
-    assert "vary" == Axis.VAR.getattr_from(thing, pre="the_", suf="_suf")
+    assert 1 == AxisName.OBS.getattr_from(thing)
+    assert 2 == AxisName.VAR.getattr_from(thing)
+    assert "observe" == AxisName.OBS.getattr_from(thing, pre="the_", suf="_suf")
+    assert "vary" == AxisName.VAR.getattr_from(thing, pre="the_", suf="_suf")
     ovdict = {"obs": "erve", "var": "y", "i_obscure": "hide", "i_varcure": "???"}
-    assert "erve" == Axis.OBS.getitem_from(ovdict)
-    assert "y" == Axis.VAR.getitem_from(ovdict)
-    assert "hide" == Axis.OBS.getitem_from(ovdict, pre="i_", suf="cure")
-    assert "???" == Axis.VAR.getitem_from(ovdict, pre="i_", suf="cure")
+    assert "erve" == AxisName.OBS.getitem_from(ovdict)
+    assert "y" == AxisName.VAR.getitem_from(ovdict)
+    assert "hide" == AxisName.OBS.getitem_from(ovdict, pre="i_", suf="cure")
+    assert "???" == AxisName.VAR.getitem_from(ovdict, pre="i_", suf="cure")

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -14,10 +14,15 @@ from scipy import sparse
 from somacore import AxisQuery, options
 
 import tiledbsoma as soma
-from tiledbsoma import ExperimentAxisQuery, SOMATileDBContext, _factory, pytiledbsoma
+from tiledbsoma import (
+    Axis,
+    ExperimentAxisQuery,
+    SOMATileDBContext,
+    _factory,
+    pytiledbsoma,
+)
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma._experiment import Experiment
-from tiledbsoma._query import Axis
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -15,7 +15,6 @@ from somacore import AxisQuery, options
 
 import tiledbsoma as soma
 from tiledbsoma import (
-    Axis,
     ExperimentAxisQuery,
     SOMATileDBContext,
     _factory,
@@ -23,6 +22,7 @@ from tiledbsoma import (
 )
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma._experiment import Experiment
+from tiledbsoma._query import Axis
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard


### PR DESCRIPTION
**Issue and/or context:** After 1.15.0 was tagged, we found that users can no longer instantiate `tiledbsoma.ExperimentAxisQuery`.

Repro:

<details>

```
import scanpy as sc
import tiledbsoma
import tiledbsoma.io
import tempfile

pbmc3k = sc.datasets.pbmc3k()
sc.pp.calculate_qc_metrics(pbmc3k, inplace=True)

tmpdir = tempfile.TemporaryDirectory().name
tiledbsoma.io.from_anndata(tmpdir, anndata=pbmc3k, measurement_name="RNA")

exp = tiledbsoma.Experiment.open(tmpdir)

exp.obs.read().concat().to_pandas()
exp.ms["RNA"].var.read().concat().to_pandas()
exp.ms["RNA"].X["data"].read().coos().concat()
exp.obs.read(
    coords=[slice(0, 99)],
    value_filter="total_counts > 4000",
    column_names=["soma_joinid", "obs_id", "total_counts"],
).concat().to_pandas()
exp.ms["RNA"].var.read(
    value_filter="var_id in ['ANXA1', 'IFI44', 'IFI44L', 'OAS1']",
    column_names=["var_id", "gene_ids", "mean_counts"],
).concat().to_pandas()

with tiledbsoma.ExperimentAxisQuery(
    experiment=exp,
    measurement_name="RNA",
    obs_query=tiledbsoma.AxisQuery(
        value_filter="n_genes_by_counts > 1000",
    ),
    var_query=tiledbsoma.AxisQuery(
        value_filter="n_cells_by_counts > 100",
    ),
) as query:
    assert (query.n_obs, query.n_vars) == (532, 4722)
    query.obs().concat().to_pandas()
    query.X(layer_name="data").tables().concat().to_pandas()
    query.to_anndata(X_name="data")
```

</details>

This should produce no output and raise no exceptions. Actual behavior in 1.15.0, which is a regression from 1.14.5:

```
Traceback (most recent call last):
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/x.py", line 35, in <module>
    with tiledbsoma.ExperimentAxisQuery(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ExperimentAxisQuery() takes no arguments
```

**Changes:**

* Since on #3307 we moved the impl from `somacore` to `tiledbsoma._query`, have `tiledbsoma` re-export the impl from where it is now located
* Update our unit-test logic to use the same API as exposed to users, namely, `tiledbsoma.ExperimentAxisQuery`

**Notes for Reviewer:**

