### PR TITLE
[c++] Modify enum labels to `{name}_{dtype}`

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1738,7 +1738,6 @@ def _update_dataframe(
                 add_attrs[add_key] = get_arrow_str_format(atype.index_type)
 
                 enmr_format = get_arrow_str_format(atype.value_type)
-                enmr_label = f"{add_key}_{enmr_format}"
                 add_enmrs[add_key] = (enmr_format, atype.ordered)
             else:
                 add_attrs[add_key] = get_arrow_str_format(atype)

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -17,6 +17,7 @@ template <typename... Args>
 using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
 
 void load_soma_context(py::module&);
+void load_fastercsx(py::module&);
 void load_soma_object(py::module&);
 void load_soma_array(py::module&);
 void load_soma_dataframe(py::module&);
@@ -30,7 +31,6 @@ void load_query_condition(py::module&);
 void load_reindexer(py::module&);
 void load_soma_vfs(py::module&);
 void load_managed_query(py::module&);
-void load_fastercsx(py::module&);
 
 PYBIND11_MODULE(pytiledbsoma, m) {
     py::register_exception<TileDBSOMAError>(m, "SOMAError");
@@ -158,9 +158,8 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def_readwrite("tile_order", &PlatformSchemaConfig::tile_order)
         .def_readwrite("cell_order", &PlatformSchemaConfig::cell_order);
 
-    m.def("_update_dataframe_schema", &SOMADataFrame::update_dataframe_schema);
-
     load_soma_context(m);
+    load_fastercsx(m);
     load_soma_object(m);
     load_soma_array(m);
     load_soma_dataframe(m);
@@ -174,7 +173,6 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     load_reindexer(m);
     load_soma_vfs(m);
     load_managed_query(m);
-    load_fastercsx(m);
 }
 
 };  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -301,7 +301,11 @@ void load_soma_dataframe(py::module& m) {
                 }
             },
             "pyarrow_domain_table"_a,
-            "function_name_for_messages"_a);
+            "function_name_for_messages"_a)
+
+        .def(
+            "_update_dataframe_schema",
+            &SOMADataFrame::update_dataframe_schema);
 }
 
 }  // namespace libtiledbsomacpp

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -574,7 +574,7 @@ void c_update_dataframe_schema(
 
     // For enum columns, two more things: value type (e.g. string) and
     // is-ordered-enum boolean. These come into us as separate lists but
-    // we will reshape them into a map from enum-attr name to pair of
+    // we will reshape them into a map from enum-attr name to tuple of
     // (value_type, ordered).
 
     // First do integrity checks.
@@ -606,11 +606,11 @@ void c_update_dataframe_schema(
                 add_cols_enum_value_types[i]);
             type_name = remap_arrow_type_code_r_to_c(type_name);
             bool ordered = Rcpp::as<bool>(add_cols_enum_ordered[i]);
-
-            add_enmrs.emplace(key, std::pair(type_name, ordered));
+            add_enmrs.emplace(key, std::make_pair(type_name, ordered));
         }
     }
 
-    tdbs::SOMADataFrame::update_dataframe_schema(
-        uri, ctxxp->ctxptr, drop_attrs, add_attrs, add_enmrs);
+    auto sdf = tdbs::SOMADataFrame::open(uri, OpenMode::write, ctxxp->ctxptr);
+    sdf->update_dataframe_schema(drop_attrs, add_attrs, add_enmrs);
+    sdf->close();
 }

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1026,9 +1026,8 @@ bool ManagedQuery::_extend_enumeration(
     ArrowArray* index_array,
     ArraySchemaEvolution se) {
     // For columns with dictionaries, we need to identify whether the
-
-    auto enmr = ArrayExperimental::get_enumeration(
-        *ctx_, *array_, index_schema->name);
+    auto enumname = util::get_enmr_label(index_schema, value_schema);
+    auto enmr = ArrayExperimental::get_enumeration(*ctx_, *array_, enumname);
     auto value_type = enmr.type();
 
     switch (value_type) {
@@ -1106,8 +1105,8 @@ bool ManagedQuery::_extend_and_evolve_schema(
     }
 
     // Get all the enumeration values in the on-disk TileDB attribute
-    std::string column_name = index_schema->name;
-    auto enmr = ArrayExperimental::get_enumeration(*ctx_, *array_, column_name);
+    auto enumname = util::get_enmr_label(index_schema, value_schema);
+    auto enmr = ArrayExperimental::get_enumeration(*ctx_, *array_, enumname);
     std::vector<ValueType> enums_existing = enmr.as_vector<ValueType>();
 
     // Find any new enumeration values
@@ -1119,6 +1118,7 @@ bool ManagedQuery::_extend_and_evolve_schema(
         }
     }
 
+    std::string column_name = index_schema->name;
     // extend_values = {true, false};
     if (extend_values.size() != 0) {
         // We have new enumeration values; additional processing needed
@@ -1199,8 +1199,8 @@ bool ManagedQuery::_extend_and_evolve_schema<std::string>(
         enums_in_write.push_back(data_v.substr(beg, sz));
     }
 
-    std::string column_name = index_schema->name;
-    auto enmr = ArrayExperimental::get_enumeration(*ctx_, *array_, column_name);
+    auto enumname = util::get_enmr_label(index_schema, value_schema);
+    auto enmr = ArrayExperimental::get_enumeration(*ctx_, *array_, enumname);
     std::vector<std::string> extend_values;
     auto enums_existing = enmr.as_vector<std::string>();
     for (auto enum_val : enums_in_write) {
@@ -1210,6 +1210,7 @@ bool ManagedQuery::_extend_and_evolve_schema<std::string>(
         }
     }
 
+    std::string column_name = index_schema->name;
     if (extend_values.size() != 0) {
         // Check that we extend the enumeration values without
         // overflowing

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -167,13 +167,15 @@ SOMAArray::SOMAArray(
     std::shared_ptr<SOMAContext> ctx,
     std::shared_ptr<Array> arr,
     std::optional<TimestampRange> timestamp)
+    // Ensure protected attributes initalized first in a consistent ordering
     : uri_(util::rstrip_uri(arr->uri()))
     , ctx_(ctx)
+    , arr_(arr)
+    , mq_(std::make_unique<ManagedQuery>(arr, ctx_->tiledb_ctx(), name_))
+    // Initialize private attributes next to control the order of destruction
     , batch_size_("auto")
     , result_order_(ResultOrder::automatic)
     , timestamp_(timestamp)
-    , mq_(std::make_unique<ManagedQuery>(arr, ctx_->tiledb_ctx(), name_))
-    , arr_(arr)
     , schema_(std::make_shared<ArraySchema>(arr->schema())) {
     reset({}, batch_size_, result_order_);
     fill_metadata_cache(timestamp);

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -46,9 +46,9 @@ std::shared_ptr<SOMAColumn> SOMAAttribute::deserialize(
         ctx, attribute);
 
     std::optional<Enumeration>
-        enumeration = enumeration_name ?
+        enumeration = enumeration_name.has_value() ?
                           std::make_optional(ArrayExperimental::get_enumeration(
-                              ctx, array, attribute.name())) :
+                              ctx, array, enumeration_name.value())) :
                           std::nullopt;
 
     return std::make_shared<SOMAAttribute>(attribute, enumeration);

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -97,7 +97,9 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
             auto enumeration = enumeration_name.has_value() ?
                                    std::make_optional(
                                        ArrayExperimental::get_enumeration(
-                                           ctx, array, attribute.name())) :
+                                           ctx,
+                                           array,
+                                           enumeration_name.value())) :
                                    std::nullopt;
 
             columns.push_back(
@@ -117,7 +119,9 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
             auto enumeration = enumeration_name.has_value() ?
                                    std::make_optional(
                                        ArrayExperimental::get_enumeration(
-                                           ctx, array, attribute.name())) :
+                                           ctx,
+                                           array,
+                                           enumeration_name.value())) :
                                    std::nullopt;
 
             columns.push_back(

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -121,13 +121,11 @@ class SOMADataFrame : public SOMAArray {
      * o drop_cols: attr_name
      * o add_attrs: attr_name -> Arrow type string for the index
      *   type, e.g. 'c' for int8
-     * o add_enmrs: attr_name -> pair of:
+     * o add_enmrs: attr_name -> tuple of:
      *   - Arrow type string the value type, e.g. "f" or "U"
      *   - bool ordered
      */
-    static void update_dataframe_schema(
-        std::string uri,
-        std::shared_ptr<SOMAContext> ctx,
+    void update_dataframe_schema(
         std::vector<std::string> drop_attrs,
         std::map<std::string, std::string> add_attrs,
         std::map<std::string, std::pair<std::string, bool>> add_enmrs);

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -85,4 +85,11 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
     return *column_it;
 }
 
+std::string get_enmr_label(
+    ArrowSchema* index_schema, ArrowSchema* value_schema) {
+    std::string format(value_schema->format);
+    format = (format == "u") ? "U" : (format == "z" ? "Z" : format);
+    return std::string(index_schema->name) + "_" + format;
+}
+
 };  // namespace tiledbsoma::util

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -67,6 +67,19 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
     std::span<const std::shared_ptr<SOMAColumn>> columns,
     std::string_view name);
 
+/**
+ * @brief Construct the enumeration label given a dictionary's index and value
+ * ArrowSchemas. The name is extracted from the index schema. The datatype is
+ * extracted from the value schema. If the format string is u or z (regular
+ * string or regular binary), then convert that to U or Z (large string or large
+ * binary).
+ *
+ * @param schema ArrowSchema representing the dictionary values
+ * @return enmr dtype as Arrow format string
+ */
+std::string get_enmr_label(
+    ArrowSchema* index_schema, ArrowSchema* value_schema);
+
 }  // namespace tiledbsoma::util
 
 #endif


### PR DESCRIPTION
**Issue and/or context:**

[[sc-63086](https://app.shortcut.com/tiledb-inc/story/63086/multiple-tiledb-soma-issues-with-schema-evolution-and-categoricals)]

**Changes:**

Previously, we set enumeration labels to be the same as attribute names. However this causes an issue when dropping a column but then readding a column with the same name but different enumeration dtypes. To fix this case, create a new util function `get_enmr_label` to create enumeration labels as `[the name of the attribute][the dictionary value's format type]`.