### PR TITLE
[c++] Show which coordinate is out of range in `fastercsx` error messages

### DIFF
--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <format>
 #include <numeric>
 #include <span>
 

--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -198,8 +198,13 @@ void count_rows_(
                         auto row = Ai_view[n];
                         if ((row < 0) ||
                             (static_cast<std::make_unsigned_t<COO_IDX>>(row) >=
-                             n_row)) [[unlikely]]
-                            throw std::out_of_range("Coordinate out of range.");
+                             n_row)) [[unlikely]] {
+                            throw std::out_of_range(std::format(
+                                "Coordinate {} out of range {}.",
+                                row,
+                                0,
+                                n_row));
+                        }
                         counts[row]++;
                     }
                 }
@@ -221,8 +226,10 @@ void count_rows_(
                 auto row = Ai_view[n];
                 if ((row < 0) ||
                     (static_cast<std::make_unsigned_t<COO_IDX>>(row) >= n_row))
-                    [[unlikely]]
-                    throw std::out_of_range("Coordinate out of range.");
+                    [[unlikely]] {
+                    throw std::out_of_range(std::format(
+                        "Coordinate {} out of range {}.", row, 0, n_row));
+                }
                 Bp[row]++;
             }
         }
@@ -268,9 +275,10 @@ void compress_coo_inner_left_(
         const auto dest = Bp[row];
         if ((Aj_[n] < 0) ||
             (static_cast<std::make_unsigned_t<COO_IDX>>(Aj_[n]) >= n_col))
-            [[unlikely]]
-            throw std::out_of_range("Coordinate out of range.");
-
+            [[unlikely]] {
+            throw std::out_of_range(std::format(
+                "Coordinate {} out of range {}.", Aj_[n], 0, n_col));
+        }
         Bj[dest] = Aj_[n];
         Bd[dest] = Ad_[n];
         Bp[row]++;
@@ -302,8 +310,10 @@ void compress_coo_inner_right_(
         const auto dest = Bp[row];
         if ((Aj_[n] < 0) ||
             (static_cast<std::make_unsigned_t<COO_IDX>>(Aj_[n]) >= n_col))
-            [[unlikely]]
-            throw std::out_of_range("Coordinate out of range.");
+            [[unlikely]] {
+            throw std::out_of_range(std::format(
+                "Coordinate {} out of range {}.", Aj_[n], 0, n_col));
+        }
 
         Bj[dest] = Aj_[n];
         Bd[dest] = Ad_[n];

--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -200,7 +200,7 @@ void count_rows_(
                             (static_cast<std::make_unsigned_t<COO_IDX>>(row) >=
                              n_row)) [[unlikely]] {
                             throw std::out_of_range(std::format(
-                                "Coordinate {} out of range {}.",
+                                "First coordinate {} out of range {}.",
                                 row,
                                 0,
                                 n_row));
@@ -228,7 +228,7 @@ void count_rows_(
                     (static_cast<std::make_unsigned_t<COO_IDX>>(row) >= n_row))
                     [[unlikely]] {
                     throw std::out_of_range(std::format(
-                        "Coordinate {} out of range {}.", row, 0, n_row));
+                        "First coordinate {} out of range {}.", row, 0, n_row));
                 }
                 Bp[row]++;
             }
@@ -277,7 +277,7 @@ void compress_coo_inner_left_(
             (static_cast<std::make_unsigned_t<COO_IDX>>(Aj_[n]) >= n_col))
             [[unlikely]] {
             throw std::out_of_range(std::format(
-                "Coordinate {} out of range {}.", Aj_[n], 0, n_col));
+                "Second coordinate {} out of range {}.", Aj_[n], 0, n_col));
         }
         Bj[dest] = Aj_[n];
         Bd[dest] = Ad_[n];
@@ -312,7 +312,7 @@ void compress_coo_inner_right_(
             (static_cast<std::make_unsigned_t<COO_IDX>>(Aj_[n]) >= n_col))
             [[unlikely]] {
             throw std::out_of_range(std::format(
-                "Coordinate {} out of range {}.", Aj_[n], 0, n_col));
+                "Second coordinate {} out of range {}.", Aj_[n], 0, n_col));
         }
 
         Bj[dest] = Aj_[n];


### PR DESCRIPTION
[[sc-61341]](https://app.shortcut.com/tiledb-inc/story/61341/indexerror-coordinate-out-of-range)
[[sc-61579]](https://app.shortcut.com/tiledb-inc/story/61579/print-actual-coordinate-values-for-out-of-bounds-errors)