### PR TITLE
[Backport release-1.15][r] Write group-level string metadata as `TILEDB_STRING_UTF8`; 1.15.1

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.0
+Version: 1.15.0.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.15.0.1
+Version: 1.15.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = c("cre", "aut"), email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,4 +1,4 @@
-# Unreleased
+# tiledbsoma 1.15.1
 
 * Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII` [#3469](https://github.com/single-cell-data/TileDB-SOMA/pull/3469)
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII` [#3469](https://github.com/single-cell-data/TileDB-SOMA/pull/3469)
+
 # tiledbsoma 1.15.0
 
 ## Changes

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -254,8 +254,9 @@ void c_group_put_metadata(
             std::string s(v[0]);
             // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
             // this best string type?
+            // Use TILEDB_STRING_UTF8 for compatibility with Python API
             xp->grpptr->set_metadata(
-                key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+                key, TILEDB_STRING_UTF8, s.length(), s.c_str());
             break;
         }
         case LGLSXP: {  // experimental: map R logical (ie TRUE, FALSE, NA) to


### PR DESCRIPTION
**Issue and/or context:** Backport of #3469. Also label 1.15.1.

**Changes:**

**Notes for Reviewer:**

