### PR TITLE
Dark/encoding spec/sc 56279

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
+        files: "encoding_specification.md"

--- a/encoding_specification.md
+++ b/encoding_specification.md
@@ -2,39 +2,53 @@
 title: Encoding Specification
 ---
 
-## SOMA Encoding Version 1.1.0
+## TileDB-SOMA encoding version 1.1.0
 
-### SOMACollection
+### SOMA abstract specification support
+
+- TileDB-SOMA encoding version 1.1.0 with spatial encoding version 0.1.0 satisfies the requirements for SOMA abstract specification 0.3.0-dev.
+
+- TileDB-SOMA encoding version 1.1.0 with spatial encoding version 0.2.0 satifies the requirements for SOMA abstract 0.3.1-dev.
+
+### Collection encoding version 1.1.0
+
+A SOMA Collection is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value            | Description           | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
 
-### SOMADataFrame
+### DataFrame encoding version 1.1.0
+
+A SOMA DataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value           | Description           | Required |
 | :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"         | SOMA encoding version | required |
 
-### SOMADenseNDArray
+### DenseNDArray encoding version 1.1.0
+
+A SOMA DenseNDArray is stored as a dense TileDB array. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value              | Description           | Required |
 | :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"            | SOMA encoding version | required |
 
-### SOMAExperiment
+### Experiment encoding version 1.1.0
+
+A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value            | Description           | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
 
-### SOMAMultiscaleImage
+### MultiscaleImage encoding version 1.1.0
 
-#### SOMAMultiscaleImage Spatial Encoding Version 0.2.0
+A SOMA MultiscaleImage is stored as a TileDB group that contains a SOMA DenseNDArray for each resolution level. The group has the following metadata:
 
 | Metadata key                    | Datatype           | Value                                             | Description                                       | Required |
 | :------------------------------ | :----------------- | :------------------------------------------------ | :------------------------------------------------ | :------- |
@@ -42,58 +56,60 @@ title: Encoding Specification
 | "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                           | general SOMA encoding version                     | required |
 | "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                           | type-specific SOMA encoding version               | required |
 | "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space        | JSON serialization of the coordinate space        | required |
-| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization fo the multiscale image schema | required |
+| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization of the multiscale image schema | required |
 
-<!-- TODO: Add description of multiscale image schema metadata-->
+JSON serialization of the multiscale image schema is given by
 
-#### SOMAMultiscaleImage Spatial Encoding Version 0.1.0
+```
+{
+    "type": "object",
+    "properties": {
+        "data_axis_permutation": {
+            "type": "array",
+            "items": {"type": "integer"}
+        },
+        "has_channel_axis": "boolean",
+        "shape": {
+            "type": "array",
+            "items": {"type": "integer"}
+        },
+        "datatype": {"type": "string"},
+    }
+}
+```
 
-| Metadata key                    | Datatype           | Value                                             | Description                                       | Required |
-| :------------------------------ | :----------------- | :------------------------------------------------ | :------------------------------------------------ | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                             | SOMA type name                                    | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                           | general SOMA encoding version                     | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                           | type-specific SOMA encoding version               | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space        | JSON serialization of the coordinate space        | required |
-| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization fo the multiscale image schema | required |
+| Serialization Key       | Description                                                                                                               |
+| :---------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| "data_axis_permutation" | The permutation of the coordinate space axis with the channel stored last to the order of the channels as stored on disk. |
+| "has_channel_axis"      | If the image has a dimension specifically for channel information.                                                        |
+| "shape"                 | The shape of the level 0 image.                                                                                           |
+| "datatype"              | The datatype of the image data stored using the PyArrow C-convention.                                                     |
 
-<!-- TODO: Add description of multiscale image schema metadata -->
+### Measurement encoding version 1.1.0
 
-### SOMAMeasurement
+A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value             | Description           | Required |
 | :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"           | SOMA encoding version | required |
 
-### SOMAPointCloudDataFrame
+### PointCloudDataFrame encoding version 1.1.0
 
-#### SOMAPointCloudDataFram Spatial Encoding Version 0.2.0
+The SOMA PointCloudDataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
 | Metadata key                    | Datatype           | Value                                      | Description                                                   | Required |
 | :------------------------------ | :----------------- | :----------------------------------------- | :------------------------------------------------------------ | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloud"                           | SOMA type name                                                | required |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloudDataFrame"                  | SOMA type name                                                | required |
 | "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version                                 | required |
 | "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version                           | required |
 | "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space                    | required |
-| "soma_geometry_type"            | TILEDB_STRING_UTF8 | enum with possible values "radius"         | optional shape of the stored points                           | optional |
+| "soma_geometry_type"            | TILEDB_STRING_UTF8 | string with possible values "radius"       | optional shape of the stored points                           | optional |
 | "soma_geometry"                 | TILEDB_FLOAT64     | floating-point value                       | the radius of circles centered at the points in the dataframe | optional |
 
-#### SOMAPointCloudDataFram Spatial Encoding Version 0.1.0
+### Scene encoding version 1.1.0
 
-| Metadata key                    | Datatype           | Value                                      | Description                                                   | Required |
-| :------------------------------ | :----------------- | :----------------------------------------- | :------------------------------------------------------------ | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloud"                           | SOMA type name                                                | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version                                 | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                    | type-specific SOMA encoding version                           | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space                    | required |
-| "soma_geometry_type"            | TILEDB_STRING_UTF8 | enum with possible values "radius"         | optional shape of the stored points                           | optional |
-| "soma_geometry"                 | TILEDB_FLOAT64     | floating-point value                       | the radius of circles centered at the points in the dataframe | optional |
-
-### SOMAScene
-
-#### SOMAScene Spatial Encoding Version 0.2.0
-
-Scene Group Metadata
+The SOMA Scene is stored as a TileDB group. It has the following group metadata:
 
 | Metadata key                    | Datatype           | Value                                      | Description                                | Required |
 | :------------------------------ | :----------------- | :----------------------------------------- | :----------------------------------------- | :------- |
@@ -102,68 +118,192 @@ Scene Group Metadata
 | "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version        | required |
 | "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
 
-Scene Transformation Metadata
+Collections inside the SOMA Scene may store transformation data from the Scene to the elements inside the collections. In addition to the standard group metadata, these collections have the following metadata:
 
-<!-- TODO Define the format for the transformation data -->
+| Metadata key                        | Datatype           | Value                                          | Description                                                                                            | Required |
+| :---------------------------------- | :----------------- | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------- | :------- |
+| "soma*scene_registry*{object_name}" | TILEDB_STRING_UTF8 | JSON serialization of the coordinate transform | The coordinate transform from a SOMA Scene to the element names `{object_name}` inside the collection. | optional |
 
-#### SOMAScene Spatial Encoding Version 0.1.0
+The SOMA CoordinateTransform are serialized using the following JSON schemas:
 
-| Metadata key                    | Datatype           | Value                                      | Description                                | Required |
-| :------------------------------ | :----------------- | :----------------------------------------- | :----------------------------------------- | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                      | SOMA type name                             | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version              | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                    | type-specific SOMA encoding version        | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
+- IdentityTransform serialization
 
-### SOMASparseNDArray
+  ```
+  {
+      "type": "object",
+      "properties": {
+          "transform_type": {"const": "IdentityTransform"},
+          "input_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          }
+          "output_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          }
+      }
+  }
+  ```
+
+- UniformScaleTransform serialization
+
+  ```
+  {
+      "type": "object",
+      "properties": {
+          "transform_type": {"const": "UniformScaleTransform"},
+          "input_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          },
+          "output_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          },
+          "scale": {"type": "number"},
+      }
+  }
+  ```
+
+- ScaleTransform serialization
+
+  ```
+  {
+      "type": "object",
+      "properties": {
+          "transform_type": {"const": "ScaleTransform"},
+          "input_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          },
+          "output_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          },
+          "scale_factors"" {
+              "type": "array",
+              "items": {"type": "number"},
+          },
+      }
+  }
+  ```
+
+- AffineTransform serializaton
+  ```
+  {
+      "type": "object",
+      "properties": {
+          "transform_type": {"const": "AffineTransform"},
+          "input_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          },
+          "output_axes": {
+              "type": "array",
+              "items": {"type": "string"},
+          }
+          "matrix": {
+              "type": "array",
+          }
+      }
+  }
+  ```
+
+| Serialization Key | Description                                                                                                                                      |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| "transform_type"  | The type of the coordinate space transform. Must be one of "IdentityTransform", "UniformScaleTransform", "ScaleTransform", or "AffineTransform". |
+| "input_axes"      | The names of the axes of the input coordinate space to the transform.                                                                            |
+| "output_axes"     | The names of the axes of the output coordinate space to the transform.                                                                           |
+| "scale"           | The scale factor for the "UniformScaleTransform".                                                                                                |
+| "scale_factors"   | An array of the scale factors for the "ScaleTransform" in order or the axis they are applied to."                                                |
+| "maxtrix"         | The matrix representation of the "AffineTransform", flattened in row-major order.                                                                |
+
+### SparseNDArray encoding version 1.1.0
+
+A SOMA SparseNDArray is stored as a sparse TileDB array. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value               | Description           | Required |
 | :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"             | SOMA encoding version | required |
 
-### JSON Serialized CoordinateSpace
+### CoordinateSpace serialization encoding version 1.1.0
 
-<!-- TODO Add serialization of CoordinateSpace -->
+The SOMA CoordinateSpace is serialized to JSON as an array of axes, stored in order. It satisfies the the following schema.
 
-## SOMA Encoding Version 1.0.0
+```
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properities": {
+            "name": {"type": "string"},
+            "unit": {"type": ["string", "null"]}
+        },
+        "required": ["name", "unit"]
+    }
+}
+```
 
-### SOMACollection
+| Serialization Key | Description                                                            |
+| :---------------- | :--------------------------------------------------------------------- |
+| "name"            | Name of the axis.                                                      |
+| "unit"            | The name of the units for the axis, or null if no units are specified. |
+
+## TileDB-SOMA encoding version 1.0.0
+
+### SOMA abstract specification
+
+TileDB-SOMA encoding version 1.0.0 satisfies the SOMA abstract specification 0.1.0-dev and 0.2.0-dev.
+
+### Collection encoding version 1.0.0
+
+A SOMA Collection is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value            | Description           | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
 
-### SOMADataFrame
+### DataFrame encoding version 1.0.0
+
+A SOMA DataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value           | Description           | Required |
 | :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"             | SOMA encoding version | required |
 
-### SOMADenseNDArray
+### DenseNDArray encoding version 1.0.0
+
+A SOMA DenseNDArray is stored as a dense TileDB array. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value              | Description           | Required |
 | :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"                | SOMA encoding version | required |
 
-### SOMAExperiment
+### Experiment encoding version 1.0.0
+
+A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value            | Description           | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
 
-### SOMAMeasurement
+### Measurement encoding version 1.0.0
+
+A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
 | Metadata key            | Datatype           | Value             | Description           | Required |
 | :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
 | "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
 | "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"               | SOMA encoding version | required |
 
-### SOMASparseNDArray
+### SparseNDArray encoding version 1.0.0
+
+A SOMA SparseNDArray is stored as a sparse TileDB array. The array has the following metadata.
 
 | Metadata key            | Datatype           | Value               | Description           | Required |
 | :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |

--- a/encoding_specification.md
+++ b/encoding_specification.md
@@ -1,6 +1,4 @@
----
-title: Encoding Specification
----
+# Encoding Specification
 
 ## TileDB-SOMA encoding version 1.1.0
 

--- a/encoding_specification.md
+++ b/encoding_specification.md
@@ -1,0 +1,171 @@
+---
+title: Encoding Specification
+---
+
+## SOMA Encoding Version 1.1.0
+
+### SOMACollection
+
+| Metadata key            | Datatype           | Value            | Description           | Required |
+| :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
+
+### SOMADataFrame
+
+| Metadata key            | Datatype           | Value           | Description           | Required |
+| :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"         | SOMA encoding version | required |
+
+### SOMADenseNDArray
+
+| Metadata key            | Datatype           | Value              | Description           | Required |
+| :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"            | SOMA encoding version | required |
+
+### SOMAExperiment
+
+| Metadata key            | Datatype           | Value            | Description           | Required |
+| :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
+
+### SOMAMultiscaleImage
+
+#### SOMAMultiscaleImage Spatial Encoding Version 0.2.0
+
+| Metadata key                    | Datatype           | Value                                             | Description                                       | Required |
+| :------------------------------ | :----------------- | :------------------------------------------------ | :------------------------------------------------ | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                             | SOMA type name                                    | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                           | general SOMA encoding version                     | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                           | type-specific SOMA encoding version               | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space        | JSON serialization of the coordinate space        | required |
+| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization fo the multiscale image schema | required |
+
+<!-- TODO: Add description of multiscale image schema metadata-->
+
+#### SOMAMultiscaleImage Spatial Encoding Version 0.1.0
+
+| Metadata key                    | Datatype           | Value                                             | Description                                       | Required |
+| :------------------------------ | :----------------- | :------------------------------------------------ | :------------------------------------------------ | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                             | SOMA type name                                    | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                           | general SOMA encoding version                     | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                           | type-specific SOMA encoding version               | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space        | JSON serialization of the coordinate space        | required |
+| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization fo the multiscale image schema | required |
+
+<!-- TODO: Add description of multiscale image schema metadata -->
+
+### SOMAMeasurement
+
+| Metadata key            | Datatype           | Value             | Description           | Required |
+| :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"           | SOMA encoding version | required |
+
+### SOMAPointCloudDataFrame
+
+#### SOMAPointCloudDataFram Spatial Encoding Version 0.2.0
+
+| Metadata key                    | Datatype           | Value                                      | Description                                                   | Required |
+| :------------------------------ | :----------------- | :----------------------------------------- | :------------------------------------------------------------ | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloud"                           | SOMA type name                                                | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version                                 | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version                           | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space                    | required |
+| "soma_geometry_type"            | TILEDB_STRING_UTF8 | enum with possible values "radius"         | optional shape of the stored points                           | optional |
+| "soma_geometry"                 | TILEDB_FLOAT64     | floating-point value                       | the radius of circles centered at the points in the dataframe | optional |
+
+#### SOMAPointCloudDataFram Spatial Encoding Version 0.1.0
+
+| Metadata key                    | Datatype           | Value                                      | Description                                                   | Required |
+| :------------------------------ | :----------------- | :----------------------------------------- | :------------------------------------------------------------ | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloud"                           | SOMA type name                                                | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version                                 | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                    | type-specific SOMA encoding version                           | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space                    | required |
+| "soma_geometry_type"            | TILEDB_STRING_UTF8 | enum with possible values "radius"         | optional shape of the stored points                           | optional |
+| "soma_geometry"                 | TILEDB_FLOAT64     | floating-point value                       | the radius of circles centered at the points in the dataframe | optional |
+
+### SOMAScene
+
+#### SOMAScene Spatial Encoding Version 0.2.0
+
+Scene Group Metadata
+
+| Metadata key                    | Datatype           | Value                                      | Description                                | Required |
+| :------------------------------ | :----------------- | :----------------------------------------- | :----------------------------------------- | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                      | SOMA type name                             | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version              | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version        | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
+
+Scene Transformation Metadata
+
+<!-- TODO Define the format for the transformation data -->
+
+#### SOMAScene Spatial Encoding Version 0.1.0
+
+| Metadata key                    | Datatype           | Value                                      | Description                                | Required |
+| :------------------------------ | :----------------- | :----------------------------------------- | :----------------------------------------- | :------- |
+| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                      | SOMA type name                             | required |
+| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version              | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.1.0"                                    | type-specific SOMA encoding version        | required |
+| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
+
+### SOMASparseNDArray
+
+| Metadata key            | Datatype           | Value               | Description           | Required |
+| :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"             | SOMA encoding version | required |
+
+### JSON Serialized CoordinateSpace
+
+<!-- TODO Add serialization of CoordinateSpace -->
+
+## SOMA Encoding Version 1.0.0
+
+### SOMACollection
+
+| Metadata key            | Datatype           | Value            | Description           | Required |
+| :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
+
+### SOMADataFrame
+
+| Metadata key            | Datatype           | Value           | Description           | Required |
+| :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"             | SOMA encoding version | required |
+
+### SOMADenseNDArray
+
+| Metadata key            | Datatype           | Value              | Description           | Required |
+| :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"                | SOMA encoding version | required |
+
+### SOMAExperiment
+
+| Metadata key            | Datatype           | Value            | Description           | Required |
+| :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
+
+### SOMAMeasurement
+
+| Metadata key            | Datatype           | Value             | Description           | Required |
+| :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"               | SOMA encoding version | required |
+
+### SOMASparseNDArray
+
+| Metadata key            | Datatype           | Value               | Description           | Required |
+| :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |
+| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name        | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"                 | SOMA encoding version | required |


### PR DESCRIPTION
**Issue and/or context:** [sc-56279](https://app.shortcut.com/tiledb-inc/story/56279/audit-soma-metadata-history)

**Changes:**

Create a document with the current and past encoding specification. 

