### PR TITLE
[python] Fix rendering of spatial docs

### DIFF
--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -24,4 +24,5 @@ Features:
 
    python-tiledbsoma
    python-tiledbsoma-io
+   python-tiledbsoma-io-spatial
    python-tiledbsoma-logging

--- a/doc/source/python-tiledbsoma-io-spatial.rst
+++ b/doc/source/python-tiledbsoma-io-spatial.rst
@@ -3,7 +3,7 @@ The tiledbsoma.io.spatial module
 
 .. currentmodule:: tiledbsoma.io.spatial
 
-.. automodule:: tiledbsoma.io
+.. automodule:: tiledbsoma.io.spatial
 
 Functions
 ---------
@@ -16,4 +16,4 @@ Functions
 
 
     tiledbsoma.io.spatial.from_visium
-    tiledbsoma.io.to_spatialdata
+    tiledbsoma.io.spatial.to_spatialdata


### PR DESCRIPTION
**Issue and/or context:** I didn't adequately test #3595. The `readthedocs` build https://app.readthedocs.org/projects/tiledbsoma/builds/26926597/ failed.

**Changes:**

**Notes for Reviewer:**

In the repo base directory, on this PR's branch, I ran

```
./doc/sandbox-gen.sh
./doc/sandbox-open.sh
```

and then looked at the changes in the browser window that opened up.