### PR TITLE
[ci] Speed up a test case

### DIFF
--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -133,11 +133,11 @@ def test_io_create_from_matrix_sparse_nd_array(
 
 @pytest.mark.parametrize(
     "num_rows",
-    [0, 1, 2, 3, 4, 10, 100, 1_000, 10_000],
+    [0, 1, 2, 3, 4, 10, 100, 1_000],
 )
 @pytest.mark.parametrize(
     "cap_nbytes",
-    [1, 100, 1_000, 10_000],
+    [1, 100, 1_000],
 )
 def test_write_arrow_table(tmp_path, num_rows, cap_nbytes):
     """


### PR DESCRIPTION
**Issue and/or context:**

Running this to imitate CI:

```
alias ttci='uadr; PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50'
```

I noticed at the end:

```
================================================= slowest 20 durations =================================================
1027.84s call     tests/test_io.py::test_write_arrow_table[100-10000]
143.45s call     tests/test_basic_anndata_io.py::test_decat_append
101.24s call     tests/ht/test_ht_sparsendarray.py::TestSOMASparseNDArray::runTest
41.43s call     tests/ht/test_ht_dataframe.py::TestSOMADataFrame::runTest
14.52s call     tests/ht/test_ht_densendarray.py::TestSOMADenseNDArray::runTest
10.42s call     tests/test_sparse_nd_array.py::test_context_cleanup
7.68s call     tests/test_update_matrix.py::test_update_matrix_X
5.76s call     tests/test_io.py::test_write_arrow_table[1000-10000]
5.22s call     tests/test_io.py::test_write_arrow_table[100-1000]
5.15s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_to_scipy
4.60s call     tests/test_registration_mappings.py::test_multimodal_names
4.57s call     tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.01-shape0-coords0]
4.18s call     tests/test_update_dataframes.py::test_enmr_add_drop_readd
3.74s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_from_ijd
3.39s call     tests/test_update_dataframes.py::test_update_non_null_to_null[True]
3.39s call     tests/test_update_matrix.py::test_update_matrix_obsm
3.32s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_clib_compress_coo
3.25s call     tests/test_basic_anndata_io.py::test_export_obsm_with_holes
3.01s call     tests/test_basic_anndata_io.py::test_ingest_relative[True]
2.99s call     tests/test_basic_anndata_io.py::test_ingest_uns_string_arrays
======================= 6414 passed, 28 skipped, 2 xfailed, 2272 warnings in 1603.07s (0:26:43) ========================
```

That 10,000 `num_rows` value (see files modified on this PR) isn't testing some magic threshold -- it's all _relative to_  `cap_nbytes`. Doing the 10,000 doesn't have a value-add in terms of coverage, and unnecessarily increases runtime and CI-runner queuering.

After this PR (also on my laptop):

```
================================================= slowest 20 durations =================================================
144.11s call     tests/test_basic_anndata_io.py::test_decat_append
104.15s call     tests/ht/test_ht_sparsendarray.py::TestSOMASparseNDArray::runTest
42.19s call     tests/ht/test_ht_dataframe.py::TestSOMADataFrame::runTest
14.91s call     tests/ht/test_ht_densendarray.py::TestSOMADenseNDArray::runTest
10.26s call     tests/test_sparse_nd_array.py::test_context_cleanup
5.12s call     tests/test_io.py::test_write_arrow_table[100-1000]
5.06s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_to_scipy
4.93s call     tests/test_update_matrix.py::test_update_matrix_X
4.78s call     tests/test_sparse_nd_array.py::test_blockwise_table_iter_reindex[0.01-shape0-coords0]
4.00s call     tests/test_registration_mappings.py::test_multimodal_names
3.94s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_clib_compress_coo
3.70s call     tests/ht/test_ht_fastercsx.py::test_fastercsx_from_ijd
3.15s call     tests/test_basic_anndata_io.py::test_export_obsm_with_holes
3.01s call     tests/test_basic_anndata_io.py::test_ingest_relative[False]
2.99s call     tests/test_update_dataframes.py::test_enmr_add_drop_readd
2.96s call     tests/test_basic_anndata_io.py::test_ingest_relative[None]
2.89s call     tests/test_basic_anndata_io.py::test_ingest_relative[True]
2.89s call     tests/test_basic_anndata_io.py::test_ingest_uns_string_arrays
2.88s call     tests/test_update_matrix.py::test_update_matrix_obsm
2.84s call     tests/test_update_dataframes.py::test_update_non_null_to_null[True]
======================== 6402 passed, 28 skipped, 2 xfailed, 2272 warnings in 561.00s (0:09:20) ========================
```

**Changes:**

**Notes for Reviewer:**

