### PR TITLE
[python] Remove `AxisName.getattr_from` from `ExperimentAxisQuery`

### DIFF
--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -389,7 +389,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
             )
 
         full_table = obs_scene.read(
-            coords=((AxisName.OBS.getattr_from(self._joinids), slice(None))),
+            coords=(self._joinids.obs, slice(None)),
             result_order=ResultOrder.COLUMN_MAJOR,
             value_filter="data != 0",
         ).concat()
@@ -416,7 +416,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
             )
 
         full_table = var_scene.read(
-            coords=((AxisName.VAR.getattr_from(self._joinids), slice(None))),
+            coords=(self._joinids.var, slice(None)),
             result_order=ResultOrder.COLUMN_MAJOR,
             value_filter="data != 0",
         ).concat()

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -867,11 +867,11 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
     def _convert_to_ndarray(
         self, axis: AxisName, table: pa.Table, n_row: int, n_col: int
     ) -> npt.NDArray[np.float32]:
-        indexer = cast(
-            Callable[[Numpyable], npt.NDArray[np.intp]],
-            axis.getattr_from(self.indexer, pre="by_"),
+        idx = (
+            self.indexer.by_obs(table["soma_dim_0"])
+            if axis.value == "obs"
+            else self.indexer.by_var(table["soma_dim_0"])
         )
-        idx = indexer(table["soma_dim_0"])
         z: npt.NDArray[np.float32] = np.zeros(n_row * n_col, dtype=np.float32)
         np.put(z, idx * n_col + table["soma_dim_1"], table["soma_data"])
         return z.reshape(n_row, n_col)

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -783,9 +783,14 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
         """Reads the specified axis. Will cache join IDs if not present."""
         column_names = axis_column_names.get(axis.value)
 
-        axis_df = axis.getattr_from(self, pre="_", suf="_df")
+        if axis.value == "obs":
+            axis_df = self._obs_df
+            axis_query = self._matrix_axis_query.obs
+        else:
+            axis_df = self._var_df
+            axis_query = self._matrix_axis_query.var
+
         assert isinstance(axis_df, DataFrame)
-        axis_query = axis.getattr_from(self._matrix_axis_query)
 
         # If we can cache join IDs, prepare to add them to the cache.
         joinids_cached = self._joinids._is_cached(axis)

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -22,7 +22,6 @@ from tiledbsoma import (
 )
 from tiledbsoma._collection import CollectionBase
 from tiledbsoma._experiment import Experiment
-from tiledbsoma._query import AxisName
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard
@@ -965,16 +964,3 @@ class IHaveObsVarStuff:
     var: int
     the_obs_suf: str
     the_var_suf: str
-
-
-def test_axis_helpers() -> None:
-    thing = IHaveObsVarStuff(obs=1, var=2, the_obs_suf="observe", the_var_suf="vary")
-    assert 1 == AxisName.OBS.getattr_from(thing)
-    assert 2 == AxisName.VAR.getattr_from(thing)
-    assert "observe" == AxisName.OBS.getattr_from(thing, pre="the_", suf="_suf")
-    assert "vary" == AxisName.VAR.getattr_from(thing, pre="the_", suf="_suf")
-    ovdict = {"obs": "erve", "var": "y", "i_obscure": "hide", "i_varcure": "???"}
-    assert "erve" == AxisName.OBS.getitem_from(ovdict)
-    assert "y" == AxisName.VAR.getitem_from(ovdict)
-    assert "hide" == AxisName.OBS.getitem_from(ovdict, pre="i_", suf="cure")
-    assert "???" == AxisName.VAR.getitem_from(ovdict, pre="i_", suf="cure")


### PR DESCRIPTION
The `ExperimentAxisQuery` used the `AxisName` enumeration to access attributes with either `obs` or `var` in the name. This PR directly calls the appropriate functions, primarily by pushing up the calls to one function higher (e.g. pass in `self.indexer.by_obs`/`self.indexer.by_var` instead of `AxisName.OBS`/`AxisName.VAR`).

This change allowed `ExperimentAxisQuery._convert_to_ndarray` and `ExperimentAxisQuery._axism_inner_ndarray` to be merged into a single non-member function, and `ExperimentAxisQuery._axisp_inner_sparray` to be replaced with a direct call to `_read_as_csr`.
