### PR TITLE
[python] On is-not-context error, show type

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -374,6 +374,6 @@ def _validate_soma_tiledb_context(context: Any) -> SOMATileDBContext:
         )
 
     if not isinstance(context, SOMATileDBContext):
-        raise TypeError("context is not a SOMATileDBContext")
+        raise TypeError(f"context is not a SOMATileDBContext: got {type(context)}")
 
     return context


### PR DESCRIPTION
**Issue and/or context:** Found while working on #3581 / #3582.

In a debug script, due to a copy/paste error, I had

```
context = tiledbsoma.SOMATileDBContext(tiledb_config={
    "key1": "value1",
    "key2": "value2",
}),
```

Note the trailing comma, which I did not see. (In the copy-from text, this had been in an argument list where comma is needed. In the paste-to text, I was assigning it to a variable, where comma is not needed.)

Then, running a repro, I got

```
  File "/Users/kerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py", line 377, in _validate_soma_tiledb_context
    raise TypeError(f"context is not a SOMATileDBContext")
TypeError: context is not a SOMATileDBContext
```

This baffled me for a while since I was clearly setting `context` to be a `tiledbsoma.SOMATileDBContext`.

Only on debugging and inserting a print of `type(context)` did I see my error.

We need to automate that helpfulness here.

**Changes:**

Now it prints:

```
  File "/Users/kerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py", line 377, in _validate_soma_tiledb_context
    raise TypeError(f"context is not a SOMATileDBContext: got {type(context)}")
TypeError: context is not a SOMATileDBContext: got <class 'tuple'>
```
**Notes for Reviewer:**

