### PR TITLE
[python] Add missing `MultiscaleImage` methods to docs

### DIFF
--- a/doc/source/python-tiledbsoma-multiscaleimage.rst
+++ b/doc/source/python-tiledbsoma-multiscaleimage.rst
@@ -32,11 +32,15 @@
       ~MultiscaleImage.pop
       ~MultiscaleImage.popitem
 
-      ~MultiscaleImage.add_new_level
       ~MultiscaleImage.get_transform_from_level
       ~MultiscaleImage.get_transform_to_level
       ~MultiscaleImage.level_shape
+      ~MultiscaleImage.level_uri
+      ~MultiscaleImage.levels
+      ~MultiscaleImage.mro
       ~MultiscaleImage.read_spatial_region
+      ~MultiscaleImage.register
+      ~MultiscaleImage.add_new_level
 
    .. rubric:: Attributes
 
@@ -58,4 +62,3 @@
       ~MultiscaleImage.has_channel_axis
       ~MultiscaleImage.level_count
       ~MultiscaleImage.nchannels
-

--- a/doc/source/python-tiledbsoma-multiscaleimage.rst
+++ b/doc/source/python-tiledbsoma-multiscaleimage.rst
@@ -37,7 +37,7 @@
       ~MultiscaleImage.level_shape
       ~MultiscaleImage.level_uri
       ~MultiscaleImage.levels
-      ~MultiscaleImage.mro
+      ~MultiscaleImage.set
       ~MultiscaleImage.read_spatial_region
       ~MultiscaleImage.register
       ~MultiscaleImage.add_new_level


### PR DESCRIPTION
**Issue and/or context:** As found by @ivirshup 

**Changes:**

**Notes for Reviewer:**

We found on #3284 that manual curation of methods is required in order to obtain correct rendering.

