### PR TITLE
[c++] Make destructors of base classes virtual

### DIFF
--- a/libtiledbsoma/src/geometry/base.h
+++ b/libtiledbsoma/src/geometry/base.h
@@ -20,6 +20,8 @@ struct BasePoint {
         , m(m) {
     }
 
+    virtual ~BasePoint() = default;
+
     double_t x;
     double_t y;
     std::optional<double_t> z;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -249,7 +249,7 @@ class SOMAArray : public SOMAObject {
     }
 
     SOMAArray() = delete;
-    ~SOMAArray() = default;
+    virtual ~SOMAArray() = default;
 
     /**
      * @brief Get URI of the SOMAArray.

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -114,7 +114,7 @@ class SOMACollection : public SOMAGroup {
     SOMACollection() = delete;
     SOMACollection(const SOMACollection&) = default;
     SOMACollection(SOMACollection&&) = default;
-    ~SOMACollection() = default;
+    virtual ~SOMACollection() = default;
 
     using iterator =
         typename std::map<std::string, std::shared_ptr<SOMAObject>>::iterator;

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -114,7 +114,7 @@ class SOMAGroup : public SOMAObject {
     SOMAGroup() = delete;
     SOMAGroup(const SOMAGroup&) = default;
     SOMAGroup(SOMAGroup&&) = default;
-    ~SOMAGroup() = default;
+    virtual ~SOMAGroup() = default;
 
     /**
      * Open the SOMAGroup object.


### PR DESCRIPTION
Prevents undefined behavior if we ever attempt to delete a derived class through a pointer to the base class.

