### PR TITLE
[python] Type/comment tweaks

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -21,7 +21,7 @@ from ._scene import Scene
 from ._soma_object import AnySOMAObject
 
 
-class Experiment(  # type: ignore[misc]  # __eq__ false positive
+class Experiment(  # type: ignore[misc]  # `SOMAObject.__eq__`, `SOMAGroup.set` false positives
     CollectionBase[AnySOMAObject],
     experiment.Experiment[  # type: ignore[type-var]
         DataFrame,

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -14,7 +14,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Literal,
     Protocol,
     Sequence,
@@ -436,7 +435,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
         tp = self._threadpool
         x_collection = self._ms.X
         all_x_names = [X_name] + list(X_layers)
-        all_x_arrays: Dict[str, SparseNDArray] = {}
+        all_x_arrays: dict[str, SparseNDArray] = {}
         for _xname in all_x_names:
             if not isinstance(_xname, str) or not _xname:
                 raise ValueError("X layer names must be specified as a string.")
@@ -601,7 +600,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
 
         # Create empty SpatialData instance and dict to store region/instance keys.
         sdata = sd.SpatialData()
-        region_joinids: Dict[str, Any] = {}
+        region_joinids: dict[str, Any] = {}
 
         # Add data from linked scenes.
         for scene_name in scene_names:

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -411,7 +411,7 @@ def to_anndata(
     varm = _resolve_futures(varm)
     obsp = _resolve_futures(obsp)
     varp = _resolve_futures(varp)
-    anndata_X = anndata_X_future.result() if anndata_X_future is not None else None
+    anndata_X = anndata_X_future.result() if anndata_X_future else None
     anndata_layers = _resolve_futures(anndata_layers_futures)
     uns: UnsDict = (
         _resolve_futures(uns_future.result(), deep=True)

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -14,7 +14,6 @@ import json
 from concurrent.futures import Future
 from typing import (
     Any,
-    Dict,
     KeysView,
     Sequence,
     Union,
@@ -55,7 +54,7 @@ from ._common import (
 )
 
 FutureUnsLeaf = Union[UnsLeaf, Future[UnsLeaf]]
-FutureUnsDictNode = Union[FutureUnsLeaf, Dict[str, "FutureUnsDictNode"]]
+FutureUnsDictNode = Union[FutureUnsLeaf, dict[str, "FutureUnsDictNode"]]
 
 
 # ----------------------------------------------------------------
@@ -67,7 +66,7 @@ def to_h5ad(
     X_layer_name: str | None = "data",
     obs_id_name: str | None = None,
     var_id_name: str | None = None,
-    obsm_varm_width_hints: Dict[str, Dict[str, int]] | None = None,
+    obsm_varm_width_hints: dict[str, dict[str, int]] | None = None,
     uns_keys: Sequence[str] | None = None,
 ) -> None:
     """Converts the experiment group to AnnData format and writes it to the specified ``.h5ad`` file.
@@ -234,7 +233,7 @@ def to_anndata(
     extra_X_layer_names: Sequence[str] | KeysView[str] | None = None,
     obs_id_name: str | None = None,
     var_id_name: str | None = None,
-    obsm_varm_width_hints: Dict[str, Dict[str, int]] | None = None,
+    obsm_varm_width_hints: dict[str, dict[str, int]] | None = None,
     uns_keys: Sequence[str] | None = None,
 ) -> ad.AnnData:
     """Converts the experiment group to AnnData format.
@@ -395,7 +394,7 @@ def to_anndata(
         for key in measurement.varp.keys():
             varp[key] = tp.submit(load_varp, measurement, key, nvar)
 
-    uns_future: Future[Dict[str, FutureUnsDictNode]] | None = None
+    uns_future: Future[dict[str, FutureUnsDictNode]] | None = None
     if "uns" in measurement:
         s = _util.get_start_stamp()
         uns_coll = cast(Collection[Any], measurement["uns"])
@@ -442,7 +441,7 @@ def _extract_obsm_or_varm(
     collection_name: str,
     element_name: str,
     num_rows: int,
-    width_configs: Dict[str, int],
+    width_configs: dict[str, int],
 ) -> Matrix:
     """
     This is a helper function for ``to_anndata`` of ``obsm`` and ``varm`` elements.
@@ -527,11 +526,11 @@ def _extract_uns(
     collection: Collection[Any],
     uns_keys: Sequence[str] | None = None,
     level: int = 0,
-) -> Dict[str, FutureUnsDictNode]:
+) -> dict[str, FutureUnsDictNode]:
     """
     This is a helper function for ``to_anndata`` of ``uns`` elements.
     """
-    extracted: Dict[str, FutureUnsDictNode] = {}
+    extracted: dict[str, FutureUnsDictNode] = {}
     tp = collection.context.threadpool
     for key in collection.keys():
         if level == 0 and uns_keys is not None and key not in uns_keys:

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -178,7 +178,7 @@ class VisiumPaths:
                 version = _read_visium_software_version(gene_expression)
             except (KeyError, ValueError):
                 raise ValueError(
-                    "Unable to determine Space Ranger vesion from gene expression file."
+                    "Unable to determine Space Ranger version from gene expression file."
                 )
 
         # Find the tissue positions file path if it wasn't supplied.

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Sequence, Tuple, Type
+from typing import List, Sequence, Tuple, Type
 
 import attrs
 import numpy as np
@@ -31,6 +31,7 @@ except ImportError as err:
 
 
 from somacore import Axis, CoordinateSpace, IdentityTransform, ScaleTransform
+from somacore.options import PlatformConfig
 
 from ... import (
     Collection,
@@ -52,11 +53,14 @@ from ..._exception import (
 )
 from ..._soma_object import AnySOMAObject
 from ..._types import IngestMode
+from ...options import SOMATileDBContext
 from ...options._tiledb_create_write_options import (
     TileDBCreateOptions,
     TileDBWriteOptions,
 )
 from .. import conversions, from_anndata
+from .._common import AdditionalMetadata
+from .._registration import ExperimentAmbientLabelMapping
 from ..ingest import (
     IngestCtx,
     IngestionParams,
@@ -66,13 +70,6 @@ from ..ingest import (
     add_metadata,
 )
 from ._util import _read_visium_software_version
-
-if TYPE_CHECKING:
-    from somacore.options import PlatformConfig
-
-    from ...options import SOMATileDBContext
-    from .._common import AdditionalMetadata
-    from .._registration import ExperimentAmbientLabelMapping
 
 
 def path_validator(instance, attribute, value: Path) -> None:  # type: ignore[no-untyped-def]
@@ -251,8 +248,8 @@ def from_visium(
     measurement_name: str,
     scene_name: str,
     *,
-    context: "SOMATileDBContext | None" = None,
-    platform_config: "PlatformConfig | None" = None,
+    context: SOMATileDBContext | None = None,
+    platform_config: PlatformConfig | None = None,
     obs_id_name: str = "obs_id",
     var_id_name: str = "var_id",
     X_layer_name: str = "data",
@@ -262,9 +259,9 @@ def from_visium(
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
     X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
-    registration_mapping: "ExperimentAmbientLabelMapping | None" = None,
+    registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
-    additional_metadata: "AdditionalMetadata" = None,
+    additional_metadata: AdditionalMetadata = None,
     use_raw_counts: bool = False,
     write_obs_spatial_presence: bool = True,
     write_var_spatial_presence: bool = False,
@@ -619,9 +616,9 @@ def _write_scene_presence_dataframe(
     df_uri: str,
     *,
     ingestion_params: IngestionParams,
-    additional_metadata: "AdditionalMetadata" = None,
-    platform_config: "PlatformConfig | None" = None,
-    context: "SOMATileDBContext | None" = None,
+    additional_metadata: AdditionalMetadata = None,
+    platform_config: PlatformConfig | None = None,
+    context: SOMATileDBContext | None = None,
 ) -> DataFrame:
     s = _util.get_start_stamp()
 
@@ -686,9 +683,9 @@ def _write_visium_spots(
     max_joinid_len: int,
     *,
     ingestion_params: IngestionParams,
-    additional_metadata: "AdditionalMetadata" = None,
-    platform_config: "PlatformConfig | None" = None,
-    context: "SOMATileDBContext | None" = None,
+    additional_metadata: AdditionalMetadata = None,
+    platform_config: PlatformConfig | None = None,
+    context: SOMATileDBContext | None = None,
 ) -> PointCloudDataFrame:
     """Creates, opens, and writes data to a ``PointCloudDataFrame`` with the spot
     locations and metadata. Returns the open dataframe for writing.
@@ -757,8 +754,8 @@ def _create_or_open_scene(
     uri: str,
     *,
     ingestion_params: IngestionParams,
-    context: "SOMATileDBContext | None",
-    additional_metadata: "AdditionalMetadata" = None,
+    context: SOMATileDBContext | None,
+    additional_metadata: AdditionalMetadata = None,
 ) -> Scene:
     """Creates or opens a ``Scene`` and returns it open for writing."""
     try:
@@ -780,9 +777,9 @@ def _create_visium_tissue_images(
     image_paths: List[Tuple[str, Path, float | None]],
     *,
     image_channel_first: bool,
-    additional_metadata: "AdditionalMetadata" = None,
-    platform_config: "PlatformConfig | None" = None,
-    context: "SOMATileDBContext | None" = None,
+    additional_metadata: AdditionalMetadata = None,
+    platform_config: PlatformConfig | None = None,
+    context: SOMATileDBContext | None = None,
     ingestion_params: IngestionParams,
     use_relative_uri: bool | None = None,
 ) -> MultiscaleImage:

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import warnings
 from pathlib import Path
-from typing import List, Sequence, Tuple, Type
+from typing import Sequence
 
 import attrs
 import numpy as np
@@ -101,7 +101,7 @@ class VisiumPaths:
         hires_image: str | Path | None = None,
         lowres_image: str | Path | None = None,
         use_raw_counts: bool = False,
-        version: int | Tuple[int, int, int] | None = None,
+        version: int | tuple[int, int, int] | None = None,
     ) -> Self:
         """Create ingestion files from Space Ranger output directory.
 
@@ -158,7 +158,7 @@ class VisiumPaths:
         fullres_image: str | Path | None = None,
         hires_image: str | Path | None = None,
         lowres_image: str | Path | None = None,
-        version: int | Tuple[int, int, int] | None = None,
+        version: int | tuple[int, int, int] | None = None,
     ) -> Self:
         """Create ingestion files from Space Ranger spatial output directory
         and the gene expression file.
@@ -227,7 +227,7 @@ class VisiumPaths:
     lowres_image: Path | None = attrs.field(
         converter=optional_path_converter, validator=optional_path_validator
     )
-    version: int | Tuple[int, int, int]
+    version: int | tuple[int, int, int]
 
     @property
     def has_image(self) -> bool:
@@ -258,7 +258,7 @@ def from_visium(
     image_channel_first: bool = True,
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
-    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
+    X_kind: type[SparseNDArray] | type[DenseNDArray] = SparseNDArray,
     registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
@@ -453,7 +453,7 @@ def from_visium(
 
     # Create a list of image paths.
     # -- Each item contains: level name, image path, and scale factors to fullres.
-    image_paths: List[Tuple[str, Path, float | None]] = []
+    image_paths: list[tuple[str, Path, float | None]] = []
     if input_paths.fullres_image is not None:
         image_paths.append(("fullres", Path(input_paths.fullres_image), None))
     if input_paths.hires_image is not None:
@@ -774,7 +774,7 @@ def _create_or_open_scene(
 
 def _create_visium_tissue_images(
     uri: str,
-    image_paths: List[Tuple[str, Path, float | None]],
+    image_paths: list[tuple[str, Path, float | None]],
     *,
     image_channel_first: bool,
     additional_metadata: AdditionalMetadata = None,
@@ -796,7 +796,7 @@ def _create_visium_tissue_images(
         im_data_numpy = np.moveaxis(im_data_numpy, -1, 0)
     else:
         data_axis_order = ("y", "x", "soma_channel")
-    ref_shape: Tuple[int, ...] = im_data_numpy.shape
+    ref_shape: tuple[int, ...] = im_data_numpy.shape
 
     # Create the multiscale image.
     with warnings.catch_warnings():

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -138,8 +138,6 @@ PROJECT_ROOT = PY_ROOT.parent.parent
 TESTDATA = PY_ROOT / "testdata"
 ROOT_DATA_DIR = PROJECT_ROOT / "data"
 
-ROOT_DATA_DIR = PROJECT_ROOT / "data"
-
 
 @contextmanager
 def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -861,8 +861,8 @@ def test_X_none(h5ad_file_X_none):
         # TODO: more
 
 
-# There exist in the wild AnnData files with categorical-int columns where the "not in the category"
-# is indicated by the presence of floating-point math.NaN in cells. Here we test that we can ingest
+# There exist in the wild AnnData files with categorical-int columns where "not in the category" is
+# indicated by the presence of floating-point math.NaN in cells. Here we test that we can ingest
 # this.
 def test_obs_with_categorical_int_nan_enumeration(
     tmp_path, h5ad_file_categorical_int_nan

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -1,7 +1,6 @@
 import re
 from concurrent import futures
 from contextlib import nullcontext
-from typing import Tuple
 from unittest import mock
 
 import attrs
@@ -15,13 +14,12 @@ from somacore import AxisQuery, options
 
 import tiledbsoma as soma
 from tiledbsoma import (
+    Experiment,
     ExperimentAxisQuery,
     SOMATileDBContext,
-    _factory,
     pytiledbsoma,
 )
 from tiledbsoma._collection import CollectionBase
-from tiledbsoma._experiment import Experiment
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard
@@ -98,9 +96,9 @@ def soma_experiment(
     return Experiment.open((tmp_path / "exp").as_posix())
 
 
-def get_soma_experiment_with_context(soma_experiment, context):
+def get_soma_experiment_with_context(soma_experiment, context) -> Experiment:
     soma_experiment.close()
-    return _factory.open(soma_experiment.uri, context=context)
+    return Experiment.open(soma_experiment.uri, context=context)
 
 
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names", [(101, 11, ("raw", "extra"))])
@@ -141,8 +139,8 @@ def test_experiment_query_all(soma_experiment):
         ad = query.to_anndata("raw")
         assert ad.n_obs == query.n_obs and ad.n_vars == query.n_vars
 
-        assert set(ad.obs.keys().to_list()) == set(["soma_joinid", "label"])
-        assert set(ad.var.keys().to_list()) == set(["soma_joinid", "label"])
+        assert set(ad.obs.keys()) == {"soma_joinid", "label"}
+        assert set(ad.var.keys()) == {"soma_joinid", "label"}
 
         obs = soma_experiment.obs.read().concat().to_pandas()
         obs.index = obs.index.map(str)
@@ -889,7 +887,7 @@ def add_dataframe(coll: CollectionBase, key: str, sz: int) -> None:
     )
 
 
-def add_sparse_array(coll: CollectionBase, key: str, shape: Tuple[int, int]) -> None:
+def add_sparse_array(coll: CollectionBase, key: str, shape: tuple[int, int]) -> None:
     a = coll.add_new_sparse_ndarray(key, type=pa.float32(), shape=shape)
     tensor = pa.SparseCOOTensor.from_scipy(
         sparse.random(

--- a/apis/python/tests/test_fastercsx.py
+++ b/apis/python/tests/test_fastercsx.py
@@ -164,7 +164,6 @@ def test_from_soma_chunked_array(
         format="coo",
     )
 
-    tables = []
     i = np.array_split(sp.row.astype(np.int64), n_tables)
     j = np.array_split(sp.col.astype(np.int64), n_tables)
     d = np.array_split(sp.data, n_tables)
@@ -350,7 +349,7 @@ def test_bad_shapes(context: soma.SOMATileDBContext, rng: np.random.Generator) -
 @pytest.mark.parametrize("format", ["csr", "csc"])
 @pytest.mark.parametrize("make_sorted", [True, False])
 def test_duplicates(
-    format: str,
+    format: Literal["csc", "csr"],
     make_sorted: bool,
     context: soma.SOMATileDBContext,
     rng: np.random.Generator,


### PR DESCRIPTION
- Use {`dict`,`tuple`,`list`,`type`} types (available since Python 3.9) in some places (instead of `typing.{Dict,Tuple,List,Type}` counterparts)
- Reference some types directly, instead of quoting them as strings
- Misc other typo fixes / lints