### PR TITLE
[c++/python] Add support for binary column

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -991,12 +991,7 @@ def _fill_out_slot_soma_domain(
     if slot_domain is not None:
         # User-specified; go with it when possible
         if (
-            (
-                pa_type == pa.string()
-                or pa_type == pa.large_string()
-                or pa_type == pa.binary()
-                or pa_type == pa.large_binary()
-            )
+            pa_type in [pa.string(), pa.large_string(), pa.binary(), pa.large_binary()]
             and tuple(slot_domain) != ("", "")
             and tuple(slot_domain) != (b"", b"")
         ):

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -991,11 +991,15 @@ def _fill_out_slot_soma_domain(
     if slot_domain is not None:
         # User-specified; go with it when possible
         if (
-            pa_type == pa.string()
-            or pa_type == pa.large_string()
-            or pa_type == pa.binary()
-            or pa_type == pa.large_binary()
-        ) and tuple(slot_domain) != ("", ""):
+            (
+                pa_type == pa.string()
+                or pa_type == pa.large_string()
+                or pa_type == pa.binary()
+                or pa_type == pa.large_binary()
+            )
+            and tuple(slot_domain) != ("", "")
+            and tuple(slot_domain) != (b"", b"")
+        ):
             # TileDB Embedded won't raise an error if the user asks for, say
             # domain=[("a", "z")].  But it will simply _ignore_ the request and
             # use [("", "")]. The decision here is to explicitly reject an

--- a/apis/python/tests/ht/_ht_test_config.py
+++ b/apis/python/tests/ht/_ht_test_config.py
@@ -25,7 +25,7 @@ HT_TEST_CONFIG = {
     # Read of new array returns incorrect info
     "sc-61676_workaround": True,
     # index columns of type binary/large_binary are reported as large_string
-    "sc-62236_workaround": True,
+    "sc-62236_workaround": False,
     # string index values starting with 0x7F barf
     "sc-62265_workaround": True,
     # dictionary of timestamps is not working

--- a/apis/python/tests/ht/test_ht_dataframe.py
+++ b/apis/python/tests/ht/test_ht_dataframe.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from hypothesis import reproduce_failure
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as ht_np
 from hypothesis.stateful import initialize, invariant, precondition, rule
@@ -610,9 +609,6 @@ def arrow_table2(
     return tbl, enumeration_metadata
 
 
-@reproduce_failure(
-    "6.131.15", b"AXicY3BkajRwZABCZkdmBgZHRkcGEIcBQoJZjkyE2IwMIO0MAFWgCGM="
-)
 class SOMADataFrameStateMachine(SOMAArrayStateMachine):
 
     def __init__(self) -> None:

--- a/apis/python/tests/ht/test_ht_dataframe.py
+++ b/apis/python/tests/ht/test_ht_dataframe.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from hypothesis import reproduce_failure
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as ht_np
 from hypothesis.stateful import initialize, invariant, precondition, rule
@@ -609,6 +610,9 @@ def arrow_table2(
     return tbl, enumeration_metadata
 
 
+@reproduce_failure(
+    "6.131.15", b"AXicY3BkajRwZABCZkdmBgZHRkcGEIcBQoJZjkyE2IwMIO0MAFWgCGM="
+)
 class SOMADataFrameStateMachine(SOMAArrayStateMachine):
 
     def __init__(self) -> None:
@@ -702,13 +706,13 @@ class SOMADataFrameStateMachine(SOMAArrayStateMachine):
             else:
                 type = self.schema.field(iname).type
                 if type in [
-                    pa.binary(),
-                    pa.large_binary(),
+                    pa.string(),
+                    pa.large_string(),
                 ]:
                     domain.append(("", ""))
                 elif type in [pa.binary(), pa.large_binary()]:
                     domain.append((b"", b""))
-                elif pa.type.is_primitive(type):
+                elif pa.types.is_primitive(type):
                     domain.append((0, 0))
                 elif pa.types.is_timestamp(type):
                     zero_ts = pa.scalar(0, type=type)

--- a/apis/python/tests/ht/test_ht_dataframe.py
+++ b/apis/python/tests/ht/test_ht_dataframe.py
@@ -702,12 +702,12 @@ class SOMADataFrameStateMachine(SOMAArrayStateMachine):
             else:
                 type = self.schema.field(iname).type
                 if type in [
-                    pa.string(),
-                    pa.large_string(),
                     pa.binary(),
                     pa.large_binary(),
                 ]:
                     domain.append(("", ""))
+                elif type in [pa.binary(), pa.large_binary()]:
+                    domain.append((b"", b""))
                 elif pa.type.is_primitive(type):
                     domain.append((0, 0))
                 elif pa.types.is_timestamp(type):

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -2139,3 +2139,90 @@ def test_types_read_errors(
     with pytest.raises(soma.SOMAError):
         with soma.DataFrame.open(uri, "r") as sdf:
             sdf.read(coords=coords).concat()
+
+
+@pytest.mark.parametrize("domain", [[None], [[b"", b""]]])
+def test_binary_index(tmp_path, domain):
+    uri = tmp_path.as_posix()
+
+    soma_joinid_data = []
+    string_data = []
+    bytes_data = []
+
+    # generate data for writing
+    for i in range(128):
+        soma_joinid_data.append(i)
+        string_data.append(str(i))
+        bytes_data.append(i.to_bytes(1, byteorder="big"))
+
+    arrow_table = pa.Table.from_pydict(
+        {
+            "soma_joinid": pa.array(soma_joinid_data, pa.int64()),
+            "string": string_data,
+            "bytes": bytes_data,
+        }
+    )
+
+    sdf = soma.DataFrame.create(
+        uri,
+        schema=arrow_table.schema,
+        index_column_names=["bytes"],
+        domain=domain,
+    )
+
+    with pytest.raises(soma.SOMAError):
+        sdf.change_domain([[b"\x00", "\x7f"]])
+
+    with pytest.raises(soma.SOMAError):
+        sdf.change_domain([["a", "b"]])
+
+    sdf.change_domain([[b"", b""]])
+    sdf.change_domain([["", ""]])
+
+    sdf.write(arrow_table)
+
+    with pytest.raises(soma.SOMAError):
+        # Write outside of current domain
+        for i in range(128, 256):
+            temp_soma_joinid_data = [i]
+            temp_string_data = [str(i)]
+            temp_bytes_data = [i.to_bytes(1, byteorder="big")]
+
+            temp_arrow_table = pa.Table.from_pydict(
+                {
+                    "soma_joinid": pa.array(temp_soma_joinid_data, pa.int64()),
+                    "string": temp_string_data,
+                    "bytes": temp_bytes_data,
+                }
+            )
+
+            sdf.write(temp_arrow_table)
+
+    sdf = sdf.reopen("r")
+
+    point_read = sdf.read([(b"\x10", b"\x20")]).concat().to_pandas()
+    slice_read = sdf.read([slice(b"\x10", b"\x20")]).concat().to_pandas()
+
+    assert len(point_read) == 2
+    assert len(slice_read) == 17
+
+    for idx, entry in enumerate(slice_read["bytes"]):
+        assert entry == bytes_data[16 + idx].decode("utf-8")
+
+    assert sdf.non_empty_domain() == ((b"\x00", b"\x7f"),)
+    assert sdf.domain == ((b"", b""),)
+    assert sdf._maxdomain() == ((b"", b""),)
+
+
+@pytest.mark.parametrize(
+    "domain", [[[b"0x00", b"0x7f"]], [[b"0x10", b"0x56"]], [[b"0x00", b"0xff"]]]
+)
+def test_binary_index_invalid_domain(tmp_path, arrow_table, domain):
+    uri = tmp_path.as_posix()
+    with pytest.raises(ValueError):
+        soma.DataFrame.create(
+            uri,
+            schema=arrow_table.schema,
+            index_column_names=["bytes"],
+            domain=domain,
+        )

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -278,7 +278,7 @@ def arrow_table():
         [
             "bytes-pa-array-typed",
             ["bytes"],
-            [["", ""]],
+            [[b"", b""]],
             [pa.array([b"cat", b"dog"], pa.binary())],
             "default23",
         ],

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_object.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_attribute.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_binary_column.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_column.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.cc
@@ -215,6 +216,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_attribute.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_binary_column.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_dimension.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_geometry_column.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_collection.h

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -27,7 +27,8 @@ enum class URIType { automatic = 0, absolute, relative };
 typedef enum {
     SOMA_COLUMN_DIMENSION = 0,
     SOMA_COLUMN_ATTRIBUTE = 1,
-    SOMA_COLUMN_GEOMETRY = 2
+    SOMA_COLUMN_GEOMETRY = 2,
+    SOMA_COLUMN_BINARY = 3
 } soma_column_datatype_t;
 
 // This enables some code deduplication between core domain, core current

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -722,7 +722,7 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
         }
     } else {
         throw TileDBSOMAError(fmt::format(
-            "[ManagedQuery][_extend_and_evolve_schema] Unknown arrow array "
+            "[ManagedQuery][_cast_dictionary_values] Unknown arrow array "
             "type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
             value_schema->format));
     }
@@ -1240,7 +1240,7 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
         }
     } else {
         throw TileDBSOMAError(fmt::format(
-            "[ManagedQuery][_extend_and_evolve_schema] Unknown arrow array "
+            "[ManagedQuery][_extend_and_evolve_schema_with_details] Unknown arrow array "
             "type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
             value_schema->format));
     }

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -706,11 +706,10 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
 
     uint64_t num_elems = value_array->length;
 
-    std::vector<uint64_t> offsets_v;
+    std::vector<uint64_t> offsets_v(num_elems + 1);
     if (strcmp(value_schema->format, "U") == 0 ||
         strcmp(value_schema->format, "Z") == 0) {
         uint64_t* offsets = (uint64_t*)value_array->buffers[1];
-        offsets_v.resize(num_elems + 1);
         offsets_v.assign(offsets, offsets + num_elems + 1);
     } else if (
         strcmp(value_schema->format, "u") == 0 ||

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -574,10 +574,9 @@ bool ManagedQuery::_cast_column(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
-            return _cast_column_aux<std::string>(schema, array, se);
         case TILEDB_BLOB:
         case TILEDB_GEOM_WKB:
-            return _cast_column_aux<std::vector<std::byte>>(schema, array, se);
+            return _cast_column_aux<std::string>(schema, array, se);
         case TILEDB_BOOL:
             return _cast_column_aux<bool>(schema, array, se);
         case TILEDB_INT8:
@@ -625,11 +624,9 @@ void ManagedQuery::_promote_indexes_to_values(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
-            return _cast_dictionary_values<std::string>(schema, array);
         case TILEDB_BLOB:
         case TILEDB_GEOM_WKB:
-            return _cast_dictionary_values<std::vector<std::byte>>(
-                schema, array);
+            return _cast_dictionary_values<std::string>(schema, array);
         case TILEDB_BOOL:
             return _cast_dictionary_values<bool>(schema, array);
         case TILEDB_INT8:
@@ -710,20 +707,23 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
     uint64_t num_elems = value_array->length;
 
     std::vector<uint64_t> offsets_v;
-    if (strcmp(value_schema->format, "U") == 0) {
+    if (strcmp(value_schema->format, "U") ||
+        strcmp(value_schema->format, "Z")) {
         uint64_t* offsets = (uint64_t*)value_array->buffers[1];
         offsets_v.resize(num_elems + 1);
         offsets_v.assign(offsets, offsets + num_elems + 1);
-    } else if (strcmp(value_schema->format, "u") == 0) {
+    } else if (
+        strcmp(value_schema->format, "u") == 0 ||
+        strcmp(value_schema->format, "z") == 0) {
         uint32_t* offsets = (uint32_t*)value_array->buffers[1];
         std::vector<uint32_t> offset_holder(offsets, offsets + num_elems + 1);
         for (auto offset : offset_holder) {
             offsets_v.push_back((uint64_t)offset);
         }
     } else {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[ManagedQuery][_extend_and_evolve_schema] Unknown arrow array "
-            "type. Expected 'U' or 'u', found '{}'",
+            "type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
             value_schema->format));
     }
 
@@ -744,68 +744,6 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
     uint64_t offset_sum = 0;
     std::vector<uint64_t> value_offsets = {0};
     std::string index_to_value;
-    for (auto i : indexes) {
-        auto value = values[i];
-        offset_sum += value.size();
-        value_offsets.push_back(offset_sum);
-        index_to_value.insert(index_to_value.end(), value.begin(), value.end());
-    }
-
-    setup_write_column(
-        schema->name,
-        value_offsets.size() - 1,
-        (const void*)index_to_value.data(),
-        (uint64_t*)value_offsets.data(),
-        std::nullopt);  // validities are set by index column
-}
-
-template <>
-void ManagedQuery::_cast_dictionary_values<std::vector<std::byte>>(
-    ArrowSchema* schema, ArrowArray* array) {
-    // String types require special handling due to large vs regular
-    // string/binary
-
-    auto value_schema = schema->dictionary;
-    auto value_array = array->dictionary;
-
-    uint64_t num_elems = value_array->length;
-
-    std::vector<uint64_t> offsets_v;
-    if (strcmp(value_schema->format, "Z") == 0) {
-        uint64_t* offsets = (uint64_t*)value_array->buffers[1];
-        offsets_v.resize(num_elems + 1);
-        offsets_v.assign(offsets, offsets + num_elems + 1);
-    } else if (strcmp(value_schema->format, "z") == 0) {
-        uint32_t* offsets = (uint32_t*)value_array->buffers[1];
-        std::vector<uint32_t> offset_holder(offsets, offsets + num_elems + 1);
-        for (auto offset : offset_holder) {
-            offsets_v.push_back((uint64_t)offset);
-        }
-    } else {
-        throw TileDBSOMAError(std::format(
-            "[ManagedQuery][_extend_and_evolve_schema] Unknown arrow array "
-            "type. Expected 'Z' or 'z', found '{}'",
-            value_schema->format));
-    }
-
-    std::span<const std::byte> data(
-        static_cast<const std::byte*>(value_array->buffers[2]),
-        offsets_v.back());
-
-    std::vector<std::span<const std::byte>> values;
-    for (size_t offset_idx = 0; offset_idx < offsets_v.size() - 1;
-         ++offset_idx) {
-        auto beg = offsets_v[offset_idx];
-        auto sz = offsets_v[offset_idx + 1] - beg;
-        values.push_back(data.subspan(beg, sz));
-    }
-
-    std::vector<int64_t> indexes = ManagedQuery::_get_index_vector(
-        schema, array);
-
-    uint64_t offset_sum = 0;
-    std::vector<uint64_t> value_offsets = {0};
-    std::vector<std::byte> index_to_value;
     for (auto i : indexes) {
         auto value = values[i];
         offset_sum += value.size();
@@ -847,10 +785,8 @@ void ManagedQuery::_cast_dictionary_values<bool>(
         std::nullopt);  // validities are set by index column
 }
 
-template <typename UserType>
-    requires std::same_as<UserType, std::string> ||
-             std::same_as<UserType, std::vector<std::byte>>
-bool ManagedQuery::_cast_column_aux(
+template <>
+bool ManagedQuery::_cast_column_aux<std::string>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
     (void)se;  // se is unused in std::string specialization
 
@@ -864,7 +800,7 @@ bool ManagedQuery::_cast_column_aux(
     //   from Python/R.)
 
     if (array->n_buffers != 3) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[ManagedQuery] internal error: Arrow-table string column should "
             "have 3 buffers; got {}",
             array->n_buffers));
@@ -984,11 +920,10 @@ bool ManagedQuery::_extend_and_write_enumeration(
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
-            return _extend_and_evolve_schema_and_write<std::string>(
-                value_schema, value_array, index_schema, index_array, se);
         case TILEDB_BLOB:
-            return _extend_and_evolve_schema_and_write<std::vector<std::byte>>(
-                value_schema, value_array, index_schema, index_array, se);
+        case TILEDB_GEOM_WKB:
+            return _extend_and_evolve_schema_and_write<std::string>(
+                value_schema, value_array, index_schema, index_array, enmr, se);
         case TILEDB_INT8:
             return _extend_and_evolve_schema_and_write<int8_t>(
                 value_schema, value_array, index_schema, index_array, enmr, se);
@@ -1290,20 +1225,23 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     // offsets to specify the starts and ends of n string values within a
     // column.
     std::vector<uint64_t> offsets_v;
-    if (strcmp(value_schema->format, "U") == 0) {
+    if (strcmp(value_schema->format, "U") == 0 ||
+        strcmp(value_schema->format, "Z") == 0) {
         uint64_t* offsets = (uint64_t*)value_array->buffers[1];
         offsets_v.assign(
             offsets + value_array->offset,
             offsets + value_array->offset + num_elems + 1);
-    } else if (strcmp(value_schema->format, "u") == 0) {
+    } else if (
+        strcmp(value_schema->format, "u") == 0 ||
+        strcmp(value_schema->format, "z") == 0) {
         uint32_t* offsets = (uint32_t*)value_array->buffers[1];
         for (size_t i = 0; i < num_elems + 1; ++i) {
             offsets_v.push_back((uint64_t)offsets[i + value_array->offset]);
         }
     } else {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[ManagedQuery][_extend_and_evolve_schema] Unknown arrow array "
-            "type. Expected 'U' or 'u', found '{}'",
+            "type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
             value_schema->format));
     }
 

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1597,40 +1597,6 @@ std::optional<std::vector<uint8_t>> ManagedQuery::_cast_validity_buffer(
 }
 
 template <>
-std::vector<std::span<const std::byte>> ManagedQuery::_enumeration_values_view(
-    Enumeration& enumeration) {
-    const void* data;
-    uint64_t data_size;
-
-    ctx_->handle_error(tiledb_enumeration_get_data(
-        ctx_->ptr().get(), enumeration.ptr().get(), &data, &data_size));
-
-    const void* offsets;
-    uint64_t offsets_size;
-    ctx_->handle_error(tiledb_enumeration_get_offsets(
-        ctx_->ptr().get(), enumeration.ptr().get(), &offsets, &offsets_size));
-
-    std::span<const std::byte> byte_data(
-        static_cast<const std::byte*>(data), data_size);
-    const uint64_t* elems = static_cast<const uint64_t*>(offsets);
-    size_t count = offsets_size / sizeof(uint64_t);
-
-    std::vector<std::span<const std::byte>> ret(count);
-    for (size_t i = 0; i < count; i++) {
-        uint64_t len;
-        if (i + 1 < count) {
-            len = elems[i + 1] - elems[i];
-        } else {
-            len = data_size - elems[i];
-        }
-
-        ret[i] = byte_data.subspan(elems[i], len);
-    }
-
-    return ret;
-}
-
-template <>
 std::vector<std::string_view> ManagedQuery::_enumeration_values_view(
     Enumeration& enumeration) {
     const void* data;

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -706,7 +706,8 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
 
     uint64_t num_elems = value_array->length;
 
-    std::vector<uint64_t> offsets_v(num_elems + 1);
+    std::vector<uint64_t> offsets_v;
+    offsets_v.reserve(num_elems + 1);
     if (strcmp(value_schema->format, "U") == 0 ||
         strcmp(value_schema->format, "Z") == 0) {
         uint64_t* offsets = (uint64_t*)value_array->buffers[1];

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -576,6 +576,7 @@ bool ManagedQuery::_cast_column(
         case TILEDB_CHAR:
             return _cast_column_aux<std::string>(schema, array, se);
         case TILEDB_BLOB:
+        case TILEDB_GEOM_WKB:
             return _cast_column_aux<std::vector<std::byte>>(schema, array, se);
         case TILEDB_BOOL:
             return _cast_column_aux<bool>(schema, array, se);
@@ -626,6 +627,7 @@ void ManagedQuery::_promote_indexes_to_values(
         case TILEDB_CHAR:
             return _cast_dictionary_values<std::string>(schema, array);
         case TILEDB_BLOB:
+        case TILEDB_GEOM_WKB:
             return _cast_dictionary_values<std::vector<std::byte>>(
                 schema, array);
         case TILEDB_BOOL:

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -707,8 +707,8 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
     uint64_t num_elems = value_array->length;
 
     std::vector<uint64_t> offsets_v;
-    if (strcmp(value_schema->format, "U") ||
-        strcmp(value_schema->format, "Z")) {
+    if (strcmp(value_schema->format, "U") == 0 ||
+        strcmp(value_schema->format, "Z") == 0) {
         uint64_t* offsets = (uint64_t*)value_array->buffers[1];
         offsets_v.resize(num_elems + 1);
         offsets_v.assign(offsets, offsets + num_elems + 1);

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1240,8 +1240,8 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
         }
     } else {
         throw TileDBSOMAError(fmt::format(
-            "[ManagedQuery][_extend_and_evolve_schema_with_details] Unknown arrow array "
-            "type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
+            "[ManagedQuery][_extend_and_evolve_schema_with_details] Unknown "
+            "arrow array type. Expected 'U', 'Z', 'u' or 'z', found '{}'",
             value_schema->format));
     }
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -700,12 +700,6 @@ class ManagedQuery {
     bool _cast_column_aux(
         ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
 
-    template <typename UserType>
-        requires std::same_as<UserType, std::string> ||
-                 std::same_as<UserType, std::vector<std::byte>>
-    bool _cast_column_aux(
-        ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
-
     template <typename UserType, typename DiskType>
     bool _set_column(
         ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
@@ -1073,8 +1067,7 @@ class ManagedQuery {
     }
 
     template <typename ValueType, typename IndexType>
-        requires std::same_as<ValueType, std::string_view> ||
-                 std::same_as<ValueType, std::span<const std::byte>>
+        requires std::same_as<ValueType, std::string_view>
     void _remap_indexes_aux(
         std::string column_name,
         Enumeration extended_enmr,
@@ -1267,15 +1260,15 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
     ArrowSchema* schema, ArrowArray* array);
 
 template <>
-void ManagedQuery::_cast_dictionary_values<std::vector<std::byte>>(
-    ArrowSchema* schema, ArrowArray* array);
-
-template <>
 void ManagedQuery::_cast_dictionary_values<bool>(
     ArrowSchema* schema, ArrowArray* array);
 
 template <>
 bool ManagedQuery::_cast_column_aux<bool>(
+    ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
+
+template <>
+bool ManagedQuery::_cast_column_aux<std::string>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
 
 template <>
@@ -1301,14 +1294,6 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     bool deduplicate,
     Enumeration enmr,
     ArraySchemaEvolution& se);
-
-template <>
-bool ManagedQuery::_extend_and_evolve_schema<std::vector<std::byte>>(
-    ArrowSchema* value_schema,
-    ArrowArray* value_array,
-    ArrowSchema* index_schema,
-    ArrowArray* index_array,
-    ArraySchemaEvolution se);
 
 template <>
 std::vector<std::span<const std::byte>> ManagedQuery::_enumeration_values_view(

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1073,7 +1073,8 @@ class ManagedQuery {
     }
 
     template <typename ValueType, typename IndexType>
-    requires std::same_as<ValueType, std::string_view> || std::same_as<ValueType, std::span<const std::byte>>
+        requires std::same_as<ValueType, std::string_view> ||
+                 std::same_as<ValueType, std::span<const std::byte>>
     void _remap_indexes_aux(
         std::string column_name,
         Enumeration extended_enmr,

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1296,10 +1296,6 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     ArraySchemaEvolution& se);
 
 template <>
-std::vector<std::span<const std::byte>> ManagedQuery::_enumeration_values_view(
-    Enumeration& enumeration);
-
-template <>
 std::vector<std::string_view> ManagedQuery::_enumeration_values_view(
     Enumeration& enumeration);
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1266,6 +1266,10 @@ void ManagedQuery::_cast_dictionary_values<std::string>(
     ArrowSchema* schema, ArrowArray* array);
 
 template <>
+void ManagedQuery::_cast_dictionary_values<std::vector<std::byte>>(
+    ArrowSchema* schema, ArrowArray* array);
+
+template <>
 void ManagedQuery::_cast_dictionary_values<bool>(
     ArrowSchema* schema, ArrowArray* array);
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1067,7 +1067,7 @@ class ManagedQuery {
     }
 
     template <typename ValueType, typename IndexType>
-        requires std::same_as<ValueType, std::string_view>
+        requires(!std::same_as<ValueType, std::string_view>)
     void _remap_indexes_aux(
         std::string column_name,
         Enumeration extended_enmr,
@@ -1264,11 +1264,11 @@ void ManagedQuery::_cast_dictionary_values<bool>(
     ArrowSchema* schema, ArrowArray* array);
 
 template <>
-bool ManagedQuery::_cast_column_aux<bool>(
+bool ManagedQuery::_cast_column_aux<std::string>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
 
 template <>
-bool ManagedQuery::_cast_column_aux<std::string>(
+bool ManagedQuery::_cast_column_aux<bool>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
 
 template <>
@@ -1294,6 +1294,16 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     bool deduplicate,
     Enumeration enmr,
     ArraySchemaEvolution& se);
+
+template <>
+bool ManagedQuery::
+    _extend_and_evolve_schema_without_details<std::string, std::string_view>(
+        ArrowSchema* value_schema,
+        ArrowArray* value_array,
+        const std::string& column_name,
+        bool deduplicate,
+        Enumeration enmr,
+        ArraySchemaEvolution& se);
 
 template <>
 std::vector<std::string_view> ManagedQuery::_enumeration_values_view(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -189,7 +189,7 @@ void SOMAArray::fill_columns() {
         }
     }
 
-    // Column metadata re optional for other SOMAArray types but some features
+    // Column metadata is optional for other SOMAArray types but some features
     // may be missing such as binary index columns
     columns_ = SOMAColumn::deserialize(*ctx_->tiledb_ctx(), *arr_, metadata_);
 }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -189,6 +189,8 @@ void SOMAArray::fill_columns() {
         }
     }
 
+    // Column metadata re optional for other SOMAArray types but some features
+    // may be missing such as binary index columns
     columns_ = SOMAColumn::deserialize(*ctx_->tiledb_ctx(), *arr_, metadata_);
 }
 

--- a/libtiledbsoma/src/soma/soma_binary_column.cc
+++ b/libtiledbsoma/src/soma/soma_binary_column.cc
@@ -376,15 +376,14 @@ ArrowSchema* SOMABinaryColumn::arrow_schema_slot(
     const SOMAContext& ctx, Array& array) const {
     if (isIndexColumn()) {
         ArrowSchema* schema = ArrowAdapter::arrow_schema_from_tiledb_dimension(
-                                  std::get<Dimension>(container))
-                                  .release();
+            std::get<Dimension>(container));
+        free((void*)schema->format);
         schema->format = strdup("Z");
 
         return schema;
     } else {
         return ArrowAdapter::arrow_schema_from_tiledb_attribute(
-                   std::get<Attribute>(container), *ctx.tiledb_ctx(), array)
-            .release();
+            std::get<Attribute>(container), *ctx.tiledb_ctx(), array);
     }
 }
 

--- a/libtiledbsoma/src/soma/soma_binary_column.cc
+++ b/libtiledbsoma/src/soma/soma_binary_column.cc
@@ -87,8 +87,8 @@ std::shared_ptr<SOMABinaryColumn> SOMABinaryColumn::create(
             array,
             soma_type,
             type_metadata,
-            "",
-            "",
+            "", //prefix
+            "", //suffix
             platform_config);
 
         return std::make_shared<SOMABinaryColumn>(dimension);
@@ -107,8 +107,7 @@ void SOMABinaryColumn::_set_dim_points(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_dim_points] Column with name {} is not an "
-            "index "
-            "column",
+            "index column",
             name()));
     }
 
@@ -128,8 +127,7 @@ void SOMABinaryColumn::_set_dim_ranges(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_dim_ranges] Column with name {} is not an "
-            "index "
-            "column",
+            "index column",
             name()));
     }
 
@@ -155,9 +153,7 @@ void SOMABinaryColumn::_set_current_domain_slot(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
-            "is "
-            "not "
-            "an index column",
+            "is not an index column",
             name()));
     }
 
@@ -174,8 +170,7 @@ void SOMABinaryColumn::_set_current_domain_slot(
     } else {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] domain (\"{}\", "
-            "\"{}\") cannot be set for "
-            "binary index columns: please use "
+            "\"{}\") cannot be set for binary index columns: please use "
             "(\"\", \"\")",
             std::string(
                 reinterpret_cast<const char*>(dom[0].data()), dom[0].size()),

--- a/libtiledbsoma/src/soma/soma_binary_column.cc
+++ b/libtiledbsoma/src/soma/soma_binary_column.cc
@@ -27,8 +27,8 @@ std::shared_ptr<SOMAColumn> SOMABinaryColumn::deserialize(
 
         if (attribute_names.size() != 1) {
             throw TileDBSOMAError(fmt::format(
-                "[SOMABinaryColumn][deserialize] Invalid number of attributes. "
-                "Epected 1, got {}",
+                "[SOMABinaryColumn][deserialize] Invalid number of attributes: "
+                "expected 1, got {}",
                 attribute_names.size()));
         }
 
@@ -87,8 +87,8 @@ std::shared_ptr<SOMABinaryColumn> SOMABinaryColumn::create(
             array,
             soma_type,
             type_metadata,
-            "", //prefix
-            "", //suffix
+            "",  // prefix
+            "",  // suffix
             platform_config);
 
         return std::make_shared<SOMABinaryColumn>(dimension);
@@ -170,8 +170,8 @@ void SOMABinaryColumn::_set_current_domain_slot(
     } else {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] domain (\"{}\", "
-            "\"{}\") cannot be set for binary index columns: please use "
-            "(\"\", \"\")",
+            "\"{}\") cannot be set for binary index columns: please use (\"\", "
+            "\"\")",
             std::string(
                 reinterpret_cast<const char*>(dom[0].data()), dom[0].size()),
             std::string(
@@ -184,9 +184,7 @@ std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
-            "is "
-            "not "
-            "an index column",
+            "is  not  an index column",
             name()));
     }
 
@@ -203,8 +201,8 @@ std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
     if (dom[0].size() != 0 || dom[1].size() != 0) {
         return std::pair(
             false,
-            "domain cannot be set for string index columns: please use "
-            "(\"\", \"\")");
+            "domain cannot be set for string index columns: please use (\"\", "
+            "\"\")");
     }
 
     return std::pair(true, "");
@@ -214,8 +212,7 @@ std::any SOMABinaryColumn::_core_domain_slot() const {
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_domain_slot] Column with name {} is not "
-            "an "
-            "index column",
+            "an index column",
             name()));
     }
 
@@ -228,9 +225,7 @@ std::any SOMABinaryColumn::_non_empty_domain_slot(Array& array) const {
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
-            "not "
-            "an "
-            "index column",
+            "not an index column",
             name()));
     }
 
@@ -255,9 +250,7 @@ std::any SOMABinaryColumn::_non_empty_domain_slot_opt(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
-            "not "
-            "an "
-            "index column",
+            "not an index column",
             name()));
     }
 
@@ -311,9 +304,7 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
-            "is "
-            "not "
-            "an index column",
+            "is not an index column",
             name()));
     }
 
@@ -330,9 +321,7 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
-            "is "
-            "not "
-            "an index column",
+            "is not an index column",
             name()));
     }
 
@@ -344,8 +333,8 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
             std::vector<std::byte>(), std::vector<std::byte>());
     } else {
         throw TileDBSOMAError(fmt::format(
-            "[SOMAColumn][core_current_domain_slot] unexpected current "
-            "domain returnd ({}, {})",
+            "[SOMAColumn][core_current_domain_slot] unexpected current domain "
+            "returnd ({}, {})",
             domain[0],
             domain[1]));
     }
@@ -356,8 +345,7 @@ std::pair<ArrowArray*, ArrowSchema*> SOMABinaryColumn::arrow_domain_slot(
     if (!isIndexColumn()) {
         throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][arrow_domain_slot] Column with name {} is not "
-            "an "
-            "index column",
+            "an index column",
             name()));
     }
 

--- a/libtiledbsoma/src/soma/soma_binary_column.cc
+++ b/libtiledbsoma/src/soma/soma_binary_column.cc
@@ -12,6 +12,7 @@
  */
 
 #include "soma_binary_column.h"
+#include "../utils/logger.h"
 
 namespace tiledbsoma {
 std::shared_ptr<SOMAColumn> SOMABinaryColumn::deserialize(
@@ -25,7 +26,7 @@ std::shared_ptr<SOMAColumn> SOMABinaryColumn::deserialize(
                                   .template get<std::vector<std::string>>();
 
         if (attribute_names.size() != 1) {
-            throw TileDBSOMAError(std::format(
+            throw TileDBSOMAError(fmt::format(
                 "[SOMABinaryColumn][deserialize] Invalid number of attributes. "
                 "Epected 1, got {}",
                 attribute_names.size()));
@@ -55,7 +56,7 @@ std::shared_ptr<SOMAColumn> SOMABinaryColumn::deserialize(
                                   .template get<std::vector<std::string>>();
 
         if (dimension_names.size() != 1) {
-            throw TileDBSOMAError(std::format(
+            throw TileDBSOMAError(fmt::format(
                 "[SOMABinaryColumn][deserialize] Invalid number of dimensions: "
                 "expected 1, got {}",
                 dimension_names.size()));
@@ -104,7 +105,7 @@ std::shared_ptr<SOMABinaryColumn> SOMABinaryColumn::create(
 void SOMABinaryColumn::_set_dim_points(
     ManagedQuery& query, const std::any& points) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_dim_points] Column with name {} is not an "
             "index "
             "column",
@@ -125,7 +126,7 @@ void SOMABinaryColumn::_set_dim_points(
 void SOMABinaryColumn::_set_dim_ranges(
     ManagedQuery& query, const std::any& ranges) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_dim_ranges] Column with name {} is not an "
             "index "
             "column",
@@ -152,7 +153,7 @@ void SOMABinaryColumn::_set_dim_ranges(
 void SOMABinaryColumn::_set_current_domain_slot(
     NDRectangle& rectangle, std::span<const std::any> domain) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
             "is "
             "not "
@@ -161,7 +162,7 @@ void SOMABinaryColumn::_set_current_domain_slot(
     }
 
     if (domain.size() != 1) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] Invalid domain size. "
             "Expected 1, got {}",
             domain.size()));
@@ -171,7 +172,7 @@ void SOMABinaryColumn::_set_current_domain_slot(
     if (dom[0].size() == 0 && dom[1].size() == 0) {
         rectangle.set_range(name(), "", "\x7f");
     } else {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] domain (\"{}\", "
             "\"{}\") cannot be set for "
             "binary index columns: please use "
@@ -186,7 +187,7 @@ void SOMABinaryColumn::_set_current_domain_slot(
 std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
     std::optional<NDRectangle>&, std::span<const std::any> new_domain) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
             "is "
             "not "
@@ -195,7 +196,7 @@ std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
     }
 
     if (new_domain.size() != 1) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_can_set_current_domain_slot] Expected domain "
             "size for '{}' is 1, found {}",
             name(),
@@ -216,7 +217,7 @@ std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
 
 std::any SOMABinaryColumn::_core_domain_slot() const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_domain_slot] Column with name {} is not "
             "an "
             "index column",
@@ -230,7 +231,7 @@ std::any SOMABinaryColumn::_core_domain_slot() const {
 
 std::any SOMABinaryColumn::_non_empty_domain_slot(Array& array) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
             "not "
             "an "
@@ -257,7 +258,7 @@ std::any SOMABinaryColumn::_non_empty_domain_slot(Array& array) const {
 std::any SOMABinaryColumn::_non_empty_domain_slot_opt(
     const SOMAContext& ctx, Array& array) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
             "not "
             "an "
@@ -313,7 +314,7 @@ std::any SOMABinaryColumn::_non_empty_domain_slot_opt(
 std::any SOMABinaryColumn::_core_current_domain_slot(
     const SOMAContext& ctx, Array& array) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
             "is "
             "not "
@@ -332,7 +333,7 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
 std::any SOMABinaryColumn::_core_current_domain_slot(
     NDRectangle& ndrect) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
             "is "
             "not "
@@ -347,7 +348,7 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
             std::pair<std::vector<std::byte>, std::vector<std::byte>>>(
             std::vector<std::byte>(), std::vector<std::byte>());
     } else {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMAColumn][core_current_domain_slot] unexpected current "
             "domain returnd ({}, {})",
             domain[0],
@@ -358,7 +359,7 @@ std::any SOMABinaryColumn::_core_current_domain_slot(
 std::pair<ArrowArray*, ArrowSchema*> SOMABinaryColumn::arrow_domain_slot(
     const SOMAContext& ctx, Array& array, enum Domainish kind) const {
     if (!isIndexColumn()) {
-        throw TileDBSOMAError(std::format(
+        throw TileDBSOMAError(fmt::format(
             "[SOMABinaryColumn][arrow_domain_slot] Column with name {} is not "
             "an "
             "index column",

--- a/libtiledbsoma/src/soma/soma_binary_column.cc
+++ b/libtiledbsoma/src/soma/soma_binary_column.cc
@@ -1,0 +1,401 @@
+/**
+ * @file   soma_binary_column.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMABinaryColumn class.
+ */
+
+#include "soma_binary_column.h"
+
+namespace tiledbsoma {
+std::shared_ptr<SOMAColumn> SOMABinaryColumn::deserialize(
+    const nlohmann::json& soma_schema,
+    const Context& ctx,
+    const Array& array,
+    const std::map<std::string, tiledbsoma::MetadataValue>&) {
+    if (soma_schema.contains(TILEDB_SOMA_SCHEMA_COL_ATTR_KEY)) {
+        std::vector<std::string>
+            attribute_names = soma_schema[TILEDB_SOMA_SCHEMA_COL_ATTR_KEY]
+                                  .template get<std::vector<std::string>>();
+
+        if (attribute_names.size() != 1) {
+            throw TileDBSOMAError(std::format(
+                "[SOMABinaryColumn][deserialize] Invalid number of attributes. "
+                "Epected 1, got {}",
+                attribute_names.size()));
+        }
+
+        if (!array.schema().has_attribute(attribute_names[0])) {
+            // Attribute probably dropped so skip column reconstruction.
+            return nullptr;
+        }
+
+        auto attribute = array.schema().attribute(attribute_names[0]);
+        auto enumeration_name = AttributeExperimental::get_enumeration_name(
+            ctx, attribute);
+
+        std::optional<Enumeration>
+            enumeration = enumeration_name ?
+                              std::make_optional(
+                                  ArrayExperimental::get_enumeration(
+                                      ctx, array, attribute.name())) :
+                              std::nullopt;
+
+        return std::make_shared<SOMABinaryColumn>(attribute, enumeration);
+
+    } else if (soma_schema.contains(TILEDB_SOMA_SCHEMA_COL_DIM_KEY)) {
+        std::vector<std::string>
+            dimension_names = soma_schema[TILEDB_SOMA_SCHEMA_COL_DIM_KEY]
+                                  .template get<std::vector<std::string>>();
+
+        if (dimension_names.size() != 1) {
+            throw TileDBSOMAError(std::format(
+                "[SOMABinaryColumn][deserialize] Invalid number of dimensions: "
+                "expected 1, got {}",
+                dimension_names.size()));
+        }
+
+        auto dimension = array.schema().domain().dimension(dimension_names[0]);
+
+        return std::make_shared<SOMABinaryColumn>(dimension);
+    } else {
+        throw TileDBSOMAError(
+            "[SOMABinaryColumn][deserialize] Missing required field "
+            "'tiledb_attributes' or 'tiledb_dimensions'");
+    }
+}
+
+std::shared_ptr<SOMABinaryColumn> SOMABinaryColumn::create(
+    std::shared_ptr<Context> ctx,
+    ArrowSchema* schema,
+    ArrowArray* array,
+    const std::string& soma_type,
+    bool is_index,
+    std::string_view type_metadata,
+    PlatformConfig platform_config) {
+    if (is_index) {
+        auto dimension = ArrowAdapter::tiledb_dimension_from_arrow_schema(
+            ctx,
+            schema,
+            array,
+            soma_type,
+            type_metadata,
+            "",
+            "",
+            platform_config);
+
+        return std::make_shared<SOMABinaryColumn>(dimension);
+
+    } else {
+        auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(
+            ctx, schema, type_metadata, platform_config);
+
+        return std::make_shared<SOMABinaryColumn>(
+            SOMABinaryColumn(attribute.first, attribute.second));
+    }
+}
+
+void SOMABinaryColumn::_set_dim_points(
+    ManagedQuery& query, const std::any& points) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_dim_points] Column with name {} is not an "
+            "index "
+            "column",
+            name()));
+    }
+
+    std::vector<std::string> casted_points;
+
+    for (const auto& bytes :
+         std::any_cast<std::span<const std::vector<std::byte>>>(points)) {
+        casted_points.push_back(std::string(
+            reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+    }
+
+    query.select_points(name(), casted_points);
+}
+
+void SOMABinaryColumn::_set_dim_ranges(
+    ManagedQuery& query, const std::any& ranges) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_dim_ranges] Column with name {} is not an "
+            "index "
+            "column",
+            name()));
+    }
+
+    std::vector<std::pair<std::string, std::string>> casted_ranges;
+
+    for (const auto& bytes : std::any_cast<std::vector<
+             std::pair<std::vector<std::byte>, std::vector<std::byte>>>>(
+             ranges)) {
+        casted_ranges.push_back(std::make_pair(
+            std::string(
+                reinterpret_cast<const char*>(bytes.first.data()),
+                bytes.first.size()),
+            std::string(
+                reinterpret_cast<const char*>(bytes.second.data()),
+                bytes.second.size())));
+    }
+
+    query.select_ranges(name(), casted_ranges);
+}
+
+void SOMABinaryColumn::_set_current_domain_slot(
+    NDRectangle& rectangle, std::span<const std::any> domain) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
+            "is "
+            "not "
+            "an index column",
+            name()));
+    }
+
+    if (domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_current_domain_slot] Invalid domain size. "
+            "Expected 1, got {}",
+            domain.size()));
+    }
+
+    auto dom = std::any_cast<std::array<std::vector<std::byte>, 2>>(domain[0]);
+    if (dom[0].size() == 0 && dom[1].size() == 0) {
+        rectangle.set_range(name(), "", "\x7f");
+    } else {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_current_domain_slot] domain (\"{}\", "
+            "\"{}\") cannot be set for "
+            "binary index columns: please use "
+            "(\"\", \"\")",
+            std::string(
+                reinterpret_cast<const char*>(dom[0].data()), dom[0].size()),
+            std::string(
+                reinterpret_cast<const char*>(dom[1].data()), dom[1].size())));
+    }
+}
+
+std::pair<bool, std::string> SOMABinaryColumn::_can_set_current_domain_slot(
+    std::optional<NDRectangle>&, std::span<const std::any> new_domain) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_set_current_domain_slot] Column with name {} "
+            "is "
+            "not "
+            "an index column",
+            name()));
+    }
+
+    if (new_domain.size() != 1) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_can_set_current_domain_slot] Expected domain "
+            "size for '{}' is 1, found {}",
+            name(),
+            new_domain.size()));
+    }
+
+    auto dom = std::any_cast<std::array<std::vector<std::byte>, 2>>(
+        new_domain[0]);
+    if (dom[0].size() != 0 || dom[1].size() != 0) {
+        return std::pair(
+            false,
+            "domain cannot be set for string index columns: please use "
+            "(\"\", \"\")");
+    }
+
+    return std::pair(true, "");
+};
+
+std::any SOMABinaryColumn::_core_domain_slot() const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_core_domain_slot] Column with name {} is not "
+            "an "
+            "index column",
+            name()));
+    }
+
+    return std::make_any<
+        std::pair<std::vector<std::byte>, std::vector<std::byte>>>(
+        std::make_pair(std::vector<std::byte>(), std::vector<std::byte>()));
+}
+
+std::any SOMABinaryColumn::_non_empty_domain_slot(Array& array) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
+            "not "
+            "an "
+            "index column",
+            name()));
+    }
+
+    auto string_non_empty_domain = array.non_empty_domain_var(name());
+
+    auto min_data_ptr = reinterpret_cast<std::byte*>(
+        string_non_empty_domain.first.data());
+    auto max_data_ptr = reinterpret_cast<std::byte*>(
+        string_non_empty_domain.second.data());
+
+    std::vector<std::byte> min(
+        min_data_ptr, min_data_ptr + string_non_empty_domain.first.size());
+    std::vector<std::byte> max(
+        max_data_ptr, max_data_ptr + string_non_empty_domain.second.size());
+
+    return std::make_any<
+        std::pair<std::vector<std::byte>, std::vector<std::byte>>>(min, max);
+}
+
+std::any SOMABinaryColumn::_non_empty_domain_slot_opt(
+    const SOMAContext& ctx, Array& array) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_non_empty_domain_slot] Column with name {} is "
+            "not "
+            "an "
+            "index column",
+            name()));
+    }
+
+    int32_t is_empty;
+    void* var_start;
+    void* var_end;
+    uint64_t size_start, size_end;
+
+    ctx.tiledb_ctx()->handle_error(
+        tiledb_array_get_non_empty_domain_var_size_from_name(
+            ctx.tiledb_ctx()->ptr().get(),
+            array.ptr().get(),
+            name().c_str(),
+            &size_start,
+            &size_end,
+            &is_empty));
+
+    if (is_empty) {
+        return std::make_any<std::optional<
+            std::pair<std::vector<std::byte>, std::vector<std::byte>>>>(
+            std::nullopt);
+    }
+
+    var_start = malloc(size_start);
+    var_end = malloc(size_end);
+
+    ctx.tiledb_ctx()->handle_error(
+        tiledb_array_get_non_empty_domain_var_from_name(
+            ctx.tiledb_ctx()->ptr().get(),
+            array.ptr().get(),
+            name().c_str(),
+            var_start,
+            var_end,
+            &is_empty));
+
+    auto min_data_ptr = reinterpret_cast<std::byte*>(var_start);
+    auto max_data_ptr = reinterpret_cast<std::byte*>(var_end);
+
+    auto ned = std::make_pair(
+        std::vector(min_data_ptr, min_data_ptr + size_start),
+        std::vector(max_data_ptr, max_data_ptr + size_end));
+    free(var_start);
+    free(var_end);
+
+    return std::make_any<std::optional<
+        std::pair<std::vector<std::byte>, std::vector<std::byte>>>>(ned);
+}
+
+std::any SOMABinaryColumn::_core_current_domain_slot(
+    const SOMAContext& ctx, Array& array) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
+            "is "
+            "not "
+            "an index column",
+            name()));
+    }
+
+    CurrentDomain
+        current_domain = tiledb::ArraySchemaExperimental::current_domain(
+            *ctx.tiledb_ctx(), array.schema());
+    NDRectangle ndrect = current_domain.ndrectangle();
+
+    return _core_current_domain_slot(ndrect);
+}
+
+std::any SOMABinaryColumn::_core_current_domain_slot(
+    NDRectangle& ndrect) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][_core_current_domain_slot] Column with name {} "
+            "is "
+            "not "
+            "an index column",
+            name()));
+    }
+
+    std::array<std::string, 2> domain = ndrect.range<std::string>(name());
+
+    auto min_data_ptr = reinterpret_cast<std::byte*>(domain[0].data());
+    auto max_data_ptr = reinterpret_cast<std::byte*>(domain[1].data());
+
+    std::vector<std::byte> min(min_data_ptr, min_data_ptr + domain[0].size());
+    std::vector<std::byte> max(max_data_ptr, max_data_ptr + domain[1].size());
+
+    return std::make_any<
+        std::pair<std::vector<std::byte>, std::vector<std::byte>>>(min, max);
+}
+
+std::pair<ArrowArray*, ArrowSchema*> SOMABinaryColumn::arrow_domain_slot(
+    const SOMAContext& ctx, Array& array, enum Domainish kind) const {
+    if (!isIndexColumn()) {
+        throw TileDBSOMAError(std::format(
+            "[SOMABinaryColumn][arrow_domain_slot] Column with name {} is not "
+            "an "
+            "index column",
+            name()));
+    }
+
+    ArrowArray* arrow_array = ArrowAdapter::make_arrow_array_child_binary(
+        domain_slot<std::vector<std::byte>>(ctx, array, kind));
+
+    return std::make_pair(arrow_array, arrow_schema_slot(ctx, array));
+}
+
+ArrowSchema* SOMABinaryColumn::arrow_schema_slot(
+    const SOMAContext& ctx, Array& array) const {
+    if (isIndexColumn()) {
+        ArrowSchema* schema = ArrowAdapter::arrow_schema_from_tiledb_dimension(
+                                  std::get<Dimension>(container))
+                                  .release();
+        schema->format = strdup("Z");
+
+        return schema;
+    } else {
+        return ArrowAdapter::arrow_schema_from_tiledb_attribute(
+                   std::get<Attribute>(container), *ctx.tiledb_ctx(), array)
+            .release();
+    }
+}
+
+void SOMABinaryColumn::serialize(nlohmann::json& columns_schema) const {
+    nlohmann::json column;
+
+    column[TILEDB_SOMA_SCHEMA_COL_TYPE_KEY] = static_cast<uint32_t>(
+        soma_column_datatype_t::SOMA_COLUMN_BINARY);
+
+    if (isIndexColumn()) {
+        column[TILEDB_SOMA_SCHEMA_COL_DIM_KEY] = {name()};
+    } else {
+        column[TILEDB_SOMA_SCHEMA_COL_ATTR_KEY] = {name()};
+    }
+
+    columns_schema.push_back(column);
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_binary_column.h
+++ b/libtiledbsoma/src/soma/soma_binary_column.h
@@ -1,0 +1,164 @@
+/**
+ * @file   soma_binary_column.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ *   This file defines the SOMABinaryColumn class. SOMABinaryColumn acts as a
+ * wrapper to a TileDB Dimension holding binary data encoded as string and
+ * implements function to perform queries as well as core domain and current
+ * domain operations. It provides a common interface identical to TileDB
+ * attributes, dimensions and composite columns.
+ */
+
+#ifndef SOMA_BINARY_COLUMN_H
+#define SOMA_BINARY_COLUMN_H
+
+#include <algorithm>
+#include <variant>
+#include <vector>
+
+#include <tiledb/tiledb>
+#include "soma_column.h"
+
+namespace tiledbsoma {
+
+using namespace tiledb;
+
+class SOMABinaryColumn : public SOMAColumn {
+   public:
+    //===================================================================
+    //= public static
+    //===================================================================
+
+    static std::shared_ptr<SOMAColumn> deserialize(
+        const nlohmann::json& soma_schema,
+        const Context& ctx,
+        const Array& array,
+        const std::map<std::string, tiledbsoma::MetadataValue>& metadata);
+
+    static std::shared_ptr<SOMABinaryColumn> create(
+        std::shared_ptr<Context> ctx,
+        ArrowSchema* schema,
+        ArrowArray* array,
+        const std::string& soma_type,
+        bool is_index,
+        std::string_view type_metadata,
+        PlatformConfig platform_config);
+
+    SOMABinaryColumn(Dimension dimension)
+        : container(dimension) {
+    }
+
+    SOMABinaryColumn(
+        Attribute attribute, std::optional<Enumeration> enumeration)
+        : container(attribute)
+        , enumeration(enumeration) {
+    }
+
+    inline std::string name() const override {
+        return std::visit([](auto&& x) { return x.name(); }, container);
+    }
+
+    inline bool isIndexColumn() const override {
+        return std::holds_alternative<Dimension>(container);
+    }
+
+    inline void select_columns(
+        ManagedQuery& query, bool if_not_empty = false) const override {
+        query.select_columns(std::vector({name()}), if_not_empty);
+    };
+
+    inline soma_column_datatype_t type() const override {
+        return soma_column_datatype_t::SOMA_COLUMN_BINARY;
+    }
+
+    inline std::optional<tiledb_datatype_t> domain_type() const override {
+        if (std::holds_alternative<Dimension>(container)) {
+            return TILEDB_BLOB;
+        }
+
+        return std::nullopt;
+    }
+
+    inline std::optional<tiledb_datatype_t> data_type() const override {
+        if (std::holds_alternative<Attribute>(container)) {
+            return TILEDB_BLOB;
+        }
+
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Dimension>> tiledb_dimensions() override {
+        if (std::holds_alternative<Dimension>(container)) {
+            return std::vector({std::get<Dimension>(container)});
+        }
+
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Attribute>> tiledb_attributes() override {
+        if (std::holds_alternative<Attribute>(container)) {
+            return std::vector({std::get<Attribute>(container)});
+        }
+
+        return std::nullopt;
+    }
+
+    inline std::optional<std::vector<Enumeration>> tiledb_enumerations()
+        override {
+        if (!enumeration.has_value()) {
+            return std::nullopt;
+        }
+
+        return std::vector({enumeration.value()});
+    }
+
+    std::pair<ArrowArray*, ArrowSchema*> arrow_domain_slot(
+        const SOMAContext& ctx,
+        Array& array,
+        enum Domainish kind) const override;
+
+    ArrowSchema* arrow_schema_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    void serialize(nlohmann::json&) const override;
+
+   protected:
+    void _set_dim_points(
+        ManagedQuery& query, const std::any& ranges) const override;
+
+    void _set_dim_ranges(
+        ManagedQuery& query, const std::any& ranges) const override;
+
+    void _set_current_domain_slot(
+        NDRectangle& rectangle,
+        std::span<const std::any> domain) const override;
+
+    std::pair<bool, std::string> _can_set_current_domain_slot(
+        std::optional<NDRectangle>& rectangle,
+        std::span<const std::any> new_domain) const override;
+
+    std::any _core_domain_slot() const override;
+
+    std::any _non_empty_domain_slot(Array& array) const override;
+
+    std::any _non_empty_domain_slot_opt(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(
+        const SOMAContext& ctx, Array& array) const override;
+
+    std::any _core_current_domain_slot(NDRectangle& ndrect) const override;
+
+   private:
+    std::variant<Attribute, Dimension> container;
+    std::optional<Enumeration> enumeration;
+};
+}  // namespace tiledbsoma
+
+#endif

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -71,6 +71,10 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
                     col = SOMAGeometryColumn::deserialize(
                         column, ctx, array, metadata);
                     break;
+                case soma_column_datatype_t::SOMA_COLUMN_BINARY:
+                    col = SOMABinaryColumn::deserialize(
+                        column, ctx, array, metadata);
+                    break;
                 default:
                     throw TileDBSOMAError(fmt::format(
                         "[SOMAColumn][deserialize] Unknown column type {}",

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -15,6 +15,7 @@
 
 #include "../utils/logger.h"
 #include "soma_attribute.h"
+#include "soma_binary_column.h"
 #include "soma_dimension.h"
 #include "soma_geometry_column.h"
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -30,21 +30,24 @@ void SOMADataFrame::create(
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    auto [tiledb_schema, soma_schema_extension] =
-        ArrowAdapter::tiledb_schema_from_arrow_schema(
-            ctx->tiledb_ctx(),
-            schema,
-            index_columns,
-            std::nullopt,
-            "SOMADataFrame",
-            true,
-            platform_config);
+    auto
+        [tiledb_schema, soma_schema_extension, required_soma_schema_extension] =
+            ArrowAdapter::tiledb_schema_from_arrow_schema(
+                ctx->tiledb_ctx(),
+                schema,
+                index_columns,
+                std::nullopt,
+                "SOMADataFrame",
+                true,
+                platform_config);
     SOMAArray::create(
         ctx,
         uri,
         tiledb_schema,
         "SOMADataFrame",
-        soma_schema_extension.dump(),
+        required_soma_schema_extension ?
+            std::make_optional(soma_schema_extension.dump()) :
+            std::nullopt,
         timestamp);
 }
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -40,7 +40,12 @@ void SOMADataFrame::create(
             true,
             platform_config);
     SOMAArray::create(
-        ctx, uri, tiledb_schema, "SOMADataFrame", std::nullopt, timestamp);
+        ctx,
+        uri,
+        tiledb_schema,
+        "SOMADataFrame",
+        soma_schema_extension.dump(),
+        timestamp);
 }
 
 std::unique_ptr<SOMADataFrame> SOMADataFrame::open(

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -67,18 +67,26 @@ void SOMADenseNDArray::create(
     attr->metadata = nullptr;
     attr->release = &ArrowAdapter::release_schema;
 
-    auto [tiledb_schema, soma_schema_extension] =
-        ArrowAdapter::tiledb_schema_from_arrow_schema(
-            ctx->tiledb_ctx(),
-            schema,
-            index_columns,
-            std::nullopt,
-            "SOMADenseNDArray",
-            false,
-            platform_config);
+    auto
+        [tiledb_schema, soma_schema_extension, required_soma_schema_extension] =
+            ArrowAdapter::tiledb_schema_from_arrow_schema(
+                ctx->tiledb_ctx(),
+                schema,
+                index_columns,
+                std::nullopt,
+                "SOMADenseNDArray",
+                false,
+                platform_config);
 
     SOMAArray::create(
-        ctx, uri, tiledb_schema, "SOMADenseNDArray", std::nullopt, timestamp);
+        ctx,
+        uri,
+        tiledb_schema,
+        "SOMADenseNDArray",
+        required_soma_schema_extension ?
+            std::make_optional(soma_schema_extension.dump()) :
+            std::nullopt,
+        timestamp);
 
     schema->release(schema.get());
 }

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -36,22 +36,25 @@ void SOMAGeometryDataFrame::create(
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
-    auto [tiledb_schema, soma_schema_extension] =
-        ArrowAdapter::tiledb_schema_from_arrow_schema(
-            ctx->tiledb_ctx(),
-            schema,
-            index_columns,
-            std::make_optional(coordinate_space),
-            "SOMAGeometryDataFrame",
-            true,
-            platform_config);
+    auto
+        [tiledb_schema, soma_schema_extension, required_soma_schema_extension] =
+            ArrowAdapter::tiledb_schema_from_arrow_schema(
+                ctx->tiledb_ctx(),
+                schema,
+                index_columns,
+                std::make_optional(coordinate_space),
+                "SOMAGeometryDataFrame",
+                true,
+                platform_config);
 
     auto array = SOMAArray::_create(
         ctx,
         uri,
         tiledb_schema,
         "SOMAGeometryDataFrame",
-        soma_schema_extension.dump(),
+        required_soma_schema_extension ?
+            std::make_optional(soma_schema_extension.dump()) :
+            std::nullopt,
         timestamp);
 
     // Add additional geometry dataframe metadata.

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -31,21 +31,24 @@ void SOMAPointCloudDataFrame::create(
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {
     // Create TileDB array that is open for writing.
-    auto [tiledb_schema, soma_schema_extension] =
-        ArrowAdapter::tiledb_schema_from_arrow_schema(
-            ctx->tiledb_ctx(),
-            schema,
-            index_columns,
-            std::make_optional(coordinate_space),
-            "SOMAPointCloudDataFrame",
-            true,
-            platform_config);
+    auto
+        [tiledb_schema, soma_schema_extension, required_soma_schema_extension] =
+            ArrowAdapter::tiledb_schema_from_arrow_schema(
+                ctx->tiledb_ctx(),
+                schema,
+                index_columns,
+                std::make_optional(coordinate_space),
+                "SOMAPointCloudDataFrame",
+                true,
+                platform_config);
     auto array = SOMAArray::_create(
         ctx,
         uri,
         tiledb_schema,
         "SOMAPointCloudDataFrame",
-        std::nullopt,
+        required_soma_schema_extension ?
+            std::make_optional(soma_schema_extension.dump()) :
+            std::nullopt,
         timestamp);
 
     // Add additional point cloud dataframe metadata.

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -68,18 +68,26 @@ void SOMASparseNDArray::create(
     attr->metadata = nullptr;
     attr->release = &ArrowAdapter::release_schema;
 
-    auto [tiledb_schema, soma_schema_extension] =
-        ArrowAdapter::tiledb_schema_from_arrow_schema(
-            ctx->tiledb_ctx(),
-            schema,
-            index_columns,
-            std::nullopt,
-            "SOMASparseNDArray",
-            true,
-            platform_config);
+    auto
+        [tiledb_schema, soma_schema_extension, required_soma_schema_extension] =
+            ArrowAdapter::tiledb_schema_from_arrow_schema(
+                ctx->tiledb_ctx(),
+                schema,
+                index_columns,
+                std::nullopt,
+                "SOMASparseNDArray",
+                true,
+                platform_config);
 
     SOMAArray::create(
-        ctx, uri, tiledb_schema, "SOMASparseNDArray", std::nullopt, timestamp);
+        ctx,
+        uri,
+        tiledb_schema,
+        "SOMASparseNDArray",
+        required_soma_schema_extension ?
+            std::make_optional(soma_schema_extension.dump()) :
+            std::nullopt,
+        timestamp);
 
     schema->release(schema.get());
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1351,7 +1351,7 @@ ArrowAdapter::to_arrow(std::shared_ptr<ColumnBuffer> column) {
         // the owner of new buffers should be responsible for clean-up.
         if (enmr->type() == TILEDB_STRING_ASCII ||
             enmr->type() == TILEDB_STRING_UTF8 || enmr->type() == TILEDB_CHAR ||
-            enmr->type() == TILEDB_BLOB) {
+            enmr->type() == TILEDB_BLOB || enmr->type() == TILEDB_GEOM_WKB) {
             dict_arr->length = _set_var_dictionary_buffers(
                 enmr.value(), enmr->context(), dict_arr->buffers);
         } else if (enmr->type() == TILEDB_BOOL) {

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -19,6 +19,7 @@
 #include "util.h"
 
 #include "../soma/soma_attribute.h"
+#include "../soma/soma_binary_column.h"
 #include "../soma/soma_coordinates.h"
 #include "../soma/soma_dimension.h"
 #include "../soma/soma_geometry_column.h"
@@ -961,26 +962,40 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
         for (int64_t i = 0; i < index_column_schema->n_children; ++i) {
             if (strcmp(child->name, index_column_schema->children[i]->name) ==
                 0) {
-                if (strcmp(child->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) ==
-                    0) {
-                    columns.push_back(SOMAGeometryColumn::create(
-                        ctx,
-                        child,
-                        index_column_schema->children[i],
-                        index_column_array->children[i],
-                        coordinate_space.value(),
-                        soma_type,
-                        type_metadata,
-                        platform_config));
-                } else {
-                    columns.push_back(SOMADimension::create(
-                        ctx,
-                        index_column_schema->children[i],
-                        index_column_array->children[i],
-                        soma_type,
-                        type_metadata,
-                        platform_config));
+                auto dtype = to_tiledb_format(child->format, type_metadata);
+                switch (dtype) {
+                    case TILEDB_BLOB:
+                        columns.push_back(SOMABinaryColumn::create(
+                            ctx,
+                            index_column_schema->children[i],
+                            index_column_array->children[i],
+                            soma_type,
+                            true,
+                            type_metadata,
+                            platform_config));
+                        break;
+                    case TILEDB_GEOM_WKB:
+                        columns.push_back(SOMAGeometryColumn::create(
+                            ctx,
+                            child,
+                            index_column_schema->children[i],
+                            index_column_array->children[i],
+                            coordinate_space.value(),
+                            soma_type,
+                            type_metadata,
+                            platform_config));
+                        break;
+                    default:
+                        columns.push_back(SOMADimension::create(
+                            ctx,
+                            index_column_schema->children[i],
+                            index_column_array->children[i],
+                            soma_type,
+                            type_metadata,
+                            platform_config));
+                        break;
                 }
+
                 isattr = false;
                 LOG_DEBUG(fmt::format(
                     "[ArrowAdapter] adding dimension {}", child->name));
@@ -1079,24 +1094,6 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
             ndrect,
             get_table_any_column_by_name<2>(
                 index_column_info, column->name(), 3));
-
-        // if (column->name() == SOMA_GEOMETRY_COLUMN_NAME) {
-        //     std::vector<std::any> cdslot;
-        //     for (int64_t j = 0; j < spatial_column_info.first->n_children;
-        //          ++j) {
-        //         cdslot.push_back(ArrowAdapter::get_table_any_column<2>(
-        //             spatial_column_info.first->children[j],
-        //             spatial_column_info.second->children[j],
-        //             3));
-        //     }
-
-        //     column->set_current_domain_slot(ndrect, cdslot);
-        // } else {
-        //     column->set_current_domain_slot(
-        //         ndrect,
-        //         get_table_any_column_by_name<2>(
-        //             index_column_info, column->name(), 3));
-        // }
     }
     current_domain.set_ndrectangle(ndrect);
 
@@ -1124,6 +1121,7 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema(
     PlatformConfig platform_config) {
     auto type = ArrowAdapter::to_tiledb_format(schema->format, type_metadata);
 
+    // TileDB dimension only support ASCII so UTF8 and BLOB need to be casted
     if (ArrowAdapter::arrow_is_var_length_type(schema->format)) {
         type = TILEDB_STRING_ASCII;
     }
@@ -1142,54 +1140,6 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema(
     }
 
     const void* buff = array->buffers[1];
-    auto dim = ArrowAdapter::_create_dim(type, col_name, buff, ctx);
-    dim.set_filter_list(filter_list);
-
-    return dim;
-}
-
-Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
-    std::shared_ptr<Context> ctx,
-    ArrowSchema* schema,
-    ArrowArray* array,
-    std::string soma_type,
-    std::string_view type_metadata,
-    std::string prefix,
-    std::string suffix,
-    PlatformConfig platform_config) {
-    if (strcmp(schema->format, "+l") != 0) {
-        throw TileDBSOMAError(
-            fmt::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should be of type list."));
-    }
-
-    if (schema->n_children != 1) {
-        throw TileDBSOMAError(
-            fmt::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should have exactly 1 child"));
-    }
-
-    auto type = ArrowAdapter::to_tiledb_format(
-        schema->children[0]->format, type_metadata);
-
-    if (ArrowAdapter::arrow_is_var_length_type(schema->format)) {
-        type = TILEDB_STRING_ASCII;
-    }
-
-    auto col_name = prefix + std::string(schema->name) + suffix;
-
-    FilterList filter_list = ArrowAdapter::_create_dim_filter_list(
-        col_name, platform_config, soma_type, ctx);
-
-    if (array->length != 5) {
-        throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
-            "'{}'",
-            array->length,
-            col_name));
-    }
-
-    const void* buff = array->children[0]->buffers[1];
     auto dim = ArrowAdapter::_create_dim(type, col_name, buff, ctx);
     dim.set_filter_list(filter_list);
 
@@ -1450,7 +1400,7 @@ tiledb_datatype_t ArrowAdapter::to_tiledb_format(
     std::string_view arrow_dtype, std::string_view arrow_dtype_metadata) {
     std::map<std::string_view, tiledb_datatype_t> _to_tiledb_format_map = {
         {"u", TILEDB_STRING_UTF8},    {"U", TILEDB_STRING_UTF8},
-        {"z", TILEDB_CHAR},           {"Z", TILEDB_CHAR},
+        {"z", TILEDB_BLOB},           {"Z", TILEDB_BLOB},
         {"c", TILEDB_INT8},           {"C", TILEDB_UINT8},
         {"s", TILEDB_INT16},          {"S", TILEDB_UINT16},
         {"i", TILEDB_INT32},          {"I", TILEDB_UINT32},
@@ -1464,7 +1414,7 @@ tiledb_datatype_t ArrowAdapter::to_tiledb_format(
     try {
         auto dtype = _to_tiledb_format_map.at(arrow_dtype);
 
-        if (dtype == TILEDB_CHAR && arrow_dtype_metadata.compare("WKB") == 0) {
+        if (dtype == TILEDB_BLOB && arrow_dtype_metadata.compare("WKB") == 0) {
             dtype = TILEDB_GEOM_WKB;
         } else if (
             dtype == TILEDB_STRING_UTF8 &&

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1109,7 +1109,7 @@ ArrowAdapter::tiledb_schema_from_arrow_schema(
     LOG_DEBUG(fmt::format("[ArrowAdapter] check"));
     schema.check();
 
-    LOG_DEBUG(std::format("[ArrowAdapter] returning"));
+    LOG_DEBUG(fmt::format("[ArrowAdapter] returning"));
     return std::make_tuple(
         schema, soma_schema_extension, required_soma_column_metadata);
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -430,26 +430,6 @@ class ArrowAdapter {
         PlatformConfig platform_config = PlatformConfig());
 
     /**
-     * @brief Get a TileDB dimension from an Arrow schema.
-     *
-     * @remarks This is a list variation which expects a schemaand a data array
-     * to describe a list instead of a simple columns. Used especialy with
-     * nested domains where it is described by a struct and each nested
-     * dimension is described by a list.
-     *
-     * @return std::pair<Dimension, bool> The TileDB dimension.
-     */
-    static Dimension tiledb_dimension_from_arrow_schema_ext(
-        std::shared_ptr<Context> ctx,
-        ArrowSchema* schema,
-        ArrowArray* array,
-        std::string soma_type,
-        std::string_view type_metadata,
-        std::string prefix = std::string(),
-        std::string suffix = std::string(),
-        PlatformConfig platform_config = PlatformConfig());
-
-    /**
      * @brief Get a TileDB attribute with its enumeration from an Arrow schema.
      *
      * @return std::pair<Attribute, std::optional<Enumeration>>
@@ -573,12 +553,62 @@ class ArrowAdapter {
         return make_arrow_array_child_string(v);
     }
 
-    static ArrowArray* make_arrow_array_child_binary() {
+    static ArrowArray* make_arrow_array_child_binary(
+        const std::pair<std::vector<std::byte>, std::vector<std::byte>>& pair) {
+        std::vector<std::vector<std::byte>> v({pair.first, pair.second});
+        return make_arrow_array_child_binary(v);
+    }
+
+    static ArrowArray* make_arrow_array_child_binary(
+        const std::vector<std::vector<std::byte>>& binaries) {
         // Use malloc here, not new, to match ArrowAdapter::release_array
         auto arrow_array = (ArrowArray*)malloc(sizeof(ArrowArray));
 
-        ArrowArrayInitFromType(
-            arrow_array, ArrowType::NANOARROW_TYPE_LARGE_BINARY);
+        size_t n = binaries.size();
+
+        arrow_array->length = n;  // Number of strings, not number of bytes
+        arrow_array->null_count = 0;
+        arrow_array->offset = 0;
+
+        // Three-buffer model for string data:
+        // * Slot 0 is the Arrow uint8_t* validity buffer
+        // * Slot 1 is the Arrow offsets buffer: uint32_t* for Arrow string
+        //   or uint64_t* for Arrow large_string
+        // * Slot 2 is data, void* but will be derefrenced as T*
+        arrow_array->n_buffers = 3;
+        arrow_array->buffers = (const void**)malloc(3 * sizeof(void*));
+        arrow_array->n_children = 0;      // leaf/child node
+        arrow_array->children = nullptr;  // leaf/child node
+        arrow_array->dictionary = nullptr;
+
+        arrow_array->release = &ArrowAdapter::release_array;
+        arrow_array->private_data = nullptr;
+
+        size_t nbytes = 0;
+        for (auto e : binaries) {
+            nbytes += e.size();
+        }
+
+        // This function produces arrow large_string, which has 64-bit offsets.
+        uint64_t* offsets = (uint64_t*)malloc((n + 1) * sizeof(uint64_t));
+
+        // Data
+        char* data = (char*)malloc(nbytes * sizeof(char));
+        uint64_t dest_start = 0;
+
+        offsets[0] = dest_start;
+        for (size_t i = 0; i < n; i++) {
+            const std::vector<std::byte>& elem = binaries[i];
+            size_t elem_len = elem.size();
+
+            memcpy(&data[dest_start], elem.data(), elem_len);
+            dest_start += elem_len;
+            offsets[i + 1] = dest_start;
+        }
+
+        arrow_array->buffers[0] = nullptr;  // validity
+        arrow_array->buffers[1] = offsets;
+        arrow_array->buffers[2] = data;
 
         return arrow_array;
     }
@@ -1181,8 +1211,7 @@ class ArrowAdapter {
             case TILEDB_STRING_UTF8:
             case TILEDB_CHAR:
             case TILEDB_GEOM_WKT: {
-                if (strcmp(schema->format, "u") == 0 ||
-                    strcmp(schema->format, "z") == 0) {
+                if (strcmp(schema->format, "u") == 0) {
                     auto offsets = static_cast<const uint32_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const char*>(array->buffers[2]);
@@ -1198,9 +1227,7 @@ class ArrowAdapter {
                     }
 
                     return std::make_any<std::array<std::string, S>>(result);
-                } else if (
-                    strcmp(schema->format, "U") == 0 ||
-                    strcmp(schema->format, "Z") == 0) {
+                } else if (strcmp(schema->format, "U") == 0) {
                     auto offsets = static_cast<const uint64_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const char*>(array->buffers[2]);
@@ -1225,8 +1252,7 @@ class ArrowAdapter {
             } break;
             case TILEDB_BLOB:
             case TILEDB_GEOM_WKB: {
-                if (strcmp(schema->format, "u") == 0 ||
-                    strcmp(schema->format, "z") == 0) {
+                if (strcmp(schema->format, "z") == 0) {
                     auto offsets = static_cast<const uint32_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const std::byte*>(
@@ -1246,9 +1272,7 @@ class ArrowAdapter {
 
                     return std::make_any<std::array<std::vector<std::byte>, S>>(
                         result);
-                } else if (
-                    strcmp(schema->format, "U") == 0 ||
-                    strcmp(schema->format, "Z") == 0) {
+                } else if (strcmp(schema->format, "Z") == 0) {
                     auto offsets = static_cast<const uint64_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const std::byte*>(

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -404,7 +404,7 @@ class ArrowAdapter {
      *
      * @return std::tuple<tiledb::ArraySchema, nlohmann::json>
      */
-    static std::tuple<ArraySchema, nlohmann::json>
+    static std::tuple<ArraySchema, nlohmann::json, bool>
     tiledb_schema_from_arrow_schema(
         std::shared_ptr<Context> ctx,
         const std::unique_ptr<ArrowSchema>& arrow_schema,

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -1212,7 +1212,7 @@ class ArrowAdapter {
             case TILEDB_CHAR:
             case TILEDB_GEOM_WKT: {
                 if (strcmp(schema->format, "u") == 0) {
-                    auto offsets = static_cast<const uint32_t*>(
+                    auto offsets = static_cast<const int32_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const char*>(array->buffers[2]);
 
@@ -1228,7 +1228,7 @@ class ArrowAdapter {
 
                     return std::make_any<std::array<std::string, S>>(result);
                 } else if (strcmp(schema->format, "U") == 0) {
-                    auto offsets = static_cast<const uint64_t*>(
+                    auto offsets = static_cast<const int64_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const char*>(array->buffers[2]);
 
@@ -1253,7 +1253,7 @@ class ArrowAdapter {
             case TILEDB_BLOB:
             case TILEDB_GEOM_WKB: {
                 if (strcmp(schema->format, "z") == 0) {
-                    auto offsets = static_cast<const uint32_t*>(
+                    auto offsets = static_cast<const int32_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const std::byte*>(
                         array->buffers[2]);
@@ -1263,17 +1263,15 @@ class ArrowAdapter {
                          i < arrow_offset + S + offset;
                          ++i) {
                         if (offsets[i + 1] - offsets[i] != 0) {
-                            std::copy(
-                                &data[offsets[i]],
-                                &data[offsets[i + 1]],
-                                result[i - arrow_offset - offset].begin());
+                            result[i - arrow_offset - offset].assign(
+                                &data[offsets[i]], &data[offsets[i + 1]]);
                         }
                     }
 
                     return std::make_any<std::array<std::vector<std::byte>, S>>(
                         result);
                 } else if (strcmp(schema->format, "Z") == 0) {
-                    auto offsets = static_cast<const uint64_t*>(
+                    auto offsets = static_cast<const int64_t*>(
                         array->buffers[1]);
                     auto data = static_cast<const std::byte*>(
                         array->buffers[2]);
@@ -1283,10 +1281,8 @@ class ArrowAdapter {
                          i < arrow_offset + S + offset;
                          ++i) {
                         if (offsets[i + 1] - offsets[i] != 0) {
-                            std::copy(
-                                &data[offsets[i]],
-                                &data[offsets[i + 1]],
-                                result[i - arrow_offset - offset].begin());
+                            result[i - arrow_offset - offset].assign(
+                                &data[offsets[i]], &data[offsets[i + 1]]);
                         }
                     }
 

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -14,7 +14,6 @@
 #ifndef TILEDBSOMA_COMMON_H
 #define TILEDBSOMA_COMMON_H
 
-#include <span>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <string>
 #include <string_view>

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -107,24 +107,4 @@ class ScopedExecutor final {
 
 };  // namespace tiledbsoma
 
-template <>
-struct std::hash<std::span<const std::byte>> {
-    std::size_t operator()(const std::span<const std::byte>& s) const noexcept {
-        return std::hash<std::string_view>{}(std::string_view(
-            reinterpret_cast<const char*>(s.data()), s.size()));
-    }
-};
-
-template <>
-struct std::equal_to<std::span<const std::byte>> {
-    bool operator()(
-        const std::span<const std::byte>& lhs,
-        const std::span<const std::byte>& rhs) const noexcept {
-        return std::string_view(
-                   reinterpret_cast<const char*>(lhs.data()), lhs.size()) ==
-               std::string_view(
-                   reinterpret_cast<const char*>(rhs.data()), rhs.size());
-    }
-};
-
 #endif  // TILEDBSOMA_COMMON_H

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -14,6 +14,7 @@
 #ifndef TILEDBSOMA_COMMON_H
 #define TILEDBSOMA_COMMON_H
 
+#include <span>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <string>
 #include <string_view>
@@ -105,5 +106,25 @@ class ScopedExecutor final {
 };
 
 };  // namespace tiledbsoma
+
+template <>
+struct std::hash<std::span<const std::byte>> {
+    std::size_t operator()(const std::span<const std::byte>& s) const noexcept {
+        return std::hash<std::string_view>{}(std::string_view(
+            reinterpret_cast<const char*>(s.data()), s.size()));
+    }
+};
+
+template <>
+struct std::equal_to<std::span<const std::byte>> {
+    bool operator()(
+        const std::span<const std::byte>& lhs,
+        const std::span<const std::byte>& rhs) const noexcept {
+        return std::string_view(
+                   reinterpret_cast<const char*>(lhs.data()), lhs.size()) ==
+               std::string_view(
+                   reinterpret_cast<const char*>(rhs.data()), rhs.size());
+    }
+};
 
 #endif  // TILEDBSOMA_COMMON_H


### PR DESCRIPTION
**Issue and/or context:** [62236](https://app.shortcut.com/tiledb-inc/story/62236/python-dataframe-create-with-binary-index-column-reports-wrong-column-type-via-schema-property)

**Changes:**
- Adds a new column type `SOMABinaryColumn` that can be both an index column and a ordinary attribute.
- When it is an index column the dimension is internally treated as `TILEDB_STRING_ASCII` type.
- When it is an index column extra metadata are required.
- Values written or returned by such column is casted as `std::vector<std::byte>`.
- Enumerations have been optimized like string attributes.

**Notes for Reviewer:**

