### PR TITLE
[python] More readthedocs fixes for spatial

### DIFF
--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -1,4 +1,5 @@
 #include <exception>
+#include <span>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/doc/build.sh
+++ b/doc/build.sh
@@ -65,7 +65,7 @@ fi
 if [ -n "$reinstall" ] || [ -n "$made_venv" ]; then
   pip install -r doc/requirements_doc.txt || die "could not install doc dependencies"
   pushd "$ext_dir"
-  pip install -e . || die "could not install tiledbsoma-py"
+  pip install -e '.[spatial]' || die "could not install tiledbsoma-py"
   popd
 fi
 

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -1,5 +1,6 @@
 breathe==4.35.0
 cmake==3.29.2
+dask==2024.9.0
 docutils==0.20.1
 ipython==8.24.0
 jinja2==3.1.5

--- a/doc/source/python-tiledbsoma-dataframe.rst
+++ b/doc/source/python-tiledbsoma-dataframe.rst
@@ -43,8 +43,6 @@
       ~DataFrame.index_column_names
 
       ~DataFrame.count
-      ~DataFrame.shape
-      ~DataFrame.maxshape
       ~DataFrame.domain
       ~DataFrame.maxdomain
       ~DataFrame.tiledbsoma_has_upgraded_domain

--- a/doc/source/python-tiledbsoma-densendarray.rst
+++ b/doc/source/python-tiledbsoma-densendarray.rst
@@ -38,7 +38,6 @@
       ~DenseNDArray.is_sparse
 
       ~DenseNDArray.ndim
-      ~DenseNDArray.nnz
       ~DenseNDArray.shape
       ~DenseNDArray.maxshape
       ~DenseNDArray.tiledbsoma_has_upgraded_shape


### PR DESCRIPTION
**Issue and/or context:** https://app.readthedocs.org/projects/tiledbsoma/builds/26936488/ is now green

**Changes:**

* `pip install '.[spatial]'` since this isn't included by default
* Extra simon-says downpin in `doc/requirements_doc.txt`
* Get rid of a few warnings I saw in sandbox doc-build

**Notes for Reviewer:**

