### PR TITLE
[python] Name temp paths for clarity

### DIFF
--- a/apis/python/tests/conftest.py
+++ b/apis/python/tests/conftest.py
@@ -27,7 +27,7 @@ def conftest_pbmc_small(conftest_pbmc_small_h5ad_path) -> AnnData:
 @pytest.fixture
 def conftest_pbmc_small_exp(conftest_pbmc_small_h5ad_path) -> Experiment:
     """Ingest an ``AnnData``, yield a ``TestCase`` with the original and new AnnData objects."""
-    with TemporaryDirectory() as exp_path:
+    with TemporaryDirectory("conftest_pbmc_small_exp_") as exp_path:
         tiledbsoma.io.from_h5ad(
             exp_path, conftest_pbmc_small_h5ad_path, measurement_name="RNA"
         )

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -96,7 +96,7 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
 
     have_ingested = False
 
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_import_anndata_")
     output_path = tempdir.name
 
     conftest_pbmc_small.layers["plus1"] = conftest_pbmc_small.X + 1
@@ -237,7 +237,7 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
     ],
 )
 def test_named_X_layers(conftest_pbmc_small_h5ad_path, X_layer_name):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_named_X_layers_")
     soma_path = tempdir.name
 
     if X_layer_name is None:
@@ -285,13 +285,13 @@ def test_resume_mode(resume_mode_h5ad_file):
     anything new
     """
 
-    tempdir1 = tempfile.TemporaryDirectory()
+    tempdir1 = tempfile.TemporaryDirectory(prefix="test_resume_mode_1_")
     output_path1 = tempdir1.name
     tiledbsoma.io.from_h5ad(
         output_path1, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write"
     )
 
-    tempdir2 = tempfile.TemporaryDirectory()
+    tempdir2 = tempfile.TemporaryDirectory(prefix="test_resume_mode_2_")
     output_path2 = tempdir2.name
     tiledbsoma.io.from_h5ad(
         output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write"
@@ -338,7 +338,7 @@ def test_resume_mode(resume_mode_h5ad_file):
 
 @pytest.mark.parametrize("use_relative_uri", [False, True, None])
 def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_relative_")
     output_path = tempdir.name
 
     tiledbsoma.io.from_h5ad(
@@ -436,7 +436,7 @@ def test_ingest_uns(
 
 
 def test_ingest_uns_string_arrays(h5ad_file_uns_string_arrays):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_uns_string_arrays_")
     output_path = tempdir.name
 
     tiledbsoma.io.from_h5ad(
@@ -462,7 +462,7 @@ def test_ingest_uns_string_arrays(h5ad_file_uns_string_arrays):
 
 
 def test_add_matrix_to_collection(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_add_matrix_to_collection_")
     output_path = tempdir.name
 
     original = conftest_pbmc_small.copy()
@@ -593,7 +593,7 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
                         use_relative_uri=use_relative_uri,
                     )
 
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_add_matrix_to_collection_1_2_7_")
     output_path = tempdir.name
     original = conftest_pbmc_small.copy()
 
@@ -658,7 +658,7 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
 
 
 def test_export_anndata(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_export_anndata_")
     output_path = tempdir.name
 
     original = conftest_pbmc_small.copy()
@@ -700,7 +700,7 @@ def test_export_anndata(conftest_pbmc_small):
 
 
 def test_ingest_additional_metadata(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_additional_metadata_")
     output_path = tempdir.name
 
     additional_metadata = {"key1": "val1", "key2": "val2"}
@@ -854,7 +854,7 @@ def test_export_obsm_with_holes(h5ad_file_with_obsm_holes, tmp_path):
 
 
 def test_X_empty(h5ad_file_X_empty):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_X_empty_")
     output_path = tempdir.name
     tiledbsoma.io.from_h5ad(
         output_path, h5ad_file_X_empty.as_posix(), measurement_name="RNA"
@@ -871,7 +871,7 @@ def test_X_empty(h5ad_file_X_empty):
 
 
 def test_X_none(h5ad_file_X_none):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_X_none_")
     output_path = tempdir.name
     tiledbsoma.io.from_h5ad(
         output_path, h5ad_file_X_none.as_posix(), measurement_name="RNA"
@@ -1170,7 +1170,7 @@ def test_index_names_io(tmp_path, obs_index_name, var_index_name):
 
 
 def test_obsm_data_type(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_obsm_data_type_")
     soma_path = tempdir.name
     bdata = anndata.AnnData(
         X=conftest_pbmc_small.X,

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -14,7 +14,7 @@ from ._util import assert_adata_equal
 def test_platform_config(conftest_pbmc_small):
     # Set up anndata input path and tiledb-group output path
     original = conftest_pbmc_small.copy()
-    with tempfile.TemporaryDirectory() as output_path:
+    with tempfile.TemporaryDirectory(prefix="test_platform_config_") as output_path:
         # Ingest
         create_cfg = {
             "capacity": 8888,

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -169,7 +169,7 @@ def create_anndata_canned(which: int, obs_field_name: str, var_field_name: str):
 
 
 def create_h5ad_canned(which: int, obs_field_name: str, var_field_name: str):
-    tmp_path = tempfile.TemporaryDirectory()
+    tmp_path = tempfile.TemporaryDirectory(prefix="create_h5ad_canned_")
     anndata = create_anndata_canned(which, obs_field_name, var_field_name)
     return create_h5ad(
         anndata,
@@ -178,7 +178,7 @@ def create_h5ad_canned(which: int, obs_field_name: str, var_field_name: str):
 
 
 def create_soma_canned(which: int, obs_field_name, var_field_name):
-    tmp_path = tempfile.TemporaryDirectory()
+    tmp_path = tempfile.TemporaryDirectory(prefix="create_soma_canned_")
     h5ad = create_h5ad_canned(which, obs_field_name, var_field_name)
     uri = tmp_path.name + f"soma{which}"
     tiledbsoma.io.from_h5ad(uri, h5ad, "measname")
@@ -198,7 +198,7 @@ def anndata_larger():
 
 @pytest.fixture
 def soma_larger(anndata_larger):
-    tmp_path = tempfile.TemporaryDirectory()
+    tmp_path = tempfile.TemporaryDirectory(prefix="soma_larger_")
     uri = tmp_path.name + "soma-larger"
     tiledbsoma.io.from_anndata(uri, anndata_larger, "measname")
     return uri

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -47,7 +47,9 @@ def multiple_fixtures_with_readback(request, conftest_pbmc_small) -> TestCase:
         AnnData/Pandas.
     * Each `TestCase` member is also exposed directly as its own `fixture` below.
     """
-    with tempfile.TemporaryDirectory() as experiment_path:
+    with tempfile.TemporaryDirectory(
+        "multiple_fixtures_with_readback_"
+    ) as experiment_path:
         old_anndata = conftest_pbmc_small.copy()
         tiledbsoma.io.from_anndata(
             experiment_path, conftest_pbmc_small, measurement_name="RNA"

--- a/apis/python/tests/test_update_matrix.py
+++ b/apis/python/tests/test_update_matrix.py
@@ -5,7 +5,7 @@ import tiledbsoma.io
 
 
 def test_update_matrix_X(conftest_pbmc3k_adata):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_update_matrix_X_")
     output_path = tempdir.name
 
     tiledbsoma.io.from_anndata(
@@ -39,7 +39,7 @@ def test_update_matrix_X(conftest_pbmc3k_adata):
 
 # Magical conftest.py fixture
 def test_update_matrix_obsm(conftest_pbmc3k_adata):
-    tempdir = tempfile.TemporaryDirectory()
+    tempdir = tempfile.TemporaryDirectory(prefix="test_update_matrix_obsm_")
     output_path = tempdir.name
 
     tiledbsoma.io.from_anndata(


### PR DESCRIPTION
**Issue and/or context:** In support of [[sc-61088]](https://app.shortcut.com/tiledb-inc/story/61088).

As detailed there:

* Using the `pytest` fixture `tmp_path`:
  * Are removed only three test runs later, not at process exit -- this is a feature
  * Most of our test cases use these
  * Total usage is tens of thousands of files and directories not reaped until three runs later
  * this is fine
* `tempfile.TemporaryDirectory` files:
  * are deleted at process exit
  * whether or not the test failed
  * whether or not a context-manager syntax was used
  * this is fine
* `tempfile.mkdtemp` files:
  * are not deleted at process exit
  * We should be removing these

**Changes:**

For this PR, simply apply the prefixing feature which makes analysis easier. This is not the final PR on this matter.

**Notes for Reviewer:**

