### PR TITLE
[c++,python] Correct slicing for `DenseNDArray`

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -230,19 +230,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             )
             result_order = somacore.ResultOrder.ROW_MAJOR
 
-        ned = []
-        for dim_name in handle.dimension_names:
-            dtype = np.dtype(self.schema.field(dim_name).type.to_pandas_dtype())
-            slot = handle.non_empty_domain_slot_opt(dim_name, dtype)
-            if slot is None:
-                use_shape = True
-                break
-            ned.append(slot[1] + 1)
-        else:
-            use_shape = False
-
-        data_shape = tuple(handle.shape if use_shape else ned)
-        target_shape = dense_indices_to_shape(coords, data_shape, result_order)
+        target_shape = dense_indices_to_shape(coords, tuple(handle.shape), result_order)
 
         arrow_table = TableReadIter(
             array=self,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -582,7 +582,7 @@ def test_read_result_order(tmp_path):
             assert np.array_equal(A.read(result_order="auto"), data)
 
 
-def test_slice_with_offset(tmp_path):
+def test_subset_slice(tmp_path):
     uri = tmp_path.as_posix()
 
     soma.DenseNDArray.create(uri, type=pa.int32(), shape=(10, 3))
@@ -596,10 +596,10 @@ def test_slice_with_offset(tmp_path):
 
     with soma.open(uri, mode="r") as A:
         actual = A.read((slice(0, 9), slice(0, 2)))
-        np.array_equal(expected, actual)
+        assert np.array_equal(expected, actual)
 
         actual = A.read()
-        np.array_equal(expected, actual)
+        assert np.array_equal(expected, actual)
 
 
 def test_slice_with_resize(tmp_path):

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -212,19 +212,16 @@ def test_dense_nd_array_requires_shape(tmp_path, shape_is_numeric):
 
 def test_dense_nd_array_ned_write(tmp_path):
     uri = tmp_path.as_posix()
+    input = np.asarray([100, 101, 102, 103])
 
-    with soma.DenseNDArray.create(
-        uri=uri,
-        type=pa.int32(),
-        shape=[1000000],
-    ) as dnda:
-        dnda.write(
-            (slice(0, 4),),
-            pa.Tensor.from_numpy(np.asarray([100, 101, 102, 103])),
-        )
+    with soma.DenseNDArray.create(uri=uri, type=pa.int32(), shape=[1000000]) as dnda:
+        dnda.write((slice(10, 14),), pa.Tensor.from_numpy(input))
 
     with soma.DenseNDArray.open(uri) as dnda:
-        assert (dnda.read().to_numpy() == np.asarray([100, 101, 102, 103])).all()
+        np.array_equal(dnda.read((slice(10, 14),)), input)
+
+        # default reads should return the entire array
+        np.array_equal(dnda.read((slice(0, 1000000),)), dnda.read())
 
 
 @pytest.mark.parametrize(
@@ -583,3 +580,39 @@ def test_read_result_order(tmp_path):
             DeprecationWarning, match="The use of 'result_order=\"auto\"' is deprecated"
         ):
             assert np.array_equal(A.read(result_order="auto"), data)
+
+
+def test_slice_with_offset(tmp_path):
+    uri = tmp_path.as_posix()
+
+    soma.DenseNDArray.create(uri, type=pa.int32(), shape=(10, 3))
+
+    with soma.open(uri, mode="r") as A:
+        expected = A.read((slice(0, 9), slice(0, 2))).to_numpy().copy()
+        expected[0][0] = 0
+
+    with soma.open(uri, mode="w") as A:
+        A.write((0, 0), pa.Tensor.from_numpy(np.array([[0]], dtype=np.int32)))
+
+    with soma.open(uri, mode="r") as A:
+        actual = A.read((slice(0, 9), slice(0, 2)))
+        np.array_equal(expected, actual)
+
+        actual = A.read()
+        np.array_equal(expected, actual)
+
+
+def test_slice_with_resize(tmp_path):
+    uri = tmp_path.as_posix()
+
+    with soma.DenseNDArray.create(uri, type=pa.int8(), shape=(1,)) as A:
+        A.write((0,), pa.Tensor.from_numpy(np.array([-127], dtype=np.int8)))
+
+    with soma.open(uri, mode="r") as A:
+        assert A.read().shape == (1,)
+
+    with soma.open(uri, mode="w") as A:
+        A.resize((2,))
+
+    with soma.open(uri, mode="r") as A:
+        assert A.read().shape == (2,)


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/3271

**Changes:**

Previously, dense arrays returned only the non-empty domain by default. With this update, dense arrays now return the full shape of the array.