### PR TITLE
[python] Throw error in `SOMAVFSFilebuf.open` on file-not-found

### DIFF
--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -106,7 +106,12 @@ void load_soma_vfs(py::module& m) {
         .def(
             "open",
             [](SOMAVFSFilebuf& buf, const std::string& uri) {
-                return buf.open(uri, std::ios::in);
+                auto fb = buf.open(uri, std::ios::in);
+                if (fb == nullptr) {
+                    TPY_ERROR_LOC(
+                        std::format("URI {} is not a valid file", uri));
+                }
+                return fb;
             },
             py::call_guard<py::gil_scoped_release>())
         .def("read", &SOMAVFSFilebuf::read, "size"_a = -1)

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -109,7 +109,7 @@ void load_soma_vfs(py::module& m) {
                 auto fb = buf.open(uri, std::ios::in);
                 if (fb == nullptr) {
                     TPY_ERROR_LOC(
-                        std::format("URI {} is not a valid file", uri));
+                        std::format("URI {} is not a valid URI", uri));
                 }
                 return fb;
             },

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1531,5 +1531,5 @@ def test_decat_append(tmp_path):
 
 
 def test_from_h5ad_bad_uri():
-    with pytest.raises(tiledbsoma.SOMAError, match="URI /nonesuch is not a valid file"):
+    with pytest.raises(tiledbsoma.SOMAError, match="URI /nonesuch is not a valid URI"):
         next(tiledbsoma.io._util.read_h5ad("/nonesuch").gen)

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1528,3 +1528,8 @@ def test_decat_append(tmp_path):
             obs_table.column("bool_enum").to_pylist()
             == bool_enum_values_over + bool_enum_values_under
         )
+
+
+def test_from_h5ad_bad_uri():
+    with pytest.raises(tiledbsoma.SOMAError, match="URI /nonesuch is not a valid file"):
+        next(tiledbsoma.io._util.read_h5ad("/nonesuch").gen)


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61909](https://app.shortcut.com/tiledb-inc/story/61909/misleading-error-message-in-soma-ingestor-when-input-file-is-not-found)]

**Changes:**

Fix misleading error by throwing an explicit error in `SOMAVFSFilebuf.open` if the file does not exist.

