### PR TITLE
[python] Add the spatial-encoding version to `Scene` and `PointCloudDataFrame` objects

### DIFF
--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -20,6 +20,8 @@ from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import (
     SOMA_COORDINATE_SPACE_METADATA_KEY,
+    SOMA_SPATIAL_ENCODING_VERSION,
+    SOMA_SPATIAL_VERSION_METADATA_KEY,
     SPATIAL_DISCLAIMER,
 )
 from ._dataframe import (
@@ -256,6 +258,9 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
             raise map_exception_for_create(e, uri) from None
 
         handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
+        handle.metadata[SOMA_SPATIAL_VERSION_METADATA_KEY] = (
+            SOMA_SPATIAL_ENCODING_VERSION
+        )
         handle.meta[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(
             coordinate_space
         )

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -24,6 +24,8 @@ from . import pytiledbsoma as clib
 from ._collection import CollectionBase
 from ._constants import (
     SOMA_COORDINATE_SPACE_METADATA_KEY,
+    SOMA_SPATIAL_ENCODING_VERSION,
+    SOMA_SPATIAL_VERSION_METADATA_KEY,
     SPATIAL_DISCLAIMER,
 )
 from ._exception import SOMAError, map_exception_for_create
@@ -116,6 +118,9 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
                 timestamp=(0, timestamp_ms),
             )
             handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
+            handle.metadata[SOMA_SPATIAL_VERSION_METADATA_KEY] = (
+                SOMA_SPATIAL_ENCODING_VERSION
+            )
             if coordinate_space is not None:
                 if not isinstance(coordinate_space, CoordinateSpace):
                     coordinate_space = CoordinateSpace.from_axis_names(coordinate_space)

--- a/apis/python/tests/test_multiscale_image.py
+++ b/apis/python/tests/test_multiscale_image.py
@@ -108,6 +108,12 @@ def test_multiscale_basic(tmp_path):
             assert shape == expected_shapes[index]
             assert image.level_shape(index) == expected_shapes[index]
 
+        # Check the spatial version encoding was written.
+        assert (
+            image.metadata[soma._constants.SOMA_SPATIAL_VERSION_METADATA_KEY]
+            == soma._constants.SOMA_SPATIAL_ENCODING_VERSION
+        )
+
         # Check the levels mapping.
         levels = image.levels()
         assert len(levels) == 3

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -88,6 +88,11 @@ def test_point_cloud_basic_read(tmp_path):
         assert [e.as_py() for e in table["x"]] == pydict["x"]
         assert [e.as_py() for e in table["y"]] == pydict["y"]
 
+        assert (
+            ptc.metadata[soma._constants.SOMA_SPATIAL_VERSION_METADATA_KEY]
+            == soma._constants.SOMA_SPATIAL_ENCODING_VERSION
+        )
+
     # Ensure it cannot be opened by another type
     with pytest.raises(soma.SOMAError):
         soma.DataFrame.open(urljoin(baseuri, "default"))

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -75,6 +75,11 @@ def test_scene_basic(tmp_path):
         assert len(scene) == 3
         assert scene.soma_type == "SOMAScene"
 
+        assert (
+            scene.metadata[soma._constants.SOMA_SPATIAL_VERSION_METADATA_KEY]
+            == soma._constants.SOMA_SPATIAL_ENCODING_VERSION
+        )
+
         assert scene.obsl == scene["obsl"]
         assert len(scene.obsl) == 1
         assert scene.obsl["df"] == scene["obsl"]["df"]


### PR DESCRIPTION
**Issue and/or context:** [sc-61913](https://app.shortcut.com/tiledb-inc/story/61913/ensure-all-spatial-elements-include-spatial-version-number)

Adds the spatial encoding version to `Scene` and `PointCloudDataFrame` objects.
