### PR TITLE
[r] Remove calls to `tiledb::tiledb_version()`

### DIFF
--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -24,7 +24,10 @@ map_query_layout <- function(layout) {
 
 get_tiledb_version <- function(compact = FALSE) {
   stopifnot("'compact' must be TRUE or FALSE" = isTRUE(compact) || isFALSE(compact))
-  version <- tiledb_embedded_version()
+  version <- `names<-`(
+    tiledb_embedded_version(),
+    c("major", "minor", "patch")
+  )
   if (compact) {
     return(paste(version, collapse = "."))
   }

--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -22,6 +22,15 @@ map_query_layout <- function(layout) {
   )
 }
 
+get_tiledb_version <- function(compact = FALSE) {
+  stopifnot("'compact' must be TRUE or FALSE" = isTRUE(compact) || isFALSE(compact))
+  version <- tiledb_embedded_version()
+  if (compact) {
+    return(paste(version, collapse = "."))
+  }
+  return(version)
+}
+
 #' Display package versions
 #'
 #' Print version information for \pkg{tiledb} (R package), libtiledbsoma, and
@@ -32,7 +41,7 @@ map_query_layout <- function(layout) {
 show_package_versions <- function() {
   cat("tiledbsoma:    ", toString(utils::packageVersion("tiledbsoma")), "\n",
     "tiledb-r:      ", toString(utils::packageVersion("tiledb")), "\n",
-    "tiledb core:   ", as.character(tiledb::tiledb_version(compact = TRUE)), "\n",
+    "tiledb core:   ", as.character(get_tiledb_version(compact = TRUE)), "\n",
     "libtiledbsoma: ", libtiledbsoma_version(compact = TRUE), "\n",
     "R:             ", R.version.string, "\n",
     "OS:            ", utils::osVersion, "\n",

--- a/apis/r/R/zzz.R
+++ b/apis/r/R/zzz.R
@@ -8,7 +8,7 @@
   ## create a slot for somactx in per-package enviroment, do no fill it yet to allow 'lazy load'
   .pkgenv[["somactx"]] <- NULL
 
-  rpkg_lib <- tiledb::tiledb_version(compact = FALSE)
+  rpkg_lib <- get_tiledb_version(compact = FALSE)
   # Check major and minor but not micro: sc-50464
   rpkg_lib_version <- paste(rpkg_lib[["major"]], rpkg_lib[["minor"]], sep = ".")
   soma_lib_version <- libtiledbsoma_version(compact = TRUE, major_minor_only = TRUE)
@@ -27,7 +27,7 @@
   if (interactive()) {
     packageStartupMessage(
       "TileDB-SOMA R package ", packageVersion(pkgname),
-      " with TileDB Embedded ", format(tiledb::tiledb_version(TRUE)),
+      " with TileDB Embedded ", format(get_tiledb_version(TRUE)),
       " on ", utils::osVersion,
       ".\nSee https://github.com/single-cell-data for more information ",
       "about the SOMA project."

--- a/apis/r/tests/testthat/test-12-SOMAExperiment-query-base.R
+++ b/apis/r/tests/testthat/test-12-SOMAExperiment-query-base.R
@@ -193,7 +193,7 @@ test_that("query by value filters with enums", {
   # Test enum query with present and missing level
   core <- list(
     tiledbsoma = numeric_version(tiledbsoma:::libtiledbsoma_version(TRUE)),
-    tiledb.r = numeric_version(paste(tiledb::tiledb_version(), collapse = "."))
+    tiledb.r = numeric_version(paste(get_tiledb_version(), collapse = "."))
   )
   skip_if(
     any(vapply(core, \(x) x < "2.21", FUN.VALUE = logical(1L))),


### PR DESCRIPTION
Replace calls to `tiledb::tiledb_version()` with new helper function `get_tiledb_version()`; `get_tiledb_version()` wraps `tiledb_embedded_version()`, but adds a parameter `compact` to replicate the `compact = TRUE` mode of `tiledb::tiledb_version()`

[SC-62779](https://app.shortcut.com/tiledb-inc/story/62779)

Note: this PR is not going into `main`, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r