### PR TITLE
[python] Fix readback of some older-style metadata

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -235,7 +235,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
             results[py::str(key)] = py::array(value_type, value_num, value)
                                         .attr("item")(0);
         } else {
-            py::dtype value_type = tdb_to_np_dtype(tdb_type, 1);
+            py::dtype value_type = tdb_to_np_dtype(tdb_type, value_num);
             results[py::str(key)] = py::array(value_type, value_num, value)
                                         .attr("item")(0);
         }

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -220,7 +220,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
     for (auto [key, val] : metadata_mapping) {
         auto [tdb_type, value_num, value] = val;
 
-        if (tdb_type == TILEDB_STRING_UTF8) {
+        if (tdb_type == TILEDB_STRING_UTF8 || tdb_type == TILEDB_STRING_ASCII) {
             // Empty strings stored as nullptr have a value_num of 1 and a \x00
             // value
             if (value_num == 1 && value == nullptr) {


### PR DESCRIPTION
**Issue and/or context:** [sc-62798](https://app.shortcut.com/tiledb-inc/story/62798/metadata-reading-back-as-first-character-for-some-uris-as-of-tiledbsoma-1-15-4)

Bug introduced as of [TileDB-SOMA 1.15.4](https://github.com/single-cell-data/TileDB-SOMA/releases/tag/1.15.4) via PR #3607 which was the backport to the `release-1.15` branch of #3558.

**Changes:**

Metadata were raeding back incorrectly in the cases when their values' `tdb_type` was `TILEDB_STRING_ASCII` (11) rather than `TILEDB_STRING_UTF8` (12).

Note, however, that I ran the following test today:

* Write arrays using TileDB-SOMA 1.14.5, 1.15.0, 1.15.1, 1.15.2, 1.15.3, 1.15.4, and 1.15.5, pip-install each version
* Outer-loop over those same versions, pip-installing each one
  * Inner-loop over the arrays from above
  * Try using version `y` to read metadata written with version `x`
  * In all cases I could not get a fail

Another test:

* I read various old arrays I'd created 1, 3, 6 months ago, and could not repro the bug

In short, this occurs for _some_ arrays but not _all_ arrays. (All arrays tested in-house read back fine, with tiledbsoma 1.15.5).

**Notes for Reviewer:**

Uncertain how to test, given failure to repro with any of my historical or current data.

One idea:

* Hack tiledbsoma (in sandbox) to write metadata with value-type `TILEDB_STRING_ASCII`
* Create some data
* Save that off in the repo as canned data
* Run unit tests on that