### PR TITLE
[python/c++] Allow GOW multi-submit for single commit

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -29,7 +29,7 @@ from . import _arrow_types, _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_GEOMETRY, SOMA_JOINID
 from ._exception import SOMAError, map_exception_for_create
-from ._read_iters import ManagedQuery, TableReadIter
+from ._read_iters import TableReadIter
 from ._soma_array import SOMAArray
 from ._tdb_handles import DataFrameWrapper
 from ._types import (
@@ -801,12 +801,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 "TileDBWriteOptions instead of TileDBCreateOptions"
             )
         write_options = TileDBWriteOptions.from_platform_config(platform_config)
-        sort_coords = write_options.sort_coords
-
-        for batch in values.to_batches():
-            mq = ManagedQuery(self)
-            mq._handle.set_array_data(batch)
-            mq._handle.submit_write(sort_coords or False)
+        self._write_table(values, write_options.sort_coords)
 
         if write_options.consolidate_and_vacuum:
             self._handle._handle.consolidate_and_vacuum()

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -315,6 +315,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         _util._set_coords(mq, new_coords)
         mq._handle.set_column_data("soma_data", input)
         mq._handle.submit_write()
+        mq._handle.finalize()
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)
         if tiledb_write_options.consolidate_and_vacuum:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -38,7 +38,7 @@ from ._dataframe import (
     _revise_domain_for_extent,
 )
 from ._exception import SOMAError, map_exception_for_create
-from ._read_iters import ManagedQuery, TableReadIter
+from ._read_iters import TableReadIter
 from ._spatial_dataframe import SpatialDataFrame
 from ._spatial_util import (
     coordinate_space_from_json,
@@ -498,24 +498,16 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         _util.check_type("values", values, (pa.Table,))
 
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
-        sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(
                 "As of TileDB-SOMA 1.13, the write method takes "
                 "TileDBWriteOptions instead of TileDBCreateOptions"
             )
         write_options = TileDBWriteOptions.from_platform_config(platform_config)
-        sort_coords = write_options.sort_coords
-
-        clib_dataframe = self._handle._handle
-
-        for batch in values.to_batches():
-            mq = ManagedQuery(self, None)
-            mq._handle.set_array_data(batch)
-            mq._handle.submit_write(sort_coords or False)
+        self._write_table(values, write_options.sort_coords)
 
         if write_options.consolidate_and_vacuum:
-            clib_dataframe.consolidate_and_vacuum()
+            self._handle._handle.consolidate_and_vacuum()
 
         return self
 

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -30,7 +30,7 @@ from ._dataframe import (
     _revise_domain_for_extent,
 )
 from ._exception import SOMAError, map_exception_for_create
-from ._read_iters import ManagedQuery, TableReadIter
+from ._read_iters import TableReadIter
 from ._spatial_dataframe import SpatialDataFrame
 from ._spatial_util import (
     coordinate_space_from_json,
@@ -480,16 +480,10 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
             )
         write_options = TileDBWriteOptions.from_platform_config(platform_config)
         sort_coords = write_options.sort_coords
-
-        clib_dataframe = self._handle._handle
-
-        for batch in values.to_batches():
-            mq = ManagedQuery(self, None)
-            mq._handle.set_array_data(batch)
-            mq._handle.submit_write(sort_coords or False)
+        self._write_table(values, sort_coords)
 
         if write_options.consolidate_and_vacuum:
-            clib_dataframe.consolidate_and_vacuum()
+            self._handle._handle.consolidate_and_vacuum()
 
         return self
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -11,6 +11,7 @@ from . import _tdb_handles
 
 # This package's pybind11 code
 from . import pytiledbsoma as clib  # noqa: E402
+from ._read_iters import ManagedQuery
 from ._soma_object import SOMAObject
 
 
@@ -159,3 +160,48 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
           resized up to core (max) domain.
         """
         return self._handle.maxdomain
+
+    def _write_table(self, values: pa.Table, sort_coords: bool) -> None:
+        """Helper function that sets the correct result order for the layout
+        and allows for multiple submissions before calling `submit` and `finalize`
+        for unordered write or `submit_and_finalize` for global order writes.
+
+        Args:
+            values:
+                An `Arrow table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_
+                containing all columns, including the index columns. The schema for the values must
+                match the schema for the :class:`DataFrame`.
+
+                If a column is of categorical type in the schema and a flattened/non-categorical
+                column is presented for data on write, a ``ValueError`` is raised.  If a column is
+                of non-categorical type in the schema and a categorical column is presented for data
+                on write, the data are written as an array of category values, and the category-type
+                information is not saved.
+            sort_coords:
+                Whether the coordinates need to be sorted (False) or are already
+                sorted in global order (True). For Arrow Tables, the coordinates
+                are already in order, so this is defaulted to False unless
+                explicitly set by the user in the PlatformConfig.
+        """
+        batches = values.to_batches()
+        if not batches:
+            return
+
+        layout = (
+            clib.ResultOrder.unordered if sort_coords else clib.ResultOrder.globalorder
+        )
+
+        if layout == clib.ResultOrder.unordered:
+            for batch in batches:
+                mq = ManagedQuery(self)._handle
+                mq.set_layout(layout)
+                mq.set_array_data(batch)
+                mq.submit_write()
+        else:
+            mq = ManagedQuery(self)._handle
+            mq.set_layout(layout)
+            for batch in batches[:-1]:
+                mq.set_array_data(batch)
+                mq.submit_write()
+            mq.set_array_data(batches[-1])
+            mq.submit_and_finalize()

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -202,7 +202,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
                 mq.submit_write()
                 mq.finalize()
 
-        else:  # globalorder
+        else:  # global order
             # Create a single ManagedQuery at the beginning
             mq = ManagedQuery(self)._handle
             mq.set_layout(layout)

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -308,14 +308,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         """
 
         write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
-        sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(
                 "As of TileDB-SOMA 1.13, the write method takes "
                 "TileDBWriteOptions instead of TileDBCreateOptions"
             )
         write_options = TileDBWriteOptions.from_platform_config(platform_config)
-        sort_coords = write_options.sort_coords
 
         clib_sparse_array = self._handle._handle
 
@@ -324,6 +322,14 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             data, coords = values.to_numpy()
 
             mq = ManagedQuery(self, platform_config)
+
+            layout = (
+                clib.ResultOrder.unordered
+                if write_options.sort_coords
+                else clib.ResultOrder.globalorder
+            )
+            mq._handle.set_layout(layout)
+
             for i, c in enumerate(coords.T):
                 mq._handle.set_column_data(
                     f"soma_dim_{i}",
@@ -338,7 +344,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                     data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
             )
-            mq._handle.submit_write(sort_coords or True)
+
+            if layout == clib.ResultOrder.unordered:
+                mq._handle.submit_write()
+                mq._handle.finalize()
+            else:
+                mq._handle.submit_and_finalize()
 
             if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
@@ -355,6 +366,14 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             sp = values.to_scipy().tocoo()
 
             mq = ManagedQuery(self, platform_config)
+
+            layout = (
+                clib.ResultOrder.unordered
+                if write_options.sort_coords
+                else clib.ResultOrder.globalorder
+            )
+            mq._handle.set_layout(layout)
+
             for i, c in enumerate([sp.row, sp.col]):
                 mq._handle.set_column_data(
                     f"soma_dim_{i}",
@@ -369,7 +388,12 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                     sp.data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()
                 ),
             )
-            mq._handle.submit_write(sort_coords or True)
+
+            if layout == clib.ResultOrder.unordered:
+                mq._handle.submit_write()
+                mq._handle.finalize()
+            else:
+                mq._handle.submit_and_finalize()
 
             if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
@@ -377,12 +401,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             return self
 
         if isinstance(values, pa.Table):
-            # Write bulk data
-            for batch in values.to_batches():
-                # clib_sparse_array.write(batch, sort_coords or False)
-                mq = ManagedQuery(self, None)
-                mq._handle.set_array_data(batch)
-                mq._handle.submit_write(sort_coords or False)
+            self._write_table(values, write_options.sort_coords)
 
             if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -156,16 +156,39 @@ void load_managed_query(py::module& m) {
                 }
                 py::gil_scoped_acquire acquire;
             })
+        .def("reset_columns", &ManagedQuery::reset_columns)
+
         .def(
             "submit_write",
-            [](ManagedQuery& mq, bool sort_coords) {
+            [](ManagedQuery& mq) {
                 try {
-                    mq.submit_write(sort_coords);
+                    mq.submit_write();
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }
             },
-            "sort_coords"_a = false,
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "submit_and_finalize",
+            [](ManagedQuery& mq) {
+                try {
+                    mq.submit_and_finalize();
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "finalize",
+            [](ManagedQuery& mq) {
+                try {
+                    mq.finalize();
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
             py::call_guard<py::gil_scoped_release>())
 
         .def("reset", &ManagedQuery::reset)

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -68,7 +68,9 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     py::enum_<ResultOrder>(m, "ResultOrder")
         .value("automatic", ResultOrder::automatic)
         .value("rowmajor", ResultOrder::rowmajor)
-        .value("colmajor", ResultOrder::colmajor);
+        .value("colmajor", ResultOrder::colmajor)
+        .value("unordered", ResultOrder::unordered)
+        .value("globalorder", ResultOrder::global);
 
     py::enum_<URIType>(m, "URIType")
         .value("automatic", URIType::automatic)

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2442,3 +2442,58 @@ def test_enum_handling_category_of_nan_62449(tmp_path):
         assert nan_check(signaling_nan, actual_dict_vals)
         assert_array_equal(expected_data1["A"], actual_data[:4])
         assert_array_equal(expected_data2["A"], actual_data[4:])
+
+
+def test_fragments_in_writes(tmp_path):
+    uri = tmp_path.as_posix()
+
+    # --- three dataframes, all with identical schema
+    df_0 = pd.DataFrame(
+        {
+            "soma_joinid": pd.Series([0, 1, 2, 3], dtype=np.int64),
+            "obs": pd.Series(["A", "B", "A", "B"], dtype="str"),
+        }
+    )
+    df_1 = pd.DataFrame(
+        {
+            "soma_joinid": pd.Series([4, 5, 6, 7], dtype=np.int64),
+            "obs": pd.Series(["A", "A", "B", "B"], dtype="str"),
+        }
+    )
+    df_2 = pd.DataFrame(
+        {
+            "soma_joinid": pd.Series([8, 9, 10, 11], dtype=np.int64),
+            "obs": pd.Series(["B", "C", "B", "C"], dtype="str"),
+        }
+    )
+    expected_df = pd.concat([df_0, df_1, df_2], ignore_index=True)
+
+    soma.DataFrame.create(
+        uri,
+        schema=pa.Schema.from_pandas(df_0, preserve_index=False),
+        domain=[[0, 11]],
+    ).close()
+
+    with soma.open(uri, mode="w") as A:
+        # Three-chunk table
+        A.write(
+            pa.concat_tables(
+                [
+                    pa.Table.from_pandas(df_0, preserve_index=False),
+                    pa.Table.from_pandas(df_1, preserve_index=False),
+                    pa.Table.from_pandas(df_2, preserve_index=False),
+                ]
+            ),
+            platform_config=soma.TileDBWriteOptions(**{"sort_coords": False}),
+        )
+
+    # There should be a single fragment even though there are three chunks (and
+    # therefore three submits) in the array because we only finalize once at
+    # the end
+    assert len(list((Path(uri) / "__commits").iterdir())) == 1
+    assert len(list((Path(uri) / "__fragments").iterdir())) == 1
+
+    with soma.open(uri) as A:
+        df = A.read().concat().to_pandas()
+
+    assert df.equals(expected_df)

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -400,7 +400,29 @@ class ManagedQuery {
      * @brief Submit the write query.
      *
      */
-    void submit_write(bool sort_coords = true);
+    void submit_write() {
+        _setup_write();
+        query_->submit();
+        _teardown_write();
+    }
+
+    /**
+     * @brief Finalize the write query.
+     *
+     */
+    void finalize() {
+        query_->finalize();
+    }
+
+    /**
+     * @brief Submit and finalize the write query.
+     *
+     */
+    void submit_and_finalize() {
+        _setup_write();
+        query_->submit_and_finalize();
+        _teardown_write();
+    }
 
     /**
      * @brief Get the schema of the array.
@@ -1049,6 +1071,19 @@ class ManagedQuery {
                 return std::memcmp(&target, &candidate, sizeof(T)) == 0;
             });
     }
+
+    /**
+     * @brief Check if the array is opened in write mode and set the subarray
+     * for dense arrays.
+     */
+    void _setup_write();
+
+    /**
+     * @brief Reset the ManagedQuery options and update the ArraySchema
+     * on-disk by re-opening the Array (required when doing schema evolution
+     * when extending enumerations).
+     */
+    void _teardown_write();
 };
 
 // These are all specializations to string/bool of various methods

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -417,7 +417,7 @@ TEST_CASE("SOMAArray: Test buffer size") {
     size_t loops = 0;
     while (auto batch = mq.read_next())
         ++loops;
-    REQUIRE(loops == 11);
+    REQUIRE(loops == 10);
     soma_array->close();
 }
 


### PR DESCRIPTION
**Issue and/or context:**

https://github.com/single-cell-data/TileDB-SOMA/issues/2054

Previously, this chunked table would have resulted in 3 fragments or commits. After separating the `submit` and `finalize` methods, this only results in a single fragment. Note that for unordered writes, this would still result in 3 fragments.

```
    with soma.open(uri, mode="w") as A:
        # Three-chunk table
        A.write(
            pa.concat_tables(
                [
                    pa.Table.from_pandas(df_0, preserve_index=False),
                    pa.Table.from_pandas(df_1, preserve_index=False),
                    pa.Table.from_pandas(df_2, preserve_index=False),
                ]
            ),

            # Do not sort the coordinates -- global order write
            platform_config=soma.TileDBWriteOptions(**{"sort_coords": False}),
        )

    # There should be a single fragment even though there are three chunks (and
    # therefore three submits) in the array because we only finalize once at
    # the end
    assert len(list((Path(uri) / "__commits").iterdir())) == 1
    assert len(list((Path(uri) / "__fragments").iterdir())) == 1
```

**Changes:**

- Separate `finalize` and `finalize_and_submit` from `submit_write`
- For sparse array writes in Python, add utility method `_write_table`. For unordered writes, the writes remained unchanged where for each batch, create a new `ManagedQuery` for each batch and `submit`. For global order writes, create a single `ManagedQuery`, `submit` for each batch, and `submit_and_finalize` at the end