### PR TITLE
[docs] Fix core logo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-<a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
+<a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/main/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
 [![TileDB-SOMA Python CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml)
 [![TileDB-SOMA R CI](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml/badge.svg)](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-ci.yml)
 [![PyPI version](https://badge.fury.io/py/tiledbsoma.svg)](https://badge.fury.io/py/tiledbsoma)
 [![tiledbsoma status badge](https://tiledb-inc.r-universe.dev/badges/tiledbsoma)](https://tiledb-inc.r-universe.dev)
 [![codecov](https://codecov.io/github/single-cell-data/TileDB-SOMA/branch/main/graph/badge.svg)](https://codecov.io/github/single-cell-data/TileDB-SOMA)
-
 
 # TileDB-SOMA
 
@@ -18,14 +17,12 @@ Embedded](https://github.com/TileDB-Inc/TileDB) to implement the
 Get started on using TileDB-SOMA:
 
 * [Quick start](#quick-start).
-* Python [documentation](https://tiledbsoma.readthedocs.io/en/latest/python-api.html). 
+* Python [documentation](https://tiledbsoma.readthedocs.io/en/latest/python-api.html).
 * R [documentation](https://single-cell-data.github.io/TileDB-SOMA/).
-
 
 ## What Can TileDB-SOMA Do?
 
 Intended to be used for single-cell data, TileDB-SOMA provides Python and R APIs to allow for storage and data access patterns at scale and for larger-than-memory operations:
-
 
 * Create and write large volumes of data.
 * Open and read data at low latency, locally and from the cloud.
@@ -41,13 +38,11 @@ TileDB-SOMA provides interoperability with existing Python or R data structures:
 * From Python create PyArrow objects, SciPy sparse matrices, NumPy arrays, and pandas data frames.
 * From R create R Arrow objects, sparse matrices (via the [Matrix](https://cran.r-project.org/package=Matrix) package), and standard data frames and (dense) matrices.
 
-
 ## Community
 
 * Please join the [TileDB Slack community](https://tiledb-community.slack.com/join/shared_invite/zt-ndq1ipwl-QcithaWG6j1BImtuQGSpag#/shared-invite/email) with dedicated channel `#genomics`.
 * Please join the [CZI Slack community](https://cziscience.slack.com/join/shared_invite/zt-czl1kp2v-sgGpY4RxO3bPYmFg2XlbZA#/shared-invite/email), with dedicated
 channel `#cellxgene-census-users`.
-
 
 ## APIs Installation and Quick Start <a id="quick-start"></a>
 
@@ -66,11 +61,11 @@ The capabilities of TileDB-SOMA lay on the different read, access, and query pat
 
 * `DenseNDArray` is a dense, N-dimensional array, with offset (zero-based) integer indexing on each dimension.
 * `SparseNDArray` is the same as `DenseNDArray` but sparse, and supports point indexing (disjoint index access).
-* `DataFrame` is a multi-column table with a user-defined columns names and value types, with support for point indexing. 
+* `DataFrame` is a multi-column table with a user-defined columns names and value types, with support for point indexing.
 * `Collection` is a persistent container of named SOMA objects.
 * `Experiment` is a class that represents a single-cell experiment. It always contains two objects:
-	* `obs`: a  `DataFrame` with primary annotations on the observation axis.
-	* `ms`: a  `Collection` of measurements, each composed of `X` matrices and axis annotation matrices or data frames (e.g. `var`, `varm`, `obsm`, etc).
+ 	* `obs`: a  `DataFrame` with primary annotations on the observation axis.
+ 	* `ms`: a  `Collection` of measurements, each composed of `X` matrices and axis annotation matrices or data frames (e.g. `var`, `varm`, `obsm`, etc).
 
 ## Who Is Using SOMA?
 
@@ -78,23 +73,19 @@ The capabilities of TileDB-SOMA lay on the different read, access, and query pat
 
 If you are interested in listing any projects here please contact us at [soma@chanzuckerberg.com](mailto:soma@chanzuckerberg.com).
 
-
 ## Issues and Contacts
 
 * Any/all questions, comments, and concerns are welcome at the [GitHub new-issue page](https://github.com/single-cell-data/TileDB-SOMA/issues/new/choose) -- or, you can also browse [existing issues](https://github.com/single-cell-data/TileDB-SOMA/issues).
 * If you believe you have found a security issue, in lieu of filing an issue please responsibly disclose it by contacting [security@tiledb.com](mailto:security@tiledb.com).
 
-
 ## Branches
 
 This branch, `main`, implements the [updated specfication](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md).  Please also see the `main-old` branch which implements the [original specification](https://github.com/single-cell-data/TileDB-SOMA/blob/main-old/spec/specification.md).
-
 
 ## Developer Information
 
 * [TileDB-SOMA wiki](https://github.com/single-cell-data/TileDB-SOMA/wiki).
 * [Build instructions for developers](libtiledbsoma/README.md).
-
 
 ## Code of Conduct
 
@@ -105,4 +96,3 @@ specific standards and reporting procedures detailed in depth in the
 https://github.com/TileDB-Inc/TileDB/blob/dev/CODE_OF_CONDUCT.md).
 
 <!-- links -->
-[tiledb]: https://github.com/TileDB-Inc/TileDB


### PR DESCRIPTION
**Issue and/or context:** TileDB logo in the README wasn't displaying.

**Changes:** Updated image URL to point to core's `main` branch, now that `dev` is no longer used.
