### PR TITLE
[c++] Check arrays are open for write at write time

### DIFF
--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -50,6 +50,9 @@ test_that("Basic mechanics", {
 
   expect_error(sdf$shape(), class = "notYetImplementedError")
 
+  # Dataframe write should fail if array opened in read mode
+  expect_error(sdf$write(tbl0))
+
   expect_equivalent(
     tiledb::tiledb_array(sdf$uri, return_as = "asis")[],
     as.list(tbl0),

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -24,6 +24,10 @@ test_that("SOMADenseNDArray creation", {
 
   # Read result in column-major order to match R matrix layout
   ndarray <- SOMADenseNDArrayOpen(uri)
+
+  # Array write should fail if array opened in read mode
+  expect_error(ndarray$write(mat))
+
   tbl <- ndarray$read_arrow_table(result_order = "COL_MAJOR")
   expect_true(is_arrow_table(tbl))
   expect_equal(tbl$ColumnNames(), c("soma_data"))

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -21,6 +21,9 @@ test_that("SOMASparseNDArray creation", {
 
   ndarray <- SOMASparseNDArrayOpen(uri)
 
+  # Array write should fail if array opened in read mode
+  expect_error(ndarray$write(mat))
+
   tbl <- ndarray$read(result_order = "COL_MAJOR")$tables()$concat()
   expect_true(is_arrow_table(tbl))
   expect_equal(tbl$ColumnNames(), c("soma_dim_0", "soma_dim_1", "soma_data"))

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -178,6 +178,11 @@ void ManagedQuery::setup_read() {
 void ManagedQuery::submit_write(bool sort_coords) {
     _fill_in_subarrays_if_dense(false);
 
+    if (array_->query_type() != TILEDB_WRITE) {
+        throw TileDBSOMAError(
+            "[ManagedQuery] write requires array to be opened in write mode");
+    }
+
     if (array_->schema().array_type() == TILEDB_DENSE) {
         query_->set_subarray(*subarray_);
     } else {

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -208,6 +208,13 @@ TEST_CASE_METHOD(
         d0[j] = j;
     std::vector<uint32_t> a0(10, 1);
 
+    // A write in read mode should fail
+    sdf = open(OpenMode::read);
+    sdf->set_column_data(dim_infos[0].name, d0.size(), d0.data());
+    sdf->set_column_data(attr_infos[0].name, a0.size(), a0.data());
+    REQUIRE_THROWS(sdf->write());
+    sdf->close();
+
     sdf = open(OpenMode::write);
     sdf->set_column_data(dim_infos[0].name, d0.size(), d0.data());
     sdf->set_column_data(attr_infos[0].name, a0.size(), a0.data());

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -147,6 +147,8 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
         PlatformConfig(),
         TimestampRange(0, 1));
 
+    // TO DO: do more data writes and readbacks here in C++ tests.
+    // https://github.com/single-cell-data/TileDB-SOMA/issues/3721
     auto dnda = SOMADenseNDArray::open(
         uri,
         OpenMode::write,

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -79,6 +79,13 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
         d0[j] = j;
     std::vector<int32_t> a0(10, 1);
 
+    // A write in read mode should fail
+    snda->open(OpenMode::read);
+    snda->set_column_data(dim_name, d0.size(), d0.data());
+    snda->set_column_data(attr_name, a0.size(), a0.data());
+    REQUIRE_THROWS(snda->write());
+    snda->close();
+
     snda->open(OpenMode::write);
     snda->set_column_data(dim_name, d0.size(), d0.data());
     snda->set_column_data(attr_name, a0.size(), a0.data());


### PR DESCRIPTION
Found during dev on a forthcoming PR. I believe we lost this check in decoupling `ManagedQuery` from `SOMArray`. And we missed the fact that we lost the check due to missing unit-test coverage. This PR fixes both.

#3720 [[sc-63626]](https://app.shortcut.com/tiledb-inc/story/63626/tiledb-soma-1-16-0)