### PR TITLE
[python/cpp] Add C++ `SOMACoordinateSpace` and use it to pushdown `Scene` metadata to C++

### DIFF
--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -24,8 +24,6 @@ from . import pytiledbsoma as clib
 from ._collection import CollectionBase
 from ._constants import (
     SOMA_COORDINATE_SPACE_METADATA_KEY,
-    SOMA_SPATIAL_ENCODING_VERSION,
-    SOMA_SPATIAL_VERSION_METADATA_KEY,
     SPATIAL_DISCLAIMER,
 )
 from ._exception import SOMAError, map_exception_for_create
@@ -130,12 +128,8 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
                 axis_units=axis_units,
                 timestamp=(0, timestamp_ms),
             )
-            handle = cls._wrapper_type.open(uri, "w", context, tiledb_timestamp)
-            handle.metadata[SOMA_SPATIAL_VERSION_METADATA_KEY] = (
-                SOMA_SPATIAL_ENCODING_VERSION
-            )
             return cls(
-                handle,
+                cls._wrapper_type.open(uri, "w", context, tiledb_timestamp),
                 _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
             )
         except SOMAError as e:

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -101,7 +101,7 @@ void load_soma_collection(py::module& m) {
                std::string_view uri,
                std::optional<TimestampRange> timestamp) {
                 try {
-                    SOMAScene::create(uri, ctx, timestamp);
+                    SOMAScene::create(uri, ctx, std::nullopt, timestamp);
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }

--- a/apis/python/tests/test_scene.py
+++ b/apis/python/tests/test_scene.py
@@ -122,36 +122,29 @@ def test_scene_basic(tmp_path):
         soma.MultiscaleImage.open(uri)
 
 
-def test_scene_coord_space_at_create(tmp_path):
+@pytest.mark.parametrize(
+    "input,expected",
+    (
+        (["x", "y"], soma.CoordinateSpace.from_axis_names(("x", "y"))),
+        (
+            soma.CoordinateSpace([soma.Axis("x", "meters"), soma.Axis("y", "meters")]),
+            soma.CoordinateSpace([soma.Axis("x", "meters"), soma.Axis("y", "meters")]),
+        ),
+    ),
+)
+def test_scene_coord_space_at_create(tmp_path, input, expected):
     uri = tmp_path.as_uri()
 
-    coord_space = soma.CoordinateSpace(
-        [
-            soma.Axis(name="x"),
-            soma.Axis(name="y"),
-        ]
-    )
-    coord_space_json = """
-    [
-        {"name": "x", "unit": null},
-        {"name": "y", "unit": null}
-    ]
-    """
-
-    with soma.Scene.create(uri, coordinate_space=("x", "y")) as scene:
+    with soma.Scene.create(uri, coordinate_space=input) as scene:
 
         # Reserved metadata key should not be settable?
         # with pytest.raises(soma.SOMAError):
-        #     scene.metadata["soma_coordinate_space"] = coord_space_json
+        #     scene.metadata["soma_coordinate_space"] = "user_metadata"
 
-        scene.coordinate_space = coord_space
-        assert scene.coordinate_space == coord_space
-        assert json.loads(scene.metadata["soma_coordinate_space"]) == json.loads(
-            coord_space_json
-        )
+        assert scene.coordinate_space == expected
 
     with soma.Scene.open(uri) as scene:
-        assert scene.coordinate_space == coord_space
+        assert scene.coordinate_space == expected
 
 
 def test_scene_coord_space_after_create(tmp_path):

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set_property(TARGET TILEDBSOMA_NANOARROW_OBJECT PROPERTY POSITION_INDEPENDENT_CO
 add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/reindexer/reindexer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/managed_query.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_coordinates.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.cc
@@ -186,6 +187,7 @@ endif()
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_experiment.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_measurement.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_scene.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_coordinates.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_geometry_dataframe.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_point_cloud_dataframe.h
 #   ${CMAKE_CURRENT_SOURCE_DIR}/cpp_api/soma_multiscale_image.h
@@ -199,6 +201,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/logger_public.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_context.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/managed_query.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_coordinates.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/array_buffers.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.h

--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -1,0 +1,151 @@
+/**
+ *   This file defines classes, structs, and helpers for managing coordinate
+ *   spaces and coordinate space transformations.
+ * @file   soma_coordinates.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines classes, structs, and helpers for managing coordinate
+ *   spaces and coordinate space transformations.
+ */
+
+#include <format>
+#include <tiledb/tiledb>
+#include <unordered_set>
+#include "nlohmann/json.hpp"
+
+#include "soma_coordinates.h"
+
+using json = nlohmann::json;
+
+namespace nlohmann {
+template <>
+struct adl_serializer<tiledbsoma::SOMAAxis> {
+    static void to_json(json& j, const tiledbsoma::SOMAAxis& axis) {
+        // void to_json(json& j, tiledbsoma::SOMAAxis& axis) {
+        if (axis.unit.has_value()) {
+            j = json{{"name", axis.name}, {"unit", axis.unit.value()}};
+        } else {
+            j = json{{"name", axis.name}, {"unit", nullptr}};
+        }
+    }
+
+    static void from_json(const json& j, tiledbsoma::SOMAAxis& axis) {
+        j.at("name").get_to(axis.name);
+        auto unit_json = j.at("unit");
+        if (unit_json.is_null()) {
+            axis.unit = std::nullopt;
+        } else {
+            unit_json.get_to(axis.unit);
+        }
+    }
+};
+}  // namespace nlohmann
+
+namespace tiledbsoma {
+
+SOMACoordinateSpace::SOMACoordinateSpace()
+    : axes_{{"x", std::nullopt}, {"y", std::nullopt}} {
+}
+
+SOMACoordinateSpace::SOMACoordinateSpace(const std::vector<SOMAAxis>& axes)
+    : axes_{axes} {
+    if (axes_.size() == 0) {
+        throw TileDBSOMAError("Coordinate space must have at least one axis.");
+    }
+    std::unordered_set<std::string> axis_names;
+    for (const auto& axis : axes_) {
+        axis_names.emplace(axis.name);
+    }
+    if (axes_.size() != axis_names.size()) {
+        throw TileDBSOMAError(
+            "The name for coordinate space axes must be unique.");
+    }
+}
+
+SOMACoordinateSpace::SOMACoordinateSpace(
+    const std::vector<std::string>& axis_names) {
+    if (axis_names.size() == 0) {
+        throw TileDBSOMAError("Coordinate space must have at least one axis.");
+    }
+    std::unordered_set<std::string> unique_axis_names(
+        axis_names.begin(), axis_names.end());
+    if (axis_names.size() != unique_axis_names.size()) {
+        throw TileDBSOMAError(
+            "The name for coordinate space axes must be unique.");
+    }
+    axes_.reserve(axis_names.size());
+    for (const auto& name : axis_names) {
+        axes_.push_back({name, std::nullopt});
+    }
+}
+
+SOMACoordinateSpace::SOMACoordinateSpace(
+    const std::vector<std::string>& axis_names,
+    const std::vector<std::optional<std::string>>& axis_units) {
+    if (axis_names.size() != axis_units.size()) {
+        throw TileDBSOMAError(
+            "[SOMACoordinateSpace]: Axis names and axis units size mismatch. ");
+    }
+    auto num_axes = axis_names.size();
+    if (num_axes == 0) {
+        throw TileDBSOMAError("Coordinate space must have at least one axis.");
+    }
+    std::unordered_set<std::string> unique_axis_names(
+        axis_names.begin(), axis_names.end());
+    if (axis_names.size() != unique_axis_names.size()) {
+        throw TileDBSOMAError(
+            "The name for coordinate space axes must be unique.");
+    }
+    axes_.reserve(num_axes);
+    for (size_t index{0}; index < num_axes; ++index) {
+        axes_.push_back({axis_names[index], axis_units[index]});
+    }
+}
+
+SOMACoordinateSpace SOMACoordinateSpace::from_metadata(
+    tiledb_datatype_t value_type, uint32_t value_num, const void* value) {
+    if (value_type != TILEDB_STRING_UTF8 && value_type != TILEDB_STRING_ASCII) {
+        throw TileDBSOMAError(std::format(
+            "[SOMACoordinateSpace]: Unexpected datatype for coordinate space "
+            "metadata. Expected {} or {}; got {}",
+            tiledb::impl::type_to_str(TILEDB_STRING_UTF8),
+            tiledb::impl::type_to_str(TILEDB_STRING_ASCII),
+            tiledb::impl::type_to_str(value_type)));
+    }
+    std::string value_str(static_cast<const char*>(value), value_num);
+    auto value_json = json::parse(value_str);
+    auto axes = value_json.template get<std::vector<SOMAAxis>>();
+
+    return SOMACoordinateSpace(axes);
+}
+
+std::string SOMACoordinateSpace::to_string() const {
+    json serializer(axes_);
+    return serializer.dump(-1, ' ', true);
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_coordinates.h
+++ b/libtiledbsoma/src/soma/soma_coordinates.h
@@ -1,0 +1,98 @@
+/**
+ * @file   soma_coordinates.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines classes, structs, and helpers for managing coordinate
+ *   spaces and coordinate space transformations.
+ */
+
+#ifndef SOMA_METADATA
+#define SOMA_METADATA
+
+#include <optional>
+#include <string>
+#include <vector>
+#include "../utils/common.h"
+
+namespace tiledbsoma {
+
+struct SOMAAxis {
+    std::string name{"x"};
+    std::optional<std::string> unit{std::nullopt};
+
+    inline friend bool operator==(const SOMAAxis& lhs, const SOMAAxis& rhs) {
+        return lhs.name == rhs.name && lhs.unit == rhs.unit;
+    }
+
+    inline friend bool operator!=(const SOMAAxis& lhs, const SOMAAxis& rhs) {
+        return !(lhs == rhs);
+    }
+};
+
+class SOMACoordinateSpace {
+   public:
+    static SOMACoordinateSpace from_metadata(
+        tiledb_datatype_t value_type, uint32_t value_num, const void* value);
+
+    SOMACoordinateSpace();
+
+    SOMACoordinateSpace(const std::vector<SOMAAxis>& axes);
+
+    SOMACoordinateSpace(const std::vector<std::string>& axis_names);
+
+    SOMACoordinateSpace(
+        const std::vector<std::string>& axis_names,
+        const std::vector<std::optional<std::string>>& axis_units);
+
+    inline friend bool operator==(
+        const SOMACoordinateSpace& lhs, const SOMACoordinateSpace& rhs) {
+        return lhs.axes_ == rhs.axes_;
+    }
+
+    inline friend bool operator!=(
+        const SOMACoordinateSpace& lhs, const SOMACoordinateSpace& rhs) {
+        return !(lhs == rhs);
+    }
+
+    std::string to_string() const;
+
+    inline size_t size() const {
+        return axes_.size();
+    }
+
+    inline const SOMAAxis& axis(size_t index) const {
+        return axes_[index];
+    }
+
+   private:
+    std::vector<SOMAAxis> axes_;
+};
+
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -32,6 +32,7 @@
 
 #include "soma_scene.h"
 #include "soma_collection.h"
+#include "utils/common.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -43,13 +44,20 @@ using namespace tiledb;
 void SOMAScene::create(
     std::string_view uri,
     std::shared_ptr<SOMAContext> ctx,
+    const std::optional<SOMACoordinateSpace>& coordinate_space,
     std::optional<TimestampRange> timestamp) {
     try {
         std::filesystem::path scene_uri(uri);
         auto group = SOMAGroup::create(
             ctx, scene_uri.string(), "SOMAScene", timestamp);
-        // TODO: Set extra metadata.
-        // (See story: https://app.shortcut.com/tiledb-inc/story/59915)
+        if (coordinate_space.has_value()) {
+            const auto coord_space_metadata = coordinate_space->to_string();
+            group->set_metadata(
+                SOMA_COORDINATE_SPACE_KEY,
+                TILEDB_STRING_UTF8,
+                static_cast<uint32_t>(coord_space_metadata.size()),
+                coord_space_metadata.c_str());
+        }
         group->close();
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
@@ -67,6 +75,15 @@ std::unique_ptr<SOMAScene> SOMAScene::open(
         if (!group->check_type("SOMAScene")) {
             throw TileDBSOMAError(
                 "[SOMAScene::open] Object is not a SOMAScene");
+        }
+
+        auto coord_space_metadata = group->get_metadata(
+            SOMA_COORDINATE_SPACE_KEY);
+        if (coord_space_metadata.has_value()) {
+            group->coord_space_ = SOMACoordinateSpace::from_metadata(
+                std::get<0>(coord_space_metadata.value()),
+                std::get<1>(coord_space_metadata.value()),
+                std::get<2>(coord_space_metadata.value()));
         }
 
         return group;

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -50,14 +50,24 @@ void SOMAScene::create(
         std::filesystem::path scene_uri(uri);
         auto group = SOMAGroup::create(
             ctx, scene_uri.string(), "SOMAScene", timestamp);
+
+        group->set_metadata(
+            SPATIAL_ENCODING_VERSION_KEY,
+            TILEDB_STRING_UTF8,
+            static_cast<uint32_t>(SPATIAL_ENCODING_VERSION_VAL.size()),
+            SPATIAL_ENCODING_VERSION_VAL.c_str(),
+            true);
+
         if (coordinate_space.has_value()) {
             const auto coord_space_metadata = coordinate_space->to_string();
             group->set_metadata(
                 SOMA_COORDINATE_SPACE_KEY,
                 TILEDB_STRING_UTF8,
                 static_cast<uint32_t>(coord_space_metadata.size()),
-                coord_space_metadata.c_str());
+                coord_space_metadata.c_str(),
+                true);
         }
+
         group->close();
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());

--- a/libtiledbsoma/src/soma/soma_scene.h
+++ b/libtiledbsoma/src/soma/soma_scene.h
@@ -36,6 +36,7 @@
 #include <tiledb/tiledb>
 
 #include "soma_collection.h"
+#include "soma_coordinates.h"
 
 namespace tiledbsoma {
 
@@ -56,6 +57,7 @@ class SOMAScene : public SOMACollection {
     static void create(
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
+        const std::optional<SOMACoordinateSpace>& coordinate_space,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
@@ -95,6 +97,10 @@ class SOMAScene : public SOMACollection {
     SOMAScene(SOMAScene&&) = default;
     ~SOMAScene() = default;
 
+    inline const std::optional<SOMACoordinateSpace>& coordinate_space() const {
+        return coord_space_;
+    };
+
     /**
      * @brief Get the collection of imagery data.
      *
@@ -121,6 +127,8 @@ class SOMAScene : public SOMACollection {
     //===================================================================
     //= private non-static
     //===================================================================
+
+    std::optional<SOMACoordinateSpace> coord_space_ = std::nullopt;
 
     // A collection of imagery data.
     std::shared_ptr<SOMACollection> img_ = nullptr;

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -47,6 +47,7 @@
 #include "soma/managed_query.h"
 #include "soma/array_buffers.h"
 #include "soma/column_buffer.h"
+#include "soma/soma_coordinates.h"
 #include "soma/soma_array.h"
 #include "soma/soma_collection.h"
 #include "soma/soma_dataframe.h"

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -42,6 +42,9 @@ namespace tiledbsoma {
 const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
 const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
 const std::string ENCODING_VERSION_VAL = "1.1.0";
+const std::string
+    SPATIAL_ENCODING_VERSION_KEY = "soma_spatial_encoding_version";
+const std::string SPATIAL_ENCODING_VERSION_VAL = "0.2.0";
 const std::string SOMA_COORDINATE_SPACE_KEY = "soma_coordinate_space";
 const std::string SOMA_GEOMETRY_COLUMN_NAME = "soma_geometry";
 const std::string SOMA_GEOMETRY_DIMENSION_PREFIX = "tiledb__internal__";

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -42,6 +42,7 @@ namespace tiledbsoma {
 const std::string SOMA_OBJECT_TYPE_KEY = "soma_object_type";
 const std::string ENCODING_VERSION_KEY = "soma_encoding_version";
 const std::string ENCODING_VERSION_VAL = "1.1.0";
+const std::string SOMA_COORDINATE_SPACE_KEY = "soma_coordinate_space";
 const std::string SOMA_GEOMETRY_COLUMN_NAME = "soma_geometry";
 const std::string SOMA_GEOMETRY_DIMENSION_PREFIX = "tiledb__internal__";
 const std::string ARROW_DATATYPE_METADATA_KEY = "dtype";

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(unit_soma
     unit_soma_geometry_dataframe.cc
     unit_soma_point_cloud_dataframe.cc
     unit_soma_multiscale_image.cc
+    unit_soma_coordinates.cc
     test_indexer.cc
 # TODO: uncomment when thread_pool is enabled
 #    unit_thread_pool.cc
@@ -158,6 +159,11 @@ if (WIN32)
     COMMAND_EXPAND_LISTS
   )
 endif()
+
+
+############################################################
+# Target for all unit tests
+############################################################
 
 add_custom_target(build_tests)
 add_dependencies(build_tests

--- a/libtiledbsoma/test/unit_soma_coordinates.cc
+++ b/libtiledbsoma/test/unit_soma_coordinates.cc
@@ -1,0 +1,160 @@
+/**
+ * @file   unit_soma_coordinates.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for coordinate spaces and coordinate space
+ * transformations.
+ */
+
+#include "common.h"
+
+TEST_CASE(
+    "SOMACoordinateSpace: invalid initialization", "[metadata][spatial]") {
+    // Check all three constructors throw for empty coordinate space.
+    std::vector<SOMAAxis> empty_axes_{};
+    std::vector<std::string> empty_axis_names_{};
+    std::vector<std::optional<std::string>> empty_axis_units_{};
+    REQUIRE_THROWS_AS(SOMACoordinateSpace(empty_axes_), TileDBSOMAError);
+    REQUIRE_THROWS_AS(SOMACoordinateSpace(empty_axis_names_), TileDBSOMAError);
+    REQUIRE_THROWS_AS(
+        SOMACoordinateSpace(empty_axis_names_, empty_axis_units_),
+        TileDBSOMAError);
+
+    // Check all three constructors throw for repeat names.
+    std::vector<SOMAAxis> repeat_axes_{
+        {"x_axis", "meter"}, {"x_axis", "nanometer"}};
+    std::vector<std::string> repeat_axis_names_{"x_axis", "x_axis"};
+    std::vector<std::optional<std::string>> repeat_axis_units_{};
+    REQUIRE_THROWS_AS(SOMACoordinateSpace(repeat_axes_), TileDBSOMAError);
+    REQUIRE_THROWS_AS(SOMACoordinateSpace(repeat_axis_names_), TileDBSOMAError);
+    REQUIRE_THROWS_AS(
+        SOMACoordinateSpace(repeat_axis_names_, repeat_axis_units_),
+        TileDBSOMAError);
+
+    // Check separate axis name/unit constructor throws for mismatched vector
+    // sizes.
+    std::vector<std::string> axis_names_len3_{"x", "y", "z"};
+    std::vector<std::optional<std::string>> axis_units_len2_{"meter", "meter"};
+    REQUIRE_THROWS_AS(
+        SOMACoordinateSpace(axis_names_len3_, axis_units_len2_),
+        TileDBSOMAError);
+    REQUIRE_THROWS_AS(
+        SOMACoordinateSpace(axis_names_len3_, empty_axis_units_),
+        TileDBSOMAError);
+}
+
+TEST_CASE("SOMACoordinateSpace: compare constructors", "[metadata][spatial]") {
+    std::vector<std::string> names1{"x", "y"};
+    std::vector<std::optional<std::string>> units1{std::nullopt, std::nullopt};
+    SOMACoordinateSpace expected1(
+        {SOMAAxis("x", std::nullopt), SOMAAxis("y", std::nullopt)});
+
+    CHECK(SOMACoordinateSpace() == expected1);
+    CHECK(SOMACoordinateSpace(names1) == expected1);
+    CHECK(SOMACoordinateSpace(names1, units1) == expected1);
+
+    std::vector<std::string> names2{"x1", "x2", "x3"};
+    std::vector<std::optional<std::string>> units2{
+        "meters", "meters", "meters"};
+    SOMACoordinateSpace expected2(
+        {SOMAAxis{"x1", "meters"},
+         SOMAAxis{"x2", "meters"},
+         SOMAAxis{"x3", "meters"}});
+
+    CHECK(SOMACoordinateSpace(names2, units2) == expected2);
+}
+
+TEST_CASE("SOMACoordinateSpace: from_metadata", "[metadata][spatial]") {
+    // Create the test data.
+    std::pair<std::string, SOMACoordinateSpace> test_data = GENERATE(
+        std::make_pair(
+            "[{\"name\":\"x\",\"unit\":null},{\"name\":\"y\",\"unit\":null}]",
+            SOMACoordinateSpace({SOMAAxis("x"), SOMAAxis("y")})),
+        std::make_pair(
+            "[{\"name\":\"z\",\"unit\":null},{\"name\":\"t\",\"unit\":"
+            "\"hour\"}]",
+            SOMACoordinateSpace(
+                {SOMAAxis("z", std::nullopt), SOMAAxis("t", "hour")})),
+        std::make_pair(
+            "[{\"name\":\"z\",\"unit\":\"meter\"},{\"name\":\"t\",\"unit\":"
+            "\"hour\"}]",
+            SOMACoordinateSpace(
+                {SOMAAxis("z", "meter"), SOMAAxis("t", "hour")})));
+    const auto& metadata = test_data.first;
+    const auto& expected_coord_space = test_data.second;
+
+    // Check `from_metadata` creates the expected SOMACoordinateSpace.
+    auto actual_coord_space = SOMACoordinateSpace::from_metadata(
+        TILEDB_STRING_ASCII,
+        static_cast<uint32_t>(metadata.size()),
+        static_cast<const void*>(metadata.c_str()));
+    REQUIRE(actual_coord_space == expected_coord_space);
+}
+
+TEST_CASE("SOMACoordinateSpace: to_string", "[metadata][spatial]") {
+    // Create the test data.
+    std::pair<std::string, SOMACoordinateSpace> test_data = GENERATE(
+        std::make_pair(
+            "[{\"name\":\"x\",\"unit\":null},{\"name\":\"y\",\"unit\":null}]",
+            SOMACoordinateSpace({SOMAAxis("x"), SOMAAxis("y")})),
+        std::make_pair(
+            "[{\"name\":\"z\",\"unit\":null},{\"name\":\"t\",\"unit\":"
+            "\"hour\"}]",
+            SOMACoordinateSpace(
+                {SOMAAxis("z", std::nullopt), SOMAAxis("t", "hour")})),
+        std::make_pair(
+            "[{\"name\":\"z\",\"unit\":\"meter\"},{\"name\":\"t\",\"unit\":"
+            "\"hour\"}]",
+            SOMACoordinateSpace(
+                {SOMAAxis("z", "meter"), SOMAAxis("t", "hour")})));
+    const auto& expected_metadata = test_data.first;
+    const auto& coord_space = test_data.second;
+
+    auto actual_metadata = coord_space.to_string();
+    REQUIRE(actual_metadata == expected_metadata);
+}
+
+TEST_CASE(
+    "SOMACoordinateSpace: mock metadata round-trip", "[metadata][spatial]") {
+    auto coord_space = GENERATE(
+        SOMACoordinateSpace(),
+        SOMACoordinateSpace(
+            {SOMAAxis("x_axis", "meter"),
+             SOMAAxis("y_axis", "meter"),
+             SOMAAxis("z_axis", "meter")}),
+        SOMACoordinateSpace({SOMAAxis("z_axis"), SOMAAxis("x_axis", "meter")}));
+
+    auto coord_json = coord_space.to_string();
+
+    auto coord_space_result = SOMACoordinateSpace::from_metadata(
+        TILEDB_STRING_ASCII,
+        static_cast<uint32_t>(coord_json.size()),
+        static_cast<const void*>(coord_json.c_str()));
+
+    REQUIRE(coord_space == coord_space_result);
+}

--- a/libtiledbsoma/test/unit_soma_scene.cc
+++ b/libtiledbsoma/test/unit_soma_scene.cc
@@ -41,6 +41,8 @@ TEST_CASE("SOMAScene: basic", "[scene][spatial]") {
     CHECK(soma_scene->uri() == uri);
     CHECK(soma_scene->ctx() == ctx);
     CHECK(soma_scene->type() == "SOMAScene");
+    CHECK(soma_scene->has_metadata("soma_encoding_version"));
+    CHECK(soma_scene->has_metadata("soma_spatial_encoding_version"));
     CHECK(not soma_scene->coordinate_space().has_value());
     soma_scene->close();
 }
@@ -57,6 +59,8 @@ TEST_CASE("SOMAScene: with coordinates", "[scene][spatial]") {
     CHECK(soma_scene->uri() == uri);
     CHECK(soma_scene->ctx() == ctx);
     CHECK(soma_scene->type() == "SOMAScene");
+    CHECK(soma_scene->has_metadata("soma_encoding_version"));
+    CHECK(soma_scene->has_metadata("soma_spatial_encoding_version"));
     auto scene_coord_space = soma_scene->coordinate_space();
     REQUIRE(scene_coord_space.has_value());
 

--- a/libtiledbsoma/test/unit_soma_scene.cc
+++ b/libtiledbsoma/test/unit_soma_scene.cc
@@ -32,7 +32,7 @@
 
 #include "common.h"
 
-TEST_CASE("SOMAScene: basic") {
+TEST_CASE("SOMAScene: basic", "[scene][spatial]") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri{"mem://unit-test-scene-basic"};
 
@@ -41,5 +41,24 @@ TEST_CASE("SOMAScene: basic") {
     CHECK(soma_scene->uri() == uri);
     CHECK(soma_scene->ctx() == ctx);
     CHECK(soma_scene->type() == "SOMAScene");
+    CHECK(not soma_scene->coordinate_space().has_value());
     soma_scene->close();
+}
+
+TEST_CASE("SOMAScene: with coordinates", "[scene][spatial]") {
+    auto ctx = std::make_shared<SOMAContext>();
+    std::string uri{"mem://unit-test-scene-coords"};
+
+    SOMACoordinateSpace coord_space{};
+
+    SOMAScene::create(uri, ctx, coord_space, std::nullopt);
+
+    auto soma_scene = SOMAScene::open(uri, OpenMode::read, ctx, std::nullopt);
+    CHECK(soma_scene->uri() == uri);
+    CHECK(soma_scene->ctx() == ctx);
+    CHECK(soma_scene->type() == "SOMAScene");
+    auto scene_coord_space = soma_scene->coordinate_space();
+    REQUIRE(scene_coord_space.has_value());
+
+    CHECK(scene_coord_space.value() == coord_space);
 }


### PR DESCRIPTION
**Issue and/or context:** [62098](https://app.shortcut.com/tiledb-inc/story/62098/create-somacoordinatespace-class-in-c) and [sc-62100](https://app.shortcut.com/tiledb-inc/story/62100/push-down-spatial-metadata-in-the-scene-class-from-python-to-c)

**Changes:**
Create a new class `SOMACoordinateSpace` in C++ and use it to read/write coordinate space metadata. Use this class to write coordinate space metadata for the `SOMAScene` class in C++. This replaces writing the metadata in the Python layer and fixes an issue where the `Scene` metadata was being written in a later timestamp than other core metadata like the SOMA datatype.
