### PR TITLE
[c++/python] Add `GeometryDataFrame` creation

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -320,6 +320,7 @@ setuptools.setup(
                 "src/tiledbsoma/soma_object.cc",
                 "src/tiledbsoma/soma_dataframe.cc",
                 "src/tiledbsoma/soma_point_cloud_dataframe.cc",
+                "src/tiledbsoma/soma_geometry_dataframe.cc",
                 "src/tiledbsoma/soma_dense_ndarray.cc",
                 "src/tiledbsoma/soma_sparse_ndarray.cc",
                 "src/tiledbsoma/soma_group.cc",

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -179,6 +179,7 @@ from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
 from ._multiscale_image import MultiscaleImage
 from ._point_cloud_dataframe import PointCloudDataFrame
+from ._geometry_dataframe import GeometryDataFrame
 from ._query import ExperimentAxisQuery
 from ._scene import Scene
 from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead
@@ -209,6 +210,7 @@ __all__ = [
     "DoesNotExistError",
     "Experiment",
     "ExperimentAxisQuery",
+    "GeometryDataFrame",
     "get_implementation_version",
     "get_implementation",
     "get_SOMA_version",

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -175,11 +175,11 @@ from ._general_utilities import (
     get_storage_engine,
     show_package_versions,
 )
+from ._geometry_dataframe import GeometryDataFrame
 from ._indexer import IntIndexer, tiledbsoma_build_index
 from ._measurement import Measurement
 from ._multiscale_image import MultiscaleImage
 from ._point_cloud_dataframe import PointCloudDataFrame
-from ._geometry_dataframe import GeometryDataFrame
 from ._query import ExperimentAxisQuery
 from ._scene import Scene
 from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -1112,7 +1112,7 @@ def _revise_domain_for_extent(
 ) -> Tuple[Any, Any]:
     if saturated_range:
         # Handle SOMA_GEOMETRY domain with is tuple[list[float], list[float]]
-        if isinstance(domain[1], list):
+        if isinstance(domain[1], tuple):
             return (
                 domain[0],
                 [dim_max - extent for dim_max in domain[1]],

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -790,7 +790,9 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
 
 def _canonicalize_schema(
-    schema: pa.Schema, index_column_names: Sequence[str]
+    schema: pa.Schema,
+    index_column_names: Sequence[str],
+    required_columns: Sequence[str] = [SOMA_JOINID],
 ) -> pa.Schema:
     """Turns an Arrow schema into the canonical version and checks for errors.
 
@@ -807,7 +809,7 @@ def _canonicalize_schema(
             raise ValueError(
                 f"{SOMA_JOINID} field must be of type Arrow int64 but is {joinid_type}"
             )
-    else:
+    elif SOMA_JOINID in required_columns:
         # add SOMA_JOINID
         schema = schema.append(pa.field(SOMA_JOINID, pa.int64()))
 
@@ -821,7 +823,7 @@ def _canonicalize_schema(
             schema.get_field_index(SOMA_GEOMETRY),
             schema.field(SOMA_GEOMETRY).with_metadata({"dtype": "WKB"}),
         )
-    else:
+    elif SOMA_GEOMETRY in required_columns:
         # add SOMA_GEOMETRY
         schema = schema.append(
             pa.field(SOMA_GEOMETRY, pa.large_binary(), metadata={"dtype": "WKB"})

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -210,18 +210,14 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
             # [4] core current domain hi
             if index_column_name == SOMA_GEOMETRY:
                 # SOMA_GEOMETRY has a specific schema
-                index_column_schema.append(pa.field(pa_field.name, pa.struct({axis:pa.list_(pa.float64()) for axis in axis_names}), nullable=True))
-                struct = []
-                for idx, axis in enumerate(axis_names):
-                    struct.append((axis,
-                        [
-                            *[float(max_domain[idx]) for max_domain in slot_core_max_domain],
-                            extent,
-                            *[float(current_domain[idx]) for current_domain in slot_core_current_domain]
-                        ]
-                    ))
-
-                index_column_data[pa_field.name] = [struct, None, None, None, None]
+                index_column_schema.append(pa.field(pa_field.name, pa.struct({axis:pa.float64() for axis in axis_names})))
+                index_column_data[pa_field.name] = [
+                    [(axis, slot_core_max_domain[0][idx]) for idx, axis in enumerate(axis_names)],
+                    [(axis, slot_core_max_domain[1][idx]) for idx, axis in enumerate(axis_names)],
+                    [(axis, extent) for axis in axis_names],
+                    [(axis, slot_core_current_domain[0][idx]) for idx, axis in enumerate(axis_names)],
+                    [(axis, slot_core_current_domain[0][idx]) for idx, axis in enumerate(axis_names)]
+                ]
             else:
                 index_column_schema.append(pa_field)
                 index_column_data[pa_field.name] = [
@@ -415,15 +411,3 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
             value
         )
         self._coord_space = value
-
-    @property
-    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
-        """The allowable range of values in each index column.
-
-        Returns: a tuple of minimum and maximum values, inclusive,
-            storable on each index column of the dataframe.
-
-        Lifecycle:
-            Experimental.
-        """
-        raise NotImplementedError()

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -124,7 +124,9 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         )
 
         context = _validate_soma_tiledb_context(context)
-        schema = _canonicalize_schema(schema, index_column_names)
+        schema = _canonicalize_schema(
+            schema, index_column_names, [SOMA_JOINID, SOMA_GEOMETRY]
+        )
 
         # SOMA-to-core mappings:
         #

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -258,7 +258,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
                         for idx, axis in enumerate(axis_names)
                     ],
                     [
-                        (axis, slot_core_current_domain[0][idx])
+                        (axis, slot_core_current_domain[1][idx])
                         for idx, axis in enumerate(axis_names)
                     ],
                 ]

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -213,7 +213,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         # Either set the new coordinate space or check the axes of the current
         # coordinate space the element is defined on.
         if coordinate_space is None:
-            elem_axis_names: Tuple[str, ...] = elem.coordinate_space.axis_names  # type: ignore[attr-defined]
+            elem_axis_names: Tuple[str, ...] = elem.coordinate_space.axis_names
             if elem_axis_names != transform.output_axes:
                 raise ValueError(
                     f"The name of transform output axes, {transform.output_axes}, do "
@@ -221,7 +221,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
                     f" space, {elem_axis_names}."
                 )
         else:
-            elem.coordinate_space = coordinate_space  # type: ignore[attr-defined]
+            elem.coordinate_space = coordinate_space
 
         # Set the transform metadata and return the multisclae image.
         coll.metadata[f"soma_scene_registry_{key}"] = transform_to_json(transform)

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -45,6 +45,7 @@ RawHandle = Union[
     clib.SOMAArray,
     clib.SOMADataFrame,
     clib.SOMAPointCloudDataFrame,
+    clib.SOMAGeometryDataFrame,
     clib.SOMASparseNDArray,
     clib.SOMADenseNDArray,
     clib.SOMAGroup,
@@ -77,6 +78,7 @@ def open(
         "somagroup": clib.SOMAGroup.open,
         "somadataframe": clib.SOMADataFrame.open,
         "somapointclouddataframe": clib.SOMAPointCloudDataFrame.open,
+        "somageometrydataframe": clib.SOMAGeometryDataFrame.open,
         "somadensendarray": clib.SOMADenseNDArray.open,
         "somasparsendarray": clib.SOMASparseNDArray.open,
         "somacollection": clib.SOMACollection.open,
@@ -105,6 +107,7 @@ def open(
     _type_to_class = {
         "somadataframe": DataFrameWrapper,
         "somapointclouddataframe": PointCloudDataFrameWrapper,
+        "somageometrydataframe": GeometryDataFrameWrapper,
         "somadensendarray": DenseNDArrayWrapper,
         "somasparsendarray": SparseNDArrayWrapper,
         "somacollection": CollectionWrapper,
@@ -629,6 +632,19 @@ class PointCloudDataFrameWrapper(SOMAArrayWrapper[clib.SOMAPointCloudDataFrame])
     """Wrapper around a Pybind11 SOMAPointCloudDataFrame handle."""
 
     _WRAPPED_TYPE = clib.SOMAPointCloudDataFrame
+
+    @property
+    def count(self) -> int:
+        return int(self._handle.count)
+
+    def write(self, values: pa.RecordBatch) -> None:
+        self._handle.write(values)
+
+
+class GeometryDataFrameWrapper(SOMAArrayWrapper[clib.SOMAGeometryDataFrame]):
+    """Wrapper around a Pybind11 SOMAGeometryDataFrame handle."""
+
+    _WRAPPED_TYPE = clib.SOMAGeometryDataFrame
 
     @property
     def count(self) -> int:

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -21,6 +21,7 @@ void load_soma_object(py::module&);
 void load_soma_array(py::module&);
 void load_soma_dataframe(py::module&);
 void load_soma_point_cloud_dataframe(py::module&);
+void load_soma_geometry_dataframe(py::module&);
 void load_soma_dense_ndarray(py::module&);
 void load_soma_sparse_ndarray(py::module&);
 void load_soma_group(py::module&);
@@ -166,6 +167,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     load_soma_dense_ndarray(m);
     load_soma_sparse_ndarray(m);
     load_soma_point_cloud_dataframe(m);
+    load_soma_geometry_dataframe(m);
     load_soma_group(m);
     load_soma_collection(m);
     load_query_condition(m);

--- a/apis/python/src/tiledbsoma/soma_geometry_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_geometry_dataframe.cc
@@ -1,0 +1,141 @@
+/**
+ * @file   soma_point_cloud_dataframe.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the SOMAGeometryDataFrame bindings.
+ */
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include <tiledbsoma/tiledbsoma>
+
+#include "common.h"
+
+namespace libtiledbsomacpp {
+
+namespace py = pybind11;
+using namespace py::literals;
+using namespace tiledbsoma;
+
+void load_soma_geometry_dataframe(py::module& m) {
+    py::class_<SOMAGeometryDataFrame, SOMAArray, SOMAObject>(
+        m, "SOMAGeometryDataFrame")
+
+        .def_static(
+            "create",
+            [](std::string_view uri,
+               py::object py_schema,
+               py::object index_column_info,
+               std::vector<std::string> axis_names,
+               std::vector<std::optional<std::string>> axis_units,
+               std::shared_ptr<SOMAContext> context,
+               PlatformConfig platform_config,
+               std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+                ArrowSchema schema;
+                uintptr_t schema_ptr = (uintptr_t)(&schema);
+                py_schema.attr("_export_to_c")(schema_ptr);
+
+                // Please see
+                // https://github.com/single-cell-data/TileDB-SOMA/issues/2869
+                // for the reasoning here.
+                //
+                // TL;DR:
+                // * The table has an `ArrowSchema`; each of its children
+                //   is also an `ArrowSchema`.
+                // * Arrow fields are nullable by default in the user API.
+                // * There is a field-level nullability flag, _and_ users
+                //   can set a "nullable" metadata as well.
+                // * In the absence of metadata, respect the flag we get.
+                // * In the present of metdata with "nullable", let that
+                //   override.
+
+                auto metadata = py_schema.attr("metadata");
+                if (py::hasattr(metadata, "get")) {
+                    for (int64_t i = 0; i < schema.n_children; ++i) {
+                        auto child = schema.children[i];
+                        auto val = metadata.attr("get")(
+                            py::str(child->name).attr("encode")("utf-8"));
+
+                        if (!val.is(py::none()) &&
+                            val.cast<std::string>() == "nullable") {
+                            child->flags |= ARROW_FLAG_NULLABLE;
+                        }
+                    }
+                }
+
+                ArrowSchema index_column_schema;
+                ArrowArray index_column_array;
+                uintptr_t
+                    index_column_schema_ptr = (uintptr_t)(&index_column_schema);
+                uintptr_t
+                    index_column_array_ptr = (uintptr_t)(&index_column_array);
+                index_column_info.attr("_export_to_c")(
+                    index_column_array_ptr, index_column_schema_ptr);
+
+                SOMACoordinateSpace coord_space{axis_names, axis_units};
+
+                try {
+                    SOMAGeometryDataFrame::create(
+                        uri,
+                        std::make_unique<ArrowSchema>(schema),
+                        ArrowTable(
+                            std::make_unique<ArrowArray>(index_column_array),
+                            std::make_unique<ArrowSchema>(index_column_schema)),
+                        coord_space,
+                        context,
+                        platform_config,
+                        timestamp);
+                } catch (const std::out_of_range& e) {
+                    throw py::type_error(e.what());
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+                schema.release(&schema);
+            },
+            "uri"_a,
+            py::kw_only(),
+            "schema"_a,
+            "index_column_info"_a,
+            "axis_names"_a,
+            "axis_units"_a,
+            "ctx"_a,
+            "platform_config"_a,
+            "timestamp"_a = py::none())
+
+        .def_static(
+            "open",
+            py::overload_cast<
+                std::string_view,
+                OpenMode,
+                std::shared_ptr<SOMAContext>,
+                std::vector<std::string>,
+                ResultOrder,
+                std::optional<std::pair<uint64_t, uint64_t>>>(
+                &SOMAGeometryDataFrame::open),
+            "uri"_a,
+            "mode"_a,
+            "context"_a,
+            py::kw_only(),
+            "column_names"_a = py::tuple(),
+            "result_order"_a = ResultOrder::automatic,
+            "timestamp"_a = py::none())
+
+        .def_static("exists", &SOMAGeometryDataFrame::exists)
+        .def_property_readonly(
+            "index_column_names", &SOMAGeometryDataFrame::index_column_names)
+        .def_property_readonly(
+            "count",
+            &SOMAGeometryDataFrame::count,
+            py::call_guard<py::gil_scoped_release>());
+}
+}  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_object.cc
+++ b/apis/python/src/tiledbsoma/soma_object.cc
@@ -68,9 +68,12 @@ void load_soma_object(py::module& m) {
 
                 if (soma_obj_type == "somadataframe")
                     return py::cast(dynamic_cast<SOMADataFrame&>(*soma_obj));
-                if (soma_obj_type == "somapointclouddataframe")
+                else if (soma_obj_type == "somapointclouddataframe")
                     return py::cast(
                         dynamic_cast<SOMAPointCloudDataFrame&>(*soma_obj));
+                else if (soma_obj_type == "somageometrydataframe")
+                    return py::cast(
+                        dynamic_cast<SOMAGeometryDataFrame&>(*soma_obj));
                 else if (soma_obj_type == "somasparsendarray")
                     return py::cast(
                         dynamic_cast<SOMASparseNDArray&>(*soma_obj));

--- a/apis/python/tests/test_geometry_dataframe.py
+++ b/apis/python/tests/test_geometry_dataframe.py
@@ -1,0 +1,57 @@
+from urllib.parse import urljoin
+
+import numpy as np
+import pyarrow as pa
+import pytest
+import shapely
+import typeguard
+
+import tiledbsoma as soma
+
+@pytest.mark.parametrize("domain", [None, [[(-1000, 1000), (0, 100)], [0, 100]]])
+def test_geometry_domain(tmp_path, domain):
+    uri = tmp_path.as_uri()
+
+    asch = pa.schema([("quality", pa.float32())])
+
+    with soma.GeometryDataFrame.create(uri, schema=asch, domain=domain) as geom:
+        soma_domain = geom.domain
+
+        assert len(soma_domain) == 2
+
+        for idx, name in enumerate(geom.index_column_names):
+            if name == "soma_geometry":
+                f64info = np.finfo(np.float64)
+
+                assert len(soma_domain[idx][0]) == 2
+                assert len(soma_domain[idx][1]) == 2
+
+                for axis_idx, axis_name in enumerate(geom.coordinate_space.axis_names):
+                    assert soma_domain[idx][0][axis_name] == (f64info.min if domain is None else domain[0][axis_idx][0])
+
+                for axis_idx, axis_name in enumerate(geom.coordinate_space.axis_names):
+                    assert soma_domain[idx][1][axis_name] == (f64info.max if domain is None else domain[0][axis_idx][1])
+
+
+def test_geometry_coordinate_space(tmp_path):
+    uri = tmp_path.as_uri()
+
+    asch = pa.schema([("quality", pa.float32())])
+
+    with soma.GeometryDataFrame.create(uri, schema=asch) as geom:
+        assert len(geom.coordinate_space) == 2
+        assert geom.coordinate_space.axis_names == ("x", "y")
+        assert geom.coordinate_space.axes == (soma.Axis(name="x"), soma.Axis(name="y"))
+
+        # Axis names do not match
+        with pytest.raises(ValueError):
+            geom.coordinate_space = soma.CoordinateSpace(
+                [soma.Axis(name="a"), soma.Axis(name="y")]
+            )
+
+        geom.coordinate_space = soma.CoordinateSpace(
+            [soma.Axis(name="x", unit="m"), soma.Axis(name="y", unit="in")]
+        )
+        assert geom.coordinate_space[0] == soma.Axis(name="x", unit="m")
+        assert geom.coordinate_space[1] == soma.Axis(name="y", unit="in")
+

--- a/apis/python/tests/test_geometry_dataframe.py
+++ b/apis/python/tests/test_geometry_dataframe.py
@@ -1,12 +1,9 @@
-from urllib.parse import urljoin
-
 import numpy as np
 import pyarrow as pa
 import pytest
-import shapely
-import typeguard
 
 import tiledbsoma as soma
+
 
 @pytest.mark.parametrize("domain", [None, [[(-1000, 1000), (0, 100)], [0, 100]]])
 def test_geometry_domain(tmp_path, domain):
@@ -27,10 +24,14 @@ def test_geometry_domain(tmp_path, domain):
                 assert len(soma_domain[idx][1]) == 2
 
                 for axis_idx, axis_name in enumerate(geom.coordinate_space.axis_names):
-                    assert soma_domain[idx][0][axis_name] == (f64info.min if domain is None else domain[0][axis_idx][0])
+                    assert soma_domain[idx][0][axis_name] == (
+                        f64info.min if domain is None else domain[0][axis_idx][0]
+                    )
 
                 for axis_idx, axis_name in enumerate(geom.coordinate_space.axis_names):
-                    assert soma_domain[idx][1][axis_name] == (f64info.max if domain is None else domain[0][axis_idx][1])
+                    assert soma_domain[idx][1][axis_name] == (
+                        f64info.max if domain is None else domain[0][axis_idx][1]
+                    )
 
 
 def test_geometry_coordinate_space(tmp_path):
@@ -54,4 +55,3 @@ def test_geometry_coordinate_space(tmp_path):
         )
         assert geom.coordinate_space[0] == soma.Axis(name="x", unit="m")
         assert geom.coordinate_space[1] == soma.Axis(name="y", unit="in")
-

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -624,8 +624,13 @@ class SOMAArray : public SOMAObject {
      * @return std::unique_ptr<ArrowSchema> Schema
      */
     std::unique_ptr<ArrowSchema> arrow_schema() const {
-        return ArrowAdapter::arrow_schema_from_tiledb_array(
-            ctx_->tiledb_ctx(), arr_);
+        auto schema = ArrowAdapter::make_arrow_schema_parent(columns_.size());
+
+        for (size_t i = 0; i < columns_.size(); ++i) {
+            schema->children[i] = columns_[i]->arrow_schema_slot(*ctx_, *arr_);
+        }
+
+        return schema;
     }
 
     /**

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -15,7 +15,10 @@
 
 namespace tiledbsoma {
 std::shared_ptr<SOMAColumn> SOMAAttribute::deserialize(
-    const nlohmann::json& soma_schema, const Context& ctx, const Array& array) {
+    const nlohmann::json& soma_schema,
+    const Context& ctx,
+    const Array& array,
+    const std::map<std::string, tiledbsoma::MetadataValue>&) {
     if (!soma_schema.contains(TILEDB_SOMA_SCHEMA_COL_ATTR_KEY)) {
         throw TileDBSOMAError(
             "[SOMAAttribute][deserialize] Missing required field "
@@ -136,7 +139,7 @@ std::any SOMAAttribute::_core_current_domain_slot(NDRectangle&) const {
         name()));
 }
 
-ArrowArray* SOMAAttribute::arrow_domain_slot(
+std::pair<ArrowArray*, ArrowSchema*> SOMAAttribute::arrow_domain_slot(
     const SOMAContext&, Array&, enum Domainish) const {
     throw TileDBSOMAError(std::format(
         "[SOMAAttribute][arrow_domain_slot] Column with name {} is not an "
@@ -145,7 +148,7 @@ ArrowArray* SOMAAttribute::arrow_domain_slot(
 }
 
 ArrowSchema* SOMAAttribute::arrow_schema_slot(
-    const SOMAContext& ctx, Array& array) {
+    const SOMAContext& ctx, Array& array) const {
     return ArrowAdapter::arrow_schema_from_tiledb_attribute(
                attribute, *ctx.tiledb_ctx(), array)
         .release();

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -35,7 +35,8 @@ class SOMAAttribute : public SOMAColumn {
     static std::shared_ptr<SOMAColumn> deserialize(
         const nlohmann::json& soma_schema,
         const Context& ctx,
-        const Array& array);
+        const Array& array,
+        const std::map<std::string, tiledbsoma::MetadataValue>& metadata);
 
     /**
      * Create a ``SOMAAttribute`` shared pointer from an Arrow schema
@@ -96,13 +97,13 @@ class SOMAAttribute : public SOMAColumn {
         return std::vector({enumeration.value()});
     }
 
-    ArrowArray* arrow_domain_slot(
+    std::pair<ArrowArray*, ArrowSchema*> arrow_domain_slot(
         const SOMAContext& ctx,
         Array& array,
         enum Domainish kind) const override;
 
     ArrowSchema* arrow_schema_slot(
-        const SOMAContext& ctx, Array& array) override;
+        const SOMAContext& ctx, Array& array) const override;
 
     void serialize(nlohmann::json&) const override;
 

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -40,9 +40,9 @@ class SOMAColumn {
     //===================================================================
 
     static std::vector<std::shared_ptr<SOMAColumn>> deserialize(
-        const nlohmann::json& soma_schema,
         const Context& ctx,
-        const Array& array);
+        const Array& array,
+        const std::map<std::string, tiledbsoma::MetadataValue>& metadata);
 
     //===================================================================
     //= public non-static
@@ -121,7 +121,7 @@ class SOMAColumn {
      * @param array
      * @param which_kind
      */
-    virtual ArrowArray* arrow_domain_slot(
+    virtual std::pair<ArrowArray*, ArrowSchema*> arrow_domain_slot(
         const SOMAContext& ctx,
         Array& array,
         enum Domainish which_kind) const = 0;
@@ -133,7 +133,7 @@ class SOMAColumn {
      * @param array
      */
     virtual ArrowSchema* arrow_schema_slot(
-        const SOMAContext& ctx, Array& array) = 0;
+        const SOMAContext& ctx, Array& array) const = 0;
 
     /**
      * Get the domain kind of the SOMAColumn.
@@ -531,7 +531,10 @@ class SOMAColumn {
 
    private:
     typedef std::shared_ptr<SOMAColumn> (*Factory)(
-        const nlohmann::json&, const Context&, const Array&);
+        const nlohmann::json&,
+        const Context&,
+        const Array&,
+        const std::map<std::string, tiledbsoma::MetadataValue>&);
 
     static std::map<uint32_t, Factory> deserialiser_map;
 };

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -14,6 +14,7 @@
 #include "soma_dataframe.h"
 #include <format>
 #include "../utils/logger.h"
+#include "soma_coordinates.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -34,6 +35,7 @@ void SOMADataFrame::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
+            std::nullopt,
             "SOMADataFrame",
             true,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -66,7 +66,7 @@ void SOMADenseNDArray::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
-            {},
+            std::nullopt,
             "SOMADenseNDArray",
             false,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -11,6 +11,7 @@
  *   This file defines the SOMADenseNDArray class.
  */
 #include "soma_dense_ndarray.h"
+#include "soma_coordinates.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -65,6 +66,7 @@ void SOMADenseNDArray::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
+            {},
             "SOMADenseNDArray",
             false,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -36,7 +36,8 @@ class SOMADimension : public SOMAColumn {
     static std::shared_ptr<SOMAColumn> deserialize(
         const nlohmann::json& soma_schema,
         const Context& ctx,
-        const Array& array);
+        const Array& array,
+        const std::map<std::string, tiledbsoma::MetadataValue>& metadata);
 
     static std::shared_ptr<SOMADimension> create(
         std::shared_ptr<Context> ctx,
@@ -89,13 +90,13 @@ class SOMADimension : public SOMAColumn {
         return std::nullopt;
     }
 
-    ArrowArray* arrow_domain_slot(
+    std::pair<ArrowArray*, ArrowSchema*> arrow_domain_slot(
         const SOMAContext& ctx,
         Array& array,
         enum Domainish kind) const override;
 
     ArrowSchema* arrow_schema_slot(
-        const SOMAContext& ctx, Array& array) override;
+        const SOMAContext& ctx, Array& array) const override;
 
     void serialize(nlohmann::json&) const override;
 

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -96,7 +96,7 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
             ctx,
             spatial_schema->children[j],
             spatial_array->children[j],
@@ -108,7 +108,7 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
             ctx,
             spatial_schema->children[j],
             spatial_array->children[j],
@@ -488,6 +488,11 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAGeometryColumn::arrow_domain_slot(
                 TDB_DIM_PER_SPATIAL_AXIS, name());
             auto parent_array = ArrowAdapter::make_arrow_array_parent(
                 TDB_DIM_PER_SPATIAL_AXIS);
+
+            parent_array->length = 2;
+            parent_array->n_buffers = 1;
+            parent_array->buffers = (const void**)malloc(sizeof(void*));
+            parent_array->buffers[0] = nullptr;
 
             auto kind_domain = domain_slot<std::vector<double_t>>(
                 ctx, array, kind);

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -15,7 +15,10 @@
 
 namespace tiledbsoma {
 std::shared_ptr<SOMAColumn> SOMAGeometryColumn::deserialize(
-    const nlohmann::json& soma_schema, const Context&, const Array& array) {
+    const nlohmann::json& soma_schema,
+    const Context&,
+    const Array& array,
+    const std::map<std::string, tiledbsoma::MetadataValue>& metadata) {
     if (!soma_schema.contains(TILEDB_SOMA_SCHEMA_COL_DIM_KEY)) {
         throw TileDBSOMAError(
             "[SOMAGeometryColumn][deserialize] Missing required field "
@@ -58,7 +61,19 @@ std::shared_ptr<SOMAColumn> SOMAGeometryColumn::deserialize(
 
     auto attribute = array.schema().attribute(attribute_names[0]);
 
-    return std::make_shared<SOMAGeometryColumn>(dimensions, attribute);
+    if (!metadata.contains(SOMA_COORDINATE_SPACE_KEY)) {
+        throw TileDBSOMAError(std::format(
+            "[SOMAGeometryColumn][deserialize] Missing required '{}' "
+            "metadata key.",
+            SOMA_COORDINATE_SPACE_KEY));
+    }
+
+    auto coordinate_space = std::apply(
+        SOMACoordinateSpace::from_metadata,
+        metadata.at(SOMA_COORDINATE_SPACE_KEY));
+
+    return std::make_shared<SOMAGeometryColumn>(
+        dimensions, attribute, coordinate_space);
 }
 
 std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
@@ -66,6 +81,7 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
     ArrowSchema* schema,
     ArrowSchema* spatial_schema,
     ArrowArray* spatial_array,
+    const SOMACoordinateSpace& coordinate_space,
     const std::string& soma_type,
     std::string_view type_metadata,
     PlatformConfig platform_config) {
@@ -107,7 +123,7 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
         ctx, schema, type_metadata, platform_config);
 
     return std::make_shared<SOMAGeometryColumn>(
-        SOMAGeometryColumn(dims, attribute.first));
+        SOMAGeometryColumn(dims, attribute.first, coordinate_space));
 }
 
 void SOMAGeometryColumn::_set_dim_points(
@@ -464,13 +480,44 @@ std::any SOMAGeometryColumn::_core_current_domain_slot(
         std::make_pair(min, max));
 }
 
-ArrowArray* SOMAGeometryColumn::arrow_domain_slot(
+std::pair<ArrowArray*, ArrowSchema*> SOMAGeometryColumn::arrow_domain_slot(
     const SOMAContext& ctx, Array& array, enum Domainish kind) const {
     switch (domain_type().value()) {
-        case TILEDB_FLOAT64:
-            return ArrowAdapter::make_arrow_array_child_var(
-                domain_slot<std::vector<double_t>>(ctx, array, kind));
-            break;
+        case TILEDB_FLOAT64: {
+            auto parent_schema = ArrowAdapter::make_arrow_schema_parent(
+                TDB_DIM_PER_SPATIAL_AXIS, name());
+            auto parent_array = ArrowAdapter::make_arrow_array_parent(
+                TDB_DIM_PER_SPATIAL_AXIS);
+
+            auto kind_domain = domain_slot<std::vector<double_t>>(
+                ctx, array, kind);
+
+            for (size_t i = 0; i < TDB_DIM_PER_SPATIAL_AXIS; ++i) {
+                // Generate coordinate space axie schema
+                auto child_schema = static_cast<ArrowSchema*>(
+                    malloc(sizeof(ArrowSchema)));
+                child_schema->format = strdup(
+                    ArrowAdapter::to_arrow_format(TILEDB_FLOAT64).data());
+                child_schema->name = strdup(
+                    coordinate_space.axis(i).name.c_str());
+                child_schema->metadata = nullptr;
+                child_schema->flags = 0;
+                child_schema->n_children = 0;
+                child_schema->children = nullptr;
+                child_schema->dictionary = nullptr;
+                child_schema->release = &ArrowAdapter::release_schema;
+                child_schema->private_data = nullptr;
+
+                parent_schema->children[i] = child_schema;
+
+                parent_array->children[i] =
+                    ArrowAdapter::make_arrow_array_child<double_t>(std::vector(
+                        {kind_domain.first[i], kind_domain.second[i]}));
+            }
+
+            return std::make_pair(
+                parent_array.release(), parent_schema.release());
+        } break;
         default:
             throw TileDBSOMAError(std::format(
                 "[SOMAGeometryColumn][arrow_domain_slot] dim {} has unhandled "
@@ -482,7 +529,7 @@ ArrowArray* SOMAGeometryColumn::arrow_domain_slot(
 }
 
 ArrowSchema* SOMAGeometryColumn::arrow_schema_slot(
-    const SOMAContext& ctx, Array& array) {
+    const SOMAContext& ctx, Array& array) const {
     return ArrowAdapter::arrow_schema_from_tiledb_attribute(
                attribute, *ctx.tiledb_ctx(), array)
         .release();

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -74,13 +74,13 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
         throw TileDBSOMAError(std::format(
             "[SOMAGeometryColumn] "
             "Unkwown type metadata for `{}`: "
-            "Expected 'WKB', got {}",
+            "Expected 'WKB', got '{}'",
             SOMA_GEOMETRY_COLUMN_NAME,
             type_metadata));
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
             ctx,
             spatial_schema->children[j],
             spatial_array->children[j],
@@ -92,7 +92,7 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
+        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
             ctx,
             spatial_schema->children[j],
             spatial_array->children[j],

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -31,7 +31,6 @@ void SOMAGeometryDataFrame::create(
     std::string_view uri,
     const std::unique_ptr<ArrowSchema>& schema,
     const ArrowTable& index_columns,
-    const ArrowTable& spatial_columns,
     const SOMACoordinateSpace& coordinate_space,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
@@ -43,8 +42,7 @@ void SOMAGeometryDataFrame::create(
             index_columns,
             "SOMAGeometryDataFrame",
             true,
-            platform_config,
-            spatial_columns);
+            platform_config);
 
     auto array = SOMAArray::_create(
         ctx,

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -16,6 +16,7 @@
 #include "../geometry/operators/envelope.h"
 #include "../geometry/operators/io/write.h"
 #include "../utils/util.h"
+#include "soma_geometry_column.h"
 
 #include <regex>
 #include <unordered_set>
@@ -40,6 +41,7 @@ void SOMAGeometryDataFrame::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
+            std::make_optional(coordinate_space),
             "SOMAGeometryDataFrame",
             true,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -49,7 +49,6 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
         std::string_view uri,
         const std::unique_ptr<ArrowSchema>& schema,
         const ArrowTable& index_columns,
-        const ArrowTable& spatial_columns,
         const SOMACoordinateSpace& coordinate_space,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -36,6 +36,7 @@ void SOMAPointCloudDataFrame::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
+            std::make_optional(coordinate_space),
             "SOMAPointCloudDataFrame",
             true,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -67,7 +67,7 @@ void SOMASparseNDArray::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
-            {},
+            std::nullopt,
             "SOMASparseNDArray",
             true,
             platform_config);

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -12,6 +12,7 @@
  */
 
 #include "soma_sparse_ndarray.h"
+#include "soma_coordinates.h"
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -66,6 +67,7 @@ void SOMASparseNDArray::create(
             ctx->tiledb_ctx(),
             schema,
             index_columns,
+            {},
             "SOMASparseNDArray",
             true,
             platform_config);

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -879,7 +879,8 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
     const ArrowTable& index_column_info,
     std::string soma_type,
     bool is_sparse,
-    PlatformConfig platform_config) {
+    PlatformConfig platform_config,
+    const ArrowTable& spatial_column_info) {
     auto& index_column_array = index_column_info.first;
     auto& index_column_schema = index_column_info.second;
 
@@ -939,12 +940,13 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
             if (strcmp(child->name, index_column_schema->children[i]->name) ==
                 0) {
                 if (strcmp(child->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) ==
-                    0) {
+                        0 &&
+                    spatial_column_info.first.get() != nullptr) {
                     columns.push_back(SOMAGeometryColumn::create(
                         ctx,
                         child,
-                        index_column_schema->children[i],
-                        index_column_array->children[i],
+                        spatial_column_info.second.get(),
+                        spatial_column_info.first.get(),
                         soma_type,
                         type_metadata,
                         platform_config));
@@ -1051,28 +1053,23 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
             continue;
         }
 
-        column->set_current_domain_slot(
-            ndrect,
-            get_table_any_column_by_name<2>(
-                index_column_info, column->name(), 3));
+        if (column->name() == SOMA_GEOMETRY_COLUMN_NAME) {
+            std::vector<std::any> cdslot;
+            for (int64_t j = 0; j < spatial_column_info.first->n_children;
+                 ++j) {
+                cdslot.push_back(ArrowAdapter::get_table_any_column<2>(
+                    spatial_column_info.first->children[j],
+                    spatial_column_info.second->children[j],
+                    3));
+            }
 
-        // if (column->name() == SOMA_GEOMETRY_COLUMN_NAME) {
-        //     std::vector<std::any> cdslot;
-        //     for (int64_t j = 0; j < spatial_column_info.first->n_children;
-        //          ++j) {
-        //         cdslot.push_back(ArrowAdapter::get_table_any_column<2>(
-        //             spatial_column_info.first->children[j],
-        //             spatial_column_info.second->children[j],
-        //             3));
-        //     }
-
-        //     column->set_current_domain_slot(ndrect, cdslot);
-        // } else {
-        //     column->set_current_domain_slot(
-        //         ndrect,
-        //         get_table_any_column_by_name<2>(
-        //             index_column_info, column->name(), 3));
-        // }
+            column->set_current_domain_slot(ndrect, cdslot);
+        } else {
+            column->set_current_domain_slot(
+                ndrect,
+                get_table_any_column_by_name<2>(
+                    index_column_info, column->name(), 3));
+        }
     }
     current_domain.set_ndrectangle(ndrect);
 
@@ -1118,54 +1115,6 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema(
     }
 
     const void* buff = array->buffers[1];
-    auto dim = ArrowAdapter::_create_dim(type, col_name, buff, ctx);
-    dim.set_filter_list(filter_list);
-
-    return dim;
-}
-
-Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
-    std::shared_ptr<Context> ctx,
-    ArrowSchema* schema,
-    ArrowArray* array,
-    std::string soma_type,
-    std::string_view type_metadata,
-    std::string prefix,
-    std::string suffix,
-    PlatformConfig platform_config) {
-    if (strcmp(schema->format, "+l") != 0) {
-        throw TileDBSOMAError(
-            std::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should be of type list."));
-    }
-
-    if (schema->n_children != 1) {
-        throw TileDBSOMAError(
-            std::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should have exactly 1 child"));
-    }
-
-    auto type = ArrowAdapter::to_tiledb_format(
-        schema->children[0]->format, type_metadata);
-
-    if (ArrowAdapter::arrow_is_var_length_type(schema->format)) {
-        type = TILEDB_STRING_ASCII;
-    }
-
-    auto col_name = prefix + std::string(schema->name) + suffix;
-
-    FilterList filter_list = ArrowAdapter::_create_dim_filter_list(
-        col_name, platform_config, soma_type, ctx);
-
-    if (array->length != 5) {
-        throw TileDBSOMAError(std::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
-            "'{}'",
-            array->length,
-            col_name));
-    }
-
-    const void* buff = array->children[0]->buffers[1];
     auto dim = ArrowAdapter::_create_dim(type, col_name, buff, ctx);
     dim.set_filter_list(filter_list);
 

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -934,15 +934,8 @@ class ArrowAdapter {
             // Complex domain like the ones required by `GeometryColumn` expect
             // a struct containing lists of values
             for (int64_t i = 0; i < selected_schema->n_children; ++i) {
-                if (strcmp(selected_schema->children[i]->format, "+l") != 0) {
-                    throw std::runtime_error(std::format(
-                        "[ArrowAdapter][get_table_any_column_by_index] Complex "
-                        "column struct should contain list but found '{}'",
-                        selected_schema->children[i]->format));
-                }
-
-                ArrowArray* array = selected_array->children[i]->children[0];
-                ArrowSchema* schema = selected_schema->children[i]->children[0];
+                ArrowArray* array = selected_array->children[i];
+                ArrowSchema* schema = selected_schema->children[i];
 
                 result.push_back(
                     get_table_any_column<S>(array, schema, offset));

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -58,6 +58,7 @@ using namespace tiledb;
 using json = nlohmann::json;
 
 class ColumnBuffer;
+class SOMACoordinateSpace;
 
 /**
  * @brief The ArrowBuffer holds a shared pointer to a ColumnBuffer, which
@@ -366,7 +367,9 @@ class ArrowAdapter {
      * @return ArrowSchema
      */
     static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_attribute(
-        Attribute& attribute, const Context& ctx, const Array& tiledb_array);
+        const Attribute& attribute,
+        const Context& ctx,
+        const Array& tiledb_array);
 
     /**
      * @brief Get members of the TileDB Schema in the form of a
@@ -406,6 +409,7 @@ class ArrowAdapter {
         std::shared_ptr<Context> ctx,
         const std::unique_ptr<ArrowSchema>& arrow_schema,
         const ArrowTable& index_column_info,
+        const std::optional<SOMACoordinateSpace>& coordinate_space,
         std::string soma_type,
         bool is_sparse = true,
         PlatformConfig platform_config = PlatformConfig());
@@ -515,7 +519,7 @@ class ArrowAdapter {
      * ArrowSchema. This constructs the parent and not the children.
      */
     static std::unique_ptr<ArrowSchema> make_arrow_schema_parent(
-        size_t num_columns);
+        size_t num_columns, std::string_view name = "parent");
 
     /**
      * @brief Creates a nanoarrow ArrowArray which accommodates

--- a/libtiledbsoma/test/common.h
+++ b/libtiledbsoma/test/common.h
@@ -68,7 +68,8 @@ struct AttrInfo {
 std::pair<std::unique_ptr<ArrowSchema>, ArrowTable>
 create_arrow_schema_and_index_columns(
     const std::vector<DimInfo>& dim_infos,
-    const std::vector<AttrInfo>& attr_infos);
+    const std::vector<AttrInfo>& attr_infos,
+    std::optional<SOMACoordinateSpace> coordinate_space = std::nullopt);
 
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos);
 
@@ -78,7 +79,8 @@ std::string to_arrow_format(tiledb_datatype_t tiledb_datatype);
 bool have_dense_current_domain_support();
 
 std::unique_ptr<ArrowSchema> create_index_cols_info_schema(
-    const std::vector<DimInfo>& dim_infos);
+    const std::vector<DimInfo>& dim_infos,
+    std::optional<SOMACoordinateSpace> coordinate_space = std::nullopt);
 
 }  // namespace helper
 #endif

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -466,7 +466,7 @@ TEST_CASE("SOMAArray: Write and read back Boolean") {
     schema.add_attribute(attr);
     schema.set_allows_dups(true);
 
-    SOMAArray::create(ctx, uri, std::move(schema), "NONE", "");
+    SOMAArray::create(ctx, uri, std::move(schema), "NONE");
     auto soma_array = SOMAArray::open(OpenMode::write, uri, ctx);
 
     auto arrow_schema = std::make_unique<ArrowSchema>();

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -14,6 +14,7 @@
 #include <format>
 #include <tiledb/tiledb>
 #include <tiledbsoma/tiledbsoma>
+#include <tuple>
 #include "../src/soma/soma_attribute.h"
 #include "../src/soma/soma_column.h"
 #include "../src/soma/soma_dimension.h"
@@ -342,33 +343,30 @@ TEST_CASE_METHOD(
             ned_str = ArrowAdapter::get_table_string_column_by_name(
                 non_empty_domain, "mystring");
 
-        std::vector<std::string>
-            ned_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_non_empty_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> ned_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_non_empty_domain));
 
         ArrowTable soma_domain = sdf->get_soma_domain();
         std::vector<std::string>
             dom_str = ArrowAdapter::get_table_string_column_by_name(
                 soma_domain, "mystring");
 
-        std::vector<std::string>
-            dom_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_core_current_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> dom_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_core_current_domain));
 
         ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
         std::vector<std::string>
             maxdom_str = ArrowAdapter::get_table_string_column_by_name(
                 soma_maxdomain, "mystring");
 
-        std::vector<std::string>
-            maxdom_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_core_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> maxdom_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_core_domain));
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));
 
@@ -501,33 +499,30 @@ TEST_CASE_METHOD(
             ned_str = ArrowAdapter::get_table_string_column_by_name(
                 non_empty_domain, "mystring");
 
-        std::vector<std::string>
-            ned_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_non_empty_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> ned_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_non_empty_domain));
 
         ArrowTable soma_domain = sdf->get_soma_domain();
         std::vector<std::string>
             dom_str = ArrowAdapter::get_table_string_column_by_name(
                 soma_domain, "mystring");
 
-        std::vector<std::string>
-            dom_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_core_current_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> dom_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_core_current_domain));
 
         ArrowTable soma_maxdomain = sdf->get_soma_maxdomain();
         std::vector<std::string>
             maxdom_str = ArrowAdapter::get_table_string_column_by_name(
                 soma_maxdomain, "mystring");
 
-        std::vector<std::string>
-            maxdom_str_col = ArrowAdapter::get_array_string_column(
-                columns[0]->arrow_domain_slot(
-                    *ctx_, raw_array, Domainish::kind_core_domain),
-                columns[0]->arrow_schema_slot(*ctx_, raw_array));
+        std::vector<std::string> maxdom_str_col = std::apply(
+            ArrowAdapter::get_array_string_column,
+            columns[0]->arrow_domain_slot(
+                *ctx_, raw_array, Domainish::kind_core_domain));
 
         REQUIRE(ned_str == std::vector<std::string>({"", ""}));
 

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -227,23 +227,31 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     while (auto batch = soma_geometry->read_next()) {
         auto arrbuf = batch.value();
         auto d0span = arrbuf->at(dim_infos[0].name)->data<int64_t>();
+        auto d1span = arrbuf->at(SOMA_GEOMETRY_DIMENSION_PREFIX + "x__min")
+                          ->data<double_t>();
+        auto d2span = arrbuf->at(SOMA_GEOMETRY_DIMENSION_PREFIX + "x__max")
+                          ->data<double_t>();
+        auto d3span = arrbuf->at(SOMA_GEOMETRY_DIMENSION_PREFIX + "y__min")
+                          ->data<double_t>();
+        auto d4span = arrbuf->at(SOMA_GEOMETRY_DIMENSION_PREFIX + "y__max")
+                          ->data<double_t>();
         auto wkbs = arrbuf->at(dim_infos[1].name)->binaries();
         auto a0span = arrbuf->at(attr_infos[0].name)->data<double>();
         CHECK(
             std::vector<int64_t>({1}) ==
             std::vector<int64_t>(d0span.begin(), d0span.end()));
-        // CHECK(
-        //     std::vector<double_t>({0}) ==
-        //     std::vector<double_t>(d1span.begin(), d1span.end()));
-        // CHECK(
-        //     std::vector<double_t>({1}) ==
-        //     std::vector<double_t>(d2span.begin(), d2span.end()));
-        // CHECK(
-        //     std::vector<double_t>({0}) ==
-        //     std::vector<double_t>(d3span.begin(), d3span.end()));
-        // CHECK(
-        //     std::vector<double_t>({1}) ==
-        //     std::vector<double_t>(d4span.begin(), d4span.end()));
+        CHECK(
+            std::vector<double_t>({0}) ==
+            std::vector<double_t>(d1span.begin(), d1span.end()));
+        CHECK(
+            std::vector<double_t>({1}) ==
+            std::vector<double_t>(d2span.begin(), d2span.end()));
+        CHECK(
+            std::vector<double_t>({0}) ==
+            std::vector<double_t>(d3span.begin(), d3span.end()));
+        CHECK(
+            std::vector<double_t>({1}) ==
+            std::vector<double_t>(d4span.begin(), d4span.end()));
         CHECK(geometry::to_wkb(polygon) == wkbs[0]);
         CHECK(
             std::vector<double_t>({63}) ==

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -70,9 +70,6 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)),
-        ArrowTable(
-            std::move(spatial_columns.first),
-            std::move(spatial_columns.second)),
         coord_space,
         ctx,
         platform_config,
@@ -156,9 +153,6 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
         std::move(schema),
         ArrowTable(
             std::move(index_columns.first), std::move(index_columns.second)),
-        ArrowTable(
-            std::move(spatial_columns.first),
-            std::move(spatial_columns.second)),
         coord_space,
         ctx,
         platform_config,


### PR DESCRIPTION
**Issue and/or context:** [sc-50295](https://app.shortcut.com/tiledb-inc/story/50295/add-geometrydataframe-class)

**Changes:**

**Notes for Reviewer:**
Adds basic implementation for `GeometryDataFrame` in the python API, adds static create method and property accessors.
Adapt already existing read methods from arrow tables to work with the newly introduced complex domain (a struct on values) used by `soma_geometry` column.

