### PR TITLE
Run `pip check` in CI

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -118,6 +118,9 @@ jobs:
     - name: Show XCode version
       run: clang --version
 
+    - name: Run pip check
+      run: pip check
+
     - name: Run libtiledbsoma unit tests
       run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
       env:


### PR DESCRIPTION
**Issue and/or context:** Many of the spatial Python packages that SOMA depends on require Python >= 3.10. `pip` still installs them into our Python 3.9 CI env, but reports messages like the [following](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/13766978880/job/38495810318#step:9:210):

```
  Link requires a different Python (3.9.21 not in: '<3.13,>=3.10'): https://files.pythonhosted.org/packages/a5/b5/ea49151c7f846a2f083271c9c0a92c046a0d5b522369e839089d8022e870/spatialdata-0.2.6-py3-none-any.whl (from https://pypi.org/simple/spatialdata/) (requires-python:<3.13,>=3.10)
```

**Changes:** Runs `pip check` to summarize the version incompatibilities

**Notes for Reviewer:**

