### PR TITLE
[python] Add spatial read to `GeometryDataFrame`

### DIFF
--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -426,7 +426,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
             )
             if region_coord_space is not None:
                 raise ValueError(
-                    "Cannot specify the output coordinate space when region transform i"
+                    "Cannot specify the output coordinate space when region transform "
                     "is ``None``."
                 )
             region_coord_space = self._coord_space

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -43,6 +43,7 @@ from ._spatial_dataframe import SpatialDataFrame
 from ._spatial_util import (
     coordinate_space_from_json,
     coordinate_space_to_json,
+    process_spatial_df_region,
 )
 from ._types import OpenTimestamp
 from .options import SOMATileDBContext
@@ -369,6 +370,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
             result_order=_util.to_clib_result_order(result_order),
             value_filter=value_filter,
             platform_config=platform_config,
+            coord_space=self._coord_space,
         )
 
     def read_spatial_region(
@@ -417,7 +419,60 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         Lifecycle:
             Experimental.
         """
-        raise NotImplementedError()
+        # Set/check transform and region coordinate space.
+        if region_transform is None:
+            region_transform = somacore.IdentityTransform(
+                self.axis_names, self.axis_names
+            )
+            if region_coord_space is not None:
+                raise ValueError(
+                    "Cannot specify the output coordinate space when region transform i"
+                    "is ``None``."
+                )
+            region_coord_space = self._coord_space
+        else:
+            if region_coord_space is None:
+                region_coord_space = CoordinateSpace.from_axis_names(
+                    region_transform.input_axes
+                )
+            elif region_transform.input_axes != region_coord_space.axis_names:
+                raise ValueError(
+                    f"The input axes '{region_transform.input_axes}' of the region "
+                    f"transform must match the axes '{region_coord_space.axis_names}' "
+                    f"of the coordinate space the requested region is defined in."
+                )
+            if region_transform.output_axes != self._coord_space.axis_names:
+                raise ValueError(
+                    f"The output axes of '{region_transform.output_axes}' of the "
+                    f"transform must match the axes '{self._coord_space.axis_names}' "
+                    f"of the coordinate space of this point cloud dataframe."
+                )
+
+        # Process the user provided region.
+        coords, data_region, inv_transform = process_spatial_df_region(
+            region,
+            region_transform,
+            dict(),  # Move index value_filters into this dict to optimize queries
+            self.index_column_names,
+            self._coord_space.axis_names,
+            self._handle.schema,
+            spatial_column=SOMA_GEOMETRY,
+        )
+
+        return somacore.SpatialRead(
+            self.read(
+                coords,
+                column_names,
+                result_order=result_order,
+                value_filter=value_filter,
+                batch_size=batch_size,
+                partitions=partitions,
+                platform_config=platform_config,
+            ),
+            self.coordinate_space,
+            region_coord_space,
+            inv_transform,
+        )
 
     def write(
         self,

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -582,12 +582,9 @@ class ArrowTableRead(Iterator[pa.Table]):
 
         self.mq._handle.set_layout(result_order)
 
-        if column_names is not None:
-            for name in column_names:
-                clib_handle.get_column(name).select_columns(self.mq._handle)
-        else:
-            for name in array.schema.names:
-                clib_handle.get_column(name).select_columns(self.mq._handle)
+        column_names = column_names or array.schema.names
+        for name in column_names:
+            clib_handle.get_column(name).select_columns(self.mq._handle)
 
         if value_filter is not None:
             self.mq._handle.set_condition(

--- a/apis/python/src/tiledbsoma/soma_column.cc
+++ b/apis/python/src/tiledbsoma/soma_column.cc
@@ -112,6 +112,13 @@ void load_soma_column(py::module& m) {
                 column->set_dim_points<uint8_t>(mq, points);
             })
         .def(
+            "set_dim_points_double_array",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<std::vector<double_t>>& points) {
+                column->set_dim_points<std::vector<double_t>>(mq, points);
+            })
+        .def(
             "set_dim_ranges_string_or_bytes",
             [](std::shared_ptr<SOMAColumn>& column,
                ManagedQuery& mq,
@@ -187,6 +194,15 @@ void load_soma_column(py::module& m) {
                ManagedQuery& mq,
                const std::vector<std::pair<uint8_t, uint8_t>>& ranges) {
                 column->set_dim_ranges<uint8_t>(mq, ranges);
+            })
+        .def(
+            "set_dim_ranges_double_array",
+            [](std::shared_ptr<SOMAColumn>& column,
+               ManagedQuery& mq,
+               const std::vector<
+                   std::pair<std::vector<double_t>, std::vector<double_t>>>&
+                   ranges) {
+                column->set_dim_ranges<std::vector<double_t>>(mq, ranges);
             })
         .def(
             "set_dim_points_arrow",

--- a/apis/python/tests/test_geometry_dataframe.py
+++ b/apis/python/tests/test_geometry_dataframe.py
@@ -62,6 +62,8 @@ def test_geometry_basic_read(tmp_path):
     uri = tmp_path.as_uri()
 
     asch = pa.schema([("quality", pa.float32())])
+    triangle = shapely.Polygon([(0, 0), (0, 1), (1, 0), (0, 0)])
+    rect = shapely.Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
 
     with soma.GeometryDataFrame.create(
         uri, schema=asch, domain=[[(-10, 10), (-10, 10)], [0, 100]]
@@ -80,15 +82,43 @@ def test_geometry_basic_read(tmp_path):
     with soma.GeometryDataFrame.open(uri) as geom:
         result = geom.read().concat()
 
-        # Internal columns will be hidden in a subsequent PR
-        assert (result[0].to_numpy() == [0, 0]).all()
-        assert (result[1].to_numpy() == [0, 0]).all()
-        assert (result[2].to_numpy() == [1, 1]).all()
-        assert (result[3].to_numpy() == [1, 1]).all()
+        assert result[0].to_numpy()[0] == triangle.wkb
+        assert result[0].to_numpy()[1] == rect.wkb
 
         assert shapely.from_wkb(result[5].to_numpy()[0]) == shapely.Polygon(
             [(0, 0), (0, 1), (1, 0), (0, 0)]
         )
         assert shapely.from_wkb(result[5].to_numpy()[1]) == shapely.Polygon(
             [(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]
+        )
+
+
+def test_geometry_basic_spatial_read(tmp_path):
+    uri = tmp_path.as_uri()
+
+    asch = pa.schema([("quality", pa.float32())])
+
+    with soma.GeometryDataFrame.create(
+        uri, schema=asch, domain=[[(-10, 10), (-10, 10)], [0, 100]]
+    ) as geom:
+        pydict = {}
+        pydict["soma_geometry"] = [
+            [0.0, 0, 0, 1, 1, 0, 0, 0],
+            [2.0, 0, 2, 1, 3, 1, 3, 0, 2, 0],
+        ]
+        pydict["soma_joinid"] = [1, 2]
+        pydict["quality"] = [4.1, 5.2]
+
+        rb = pa.Table.from_pydict(pydict)
+        geom.from_outlines(rb)
+
+    with soma.GeometryDataFrame.open(uri) as geom:
+
+        result = geom.read_spatial_region(region=[0.5, 0.5, 1.5, 1.5]).data.concat()
+
+        # Internal columns will be hidden in a subsequent PR
+        assert len(result) == 1
+
+        assert shapely.from_wkb(result[5].to_numpy()[0]) == shapely.Polygon(
+            [(0, 0), (0, 1), (1, 0), (0, 0)]
         )

--- a/apis/python/tests/test_geometry_dataframe.py
+++ b/apis/python/tests/test_geometry_dataframe.py
@@ -85,12 +85,12 @@ def test_geometry_basic_read(tmp_path):
         assert result[0].to_numpy()[0] == triangle.wkb
         assert result[0].to_numpy()[1] == rect.wkb
 
-        assert shapely.from_wkb(result[5].to_numpy()[0]) == shapely.Polygon(
-            [(0, 0), (0, 1), (1, 0), (0, 0)]
-        )
-        assert shapely.from_wkb(result[5].to_numpy()[1]) == shapely.Polygon(
-            [(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]
-        )
+        assert shapely.from_wkb(
+            result["soma_geometry"].to_numpy()[0]
+        ) == shapely.Polygon([(0, 0), (0, 1), (1, 0), (0, 0)])
+        assert shapely.from_wkb(
+            result["soma_geometry"].to_numpy()[1]
+        ) == shapely.Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
 
 
 def test_geometry_basic_spatial_read(tmp_path):
@@ -119,6 +119,6 @@ def test_geometry_basic_spatial_read(tmp_path):
         # Internal columns will be hidden in a subsequent PR
         assert len(result) == 1
 
-        assert shapely.from_wkb(result[5].to_numpy()[0]) == shapely.Polygon(
-            [(0, 0), (0, 1), (1, 0), (0, 0)]
-        )
+        assert shapely.from_wkb(
+            result["soma_geometry"].to_numpy()[0]
+        ) == shapely.Polygon([(0, 0), (0, 1), (1, 0), (0, 0)])

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -495,6 +495,17 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->private_data = nullptr;
 
+    if (attribute.type() == TILEDB_GEOM_WKB) {
+        nanoarrow::UniqueBuffer metadata_buffer;
+        ArrowMetadataBuilderInit(metadata_buffer.get(), nullptr);
+        ArrowMetadataBuilderAppend(
+            metadata_buffer.get(),
+            ArrowCharView("dtype"),
+            ArrowCharView("WKB"));
+        ArrowSchemaSetMetadata(
+            arrow_schema.get(), reinterpret_cast<char*>(metadata_buffer->data));
+    }
+
     LOG_TRACE(std::format(
         "[ArrowAdapter] arrow_schema_from_tiledb_array format {} "
         "name {}",


### PR DESCRIPTION
**Issue and/or context:** [sc-52732](https://app.shortcut.com/tiledb-inc/story/52732/polygonal-geometry-queries-for-geometrydataframe)

**Changes:**
Coordinate setter utils are now aware of SpatialDataFrame coordinate space. Also domain is expected to be a mapping between axis names and the axis domain for geometry columns. 

**Notes for Reviewer:**
This PR adds spatial reads to `GeometryDataFrame`. The spatial ranges per axis are all grouped under the spatial column's name. When setting the coordinate ranges for each dimension the geometry column is identified by the added `dtype` metadata field on the arrow schema field.

