### PR TITLE
[C++] Fix `ManagedQuery` segv: ctor/dtor order fix

### DIFF
--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import gc
 import itertools
 import json
 import operator
@@ -1979,3 +1980,27 @@ def test_iter(tmp_path: pathlib.Path):
         next(a)
     with pytest.raises(StopIteration):
         next(b)
+
+
+def test_context_cleanup(tmp_path: pathlib.Path) -> None:
+    arrow_tensor = create_random_tensor("table", (1,), np.float32(), density=1)
+    with soma.SparseNDArray.create(
+        tmp_path.as_uri(), type=pa.float64(), shape=(1,)
+    ) as write_arr:
+        write_arr.write(arrow_tensor)
+
+    def test(path, tiledb_config):
+        context = soma.SOMATileDBContext().replace(tiledb_config=tiledb_config)
+        X = soma.SparseNDArray.open(path, context=context, mode="r")
+        mq = X.read().tables()
+        return mq
+
+    for _ in range(100):
+        _ = test(
+            tmp_path.as_uri(),
+            {
+                "vfs.s3.no_sign_request": "true",
+                "vfs.s3.region": "us-west-2",
+            },
+        )
+        gc.collect()

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1996,6 +1996,9 @@ def test_context_cleanup(tmp_path: pathlib.Path) -> None:
         return mq
 
     for _ in range(100):
+        # Run test multiple times. While the C++ this tests (dtor order)
+        # is deterministic, it is triggered by the Python GC, which makes
+        # no specific guarantees about when it will sweep any given object.
         _ = test(
             tmp_path.as_uri(),
             {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -51,8 +51,8 @@ ManagedQuery::ManagedQuery(
     std::shared_ptr<Array> array,
     std::shared_ptr<Context> ctx,
     std::string_view name)
-    : array_(array)
-    , ctx_(ctx)
+    : ctx_(ctx)
+    , array_(array)
     , name_(name)
     , schema_(std::make_shared<ArraySchema>(array->schema())) {
     reset();
@@ -62,8 +62,8 @@ ManagedQuery::ManagedQuery(
     std::unique_ptr<SOMAArray> array,
     std::shared_ptr<Context> ctx,
     std::string_view name)
-    : array_(array->arr_)
-    , ctx_(ctx)
+    : ctx_(ctx)
+    , array_(array->arr_)
     , name_(name)
     , schema_(std::make_shared<ArraySchema>(array->arr_->schema())) {
     reset();

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -499,7 +499,11 @@ class ManagedQuery {
         const CurrentDomain& current_domain, bool is_read);
     void _fill_in_subarrays_if_dense_without_new_shape(bool is_read);
 
-    // TileDB context object
+    // NB: the Array dtor REQUIRES that this context be alive, so member
+    // declaration order is significant.  Context (ctx_) MUST be declared
+    // BEFORE Array (array_) so that ctx_ will be destructed last.
+
+    // TileDB context object. 
     std::shared_ptr<Context> ctx_;
 
     // TileDB array being queried.

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -503,7 +503,7 @@ class ManagedQuery {
     // declaration order is significant.  Context (ctx_) MUST be declared
     // BEFORE Array (array_) so that ctx_ will be destructed last.
 
-    // TileDB context object. 
+    // TileDB context object
     std::shared_ptr<Context> ctx_;
 
     // TileDB array being queried.

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -34,6 +34,7 @@
 #define MANAGED_QUERY_H
 
 #include <future>
+#include <iostream>
 #include <span>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <unordered_set>
@@ -98,8 +99,8 @@ class ManagedQuery {
     ManagedQuery(const ManagedQuery&) = delete;
 
     ManagedQuery(ManagedQuery&& other)
-        : array_(other.array_)
-        , ctx_(other.ctx_)
+        : ctx_(other.ctx_)
+        , array_(other.array_)
         , name_(other.name_)
         , schema_(other.schema_)
         , query_(std::make_unique<Query>(*other.ctx_, *other.array_))
@@ -499,11 +500,11 @@ class ManagedQuery {
         const CurrentDomain& current_domain, bool is_read);
     void _fill_in_subarrays_if_dense_without_new_shape(bool is_read);
 
-    // TileDB array being queried.
-    std::shared_ptr<Array> array_;
-
     // TileDB context object
     std::shared_ptr<Context> ctx_;
+
+    // TileDB array being queried.
+    std::shared_ptr<Array> array_;
 
     // Name displayed in log messages
     std::string name_;

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -34,7 +34,6 @@
 #define MANAGED_QUERY_H
 
 #include <future>
-#include <iostream>
 #include <span>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <unordered_set>

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1544,6 +1544,10 @@ class SOMAArray : public SOMAObject {
     // SOMAArray name for debugging
     std::string name_;
 
+    // NB: the Array dtor REQUIRES that this context be alive, so member
+    // declaration order is significant.  Context (ctx_) MUST be declared
+    // BEFORE Array (arr_) so that ctx_ will be destructed last.
+
     // SOMA context
     std::shared_ptr<SOMAContext> ctx_;
 


### PR DESCRIPTION
**Issue and/or context:**

But reported via chanzuckerberg/cellxgene-census#1327 - root cause was incorrect destructor ordering in the new ManagedQuery class.

The tiledb::Array class _requires_ a tiledb::Context to destruct, but only holds a `std::reference_wrapper<Context>`.  It is holder's responsibility to ensure that the Array's context is alive when the array is destructed.

ManagedQuery just had the context and array shared pointers in the wrong order, causing the context to destruct first in some cases.

[sc-61614]

**Changes:**

Change declaration order of members, thereby correctly ordering the dtor calls.
