### PR TITLE
[r/c++/python] (DRAFT) Add SOMA type-specific `allows_duplicates` options

### DIFF
--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -335,6 +335,11 @@ def build_clib_platform_config(
     plt_cfg.offsets_filters = _build_filter_list(ops.offsets_filters)
     plt_cfg.validity_filters = _build_filter_list(ops.validity_filters)
     plt_cfg.allows_duplicates = ops.allows_duplicates
+    plt_cfg.sparse_nd_array_allows_duplicates = ops.sparse_nd_array_allows_duplicates
+    plt_cfg.dataframe_allows_duplicates = ops.dataframe_allows_duplicates
+    plt_cfg.point_cloud_dataframe_allows_duplicates = (
+        ops.point_cloud_dataframe_allows_duplicates
+    )
     plt_cfg.tile_order = ops.tile_order
     plt_cfg.cell_order = ops.cell_order
     plt_cfg.dims = _build_column_config(ops.dims)

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -144,6 +144,19 @@ class TileDBCreateOptions:
         validator=vld.instance_of(bool),
         default=False,
     )
+    sparse_nd_array_allows_duplicates: bool | None = attrs_.field(
+        validator=vld.instance_of(Union[bool, None]),
+        default=None,
+    )
+    dataframe_allows_duplicates: bool | None = attrs_.field(
+        validator=vld.instance_of(Union[bool, None]),
+        default=None,
+    )
+    point_cloud_dataframe_allows_duplicates: bool | None = attrs_.field(
+        validator=vld.instance_of(Union[bool, None]),
+        default=None,
+    )
+
     tile_order: str | None = attrs_.field(
         validator=vld.optional(vld.instance_of(str)), default=None
     )

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -138,6 +138,15 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def_readwrite("attrs", &PlatformConfig::attrs)
         .def_readwrite("dims", &PlatformConfig::dims)
         .def_readwrite("allows_duplicates", &PlatformConfig::allows_duplicates)
+        .def_readwrite(
+            "sparse_nd_array_allows_duplicates",
+            &PlatformConfig::sparse_nd_array_allows_duplicates)
+        .def_readwrite(
+            "dataframe_allows_duplicates",
+            &PlatformConfig::dataframe_allows_duplicates)
+        .def_readwrite(
+            "point_cloud_dataframe_allows_duplicates",
+            &PlatformConfig::point_cloud_dataframe_allows_duplicates)
         .def_readwrite("tile_order", &PlatformConfig::tile_order)
         .def_readwrite("cell_order", &PlatformConfig::cell_order)
         .def_readwrite(

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -153,6 +153,38 @@ def test_sparse_nd_array_reopen(tmp_path):
                 assert A3.tiledb_timestamp <= now
 
 
+@pytest.mark.parametrize(
+    "allows_duplicates,sparse_nd_array_allows_duplicates,expected",
+    [
+        (True, None, True),
+        (False, None, False),
+        (True, False, False),
+        (False, True, True),
+    ],
+)
+def test_sparse_nd_array_create_allows_duplicates(
+    tmp_path, allows_duplicates, sparse_nd_array_allows_duplicates, expected
+):
+    uri = tmp_path.as_posix()
+    platform_config = {
+        "tiledb": {
+            "create": {
+                "allows_duplicates": allows_duplicates,
+                "sparse_nd_array_allows_duplicates": sparse_nd_array_allows_duplicates,
+            }
+        }
+    }
+
+    with soma.SparseNDArray.create(
+        uri, type=pa.float32(), shape=(100, 1000), platform_config=platform_config
+    ) as array:
+        config_result = array.schema_config_options()
+
+    result = config_result.allows_duplicates
+
+    assert result == expected
+
+
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
 def test_sparse_nd_array_create_fail(

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -166,8 +166,34 @@ struct PlatformConfig {
     /* Set the validity filters. */
     std::string validity_filters = "";
 
-    /* Set whether the TileDB Array allows duplicate values */
+    /* Set whether the TileDB Array allows duplicate values.
+     *
+     * This values only affects `SparseNDArray`, `DataFrame`, and
+     * `PointCloudDataFrame` types. It can be over-ridden by the type specific
+     * values `sparse_nd_array_allows_duplicates`,
+     * `dataframe_allows_duplicates`, and
+     * `point_cloud_dataframe_allows_duplicates`.
+     *
+     * Duplicates are always enabled for the `geometry_dataframe`.
+     *
+     * Duplicates are always disabled for `DenseNDArray` and `MultiscaleImage`.
+     */
     bool allows_duplicates = false;
+
+    /* Set whether the Sparse TileDB Array allows duplicate values. Overrides
+     * `allows_duplicates` for ``SparseNDArray`` classes.
+     */
+    std::optional<bool> sparse_nd_array_allows_duplicates = std::nullopt;
+
+    /* Set whether the Sparse TileDB Array allows duplicate values. Overrides
+     * `allows_duplicates` for ``DataFrame`` classes.
+     */
+    std::optional<bool> dataframe_allows_duplicates = std::nullopt;
+
+    /* Set whether the Sparse TileDB Array allows duplicate values. Overrides
+     * `allows_duplicates` for ``PointCloudDataFrame`` classes.
+     */
+    std::optional<bool> point_cloud_dataframe_allows_duplicates = std::nullopt;
 
     /* Set the tile order as "row", "row-major", "col", or "col-major" */
     std::optional<std::string> tile_order = std::nullopt;


### PR DESCRIPTION
**Issue and/or context:** [sc-61642]

**Changes:**
Adds new options `sparse_nd_array_allows_duplicates`, `dataframe_allows_duplicates`, and `point_cloud_dataframe_allows_duplicates` to the `PlatformConfig` that can override the generic `allows_duplicates` option for all arrays.


