### PR TITLE
[c++] Prohibit `soma_` prefix in axis names

### DIFF
--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -58,6 +58,11 @@ SOMACoordinateSpace::SOMACoordinateSpace(const std::vector<SOMAAxis>& axes)
     }
     std::unordered_set<std::string> axis_names;
     for (const auto& axis : axes_) {
+        if (axis.name.starts_with("soma_")) {
+            throw TileDBSOMAError(
+                "The name for coordinate space axes cannot start with "
+                "'soma_'.");
+        }
         axis_names.emplace(axis.name);
     }
     if (axes_.size() != axis_names.size()) {
@@ -79,6 +84,11 @@ SOMACoordinateSpace::SOMACoordinateSpace(
     }
     axes_.reserve(axis_names.size());
     for (const auto& name : axis_names) {
+        if (name.starts_with("soma_")) {
+            throw TileDBSOMAError(
+                "The name for coordinate space axes cannot start with "
+                "'soma_'.");
+        }
         axes_.push_back({name, std::nullopt});
     }
 }
@@ -102,6 +112,11 @@ SOMACoordinateSpace::SOMACoordinateSpace(
     }
     axes_.reserve(num_axes);
     for (size_t index{0}; index < num_axes; ++index) {
+        if (axis_names[index].starts_with("soma_")) {
+            throw TileDBSOMAError(
+                "The name for coordinate space axes cannot start with "
+                "'soma_'.");
+        }
         axes_.push_back({axis_names[index], axis_units[index]});
     }
 }

--- a/libtiledbsoma/test/unit_soma_coordinates.cc
+++ b/libtiledbsoma/test/unit_soma_coordinates.cc
@@ -20,9 +20,9 @@ TEST_CASE(
     std::vector<SOMAAxis> empty_axes_{};
     std::vector<std::string> empty_axis_names_{};
     std::vector<std::optional<std::string>> empty_axis_units_{};
-    REQUIRE_THROWS_AS(SOMACoordinateSpace(empty_axes_), TileDBSOMAError);
-    REQUIRE_THROWS_AS(SOMACoordinateSpace(empty_axis_names_), TileDBSOMAError);
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(SOMACoordinateSpace(empty_axes_), TileDBSOMAError);
+    CHECK_THROWS_AS(SOMACoordinateSpace(empty_axis_names_), TileDBSOMAError);
+    CHECK_THROWS_AS(
         SOMACoordinateSpace(empty_axis_names_, empty_axis_units_),
         TileDBSOMAError);
 
@@ -31,9 +31,9 @@ TEST_CASE(
         {"x_axis", "meter"}, {"x_axis", "nanometer"}};
     std::vector<std::string> repeat_axis_names_{"x_axis", "x_axis"};
     std::vector<std::optional<std::string>> repeat_axis_units_{};
-    REQUIRE_THROWS_AS(SOMACoordinateSpace(repeat_axes_), TileDBSOMAError);
-    REQUIRE_THROWS_AS(SOMACoordinateSpace(repeat_axis_names_), TileDBSOMAError);
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(SOMACoordinateSpace(repeat_axes_), TileDBSOMAError);
+    CHECK_THROWS_AS(SOMACoordinateSpace(repeat_axis_names_), TileDBSOMAError);
+    CHECK_THROWS_AS(
         SOMACoordinateSpace(repeat_axis_names_, repeat_axis_units_),
         TileDBSOMAError);
 
@@ -41,12 +41,21 @@ TEST_CASE(
     // sizes.
     std::vector<std::string> axis_names_len3_{"x", "y", "z"};
     std::vector<std::optional<std::string>> axis_units_len2_{"meter", "meter"};
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(
         SOMACoordinateSpace(axis_names_len3_, axis_units_len2_),
         TileDBSOMAError);
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(
         SOMACoordinateSpace(axis_names_len3_, empty_axis_units_),
         TileDBSOMAError);
+
+    // Check valid axis names.
+    std::vector<std::string> axis_names_reserved_{"x", "soma_y"};
+    std::vector<SOMAAxis> axis_reserved_{{"soma_x", "meter"}, {"y", "meter"}};
+    CHECK_THROWS_AS(SOMACoordinateSpace(axis_names_reserved_), TileDBSOMAError);
+    CHECK_THROWS_AS(
+        SOMACoordinateSpace(axis_names_reserved_, axis_units_len2_),
+        TileDBSOMAError);
+    CHECK_THROWS_AS(SOMACoordinateSpace(axis_reserved_), TileDBSOMAError);
 }
 
 TEST_CASE("SOMACoordinateSpace: compare constructors", "[metadata][spatial]") {


### PR DESCRIPTION
**Issue and/or context:** [sc-58926](https://app.shortcut.com/tiledb-inc/story/58926/prevent-coordinatespace-axis-name-from-starting-with-soma)

**Changes:**
Add a check in the C++ `SOMACoordinateSpace` constructor for axis names starting with 'soma_'.

