### PR TITLE
[c++] Use const references and `std::string_view` in `create` function

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -43,11 +43,11 @@ using namespace tiledb;
 //= public static
 //===================================================================
 
-std::unique_ptr<SOMAArray> SOMAArray::create(
+void SOMAArray::create(
     std::shared_ptr<SOMAContext> ctx,
     std::string_view uri,
     ArraySchema schema,
-    std::string soma_type,
+    std::string_view soma_type,
     std::optional<TimestampRange> timestamp) {
     Array::create(std::string(uri), schema);
 
@@ -68,15 +68,13 @@ std::unique_ptr<SOMAArray> SOMAArray::create(
         SOMA_OBJECT_TYPE_KEY,
         TILEDB_STRING_UTF8,
         static_cast<uint32_t>(soma_type.length()),
-        soma_type.c_str());
+        soma_type.data());
 
     array->put_metadata(
         ENCODING_VERSION_KEY,
         TILEDB_STRING_UTF8,
         static_cast<uint32_t>(ENCODING_VERSION_VAL.length()),
         ENCODING_VERSION_VAL.c_str());
-
-    return std::make_unique<SOMAArray>(ctx, array, timestamp);
 }
 
 std::unique_ptr<SOMAArray> SOMAArray::open(

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -115,11 +115,11 @@ class SOMAArray : public SOMAObject {
      * @param soma_type SOMADataFrame, SOMADenseNDArray, or
      * SOMASparseNDArray
      */
-    static std::unique_ptr<SOMAArray> create(
+    static void create(
         std::shared_ptr<SOMAContext> ctx,
         std::string_view uri,
         ArraySchema schema,
-        std::string soma_type,
+        std::string_view soma_type,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1539,7 +1539,7 @@ class SOMAArray : public SOMAObject {
     std::string uri_;
 
     // SOMAArray name for debugging
-    std::string_view name_;
+    std::string name_;
 
     // SOMA context
     std::shared_ptr<SOMAContext> ctx_;

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -42,16 +42,15 @@ using namespace tiledb;
 
 void SOMADataFrame::create(
     std::string_view uri,
-    std::unique_ptr<ArrowSchema> schema,
-    ArrowTable index_columns,
+    const std::unique_ptr<ArrowSchema>& schema,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
+        schema,
+        index_columns,
         "SOMADataFrame",
         true,
         platform_config);

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -62,8 +62,8 @@ class SOMADataFrame : public SOMAArray {
      */
     static void create(
         std::string_view uri,
-        std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns,
+        const std::unique_ptr<ArrowSchema>& schema,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -41,12 +41,11 @@ using namespace tiledb;
 void SOMADenseNDArray::create(
     std::string_view uri,
     std::string_view format,
-    ArrowTable index_columns,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    auto index_column_array = std::move(index_columns.first);
-    auto index_column_schema = std::move(index_columns.second);
+    auto& index_column_schema = index_columns.second;
     uint64_t index_column_size = index_column_schema->n_children;
 
     auto schema = std::make_unique<ArrowSchema>();
@@ -82,9 +81,8 @@ void SOMADenseNDArray::create(
 
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
-        std::move(schema),
-        ArrowTable(
-            std::move(index_column_array), std::move(index_column_schema)),
+        schema,
+        index_columns,
         "SOMADenseNDArray",
         false,
         platform_config);

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -63,7 +63,7 @@ class SOMADenseNDArray : public SOMAArray {
     static void create(
         std::string_view uri,
         std::string_view format,
-        ArrowTable index_columns,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -43,8 +43,8 @@ using namespace tiledb;
 
 void SOMAExperiment::create(
     std::string_view uri,
-    std::unique_ptr<ArrowSchema> schema,
-    ArrowTable index_columns,
+    const std::unique_ptr<ArrowSchema>& schema,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
@@ -55,10 +55,8 @@ void SOMAExperiment::create(
             ctx, experiment_uri.string(), "SOMAExperiment", timestamp);
         SOMADataFrame::create(
             (experiment_uri / "obs").string(),
-            std::move(schema),
-            ArrowTable(
-                std::move(index_columns.first),
-                std::move(index_columns.second)),
+            schema,
+            index_columns,
             ctx,
             platform_config,
             timestamp);

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -56,8 +56,8 @@ class SOMAExperiment : public SOMACollection {
      */
     static void create(
         std::string_view uri,
-        std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns,
+        const std::unique_ptr<ArrowSchema>& schema,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -63,7 +63,8 @@ void SOMAGeometryDataFrame::create(
         true,
         platform_config,
         spatial_columns);
-    auto array = SOMAArray::create(
+
+    SOMAArray::create(
         ctx, uri, tiledb_schema, "SOMAGeometryDataFrame", timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -44,7 +44,7 @@ using namespace tiledb;
 std::unique_ptr<SOMAGroup> SOMAGroup::create(
     std::shared_ptr<SOMAContext> ctx,
     std::string_view uri,
-    std::string soma_type,
+    std::string_view soma_type,
     std::optional<TimestampRange> timestamp) {
     try {
         Group::create(*ctx->tiledb_ctx(), std::string(uri));
@@ -59,7 +59,7 @@ std::unique_ptr<SOMAGroup> SOMAGroup::create(
             SOMA_OBJECT_TYPE_KEY,
             TILEDB_STRING_UTF8,
             static_cast<uint32_t>(soma_type.length()),
-            soma_type.c_str());
+            soma_type.data());
 
         group->put_metadata(
             ENCODING_VERSION_KEY,

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -65,7 +65,7 @@ class SOMAGroup : public SOMAObject {
     static std::unique_ptr<SOMAGroup> create(
         std::shared_ptr<SOMAContext> ctx,
         std::string_view uri,
-        std::string soma_type,
+        std::string_view soma_type,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -43,8 +43,8 @@ using namespace tiledb;
 
 void SOMAMeasurement::create(
     std::string_view uri,
-    std::unique_ptr<ArrowSchema> schema,
-    ArrowTable index_columns,
+    const std::unique_ptr<ArrowSchema>& schema,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
@@ -55,10 +55,8 @@ void SOMAMeasurement::create(
             ctx, measurement_uri.string(), "SOMAMeasurement", timestamp);
         SOMADataFrame::create(
             (measurement_uri / "var").string(),
-            std::move(schema),
-            ArrowTable(
-                std::move(index_columns.first),
-                std::move(index_columns.second)),
+            schema,
+            index_columns,
             ctx,
             platform_config,
             timestamp);

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -57,8 +57,8 @@ class SOMAMeasurement : public SOMACollection {
      */
     static void create(
         std::string_view uri,
-        std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns,
+        const std::unique_ptr<ArrowSchema>& schema,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -41,16 +41,15 @@ using namespace tiledb;
 
 void SOMAPointCloudDataFrame::create(
     std::string_view uri,
-    std::unique_ptr<ArrowSchema> schema,
-    ArrowTable index_columns,
+    const std::unique_ptr<ArrowSchema>& schema,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
-        std::move(schema),
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
+        schema,
+        index_columns,
         "SOMAPointCloudDataFrame",
         true,
         platform_config);

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
@@ -62,8 +62,8 @@ class SOMAPointCloudDataFrame : public SOMAArray {
      */
     static void create(
         std::string_view uri,
-        std::unique_ptr<ArrowSchema> schema,
-        ArrowTable index_columns,
+        const std::unique_ptr<ArrowSchema>& schema,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -42,12 +42,11 @@ using namespace tiledb;
 void SOMASparseNDArray::create(
     std::string_view uri,
     std::string_view format,
-    ArrowTable index_columns,
+    const ArrowTable& index_columns,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    auto index_column_array = std::move(index_columns.first);
-    auto index_column_schema = std::move(index_columns.second);
+    auto& index_column_schema = index_columns.second;
     uint64_t index_column_size = index_column_schema->n_children;
 
     auto schema = std::make_unique<ArrowSchema>();
@@ -83,9 +82,8 @@ void SOMASparseNDArray::create(
 
     auto tiledb_schema = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(),
-        std::move(schema),
-        ArrowTable(
-            std::move(index_column_array), std::move(index_column_schema)),
+        schema,
+        index_columns,
         "SOMASparseNDArray",
         true,
         platform_config);

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -63,7 +63,7 @@ class SOMASparseNDArray : public SOMAArray {
     static void create(
         std::string_view uri,
         std::string_view format,
-        ArrowTable index_columns,
+        const ArrowTable& index_columns,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);


### PR DESCRIPTION
Replace unnecessary `std::move` and `std::string` with const references and `std::string_view` where possible in all the static create functions.