### PR TITLE
[python] Deprecate `result_order="auto"` for `DenseNDArray` reads

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -8,6 +8,7 @@ Implementation of SOMA DenseNDArray.
 
 from __future__ import annotations
 
+import warnings
 from typing import List, Sequence, Tuple, Union
 
 import numpy as np
@@ -190,7 +191,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 The coordinates for slicing the array.
             result_order:
                 Order of read results.
-                This can be one of 'row-major', 'col-major', or 'auto'.
+                This can be one of 'row-major' (default) or 'column-major'
             partitions:
                 An optional :class:`ReadPartitions` hint to indicate
                 how results should be organized.
@@ -219,6 +220,15 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         # The only exception is if the array has been created but no data have been written at
         # all, in which case the best we can do is use the schema shape.
         handle: clib.SOMADenseNDArray = self._handle._handle
+
+        if result_order == options.ResultOrder.AUTO:
+            warnings.warn(
+                "The use of 'result_order=\"auto\"' is deprecated and will be "
+                "removed in future versions. Please use 'row-order' (the default "
+                "if no option is provided) or 'col-order' instead.",
+                DeprecationWarning,
+            )
+            result_order = somacore.ResultOrder.ROW_MAJOR
 
         ned = []
         for dim_name in handle.dimension_names:

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -203,7 +203,7 @@ def dense_indices_to_shape(
         dense_index_to_shape(coord, extent)
         for coord, extent in zip_longest(coords, array_shape)
     )
-    if result_order is somacore.ResultOrder.ROW_MAJOR:
+    if result_order == somacore.ResultOrder.ROW_MAJOR:
         return shape
     return tuple(reversed(shape))
 


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61920](https://app.shortcut.com/tiledb-inc/story/61920/python-densendarray-read-with-result-order-auto-returns-non-deterministic-result-order-and-default-behavior-is-undefined)]

**Changes:**

- Deprecate `auto` result order option for `DenseNDArray` reads
- By default, use row order
- Add test