### PR TITLE
[python] Make the testing of `from_visium` more thorough

### DIFF
--- a/apis/python/tests/test_from_visium.py
+++ b/apis/python/tests/test_from_visium.py
@@ -91,6 +91,68 @@ def test_visium_paths_v2(visium_v2_path):
 
 
 @pytest.mark.slow
+def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
+    """Test `from_visium` runs without error."""
+    PIL = pytest.importorskip("PIL")
+    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_v2"
+    exp_uri = spatial_io.from_visium(
+        uri,
+        visium_v1_path,
+        "RNA",
+        "fresh_frozen_mouse_brain",
+        write_obs_spatial_presence=True,
+        write_var_spatial_presence=True,
+    )
+    with soma.Experiment.open(exp_uri) as exp:
+
+        # Check for the existance of obs, RNA/X, and RNA/var
+        assert isinstance(exp.obs, soma.DataFrame)
+        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
+        assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
+
+        # Check for the existance of the presence matrices.
+        assert isinstance(exp.obs_spatial_presence, soma.DataFrame)
+        assert isinstance(exp.ms["RNA"].var_spatial_presence, soma.DataFrame)
+
+        # Check for scene.
+        assert isinstance(exp.spatial["fresh_frozen_mouse_brain"], soma.Scene)
+
+        # Check expected datatypes in scene.
+        scene = exp.spatial["fresh_frozen_mouse_brain"]
+        assert isinstance(scene.obsl["loc"], soma.PointCloudDataFrame)
+        assert len(scene.varl.items()) == 0
+        assert isinstance(scene.img["tissue"], soma.MultiscaleImage)
+
+        # Check point cloud dataframe data.
+        output_points_df = scene.obsl["loc"].read().concat().to_pandas()
+        assert output_points_df.columns.tolist() == [
+            "x",
+            "y",
+            "soma_joinid",
+            "in_tissue",
+            "array_row",
+            "array_col",
+            "spot_diameter_fullres",
+        ]
+        assert len(output_points_df) == 4035
+
+        # Check image.
+        image = scene.img["tissue"]
+        hires_data = np.moveaxis(image["hires"].read().to_numpy(), 0, -1)
+        with PIL.Image.open(
+            visium_v1_path / "spatial" / "tissue_hires_image.png"
+        ) as input_hires:
+            expected = np.array(input_hires)
+            np.testing.assert_equal(expected, hires_data)
+        lowres_data = np.moveaxis(image["lowres"].read().to_numpy(), 0, -1)
+        with PIL.Image.open(
+            visium_v1_path / "spatial" / "tissue_lowres_image.png"
+        ) as input_lowres:
+            expected = np.array(input_lowres)
+            np.testing.assert_equal(expected, lowres_data)
+
+
+@pytest.mark.slow
 def test_from_visium_for_visium_v2(tmp_path, visium_v2_path):
     """Test `from_visium` runs without error."""
     PIL = pytest.importorskip("PIL")

--- a/apis/python/tests/test_from_visium.py
+++ b/apis/python/tests/test_from_visium.py
@@ -24,6 +24,7 @@ def visium_v1_path():
         "filtered_feature_bc_matrix.h5",
         "raw_feature_bc_matrix.h5",
         "spatial/tissue_positions_list.csv",
+        "filtered_visium1_loc.csv",
         "spatial/scalefactors_json.json",
         "spatial/tissue_hires_image.png",
         "spatial/tissue_lowres_image.png",
@@ -50,6 +51,7 @@ def visium_v2_path():
     for filename in [
         "filtered_feature_bc_matrix.h5",
         "raw_feature_bc_matrix.h5",
+        "filtered_visium2_loc.csv",
         "spatial/tissue_positions.csv",
         "spatial/scalefactors_json.json",
         "spatial/tissue_hires_image.png",
@@ -200,30 +202,53 @@ def test_from_visium_for_visium_v2(tmp_path, visium_v2_path):
         assert isinstance(exp.obs_spatial_presence, soma.DataFrame)
         assert isinstance(exp.ms["RNA"].var_spatial_presence, soma.DataFrame)
 
-        # Check for scene.
-        assert isinstance(exp.spatial["fresh_frozen_mouse_brain"], soma.Scene)
+        # Define some expected data.
+        pixel_coord_space = soma.CoordinateSpace(
+            (soma.Axis("x", "pixels"), soma.Axis("y", "pixels"))
+        )
 
-        # Check expected datatypes in scene.
+        # Check the scene exists and has the desired metadata.
+        assert isinstance(exp.spatial["fresh_frozen_mouse_brain"], soma.Scene)
         scene = exp.spatial["fresh_frozen_mouse_brain"]
+        assert scene.coordinate_space == pixel_coord_space
+
+        # Check the scene subcollections:
+        # - `obsl` only has a point cloud dataframe named `loc`,
+        # - `varl` is empty,
+        # - `img` only has a multiscale image named `tissue`.
+        assert len(scene.obsl.items()) == 1
         assert isinstance(scene.obsl["loc"], soma.PointCloudDataFrame)
         assert len(scene.varl.items()) == 0
+        assert len(scene.img.items()) == 1
         assert isinstance(scene.img["tissue"], soma.MultiscaleImage)
 
+        # Check transform to `loc`.
+        loc_transform = scene.get_transform_to_point_cloud_dataframe("loc", "obsl")
+        assert isinstance(loc_transform, soma.IdentityTransform)
+        assert loc_transform.input_axes == ("x", "y")
+        assert loc_transform.output_axes == ("x", "y")
+
+        # Check transform to `img`.
+        img_transform = scene.get_transform_to_multiscale_image("tissue", "img")
+        assert isinstance(img_transform, soma.ScaleTransform)
+        assert img_transform.input_axes == ("x", "y")
+        assert img_transform.output_axes == ("x", "y")
+        np.testing.assert_allclose(
+            img_transform.scale_factors,
+            np.array([0.150015, 0.150015], dtype=np.float64),
+            atol=0.000001,
+        )
+
         # Check point cloud dataframe data.
-        output_points_df = scene.obsl["loc"].read().concat().to_pandas()
-        assert output_points_df.columns.tolist() == [
-            "x",
-            "y",
-            "soma_joinid",
-            "in_tissue",
-            "array_row",
-            "array_col",
-            "spot_diameter_fullres",
-        ]
-        assert len(output_points_df) == 2797
+        loc = scene.obsl["loc"]
+        assert loc.coordinate_space == pixel_coord_space
+        actual_loc_data = loc.read().concat().to_pandas()
+        expected_loc_data = pd.read_csv(visium_v2_path / "filtered_visium2_loc.csv")
+        pd.testing.assert_frame_equal(actual_loc_data, expected_loc_data)
 
         # Check image.
         image = scene.img["tissue"]
+        assert image.coordinate_space == pixel_coord_space
         hires_data = np.moveaxis(image["hires"].read().to_numpy(), 0, -1)
         with PIL.Image.open(
             visium_v2_path / "spatial" / "tissue_hires_image.png"

--- a/scripts/prepare-test-data.sh
+++ b/scripts/prepare-test-data.sh
@@ -34,6 +34,7 @@ else
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-19/filtered_feature_bc_matrix.h5
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-19/raw_feature_bc_matrix.h5
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-19/spatial.tar.gz
+    wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-19/filtered_visium2_loc.csv
     tar zxf spatial.tar.gz
     cd ..
     echo "   ... finished preparing dataset 'data/$name'."
@@ -49,6 +50,7 @@ else
     mkdir $name && cd $name
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-21/filtered_feature_bc_matrix.h5
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-21/raw_feature_bc_matrix.h5
+    wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-21/filtered_visium1_loc.csv
     wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-21/spatial.tar.gz
     tar zxf spatial.tar.gz
     cd ..


### PR DESCRIPTION
**Issue and/or context:** [sc-56889](https://app.shortcut.com/tiledb-inc/story/56889/test-visium-ingestor-on-a-wider-range-of-input-datasets) [sc-63606](https://app.shortcut.com/tiledb-inc/story/63606/add-additional-checks-in-visium-test) 

**Changes:**
* Download additional data for the `from_visium` tests.
* Add a complete test of ingesting a Visium v1 dataset.
* Update Visium v2 test to include checking point/spot data, coordinate space data, and coordinate transform data.

