### PR TITLE
[c++] Robustify detection of insufficient compiler version

### DIFF
--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -173,6 +173,19 @@ message(STATUS "Starting TileDB-SOMA regular build.")
 set(EP_SOURCE_DIR "${EP_BASE}/src")
 set(EP_INSTALL_PREFIX "${EP_BASE}/install")
 
+
+# ###########################################################
+# Check compiler version supports full C++20 standard.
+# ###########################################################
+
+set(GCC_MIN 13.0)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_MIN)
+        message(FATAL_ERROR "GNU GCC must be at least version ${GCC_MIN}. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
+    endif()
+endif()
+
+
 # ###########################################################
 # Compile options/definitions for all targets
 # ###########################################################
@@ -220,6 +233,7 @@ if(MSVC)
     $<$<CONFIG:RelWithDebInfo>:/DNDEBUG /Ox /Zi>
   )
 else()
+
 
   set(TILEDBSOMA_COMPILE_OPTIONS -Wall -Wextra -DSPDLOG_USE_STD_FORMAT -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2)
 

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -14,6 +14,14 @@
 #ifndef TILEDBSOMA_REINDEXER_H
 #define TILEDBSOMA_REINDEXER_H
 
+#ifndef __clang__
+#ifdef __GNUC__
+#if __GNUC__ < 13
+#error If compiled with GCC, TileDB-SOMA requires GCC 13 or greater.
+#endif
+#endif
+#endif
+
 #include <assert.h>
 #include <format>
 #include <memory>

--- a/libtiledbsoma/src/reindexer/reindexer.h
+++ b/libtiledbsoma/src/reindexer/reindexer.h
@@ -18,6 +18,7 @@
 #ifdef __GNUC__
 #if __GNUC__ < 13
 #error If compiled with GCC, TileDB-SOMA requires GCC 13 or greater.
+#include <stop/the/build>
 #endif
 #endif
 #endif

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -14,6 +14,15 @@
 #ifndef __TILEDBSOMA__
 #define __TILEDBSOMA__
 
+// See https://github.com/single-cell-data/TileDB-SOMA/pull/3673 for narrative.
+#ifndef __clang__
+#ifdef __GNUC__
+#if __GNUC__ < 13
+#error If compiled with GCC, TileDB-SOMA requires GCC 13 or greater.
+#endif
+#endif
+#endif
+
 // Auto-generated file by CMake, used to define the TILEDBSOMA_EXPORT macro
 // that allows exporting symbols in a cross-platform fashion.
 #include "tiledbsoma_export.h"

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -14,6 +14,14 @@
 #ifndef ARROW_ADAPTER_H
 #define ARROW_ADAPTER_H
 
+#ifndef __clang__
+#ifdef __GNUC__
+#if __GNUC__ < 13
+#error If compiled with GCC, TileDB-SOMA requires GCC 13 or greater.
+#endif
+#endif
+#endif
+
 #include <any>
 #include <format>
 #include <tiledb/tiledb>


### PR DESCRIPTION
**Issue and/or context:** For #3154 / [[sc-57301]](https://app.shortcut.com/tiledb-inc/story/57301/use-c-20).

Issue is:

* On our `main` branch we now use C++20 (see #3154).
* GCC11 "supports" C++20 in the sense that `g++ -std=c++20` is recognized -- however, builds fail with failure to find `#include <format>`. That is, GCC 11's support of C++20 is inadequate.
  * Aside: Ubuntu 22.04 LTS has GCC 11; Ubutu 24.04 LTS has GCC 13.
* Multiple users have been tripped up by this cryptic error (e.g. #3545). It's important that we surface the problem, and its recommended resolution, more clearly and more actionably.

**Changes:**

* Run a compile-time assert
* It's a little tricky because `clang` (MacOS) does indeed have `__GNUC__` defined but has it set to 4.

Test program:

<details>

```
#include <iostream>
// g++ -E -dM gvers.cpp

int main() {

#ifdef GCC_VERSION
  std::cout << "GCC_VERSION " << GCC_VERSION << "\n";
#else
  std::cout << "GCC_VERSION is not defined\n";
#endif

#ifdef __GNUC__
  std::cout << "__GNUC__ " << __GNUC__ << "\n";
#else
  std::cout << "__GNUC__ is not defined\n";
#endif

#ifdef __GNUC_MINOR__
  std::cout << "__GNUC_MINOR__ " << __GNUC_MINOR__ << "\n";
#else
  std::cout << "__GNUC_MINOR__ is not defined\n";
#endif

#ifdef __GNUC_PATCHLEVEL__
  std::cout << "__GNUC_PATCHLEVEL__ " << __GNUC_PATCHLEVEL__ << "\n";
#else
  std::cout << "__GNUC_PATCHLEVEL__ is not defined\n";
#endif

  return 0;
}

// MacOS
// GCC_VERSION is not defined
// __GNUC__ 4
// __GNUC_MINOR__ 2
// __GNUC_PATCHLEVEL__ 1

// Ubuntu 22.04
// GCC_VERSION is not defined
// __GNUC__ 11
// __GNUC_MINOR__ 4
// __GNUC_PATCHLEVEL__ 0

// GCC_VERSION is not defined
// __GNUC__ 13
// __GNUC_MINOR__ 3
// __GNUC_PATCHLEVEL__ 0
```

</details>

**Notes for Reviewer:**

Note that `#error` doesn't stop the build entirely; we coud use `-Wfatal-errors` (and suitable replacements on Windows), or, use an intentionally bad `#include`.