### PR TITLE
[c++] Push-down spatial metadata in the `MultiscaleImage` class from Python to C++

### DIFF
--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -29,7 +29,6 @@ from ._arrow_types import carrow_type_to_pyarrow, pyarrow_to_carrow_type
 from ._constants import (
     SOMA_COORDINATE_SPACE_METADATA_KEY,
     SOMA_MULTISCALE_IMAGE_SCHEMA,
-    SOMA_SPATIAL_ENCODING_VERSION,
     SOMA_SPATIAL_VERSION_METADATA_KEY,
     SPATIAL_DISCLAIMER,
 )
@@ -172,8 +171,12 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         context = _validate_soma_tiledb_context(context)
 
         # Create the coordinate space.
-        if not isinstance(coordinate_space, CoordinateSpace):
-            coordinate_space = CoordinateSpace.from_axis_names(coordinate_space)
+        if isinstance(coordinate_space, CoordinateSpace):
+            axis_names = tuple(axis.name for axis in coordinate_space)
+            axis_units = tuple(axis.unit for axis in coordinate_space)
+        else:
+            axis_names = tuple(coordinate_space)
+            axis_units = tuple(len(axis_names) * [None])
 
         ndim = len(coordinate_space)
         if has_channel_axis:
@@ -191,9 +194,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         if data_axis_order is None:
             axis_permutation = tuple(range(ndim - 1, -1, -1))
         else:
-            axis_indices = {
-                name: index for index, name in enumerate(coordinate_space.axis_names)
-            }
+            axis_indices = {name: index for index, name in enumerate(axis_names)}
             if has_channel_axis:
                 axis_indices["soma_channel"] = len(coordinate_space)
             if set(data_axis_order) != set(axis_indices.keys()):
@@ -213,22 +214,19 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         )
 
         _image_meta_str = image_meta.to_json()
-        coord_space_str = coordinate_space_to_json(coordinate_space)
         try:
             timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
             clib.SOMAMultiscaleImage.create(
                 uri=uri,
+                axis_names=axis_names,
+                axis_units=axis_units,
                 ctx=context.native_context,
                 timestamp=(0, timestamp_ms),
             )
             handle = _tdb_handles.MultiscaleImageWrapper.open(
                 uri, "w", context, tiledb_timestamp
             )
-            handle.metadata[SOMA_SPATIAL_VERSION_METADATA_KEY] = (
-                SOMA_SPATIAL_ENCODING_VERSION
-            )
             handle.metadata[SOMA_MULTISCALE_IMAGE_SCHEMA] = _image_meta_str
-            handle.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coord_space_str
             multiscale = cls(
                 handle,
                 _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -216,9 +216,8 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         coord_space_str = coordinate_space_to_json(coordinate_space)
         try:
             timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
-            clib.SOMAGroup.create(
+            clib.SOMAMultiscaleImage.create(
                 uri=uri,
-                soma_type=somacore.MultiscaleImage.soma_type,
                 ctx=context.native_context,
                 timestamp=(0, timestamp_ms),
             )

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -80,8 +80,8 @@ void load_soma_collection(py::module& m) {
             "create",
             [](std::shared_ptr<SOMAContext> ctx,
                std::string_view uri,
-               std::optional<std::vector<std::string>> axis_names,
-               std::optional<std::vector<std::optional<std::string>>>
+               const std::optional<std::vector<std::string>>& axis_names,
+               const std::optional<std::vector<std::optional<std::string>>>&
                    axis_units,
                std::optional<TimestampRange> timestamp) {
                 if (axis_units.has_value() && !axis_names.has_value()) {

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -122,6 +122,21 @@ void load_soma_collection(py::module& m) {
     py::class_<SOMAMultiscaleImage, SOMACollection, SOMAGroup, SOMAObject>(
         m, "SOMAMultiscaleImage")
         .def_static(
+            "create",
+            [](std::shared_ptr<SOMAContext> ctx,
+               std::string_view uri,
+               std::optional<TimestampRange> timestamp) {
+                try {
+                    SOMAMultiscaleImage::create(uri, ctx, timestamp);
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
+            py::kw_only(),
+            "ctx"_a,
+            "uri"_a,
+            "timestamp"_a = py::none())
+        .def_static(
             "open",
             &SOMAMultiscaleImage::open,
             "uri"_a,

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -125,9 +125,13 @@ void load_soma_collection(py::module& m) {
             "create",
             [](std::shared_ptr<SOMAContext> ctx,
                std::string_view uri,
+               const std::vector<std::string>& axis_names,
+               const std::vector<std::optional<std::string>>& axis_units,
                std::optional<TimestampRange> timestamp) {
+                SOMACoordinateSpace coord_space{axis_names, axis_units};
                 try {
-                    SOMAMultiscaleImage::create(uri, ctx, timestamp);
+                    SOMAMultiscaleImage::create(
+                        uri, ctx, coord_space, timestamp);
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }
@@ -135,6 +139,8 @@ void load_soma_collection(py::module& m) {
             py::kw_only(),
             "ctx"_a,
             "uri"_a,
+            "axis_names"_a,
+            "axis_units"_a,
             "timestamp"_a = py::none())
         .def_static(
             "open",

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -31,7 +31,7 @@ void SOMAMultiscaleImage::create(
         auto group = SOMAGroup::create(
             ctx, image_uri.string(), "SOMAMultiscaleImage", timestamp);
 
-        // Set spatial encoding metadata.
+        // Set spatial-encoding metadata.
         group->set_metadata(
             SPATIAL_ENCODING_VERSION_KEY,
             TILEDB_STRING_UTF8,

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -24,11 +24,30 @@ using namespace tiledb;
 void SOMAMultiscaleImage::create(
     std::string_view uri,
     std::shared_ptr<SOMAContext> ctx,
+    const SOMACoordinateSpace& coordinate_space,
     std::optional<TimestampRange> timestamp) {
     try {
         std::filesystem::path image_uri(uri);
-        SOMAGroup::create(
+        auto group = SOMAGroup::create(
             ctx, image_uri.string(), "SOMAMultiscaleImage", timestamp);
+
+        // Set spatial encoding metadata.
+        group->set_metadata(
+            SPATIAL_ENCODING_VERSION_KEY,
+            TILEDB_STRING_UTF8,
+            static_cast<uint32_t>(SPATIAL_ENCODING_VERSION_VAL.size()),
+            SPATIAL_ENCODING_VERSION_VAL.c_str(),
+            true);
+
+        // Set coordinate space metadata.
+        const auto coord_space_metadata = coordinate_space.to_string();
+        group->set_metadata(
+            SOMA_COORDINATE_SPACE_KEY,
+            TILEDB_STRING_UTF8,
+            static_cast<uint32_t>(coord_space_metadata.size()),
+            coord_space_metadata.c_str(),
+            true);
+
     } catch (TileDBError& e) {
         throw TileDBSOMAError(e.what());
     }

--- a/libtiledbsoma/src/soma/soma_multiscale_image.h
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.h
@@ -17,6 +17,7 @@
 #include <tiledb/tiledb>
 
 #include "soma_collection.h"
+#include "soma_coordinates.h"
 
 namespace tiledbsoma {
 
@@ -37,6 +38,7 @@ class SOMAMultiscaleImage : public SOMACollection {
     static void create(
         std::string_view uri,
         std::shared_ptr<SOMAContext> ctx,
+        const SOMACoordinateSpace& coordinate_space,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
@@ -76,10 +78,16 @@ class SOMAMultiscaleImage : public SOMACollection {
     SOMAMultiscaleImage(SOMAMultiscaleImage&&) = default;
     ~SOMAMultiscaleImage() = default;
 
+    inline const SOMACoordinateSpace& coordinate_space() const {
+        return coord_space_;
+    }
+
    private:
     //===================================================================
     //= private non-static
     //===================================================================
+
+    SOMACoordinateSpace coord_space_;
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/test/unit_soma_multiscale_image.cc
+++ b/libtiledbsoma/test/unit_soma_multiscale_image.cc
@@ -12,15 +12,17 @@
  */
 #include "common.h"
 
-TEST_CASE("SOMAMultiscaleImage: basic") {
+TEST_CASE("SOMAMultiscaleImage: basic", "[multiscale_image][spatial]") {
     auto ctx = std::make_shared<SOMAContext>();
     std::string uri = "mem://unit-test-multiscale-image-basic";
 
-    SOMAMultiscaleImage::create(uri, ctx, std::nullopt);
+    SOMACoordinateSpace coord_space{};
+    SOMAMultiscaleImage::create(uri, ctx, coord_space, std::nullopt);
     auto soma_image = SOMAMultiscaleImage::open(
         uri, OpenMode::read, ctx, std::nullopt);
     REQUIRE(soma_image->uri() == uri);
     REQUIRE(soma_image->ctx() == ctx);
     REQUIRE(soma_image->type() == "SOMAMultiscaleImage");
+    REQUIRE(soma_image->coordinate_space() == coord_space);
     soma_image->close();
 }


### PR DESCRIPTION
**Issue and/or context:** [sc-62102](https://app.shortcut.com/tiledb-inc/story/62102/push-down-spatial-metadata-in-the-multiscaleimage-class-from-python-to-c)

**Changes:**
Write the `MultiscaleImage` coordinate-space metadata and spatial-encoding metadata in the C++ layer instead of in Python. This leaves the `MultiscaleImageMetadata` properties to be addressed in a future PR.
