### PR TITLE
[c++] Add CMake check for GCC minimum version 13

### DIFF
--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -181,7 +181,7 @@ set(EP_INSTALL_PREFIX "${EP_BASE}/install")
 set(GCC_MIN 13.0)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_MIN)
-        message(FATAL_ERROR "GNU GCC must be at least version ${GCC_MIN}. Using version ${CMAKE_CXX_COMPILER_VERSION}.")
+        message(FATAL_ERROR "GNU GCC must be at least version ${GCC_MIN}. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
     endif()
 endif()
 

--- a/libtiledbsoma/CMakeLists.txt
+++ b/libtiledbsoma/CMakeLists.txt
@@ -173,6 +173,19 @@ message(STATUS "Starting TileDB-SOMA regular build.")
 set(EP_SOURCE_DIR "${EP_BASE}/src")
 set(EP_INSTALL_PREFIX "${EP_BASE}/install")
 
+
+# ###########################################################
+# Check compiler version supports full C++20 standard.
+# ###########################################################
+
+set(GCC_MIN 13.0)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_MIN)
+        message(FATAL_ERROR "GNU GCC must be at least version ${GCC_MIN}. Using version ${CMAKE_CXX_COMPILER_VERSION}.")
+    endif()
+endif()
+
+
 # ###########################################################
 # Compile options/definitions for all targets
 # ###########################################################
@@ -220,6 +233,7 @@ if(MSVC)
     $<$<CONFIG:RelWithDebInfo>:/DNDEBUG /Ox /Zi>
   )
 else()
+
 
   set(TILEDBSOMA_COMPILE_OPTIONS -Wall -Wextra -DSPDLOG_USE_STD_FORMAT -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2)
 


### PR DESCRIPTION
Add GCC minimum version check to CMake.

Context: #3154 / [[sc-57301]](https://app.shortcut.com/tiledb-inc/story/57301/use-c-20). See also https://github.com/single-cell-data/TileDB-SOMA/pull/3673#pullrequestreview-2595929065.