### PR TITLE
[Backport release-1.15][c++] Simplify C++ copyright headers

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -1,3 +1,16 @@
+/**
+ * @file  common.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines common functions for the SOMA PyBind layer.
+ */
+
 #include "common.h"
 
 namespace tiledbsoma {

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -1,3 +1,16 @@
+/**
+ * @file  common.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines common functions for the SOMA PyBind layer.
+ */
+
 #include <exception>
 
 #include <pybind11/numpy.h>

--- a/apis/python/src/tiledbsoma/fastercsx.cc
+++ b/apis/python/src/tiledbsoma/fastercsx.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/query_condition.cc
+++ b/apis/python/src/tiledbsoma/query_condition.cc
@@ -5,29 +5,12 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *
- *   This file implements the TileDB-Py query condition.
+ * This file implements the TileDB-Py query condition.
  */
 
 #include "common.h"

--- a/apis/python/src/tiledbsoma/reindexer.cc
+++ b/apis/python/src/tiledbsoma/reindexer.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_collection.cc
+++ b/apis/python/src/tiledbsoma/soma_collection.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_context.cc
+++ b/apis/python/src/tiledbsoma/soma_context.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.Os
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_point_cloud_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_point_cloud_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -3,27 +3,9 @@
  *
  * @section LICENSE
  *
- * The MIT License
  *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/cmake/Modules/CheckAVX2Support.cmake
+++ b/libtiledbsoma/cmake/Modules/CheckAVX2Support.cmake
@@ -1,28 +1,8 @@
 #
 # CheckAVX2Support.cmake
 #
-#
-# The MIT License
-#
-# Copyright (c) 2018-2021 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Licensed under the MIT License.
+# Copyright (c) TileDB, Inc.
 #
 # This file defines a function to detect toolchain support for AVX2.
 #

--- a/libtiledbsoma/cmake/Modules/FindSpdlog_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindSpdlog_EP.cmake
@@ -1,28 +1,8 @@
 #
 # FindSpdlog_EP.cmake
 #
-#
-# The MIT License
-#
-# Copyright (c) 2018-2021 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Licensed under the MIT License.
+# Copyright (c) TileDB, Inc.
 #
 # Finds the Spdlog library, installing with an ExternalProject as necessary.
 # This module defines:

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -1,28 +1,8 @@
 #
 # FindTileDB_EP.cmake
 #
-#
-# The MIT License
-#
-# Copyright (c) 2018 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Licensed under the MIT License.
+# Copyright (c) TileDB, Inc.
 #
 # Finds the TileDB library, installing with an ExternalProject as necessary.
 

--- a/libtiledbsoma/cmake/Modules/TileDBCommon.cmake
+++ b/libtiledbsoma/cmake/Modules/TileDBCommon.cmake
@@ -1,28 +1,8 @@
 #
 # TileDBCommon.cmake
 #
-#
-# The MIT License
-#
-# Copyright (c) 2018 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Licensed under the MIT License.
+# Copyright (c) TileDB, Inc.
 #
 # This file defines some common helper functions used by the external projects.
 #
@@ -84,7 +64,7 @@ function(install_target_libs LIB_TARGET)
   if (TARGET_LIBRARIES MATCHES "NOTFOUND")
     message(FATAL_ERROR "Could not determine library location for ${LIB_TARGET}")
   endif()
-  
+
   get_filename_component(LIB_PATH ${TARGET_LIBRARIES} DIRECTORY)
   set(HEADERS_PATH ${LIB_PATH}/../include)
 
@@ -99,4 +79,3 @@ function(install_target_libs LIB_TARGET)
     install(FILES ${HEADERS_PATH}/tiledb_export.h DESTINATION include)
   endif()
 endfunction()
-

--- a/libtiledbsoma/cmake/Superbuild.cmake
+++ b/libtiledbsoma/cmake/Superbuild.cmake
@@ -1,28 +1,8 @@
 #
 # Superbuild.cmake
 #
-#
-# The MIT License
-#
-# Copyright (c) 2018-2021 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Licensed under the MIT License.
+# Copyright (c) TileDB, Inc.
 #
 
 include(ExternalProject)

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/external/include/thread_pool/producer_consumer_queue.h
+++ b/libtiledbsoma/src/external/include/thread_pool/producer_consumer_queue.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc.
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/external/include/thread_pool/thread_pool.h
+++ b/libtiledbsoma/src/external/include/thread_pool/thread_pool.h
@@ -5,25 +5,8 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc.
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/external/src/thread_pool/thread_pool.cc
+++ b/libtiledbsoma/src/external/src/thread_pool/thread_pool.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc.
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/reindexer/reindexer.cc
+++ b/libtiledbsoma/src/reindexer/reindexer.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/array_buffers.cc
+++ b/libtiledbsoma/src/soma/array_buffers.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *
@@ -42,5 +23,19 @@ enum class ResultOrder { automatic = 0, rowmajor, colmajor };
 
 /** Defines whether the SOMAGroup URI is absolute or relative */
 enum class URIType { automatic = 0, absolute, relative };
+
+typedef enum {
+    SOMA_COLUMN_DIMENSION = 0,
+    SOMA_COLUMN_ATTRIBUTE = 1,
+    SOMA_COLUMN_GEOMETRY = 2
+} soma_column_datatype_t;
+
+// This enables some code deduplication between core domain, core current
+// domain, and core non-empty domain.
+enum class Domainish {
+    kind_core_domain = 0,
+    kind_core_current_domain = 1,
+    kind_non_empty_domain = 2
+};
 
 #endif  // SOMA_ENUMS

--- a/libtiledbsoma/src/soma/logger_public.h
+++ b/libtiledbsoma/src/soma/logger_public.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -2,27 +2,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -1,0 +1,108 @@
+/**
+ * @file   soma_attribute.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAAttribute class.
+ */
+
+#include "soma_attribute.h"
+
+namespace tiledbsoma {
+std::shared_ptr<SOMAAttribute> SOMAAttribute::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(
+        ctx, schema, type_metadata, platform_config);
+
+    return std::make_shared<SOMAAttribute>(
+        SOMAAttribute(attribute.first, attribute.second));
+}
+
+void SOMAAttribute::_set_dim_points(
+    const std::unique_ptr<ManagedQuery>&,
+    const SOMAContext&,
+    const std::any&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_set_dim_points] Column with name {} is not an index "
+        "column",
+        name()));
+}
+
+void SOMAAttribute::_set_dim_ranges(
+    const std::unique_ptr<ManagedQuery>&,
+    const SOMAContext&,
+    const std::any&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_set_dim_ranges] Column with name {} is not an index "
+        "column",
+        name()));
+}
+
+void SOMAAttribute::_set_current_domain_slot(
+    NDRectangle&, std::span<const std::any>) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+}
+
+std::pair<bool, std::string> SOMAAttribute::_can_set_current_domain_slot(
+    std::optional<NDRectangle>&, std::span<const std::any>) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+};
+
+std::any SOMAAttribute::_core_domain_slot() const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_core_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
+}
+
+std::any SOMAAttribute::_non_empty_domain_slot(Array&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
+}
+
+std::any SOMAAttribute::_core_current_domain_slot(
+    const SOMAContext&, Array&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+}
+
+std::any SOMAAttribute::_core_current_domain_slot(NDRectangle&) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+        "an index column",
+        name()));
+}
+
+ArrowArray* SOMAAttribute::arrow_domain_slot(
+    const SOMAContext&, Array&, enum Domainish) const {
+    throw TileDBSOMAError(std::format(
+        "[SOMAAttribute][arrow_domain_slot] Column with name {} is not an "
+        "index column",
+        name()));
+}
+
+ArrowSchema* SOMAAttribute::arrow_schema_slot(
+    const SOMAContext& ctx, Array& array) {
+    return ArrowAdapter::arrow_schema_from_tiledb_attribute(
+               attribute, *ctx.tiledb_ctx(), array)
+        .release();
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -1,0 +1,131 @@
+/**
+ * @file   soma_attribute.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAAttribute class. SOMAAttribute extends SOMAColumn
+ * and wraps a TileDB Attribute and optionally an enumeration associated with
+ * the attribute. The purpose of this class is to provide a common interface
+ * identical to TileDB dimensions and composite columns.
+ */
+
+#ifndef SOMA_ATTRIBUTE_H
+#define SOMA_ATTRIBUTE_H
+
+#include <algorithm>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+class SOMAAttribute : public SOMAColumn {
+   public:
+    /**
+     * Create a ``SOMAAttribute`` shared pointer from an Arrow schema
+     */
+    static std::shared_ptr<SOMAAttribute> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMAAttribute(
+        Attribute attribute,
+        std::optional<Enumeration> enumeration = std::nullopt)
+        : attribute(attribute)
+        , enumeration(enumeration) {
+    }
+
+    inline std::string name() const override {
+        return attribute.name();
+    }
+
+    inline bool isIndexColumn() const override {
+        return false;
+    }
+
+    inline void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const override {
+        query->select_columns(std::vector({attribute.name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const override {
+        return soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
+        return std::nullopt;
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const override {
+        return attribute.type();
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
+        return std::vector({attribute});
+    }
+
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
+        if (!enumeration.has_value()) {
+            return std::nullopt;
+        }
+
+        return std::vector({enumeration.value()});
+    }
+
+    ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) override;
+
+   private:
+    void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& points) const override;
+
+    void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_current_domain_slot(
+        NDRectangle& rectangle,
+        std::span<const std::any> domain) const override;
+
+    std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const override;
+
+    std::any _core_domain_slot() const override;
+
+    std::any _non_empty_domain_slot(Array& array) const override;
+
+    std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
+
+    Attribute attribute;
+    std::optional<Enumeration> enumeration;
+};
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_collection.h
+++ b/libtiledbsoma/src/soma/soma_collection.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -1,0 +1,62 @@
+/**
+ * @file   soma_column.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAColumn class.
+ */
+
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+template <>
+std::pair<std::string, std::string> SOMAColumn::core_domain_slot<std::string>()
+    const {
+    return std::pair<std::string, std::string>("", "");
+}
+
+template <>
+std::pair<std::string, std::string>
+SOMAColumn::core_current_domain_slot<std::string>(
+    const SOMAContext& ctx, Array& array) const {
+    // Here is an intersection of a few oddities:
+    //
+    // * Core domain for string dims must be a nullptr pair; it cannot
+    // be
+    //   anything else.
+    // * TileDB-Py shows this by using an empty-string pair, which we
+    //   imitate.
+    // * Core current domain for string dims must _not_ be a nullptr
+    // pair.
+    // * In TileDB-SOMA, unless the user specifies otherwise, we use ""
+    // for
+    //   min and "\x7f" for max. (We could use "\x7f" but that causes
+    //   display problems in Python.)
+    //
+    // To work with all these factors, if the current domain is the
+    // default
+    // "" to "\x7f", return an empty-string pair just as we do for
+    // domain. (There was some pre-1.15 software using "\xff" and it's
+    // super-cheap to check for that as well.)
+    try {
+        std::pair<std::string, std::string>
+            current_domain = std::any_cast<std::pair<std::string, std::string>>(
+                _core_current_domain_slot(ctx, array));
+
+        if (current_domain.first == "" && (current_domain.second == "\x7f" ||
+                                           current_domain.second == "\xff")) {
+            return std::pair<std::string, std::string>("", "");
+        }
+
+        return current_domain;
+    } catch (const std::exception& e) {
+        throw TileDBSOMAError(e.what());
+    }
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -1,0 +1,496 @@
+/**
+ * @file   soma_column.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAColumn class. SOMAColumn is an abstraction over
+ * TileDB dimensions, attributes and combinations of them. It is designed to add
+ * indexing capabilities to any datatype utilizing native TileDB dimensions
+ * without exposing the internal indexing to the end user.
+ */
+
+#ifndef SOMA_COLUMN_H
+#define SOMA_COLUMN_H
+
+#include <any>
+#include <format>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "enums.h"
+#include "managed_query.h"
+#include "nanoarrow/nanoarrow.hpp"
+#include "utils/common.h"
+
+namespace tiledbsoma {
+using namespace tiledb;
+
+class SOMAColumn {
+   public:
+    //===================================================================
+    //= public non-static
+    //===================================================================
+    SOMAColumn() = default;
+    SOMAColumn(const SOMAColumn&) = default;
+    SOMAColumn(SOMAColumn&&) = default;
+    SOMAColumn& operator=(const SOMAColumn&) = default;
+    SOMAColumn& operator=(SOMAColumn&&) = default;
+
+    virtual ~SOMAColumn() = default;
+
+    /**
+     * Get the SOMAColumn name as defined in schema.
+     */
+    virtual std::string name() const = 0;
+
+    /**
+     * If true, this column is used as index.
+     *
+     * @remark SOMAColumns used as indexes should define at least one TileDB
+     * Dimension
+     */
+    virtual bool isIndexColumn() const = 0;
+
+    /**
+     * Get the TileDB Dimensions defined by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Dimension>> tiledb_dimensions() = 0;
+
+    /**
+     * Get the TileDB Attributes defined by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Attribute>> tiledb_attributes() = 0;
+
+    /**
+     * Get the TileDB Enumerations used by the SOMAColumn object, if any.
+     */
+    virtual std::optional<std::vector<Enumeration>> tiledb_enumerations() = 0;
+
+    /**
+     * Get the SOMAColumn type. Each subclass should define its own type.
+     */
+    virtual soma_column_datatype_t type() const = 0;
+
+    /**
+     * Get the datatype of the TileDB Dimensions if any. All dimensions must
+     * have the same type.
+     */
+    virtual std::optional<tiledb_datatype_t> domain_type() const = 0;
+
+    /**
+     * Get the datatype of the TileDB Attributes if any. All attributes must
+     * have the same type.
+     */
+    virtual std::optional<tiledb_datatype_t> data_type() const = 0;
+
+    /**
+     * @brief Select columns names to query (dim and attr). If the
+     * `if_not_empty` parameter is `true`, the column will be selected iff the
+     * list of selected columns is empty. This prevents a `select_columns` call
+     * from changing an empty list (all columns) to a subset of columns.
+     *
+     * @param query the ManagedQuery object to modify
+     * @param if_not_empty Prevent changing an "empty" selection of all columns
+     */
+    virtual void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const = 0;
+
+    /**
+     * Get the domain kind of the SOMAColumn as an ArrowArray for use with
+     * R/Python API.
+     *
+     * @param ctx
+     * @param array
+     * @param which_kind
+     */
+    virtual ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish which_kind) const = 0;
+
+    /**
+     * Get the SOMAColumn encoded as an ArrowSchema for use with R/Python API.
+     *
+     * @param ctx
+     * @param array
+     */
+    virtual ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) = 0;
+
+    /**
+     * Get the domain kind of the SOMAColumn.
+     *
+     * @tparam T
+     * @param ctx
+     * @param array
+     * @param which_kind
+     */
+    template <typename T>
+    std::pair<T, T> domain_slot(
+        const SOMAContext& ctx, Array& array, enum Domainish which_kind) const {
+        switch (which_kind) {
+            case Domainish::kind_core_domain:
+                return core_domain_slot<T>();
+            case Domainish::kind_core_current_domain:
+                return core_current_domain_slot<T>(ctx, array);
+            case Domainish::kind_non_empty_domain:
+                return non_empty_domain_slot<T>(array);
+            default:
+                throw std::runtime_error(
+                    "internal coding error in SOMAArray::_core_domainish_slot: "
+                    "unknown kind");
+        }
+    }
+
+    /**
+     * Set the current domain of this SOMAColumn.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector of the n-dimensional domain in the form
+     * [dim_0_min, dim_1_min, ..., dim_n_max]
+     */
+    template <typename T>
+    void set_current_domain_slot(
+        NDRectangle& rectangle, const std::vector<T>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        if (domain.size() % 2 != 0) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Provided domain for "
+                "column {} has missing values",
+                name()));
+        }
+
+        std::vector<std::any> transformed_domain;
+        size_t dim_count = domain.size() / 2;
+        for (size_t i = 0; i < dim_count; ++i) {
+            transformed_domain.push_back(std::make_any<std::array<T, 2>>(
+                std::array<T, 2>({domain[i], domain[i + dim_count]})));
+        }
+
+        try {
+            _set_current_domain_slot(rectangle, transformed_domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Set the multi-type current domain of this SOMAColumn.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector holding std::arrays with 2 elements each [min,
+     * max], casted as std::any
+     */
+    void set_current_domain_slot(
+        NDRectangle& rectangle, const std::vector<std::any>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        try {
+            _set_current_domain_slot(rectangle, domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Test if the multi-type current domain of this SOMAColumn can be set with
+     * the supplied new current domain.
+     *
+     * @tparam T
+     * @param rectangle The current domain rectangle to modify.
+     * @param domain A vector holding std::arrays with 2 elements each [min,
+     * max], casted as std::any
+     */
+    std::pair<bool, std::string> can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        const std::vector<std::any>& domain) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_current_domain_slot] Column with name {} is "
+                "not an index column",
+                name()));
+        }
+
+        try {
+            return _can_set_current_domain_slot(rectangle, domain);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][can_set_current_domain_slot] Failed on \"{}\" "
+                "with error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using one point
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ctx
+     * @param point
+     */
+    template <typename T>
+    void set_dim_point(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const T& point) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        T points[] = {point};
+
+        try {
+            this->_set_dim_points(
+                query,
+                ctx,
+                std::make_any<std::span<const T>>(std::span<const T>(points)));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_point] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using multiple points
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ctx
+     * @param points
+     */
+    template <typename T>
+    void set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        std::span<const T> points) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        try {
+            this->_set_dim_points(
+                query, ctx, std::make_any<std::span<const T>>(points));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_points] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * @brief Set the dimension slice using multiple ranges
+     *
+     * @note Partitioning is not supported
+     *
+     * @tparam T
+     * @param query
+     * @param ranges
+     */
+    template <typename T>
+    void set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::vector<std::pair<T, T>>& ranges) const {
+        if (!isIndexColumn()) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn] Column with name {} is not an index column",
+                name()));
+        }
+
+        try {
+            this->_set_dim_ranges(
+                query,
+                ctx,
+                std::make_any<std::vector<std::pair<T, T>>>(ranges));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][set_dim_ranges] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core domain of this column.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_domain_slot() const {
+        try {
+            return std::any_cast<std::pair<T, T>>(_core_domain_slot());
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][core_domain_slot] Failed on \"{}\" with error "
+                "\"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Retrieves the non-empty domain from the array. This is the union of the
+     * non-empty domains of the array fragments. Returns (0, 0) for empty
+     * domains.
+     */
+    template <typename T>
+    std::pair<T, T> non_empty_domain_slot(Array& array) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _non_empty_domain_slot(array));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][non_empty_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core current domain of this column.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _core_current_domain_slot(ctx, array));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(std::format(
+                "[SOMAColumn][core_current_domain_slot] Failed on \"{}\" with "
+                "error \"{}\"",
+                name(),
+                e.what()));
+        }
+    }
+
+    /**
+     * Returns the core current domain of this column from the supplied
+     * NDRectangle.
+     *
+     * o For arrays with core current-domain support:
+     *   - soma domain is core current domain
+     *   - soma maxdomain is core domain
+     * o For arrays without core current-domain support:
+     *   - soma domain is core domain
+     *   - soma maxdomain is core domain
+     *   - core current domain is not accessed at the soma level
+     *
+     * @tparam T Domain datatype
+     * @return Pair of [lower, upper] inclusive bounds.
+     */
+    template <typename T>
+    std::pair<T, T> core_current_domain_slot(NDRectangle& ndrect) const {
+        try {
+            return std::any_cast<std::pair<T, T>>(
+                _core_current_domain_slot(ndrect));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(e.what());
+        }
+    }
+
+   protected:
+    virtual void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& points) const = 0;
+
+    virtual void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const = 0;
+
+    virtual void _set_current_domain_slot(
+        NDRectangle& rectangle, std::span<const std::any> domain) const = 0;
+
+    virtual std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const = 0;
+
+    virtual std::any _core_domain_slot() const = 0;
+
+    virtual std::any _non_empty_domain_slot(Array& array) const = 0;
+
+    virtual std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const = 0;
+
+    virtual std::any _core_current_domain_slot(NDRectangle& ndrect) const = 0;
+};
+
+template <>
+std::pair<std::string, std::string> SOMAColumn::core_domain_slot<std::string>()
+    const;
+
+template <>
+std::pair<std::string, std::string>
+SOMAColumn::core_current_domain_slot<std::string>(
+    const SOMAContext& ctx, Array& array) const;
+
+}  // namespace tiledbsoma
+#endif

--- a/libtiledbsoma/src/soma/soma_context.cc
+++ b/libtiledbsoma/src/soma/soma_context.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_context.h
+++ b/libtiledbsoma/src/soma/soma_context.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -1,31 +1,10 @@
 /**
- *   This file defines classes, structs, and helpers for managing coordinate
- *   spaces and coordinate space transformations.
  * @file   soma_coordinates.cc
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2025 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_coordinates.h
+++ b/libtiledbsoma/src/soma/soma_coordinates.h
@@ -1,29 +1,9 @@
-/**
- * @file   soma_coordinates.h
+/** * @file   soma_coordinates.h
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2025 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -1,29 +1,9 @@
-/**
- * @file   soma_dense_ndarray.h
+/** * @file   soma_dense_ndarray.h
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -1,0 +1,748 @@
+/**
+ * @file   soma_dimension.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMADimension class.
+ */
+
+#include "soma_dimension.h"
+#include "utils/arrow_adapter.h"
+
+namespace tiledbsoma {
+
+std::shared_ptr<SOMADimension> SOMADimension::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    ArrowArray* array,
+    const std::string& soma_type,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    auto dimension = ArrowAdapter::tiledb_dimension_from_arrow_schema(
+        ctx, schema, array, soma_type, type_metadata, "", "", platform_config);
+
+    return std::make_shared<SOMADimension>(SOMADimension(dimension));
+}
+
+void SOMADimension::_set_dim_points(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext&,
+    const std::any& points) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint8_t>>(points));
+            break;
+        case TILEDB_UINT16:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint16_t>>(points));
+            break;
+        case TILEDB_UINT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint32_t>>(points));
+            break;
+        case TILEDB_UINT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const uint64_t>>(points));
+            break;
+        case TILEDB_INT8:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int8_t>>(points));
+            break;
+        case TILEDB_INT16:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int16_t>>(points));
+            break;
+        case TILEDB_INT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int32_t>>(points));
+            break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const int64_t>>(points));
+            break;
+        case TILEDB_FLOAT32:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const float_t>>(points));
+            break;
+        case TILEDB_FLOAT64:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const double_t>>(points));
+            break;
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+            query->select_points(
+                dimension.name(),
+                std::any_cast<std::span<const std::string>>(points));
+            break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+void SOMADimension::_set_dim_ranges(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext&,
+    const std::any& ranges) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint8_t, uint8_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT16:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint16_t, uint16_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint32_t, uint32_t>>>(
+                    ranges));
+            break;
+        case TILEDB_UINT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<uint64_t, uint64_t>>>(
+                    ranges));
+            break;
+        case TILEDB_INT8:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int8_t, int8_t>>>(ranges));
+            break;
+        case TILEDB_INT16:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int16_t, int16_t>>>(
+                    ranges));
+            break;
+        case TILEDB_INT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int32_t, int32_t>>>(
+                    ranges));
+            break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<int64_t, int64_t>>>(
+                    ranges));
+            break;
+        case TILEDB_FLOAT32:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<float_t, float_t>>>(
+                    ranges));
+            break;
+        case TILEDB_FLOAT64:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<double_t, double_t>>>(
+                    ranges));
+            break;
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB:
+            query->select_ranges(
+                dimension.name(),
+                std::any_cast<std::vector<std::pair<std::string, std::string>>>(
+                    ranges));
+            break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+void SOMADimension::_set_current_domain_slot(
+    NDRectangle& rectangle, std::span<const std::any> domain) const {
+    if (domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMADimension][_set_current_domain_slot] Invalid domain size. "
+            "Expected 1, got {}",
+            domain.size()));
+    }
+
+    switch (dimension.type()) {
+        case TILEDB_UINT8: {
+            auto dom = std::any_cast<std::array<uint8_t, 2>>(domain[0]);
+            rectangle.set_range<uint8_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT16: {
+            auto dom = std::any_cast<std::array<uint16_t, 2>>(domain[0]);
+            rectangle.set_range<uint16_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT32: {
+            auto dom = std::any_cast<std::array<uint32_t, 2>>(domain[0]);
+            rectangle.set_range<uint32_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_UINT64: {
+            auto dom = std::any_cast<std::array<uint64_t, 2>>(domain[0]);
+            rectangle.set_range<uint64_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT8: {
+            auto dom = std::any_cast<std::array<int8_t, 2>>(domain[0]);
+            rectangle.set_range<int8_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT16: {
+            auto dom = std::any_cast<std::array<int16_t, 2>>(domain[0]);
+            rectangle.set_range<int16_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_INT32: {
+            auto dom = std::any_cast<std::array<int32_t, 2>>(domain[0]);
+            rectangle.set_range<int32_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64: {
+            auto dom = std::any_cast<std::array<int64_t, 2>>(domain[0]);
+            rectangle.set_range<int64_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_FLOAT32: {
+            auto dom = std::any_cast<std::array<float_t, 2>>(domain[0]);
+            rectangle.set_range<float_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_FLOAT64: {
+            auto dom = std::any_cast<std::array<double_t, 2>>(domain[0]);
+            rectangle.set_range<double_t>(dimension.name(), dom[0], dom[1]);
+        } break;
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            // Here is an intersection of a few oddities:
+            //
+            // * Core domain for string dims must be a nullptr pair; it cannot
+            // be
+            //   anything else.
+            // * TileDB-Py shows this by using an empty-string pair, which we
+            //   imitate.
+            // * Core current domain for string dims must _not_ be a nullptr
+            // pair.
+            // * In TileDB-SOMA, unless the user specifies otherwise, we use ""
+            // for
+            //   min and "\x7f" for max. (We could use "\x7f" but that causes
+            //   display problems in Python.)
+            //
+            // To work with all these factors, if the current domain is the
+            // default
+            // "" to "\7f", return an empty-string pair just as we do for
+            // domain. (There was some pre-1.15 software using "\xff" and it's
+            // super-cheap to check for that as well.)
+            auto dom = std::any_cast<std::array<std::string, 2>>(domain[0]);
+            if (dom[0] == "" && dom[1] == "") {
+                rectangle.set_range(dimension.name(), "", "\x7f");
+            } else {
+                throw TileDBSOMAError(std::format(
+                    "[SOMADimension][_set_current_domain_slot] domain (\"{}\", "
+                    "\"{}\") cannot be set for "
+                    "string index columns: please use "
+                    "(\"\", \"\")",
+                    dom[0],
+                    dom[1]));
+            }
+
+        } break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_set_current_domain_slot] Unknown datatype {}",
+                tiledb::impl::type_to_str(dimension.type())));
+    }
+}
+
+std::pair<bool, std::string> SOMADimension::_can_set_current_domain_slot(
+    std::optional<NDRectangle>& rectangle,
+    std::span<const std::any> new_domain) const {
+    if (new_domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMADimension][_can_set_current_domain_slot] Expected domain "
+            "size is 1, found {}",
+            new_domain.size()));
+    }
+
+    auto comparator =
+        [&]<typename T>(
+            const std::array<T, 2>& new_dom) -> std::pair<bool, std::string> {
+        if (new_dom[0] > new_dom[1]) {
+            return std::pair(
+                false,
+                std::format(
+                    "index-column name {}: new lower > new upper",
+                    dimension.name()));
+        }
+
+        // If we're checking against the core current domain: the user-provided
+        // domain must contain the core current domain.
+        //
+        // If we're checking against the core (max) domain: the user-provided
+        // domain must be contained within the core (max) domain.
+
+        if (rectangle.has_value()) {
+            auto dom = rectangle.value().range<T>(dimension.name());
+
+            if (new_dom[0] > dom[0]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower > old lower (downsize "
+                        "is unsupported)",
+                        dimension.name()));
+            }
+            if (new_dom[1] < dom[1]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper < old upper (downsize "
+                        "is unsupported)",
+                        dimension.name()));
+            }
+        } else {
+            auto dom = std::any_cast<std::pair<T, T>>(_core_domain_slot());
+
+            if (new_dom[0] < dom.first) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower < limit lower",
+                        dimension.name()));
+            }
+            if (new_dom[1] > dom.second) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper > limit upper",
+                        dimension.name()));
+            }
+        }
+
+        return std::pair(true, "");
+    };
+
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return comparator(
+                std::any_cast<std::array<uint8_t, 2>>(new_domain[0]));
+        case TILEDB_UINT16:
+            return comparator(
+                std::any_cast<std::array<uint16_t, 2>>(new_domain[0]));
+        case TILEDB_UINT32:
+            return comparator(
+                std::any_cast<std::array<uint32_t, 2>>(new_domain[0]));
+        case TILEDB_UINT64:
+            return comparator(
+                std::any_cast<std::array<uint64_t, 2>>(new_domain[0]));
+        case TILEDB_INT8:
+            return comparator(
+                std::any_cast<std::array<int8_t, 2>>(new_domain[0]));
+        case TILEDB_INT16:
+            return comparator(
+                std::any_cast<std::array<int16_t, 2>>(new_domain[0]));
+        case TILEDB_INT32:
+            return comparator(
+                std::any_cast<std::array<int32_t, 2>>(new_domain[0]));
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return comparator(
+                std::any_cast<std::array<int64_t, 2>>(new_domain[0]));
+        case TILEDB_FLOAT32:
+            return comparator(
+                std::any_cast<std::array<float_t, 2>>(new_domain[0]));
+        case TILEDB_FLOAT64:
+            return comparator(
+                std::any_cast<std::array<double_t, 2>>(new_domain[0]));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            auto dom = std::any_cast<std::array<std::string, 2>>(new_domain[0]);
+            if (dom[0] != "" || dom[1] != "") {
+                return std::pair(
+                    false,
+                    "domain cannot be set for string index columns: please use "
+                    "(\"\", \"\")");
+            }
+
+            return std::pair(true, "");
+        }
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_can_set_current_domain_slot] Unknown dataype "
+                "{}",
+                tiledb::impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_core_domain_slot() const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                dimension.domain<uint8_t>());
+        case TILEDB_UINT16:
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                dimension.domain<uint16_t>());
+        case TILEDB_UINT32:
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                dimension.domain<uint32_t>());
+        case TILEDB_UINT64:
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                dimension.domain<uint64_t>());
+        case TILEDB_INT8:
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                dimension.domain<int8_t>());
+        case TILEDB_INT16:
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                dimension.domain<int16_t>());
+        case TILEDB_INT32:
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                dimension.domain<int32_t>());
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                dimension.domain<int64_t>());
+        case TILEDB_FLOAT32:
+            return std::make_any<std::pair<float_t, float_t>>(
+                dimension.domain<float_t>());
+        case TILEDB_FLOAT64:
+            return std::make_any<std::pair<double_t, double_t>>(
+                dimension.domain<double_t>());
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_core_domain_slot] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_non_empty_domain_slot(Array& array) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8:
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                array.non_empty_domain<uint8_t>(dimension.name()));
+        case TILEDB_UINT16:
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                array.non_empty_domain<uint16_t>(dimension.name()));
+        case TILEDB_UINT32:
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                array.non_empty_domain<uint32_t>(dimension.name()));
+        case TILEDB_UINT64:
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                array.non_empty_domain<uint64_t>(dimension.name()));
+        case TILEDB_INT8:
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                array.non_empty_domain<int8_t>(dimension.name()));
+        case TILEDB_INT16:
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                array.non_empty_domain<int16_t>(dimension.name()));
+        case TILEDB_INT32:
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                array.non_empty_domain<int32_t>(dimension.name()));
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64:
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                array.non_empty_domain<int64_t>(dimension.name()));
+        case TILEDB_FLOAT32:
+            return std::make_any<std::pair<float_t, float_t>>(
+                array.non_empty_domain<float_t>(dimension.name()));
+        case TILEDB_FLOAT64:
+            return std::make_any<std::pair<double_t, double_t>>(
+                array.non_empty_domain<double_t>(dimension.name()));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_BLOB:
+        case TILEDB_CHAR:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
+            return std::make_any<std::pair<std::string, std::string>>(
+                array.non_empty_domain_var(dimension.name()));
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][_non_empty_domain_slot] Unknown dimension "
+                "type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+std::any SOMADimension::_core_current_domain_slot(
+    const SOMAContext& ctx, Array& array) const {
+    CurrentDomain
+        current_domain = tiledb::ArraySchemaExperimental::current_domain(
+            *ctx.tiledb_ctx(), array.schema());
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    return _core_current_domain_slot(ndrect);
+}
+
+std::any SOMADimension::_core_current_domain_slot(NDRectangle& ndrect) const {
+    switch (dimension.type()) {
+        case TILEDB_UINT8: {
+            std::array<uint8_t, 2> domain = ndrect.range<uint8_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint8_t, uint8_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT16: {
+            std::array<uint16_t, 2> domain = ndrect.range<uint16_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint16_t, uint16_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT32: {
+            std::array<uint32_t, 2> domain = ndrect.range<uint32_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint32_t, uint32_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_UINT64: {
+            std::array<uint64_t, 2> domain = ndrect.range<uint64_t>(
+                dimension.name());
+            return std::make_any<std::pair<uint64_t, uint64_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT8: {
+            std::array<int8_t, 2> domain = ndrect.range<int8_t>(
+                dimension.name());
+            return std::make_any<std::pair<int8_t, int8_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT16: {
+            std::array<int16_t, 2> domain = ndrect.range<int16_t>(
+                dimension.name());
+            return std::make_any<std::pair<int16_t, int16_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_INT32: {
+            std::array<int32_t, 2> domain = ndrect.range<int32_t>(
+                dimension.name());
+            return std::make_any<std::pair<int32_t, int32_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_INT64: {
+            std::array<int64_t, 2> domain = ndrect.range<int64_t>(
+                dimension.name());
+            return std::make_any<std::pair<int64_t, int64_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_FLOAT32: {
+            std::array<float_t, 2> domain = ndrect.range<float_t>(
+                dimension.name());
+            return std::make_any<std::pair<float_t, float_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_FLOAT64: {
+            std::array<double_t, 2> domain = ndrect.range<double_t>(
+                dimension.name());
+            return std::make_any<std::pair<double_t, double_t>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_CHAR:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB: {
+            std::array<std::string, 2> domain = ndrect.range<std::string>(
+                dimension.name());
+            return std::make_any<std::pair<std::string, std::string>>(
+                std::make_pair(domain[0], domain[1]));
+        }
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension] Unknown dimension type {}",
+                impl::type_to_str(dimension.type())));
+    }
+}
+
+ArrowArray* SOMADimension::arrow_domain_slot(
+    const SOMAContext& ctx, Array& array, enum Domainish kind) const {
+    switch (domain_type().value()) {
+        case TILEDB_INT64:
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_TIME_HR:
+        case TILEDB_TIME_MIN:
+        case TILEDB_TIME_SEC:
+        case TILEDB_TIME_MS:
+        case TILEDB_TIME_US:
+        case TILEDB_TIME_NS:
+        case TILEDB_TIME_PS:
+        case TILEDB_TIME_FS:
+        case TILEDB_TIME_AS:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int64_t>(ctx, array, kind));
+        case TILEDB_UINT64:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint64_t>(ctx, array, kind));
+        case TILEDB_INT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int32_t>(ctx, array, kind));
+        case TILEDB_UINT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint32_t>(ctx, array, kind));
+        case TILEDB_INT16:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int16_t>(ctx, array, kind));
+        case TILEDB_UINT16:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint16_t>(ctx, array, kind));
+        case TILEDB_INT8:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<int8_t>(ctx, array, kind));
+        case TILEDB_UINT8:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<uint8_t>(ctx, array, kind));
+        case TILEDB_FLOAT64:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<double>(ctx, array, kind));
+        case TILEDB_FLOAT32:
+            return ArrowAdapter::make_arrow_array_child(
+                domain_slot<float>(ctx, array, kind));
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+        case TILEDB_GEOM_WKB:
+        case TILEDB_GEOM_WKT:
+            return ArrowAdapter::make_arrow_array_child_string(
+                domain_slot<std::string>(ctx, array, kind));
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMADimension][arrow_domain_slot] dim {} has unhandled "
+                "type "
+                "{}",
+                name(),
+                tiledb::impl::type_to_str(domain_type().value())));
+    }
+}
+
+ArrowSchema* SOMADimension::arrow_schema_slot(const SOMAContext&, Array&) {
+    return ArrowAdapter::arrow_schema_from_tiledb_dimension(dimension)
+        .release();
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -1,0 +1,124 @@
+/**
+ * @file   soma_dimension.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMADimension class. SOMADimension acts as a wrapper
+ * to a TileDB Dimension and implements function to perform queries as well as
+ * core domain and current domain operations. It provides a common interface
+ * identical to TileDB attributes and composite columns.
+ */
+
+#ifndef SOMA_DIMENSION_H
+#define SOMA_DIMENSION_H
+
+#include <algorithm>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+
+class SOMADimension : public SOMAColumn {
+   public:
+    static std::shared_ptr<SOMADimension> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        ArrowArray* array,
+        const std::string& soma_type,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMADimension(Dimension dimension)
+        : dimension(dimension) {
+    }
+
+    inline std::string name() const override {
+        return dimension.name();
+    }
+
+    inline bool isIndexColumn() const override {
+        return true;
+    }
+
+    inline void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const override {
+        query->select_columns(std::vector({dimension.name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const override {
+        return soma_column_datatype_t::SOMA_COLUMN_DIMENSION;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
+        return dimension.type();
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const override {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
+        return std::vector({dimension});
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
+        return std::nullopt;
+    }
+
+    ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) override;
+
+   protected:
+    void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_current_domain_slot(
+        NDRectangle& rectangle,
+        std::span<const std::any> domain) const override;
+
+    std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const override;
+
+    std::any _core_domain_slot() const override;
+
+    std::any _non_empty_domain_slot(Array& array) const override;
+
+    std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
+
+   private:
+    Dimension dimension;
+};
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_experiment.h
+++ b/libtiledbsoma/src/soma/soma_experiment.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -1,0 +1,399 @@
+/**
+ * @file   soma_geometry_column.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryColumn class.
+ */
+
+#include "soma_geometry_column.h"
+
+namespace tiledbsoma {
+
+std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    ArrowSchema* spatial_schema,
+    ArrowArray* spatial_array,
+    const std::string& soma_type,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    std::vector<Dimension> dims;
+    if (type_metadata.compare("WKB") != 0) {
+        throw TileDBSOMAError(std::format(
+            "[SOMAGeometryColumn] "
+            "Unkwown type metadata for `{}`: "
+            "Expected 'WKB', got {}",
+            SOMA_GEOMETRY_COLUMN_NAME,
+            type_metadata));
+    }
+
+    for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
+            ctx,
+            spatial_schema->children[j],
+            spatial_array->children[j],
+            soma_type,
+            type_metadata,
+            SOMA_GEOMETRY_DIMENSION_PREFIX,
+            "__min",
+            platform_config));
+    }
+
+    for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
+            ctx,
+            spatial_schema->children[j],
+            spatial_array->children[j],
+            soma_type,
+            type_metadata,
+            SOMA_GEOMETRY_DIMENSION_PREFIX,
+            "__max",
+            platform_config));
+    }
+
+    auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(
+        ctx, schema, type_metadata, platform_config);
+
+    return std::make_shared<SOMAGeometryColumn>(
+        SOMAGeometryColumn(dims, attribute.first));
+}
+
+void SOMAGeometryColumn::_set_dim_points(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext& ctx,
+    const std::any& points) const {
+    std::vector<std::pair<double_t, double_t>>
+        transformed_points = _transform_points(
+            std::any_cast<std::span<const std::vector<double_t>>>(points));
+
+    // The limits of the current domain if it exists or the core domain
+    // otherwise.
+    auto limits = _limits(ctx, *query->schema());
+
+    // Create a range object and reuse if for all dimensions
+    std::vector<std::pair<double_t, double_t>> range(1);
+    size_t dimensionality = dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS;
+
+    for (size_t i = 0; i < transformed_points.size(); ++i) {
+        range[0] = std::make_pair(
+            limits[i].first,
+            std::min(transformed_points[i].second, limits[i].second));
+        query->select_ranges(dimensions[i].name(), range);
+
+        range[0] = std::make_pair(
+            std::max(transformed_points[i].first, limits[i].first),
+            limits[i].second);
+        query->select_ranges(dimensions[i + dimensionality].name(), range);
+    }
+}
+
+void SOMAGeometryColumn::_set_dim_ranges(
+    const std::unique_ptr<ManagedQuery>& query,
+    const SOMAContext& ctx,
+    const std::any& ranges) const {
+    std::vector<std::pair<double_t, double_t>>
+        transformed_ranges = _transform_ranges(
+            std::any_cast<std::vector<
+                std::pair<std::vector<double_t>, std::vector<double_t>>>>(
+                ranges));
+
+    // The limits of the current domain if it exists or the core domain
+    // otherwise.
+    auto limits = _limits(ctx, *query->schema());
+
+    // Create a range object and reuse if for all dimensions
+    std::vector<std::pair<double_t, double_t>> range(1);
+    size_t dimensionality = dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS;
+
+    for (size_t i = 0; i < transformed_ranges.size(); ++i) {
+        range[0] = std::make_pair(
+            limits[i].first,
+            std::min(transformed_ranges[i].second, limits[i].second));
+        query->select_ranges(dimensions[i].name(), range);
+
+        range[0] = std::make_pair(
+            std::max(transformed_ranges[i].first, limits[i].first),
+            limits[i].second);
+        query->select_ranges(dimensions[i + dimensionality].name(), range);
+    }
+}
+
+void SOMAGeometryColumn::_set_current_domain_slot(
+    NDRectangle& rectangle,
+    std::span<const std::any> new_current_domain) const {
+    if (TDB_DIM_PER_SPATIAL_AXIS * new_current_domain.size() !=
+        dimensions.size()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMAGeometryColumn] Dimension - Current Domain mismatch. "
+            "Expected current domain of size {}, found {}",
+            dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS,
+            new_current_domain.size()));
+    }
+
+    for (size_t i = 0; i < new_current_domain.size(); ++i) {
+        auto range = std::any_cast<std::array<double_t, 2>>(
+            new_current_domain[i]);
+        rectangle.set_range<double_t>(dimensions[i].name(), range[0], range[1]);
+    }
+
+    for (size_t i = 0; i < new_current_domain.size(); ++i) {
+        auto range = std::any_cast<std::array<double_t, 2>>(
+            new_current_domain[i]);
+        rectangle.set_range<double_t>(
+            dimensions[i + new_current_domain.size()].name(),
+            range[0],
+            range[1]);
+    }
+}
+
+std::pair<bool, std::string> SOMAGeometryColumn::_can_set_current_domain_slot(
+    std::optional<NDRectangle>& rectangle,
+    std::span<const std::any> new_current_domain) const {
+    if (new_current_domain.size() !=
+        dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS) {
+        throw TileDBSOMAError(std::format(
+            "[SOMADimension][_can_set_current_domain_slot] Expected current "
+            "domain "
+            "size is 2, found {}",
+            new_current_domain.size()));
+    }
+
+    for (size_t i = 0; i < new_current_domain.size(); ++i) {
+        auto range = std::any_cast<std::array<double_t, 2>>(
+            new_current_domain[i]);
+
+        if (range[0] > range[1]) {
+            return std::pair(
+                false,
+                std::format(
+                    "index-column name {}: new lower > new upper",
+                    dimensions[i].name()));
+        }
+
+        auto dimension_min = dimensions[i];
+        auto dimension_max =
+            dimensions[i + dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS];
+
+        if (rectangle.has_value()) {
+            auto range_min = rectangle.value().range<double_t>(
+                dimension_min.name());
+            auto range_max = rectangle.value().range<double_t>(
+                dimension_max.name());
+
+            if (range[0] > range_min[0]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower > old lower (downsize "
+                        "is unsupported)",
+                        dimension_min.name()));
+            }
+            if (range[0] > range_max[0]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower > old lower (downsize "
+                        "is unsupported)",
+                        dimension_max.name()));
+            }
+            if (range[1] < range_min[1]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper < old upper (downsize "
+                        "is unsupported)",
+                        dimension_min.name()));
+            }
+            if (range[1] < range_max[1]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper < old upper (downsize "
+                        "is unsupported)",
+                        dimension_max.name()));
+            }
+        } else {
+            auto core_domain = std::any_cast<
+                std::pair<std::vector<double_t>, std::vector<double_t>>>(
+                _core_domain_slot());
+
+            if (range[0] > core_domain.first[i]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new lower < limit lower",
+                        dimension_min.name()));
+            }
+            if (range[1] < core_domain.second[i]) {
+                return std::pair(
+                    false,
+                    std::format(
+                        "index-column name {}: new upper > limit upper",
+                        dimension_min.name()));
+            }
+        }
+    }
+
+    return std::pair(true, "");
+}
+
+std::vector<std::pair<double_t, double_t>> SOMAGeometryColumn::_limits(
+    const SOMAContext& ctx, const ArraySchema& schema) const {
+    std::vector<std::pair<double_t, double_t>> limits;
+
+    if (ArraySchemaExperimental::current_domain(*ctx.tiledb_ctx(), schema)
+            .is_empty()) {
+        for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS;
+             ++i) {
+            std::pair<double_t, double_t> core_domain = dimensions[i]
+                                                            .domain<double_t>();
+
+            limits.push_back(
+                std::make_pair(core_domain.first, core_domain.second));
+        }
+    } else {
+        NDRectangle ndrect = ArraySchemaExperimental::current_domain(
+                                 *ctx.tiledb_ctx(), schema)
+                                 .ndrectangle();
+        for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS;
+             ++i) {
+            std::array<double_t, 2> range = ndrect.range<double_t>(
+                dimensions.at(i).name());
+
+            limits.push_back(std::make_pair(range[0], range[1]));
+        }
+    }
+
+    return limits;
+}
+
+std::vector<std::pair<double_t, double_t>>
+SOMAGeometryColumn::_transform_ranges(
+    const std::vector<std::pair<std::vector<double_t>, std::vector<double_t>>>&
+        ranges) const {
+    if (ranges.size() != 1) {
+        throw TileDBSOMAError(
+            "Multiranges are not supported for geometry dimension");
+    }
+
+    std::vector<std::pair<double_t, double_t>> transformed_ranges;
+    std::vector<double_t> min_ranges = ranges.front().first;
+    std::vector<double_t> max_ranges = ranges.front().second;
+    for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS; ++i) {
+        transformed_ranges.push_back(
+            std::make_pair(min_ranges[i], max_ranges[i]));
+    }
+
+    return transformed_ranges;
+}
+
+std::vector<std::pair<double_t, double_t>>
+SOMAGeometryColumn::_transform_points(
+    const std::span<const std::vector<double_t>>& points) const {
+    if (points.size() != 1) {
+        throw TileDBSOMAError(
+            "Multipoints are not supported for geometry dimension");
+    }
+
+    std::vector<std::pair<double_t, double_t>> transformed_ranges;
+    for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS; ++i) {
+        transformed_ranges.push_back(
+            std::make_pair(points.front()[i], points.front()[i]));
+    }
+
+    return transformed_ranges;
+}
+
+std::any SOMAGeometryColumn::_core_domain_slot() const {
+    std::vector<double_t> min, max;
+    for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS; ++i) {
+        std::pair<double_t, double_t> core_domain = dimensions[i]
+                                                        .domain<double_t>();
+
+        min.push_back(core_domain.first);
+        max.push_back(core_domain.second);
+    }
+
+    return std::make_any<
+        std::pair<std::vector<double_t>, std::vector<double_t>>>(
+        std::make_pair(min, max));
+};
+
+std::any SOMAGeometryColumn::_non_empty_domain_slot(Array& array) const {
+    std::vector<double_t> min, max;
+    size_t dimensionality = dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS;
+    for (size_t i = 0; i < dimensionality; ++i) {
+        std::pair<double_t, double_t>
+            min_non_empty_dom = array.non_empty_domain<double_t>(
+                dimensions[i].name());
+        std::pair<double_t, double_t>
+            max_non_empty_dom = array.non_empty_domain<double_t>(
+                dimensions[i + dimensionality].name());
+
+        min.push_back(min_non_empty_dom.first);
+        max.push_back(max_non_empty_dom.second);
+    }
+
+    return std::make_any<
+        std::pair<std::vector<double_t>, std::vector<double_t>>>(
+        std::make_pair(min, max));
+}
+
+std::any SOMAGeometryColumn::_core_current_domain_slot(
+    const SOMAContext& ctx, Array& array) const {
+    CurrentDomain
+        current_domain = tiledb::ArraySchemaExperimental::current_domain(
+            *ctx.tiledb_ctx(), array.schema());
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    return _core_current_domain_slot(ndrect);
+}
+
+std::any SOMAGeometryColumn::_core_current_domain_slot(
+    NDRectangle& ndrect) const {
+    std::vector<double_t> min, max;
+
+    for (size_t i = 0; i < dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS; ++i) {
+        std::array<double_t, 2> range = ndrect.range<double_t>(
+            dimensions[i].name());
+
+        min.push_back(range[0]);
+        max.push_back(range[1]);
+    }
+
+    return std::make_any<
+        std::pair<std::vector<double_t>, std::vector<double_t>>>(
+        std::make_pair(min, max));
+}
+
+ArrowArray* SOMAGeometryColumn::arrow_domain_slot(
+    const SOMAContext& ctx, Array& array, enum Domainish kind) const {
+    switch (domain_type().value()) {
+        case TILEDB_FLOAT64:
+            return ArrowAdapter::make_arrow_array_child_var(
+                domain_slot<std::vector<double_t>>(ctx, array, kind));
+            break;
+        default:
+            throw TileDBSOMAError(std::format(
+                "[SOMAGeometryColumn][arrow_domain_slot] dim {} has unhandled "
+                "extended type "
+                "{}",
+                name(),
+                tiledb::impl::type_to_str(domain_type().value())));
+    }
+}
+
+ArrowSchema* SOMAGeometryColumn::arrow_schema_slot(
+    const SOMAContext& ctx, Array& array) {
+    return ArrowAdapter::arrow_schema_from_tiledb_attribute(
+               attribute, *ctx.tiledb_ctx(), array)
+        .release();
+}
+
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_geometry_column.h
+++ b/libtiledbsoma/src/soma/soma_geometry_column.h
@@ -1,0 +1,156 @@
+/**
+ * @file   soma_geometry_column.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMAGeometryColumn class. SOMAGeometryColumn wraps a
+ * TileDB Attribute storing the WKB (Well-Known Binary) encoded geometry and
+ * adds a collection of internal TileDB dimension to provide spatial indexing.
+ * It implements function to perform queries as well as core domain and current
+ * domain operations. The purpose of this class is to provide a common interface
+ * identical to TileDB dimensions, attributes and other composite columns.
+ *
+ * The current indexing mechanish adapts the idea of Priority R-tree on top of a
+ * TileDB Array using a set of TIleDB Dimensions to store the MBR corners of
+ * each geometry.
+ */
+
+#ifndef SOMA_GEOMETRY_COLUMN_H
+#define SOMA_GEOMETRY_COLUMN_H
+
+#include <algorithm>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+class ArrayBuffers;
+
+using namespace tiledb;
+
+class SOMAGeometryColumn : public SOMAColumn {
+   public:
+    static std::shared_ptr<SOMAGeometryColumn> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        ArrowSchema* spatial_schema,
+        ArrowArray* spatial_array,
+        const std::string& soma_type,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMAGeometryColumn(std::vector<Dimension> dimensions, Attribute attribute)
+        : dimensions(dimensions)
+        , attribute(attribute){};
+
+    inline std::string name() const override {
+        return SOMA_GEOMETRY_COLUMN_NAME;
+    }
+
+    inline bool isIndexColumn() const override {
+        return true;
+    }
+
+    inline void select_columns(
+        const std::unique_ptr<ManagedQuery>& query,
+        bool if_not_empty = false) const override {
+        query->select_columns(std::vector({attribute.name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const override {
+        return soma_column_datatype_t::SOMA_COLUMN_GEOMETRY;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
+        return dimensions.front().type();
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const override {
+        return attribute.type();
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
+        return dimensions;
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
+        return std::vector({attribute});
+    }
+
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
+        return std::nullopt;
+    }
+
+    ArrowArray* arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) override;
+
+   protected:
+    void _set_dim_points(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& points) const override;
+
+    void _set_dim_ranges(
+        const std::unique_ptr<ManagedQuery>& query,
+        const SOMAContext& ctx,
+        const std::any& ranges) const override;
+
+    void _set_current_domain_slot(
+        NDRectangle& rectangle,
+        std::span<const std::any> new_current_domain) const override;
+
+    std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_current_domain) const override;
+
+    std::any _core_domain_slot() const override;
+
+    std::any _non_empty_domain_slot(Array& array) const override;
+
+    std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
+
+   private:
+    /**
+     * The current implementation of SOMAGeometryColumn uses a pair of TileDB
+     * dimensions to store the min and max point of the bounding box per
+     * dimension. E.g. a 2D geometry will have 4 TileDB dimensions (2 *
+     * num_spatial_axes) to provide spatial indexing.
+     */
+    const size_t TDB_DIM_PER_SPATIAL_AXIS = 2;
+    std::vector<Dimension> dimensions;
+    Attribute attribute;
+
+    /**
+     * Compute the usable domain limits. If the array has a current domain then
+     * it is used to compute the limits, otherwise the core domain is used.
+     */
+    std::vector<std::pair<double_t, double_t>> _limits(
+        const SOMAContext& ctx, const ArraySchema& schema) const;
+
+    std::vector<std::pair<double_t, double_t>> _transform_ranges(
+        const std::vector<
+            std::pair<std::vector<double_t>, std::vector<double_t>>>& ranges)
+        const;
+
+    std::vector<std::pair<double_t, double_t>> _transform_points(
+        const std::span<const std::vector<double_t>>& points) const;
+};
+
+}  // namespace tiledbsoma
+#endif

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_measurement.h
+++ b/libtiledbsoma/src/soma/soma_measurement.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_multiscale_image.h
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_scene.h
+++ b/libtiledbsoma/src/soma/soma_scene.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -1,3 +1,16 @@
+/**
+ * @file   arrow_adapter.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the ArrowAdapter class.
+ */
+
 #ifndef ARROW_ADAPTER_H
 #define ARROW_ADAPTER_H
 

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/fastercsx.h
+++ b/libtiledbsoma/src/utils/fastercsx.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/logger.cc
+++ b/libtiledbsoma/src/utils/logger.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/logger.h
+++ b/libtiledbsoma/src/utils/logger.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/parallel_functions.h
+++ b/libtiledbsoma/src/utils/parallel_functions.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2018-2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/stats.cc
+++ b/libtiledbsoma/src/utils/stats.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/stats.h
+++ b/libtiledbsoma/src/utils/stats.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/version.cc
+++ b/libtiledbsoma/src/utils/version.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/src/utils/version.h
+++ b/libtiledbsoma/src/utils/version.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/test_indexer.cc
+++ b/libtiledbsoma/test/test_indexer.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_arrow_adapter.cc
+++ b/libtiledbsoma/test/unit_arrow_adapter.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_column_buffer.cc
+++ b/libtiledbsoma/test/unit_column_buffer.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_geometry_envelope.cc
+++ b/libtiledbsoma/test/unit_geometry_envelope.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_geometry_roundtrip.cc
+++ b/libtiledbsoma/test/unit_geometry_roundtrip.cc
@@ -1,29 +1,9 @@
-/**
- * @file   unit_geometry_roundtrip.cc
+/** * @file   unit_geometry_roundtrip.cc
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_managed_query.cc
+++ b/libtiledbsoma/test/unit_managed_query.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022-2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -1,0 +1,418 @@
+/**
+ * @file   unit_soma_column.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for implementation of SOMAColumn class
+ */
+
+#include <format>
+#include <tiledb/tiledb>
+#include <tiledbsoma/tiledbsoma>
+#include "../src/soma/soma_attribute.h"
+#include "../src/soma/soma_column.h"
+#include "../src/soma/soma_dimension.h"
+#include "../src/soma/soma_geometry_column.h"
+#include "common.h"
+
+// This is a keystroke-reduction fixture for some similar unit-test cases For
+// convenience there are dims/attrs of type int64, uint32, and string. (Feel
+// free to add more types.) The main value-adds of this fixture are (a) simple
+// keystroke-reduction; (b) you get to pick which ones are the dim(s) and which
+// are the attr(s).
+struct VariouslyIndexedDataFrameFixture {
+    std::shared_ptr<SOMAContext> ctx_;
+    std::string uri_;
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Using Catch2's TEST_CASE_METHOD we can't pass constructor args.
+    // This is a call-after-construction method.
+    void set_up(std::shared_ptr<SOMAContext> ctx, std::string uri) {
+        ctx_ = ctx;
+        uri_ = uri;
+    }
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Helpers for setting up dim/attr configs and data
+    static const inline int64_t i64_dim_max = 99;
+    static const inline int64_t u32_dim_max = 9999;
+    static const inline int64_t str_dim_max = 0;  // not used for string dims
+
+    static const inline std::string i64_name = "soma_joinid";
+    static const inline std::string u32_name = "myuint32";
+    static const inline std::string str_name = "mystring";
+
+    tiledb_datatype_t i64_datatype = TILEDB_INT64;
+    tiledb_datatype_t u32_datatype = TILEDB_UINT32;
+    tiledb_datatype_t str_datatype = TILEDB_STRING_ASCII;
+
+    std::string i64_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        i64_datatype);
+    std::string u32_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        u32_datatype);
+    std::string attr_1_arrow_format = ArrowAdapter::tdb_to_arrow_type(
+        str_datatype);
+
+    helper::DimInfo i64_dim_info() {
+        return helper::DimInfo(
+            {.name = i64_name,
+             .tiledb_datatype = i64_datatype,
+             .dim_max = i64_dim_max,
+             .string_lo = "N/A",
+             .string_hi = "N/A"});
+    }
+    helper::DimInfo u32_dim_info() {
+        return helper::DimInfo(
+            {.name = u32_name,
+             .tiledb_datatype = u32_datatype,
+             .dim_max = u32_dim_max,
+             .string_lo = "N/A",
+             .string_hi = "N/A"});
+    }
+    helper::DimInfo str_dim_info(std::string string_lo, std::string string_hi) {
+        return helper::DimInfo(
+            {.name = str_name,
+             .tiledb_datatype = str_datatype,
+             .dim_max = str_dim_max,
+             .string_lo = string_lo,
+             .string_hi = string_hi});
+    }
+
+    helper::AttrInfo i64_attr_info(std::string name = i64_name) {
+        return helper::AttrInfo(
+            {.name = name, .tiledb_datatype = i64_datatype});
+    }
+    helper::AttrInfo u32_attr_info() {
+        return helper::AttrInfo(
+            {.name = u32_name, .tiledb_datatype = u32_datatype});
+    }
+    helper::AttrInfo str_attr_info() {
+        return helper::AttrInfo(
+            {.name = str_name, .tiledb_datatype = str_datatype});
+    }
+
+    //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Helper methods for create/open/write/etc.
+
+    void create(
+        const std::vector<helper::DimInfo>& dim_infos,
+        const std::vector<helper::AttrInfo>& attr_infos) {
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        SOMADataFrame::create(
+            uri_,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx_);
+    }
+
+    void create(
+        const std::vector<helper::DimInfo>& dim_infos,
+        const std::vector<helper::AttrInfo>& attr_infos,
+        const PlatformConfig& platform_config,
+        std::optional<TimestampRange> timestamp_range = std::nullopt) {
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        SOMADataFrame::create(
+            uri_,
+            std::move(schema),
+            ArrowTable(
+                std::move(index_columns.first),
+                std::move(index_columns.second)),
+            ctx_,
+            platform_config,
+            timestamp_range);
+    }
+
+    std::unique_ptr<SOMADataFrame> open(
+        OpenMode mode,
+        ResultOrder result_order = ResultOrder::automatic,
+        std::optional<TimestampRange> timestamp_range = std::nullopt) {
+        return SOMADataFrame::open(
+            uri_,
+            mode,
+            ctx_,
+            {},  // column_names
+            result_order,
+            timestamp_range);
+    }
+
+    void write_sjid_u32_str_data_from(int64_t sjid_base) {
+        auto sdf = SOMADataFrame::open(uri_, OpenMode::write, ctx_);
+
+        auto i64_data = std::vector<int64_t>({sjid_base + 1, sjid_base + 2});
+
+        auto u32_data = std::vector<uint32_t>({1234, 5678});
+
+        // We like to think we're writing an array of strings ...
+        auto strings = std::vector<std::string>({"apple", "bat"});
+        // ... but really we're writing an array of characters along
+        // with offsets data.
+        //
+        // It would be possible here to just hard-code a string "applebat" and
+        // an offsets array {0, 5, 8}. The following bits simply automate that.
+        std::string char_data("");
+        std::vector<uint64_t> char_offsets(0);
+        uint64_t offset = 0;
+        for (auto e : strings) {
+            char_data += e;
+            char_offsets.push_back(offset);
+            offset += e.size();
+        }
+        char_offsets.push_back(offset);
+
+        sdf->set_column_data(i64_name, i64_data.size(), i64_data.data());
+        sdf->set_column_data(
+            str_name, strings.size(), char_data.data(), char_offsets.data());
+        sdf->set_column_data(u32_name, u32_data.size(), u32_data.data());
+        sdf->write();
+
+        sdf->close();
+    }
+};
+
+TEST_CASE("SOMAColumn: SOMADimension") {
+    auto ctx = std::make_shared<SOMAContext>();
+    PlatformConfig platform_config{};
+
+    std::vector<helper::DimInfo> dim_infos(
+        {helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_UINT32,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_INT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "dimension",
+              .tiledb_datatype = TILEDB_STRING_ASCII,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"})});
+
+    std::vector<helper::DimInfo> geom_dim_infos({helper::DimInfo(
+        {.name = "dimension",
+         .tiledb_datatype = TILEDB_GEOM_WKB,
+         .dim_max = 100,
+         .string_lo = "N/A",
+         .string_hi = "N/A"})});
+
+    std::vector<helper::DimInfo> spatial_dim_infos(
+        {helper::DimInfo(
+             {.name = "x",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 200,
+              .string_lo = "N/A",
+              .string_hi = "N/A"}),
+         helper::DimInfo(
+             {.name = "y",
+              .tiledb_datatype = TILEDB_FLOAT64,
+              .dim_max = 100,
+              .string_lo = "N/A",
+              .string_hi = "N/A"})});
+
+    auto index_columns = helper::create_column_index_info(dim_infos);
+
+    std::vector<std::shared_ptr<SOMAColumn>> columns;
+
+    for (int64_t i = 0; i < index_columns.second->n_children; ++i) {
+        columns.push_back(SOMADimension::create(
+            ctx->tiledb_ctx(),
+            index_columns.second->children[i],
+            index_columns.first->children[i],
+            "SOMAGeometryDataFrame",
+            "",
+            platform_config));
+
+        REQUIRE(
+            columns.back()->tiledb_dimensions().value()[0].type() ==
+            dim_infos[i].tiledb_datatype);
+    }
+
+    REQUIRE(
+        columns[1]->core_domain_slot<double_t>() ==
+        std::make_pair<double_t, double_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[1]->core_domain_slot<double_t>() ==
+        std::make_pair<double_t, double_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[2]->core_domain_slot<int64_t>() ==
+        std::make_pair<int64_t, int64_t>(0, helper::CORE_DOMAIN_MAX));
+    REQUIRE(
+        columns[3]->core_domain_slot<std::string>() ==
+        std::make_pair<std::string, std::string>("", ""));
+}
+
+TEST_CASE_METHOD(
+    VariouslyIndexedDataFrameFixture,
+    "SOMAColumn: query variant-indexed dataframe dim-str-u32 attr-sjid",
+    "[SOMAColumn]") {
+    auto specify_domain = GENERATE(false, true);
+    SECTION(std::format("- specify_domain={}", specify_domain)) {
+        std::string suffix1 = specify_domain ? "true" : "false";
+        set_up(
+            std::make_shared<SOMAContext>(),
+            "mem://unit-test-column-variant-indexed-dataframe-4-" + suffix1);
+
+        std::string string_lo = "";
+        std::string string_hi = "";
+        std::vector<helper::DimInfo> dim_infos(
+            {str_dim_info(string_lo, string_hi), u32_dim_info()});
+        std::vector<helper::AttrInfo> attr_infos({i64_attr_info()});
+
+        // Create
+        create(dim_infos, attr_infos);
+
+        // Check current domain
+        auto sdf = open(OpenMode::read);
+
+        // External column initialization
+        auto raw_array = tiledb::Array(*ctx_->tiledb_ctx(), uri_, TILEDB_READ);
+        std::vector<std::shared_ptr<SOMAColumn>> columns;
+
+        for (auto dimension : sdf->tiledb_schema()->domain().dimensions()) {
+            columns.push_back(
+                std::make_shared<SOMADimension>(SOMADimension(dimension)));
+        }
+
+        CurrentDomain current_domain = sdf->get_current_domain_for_test();
+
+        REQUIRE(!current_domain.is_empty());
+        REQUIRE(current_domain.type() == TILEDB_NDRECTANGLE);
+        NDRectangle ndrect = current_domain.ndrectangle();
+
+        std::array<std::string, 2> str_range = ndrect.range<std::string>(
+            dim_infos[0].name);
+        std::pair<std::string, std::string>
+            str_external = columns[0]->core_current_domain_slot<std::string>(
+                *ctx_, raw_array);
+
+        // Can we write empty strings in this range?
+        REQUIRE(str_range[0] <= "");
+        REQUIRE(str_external.first <= "");
+        REQUIRE(str_range[1] >= "");
+        REQUIRE(str_external.second >= "");
+        // Can we write ASCII values in this range?
+        REQUIRE(str_range[0] < " ");
+        REQUIRE(str_external.first <= " ");
+        REQUIRE(str_range[1] > "~");
+        // REQUIRE(str_external.second >= "~");
+
+        std::array<uint32_t, 2> u32_range = ndrect.range<uint32_t>(
+            dim_infos[1].name);
+        std::pair<uint32_t, uint32_t>
+            u32_external = columns[1]->core_current_domain_slot<uint32_t>(
+                *ctx_, raw_array);
+        REQUIRE(u32_range[0] == u32_external.first);
+        REQUIRE(u32_range[1] == u32_external.second);
+
+        // Check shape before write
+        std::optional<int64_t> actual = sdf->maybe_soma_joinid_shape();
+        REQUIRE(!actual.has_value());
+
+        // Check domainish accessors before resize
+        ArrowTable non_empty_domain = sdf->get_non_empty_domain();
+        std::vector<std::string>
+            ned_str = ArrowAdapter::get_table_string_column_by_name(
+                non_empty_domain, "mystring");
+
+        std::vector<std::string>
+            ned_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_non_empty_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        ArrowTable soma_domain = sdf->get_soma_domain();
+        std::vector<std::string>
+            dom_str = ArrowAdapter::get_table_string_column_by_name(
+                soma_domain, "mystring");
+
+        std::vector<std::string>
+            dom_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_core_current_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
+        std::vector<std::string>
+            maxdom_str = ArrowAdapter::get_table_string_column_by_name(
+                soma_maxdomain, "mystring");
+
+        std::vector<std::string>
+            maxdom_str_col = ArrowAdapter::get_array_string_column(
+                columns[0]->arrow_domain_slot(
+                    *ctx_, raw_array, Domainish::kind_core_domain),
+                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+
+        REQUIRE(ned_str == std::vector<std::string>({"", ""}));
+
+        REQUIRE(ned_str == ned_str_col);
+        REQUIRE(dom_str == dom_str_col);
+        REQUIRE(maxdom_str == maxdom_str_col);
+
+        if (specify_domain) {
+            REQUIRE(dom_str[0] == dim_infos[0].string_lo);
+            REQUIRE(dom_str[1] == dim_infos[0].string_hi);
+        } else {
+            REQUIRE(dom_str == std::vector<std::string>({"", ""}));
+        }
+        REQUIRE(maxdom_str == std::vector<std::string>({"", ""}));
+
+        sdf->close();
+
+        sdf = open(OpenMode::write);
+        write_sjid_u32_str_data_from(0);
+
+        sdf->close();
+
+        sdf = open(OpenMode::read);
+        REQUIRE(sdf->nnz() == 2);
+
+        sdf->close();
+
+        auto external_query = std::make_unique<ManagedQuery>(
+            open(OpenMode::read), ctx_->tiledb_ctx());
+
+        columns[1]->select_columns(external_query);
+        columns[1]->set_dim_point<uint32_t>(external_query, *ctx_, 1234);
+
+        // Configure query and allocate result buffers
+        auto ext_res = external_query->read_next().value();
+
+        REQUIRE(ext_res->num_rows() == 1);
+
+        external_query->reset();
+
+        columns[0]->select_columns(external_query);
+        columns[0]->set_dim_ranges<std::string>(
+            external_query,
+            *ctx_,
+            std::vector(
+                {std::make_pair<std::string, std::string>("apple", "b")}));
+
+        // Configure query and allocate result buffers
+        ext_res = external_query->read_next().value();
+
+        REQUIRE(ext_res->num_rows() == 1);
+    }
+}

--- a/libtiledbsoma/test/unit_soma_coordinates.cc
+++ b/libtiledbsoma/test/unit_soma_coordinates.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -1,29 +1,9 @@
-/**
- * @file   unit_soma_geometry_dataframe.cc
+/** * @file   unit_soma_geometry_dataframe.cc
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2023 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_multiscale_image.cc
+++ b/libtiledbsoma/test/unit_soma_multiscale_image.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_scene.cc
+++ b/libtiledbsoma/test/unit_soma_scene.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2024 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2022 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *

--- a/libtiledbsoma/test/unit_thread_pool.cc
+++ b/libtiledbsoma/test/unit_thread_pool.cc
@@ -3,27 +3,8 @@
  *
  * @section LICENSE
  *
- * The MIT License
- *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  *
  * @section DESCRIPTION
  *


### PR DESCRIPTION
**Issue and/or context:** Manually backport #3619 to the `release-1.15` branch given https://github.com/single-cell-data/TileDB-SOMA/pull/3619#issuecomment-2631423039

**Changes:**

**Notes for Reviewer:**

