### PR TITLE
[python] Release GIL in VFS bindings

### DIFF
--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -104,10 +104,23 @@ void load_soma_vfs(py::module& m) {
             "open",
             [](SOMAVFSFilebuf& buf, const std::string& uri) {
                 return buf.open(uri, std::ios::in);
-            })
-        .def("read", &SOMAVFSFilebuf::read, "size"_a = -1)
-        .def("tell", &SOMAVFSFilebuf::tell)
-        .def("seek", &SOMAVFSFilebuf::seek, "offset"_a, "whence"_a = 0)
+            },
+            py::call_guard<py::gil_scoped_release>())
+        .def(
+            "read",
+            &SOMAVFSFilebuf::read,
+            "size"_a = -1,
+            py::call_guard<py::gil_scoped_release>())
+        .def(
+            "tell",
+            &SOMAVFSFilebuf::tell,
+            py::call_guard<py::gil_scoped_release>())
+        .def(
+            "seek",
+            &SOMAVFSFilebuf::seek,
+            "offset"_a,
+            "whence"_a = 0,
+            py::call_guard<py::gil_scoped_release>())
         .def("close", &SOMAVFSFilebuf::close, "should_throw"_a = true);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -113,8 +113,7 @@ void load_soma_vfs(py::module& m) {
             py::call_guard<py::gil_scoped_release>())
         .def(
             "tell",
-            &SOMAVFSFilebuf::tell,
-            py::call_guard<py::gil_scoped_release>())
+            &SOMAVFSFilebuf::tell)
         .def(
             "seek",
             &SOMAVFSFilebuf::seek,

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -80,8 +80,11 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
             return py::bytes("");
         }
 
+        py::gil_scoped_release release;
         std::string buffer(nbytes, '\0');
         offset_ += xsgetn(&buffer[0], nbytes);
+        py::gil_scoped_acquire acquire;
+
         return py::bytes(buffer);
     }
 
@@ -109,8 +112,7 @@ void load_soma_vfs(py::module& m) {
         .def(
             "read",
             &SOMAVFSFilebuf::read,
-            "size"_a = -1,
-            py::call_guard<py::gil_scoped_release>())
+            "size"_a = -1)
         .def(
             "tell",
             &SOMAVFSFilebuf::tell)

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -109,13 +109,8 @@ void load_soma_vfs(py::module& m) {
                 return buf.open(uri, std::ios::in);
             },
             py::call_guard<py::gil_scoped_release>())
-        .def(
-            "read",
-            &SOMAVFSFilebuf::read,
-            "size"_a = -1)
-        .def(
-            "tell",
-            &SOMAVFSFilebuf::tell)
+        .def("read", &SOMAVFSFilebuf::read, "size"_a = -1)
+        .def("tell", &SOMAVFSFilebuf::tell)
         .def(
             "seek",
             &SOMAVFSFilebuf::seek,


### PR DESCRIPTION
**Issue and/or context:**

Follow up to https://github.com/single-cell-data/TileDB-SOMA/pull/3543

**Changes:**

Release GIL for long-lived I/O methods `open`, `read`, and `seek`.