### PR TITLE
[c++] Make `SOMAColumn` metadata required only for `GeometryDataframe`

### DIFF
--- a/apis/r/tests/testthat/test-04-TileDBArray.R
+++ b/apis/r/tests/testthat/test-04-TileDBArray.R
@@ -33,7 +33,7 @@ test_that("TileDBArray helper functions", {
   tdba$open(mode = "READ", internal_use_only = "allowed_use")
   expect_equal(tdba$get_metadata(key = "int_column"), "float_column")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
-  expect_equal(length(tdba$get_metadata()), 3)
+  expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
 
   # The SOMA spec requires the ability to read back metadata even when the
@@ -41,7 +41,7 @@ test_that("TileDBArray helper functions", {
   tdba$open(mode = "WRITE", internal_use_only = "allowed_use")
   expect_equal(tdba$get_metadata(key = "int_column"), "float_column")
   expect_equal(tdba$get_metadata(key = "string_column"), "qux")
-  expect_equal(length(tdba$get_metadata()), 3)
+  expect_equal(length(tdba$get_metadata()), 2)
   tdba$close()
 
   ## shape

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -46,7 +46,7 @@ void SOMAArray::create(
     std::string_view uri,
     ArraySchema schema,
     std::string_view soma_type,
-    std::string_view soma_schema,
+    std::optional<std::string_view> soma_schema,
     std::optional<TimestampRange> timestamp) {
     Array::create(std::string(uri), schema);
 
@@ -75,11 +75,13 @@ void SOMAArray::create(
         static_cast<uint32_t>(ENCODING_VERSION_VAL.length()),
         ENCODING_VERSION_VAL.c_str());
 
-    array->put_metadata(
-        TDB_SOMA_SCHEMA_KEY,
-        TILEDB_STRING_UTF8,
-        static_cast<uint32_t>(soma_schema.length()),
-        soma_schema.data());
+    if (soma_schema.has_value()) {
+        array->put_metadata(
+            TDB_SOMA_SCHEMA_KEY,
+            TILEDB_STRING_UTF8,
+            static_cast<uint32_t>(soma_schema->length()),
+            soma_schema->data());
+    }
 }
 
 std::unique_ptr<SOMAArray> SOMAArray::open(
@@ -218,79 +220,47 @@ void SOMAArray::fill_metadata_cache(std::optional<TimestampRange> timestamp) {
 }
 
 void SOMAArray::fill_columns() {
+    // Clear columns in case of reopen
     columns_.clear();
 
-    bool generate_metadata = false;
+    if (type().value_or("") == "SOMAGeometryDataFrame") {
+        if (!has_metadata(TDB_SOMA_SCHEMA_KEY)) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAArray][fill_columns] Missing required metadata key '{}' "
+                "from SOMAGeometryDataFrame '{}'",
+                TDB_SOMA_SCHEMA_KEY,
+                uri()));
+        }
 
-    if (!has_metadata(TDB_SOMA_SCHEMA_KEY)) {
-        LOG_DEBUG(std::format(
-            "[SOMAArray][fill_columns] Missing '{}' metadata key",
-            TDB_SOMA_SCHEMA_KEY));
-
-        generate_metadata = true;
-    } else {
         auto soma_schema_extension_raw = get_metadata(TDB_SOMA_SCHEMA_KEY)
                                              .value();
         auto data = static_cast<const char*>(
-            std::get<const void*>(soma_schema_extension_raw));
+            std::get<2>(soma_schema_extension_raw));
         auto soma_schema_extension = data != nullptr ?
                                          nlohmann::json::parse(std::string(
                                              data,
-                                             std::get<uint32_t>(
+                                             std::get<1>(
                                                  soma_schema_extension_raw))) :
                                          nlohmann::json::object();
 
         if (!soma_schema_extension.contains(TDB_SOMA_SCHEMA_COL_KEY)) {
-            LOG_DEBUG(std::format(
+            throw TileDBSOMAError(std::format(
                 "[SOMAArray][fill_columns] Missing '{}' key from '{}'",
                 TDB_SOMA_SCHEMA_COL_KEY,
                 TDB_SOMA_SCHEMA_KEY));
-
-            generate_metadata = true;
-        } else {
-            columns_ = SOMAColumn::deserialize(
-                soma_schema_extension.value(
-                    TDB_SOMA_SCHEMA_COL_KEY, nlohmann::json::array()),
-                *ctx_->tiledb_ctx(),
-                *arr_);
         }
-    }
 
-    if (generate_metadata) {
+        columns_ = SOMAColumn::deserialize(
+            soma_schema_extension.value(
+                TDB_SOMA_SCHEMA_COL_KEY, nlohmann::json::array()),
+            *ctx_->tiledb_ctx(),
+            *arr_);
+
+    } else {
+        // Non geometry dataframes have trivially constructible columns and do
+        // not require a schema
         columns_ = SOMAColumn::deserialize(
             nlohmann::json::array(), *ctx_->tiledb_ctx(), *arr_);
-
-        if (mode() == OpenMode::write) {
-            LOG_DEBUG(std::format(
-                "[SOMAArray][fill_columns] Generating '{}' metadata for "
-                "existing "
-                "array '{}'",
-                TDB_SOMA_SCHEMA_KEY,
-                uri()));
-
-            nlohmann::json soma_schema_extension = {
-                {TDB_SOMA_SCHEMA_COL_KEY, nlohmann::json::array()},
-                {"version", TDB_SOMA_SCHEMA_VERSION},
-            };
-
-            std::for_each(
-                columns_.cbegin(),
-                columns_.cend(),
-                [&soma_schema_extension](
-                    const std::shared_ptr<SOMAColumn>& column) {
-                    column->serialize(
-                        soma_schema_extension[TDB_SOMA_SCHEMA_COL_KEY]);
-                });
-
-            LOG_DEBUG("[SOMAArray][fill_columns] Writing generated metadata");
-
-            auto soma_schema_extension_str = soma_schema_extension.dump();
-            arr_->put_metadata(
-                TDB_SOMA_SCHEMA_KEY,
-                TILEDB_STRING_UTF8,
-                soma_schema_extension_str.length(),
-                soma_schema_extension_str.c_str());
-        }
     }
 }
 

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -113,7 +113,7 @@ class SOMAArray : public SOMAObject {
         std::string_view uri,
         ArraySchema schema,
         std::string_view soma_type,
-        std::string_view soma_schema,
+        std::optional<std::string_view> soma_schema = std::nullopt,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -57,12 +57,7 @@ void SOMADataFrame::create(
             true,
             platform_config);
     SOMAArray::create(
-        ctx,
-        uri,
-        tiledb_schema,
-        "SOMADataFrame",
-        soma_schema_extension.dump(),
-        timestamp);
+        ctx, uri, tiledb_schema, "SOMADataFrame", std::nullopt, timestamp);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -89,12 +89,7 @@ void SOMADenseNDArray::create(
             platform_config);
 
     SOMAArray::create(
-        ctx,
-        uri,
-        tiledb_schema,
-        "SOMADenseNDArray",
-        soma_schema_extension.dump(),
-        timestamp);
+        ctx, uri, tiledb_schema, "SOMADenseNDArray", std::nullopt, timestamp);
 }
 
 std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -59,7 +59,7 @@ void SOMAPointCloudDataFrame::create(
         uri,
         tiledb_schema,
         "SOMAPointCloudDataFrame",
-        soma_schema_extension.dump(),
+        std::nullopt,
         timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -90,12 +90,7 @@ void SOMASparseNDArray::create(
             platform_config);
 
     SOMAArray::create(
-        ctx,
-        uri,
-        tiledb_schema,
-        "SOMASparseNDArray",
-        soma_schema_extension.dump(),
-        timestamp);
+        ctx, uri, tiledb_schema, "SOMASparseNDArray", std::nullopt, timestamp);
 }
 
 std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -92,7 +92,12 @@ std::tuple<std::string, uint64_t> create_array(
 
     // Create array
     SOMAArray::create(
-        ctx, uri, std::move(schema), "NONE", "", TimestampRange(0, 2));
+        ctx,
+        uri,
+        std::move(schema),
+        "NONE",
+        std::nullopt,
+        TimestampRange(0, 2));
 
     uint64_t nnz = num_fragments * num_cells_per_fragment;
 
@@ -386,7 +391,7 @@ TEST_CASE("SOMAArray: metadata") {
 
     // Read metadata
     soma_array->open(OpenMode::read, TimestampRange(0, 2));
-    REQUIRE(soma_array->metadata_num() == 4);
+    REQUIRE(soma_array->metadata_num() == 3);
     REQUIRE(soma_array->has_metadata("soma_object_type"));
     REQUIRE(soma_array->has_metadata("soma_encoding_version"));
     REQUIRE(soma_array->has_metadata("md"));
@@ -398,7 +403,7 @@ TEST_CASE("SOMAArray: metadata") {
 
     // md should not be available at (2, 2)
     soma_array->open(OpenMode::read, TimestampRange(2, 2));
-    REQUIRE(soma_array->metadata_num() == 3);
+    REQUIRE(soma_array->metadata_num() == 2);
     REQUIRE(soma_array->has_metadata("soma_object_type"));
     REQUIRE(soma_array->has_metadata("soma_encoding_version"));
     REQUIRE(!soma_array->has_metadata("md"));
@@ -406,7 +411,7 @@ TEST_CASE("SOMAArray: metadata") {
 
     // Metadata should also be retrievable in write mode
     soma_array->open(OpenMode::write, TimestampRange(0, 2));
-    REQUIRE(soma_array->metadata_num() == 4);
+    REQUIRE(soma_array->metadata_num() == 3);
     REQUIRE(soma_array->has_metadata("soma_object_type"));
     REQUIRE(soma_array->has_metadata("soma_encoding_version"));
     REQUIRE(soma_array->has_metadata("md"));
@@ -422,7 +427,7 @@ TEST_CASE("SOMAArray: metadata") {
     // Confirm delete in read mode
     soma_array->open(OpenMode::read, TimestampRange(0, 2));
     REQUIRE(!soma_array->has_metadata("md"));
-    REQUIRE(soma_array->metadata_num() == 3);
+    REQUIRE(soma_array->metadata_num() == 2);
 }
 
 TEST_CASE("SOMAArray: Test buffer size") {

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -388,7 +388,7 @@ TEST_CASE_METHOD(
 
     // Read metadata
     sdf->open(OpenMode::read, TimestampRange(0, 2));
-    REQUIRE(sdf->metadata_num() == 4);
+    REQUIRE(sdf->metadata_num() == 3);
     REQUIRE(sdf->has_metadata("soma_object_type"));
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
     REQUIRE(sdf->has_metadata("md"));
@@ -400,7 +400,7 @@ TEST_CASE_METHOD(
 
     // md should not be available at (0, 1)
     sdf->open(OpenMode::read, TimestampRange(0, 1));
-    REQUIRE(sdf->metadata_num() == 3);
+    REQUIRE(sdf->metadata_num() == 2);
     REQUIRE(sdf->has_metadata("soma_object_type"));
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
     REQUIRE(!sdf->has_metadata("md"));
@@ -408,7 +408,7 @@ TEST_CASE_METHOD(
 
     // Metadata should also be retrievable in write mode
     sdf->open(OpenMode::write);
-    REQUIRE(sdf->metadata_num() == 4);
+    REQUIRE(sdf->metadata_num() == 3);
     REQUIRE(sdf->has_metadata("soma_object_type"));
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
     REQUIRE(sdf->has_metadata("md"));
@@ -424,7 +424,7 @@ TEST_CASE_METHOD(
     // Confirm delete in read mode
     sdf->open(OpenMode::read);
     REQUIRE(!sdf->has_metadata("md"));
-    REQUIRE(sdf->metadata_num() == 3);
+    REQUIRE(sdf->metadata_num() == 2);
 }
 
 TEST_CASE_METHOD(

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -180,7 +180,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
 
     // Read metadata
     dnda->open(OpenMode::read, TimestampRange(0, 2));
-    REQUIRE(dnda->metadata_num() == 4);
+    REQUIRE(dnda->metadata_num() == 3);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
     REQUIRE(dnda->has_metadata("md"));
@@ -192,7 +192,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
 
     // md should not be available at (0, 1)
     dnda->open(OpenMode::read, TimestampRange(0, 1));
-    REQUIRE(dnda->metadata_num() == 3);
+    REQUIRE(dnda->metadata_num() == 2);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
     REQUIRE(!dnda->has_metadata("md"));
@@ -200,7 +200,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
 
     // Metadata should also be retrievable in write mode
     dnda->open(OpenMode::write);
-    REQUIRE(dnda->metadata_num() == 4);
+    REQUIRE(dnda->metadata_num() == 3);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
     REQUIRE(dnda->has_metadata("md"));
@@ -216,5 +216,5 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     // Confirm delete in read mode
     dnda->open(OpenMode::read);
     REQUIRE(!dnda->has_metadata("md"));
-    REQUIRE(dnda->metadata_num() == 3);
+    REQUIRE(dnda->metadata_num() == 2);
 }

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -239,7 +239,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
 
     // Read metadata
     snda->open(OpenMode::read, TimestampRange(0, 2));
-    REQUIRE(snda->metadata_num() == 4);
+    REQUIRE(snda->metadata_num() == 3);
     REQUIRE(snda->has_metadata("soma_object_type"));
     REQUIRE(snda->has_metadata("soma_encoding_version"));
     REQUIRE(snda->has_metadata("md"));
@@ -251,7 +251,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
 
     // md should not be available at (0, 1)
     snda->open(OpenMode::read, TimestampRange(0, 1));
-    REQUIRE(snda->metadata_num() == 3);
+    REQUIRE(snda->metadata_num() == 2);
     REQUIRE(snda->has_metadata("soma_object_type"));
     REQUIRE(snda->has_metadata("soma_encoding_version"));
     REQUIRE(!snda->has_metadata("md"));
@@ -259,7 +259,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
 
     // Metadata should also be retrievable in write mode
     snda->open(OpenMode::write);
-    REQUIRE(snda->metadata_num() == 4);
+    REQUIRE(snda->metadata_num() == 3);
     REQUIRE(snda->has_metadata("soma_object_type"));
     REQUIRE(snda->has_metadata("soma_encoding_version"));
     REQUIRE(snda->has_metadata("md"));
@@ -269,7 +269,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     // Delete and have it reflected when reading metadata while in write mode
     snda->delete_metadata("md");
     REQUIRE(!snda->has_metadata("md"));
-    REQUIRE(snda->metadata_num() == 3);
+    REQUIRE(snda->metadata_num() == 2);
     mdval = snda->get_metadata("md");
     REQUIRE(!mdval.has_value());
     snda->close();
@@ -277,7 +277,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     // Confirm delete in read mode
     snda->open(OpenMode::read);
     REQUIRE(!snda->has_metadata("md"));
-    REQUIRE(snda->metadata_num() == 3);
+    REQUIRE(snda->metadata_num() == 2);
 }
 
 TEST_CASE(


### PR DESCRIPTION
**Issue and/or context:**
Remove the requirement for additional metadata to reconstruct `SOMAColumn` list from all `SOMAArray` derived classes except `GeometryDataframe`. Also removed automatic metadata reconstruction since a `GeometryDataframe` should always have associated metadata.

**Changes:**

**Notes for Reviewer:**

