### PR TITLE
[python] Iterate on spatial + readthedocs

### DIFF
--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -8,6 +8,7 @@ pandoc==2.3
 pybind11==2.12.0
 setuptools==75.1.0
 setuptools-scm==8.1.0
+spatialdata==0.2.6
 sphinx==7.3.7
 sphinxcontrib-jquery==4.1
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
**Issue and/or context:** #3606 was nice, but, readthedocs failed at https://app.readthedocs.org/projects/tiledbsoma/builds/26927429/ with

```
/home/docs/checkouts/readthedocs.org/user_builds/tiledbsoma/checkouts/latest/apis/python/src/tiledbsoma/io/spatial/outgest.py:16: UserWarning: Experimental spatial outgestor requires the spatialdata package.
  warnings.warn("Experimental spatial outgestor requires the spatialdata package.")
WARNING: Failed to import tiledbsoma.io.spatial.
...
* ModuleNotFoundError: No module named 'spatialdata'
* AttributeError: module 'tiledbsoma.io' has no attribute 'spatial'
...
```

**Changes:**

Add in the `spatialdata` dependency to `doc/requirements_doc.txt`

**Notes for Reviewer:**

