### PR TITLE
[python] Filter spatial disclaimer from pytest

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -32,3 +32,7 @@ no-lines-before = ["tiledb"]
 [tool.ruff.lint.isort.sections]
 "tiledbsoma" = ["tiledbsoma"]
 "tiledb" = ["tiledb"]
+
+
+[tool.pytest.ini_options]
+filterwarnings = ['ignore:Support for spatial types is experimental']


### PR DESCRIPTION
Prevent spatial disclaimer from being printed to the pytest output.
