### PR TITLE
[c++/python] Integrate `SOMAColumn` into `ManagedQuery` read

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -334,7 +334,7 @@ setuptools.setup(
             library_dirs=LIB_DIRS,
             libraries=["tiledbsoma"] + (["tiledb"] if os.name == "nt" else []),
             extra_link_args=CXX_FLAGS,
-            extra_compile_args=["-std=c++20" if os.name != "nt" else "/std:c++20", "-g"]
+            extra_compile_args=["-std=c++20" if os.name != "nt" else "/std:c++20"]
             + CXX_FLAGS,
             language="c++",
         )

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -318,6 +318,7 @@ setuptools.setup(
                 "src/tiledbsoma/soma_context.cc",
                 "src/tiledbsoma/soma_array.cc",
                 "src/tiledbsoma/soma_object.cc",
+                "src/tiledbsoma/soma_column.cc",
                 "src/tiledbsoma/soma_dataframe.cc",
                 "src/tiledbsoma/soma_point_cloud_dataframe.cc",
                 "src/tiledbsoma/soma_geometry_dataframe.cc",
@@ -333,7 +334,7 @@ setuptools.setup(
             library_dirs=LIB_DIRS,
             libraries=["tiledbsoma"] + (["tiledb"] if os.name == "nt" else []),
             extra_link_args=CXX_FLAGS,
-            extra_compile_args=["-std=c++20" if os.name != "nt" else "/std:c++20"]
+            extra_compile_args=["-std=c++20" if os.name != "nt" else "/std:c++20", "-g"]
             + CXX_FLAGS,
             language="c++",
         )

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -573,7 +573,10 @@ class ArrowTableRead(Iterator[pa.Table]):
         self.mq._handle.set_layout(result_order)
 
         if column_names is not None:
-            self.mq._handle.select_columns(list(column_names))
+            for name in column_names:
+                clib_handle.get_column(name).select_columns(self.mq._handle)
+
+            # self.mq._handle.select_columns(list(column_names))
 
         if value_filter is not None:
             self.mq._handle.set_condition(

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -576,8 +576,6 @@ class ArrowTableRead(Iterator[pa.Table]):
             for name in column_names:
                 clib_handle.get_column(name).select_columns(self.mq._handle)
 
-            # self.mq._handle.select_columns(list(column_names))
-
         if value_filter is not None:
             self.mq._handle.set_condition(
                 QueryCondition(value_filter), clib_handle.schema

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -485,7 +485,7 @@ def _set_coord(dim_idx: int, mq: ManagedQuery, coord: object) -> None:
         return
 
     if isinstance(coord, (pa.Array, pa.ChunkedArray)):
-        column.set_dim_points_arrow(mq, coord)
+        column.set_dim_points_arrow(mq._handle, coord)
         return
 
     if isinstance(coord, (Sequence, np.ndarray)):
@@ -512,7 +512,7 @@ def _set_coord(dim_idx: int, mq: ManagedQuery, coord: object) -> None:
             _, stop = ned[dim_idx]
         else:
             stop = coord.stop
-        column.set_dim_ranges_string_or_bytes(mq, [(start, stop)])
+        column.set_dim_ranges_string_or_bytes(mq._handle, [(start, stop)])
         return
 
     # Note: slice(None, None) matches the is_slice_of part, unless we also check
@@ -535,7 +535,7 @@ def _set_coord(dim_idx: int, mq: ManagedQuery, coord: object) -> None:
         else:
             istop = ts_dom[1].as_py()
 
-        column.set_dim_ranges_int64(mq, [(istart, istop)])
+        column.set_dim_ranges_int64(mq._handle, [(istart, istop)])
         return
 
     if isinstance(coord, slice):
@@ -603,7 +603,7 @@ def _set_coord_by_numeric_slice(
 
     try:
         set_dim_range = getattr(column, f"set_dim_ranges_{dim.type}")
-        set_dim_range(mq, [lo_hi])
+        set_dim_range(mq._handle, [lo_hi])
         return
     except AttributeError:
         return

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -561,13 +561,11 @@ def _set_coord_by_py_seq_or_np_array(
 
     try:
         set_dim_points = getattr(column, f"set_dim_points_{dim.type}")
-        # set_dim_points = getattr(mq._handle, f"set_dim_points_{dim.type}")
     except AttributeError:
         # We have to handle this type specially below
         pass
     else:
         set_dim_points(mq._handle, coord)
-        # set_dim_points(column, coord)
         return
 
     if pa_types_is_string_or_bytes(dim.type):

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -198,10 +198,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_string_or_bytes",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<std::string>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<std::string>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -210,10 +211,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_double",
             [](ManagedQuery& mq,
-               const std::string& dim,
-               const std::vector<double>& points) {
+               std::shared_ptr<SOMAColumn> column,
+               const std::vector<double_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<double_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -222,10 +224,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_float",
             [](ManagedQuery& mq,
-               const std::string& dim,
-               const std::vector<float>& points) {
+               std::shared_ptr<SOMAColumn> column,
+               const std::vector<float_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<float_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -234,10 +237,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int64",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<int64_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<int64_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -246,10 +250,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int32",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<int32_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<int32_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -258,10 +263,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int16",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<int16_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<int16_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -270,10 +276,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int8",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<int8_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<int8_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -282,10 +289,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint64",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<uint64_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<uint64_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -294,10 +302,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint32",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<uint32_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<uint32_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -306,10 +315,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint16",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<uint16_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<uint16_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -318,10 +328,11 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint8",
             [](ManagedQuery& mq,
-               const std::string& dim,
+               std::shared_ptr<SOMAColumn> column,
                const std::vector<uint8_t>& points) {
                 try {
-                    mq.select_points(dim, points);
+                    column->set_dim_points<uint8_t>(mq, points);
+                    // mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -578,5 +589,13 @@ void load_managed_query(py::module& m) {
             "py_arrow_array"_a,
             "partition_index"_a = 0,
             "partition_count"_a = 1);
+
+    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m.attr("SOMAColumn"))
+        .def(
+            "select_columns",
+            [](std::shared_ptr<SOMAColumn>& column, ManagedQuery& query) {
+                column->select_columns(query);
+            },
+            "query"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -198,11 +198,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_string_or_bytes",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<std::string>& points) {
                 try {
-                    column->set_dim_points<std::string>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -211,11 +210,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_double",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<double_t>& points) {
                 try {
-                    column->set_dim_points<double_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -224,11 +222,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_float",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<float_t>& points) {
                 try {
-                    column->set_dim_points<float_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -237,11 +234,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int64",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<int64_t>& points) {
                 try {
-                    column->set_dim_points<int64_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -250,11 +246,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int32",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<int32_t>& points) {
                 try {
-                    column->set_dim_points<int32_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -263,11 +258,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int16",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<int16_t>& points) {
                 try {
-                    column->set_dim_points<int16_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -276,11 +270,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_int8",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<int8_t>& points) {
                 try {
-                    column->set_dim_points<int8_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -289,11 +282,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint64",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<uint64_t>& points) {
                 try {
-                    column->set_dim_points<uint64_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -302,11 +294,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint32",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<uint32_t>& points) {
                 try {
-                    column->set_dim_points<uint32_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -315,11 +306,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint16",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<uint16_t>& points) {
                 try {
-                    column->set_dim_points<uint16_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -328,11 +318,10 @@ void load_managed_query(py::module& m) {
         .def(
             "set_dim_points_uint8",
             [](ManagedQuery& mq,
-               std::shared_ptr<SOMAColumn> column,
+               const std::string& dim,
                const std::vector<uint8_t>& points) {
                 try {
-                    column->set_dim_points<uint8_t>(mq, points);
-                    // mq.select_points(dim, points);
+                    mq.select_points(dim, points);
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
@@ -589,121 +578,5 @@ void load_managed_query(py::module& m) {
             "py_arrow_array"_a,
             "partition_index"_a = 0,
             "partition_count"_a = 1);
-
-    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m.attr("SOMAColumn"))
-        .def(
-            "select_columns",
-            [](std::shared_ptr<SOMAColumn>& column, ManagedQuery& query) {
-                column->select_columns(query);
-            },
-            "query"_a)
-        .def(
-            "set_dim_points_string",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<std::string>& points) {
-                column->set_dim_points<std::string>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_bytes",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<std::vector<std::byte>>& points) {
-                column->set_dim_points<std::vector<std::byte>>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_double",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<double_t>& points) {
-                column->set_dim_points<double_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_float",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<float_t>& points) {
-                column->set_dim_points<float_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_int64",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<int64_t>& points) {
-                column->set_dim_points<int64_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_int32",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<int32_t>& points) {
-                column->set_dim_points<int32_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_int16",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<int16_t>& points) {
-                column->set_dim_points<int16_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_int8",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<int8_t>& points) {
-                column->set_dim_points<int8_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_uint64",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<uint64_t>& points) {
-                column->set_dim_points<uint64_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_uint32",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<uint32_t>& points) {
-                column->set_dim_points<uint32_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_uint16",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<uint16_t>& points) {
-                column->set_dim_points<uint16_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a)
-        .def(
-            "set_dim_points_uint8",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<uint8_t>& points) {
-                column->set_dim_points<uint8_t>(mq, points);
-            },
-            "mq"_a,
-            "points"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -596,6 +596,114 @@ void load_managed_query(py::module& m) {
             [](std::shared_ptr<SOMAColumn>& column, ManagedQuery& query) {
                 column->select_columns(query);
             },
-            "query"_a);
+            "query"_a)
+        .def(
+            "set_dim_points_string",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::string>& points) {
+                column->set_dim_points<std::string>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_bytes",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::vector<std::byte>>& points) {
+                column->set_dim_points<std::vector<std::byte>>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_double",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<double_t>& points) {
+                column->set_dim_points<double_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_float",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<float_t>& points) {
+                column->set_dim_points<float_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_int64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int64_t>& points) {
+                column->set_dim_points<int64_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_int32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int32_t>& points) {
+                column->set_dim_points<int32_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_int16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int16_t>& points) {
+                column->set_dim_points<int16_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_int8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int8_t>& points) {
+                column->set_dim_points<int8_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_uint64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint64_t>& points) {
+                column->set_dim_points<uint64_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_uint32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint32_t>& points) {
+                column->set_dim_points<uint32_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_uint16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint16_t>& points) {
+                column->set_dim_points<uint16_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a)
+        .def(
+            "set_dim_points_uint8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint8_t>& points) {
+                column->set_dim_points<uint8_t>(mq, points);
+            },
+            "mq"_a,
+            "points"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -31,6 +31,7 @@ void load_query_condition(py::module&);
 void load_reindexer(py::module&);
 void load_soma_vfs(py::module&);
 void load_managed_query(py::module&);
+void load_soma_column(py::module&);
 void load_transformers(py::module&);
 
 PYBIND11_MODULE(pytiledbsoma, m) {
@@ -159,6 +160,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def_readwrite("tile_order", &PlatformSchemaConfig::tile_order)
         .def_readwrite("cell_order", &PlatformSchemaConfig::cell_order);
 
+    m.def("_update_dataframe_schema", &SOMADataFrame::update_dataframe_schema);
+
+    // Forward declarations
+    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m, "SOMAColumn");
+
     load_soma_context(m);
     load_fastercsx(m);
     load_soma_object(m);
@@ -174,6 +180,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     load_reindexer(m);
     load_soma_vfs(m);
     load_managed_query(m);
+    load_soma_column(m);
     load_transformers(m);
 }
 

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -49,6 +49,8 @@ py::list domainish_to_list(ArrowArray* arrow_array, ArrowSchema* arrow_schema) {
 }
 
 void load_soma_array(py::module& m) {
+    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m, "SOMAColumn");
+
     py::class_<SOMAArray, SOMAObject>(m, "SOMAArray")
         .def(
             py::init(
@@ -446,6 +448,16 @@ void load_soma_array(py::module& m) {
                     throw TileDBSOMAError(e.what());
                 }
             },
-            "newshape"_a);
+            "newshape"_a)
+        .def(
+            "get_column",
+            [](SOMAArray& array, const std::string name) {
+                try {
+                    return array.get_column(name);
+                } catch (const std::exception& e) {
+                    throw TileDBSOMAError(e.what());
+                }
+            },
+            "name"_a);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -49,8 +49,6 @@ py::list domainish_to_list(ArrowArray* arrow_array, ArrowSchema* arrow_schema) {
 }
 
 void load_soma_array(py::module& m) {
-    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m, "SOMAColumn");
-
     py::class_<SOMAArray, SOMAObject>(m, "SOMAArray")
         .def(
             py::init(

--- a/apis/python/src/tiledbsoma/soma_column.cc
+++ b/apis/python/src/tiledbsoma/soma_column.cc
@@ -35,29 +35,11 @@ void load_soma_column(py::module& m) {
                 column->select_columns(query);
             })
         .def(
-            "set_dim_points_string",
+            "set_dim_points_string_or_bytes",
             [](std::shared_ptr<SOMAColumn>& column,
                ManagedQuery& mq,
                const std::vector<std::string>& points) {
                 column->set_dim_points<std::string>(mq, points);
-            })
-        .def(
-            "set_dim_points_bytes",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<py::bytes>& points) {
-                std::vector<std::vector<std::byte>> casted_points;
-                for (const auto& point : points) {
-                    py::buffer_info info(py::buffer(point).request());
-                    const std::byte* data = reinterpret_cast<const std::byte*>(
-                        info.ptr);
-                    size_t length = static_cast<size_t>(info.size);
-                    casted_points.push_back(
-                        std::vector<std::byte>(data, data + length));
-                }
-
-                column->set_dim_points<std::vector<std::byte>>(
-                    mq, casted_points);
             })
         .def(
             "set_dim_points_double",
@@ -130,20 +112,11 @@ void load_soma_column(py::module& m) {
                 column->set_dim_points<uint8_t>(mq, points);
             })
         .def(
-            "set_dim_ranges_string",
+            "set_dim_ranges_string_or_bytes",
             [](std::shared_ptr<SOMAColumn>& column,
                ManagedQuery& mq,
                const std::vector<std::pair<std::string, std::string>>& ranges) {
                 column->set_dim_ranges<std::string>(mq, ranges);
-            })
-        .def(
-            "set_dim_ranges_bytes",
-            [](std::shared_ptr<SOMAColumn>& column,
-               ManagedQuery& mq,
-               const std::vector<
-                   std::pair<std::vector<std::byte>, std::vector<std::byte>>>&
-                   ranges) {
-                column->set_dim_ranges<std::vector<std::byte>>(mq, ranges);
             })
         .def(
             "set_dim_ranges_double",
@@ -280,7 +253,9 @@ void load_soma_column(py::module& m) {
                                 mq, coords.cast<std::vector<double_t>>());
                         } else if (
                             !strcmp(arrow_schema.format, "u") ||
-                            !strcmp(arrow_schema.format, "U")) {
+                            !strcmp(arrow_schema.format, "U") ||
+                            !strcmp(arrow_schema.format, "z") ||
+                            !strcmp(arrow_schema.format, "Z")) {
                             column->set_dim_points<std::string>(
                                 mq, coords.cast<std::vector<std::string>>());
                         } else if (
@@ -295,13 +270,6 @@ void load_soma_column(py::module& m) {
                                          .attr("tolist")();
                             column->set_dim_points<int64_t>(
                                 mq, coords.cast<std::vector<int64_t>>());
-                        } else if (
-                            !strcmp(arrow_schema.format, "z") ||
-                            !strcmp(arrow_schema.format, "Z")) {
-                            column->set_dim_points<std::vector<std::byte>>(
-                                mq,
-                                coords.cast<
-                                    std::vector<std::vector<std::byte>>>());
                         } else {
                             TPY_ERROR_LOC(
                                 "[pytiledbsoma] set_dim_points: type={} not "

--- a/apis/python/src/tiledbsoma/soma_column.cc
+++ b/apis/python/src/tiledbsoma/soma_column.cc
@@ -1,0 +1,324 @@
+/**
+ * @file   soma_column.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the ManagedQuery bindings.
+ */
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include <tiledbsoma/tiledbsoma>
+
+#include "common.h"
+
+namespace libtiledbsomacpp {
+
+namespace py = pybind11;
+using namespace py::literals;
+using namespace tiledbsoma;
+
+void load_soma_column(py::module& m) {
+    py::class_<SOMAColumn, std::shared_ptr<SOMAColumn>>(m.attr("SOMAColumn"))
+        .def(
+            "select_columns",
+            [](std::shared_ptr<SOMAColumn>& column, ManagedQuery& query) {
+                column->select_columns(query);
+            })
+        .def(
+            "set_dim_points_string",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::string>& points) {
+                column->set_dim_points<std::string>(mq, points);
+            })
+        .def(
+            "set_dim_points_bytes",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<py::bytes>& points) {
+                std::vector<std::vector<std::byte>> casted_points;
+                for (const auto& point : points) {
+                    py::buffer_info info(py::buffer(point).request());
+                    const std::byte* data = reinterpret_cast<const std::byte*>(
+                        info.ptr);
+                    size_t length = static_cast<size_t>(info.size);
+                    casted_points.push_back(
+                        std::vector<std::byte>(data, data + length));
+                }
+
+                column->set_dim_points<std::vector<std::byte>>(
+                    mq, casted_points);
+            })
+        .def(
+            "set_dim_points_double",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<double_t>& points) {
+                column->set_dim_points<double_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_float",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<float_t>& points) {
+                column->set_dim_points<float_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_int64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int64_t>& points) {
+                column->set_dim_points<int64_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_int32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int32_t>& points) {
+                column->set_dim_points<int32_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_int16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int16_t>& points) {
+                column->set_dim_points<int16_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_int8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<int8_t>& points) {
+                column->set_dim_points<int8_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_uint64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint64_t>& points) {
+                column->set_dim_points<uint64_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_uint32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint32_t>& points) {
+                column->set_dim_points<uint32_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_uint16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint16_t>& points) {
+                column->set_dim_points<uint16_t>(mq, points);
+            })
+        .def(
+            "set_dim_points_uint8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<uint8_t>& points) {
+                column->set_dim_points<uint8_t>(mq, points);
+            })
+        .def(
+            "set_dim_ranges_string",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<std::string, std::string>>& ranges) {
+                column->set_dim_ranges<std::string>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_bytes",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<
+                   std::pair<std::vector<std::byte>, std::vector<std::byte>>>&
+                   ranges) {
+                column->set_dim_ranges<std::vector<std::byte>>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_double",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<double_t, double_t>>& ranges) {
+                column->set_dim_ranges<double_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_float",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<float_t, float_t>>& ranges) {
+                column->set_dim_ranges<float_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_int64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<int64_t, int64_t>>& ranges) {
+                column->set_dim_ranges<int64_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_int32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<int32_t, int32_t>>& ranges) {
+                column->set_dim_ranges<int32_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_int16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<int16_t, int16_t>>& ranges) {
+                column->set_dim_ranges<int16_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_int8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<int8_t, int8_t>>& ranges) {
+                column->set_dim_ranges<int8_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_uint64",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<uint64_t, uint64_t>>& ranges) {
+                column->set_dim_ranges<uint64_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_uint32",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+                column->set_dim_ranges<uint32_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_uint16",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<uint16_t, uint16_t>>& ranges) {
+                column->set_dim_ranges<uint16_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_uint8",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::pair<uint8_t, uint8_t>>& ranges) {
+                column->set_dim_ranges<uint8_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_points_arrow",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               py::object py_arrow_array,
+               int partition_index,
+               int partition_count) {
+                // Create a list of array chunks
+                py::list array_chunks;
+                if (py::hasattr(py_arrow_array, "chunks")) {
+                    array_chunks = py_arrow_array.attr("chunks")
+                                       .cast<py::list>();
+                } else {
+                    array_chunks.append(py_arrow_array);
+                }
+
+                for (const pybind11::handle array_handle : array_chunks) {
+                    ArrowSchema arrow_schema;
+                    ArrowArray arrow_array;
+                    uintptr_t arrow_schema_ptr = (uintptr_t)(&arrow_schema);
+                    uintptr_t arrow_array_ptr = (uintptr_t)(&arrow_array);
+
+                    // Call handle._export_to_c to get arrow array and schema
+                    //
+                    // If ever a NumPy array gets in here, there will be an
+                    // exception like "AttributeError: 'numpy.ndarray' object
+                    // has no attribute '_export_to_c'".
+                    array_handle.attr("_export_to_c")(
+                        arrow_array_ptr, arrow_schema_ptr);
+
+                    auto coords = array_handle.attr("tolist")();
+
+                    try {
+                        if (!strcmp(arrow_schema.format, "l")) {
+                            column->set_dim_points<int64_t>(
+                                mq, coords.cast<std::vector<int64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "i")) {
+                            column->set_dim_points<int32_t>(
+                                mq, coords.cast<std::vector<int32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "s")) {
+                            column->set_dim_points<int16_t>(
+                                mq, coords.cast<std::vector<int16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "c")) {
+                            column->set_dim_points<int8_t>(
+                                mq, coords.cast<std::vector<int8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "L")) {
+                            column->set_dim_points<uint64_t>(
+                                mq, coords.cast<std::vector<uint64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "I")) {
+                            column->set_dim_points<uint32_t>(
+                                mq, coords.cast<std::vector<uint32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "S")) {
+                            column->set_dim_points<uint16_t>(
+                                mq, coords.cast<std::vector<uint16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "C")) {
+                            column->set_dim_points<uint8_t>(
+                                mq, coords.cast<std::vector<uint8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "f")) {
+                            column->set_dim_points<float_t>(
+                                mq, coords.cast<std::vector<float_t>>());
+                        } else if (!strcmp(arrow_schema.format, "g")) {
+                            column->set_dim_points<double_t>(
+                                mq, coords.cast<std::vector<double_t>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "u") ||
+                            !strcmp(arrow_schema.format, "U")) {
+                            column->set_dim_points<std::string>(
+                                mq, coords.cast<std::vector<std::string>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "tss:") ||
+                            !strcmp(arrow_schema.format, "tsm:") ||
+                            !strcmp(arrow_schema.format, "tsu:") ||
+                            !strcmp(arrow_schema.format, "tsn:")) {
+                            // convert the Arrow Array to int64
+                            auto pa = py::module::import("pyarrow");
+                            coords = array_handle
+                                         .attr("cast")(pa.attr("int64")())
+                                         .attr("tolist")();
+                            column->set_dim_points<int64_t>(
+                                mq, coords.cast<std::vector<int64_t>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "z") ||
+                            !strcmp(arrow_schema.format, "Z")) {
+                            column->set_dim_points<std::vector<std::byte>>(
+                                mq,
+                                coords.cast<
+                                    std::vector<std::vector<std::byte>>>());
+                        } else {
+                            TPY_ERROR_LOC(
+                                "[pytiledbsoma] set_dim_points: type={} not "
+                                "supported" +
+                                std::string(arrow_schema.format));
+                        }
+                    } catch (const std::exception& e) {
+                        throw TileDBSOMAError(e.what());
+                    }
+
+                    // Release arrow schema
+                    arrow_schema.release(&arrow_schema);
+                }
+            },
+            "mq"_a,
+            "py_arrow_array"_a,
+            "partition_index"_a = 0,
+            "partition_count"_a = 1);
+}
+}  // namespace libtiledbsomacpp

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -175,7 +175,7 @@ class ColumnBuffer {
     /**
      * @brief Return data in a vector of binary buffers.
      *
-     * @return std::vector<std::vector<uint8_t>>
+     * @return std::vector<std::vector<std::byte>>
      */
     std::vector<std::vector<std::byte>> binaries();
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -412,6 +412,15 @@ class ManagedQuery {
     }
 
     /**
+     * @brief Get the context of the query.
+     *
+     * @return std::shared_ptr<Context> Ctx
+     */
+    std::shared_ptr<Context> ctx() const {
+        return ctx_;
+    }
+
+    /**
      * @brief Return true if the only ranges selected were empty.
      *
      * @return true if the query contains only empty ranges.

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -66,20 +66,14 @@ std::shared_ptr<SOMAAttribute> SOMAAttribute::create(
         SOMAAttribute(attribute.first, attribute.second));
 }
 
-void SOMAAttribute::_set_dim_points(
-    const std::unique_ptr<ManagedQuery>&,
-    const SOMAContext&,
-    const std::any&) const {
+void SOMAAttribute::_set_dim_points(ManagedQuery&, const std::any&) const {
     throw TileDBSOMAError(std::format(
         "[SOMAAttribute][_set_dim_points] Column with name {} is not an index "
         "column",
         name()));
 }
 
-void SOMAAttribute::_set_dim_ranges(
-    const std::unique_ptr<ManagedQuery>&,
-    const SOMAContext&,
-    const std::any&) const {
+void SOMAAttribute::_set_dim_ranges(ManagedQuery&, const std::any&) const {
     throw TileDBSOMAError(std::format(
         "[SOMAAttribute][_set_dim_ranges] Column with name {} is not an index "
         "column",

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -63,9 +63,8 @@ class SOMAAttribute : public SOMAColumn {
     }
 
     inline void select_columns(
-        const std::unique_ptr<ManagedQuery>& query,
-        bool if_not_empty = false) const override {
-        query->select_columns(std::vector({attribute.name()}), if_not_empty);
+        ManagedQuery& query, bool if_not_empty = false) const override {
+        query.select_columns(std::vector({attribute.name()}), if_not_empty);
     };
 
     inline soma_column_datatype_t type() const override {
@@ -109,14 +108,10 @@ class SOMAAttribute : public SOMAColumn {
 
    private:
     void _set_dim_points(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& points) const override;
+        ManagedQuery& query, const std::any& points) const override;
 
     void _set_dim_ranges(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& ranges) const override;
+        ManagedQuery& query, const std::any& ranges) const override;
 
     void _set_current_domain_slot(
         NDRectangle& rectangle,

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -110,8 +110,7 @@ class SOMAColumn {
      * @param if_not_empty Prevent changing an "empty" selection of all columns
      */
     virtual void select_columns(
-        const std::unique_ptr<ManagedQuery>& query,
-        bool if_not_empty = false) const = 0;
+        ManagedQuery& query, bool if_not_empty = false) const = 0;
 
     /**
      * Get the domain kind of the SOMAColumn as an ArrowArray for use with
@@ -272,10 +271,7 @@ class SOMAColumn {
      * @param point
      */
     template <typename T>
-    void set_dim_point(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const T& point) const {
+    void set_dim_point(ManagedQuery& query, const T& point) const {
         if (!isIndexColumn()) {
             throw TileDBSOMAError(std::format(
                 "[SOMAColumn] Column with name {} is not an index column",
@@ -287,7 +283,6 @@ class SOMAColumn {
         try {
             this->_set_dim_points(
                 query,
-                ctx,
                 std::make_any<std::span<const T>>(std::span<const T>(points)));
         } catch (const std::exception& e) {
             throw TileDBSOMAError(std::format(
@@ -309,10 +304,7 @@ class SOMAColumn {
      * @param points
      */
     template <typename T>
-    void set_dim_points(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        std::span<const T> points) const {
+    void set_dim_points(ManagedQuery& query, std::span<const T> points) const {
         if (!isIndexColumn()) {
             throw TileDBSOMAError(std::format(
                 "[SOMAColumn] Column with name {} is not an index column",
@@ -321,7 +313,7 @@ class SOMAColumn {
 
         try {
             this->_set_dim_points(
-                query, ctx, std::make_any<std::span<const T>>(points));
+                query, std::make_any<std::span<const T>>(points));
         } catch (const std::exception& e) {
             throw TileDBSOMAError(std::format(
                 "[SOMAColumn][set_dim_points] Failed on \"{}\" with error "
@@ -342,9 +334,7 @@ class SOMAColumn {
      */
     template <typename T>
     void set_dim_ranges(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::vector<std::pair<T, T>>& ranges) const {
+        ManagedQuery& query, const std::vector<std::pair<T, T>>& ranges) const {
         if (!isIndexColumn()) {
             throw TileDBSOMAError(std::format(
                 "[SOMAColumn] Column with name {} is not an index column",
@@ -353,9 +343,7 @@ class SOMAColumn {
 
         try {
             this->_set_dim_ranges(
-                query,
-                ctx,
-                std::make_any<std::vector<std::pair<T, T>>>(ranges));
+                query, std::make_any<std::vector<std::pair<T, T>>>(ranges));
         } catch (const std::exception& e) {
             throw TileDBSOMAError(std::format(
                 "[SOMAColumn][set_dim_ranges] Failed on \"{}\" with error "
@@ -501,14 +489,10 @@ class SOMAColumn {
 
    protected:
     virtual void _set_dim_points(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& points) const = 0;
+        ManagedQuery& query, const std::any& points) const = 0;
 
     virtual void _set_dim_ranges(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& ranges) const = 0;
+        ManagedQuery& query, const std::any& ranges) const = 0;
 
     virtual void _set_current_domain_slot(
         NDRectangle& rectangle, std::span<const std::any> domain) const = 0;

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -57,42 +57,40 @@ std::shared_ptr<SOMADimension> SOMADimension::create(
 }
 
 void SOMADimension::_set_dim_points(
-    const std::unique_ptr<ManagedQuery>& query,
-    const SOMAContext&,
-    const std::any& points) const {
+    ManagedQuery& query, const std::any& points) const {
     switch (dimension.type()) {
         case TILEDB_UINT8:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const uint8_t>>(points));
             break;
         case TILEDB_UINT16:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const uint16_t>>(points));
             break;
         case TILEDB_UINT32:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const uint32_t>>(points));
             break;
         case TILEDB_UINT64:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const uint64_t>>(points));
             break;
         case TILEDB_INT8:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const int8_t>>(points));
             break;
         case TILEDB_INT16:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const int16_t>>(points));
             break;
         case TILEDB_INT32:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const int32_t>>(points));
             break;
@@ -119,23 +117,23 @@ void SOMADimension::_set_dim_points(
         case TILEDB_TIME_FS:
         case TILEDB_TIME_AS:
         case TILEDB_INT64:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const int64_t>>(points));
             break;
         case TILEDB_FLOAT32:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const float_t>>(points));
             break;
         case TILEDB_FLOAT64:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const double_t>>(points));
             break;
         case TILEDB_STRING_UTF8:
         case TILEDB_STRING_ASCII:
-            query->select_points(
+            query.select_points(
                 dimension.name(),
                 std::any_cast<std::span<const std::string>>(points));
             break;
@@ -147,47 +145,45 @@ void SOMADimension::_set_dim_points(
 }
 
 void SOMADimension::_set_dim_ranges(
-    const std::unique_ptr<ManagedQuery>& query,
-    const SOMAContext&,
-    const std::any& ranges) const {
+    ManagedQuery& query, const std::any& ranges) const {
     switch (dimension.type()) {
         case TILEDB_UINT8:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<uint8_t, uint8_t>>>(
                     ranges));
             break;
         case TILEDB_UINT16:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<uint16_t, uint16_t>>>(
                     ranges));
             break;
         case TILEDB_UINT32:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<uint32_t, uint32_t>>>(
                     ranges));
             break;
         case TILEDB_UINT64:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<uint64_t, uint64_t>>>(
                     ranges));
             break;
         case TILEDB_INT8:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<int8_t, int8_t>>>(ranges));
             break;
         case TILEDB_INT16:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<int16_t, int16_t>>>(
                     ranges));
             break;
         case TILEDB_INT32:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<int32_t, int32_t>>>(
                     ranges));
@@ -215,26 +211,26 @@ void SOMADimension::_set_dim_ranges(
         case TILEDB_TIME_FS:
         case TILEDB_TIME_AS:
         case TILEDB_INT64:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<int64_t, int64_t>>>(
                     ranges));
             break;
         case TILEDB_FLOAT32:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<float_t, float_t>>>(
                     ranges));
             break;
         case TILEDB_FLOAT64:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<double_t, double_t>>>(
                     ranges));
             break;
         case TILEDB_STRING_UTF8:
         case TILEDB_STRING_ASCII:
-            query->select_ranges(
+            query.select_ranges(
                 dimension.name(),
                 std::any_cast<std::vector<std::pair<std::string, std::string>>>(
                     ranges));

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -60,9 +60,8 @@ class SOMADimension : public SOMAColumn {
     }
 
     inline void select_columns(
-        const std::unique_ptr<ManagedQuery>& query,
-        bool if_not_empty = false) const override {
-        query->select_columns(std::vector({dimension.name()}), if_not_empty);
+        ManagedQuery& query, bool if_not_empty = false) const override {
+        query.select_columns(std::vector({dimension.name()}), if_not_empty);
     };
 
     inline soma_column_datatype_t type() const override {
@@ -102,14 +101,10 @@ class SOMADimension : public SOMAColumn {
 
    protected:
     void _set_dim_points(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& ranges) const override;
+        ManagedQuery& query, const std::any& ranges) const override;
 
     void _set_dim_ranges(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& ranges) const override;
+        ManagedQuery& query, const std::any& ranges) const override;
 
     void _set_current_domain_slot(
         NDRectangle& rectangle,

--- a/libtiledbsoma/src/soma/soma_geometry_column.h
+++ b/libtiledbsoma/src/soma/soma_geometry_column.h
@@ -74,9 +74,8 @@ class SOMAGeometryColumn : public SOMAColumn {
     }
 
     inline void select_columns(
-        const std::unique_ptr<ManagedQuery>& query,
-        bool if_not_empty = false) const override {
-        query->select_columns(std::vector({attribute.name()}), if_not_empty);
+        ManagedQuery& query, bool if_not_empty = false) const override {
+        query.select_columns(std::vector({attribute.name()}), if_not_empty);
     };
 
     inline soma_column_datatype_t type() const override {
@@ -120,14 +119,10 @@ class SOMAGeometryColumn : public SOMAColumn {
 
    protected:
     void _set_dim_points(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& points) const override;
+        ManagedQuery& query, const std::any& points) const override;
 
     void _set_dim_ranges(
-        const std::unique_ptr<ManagedQuery>& query,
-        const SOMAContext& ctx,
-        const std::any& ranges) const override;
+        ManagedQuery& query, const std::any& ranges) const override;
 
     void _set_current_domain_slot(
         NDRectangle& rectangle,
@@ -166,7 +161,7 @@ class SOMAGeometryColumn : public SOMAColumn {
      * it is used to compute the limits, otherwise the core domain is used.
      */
     std::vector<std::pair<double_t, double_t>> _limits(
-        const SOMAContext& ctx, const ArraySchema& schema) const;
+        const Context& ctx, const ArraySchema& schema) const;
 
     std::vector<std::pair<double_t, double_t>> _transform_ranges(
         const std::vector<

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -102,14 +102,6 @@ uint64_t SOMAGeometryDataFrame::count() {
     return this->nnz();
 }
 
-ArrowTable SOMAGeometryDataFrame::cast_array_data(
-    std::unique_ptr<ArrowSchema> arrow_schema,
-    std::unique_ptr<ArrowArray> arrow_array) {
-    return TransformerPipeline(std::move(arrow_array), std::move(arrow_schema))
-        .transform(OutlineTransformer(coord_space_))
-        .asTable();
-}
-
 //===================================================================
 //= private non-static
 //===================================================================

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -144,17 +144,6 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
      */
     uint64_t count();
 
-    /**
-     * SOMAGeometryDataFrame requires special casting when writing.
-     *
-     * @param arrow_schema ArrowSchema of the Arrow Table to write
-     * @param arrow_array ArrowArray of the Arrow Table to write
-     *
-     */
-    ArrowTable cast_array_data(
-        std::unique_ptr<ArrowSchema> arrow_schema,
-        std::unique_ptr<ArrowArray> arrow_array);
-
    private:
     //===================================================================
     //= private non-static

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -32,6 +32,7 @@
 #include "soma/soma_coordinates.h"
 #include "soma/soma_array.h"
 #include "soma/soma_collection.h"
+#include "soma/soma_column.h"
 #include "soma/soma_dataframe.h"
 #include "soma/soma_group.h"
 #include "soma/soma_experiment.h"
@@ -45,5 +46,6 @@
 #include "soma/soma_dense_ndarray.h"
 #include "soma/soma_sparse_ndarray.h"
 #include "soma/soma_transformers.h"
+
 
 #endif

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -390,28 +390,29 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        auto external_query = std::make_unique<ManagedQuery>(
-            *open(OpenMode::read), ctx_->tiledb_ctx());
+        ManagedQuery external_query(*open(OpenMode::read), ctx_->tiledb_ctx());
 
         columns[1]->select_columns(external_query);
-        columns[1]->set_dim_point<uint32_t>(external_query, *ctx_, 1234);
+        columns[1]->set_dim_point<uint32_t>(external_query, 1234);
 
         // Configure query and allocate result buffers
-        auto ext_res = external_query->read_next().value();
+        auto ext_res = external_query.read_next().value();
 
         REQUIRE(ext_res->num_rows() == 1);
 
-        external_query->reset();
+        external_query.reset();
+
+        const std::vector a(
+            {std::make_pair<std::string, std::string>("apple", "b")});
 
         columns[0]->select_columns(external_query);
-        columns[0]->set_dim_ranges<std::string>(
+        columns[0]->set_dim_ranges(
             external_query,
-            *ctx_,
             std::vector(
                 {std::make_pair<std::string, std::string>("apple", "b")}));
 
         // Configure query and allocate result buffers
-        ext_res = external_query->read_next().value();
+        ext_res = external_query.read_next().value();
 
         REQUIRE(ext_res->num_rows() == 1);
     }
@@ -546,28 +547,26 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        auto external_query = std::make_unique<ManagedQuery>(
-            *open(OpenMode::read), ctx_->tiledb_ctx());
+        ManagedQuery external_query(*open(OpenMode::read), ctx_->tiledb_ctx());
 
         columns[1]->select_columns(external_query);
-        columns[1]->set_dim_point<uint32_t>(external_query, *ctx_, 1234);
+        columns[1]->set_dim_point<uint32_t>(external_query, 1234);
 
         // Configure query and allocate result buffers
-        auto ext_res = external_query->read_next().value();
+        auto ext_res = external_query.read_next().value();
 
         REQUIRE(ext_res->num_rows() == 1);
 
-        external_query->reset();
+        external_query.reset();
 
         columns[0]->select_columns(external_query);
         columns[0]->set_dim_ranges<std::string>(
             external_query,
-            *ctx_,
             std::vector(
                 {std::make_pair<std::string, std::string>("apple", "b")}));
 
         // Configure query and allocate result buffers
-        ext_res = external_query->read_next().value();
+        ext_res = external_query.read_next().value();
 
         REQUIRE(ext_res->num_rows() == 1);
     }

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -199,15 +199,13 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     // Write to point cloud.
     auto soma_geometry = SOMAGeometryDataFrame::open(
         uri, OpenMode::write, ctx, std::nullopt);
-    auto [casted_schema, casted_data] = soma_geometry->cast_array_data(
-        std::move(data_schema), std::move(data_array));
     auto mq = ManagedQuery(*soma_geometry, ctx->tiledb_ctx());
     std::tie(data_array, data_schema) = TransformerPipeline(
-        std::move(data_array),
-        std::move(data_schema))
-        .transform(
-            OutlineTransformer(coord_space))
-        .asTable();
+                                            std::move(data_array),
+                                            std::move(data_schema))
+                                            .transform(
+                                                OutlineTransformer(coord_space))
+                                            .asTable();
 
     mq.set_array_data(std::move(data_schema), std::move(data_array));
     mq.submit_write();

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -202,7 +202,14 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     auto [casted_schema, casted_data] = soma_geometry->cast_array_data(
         std::move(data_schema), std::move(data_array));
     auto mq = ManagedQuery(*soma_geometry, ctx->tiledb_ctx());
-    mq.set_array_data(std::move(casted_data), std::move(casted_schema));
+    std::tie(data_array, data_schema) = TransformerPipeline(
+        std::move(data_array),
+        std::move(data_schema))
+        .transform(
+            OutlineTransformer(coord_space))
+        .asTable();
+
+    mq.set_array_data(std::move(data_schema), std::move(data_array));
     mq.submit_write();
     soma_geometry->close();
 


### PR DESCRIPTION
**Issue and/or context:** [sc-52732](https://app.shortcut.com/tiledb-inc/story/52732/polygonal-geometry-queries-for-geometrydataframe)

**Changes:**
`ManagedQuery` ranges are not set directly, but the associated `SOMAColumn` sets the necessary dimension ranges

**Notes for Reviewer:**
This PR adds SOMAColumn bindings to python and updates the coordinate setter to use the new `SOMAColumn` setters. To better work with the `ManagedQuery` binding the SOMAColumn method signatures are changed to accept a reference to a `ManagedQuery` object instead of a unique pointer.
