### PR TITLE
[python] Fix `make data` sandbox issue

### DIFF
--- a/apis/python/tests/test_aaa_setup.py
+++ b/apis/python/tests/test_aaa_setup.py
@@ -3,7 +3,7 @@
 import os
 
 TEST_DIR = os.path.dirname(__file__)
-SOMA_URI = f"{TEST_DIR}/../../../test/soco/pbmc3k_processed"
+SOMA_URI = f"{TEST_DIR}/../../../data/soco/pbmc3k_processed"
 
 if not os.path.exists(SOMA_URI):
     raise RuntimeError("Please run `make data` in the repo base directory")

--- a/apis/python/tests/test_aaa_setup.py
+++ b/apis/python/tests/test_aaa_setup.py
@@ -3,7 +3,7 @@
 import os
 
 TEST_DIR = os.path.dirname(__file__)
-SOMA_URI = f"{TEST_DIR}/../../../data/soco/pbmc3k_processed"
+SOMA_URI = f"{TEST_DIR}/../../../test/soco/pbmc3k_processed"
 
 if not os.path.exists(SOMA_URI):
     raise RuntimeError("Please run `make data` in the repo base directory")

--- a/scripts/prepare-test-data.sh
+++ b/scripts/prepare-test-data.sh
@@ -15,12 +15,12 @@ cd "$(dirname "$0")/../data"
 
 
 # Extract saco dataset.
-if [ -d ../test/soco ]; then
+if [ -d ../data/soco ]; then
     echo "-- Skipping dataset 'data/soco'; directory 'data/soco' already exists."
 else
     echo "-- Preparing dataset 'data/soco' ..."
     tar zxf ../test/soco.tgz
-    echo "   ... finished preparing 'test/soco.tgz'."
+    echo "   ... finished preparing 'data/soco'."
 fi
 
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 soco.tgz was created by running the following from the repo base directory (.. from here):
 
 ```
-apis/python/devtools/ingestor --debug --soco -o test/soco -n \
+apis/python/devtools/ingestor --debug --soco -o data/soco -n \
   data/pbmc3k_processed.h5ad data/10x-pbmc-multiome-v1.0/subset_100_100.h5ad
 ```
 


### PR DESCRIPTION
**Issue and/or context:**

Found today in my sandbox:

```
kerl@arvad[prod][kerl/dots-in][TileDB-SOMA]$ make data
Begin preparing data.
-- Skipping dataset 'data/soco'; directory 'data/soco' already exists.
-- Skipping dataset 'data/example-visium-v2'; directory 'data/example-visium-v2' already exists.
-- Skipping dataset 'data/example-visium-v1'; directory 'data/example-visium-v1' already exists.
-- Preparing dataset 'data/soma-experiment-versions' ...
-- Skipping dataset 'data/soma-experiment-versions'; directory 'data/soma-experiment-versions' already exists.
   ... finished preparing dataset 'data/soma-experiment-versions'.
```

```
kerl@arvad[prod][kerl/dots-in][TileDB-SOMA]$ python -m pytest apis/python/tests/
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.11.10, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/kerl/git/single-cell-data/TileDB-SOMA/apis/python
configfile: pyproject.toml
plugins: cov-6.0.0, typeguard-4.4.0, hypothesis-6.125.1
collected 6506 items / 1 error

====================================================================================== ERRORS =======================================================================================
_____________________________________________________________________ ERROR collecting tests/test_aaa_setup.py ______________________________________________________________________
apis/python/tests/test_aaa_setup.py:9: in <module>
    raise RuntimeError("Please run `make data` in the repo base directory")
E   RuntimeError: Please run `make data` in the repo base directory
================================================================================= warnings summary ==================================================================================
apis/python/tests/test_update_dataframes.py:24
  /Users/kerl/git/single-cell-data/TileDB-SOMA/apis/python/tests/test_update_dataframes.py:24: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: tests/test_update_dataframes.py)
    @dataclass

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== short test summary info ==============================================================================
ERROR apis/python/tests/test_aaa_setup.py - RuntimeError: Please run `make data` in the repo base directory
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================ 1 warning, 1 error in 2.05s ============================================================================
```

**Changes:**

**Notes for Reviewer:**

