### PR TITLE
Fix #3569 backport to `release-1.15`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -110,7 +110,7 @@ void load_soma_vfs(py::module& m) {
                 if (fb == nullptr) {
                     // No std::format in C++17, and fmt::format is overkill here
                     std::stringstream ss;
-                    ss << "URI {" << uri << "} is not a valid URI";
+                    ss << "URI " << uri << " is not a valid URI";
                     TPY_ERROR_LOC(ss.str());
                 }
                 return fb;

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -108,8 +108,10 @@ void load_soma_vfs(py::module& m) {
             [](SOMAVFSFilebuf& buf, const std::string& uri) {
                 auto fb = buf.open(uri, std::ios::in);
                 if (fb == nullptr) {
-                    TPY_ERROR_LOC(
-                        std::format("URI {} is not a valid URI", uri));
+                    // No std::format in C++17, and fmt::format is overkill here
+                    std::stringstream ss;
+                    ss << "URI {" << uri << "} is not a valid URI";
+                    TPY_ERROR_LOC(ss.str());
                 }
                 return fb;
             },


### PR DESCRIPTION
**Issue and/or context:** When backporting #3569 I failed to check for C++ 17 isms. See also #3154 which is still open.

**Changes:**

**Notes for Reviewer:**

