### PR TITLE
[python] Change `from_visium` to create `obs` presence matrix by default

### DIFF
--- a/apis/python/notebooks/tutorial_spatial.ipynb
+++ b/apis/python/notebooks/tutorial_spatial.ipynb
@@ -158,7 +158,15 @@
    "execution_count": 6,
    "id": "e27b622a-a1d0-40c2-bea7-cc9a9bc80596",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma exists; skipping 10x data download\n"
+     ]
+    }
+   ],
    "source": [
     "paths = {\n",
     "    filtered_h5: 'filtered_feature_bc_matrix.h5',\n",
@@ -186,17 +194,7 @@
    "execution_count": 7,
    "id": "f8f71d9d-cdaf-4b9f-81f8-39473e930a7e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Ingesting data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/10x to data/CytAssist_FFPE_Protein_Expression_Human_Glioblastoma/soma\n",
-      "/tmp/ipykernel_281835/2080821725.py:3: UserWarning: Support for spatial types is experimental. Changes to both the API and data storage may not be backwards compatible.\n",
-      "  from_visium(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if not exists(exp_uri):\n",
     "    err(f\"Ingesting {data_dir_10x} to {exp_uri}\")\n",
@@ -557,7 +555,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0xffb1482f7f20>"
+       "<matplotlib.image.AxesImage at 0xff6b402b8560>"
       ]
      },
      "execution_count": 19,
@@ -1190,7 +1188,7 @@
     {
      "data": {
       "text/plain": [
-       "SpatialRead(data=<tiledbsoma._read_iters.TableReadIter object at 0xffb12c6c5640>, data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), coordinate_transform=<IdentityTransform\n",
+       "SpatialRead(data=<tiledbsoma._read_iters.TableReadIter object at 0xff6afc7015e0>, data_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), output_coordinate_space=CoordinateSpace(axes=(Axis(name='x', unit='pixels'), Axis(name='y', unit='pixels'))), coordinate_transform=<IdentityTransform\n",
        "  input axes: ('x', 'y')\n",
        "  output axes: ('x', 'y')>)"
       ]

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -268,7 +268,7 @@ def from_visium(
     uns_keys: Sequence[str] | None = None,
     additional_metadata: "AdditionalMetadata" = None,
     use_raw_counts: bool = False,
-    write_obs_spatial_presence: bool = False,
+    write_obs_spatial_presence: bool = True,
     write_var_spatial_presence: bool = False,
 ) -> str:
     """Reads a 10x Visium dataset and writes it to an :class:`Experiment`.
@@ -375,7 +375,7 @@ def from_visium(
             not a ``VisiumPaths`` object. Defaults to ``False``.
 
         write_obs_spatial_presence: If ``True`` create and write data to the ``obs``
-            presence matrix. Defaults to ``False``.
+            presence matrix. Defaults to ``True``.
 
         write_var_spatial_presence: If ``True`` create and write data to the ``var``
             presence matrix. Defaults to ``False``.


### PR DESCRIPTION
**Issue and/or context:** [sc-61587](https://app.shortcut.com/tiledb-inc/story/61587/enable-obs-presence-matrix-by-default-in-visium-ingestor)

**Changes:** 
Change the `from_visium` ingestor to create the `obs` presence matrix by default. A presence matrix is required for exporting to SpatialData from a `ExperimentAxisQuery`.


