### PR TITLE
[r] Remove calls to `tiledb::tiledb_object_type()`

### DIFF
--- a/apis/r/tests/testthat/test-04-TileDBGroup.R
+++ b/apis/r/tests/testthat/test-04-TileDBGroup.R
@@ -23,7 +23,10 @@ test_that("Create empty", {
   expect_true(file.exists(file.path(uri, "__group")))
   expect_true(group$exists())
   fp <- file.path(uri, "__group")
-  expect_match(tiledb::tiledb_object_type(uri), "GROUP")
+  expect_match(
+    get_tiledb_object_type(group$uri, group$.__enclos_env__$private$.soma_context),
+    "GROUP"
+  )
   group$close()
 })
 

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -10,7 +10,13 @@ test_that("SOMACollection basics", {
   # Verify the empty collection is accessible and reads back as empty
   collection <- SOMACollectionOpen(uri)
   expect_true(dir.exists(uri))
-  expect_match(tiledb::tiledb_object_type(uri), "GROUP")
+  expect_match(
+    get_tiledb_object_type(
+      collection$uri,
+      collection$.__enclos_env__$private$.soma_context
+    ),
+    "GROUP"
+  )
   expect_true(collection$soma_type == "SOMACollection")
   expect_true(collection$exists())
   expect_equal(collection$length(), 0)

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -9,7 +9,13 @@ test_that("SOMADenseNDArray creation", {
   ndarray$close()
   ndarray <- SOMADenseNDArrayOpen(uri, "WRITE")
 
-  expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
+  expect_match(
+    get_tiledb_object_type(
+      ndarray$uri,
+      ndarray$.__enclos_env__$private$.soma_context
+    ),
+    "ARRAY"
+  )
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
   expect_equal(ndarray$attrnames(), "soma_data")
   expect_equal(tiledb::datatype(ndarray$attributes()$soma_data), "INT32")

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -3,7 +3,13 @@ test_that("SOMASparseNDArray creation", {
   uri <- tempfile(pattern = "sparse-ndarray")
   ndarray <- SOMASparseNDArrayCreate(uri, arrow::int32(), shape = c(10, 10))
 
-  expect_equal(tiledb::tiledb_object_type(uri), "ARRAY")
+  expect_match(
+    get_tiledb_object_type(
+      ndarray$uri,
+      ndarray$.__enclos_env__$private$.soma_context
+    ),
+    "ARRAY"
+  )
   expect_equal(ndarray$dimnames(), c("soma_dim_0", "soma_dim_1"))
 
   expect_equal(ndarray$attrnames(), "soma_data")

--- a/apis/r/tests/testthat/test-11-example-datasets.R
+++ b/apis/r/tests/testthat/test-11-example-datasets.R
@@ -7,7 +7,10 @@ test_that("example dataset access", {
   # Test that the dataset can be extracted
   dataset_uri <- extract_dataset("soma-exp-pbmc-small")
   expect_true(dir.exists(dataset_uri))
-  expect_equal(tiledb::tiledb_object_type(dataset_uri), "GROUP")
+  expect_match(
+    get_tiledb_object_type(dataset_uri, soma_context()),
+    "GROUP"
+  )
 
   # Test the datasets can be loaded
   exp <- load_dataset("soma-exp-pbmc-small")


### PR DESCRIPTION
Replace calls to `tiledb::tiledb_object_type()` with `get_tiledb_object_type()`

[SC-62778](https://app.shortcut.com/tiledb-inc/story/62778)

Note: this PR is not going into `main`, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r