### PR TITLE
[python] Correct Arrow offsets for Enumeration and Boolean columns

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2041,10 +2041,11 @@ def test_arrow_table_sliced_writer(tmp_path):
 
     with soma.DataFrame.open(uri) as sdf:
         pdf = sdf.read().concat().to_pandas()
+        
         assert list(pdf["myint"]) == pydict["myint"]
         assert list(pdf["mystring"]) == pydict["mystring"]
         assert list(pdf["mybool"]) == pydict["mybool"]
-
+        
         np.testing.assert_array_equal(pdf["myenumint"], pydict["myenumint"])
         np.testing.assert_array_equal(pdf["myenumstr"], pydict["myenumstr"])
         np.testing.assert_array_equal(pdf["myenumbool"], pydict["myenumbool"])

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2041,11 +2041,11 @@ def test_arrow_table_sliced_writer(tmp_path):
 
     with soma.DataFrame.open(uri) as sdf:
         pdf = sdf.read().concat().to_pandas()
-        
+
         assert list(pdf["myint"]) == pydict["myint"]
         assert list(pdf["mystring"]) == pydict["mystring"]
         assert list(pdf["mybool"]) == pydict["mybool"]
-        
+
         np.testing.assert_array_equal(pdf["myenumint"], pydict["myenumint"])
         np.testing.assert_array_equal(pdf["myenumstr"], pydict["myenumstr"])
         np.testing.assert_array_equal(pdf["myenumbool"], pydict["myenumbool"])

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1023,7 +1023,7 @@ bool ManagedQuery::_cast_column_aux<bool>(
     setup_write_column(
         schema->name,
         array->length,
-        (const void*)(casted.data()),
+        (const void*)casted.data(),
         (uint64_t*)nullptr,
         (uint8_t*)validity);
     return false;
@@ -1122,7 +1122,6 @@ bool ManagedQuery::_extend_and_evolve_schema(
 
     // Find any new enumeration values
     std::vector<ValueType> extend_values;
-
     for (auto enum_val : enums_in_write) {
         if (std::find(enums_existing.begin(), enums_existing.end(), enum_val) ==
             enums_existing.end()) {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1023,7 +1023,7 @@ bool ManagedQuery::_cast_column_aux<bool>(
     setup_write_column(
         schema->name,
         array->length,
-        (const void*)casted.data(),
+        (const void*)(casted.data()),
         (uint64_t*)nullptr,
         (uint8_t*)validity);
     return false;

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -725,9 +725,9 @@ class ManagedQuery {
         // Get the user passed-in dictionary indexes
         IndexType* idxbuf;
         if (index_array->n_buffers == 3) {
-            idxbuf = (IndexType*)index_array->buffers[2];
+            idxbuf = (IndexType*)index_array->buffers[2] + index_array->offset;
         } else {
-            idxbuf = (IndexType*)index_array->buffers[1];
+            idxbuf = (IndexType*)index_array->buffers[1] + index_array->offset;
         }
         std::vector<IndexType> original_indexes(
             idxbuf, idxbuf + index_array->length);
@@ -794,12 +794,17 @@ class ManagedQuery {
         std::vector<DiskIndexType> casted_indexes(
             shifted_indexes.begin(), shifted_indexes.end());
 
+        uint8_t* validity = (uint8_t*)index_array->buffers[0];
+        if (validity != nullptr) {
+            validity += index_array->offset;
+        }
+
         setup_write_column(
             column_name,
             casted_indexes.size(),
             (const void*)casted_indexes.data(),
             (uint64_t*)nullptr,
-            (uint8_t*)index_array->buffers[0]);
+            (uint8_t*)validity);
     }
 
     bool _extend_enumeration(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -327,7 +327,8 @@ void SOMAArray::write(bool sort_coords) {
     }
     mq_->submit_write(sort_coords);
 
-    mq_->reset();
+    arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, TILEDB_WRITE);
+    mq_ = std::make_unique<ManagedQuery>(arr_, ctx_->tiledb_ctx(), name_);
 }
 
 void SOMAArray::consolidate_and_vacuum(std::vector<std::string> modes) {

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -327,6 +327,8 @@ void SOMAArray::write(bool sort_coords) {
     }
     mq_->submit_write(sort_coords);
 
+    // When we evolve the schema, the ArraySchema needs to be updated to the
+    // latest version so re-open the Array
     arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, TILEDB_WRITE);
     mq_ = std::make_unique<ManagedQuery>(arr_, ctx_->tiledb_ctx(), name_);
 }

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -81,18 +81,17 @@ std::vector<uint8_t> cast_bit_to_uint8(ArrowSchema* schema, ArrowArray* array) {
             schema->format));
     }
 
-    const void* data;
+    uint8_t* data;
     if (array->n_buffers == 3) {
-        data = array->buffers[2];
+        data = (uint8_t*)array->buffers[2] + array->offset;
     } else {
-        data = array->buffers[1];
+        data = (uint8_t*)array->buffers[1] + array->offset;
     }
 
     std::vector<uint8_t> casted;
     for (int64_t i = 0; i * 8 < array->length; ++i) {
-        uint8_t byte = ((uint8_t*)data)[i];
         for (int64_t j = 0; j < 8; ++j) {
-            casted.push_back((uint8_t)((byte >> j) & 0x01));
+            casted.push_back(data[i] >> j & 0x01);
         }
     }
     return casted;

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -83,18 +83,19 @@ std::vector<uint8_t> cast_bit_to_uint8(ArrowSchema* schema, ArrowArray* array) {
 
     uint8_t* data;
     if (array->n_buffers == 3) {
-        data = (uint8_t*)array->buffers[2] + array->offset;
+        data = (uint8_t*)array->buffers[2];
     } else {
-        data = (uint8_t*)array->buffers[1] + array->offset;
+        data = (uint8_t*)array->buffers[1];
     }
 
     std::vector<uint8_t> casted;
-    for (int64_t i = 0; i * 8 < array->length; ++i) {
+    for (int64_t i = 0; i * 8 < array->offset + array->length; ++i) {
         for (int64_t j = 0; j < 8; ++j) {
             casted.push_back(data[i] >> j & 0x01);
         }
     }
-    return casted;
+
+    return std::vector<uint8_t>(casted.begin() + array->offset, casted.end());
 }
 
 };  // namespace tiledbsoma::util


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61239](https://app.shortcut.com/tiledb-inc/story/61239/c-tiledbsoma-soma-write-will-corrupt-data-written-to-array-if-array-is-a-slice-with-offset-0)]

**Changes:**

- Add additional unit tests to handle offset slicing for more datatypes
- Enumerations
  - Re-open the array at the end of the write call to get updated schema after performing schema evolution
  - Add in offset calculations where missing
- Booleans
  - Account for offset in `cast_bit_to_uint8`
  - Account for offset in validity buffer

