### PR TITLE
[python] Fix `obsm` outgest shape for non-upgraded pre-1.15 arrays

### DIFF
--- a/apis/python/tests/test_soma_experiment_versions.py
+++ b/apis/python/tests/test_soma_experiment_versions.py
@@ -10,11 +10,7 @@ from ._util import ROOT_DATA_DIR
 @pytest.mark.parametrize("version", ["1.7.3", "1.12.3", "1.14.5", "1.15.0", "1.15.7"])
 @pytest.mark.parametrize(
     "name_and_expected_shape",
-    [
-        ["pbmc3k_unprocessed", (2700, 13714)],
-        # Will be addressed on a separate PR later today
-        # ["pbmc3k_processed", (2638, 1838)]
-    ],
+    [["pbmc3k_unprocessed", (2700, 13714)], ["pbmc3k_processed", (2638, 1838)]],
 )
 def test_to_anndata(version, name_and_expected_shape):
     """Checks that experiments written by older versions are still readable,
@@ -48,8 +44,11 @@ def test_to_anndata(version, name_and_expected_shape):
         assert adata.X.shape[1] == expected_nvar
 
         if name == "pbmc3k_processed":
-            for key in ["X_pca", "X_tsne", "X_umap", "X_draw_graph_fr"]:
+            for key in ["X_pca"]:
                 assert adata.obsm[key].shape == (expected_nobs, 50)
+
+            for key in ["X_tsne", "X_umap", "X_draw_graph_fr"]:
+                assert adata.obsm[key].shape == (expected_nobs, 2)
 
             for key in ["connectivities", "distances"]:
                 assert adata.obsp[key].shape == (expected_nobs, expected_nobs)


### PR DESCRIPTION
**Issue and/or context:** [[sc-63713]](https://app.shortcut.com/tiledb-inc/story/63713/defect-in-used-shape-removal); #3729; blocks 1.16.0 #3720

**Changes:** 

#3723 was defective. After `used_shape` was removed -- as planned, with deprecation in 1.15. and removal in 1.16 -- an old, pre-existing defect in the case beneath it was revealed.

**Notes for Reviewer:** Stacked atop #3730.