### PR TITLE
[python/ci] Remove redundant step to prepare test data

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -118,14 +118,6 @@ jobs:
     - name: Show XCode version
       run: clang --version
 
-    - name: Obtain test data
-      shell: bash
-      run: |
-        cd test
-        rm -rf soco
-        tar zxf soco.tgz
-        cd ..
-
     - name: Run libtiledbsoma unit tests
       run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
       env:


### PR DESCRIPTION
**Issue and/or context:**

xref: https://github.com/single-cell-data/TileDB-SOMA/pull/3712, https://github.com/TileDB-Inc/centralized-tiledb-nightlies/pull/40, https://github.com/TileDB-Inc/centralized-tiledb-nightlies/pull/39#discussion_r1973716522

**Changes:**

Remove redundant step to prepare test data

**Notes for Reviewer:**



