### PR TITLE
make EAQ inherit somacore, restore EAQ.close

### DIFF
--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -188,7 +188,7 @@ class AxisQueryResult:
         )
 
 
-class ExperimentAxisQuery:
+class ExperimentAxisQuery(query.ExperimentAxisQuery):
     """Axis-based query against a SOMA Experiment.
 
     ExperimentAxisQuery allows easy selection and extraction of data from a
@@ -568,6 +568,8 @@ class ExperimentAxisQuery:
         return sdata
 
     # Context management
+    def close(self) -> None:
+        pass
 
     def __enter__(self) -> Self:
         return self


### PR DESCRIPTION
**Issue and/or context:**
- [#3307](https://github.com/single-cell-data/TileDB-SOMA/pull/3307)/[somacore#244](https://github.com/single-cell-data/SOMA/pull/244) moved ExperimentAxisQuery over from somacore, but mistakenly didn't inherit from the somacore.EAQ ABC.
- It also made `EAQ.close` a no-op (per [this thread](https://github.com/single-cell-data/TileDB-SOMA/pull/3307#pullrequestreview-2443384746)).
- [#3359](https://github.com/single-cell-data/TileDB-SOMA/pull/3359) removed `EAQ.close` altogether, which should have triggered a pre-commit error since EAQ was no longer implementing the somacore ABC.
- This corrects both issues. I also verified that adding the inheritance causes the missing `close` to fail pre-commit.

