### PR TITLE
[r] [CI] Use binaries for packages on macOS

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -88,6 +88,10 @@ jobs:
       #  if: ${{ matrix.os != 'macOS-latest' }}
       #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
 
+      - name: R Package Type (macOS)
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"
+
       - name: Dependencies
         run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
 

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -52,7 +52,7 @@ LinkingTo:
     RcppSpdlog (>= 0.0.19),
     RcppInt64,
     nanoarrow
-Additional_repositories: https://ghrr.github.io/drat
+Additional_repositories: https://tiledb-inc.r-universe.dev
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Suggests:


### PR DESCRIPTION
Configure R on macOS CI to use package binaries instead of sources. Also adjust the `Additional_repositories` field of `DESCRIPTION` to fetch package binaries for data packages

[SC-62227](https://app.shortcut.com/tiledb-inc/story/62227) 
resolves #3590