### PR TITLE
[python] Improve an error message in `fastercsx`

### DIFF
--- a/apis/python/src/tiledbsoma/fastercsx.cc
+++ b/apis/python/src/tiledbsoma/fastercsx.cc
@@ -220,8 +220,10 @@ T lookup_dtype_(
         return index.at(dtype.num());
     } catch (const std::out_of_range& oor) {
         // will bubble up as a ValueError
+        std::string name = dtype.attr("name").cast<std::string>();
         throw std::invalid_argument(
-            "Unsupported type: " + array_name + " has an unsupported dtype");
+            "Unsupported type: " + array_name + " has an unsupported dtype: '" +
+            name + "'");
     }
 }
 


### PR DESCRIPTION
**Issue and/or context:** Found in drive-by. Current error message:

```
ValueError: Unsupported type: COO index (row, col) arrays has an unsupported dtype
```

This could be more helpful.

**Changes:** Say what the dtype was.

**Notes for Reviewer:**

