### PR TITLE
[c++] Handle add/drop/re-add of enumerated types

### DIFF
--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -335,6 +335,7 @@ def test_enmr_add_drop_readd(tmp_path, conftest_pbmc3k_adata):
 
     # Re-add
     with tiledbsoma.Experiment.open(uri, "w") as exp:
+        # Most importantly, we're implicitly checking for no throw here.
         tiledbsoma.io.update_obs(exp, conftest_pbmc3k_adata.obs)
 
     with tiledbsoma.Experiment.open(uri, "r") as exp:

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -307,3 +307,37 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
     conftest_pbmc3k_adata.obs["myfloat"] = np.nan
     # We need nan_safe since pd.NA != pd.NA
     verify_updates(uri, conftest_pbmc3k_adata.obs, conftest_pbmc3k_adata.var)
+
+
+def test_enmr_add_drop_readd(tmp_path, conftest_pbmc3k_adata):
+    uri = tmp_path.as_posix()
+
+    # Add
+    tiledbsoma.io.from_anndata(uri, conftest_pbmc3k_adata, measurement_name="RNA")
+
+    with tiledbsoma.Experiment.open(uri, "r") as exp:
+        schema = exp.obs.schema
+        assert "louvain" in schema.names
+        field = schema.field("louvain")
+        assert pa.types.is_dictionary(field.type)
+
+    # Drop
+    with tiledbsoma.Experiment.open(uri, "r") as exp:
+        obs = exp.obs.read().concat().to_pandas()
+    obs.drop(columns=["louvain"], inplace=True)
+
+    with tiledbsoma.Experiment.open(uri, "w") as exp:
+        tiledbsoma.io.update_obs(exp, obs)
+
+    with tiledbsoma.Experiment.open(uri, "r") as exp:
+        schema = exp.obs.schema
+        assert "louvain" not in schema.names
+
+    # Re-add
+    with tiledbsoma.Experiment.open(uri, "w") as exp:
+        tiledbsoma.io.update_obs(exp, conftest_pbmc3k_adata.obs)
+
+    with tiledbsoma.Experiment.open(uri, "r") as exp:
+        schema = exp.obs.schema
+        assert "louvain" in schema.names
+        assert pa.types.is_dictionary(field.type)

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -220,7 +220,10 @@ void SOMADataFrame::update_dataframe_schema(
                 }
                 array_already_has_it = true;
 
-            } catch (const TileDBError& e) {
+            } catch (const std::exception& e) {
+                // Oddly, catch (tiledb::TileDBError& e) did not enter this
+                // block in unit test.
+                //
                 // Make sure the exception was for the reason we're considering.
                 // If it was for some other reason, fail.
                 const std::string msg = e.what();


### PR DESCRIPTION
## Scenario

Users adds an enumeration column, then drops it, then re-adds it.

Error message:

```
RuntimeError: [TileDB::REST] Error: Error in libcurl POST operation: libcurl error message 'CURLE_OK';
HTTP code 500; server response data '{"code":1006,"message":"error evolving schema for array try 
again","request_id":"8e33095a-4ea2-4c89-9335-420238c29f9f"}'.
```

or:

```
error evolving schema for array [...] ArraySchema: Error adding enumeration.
Enumeration with name '[...]' already exists in this ArraySchema
```

## Repro

```
#!/usr/bin/env python

import tiledbsoma
import tiledbsoma.io
import anndata as ad
import os, shutil

soma_uri = './repro-460'
h5ad_uri = '/var/s/a/pbmc3k_processed.h5ad'

if os.path.exists(soma_uri):
    shutil.rmtree(soma_uri)

# ----------------------------------------------------------------
# Add
tiledbsoma.io.from_h5ad(soma_uri, h5ad_uri, measurement_name = 'RNA')

# ----------------------------------------------------------------
# Drop
with tiledbsoma.Experiment.open(soma_uri, 'r') as exp:
    obs = exp.obs.read().concat().to_pandas()
obs.drop(columns=['louvain'], inplace=True)

with tiledbsoma.Experiment.open(soma_uri, 'w') as exp:
    tiledbsoma.io.update_obs(exp, obs)

# ----------------------------------------------------------------
# Re-add
adata = ad.read_h5ad(h5ad_uri)
with tiledbsoma.Experiment.open(soma_uri, 'w') as exp:
    tiledbsoma.io.update_obs(exp, adata.obs)
```

## Problem

* When we drop columns, we don't drop enumerations
* We don't _want_ to drop enumerations entirely:
  * Suppose the dataframe is created Monday with enum column `foo`
  * Suppose its column `foo` is dropped Tuesday
  * Suppose `foo` is added Wednesday
  * We don't want to remove the enumeration on Tuesday, since then people would be unable to do a time-travel read of the data when opened at the Monday timestamp

[[sc-61984]](https://app.shortcut.com/tiledb-inc/story/61984/error-evolving-schema-in-a-certain-context)