### PR TITLE
[python] Show DataFrame `.count` in `show_experiment_shapes`

### DIFF
--- a/apis/python/notebooks/tutorial_soma_append_mode.ipynb
+++ b/apis/python/notebooks/tutorial_soma_append_mode.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "d6b81174",
    "metadata": {
     "tags": []
@@ -46,8 +46,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tiledbsoma.__version__              1.15.7\n",
-      "TileDB core version (libtiledbsoma) 2.27.1\n",
+      "tiledbsoma.__version__              1.16.0\n",
+      "TileDB core version (libtiledbsoma) 2.27.2\n",
       "python version                      3.11.10.final.0\n",
       "OS version                          Darwin 24.3.0\n"
      ]
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "24108e1c",
    "metadata": {
     "tags": []
@@ -84,10 +84,10 @@
     {
      "data": {
       "text/plain": [
-       "'/tmp/append-example-20250221-133242'"
+       "'/tmp/append-example-20250307-175702'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "fe0e7a46",
    "metadata": {
     "tags": []
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "10cbd82b",
    "metadata": {
     "tags": []
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "a7c7914f",
    "metadata": {
     "tags": []
@@ -185,20 +185,20 @@
      "output_type": "stream",
      "text": [
       "Registration: registering isolated AnnData object.\n",
-      "Wrote   /tmp/append-example-20250221-133242/obs\n",
-      "Wrote   /tmp/append-example-20250221-133242/ms/RNA/var\n",
-      "Writing /tmp/append-example-20250221-133242/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133242/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133242\n"
+      "Wrote   /tmp/append-example-20250307-175702/obs\n",
+      "Wrote   /tmp/append-example-20250307-175702/ms/RNA/var\n",
+      "Writing /tmp/append-example-20250307-175702/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175702/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175702\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'/tmp/append-example-20250221-133242'"
+       "'/tmp/append-example-20250307-175702'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "d6ca5c9e",
    "metadata": {
     "tags": []
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "221c472f",
    "metadata": {
     "tags": []
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "851fb064-2f40-43ff-b6a5-402c194ba177",
    "metadata": {
     "tags": []
@@ -390,21 +390,23 @@
      "text": [
       "\n",
       "[DataFrame] obs \n",
-      "  URI file:///tmp/append-example-20250221-133242/obs\n",
+      "  URI file:///tmp/append-example-20250307-175702/obs\n",
+      "  count                2700\n",
       "  non_empty_domain     ((0, 2699),)\n",
       "  domain               ((0, 2699),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[DataFrame] ms/RNA/var \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/var\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/var\n",
+      "  count                32738\n",
       "  non_empty_domain     ((0, 32737),)\n",
       "  domain               ((0, 32737),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[SparseNDArray] ms/RNA/X/data \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/X/data\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/X/data\n",
       "  non_empty_domain     ((0, 2699), (5, 32732))\n",
       "  shape                (2700, 32738)\n",
       "  maxshape             (9223372036854773759, 9223372036854773759)\n",
@@ -417,7 +419,7 @@
        "True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "81ca4031",
    "metadata": {
     "tags": []
@@ -462,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "d703ebb7",
    "metadata": {
     "tags": []
@@ -486,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "38f78883-6af5-43f9-8661-add028e3dee1",
    "metadata": {
     "tags": []
@@ -496,7 +498,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Registration: starting with experiment /tmp/append-example-20250221-133242\n",
+      "Registration: starting with experiment /tmp/append-example-20250307-175702\n",
       "Registration: found nobs=2700 nvar=32738 from experiment.\n",
       "Registration: registering AnnData object.\n",
       "Registration: accumulated to nobs=5400 nvar=32738.\n",
@@ -528,7 +530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "68a236ff-15fc-49f5-9285-bbd128aeae6b",
    "metadata": {
     "tags": []
@@ -540,21 +542,23 @@
      "text": [
       "\n",
       "[DataFrame] obs \n",
-      "  URI file:///tmp/append-example-20250221-133242/obs\n",
+      "  URI file:///tmp/append-example-20250307-175702/obs\n",
+      "  count                2700\n",
       "  non_empty_domain     ((0, 2699),)\n",
       "  domain               ((0, 2699),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[DataFrame] ms/RNA/var \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/var\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/var\n",
+      "  count                32738\n",
       "  non_empty_domain     ((0, 32737),)\n",
       "  domain               ((0, 32737),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[SparseNDArray] ms/RNA/X/data \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/X/data\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/X/data\n",
       "  non_empty_domain     ((0, 2699), (5, 32732))\n",
       "  shape                (2700, 32738)\n",
       "  maxshape             (9223372036854773759, 9223372036854773759)\n",
@@ -567,7 +571,7 @@
        "True"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -588,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "09e8a10f-90c7-493c-9e91-26f09d96e527",
    "metadata": {
     "tags": []
@@ -600,7 +604,7 @@
        "True"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -611,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "f183088d-b428-47ce-99f6-c12157867357",
    "metadata": {
     "tags": []
@@ -623,21 +627,23 @@
      "text": [
       "\n",
       "[DataFrame] obs \n",
-      "  URI file:///tmp/append-example-20250221-133242/obs\n",
+      "  URI file:///tmp/append-example-20250307-175702/obs\n",
+      "  count                2700\n",
       "  non_empty_domain     ((0, 2699),)\n",
       "  domain               ((0, 5399),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[DataFrame] ms/RNA/var \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/var\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/var\n",
+      "  count                32738\n",
       "  non_empty_domain     ((0, 32737),)\n",
       "  domain               ((0, 32737),)\n",
       "  maxdomain            ((0, 9223372036854773758),)\n",
       "  upgraded             True\n",
       "\n",
       "[SparseNDArray] ms/RNA/X/data \n",
-      "  URI file:///tmp/append-example-20250221-133242/ms/RNA/X/data\n",
+      "  URI file:///tmp/append-example-20250307-175702/ms/RNA/X/data\n",
       "  non_empty_domain     ((0, 2699), (5, 32732))\n",
       "  shape                (5400, 32738)\n",
       "  maxshape             (9223372036854773759, 9223372036854773759)\n",
@@ -650,7 +656,7 @@
        "True"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "2f500c43-1e44-4a56-bf87-3ba936b973f7",
    "metadata": {
     "tags": []
@@ -681,20 +687,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Wrote   /tmp/append-example-20250221-133242/obs\n",
-      "Wrote   /tmp/append-example-20250221-133242/ms/RNA/var\n",
-      "Writing /tmp/append-example-20250221-133242/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133242/ms/RNA/X/data\n",
-      "Wrote   file:///tmp/append-example-20250221-133242\n"
+      "Wrote   /tmp/append-example-20250307-175702/obs\n",
+      "Wrote   /tmp/append-example-20250307-175702/ms/RNA/var\n",
+      "Writing /tmp/append-example-20250307-175702/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175702/ms/RNA/X/data\n",
+      "Wrote   file:///tmp/append-example-20250307-175702\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'file:///tmp/append-example-20250221-133242'"
+       "'file:///tmp/append-example-20250307-175702'"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -722,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "a7b2aebe",
    "metadata": {
     "tags": []
@@ -772,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "4a1cc20e",
    "metadata": {
     "tags": []
@@ -821,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "d640bde0",
    "metadata": {
     "tags": []
@@ -887,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "c3c185fb",
    "metadata": {
     "tags": []
@@ -924,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "ae2d62ae",
    "metadata": {
     "tags": []
@@ -933,10 +939,10 @@
     {
      "data": {
       "text/plain": [
-       "'/tmp/append-example-20250221-133458'"
+       "'/tmp/append-example-20250307-175704'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -960,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "ac21dd19-2fd5-41ec-98e5-2596e0795f0d",
    "metadata": {
     "tags": []
@@ -1008,7 +1014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "27ed22b2",
    "metadata": {
     "tags": []
@@ -1018,21 +1024,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Wrote   /tmp/append-example-20250221-133458/obs\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/var\n",
-      "Writing /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133458\n",
-      "Wrote   /tmp/append-example-20250221-133458/obs\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/var\n",
-      "Writing /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   file:///tmp/append-example-20250221-133458\n",
-      "Wrote   /tmp/append-example-20250221-133458/obs\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/var\n",
-      "Writing /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   /tmp/append-example-20250221-133458/ms/RNA/X/data\n",
-      "Wrote   file:///tmp/append-example-20250221-133458\n"
+      "Wrote   /tmp/append-example-20250307-175704/obs\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/var\n",
+      "Writing /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175704\n",
+      "Wrote   /tmp/append-example-20250307-175704/obs\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/var\n",
+      "Writing /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   file:///tmp/append-example-20250307-175704\n",
+      "Wrote   /tmp/append-example-20250307-175704/obs\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/var\n",
+      "Writing /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   /tmp/append-example-20250307-175704/ms/RNA/X/data\n",
+      "Wrote   file:///tmp/append-example-20250307-175704\n"
      ]
     }
    ],
@@ -1065,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "8f86fd3d",
    "metadata": {
     "tags": []
@@ -1113,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "bffce533",
    "metadata": {
     "tags": []
@@ -1162,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "05cf63a0",
    "metadata": {
     "tags": []

--- a/apis/python/notebooks/tutorial_soma_shape.ipynb
+++ b/apis/python/notebooks/tutorial_soma_shape.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "90db6017-a084-43f5-8f7e-bff281e9a898",
    "metadata": {
     "tags": []
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "1e02d2b9-c492-4e02-9022-203a1d65282c",
    "metadata": {},
    "outputs": [],
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "c90a840e-559f-4dfb-a9f8-5bcd629c714c",
    "metadata": {},
    "outputs": [
@@ -104,7 +104,7 @@
        "((0, 2637),)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "9a17cd6c-864d-4b83-915e-9ea67e042bab",
    "metadata": {},
    "outputs": [
@@ -125,7 +125,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "9967e115-6277-4203-b61b-96d1c5b04fde",
    "metadata": {},
    "outputs": [
@@ -304,7 +304,7 @@
        "[2638 rows x 6 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "882ab5f8-6fa7-4920-84bc-b72caf65ec09",
    "metadata": {},
    "outputs": [
@@ -341,7 +341,7 @@
        "((0, 1837),)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "8685af65-62f4-4816-a713-55fc90e3c983",
    "metadata": {},
    "outputs": [
@@ -363,7 +363,7 @@
        "((0, 9223372036854773968),)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -386,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "67e043fd-5173-44bf-8b57-811f32f4c85f",
    "metadata": {},
    "outputs": [
@@ -396,7 +396,7 @@
        "((0, 2637),)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "c32892ee-0c1e-4393-9ad9-620d8eb178ad",
    "metadata": {},
    "outputs": [
@@ -417,7 +417,7 @@
        "((0, 1837),)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "cd67a1ac-ec1f-4a0a-adb3-b7c3f75592e7",
    "metadata": {},
    "outputs": [
@@ -438,7 +438,7 @@
        "(2638, 1838)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -449,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "98f6c5f2-d002-428d-9cfe-3c817764199a",
    "metadata": {},
    "outputs": [
@@ -459,7 +459,7 @@
        "(9223372036854773759, 9223372036854773759)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "96523a2b-10d3-4e2c-b76e-1b6e814c8774",
    "metadata": {},
    "outputs": [
@@ -488,7 +488,7 @@
        "['X_draw_graph_fr', 'X_pca', 'X_tsne', 'X_umap']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "82b16ded-298c-4d7e-8dfd-ffb4b36c37c6",
    "metadata": {},
    "outputs": [
@@ -510,7 +510,7 @@
        "['connectivities', 'distances']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -522,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "bbe56e08-c237-48df-8b0d-393057e7e6fa",
    "metadata": {},
    "outputs": [
@@ -532,7 +532,7 @@
        "[(2638, 50), (9223372036854773759, 9223372036854773759)]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -546,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "7577221c-85c7-4549-847d-8cbcc1b771ab",
    "metadata": {},
    "outputs": [
@@ -556,7 +556,7 @@
        "[(2638, 2638), (9223372036854773759, 9223372036854773759)]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -643,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "6bce4d88-84ef-4f13-8441-473bbceb8292",
    "metadata": {},
    "outputs": [],
@@ -669,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "876f04a4-089d-40fe-bfe1-6c2f8474817f",
    "metadata": {},
    "outputs": [
@@ -679,7 +679,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -690,7 +690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "9d4e1343-f3bc-4ed7-a1db-fdc69eef3745",
    "metadata": {},
    "outputs": [
@@ -700,7 +700,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -711,7 +711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "c02671f3-21c7-4b5d-b659-f3b14f29d1d4",
    "metadata": {},
    "outputs": [
@@ -721,7 +721,7 @@
        "False"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -732,7 +732,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "2c690a8d-3654-430a-ba15-eb65dfbf789b",
    "metadata": {},
    "outputs": [
@@ -744,7 +744,7 @@
        " False]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -765,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "012d726c-37f7-48a7-895c-8a69a2df2323",
    "metadata": {},
    "outputs": [
@@ -775,7 +775,7 @@
        "True"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -786,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "3d1387ef-1738-420e-861e-6676afba58a3",
    "metadata": {},
    "outputs": [],
@@ -796,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "d8a98c8d-6446-4a9f-91f5-9024e18b56da",
    "metadata": {},
    "outputs": [
@@ -806,7 +806,7 @@
        "[(2638, 1838), (9223372036854773759, 9223372036854773759), True]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "687f9cde-1ef4-49de-9cea-f80a5765a58e",
    "metadata": {},
    "outputs": [
@@ -861,7 +861,7 @@
        "soma_data: float not null"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -882,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "39a52da4-da14-421c-91aa-ba63259db1bd",
    "metadata": {},
    "outputs": [
@@ -897,7 +897,7 @@
        "louvain: dictionary<values=string, indices=int32, ordered=0>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "5c26c39b-c194-4d08-8840-c3d945ace18a",
    "metadata": {},
    "outputs": [
@@ -918,7 +918,7 @@
        "('soma_joinid',)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -939,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "453b64d0-9a6a-4b00-80f0-38259fa1ffa4",
    "metadata": {},
    "outputs": [],
@@ -950,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "d93f35b4-72de-4895-aeaa-a769555de7b3",
    "metadata": {},
    "outputs": [],
@@ -974,7 +974,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "id": "86a09444-0ea6-4359-bf96-871832bb3878",
    "metadata": {},
    "outputs": [],
@@ -998,7 +998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "id": "c51530f4-a652-4b33-be26-4ec87f6b2112",
    "metadata": {},
    "outputs": [],
@@ -1008,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "eef4b4ba-65fe-4621-a6e0-04dd80ba9a31",
    "metadata": {},
    "outputs": [
@@ -1018,7 +1018,7 @@
        "('soma_joinid', 'mystring')"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1051,7 +1051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "id": "d4ef8d2b-3696-4554-aab4-6641c6f5eb98",
    "metadata": {},
    "outputs": [
@@ -1061,7 +1061,7 @@
        "((0, 9), ('', ''))"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1072,7 +1072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "id": "c71d796a-6160-4ade-81e0-8650dd773cc7",
    "metadata": {},
    "outputs": [
@@ -1082,7 +1082,7 @@
        "((0, 9223372036854775796), ('', ''))"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1101,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "id": "417d1039-a646-4c47-bc63-22847fbaaf67",
    "metadata": {},
    "outputs": [],
@@ -1117,7 +1117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "id": "f31e4b81-b009-497c-9fa8-a88eb14f99ff",
    "metadata": {},
    "outputs": [],
@@ -1127,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "id": "fb4ee7ee-b038-4c82-a42b-bc2aa3b49734",
    "metadata": {},
    "outputs": [
@@ -1137,7 +1137,7 @@
        "('myfloat', 'myint')"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1156,7 +1156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "id": "2f81b556-b52b-47b2-a3fd-24f55edfbbd5",
    "metadata": {},
    "outputs": [
@@ -1166,7 +1166,7 @@
        "((0.0, 999.0), (-1000, 1000))"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,7 +1177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "id": "abc9e8c4-ec87-4ca3-8529-44593b24c5ac",
    "metadata": {},
    "outputs": [
@@ -1187,7 +1187,7 @@
        "((-3.4028234663852886e+38, 3.4028234663852886e+38), (-2147483648, 2147481645))"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1229,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "id": "e8112d72-0abf-46aa-8e7f-962cf37c7199",
    "metadata": {},
    "outputs": [],
@@ -1254,7 +1254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "id": "d3a0c977-edf0-4497-8adc-8d8fb86da980",
    "metadata": {},
    "outputs": [
@@ -1264,7 +1264,7 @@
        "False"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1275,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "id": "d781b504-f7eb-4d80-88fd-a8e18dea179d",
    "metadata": {},
    "outputs": [
@@ -1285,7 +1285,7 @@
        "(9223372036854773759, 9223372036854773759)"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1304,7 +1304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "id": "074666e9-8e47-45bf-98c8-2bb31841cd9e",
    "metadata": {},
    "outputs": [
@@ -1314,7 +1314,7 @@
        "((0, 2637), (0, 1837))"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1325,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "id": "8ac6ce56-114c-414d-a631-ebce5849754a",
    "metadata": {},
    "outputs": [],
@@ -1344,7 +1344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 46,
    "id": "74ac2f06-1b41-43b2-af84-7c02c2f975ac",
    "metadata": {},
    "outputs": [],
@@ -1355,7 +1355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 47,
    "id": "0b4b0170-75c3-4d14-8aca-ad93ac2179a1",
    "metadata": {},
    "outputs": [
@@ -1365,7 +1365,7 @@
        "True"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1376,7 +1376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 48,
    "id": "1f98a73d-e20f-4cb0-9f36-8824dcfffbe6",
    "metadata": {},
    "outputs": [
@@ -1386,7 +1386,7 @@
        "(2638, 1838)"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1397,7 +1397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 49,
    "id": "1eaa602b-8158-4413-a5a2-449ae2ab730f",
    "metadata": {},
    "outputs": [
@@ -1407,7 +1407,7 @@
        "(9223372036854773759, 9223372036854773759)"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1426,7 +1426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 50,
    "id": "ec0cbae6-84b6-44bf-b8d4-abd964929d14",
    "metadata": {},
    "outputs": [],
@@ -1437,7 +1437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 51,
    "id": "175c3b22-d696-43c9-bc00-c70644c09ed8",
    "metadata": {},
    "outputs": [],
@@ -1448,7 +1448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 52,
    "id": "fa307631-094a-45c7-b5a1-d40b24bd24bb",
    "metadata": {},
    "outputs": [
@@ -1458,7 +1458,7 @@
        "(7200, 1848)"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1480,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 53,
    "id": "0362cafc-50ad-467a-ad2a-9a9bdb9de4a3",
    "metadata": {},
    "outputs": [
@@ -1490,7 +1490,7 @@
        "False"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1501,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 54,
    "id": "e5f7d227-8099-41bf-b9b9-66abf78a895a",
    "metadata": {},
    "outputs": [
@@ -1511,7 +1511,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1522,7 +1522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 55,
    "id": "1cfe37da-0b5f-47a2-b7cf-f572f1f5b3ae",
    "metadata": {},
    "outputs": [
@@ -1532,7 +1532,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1543,7 +1543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 56,
    "id": "0bd612dd-6722-47ac-ad1f-9ae48fc3d121",
    "metadata": {},
    "outputs": [
@@ -1553,7 +1553,7 @@
        "((0, 2637),)"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1564,7 +1564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 57,
    "id": "07034a75-f509-42d5-8de9-56798b523f2b",
    "metadata": {},
    "outputs": [],
@@ -1575,7 +1575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 58,
    "id": "74e90a63-c8e7-4892-895a-584363d58284",
    "metadata": {},
    "outputs": [],
@@ -1585,7 +1585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 59,
    "id": "ab5ed97a-f151-42de-be48-237e0b788501",
    "metadata": {},
    "outputs": [
@@ -1595,7 +1595,7 @@
        "True"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1606,7 +1606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 60,
    "id": "f70a0d9c-1cde-4f80-9b3b-d2692e796973",
    "metadata": {},
    "outputs": [
@@ -1616,7 +1616,7 @@
        "((0, 2638),)"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1627,7 +1627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 61,
    "id": "41968785-373b-4c48-b90e-3a24a6b9c199",
    "metadata": {},
    "outputs": [
@@ -1637,7 +1637,7 @@
        "((0, 9223372036854773758),)"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1657,7 +1657,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "3.11.10",
    "language": "python",
    "name": "python3"
   },
@@ -1671,7 +1671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -356,6 +356,7 @@ def _leaf_visitor_show_shapes(
     retval = True
     if isinstance(item, tiledbsoma.DataFrame):
         _print_leaf_node_banner("DataFrame", node_name, item.uri, args)
+        _bannerize(args, "count", item.count)
         _bannerize(args, "non_empty_domain", item.non_empty_domain())
         _bannerize(args, "domain", item.domain)
         _bannerize(args, "maxdomain", item.maxdomain)


### PR DESCRIPTION
**Issue and/or context:** After extensive, thoughtful, and deliberate team discussion including @ivirshup and @bkmartinjr , we decided not to expose a `.shape` accessor for dataframes.

The thinking we agreed to, collectively and as a team, at that point in time was that having a `.shape`  accessor for DataFrame objects would decrease confusion for some others but add confusion for others.

The status quo is:

* Suppose an experiment has `nobs=1000` and `nvar=2000`
* In AnnData, one would have
  * `adata.obs.shape = (1000, m)` where `m` is the number of columns in `obs`
  * `adata.var.shape = (2000, n)` where `n` is the number of columns in `var`
  * `adata.X.shape` = (1000, 2000)`
* In TileDB-SOMA, we have
  * `exp.obs.shape` does not exist (as discussed above)
  * `exp.obs.domain = ((0, 999),)`
  * `exp.ms["RNA"].var.shape` does not exist (as discussed above)
  * `exp.ms["RNA"].var.domain = ((0, 1999),)`
  * `exp.ms["RNA"].X["data"].shape = (1000, 2000)`
 * This looks to users like an off-by-one error. User reports are that this is confusing.

While we have agreed collectively not to expose a `.shape` accessor for DataFrame objects, we do have a `.count`. These need to be exposed in `tiledbsoma.io.show_experiment_shapes`.

**Changes:**

```
>>> import tiledbsoma.io

>>> tiledbsoma.io.show_experiment_shapes("/var/s/v/pbmc3k_unprocessed")

[DataFrame] obs
  URI file:///var/s/v/pbmc3k_unprocessed/obs
  count                2700 <-------------------------- New on this PR
  non_empty_domain     ((0, 2699),)
  domain               ((0, 2699),)
  maxdomain            ((0, 9223372036854773758),)
  upgraded             True

[DataFrame] ms/RNA/var
  URI file:///var/s/v/pbmc3k_unprocessed/ms/RNA/var
  count                13714 <-------------------------- New on this PR
  non_empty_domain     ((0, 13713),)
  domain               ((0, 13713),)
  maxdomain            ((0, 9223372036854773758),)
  upgraded             True

[SparseNDArray] ms/RNA/X/data
  URI file:///var/s/v/pbmc3k_unprocessed/ms/RNA/X/data
  non_empty_domain     ((0, 2699), (0, 13713))
  shape                (2700, 13714)
  maxshape             (9223372036854773759, 9223372036854773759)
  upgraded             True
```

**Notes for Reviewer:**

