### PR TITLE
[python] More `readthedocs` search fix

### DIFF
--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -8,7 +8,7 @@ pandoc==2.3
 pybind11==2.12.0
 setuptools==75.1.0
 setuptools-scm==8.1.0
-sphinx==8.1.3
+sphinx==7.3.7
 sphinxcontrib-jquery==4.1
 sphinx-rtd-theme==2.0.0
 wheel==0.43.0


### PR DESCRIPTION
**Issue and/or context:** #3573 was fine in sandbox test as noted there. However, `latest` build at `readthedocs` failed at https://app.readthedocs.org/projects/tiledbsoma/builds/26876140 with

```
ERROR: Cannot install -r doc/requirements_doc.txt (line 1), -r doc/requirements_doc.txt (line 12), -r doc/requirements_doc.txt (line 13), -r doc/requirements_doc.txt (line 6) and sphinx==8.1.3 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested sphinx==8.1.3
    breathe 4.35.0 depends on Sphinx!=5.0.0 and >=4.0
    nbsphinx 0.9.3 depends on sphinx>=1.8
    sphinxcontrib-jquery 4.1 depends on Sphinx>=1.8
    sphinx-rtd-theme 2.0.0 depends on sphinx<8 and >=5
```

**Changes:** Go back to 7.3.7.

**Notes for Reviewer:**

