### PR TITLE
[python] Link lifetimes of `SOMAArray` and `ManagedQuery`

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -22,7 +22,7 @@ from . import pytiledbsoma as clib
 from ._arrow_types import pyarrow_to_carrow_type
 from ._common_nd_array import NDArray
 from ._exception import SOMAError, map_exception_for_create
-from ._read_iters import TableReadIter
+from ._read_iters import ManagedQuery, TableReadIter
 from ._tdb_handles import DenseNDArrayWrapper
 from ._types import OpenTimestamp, Slice
 from ._util import dense_indices_to_shape
@@ -313,11 +313,11 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 input = np.ascontiguousarray(input)
             order = clib.ResultOrder.rowmajor
 
-        mq = clib.ManagedQuery(clib_handle, clib_handle.context())
-        mq.set_layout(order)
-        _util._set_coords(mq, clib_handle, new_coords)
-        mq.set_soma_data(input)
-        mq.submit_write()
+        mq = ManagedQuery(self, platform_config)
+        mq._handle.set_layout(order)
+        _util._set_coords(mq, new_coords)
+        mq._handle.set_soma_data(input)
+        mq._handle.submit_write()
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)
         if tiledb_write_options.consolidate_and_vacuum:

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -489,9 +489,7 @@ class ManagedQuery:
         else:
             ctx = clib_handle.context()
 
-        object.__setattr__(
-            self, "_handle", clib.ManagedQuery(clib_handle, ctx)
-        )
+        object.__setattr__(self, "_handle", clib.ManagedQuery(clib_handle, ctx))
 
 
 class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -490,7 +490,7 @@ class ManagedQuery:
             ctx = clib_handle.context()
 
         object.__setattr__(
-            self, "_handle", clib.ManagedQuery(self._array._handle._handle, ctx)
+            self, "_handle", clib.ManagedQuery(clib_handle, ctx)
         )
 
 

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -23,6 +23,7 @@ from typing import (
     cast,
 )
 
+import attrs
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
@@ -470,6 +471,29 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
             yield sp, indices
 
 
+@attrs.define(frozen=True)
+class ManagedQuery:
+    """Keep the lifetime of the SOMAArray tethered to ManagedQuery."""
+
+    _array: SOMAArray
+    _platform_config: options.PlatformConfig | None
+    _handle: clib.ManagedQuery = attrs.field(init=False)
+
+    def __attrs_post_init__(self) -> None:
+        clib_handle = self._array._handle._handle
+
+        if self._platform_config is not None:
+            cfg = clib_handle.context().config()
+            cfg.update(self._platform_config)
+            ctx = clib.SOMAContext(cfg)
+        else:
+            ctx = clib_handle.context()
+
+        object.__setattr__(
+            self, "_handle", clib.ManagedQuery(self._array._handle._handle, ctx)
+        )
+
+
 class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
     """Private implementation class"""
 
@@ -487,27 +511,18 @@ class SparseTensorReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         self.result_order = result_order
         self.platform_config = platform_config
 
-        clib_handle = array._handle._handle
+        self.mq = ManagedQuery(array, platform_config)
 
-        if platform_config is not None:
-            cfg = clib_handle.context().config()
-            cfg.update(platform_config)
-            ctx = clib.SOMAContext(cfg)
-        else:
-            ctx = clib_handle.context()
+        self.mq._handle.set_layout(result_order)
 
-        self.mq = clib.ManagedQuery(clib_handle, ctx)
-
-        self.mq.set_layout(result_order)
-
-        _util._set_coords(self.mq, clib_handle, coords)
+        _util._set_coords(self.mq, coords)
 
     @abc.abstractmethod
     def _from_table(self, arrow_table: pa.Table) -> _RT:
         raise NotImplementedError()
 
     def __next__(self) -> _RT:
-        return self._from_table(self.mq.next())
+        return self._from_table(self.mq._handle.next())
 
     def concat(self) -> _RT:
         """Returns all the requested data in a single operation.
@@ -556,27 +571,22 @@ class ArrowTableRead(Iterator[pa.Table]):
     ):
         clib_handle = array._handle._handle
 
-        if platform_config is not None:
-            cfg = clib_handle.context().config()
-            cfg.update(platform_config)
-            ctx = clib.SOMAContext(cfg)
-        else:
-            ctx = clib_handle.context()
+        self.mq = ManagedQuery(array, platform_config)
 
-        self.mq = clib.ManagedQuery(clib_handle, ctx)
-
-        self.mq.set_layout(result_order)
+        self.mq._handle.set_layout(result_order)
 
         if column_names is not None:
-            self.mq.select_columns(list(column_names))
+            self.mq._handle.select_columns(list(column_names))
 
         if value_filter is not None:
-            self.mq.set_condition(QueryCondition(value_filter), clib_handle.schema)
+            self.mq._handle.set_condition(
+                QueryCondition(value_filter), clib_handle.schema
+            )
 
-        _util._set_coords(self.mq, clib_handle, coords)
+        _util._set_coords(self.mq, coords)
 
     def __next__(self) -> pa.Table:
-        return self.mq.next()
+        return self.mq._handle.next()
 
 
 def _coords_strider(


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61128](https://app.shortcut.com/tiledb-inc/story/61128/python-1-15-regression-on-table-iterator)]

**Changes:**

- Introduce a high-level `ManagedQuery` class, analogous to the other `SOMAObject` classes, serving as a thin wrapper around the `clib.ManagedQuery` pybind11 object. This class links together the lifetime of `clib.ManagedQuery` to the high-level `SOMAArray` object (not `clib.SOMAArray`)
- Clean up the array setters in `_util.py` to use the `_array` stored in `ManagedQuery`, eliminating the need to pass the array in as a separate argument
- Add a test to confirm the resolution of the previously reported bug and to ensure separate `SOMArray` instances at the same URI iterate using distinct `ManagedQuery` instances

**Notes for Reviewer:**

Another solution for the reported bug is to pass a `shared_ptr<SOMAArray>` instead of `unique_ptr` into the `clib.ManagedQuery` constructor. This is similar to what we already do for `clib.SOMAContext`. We attempted this solution, but it was unfeasible to a bug in the Pybind11 library. A pull request addressing this issue is currently under review: https://github.com/pybind/pybind11/pull/2839. Given the current circumstances, the most effective solution is to implement this high-level thin wrapper class.