### PR TITLE
[python] Use same inclusive slicing semantics for `DenseNDArray`

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -294,7 +294,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         new_coords: List[Union[int, Slice[int], None]] = []
         for c in coords:
             if isinstance(c, slice) and isinstance(c.stop, int):
-                new_coords.append(slice(c.start, c.stop - 1, c.step))
+                new_coords.append(slice(c.start, c.stop, c.step))
             else:
                 new_coords.append(c)
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2072,9 +2072,9 @@ def _write_matrix_to_denseNDArray(
         else:
             tensor = pa.Tensor.from_numpy(chunk.toarray())
         if matrix.ndim == 2:
-            soma_ndarray.write((slice(i, i2), slice(0, ncol)), tensor)
+            soma_ndarray.write((slice(i, i2 - 1), slice(0, ncol - 1)), tensor)
         else:
-            soma_ndarray.write((slice(i, i2),), tensor)
+            soma_ndarray.write((slice(i, i2 - 1),), tensor)
 
         t2 = time.time()
         chunk_seconds = t2 - t1

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -454,7 +454,7 @@ def test_timestamped_ops(tmp_path):
     # add array A to it @ t=20
     with soma.Collection.open(tmp_path.as_uri(), mode="w", tiledb_timestamp=20) as sc:
         darr = sc.add_new_dense_ndarray("A", type=pa.uint8(), shape=(2, 2)).write(
-            (slice(0, 2), slice(0, 2)),
+            (slice(0, 1), slice(0, 1)),
             pa.Tensor.from_numpy(np.zeros((2, 2), dtype=np.uint8)),
         )
         assert darr.tiledb_timestamp_ms == 20
@@ -462,7 +462,7 @@ def test_timestamped_ops(tmp_path):
     # access A via collection @ t=30 and write something into it
     with soma.Collection.open(tmp_path.as_uri(), mode="w", tiledb_timestamp=30) as sc:
         darr = sc["A"].write(
-            (slice(0, 1), slice(0, 1)),
+            (0, 0),
             pa.Tensor.from_numpy(np.ones((1, 1), dtype=np.uint8)),
         )
         assert darr.tiledb_timestamp.isoformat() == "1970-01-01T00:00:00.030000+00:00"


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61815](https://app.shortcut.com/tiledb-inc/story/61815/python-densearray-read-and-write-use-different-definition-of-coordinate-slices)]

**Changes:**

Modify read slicing to be inclusive.