### PR TITLE
[python] Add Unicode metadata support 

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -20,7 +20,6 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
-    MutableSequence,
     Sequence,
     Tuple,
     Type,
@@ -811,7 +810,7 @@ class MetadataWrapper(MutableMapping[str, Any]):
             return
         # Only try to get the writer if there are changes to be made.
 
-        errors: MutableSequence[Exception] = []
+        errors: list[Exception] = []
         for key, mod in self._mods.items():
             try:
                 if mod in (_DictMod.ADDED, _DictMod.UPDATED):

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -20,6 +20,7 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    MutableSequence,
     Sequence,
     Tuple,
     Type,
@@ -809,20 +810,33 @@ class MetadataWrapper(MutableMapping[str, Any]):
             # There were no changes (e.g., it's a read handle).  Do nothing.
             return
         # Only try to get the writer if there are changes to be made.
+
+        errors: MutableSequence[Exception] = []
         for key, mod in self._mods.items():
-            if mod in (_DictMod.ADDED, _DictMod.UPDATED):
-                set_metadata = self.owner._handle.set_metadata
-                val = self.cache[key]
-                if isinstance(val, str):
-                    set_metadata(key, np.array([val], "S"))
-                else:
-                    set_metadata(key, np.array([val]))
-            if mod is _DictMod.DELETED:
-                self.owner._handle.delete_metadata(key)
+            try:
+                if mod in (_DictMod.ADDED, _DictMod.UPDATED):
+                    set_metadata = self.owner._handle.set_metadata
+                    val = self.cache[key]
+                    if isinstance(val, str):
+                        if val.isascii():
+                            set_metadata(key, np.array([val], "S"))
+                        else:
+                            set_metadata(key, np.array([val], "U"))
+                    else:
+                        set_metadata(key, np.array([val]))
+                if mod is _DictMod.DELETED:
+                    self.owner._handle.delete_metadata(key)
+            except Exception as e:
+                errors.append(e)
 
         # Temporary hack: When we flush writes, note that the cache
         # is back in sync with disk.
         self._mods.clear()
+
+        if errors:
+            raise SOMAError(
+                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk."
+            )
 
     def __repr__(self) -> str:
         prefix = f"{type(self).__name__}({self.owner})"

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -818,10 +818,9 @@ class MetadataWrapper(MutableMapping[str, Any]):
                     set_metadata = self.owner._handle.set_metadata
                     val = self.cache[key]
                     if isinstance(val, str):
-                        if val.isascii():
-                            set_metadata(key, np.array([val], "S"))
-                        else:
-                            set_metadata(key, np.array([val], "U"))
+                        set_metadata(key, np.array([val.encode("UTF-8")], "S"))
+                    elif isinstance(val, bytes):
+                        set_metadata(key, np.array([val], "V"))
                     else:
                         set_metadata(key, np.array([val]))
                 if mod is _DictMod.DELETED:

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -140,10 +140,9 @@ tiledb_datatype_t np_to_tdb_dtype(py::dtype type) {
 
     auto kind = py::str(py::getattr(type, "kind"));
 
-    if (kind.is(py::str("V")))
-        return TILEDB_BLOB;
     if (kind.is(py::str("S")))
         return TILEDB_STRING_UTF8;
+    // Numpy encodes strings as UTF-32
     if (kind.is(py::str("U")))
         TPY_ERROR_LOC(
             "[np_to_tdb_dtype] UTF-32 encoded strings are not supported");

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -251,9 +251,7 @@ void set_metadata(
     if (value_buffer.ndim != 1)
         throw py::type_error("Only 1D Numpy arrays can be stored as metadata");
 
-    auto value_num = (is_tdb_str(value_type) || value_type == TILEDB_BLOB) ?
-                         value.nbytes() :
-                         value.size();
+    auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
 
     if (is_tdb_str(value_type) && value_num > 0) {
         // If an empty string is passed by default results in a NULL byte

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -17,6 +17,22 @@ namespace py = pybind11;
 
 namespace tiledbsoma {
 
+template <typename T>
+size_t sanitize_string(std::span<const T> string_raw, size_t num_elements) {
+    if (num_elements == 1 && string_raw[0] == 0) {
+        return 0;
+    }
+
+    for (const T& element : string_raw) {
+        if (element == 0) {
+            throw TileDBSOMAError(
+                "[sanitize_string] String contains NULL bytes");
+        }
+    }
+
+    return num_elements;
+}
+
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
 
 tiledb_datatype_t np_to_tdb_dtype(py::dtype type);

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -192,11 +192,7 @@ def non_soma_metadata(obj) -> Dict[str, Any]:
         "\U00000000",  # get's casted to \x00
         "\x10abc",
         "\U00081a63×\x84\x94𘪩a\U000a4f44Î\x10m",
-        b"foo",
-        b"\xc2",
-        b"\x00",
         np.str_("foo"),
-        np.bytes_("foo"),
         "a string",
         math.nan,
         math.inf,
@@ -266,7 +262,15 @@ def test_metadata_bad_key(soma_object, bad_key):
 
 @pytest.mark.parametrize(
     "bad_value",
-    ["AA\x00BB", "AA\U00000000BB", np.str_("foo\x00bar")],
+    [
+        "AA\x00BB",
+        "AA\U00000000BB",
+        np.str_("foo\x00bar"),
+        b"foo",
+        b"\xc2",
+        b"\x00",
+        np.bytes_("foo"),
+    ],
 )
 def test_metadata_bad_string_value(soma_object, bad_value):
     """Verify that unsupported metadata types raise an error immediately."""

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -195,6 +195,8 @@ def non_soma_metadata(obj) -> Dict[str, Any]:
         b"foo",
         b"\xc2",
         b"\x00",
+        np.str_("foo"),
+        np.bytes_("foo"),
         "a string",
         math.nan,
         math.inf,
@@ -264,7 +266,7 @@ def test_metadata_bad_key(soma_object, bad_key):
 
 @pytest.mark.parametrize(
     "bad_value",
-    ["AA\x00BB", "AA\U00000000BB"],
+    ["AA\x00BB", "AA\U00000000BB", np.str_("foo\x00bar")],
 )
 def test_metadata_bad_string_value(soma_object, bad_value):
     """Verify that unsupported metadata types raise an error immediately."""

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -192,6 +192,9 @@ def non_soma_metadata(obj) -> Dict[str, Any]:
         "\U00000000",  # get's casted to \x00
         "\x10abc",
         "\U00081a63×\x84\x94𘪩a\U000a4f44Î\x10m",
+        b"foo",
+        b"\xc2",
+        b"\x00",
         "a string",
         math.nan,
         math.inf,


### PR DESCRIPTION
A follow-up PR to #3548 that adds support for Unicode metadata. 

UTF-8 support is not enough to store 1D numpy string arrays because Unicode arrays are by default UTF-32 encoded and can contain NULL bytes. 

Additionally improved robustness of metadata writing by attempting to write all modifications and collecting errors throughout the process and raising an exception cumulative at the end, rather than throwing midway. 

[sc-61687](https://app.shortcut.com/tiledb-inc/story/61687/python-add-unicode-metadata-support)