### PR TITLE
[python] Make `region_key` a categorical when exporting to SpatialData

### DIFF
--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -752,6 +752,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
                         "Unable to export to SpatialData; exported assets have "
                         "overlapping observations."
                     ) from err
+                ad.obs["region_key"] = pd.Categorical(ad.obs["region_key"])
                 regions = list(region_joinids.keys())
                 region_key = "region_key"
                 instance_key = "instance_key"


### PR DESCRIPTION
**Issue and/or context:** [sc-61662](https://app.shortcut.com/tiledb-inc/story/61662/convert-the-spatialdata-region-key-column-to-a-categorical)

**Changes:**
SpatialData expects the "region_key" column in the `obs` dataframe to be a categorical. This makes that change.

