### PR TITLE
[Backport release-1.15] [python] Resolve issue with #3611 and `pyarrow<17`

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2092,10 +2092,13 @@ def test_arrow_table_validity_with_slicing(tmp_path):
     )
     table = pa.Table.from_pydict(pydict)
 
-    with soma.DataFrame.open(uri, "w") as A:
-        with raises_no_typeguard(soma.SOMAError):
-            # soma_joinid cannot be nullable
-            A.write(table)
+    # As of version 1.15.6 we were throwing in this case. However, we found
+    # a compatibility issue with pyarrow versions below 17. Thus this is
+    # now non-fatal.
+    # with soma.DataFrame.open(uri, "w") as A:
+    #    with raises_no_typeguard(soma.SOMAError):
+    #        # soma_joinid cannot be nullable
+    #        A.write(table)
 
     pydict["soma_joinid"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     table = pa.Table.from_pydict(pydict)

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2022,11 +2022,14 @@ def test_sparse_nd_array_null(tmp_path):
 
     soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,))
 
-    with soma.SparseNDArray.open(uri, "w") as A:
-        with raises_no_typeguard(soma.SOMAError):
-            # soma_joinid cannot be nullable
-            A.write(table[:5])
-            A.write(table[5:])
+    # As of version 1.15.6 we were throwing in this case. However, we found
+    # a compatibility issue with pyarrow versions below 17. Thus this is
+    # now non-fatal.
+    # with soma.SparseNDArray.open(uri, "w") as A:
+    #    with raises_no_typeguard(soma.SOMAError):
+    #        # soma_joinid cannot be nullable
+    #        A.write(table[:5])
+    #        A.write(table[5:])
 
     pydict["soma_dim_0"] = pa.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     table = pa.Table.from_pydict(pydict)

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -163,7 +163,8 @@ void ColumnBuffer::attach(Query& query, std::optional<Subarray> subarray) {
     if (!validity_.empty() && is_dim) {
         LOG_DEBUG(fmt::format(
             "[ColumnBuffer::attach] Validity buffer passed for dimension '{}' "
-            "is being ignored"));
+            "is being ignored",
+            name_));
     }
 
     return use_subarray ? attach_subarray(*subarray) : attach_buffer(query);

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -157,10 +157,13 @@ void ColumnBuffer::attach(Query& query, std::optional<Subarray> subarray) {
             "to attach to Query");
     }
 
+    // As of version 1.15.6 we were throwing here. However, we found a
+    // compatibility issue with pyarrow versions below 17. Thus we log and
+    // continue.
     if (!validity_.empty() && is_dim) {
-        throw TileDBSOMAError(fmt::format(
-            "[ColumnBuffer::attach] Validity buffer passed for dimension '{}'",
-            name_));
+        LOG_DEBUG(fmt::format(
+            "[ColumnBuffer::attach] Validity buffer passed for dimension '{}' "
+            "is being ignored"));
     }
 
     return use_subarray ? attach_subarray(*subarray) : attach_buffer(query);


### PR DESCRIPTION
Manual bcakport of #3669.

Resolves #3667 as described on #3667; see also #3611.
