### PR TITLE
[python] Allow `("","")` for `binary` as well as `string` dataframe domain

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -937,7 +937,7 @@ def _fill_out_slot_soma_domain(
             or pa_type == pa.large_string()
             or pa_type == pa.binary()
             or pa_type == pa.large_binary()
-        ) and slot_domain != ("", ""):
+        ) and tuple(slot_domain) != ("", ""):
             # TileDB Embedded won't raise an error if the user asks for, say
             # domain=[("a", "z")].  But it will simply _ignore_ the request and
             # use [("", "")]. The decision here is to explicitly reject an

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -933,13 +933,11 @@ def _fill_out_slot_soma_domain(
     if slot_domain is not None:
         # User-specified; go with it when possible
         if (
-            (
-                (pa_type == pa.string() or pa_type == pa.large_string())
-                and slot_domain != ("", "")
-            )
+            pa_type == pa.string()
+            or pa_type == pa.large_string()
             or pa_type == pa.binary()
             or pa_type == pa.large_binary()
-        ):
+        ) and slot_domain != ("", ""):
             # TileDB Embedded won't raise an error if the user asks for, say
             # domain=[("a", "z")].  But it will simply _ignore_ the request and
             # use [("", "")]. The decision here is to explicitly reject an

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -177,6 +177,13 @@ def arrow_table():
             "default01234",
         ],
         [
+            "STRING-ALL",
+            ["string"],
+            [["", ""]],
+            [],
+            "default01234",
+        ],
+        [
             "string-py-list",
             ["string"],
             [None],
@@ -265,6 +272,13 @@ def arrow_table():
             "bytes-pa-array-typed",
             ["bytes"],
             [None],
+            [pa.array([b"cat", b"dog"], pa.binary())],
+            "default23",
+        ],
+        [
+            "bytes-pa-array-typed",
+            ["bytes"],
+            [["", ""]],
             [pa.array([b"cat", b"dog"], pa.binary())],
             "default23",
         ],


### PR DESCRIPTION
**Issue and/or context:** [[sc-62231]](https://app.shortcut.com/tiledb-inc/story/62231)

**Changes:**

Make it the same for `binary` as for `string`.

**Notes for Reviewer:**

Repro script (in addition to unit-test cases on this PR):

```
#!/usr/bin/env python

import tiledbsoma
import pyarrow as pa
import numpy as np
import sys, os, shutil

uri_a = "62231a"
uri_b = "62231b"
for uri in [uri_a, uri_b]:
    if os.path.exists(uri):
        shutil.rmtree(uri)

schema_a = pa.schema([
    pa.field('soma_joinid',pa.int64(),nullable=False),
    pa.field('00', pa.large_string(), nullable=False),
    pa.field('B', pa.int8()),
])

with tiledbsoma.DataFrame.create(
    uri_a,
    schema=schema_a,
    domain=((0, np.iinfo(np.int64).max-2050), ('','')),
    index_column_names=['soma_joinid','00'],
) as A:
    print("A domain")
    print(A.domain)

schema_b = pa.schema([
    pa.field('soma_joinid',pa.int64(),nullable=False),
    pa.field('00', pa.large_binary(), nullable=False),
    pa.field('B', pa.int8()),
])

with tiledbsoma.DataFrame.create(
    uri_b,
    schema=schema_b,
    domain=((0, np.iinfo(np.int64).max-2050), ('','')),
    index_column_names=['soma_joinid','00'],
) as B:
    print("B domain")
    print(B.domain)

# ValueError: TileDB str and bytes index-column types do not support domain specfication
```

