### PR TITLE
[c++] Update minimum macOS deployment target

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -112,7 +112,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX : CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
-          MACOSX_DEPLOYMENT_TARGET: "11.0"
+          MACOSX_DEPLOYMENT_TARGET: "13.3"
       - name: Upload wheel-${{ matrix.wheel-name }}-${{ matrix.python-version }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           xcode-version: '15.4'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.22.0
         with:
           package-dir: tiledbsoma.tar.gz
           only: cp${{ matrix.python-version }}-${{ matrix.cibw_build }}
@@ -113,6 +113,7 @@ jobs:
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
           MACOSX_DEPLOYMENT_TARGET: "13.3"
+
       - name: Upload wheel-${{ matrix.wheel-name }}-${{ matrix.python-version }} to GitHub Actions storage
         uses: actions/upload-artifact@v4
         with:

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -1,6 +1,6 @@
 CXX_STD = CXX20
 
-## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 10.14 for macOS
+## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 13.3 for macOS
 PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx20_macos@ -D SPDLOG_USE_STD_FORMAT
 
 ## We also need the TileDB library

--- a/apis/r/src/Makevars.in
+++ b/apis/r/src/Makevars.in
@@ -1,7 +1,7 @@
 CXX_STD = CXX20
 
 ## We need the TileDB Headers, and for macOS aka Darwin need to set minimum version 13.3 for macOS
-PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx20_macos@ -D SPDLOG_USE_STD_FORMAT
+PKG_CPPFLAGS = -I. -I../inst/include/ @tiledb_include@ @cxx20_macos@ -DSPDLOG_USE_STD_FORMAT
 
 ## We also need the TileDB library
 PKG_LIBS = @cxx20_macos@ @tiledb_libs@ @tiledb_rpath@

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -114,7 +114,7 @@ if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
 
   # Set minimum macOS version to enable certain C++20 features
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 13.3)
+  # set(CMAKE_OSX_DEPLOYMENT_TARGET 13.3)
 
   # Don't allow macOS .frameworks to be used for dependencies.
   set(CMAKE_FIND_FRAMEWORK NEVER)

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -113,6 +113,9 @@ endif()
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
 
+  # Set minimum macOS version to enable certain C++20 features
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 13.3)
+
   # Don't allow macOS .frameworks to be used for dependencies.
   set(CMAKE_FIND_FRAMEWORK NEVER)
 endif()

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -127,13 +127,6 @@ target_include_directories(TILEDB_SOMA_GEOMETRY_OBJECTS
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/vendor
-  ${CMAKE_CURRENT_SOURCE_DIR}/soma
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/khash
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/include/nanoarrow
-  $<TARGET_PROPERTY:TileDB::tiledb_shared,INTERFACE_INCLUDE_DIRECTORIES>
-  $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
-  ${pybind11_INCLUDE_DIRS}
 )
 
 # ###########################################################

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -34,10 +34,10 @@
 #define TILEDBSOMA_REINDEXER_H
 
 #include <assert.h>
+#include <format>
 #include <memory>
 #include <stdexcept>
 #include <vector>
-#include <format>
 
 struct kh_m64_s;
 

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <stdexcept>
 #include <vector>
+#include <format>
 
 struct kh_m64_s;
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -34,8 +34,6 @@
 #include "../utils/logger.h"
 #include "../utils/util.h"
 
-#include <format>
-
 namespace tiledbsoma {
 using namespace tiledb;
 


### PR DESCRIPTION
For the C++20 migration to work we need to increase the minimum macOS deployment target to 13.3 to have support for floating-point formatter. 

#3154

[[sc-57301]](https://app.shortcut.com/tiledb-inc/story/57301/use-c-20)