### PR TITLE
[python] Implement `read`, `seek`, and `tell` for `SOMAVFSFilebuf`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -37,13 +37,59 @@ namespace libtiledbsomacpp {
 namespace py = pybind11;
 using namespace py::literals;
 using namespace tiledbsoma;
-using VFSFilebuf = tiledb::impl::VFSFilebuf;
 
 // TODO This temporary workaround prevents namespace clash with tiledb-py.
 // Bind tiledb::VFS directly once tiledb-py dependency is removed
 class SOMAVFS : public tiledb::VFS {
    public:
     using tiledb::VFS::VFS;
+    SOMAVFS(const tiledb::VFS& vfs)
+        : tiledb::VFS(vfs) {
+    }
+};
+
+class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
+   private:
+    std::streamsize offset_ = 0;
+    SOMAVFS vfs_;
+
+   public:
+    SOMAVFSFilebuf(const VFS& vfs)
+        : tiledb::impl::VFSFilebuf(vfs)
+        , vfs_(vfs){};
+
+    std::streamsize seek(std::streamsize offset, uint64_t whence) {
+        if (whence == 0) {
+            seekoff(offset, std::ios::beg, std::ios::in);
+            offset_ = seekoff(offset, std::ios::beg, std::ios::in);
+        } else if (whence == 1) {
+            seekoff(offset, std::ios::cur, std::ios::in);
+            offset_ += offset;
+        } else if (whence == 2) {
+            seekoff(offset, std::ios::end, std::ios::in);
+            offset_ = vfs_.file_size(get_uri()) - offset;
+        } else {
+            TPY_ERROR_LOC(
+                "whence must be equal to SEEK_SET, SEEK_CUR, SEEK_END");
+        }
+
+        return offset_;
+    }
+
+    py::bytes read(std::streamsize size) {
+        int64_t nbytes = (size < 0 || size > showmanyc()) ? showmanyc() : size;
+        if (nbytes <= 0) {
+            return py::bytes("");
+        }
+
+        std::string buffer(nbytes, '\0');
+        offset_ += xsgetn(&buffer[0], nbytes);
+        return py::bytes(buffer);
+    }
+
+    std::streamsize tell() {
+        return offset_;
+    }
 };
 
 void load_soma_vfs(py::module& m) {
@@ -54,13 +100,16 @@ void load_soma_vfs(py::module& m) {
             }),
             "ctx"_a);
 
-    py::class_<VFSFilebuf>(m, "SOMAVFSFilebuf")
+    py::class_<SOMAVFSFilebuf>(m, "SOMAVFSFilebuf")
         .def(py::init<const SOMAVFS&>())
         .def(
             "open",
-            [](VFSFilebuf& buf, const std::string& uri) {
+            [](SOMAVFSFilebuf& buf, const std::string& uri) {
                 return buf.open(uri, std::ios::in);
             })
-        .def("close", &VFSFilebuf::close, "should_throw"_a = true);
+        .def("read", &SOMAVFSFilebuf::read, "size"_a = -1)
+        .def("tell", &SOMAVFSFilebuf::tell)
+        .def("seek", &SOMAVFSFilebuf::seek, "offset"_a, "whence"_a = 0)
+        .def("close", &SOMAVFSFilebuf::close, "should_throw"_a = true);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -60,14 +60,12 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
 
     std::streamsize seek(std::streamsize offset, uint64_t whence) {
         if (whence == 0) {
-            seekoff(offset, std::ios::beg, std::ios::in);
             offset_ = seekoff(offset, std::ios::beg, std::ios::in);
         } else if (whence == 1) {
-            seekoff(offset, std::ios::cur, std::ios::in);
-            offset_ += offset;
+            offset_ += seekoff(offset, std::ios::cur, std::ios::in);
         } else if (whence == 2) {
-            seekoff(offset, std::ios::end, std::ios::in);
-            offset_ = vfs_.file_size(get_uri()) - offset;
+            offset_ = vfs_.file_size(get_uri()) -
+                      seekoff(offset, std::ios::end, std::ios::in);
         } else {
             TPY_ERROR_LOC(
                 "whence must be equal to SEEK_SET, SEEK_CUR, SEEK_END");


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61381]](https://app.shortcut.com/tiledb-inc/story/61381/python-from-h5ad-fails-with-filenotfounderror-when-using-s3-uris-regression-in-1-15)

Although `h5py` does [support](https://github.com/h5py/h5py/blob/master/h5py/_hl/files.py#L503-L507) ingesting S3 files directly, as already [noted](https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/python/src/tiledbsoma/io/_util.py#L63-L65) in our documentation, `anndata` uses the [default driver](https://github.com/h5py/h5py/blob/master/h5py/_hl/files.py#L499) which means it expects local files with `os.PathLike URIs`. This is what motivates us to [implement](https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/python/src/tiledbsoma/io/_util.py#L66) the `_FSPathWrapper` so that `anndata` can pass the file to `h5ad` and parse it as a file-like object. However, in order to actually be a file-like object, we need to implement the read and seek [methods](https://github.com/h5py/h5py/blob/master/h5py/_hl/files.py#L526-L534). Otherwise, when `make_fid` attempts to [open the file](https://github.com/h5py/h5py/blob/master/h5py/_hl/files.py#L235), it errors out with `FileNotFoundError` because the object does not exist as a file-like object even though an object does exist at the given URI.

This regression was introduced during the C++-ification work when `tiledb.VFS()` (which fully implements all file I/O methods required by `h5py`) and replaced with `clib.SOMAVFS` and `clib.SOMAVFSFilebuf`.

**Changes:**

Implement `read`, `seek`, and `tell` for `SOMAVFSFilebuf`.

**Notes for Reviewer:**

Proof that the original bug is fixed for 1.15:
```
(py311) vivian@mangonada:~/TileDB-SOMA$ cat ~/tiledb-bugs/s3-fails.py
#!/usr/bin/env python3

import tempfile
from pathlib import Path
import pathlib

import tiledbsoma as soma
import tiledbsoma.pytiledbsoma as clib
import anndata as ad
import tiledbsoma.io
import tiledb

from anndata._core import file_backing
from unittest import mock

tiledbsoma.show_package_versions()

vfs = tiledb.VFS()
S3_BUCKET = "s3://tiledb-johnkerl/s/a/stack-small/"

# # List the files in the S3 bucket, verifying env has access to the bucket
h5ad_files = vfs.ls(S3_BUCKET)
print(f"Discovered {len(h5ad_files)} files in {S3_BUCKET}")

# # Ingest the first file
h5ad_file = h5ad_files[0]
print(f"Ingesting {h5ad_file}")

print("...starting ingestion")
experiment_uri: str = tiledbsoma.io.from_h5ad(
    input_path=h5ad_file,
    experiment_uri=tempfile.mkdtemp(prefix=f"soma-{Path(h5ad_file).stem}-"),
    measurement_name="RNA",
)

print(f"Experiment URI: {experiment_uri}")
with tiledbsoma.Experiment.open(experiment_uri) as exp:
    print("...obs data:")
    print(exp.obs.read().concat().to_pandas())
```
```
(py311) vivian@mangonada:~/TileDB-SOMA$ python ~/tiledb-bugs/s3-fails~/tiledb-bugs/s3-fails.py
tiledbsoma.__version__              1.15.0rc0.post225.dev28053676759
TileDB core version (libtiledbsoma) 2.27.0
python version                      3.11.11.final.0
OS version                          Linux 5.15.167.4-microsoft-standard-WSL2
Discovered 4 files in s3://tiledb-johnkerl/s/a/stack-small/
Ingesting s3://tiledb-johnkerl/s/a/stack-small/stack1.h5ad
...starting ingestion
Experiment URI: /tmp/soma-stack1-r3wgnyn4
...obs data:
   soma_joinid obs_id cell_type  is_primary_data
0            0   AAAT    B cell             True
1            1   ACTG    T cell             True
2            2   AGAG    B cell             True
```

No new tests were added because this only affects files on S3. However, this bug is further motivation to introduce testing with cloud storage.