### PR TITLE
[python] Add `register_visium_dataset` function with `NotImplementedError`

### DIFF
--- a/apis/python/src/tiledbsoma/io/spatial/__init__.py
+++ b/apis/python/src/tiledbsoma/io/spatial/__init__.py
@@ -8,7 +8,7 @@ This module is for experimental features. Support for these features
 may be dropped.
 """
 
-from .ingest import VisiumPaths, from_visium
+from .ingest import VisiumPaths, from_visium, register_visium_datasets
 from .outgest import to_spatialdata
 
-__all__ = ["to_spatialdata", "from_visium", "VisiumPaths"]
+__all__ = ["to_spatialdata", "from_visium", "register_visium_datasets", "VisiumPaths"]

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -242,6 +242,26 @@ class VisiumPaths:
         return self.version[0] if isinstance(self.version, tuple) else self.version
 
 
+def register_visium_datasets(
+    experiment_uri: str | None,
+    visium_paths: Sequence[VisiumPaths | Path] | VisiumPaths | Path,
+    *,
+    measurement_name: str,
+    context: SOMATileDBContext | None = None,
+) -> ExperimentAmbientLabelMapping:
+    """Create registration for adding one or more Visium datasets to
+    a single :class:`Experiment`.
+
+    Args:
+        experiment_uri: The experiment to append data to.
+        visium_paths: A path or paths to Visium datasets.
+        measurement_name: Name of the measurement to store data in.
+        context: Optional :class:`SOMATileDBContext` for opening the existing
+            :class:`Experiment`.
+    """
+    raise NotImplementedError()
+
+
 def from_visium(
     experiment_uri: str,
     input_path: Path | VisiumPaths,


### PR DESCRIPTION
* Add placeholder function `register_visium_dataset` that throws a `NotImplementedError`.
* Clean-up parameters to the `from_visium` function. Some of the options that are used in append mode don't apply to `from_visium`.
* Clean-up `from_visium` docstring.

