### PR TITLE
[r] [ci] Migrate R CI to r-lib/actions

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -67,7 +67,7 @@ jobs:
           extra-repositories: https://tiledb-inc.r-universe.dev
 
       - name: P3M Bioconductor
-        run: >
+        run: |
           echo -e 'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n' \
           'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")' | \
           tee -a "$(R RHOME)/etc/Rprofile.site"

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -20,6 +20,8 @@ on:
 env:
   COVERAGE_FLAGS: "r"
   COVERAGE_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  R_KEEP_PKG_SOURCE: yes
   _R_CHECK_TESTS_NLINES_: 0
   CATCHSEGV: "TRUE"
   R_REMOTES_UPGRADE: "never"
@@ -57,47 +59,18 @@ jobs:
         if: ${{ matrix.os == 'macOS-latest' }}
         run: sysctl -a | grep cpu
 
-      - name: Bootstrap
-        run: cd apis/r && tools/r-ci.sh bootstrap
-
-      - name: Install BioConductor package SingleCellExperiment
-        run: cd apis/r && tools/r-ci.sh install_bioc SingleCellExperiment
-
-      # Uncomment these next two stanzas as needed whenever we've just released a new tiledb-r for
-      # which source is available but CRAN releases (and hence update r2u binaries) are not yet:
-      #
-      # IMPORTANT: these two stanzas should remain uncommented _only_ during the propagation time
-      # between (a) publication of source for a new TileDB-R _upon which_ TileDB-SOMA depends in its
-      # apis/R/DESCRIPTION file and (b) appearance of binaries.
-      #
-      # Please see https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases which
-      # is crucial for anyone doing releases of TileDB-SOMA.
-      #
-      # Please edit both files in the same way:
-      # * r-ci.yml
-      # * r-python-interop-testing.yml
-      #
-      # Do not remove these comments until such time as we have eliminated our dependency on
-      # the TileDB-R package.
-
-      #- name: Install r-universe build of tiledb-r (macOS)
-      #  if: ${{ matrix.os == 'macOS-latest' }}
-      #  run: cd apis/r && Rscript -e "install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev', 'https://cloud.r-project.org'))"
-
-      #- name: Install r-universe build of tiledb-r (linux)
-      #  if: ${{ matrix.os != 'macOS-latest' }}
-      #  run: cd apis/r && Rscript -e "options(bspm.version.check=TRUE); install.packages('tiledb', repos = c('https://eddelbuettel.r-universe.dev/bin/linux/jammy/4.3/', 'https://cloud.r-project.org'))"
-
       - name: R Package Type (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
         run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"
 
-      - name: Dependencies
-        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      # - name: Install dataset packages from source (macOS)
-      #   if: ${{ matrix.os == 'macOS-latest' }}
-      #   run: cd apis/r && _CI_PKG_TYPE_=both _CI_USE_BIOC_=true Rscript tools/install_missing_deps.R
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: https://tiledb-inc.r-universe.dev
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
 
       # - name: CMake
       #   uses: lukka/get-cmake@latest

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -72,7 +72,7 @@ jobs:
             'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n',
             'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")\n',
             sep = '',
-            file = file.path(R.home('etc'), 'Rprofile.site'),
+            file = '~/.Rprofile',
             append = TRUE
           )
         shell: Rscript {0}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -68,9 +68,14 @@ jobs:
 
       - name: P3M Bioconductor
         run: |
-          echo -e 'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n' \
-          'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")' | \
-          tee -a "$(R RHOME)/etc/Rprofile.site"
+          cat(
+            'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n',
+            'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")\n',
+            sep = '',
+            file = file.path(R.home('etc'), 'Rprofile.site'),
+            append = TRUE
+          )
+        shell: Rscript {0}
 
       - name: R Package Type (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -66,6 +66,12 @@ jobs:
           use-public-rspm: true
           extra-repositories: https://tiledb-inc.r-universe.dev
 
+      - name: P3M Bioconductor
+        run: >
+          echo -e 'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n' \
+          'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")' | \
+          tee -a "$(R RHOME)/etc/Rprofile.site"
+
       - name: R Package Type (macOS)
         if: ${{ matrix.os == 'macOS-latest' }}
         run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: 'apis/r/'
 
       # - name: CMake
       #   uses: lukka/get-cmake@latest

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -59,16 +59,16 @@ jobs:
         if: ${{ matrix.os == 'macOS-latest' }}
         run: sysctl -a | grep cpu
 
-      - name: R Package Type (macOS)
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"
-
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
           extra-repositories: https://tiledb-inc.r-universe.dev
+
+      - name: R Package Type (macOS)
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: echo 'options(pkgType = "binary")' | tee -a "$(R RHOME)/etc/Rprofile.site"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
 

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -100,9 +100,6 @@ jobs:
           python -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
           python scripts/show-versions.py
 
-      - name: Update Packages
-        run: Rscript -e 'update.packages(ask=FALSE)'
-
       - name: Interop tests
         run: python -m pytest apis/system/tests/
         env:

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -29,11 +29,27 @@ jobs:
         with:
           fetch-depth: 0 # ensure we get all tags to inform package version determination
 
-      - name: Bootstrap
-        run: cd apis/r && tools/r-ci.sh bootstrap
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Dependencies
-        run: cd apis/r && Rscript -e "remotes::install_deps(dependencies = TRUE, upgrade = FALSE)"
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: https://tiledb-inc.r-universe.dev
+
+      - name: P3M Bioconductor
+        run: |
+          cat(
+            'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n',
+            'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")\n',
+            sep = '',
+            file = '~/.Rprofile',
+            append = TRUE
+          )
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: 'apis/r/'
 
       - name: Build Package
         run: cd apis/r && R CMD build --no-build-vignettes --no-manual .

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ apis/r/src/cmake_log.txt
 apis/r/.editorconfig
 !apis/r/man/roxygen/*
 apis/r/**/local/*
+apis/r/.Rproj*
+apis/r/*.Rproj
+apis/r/.Rhistory
 
 # Coverage/codecov
 .coverage


### PR DESCRIPTION
Use r-lib/actions instead of `tools/r-ci.sh` for R CI; also makes use of RSPM/P3M + pak for binaries and system requirements

[SC-63716](https://app.shortcut.com/tiledb-inc/story/63716)