### PR TITLE
[python] Add `_fastercsx.Format` type alias

### DIFF
--- a/apis/python/src/tiledbsoma/_fastercsx.py
+++ b/apis/python/src/tiledbsoma/_fastercsx.py
@@ -19,6 +19,7 @@ from .pytiledbsoma.fastercsx import compress_coo, copy_csx_to_dense, sort_csx_in
 
 NDArrayIndex: TypeAlias = npt.NDArray[np.integer[Any]]
 NDArrayNumber: TypeAlias = npt.NDArray[Union[np.integer[Any], np.floating[Any]]]
+Format = Literal["csc", "csr"]
 
 
 class CompressedMatrix:
@@ -45,7 +46,7 @@ class CompressedMatrix:
         indices: NDArrayIndex,
         data: NDArrayNumber,
         shape: Tuple[int, int],
-        format: Literal["csc", "csr"],
+        format: Format,
         is_sorted: bool,
         no_duplicates: bool | None,
         context: SOMATileDBContext,
@@ -73,7 +74,7 @@ class CompressedMatrix:
         j: NDArrayIndex | Sequence[NDArrayIndex],
         d: NDArrayNumber | Sequence[NDArrayNumber],
         shape: Tuple[int, int],
-        format: Literal["csc", "csr"],
+        format: Format,
         make_sorted: bool,
         context: SOMATileDBContext,
     ) -> CompressedMatrix:
@@ -109,7 +110,7 @@ class CompressedMatrix:
     def from_soma(
         tables: pa.Table | Sequence[pa.Table],
         shape: Tuple[int, int],
-        format: Literal["csc", "csr"],
+        format: Format,
         make_sorted: bool,
         context: SOMATileDBContext,
     ) -> CompressedMatrix:
@@ -251,7 +252,7 @@ class CompressedMatrix:
         indices: NDArrayNumber,
         data: NDArrayNumber,
         shape: Tuple[int, int],
-        format: Literal["csc", "csr"],
+        format: Format,
         is_sorted: bool,
         no_duplicates: bool | None,
     ) -> scipy.sparse.csr_matrix | scipy.sparse.csc_matrix:

--- a/apis/python/tests/ht/test_ht_fastercsx.py
+++ b/apis/python/tests/ht/test_ht_fastercsx.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Union
+from typing import Any, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -16,6 +16,7 @@ from typing_extensions import TypeAlias
 import tiledbsoma as soma
 import tiledbsoma._fastercsx as fastercsx
 import tiledbsoma.pytiledbsoma.fastercsx as clib_fastercsx
+from tiledbsoma._fastercsx import Format
 
 from tests.ht._ht_util import (
     arrow_array,
@@ -330,7 +331,7 @@ def test_fastercsx_from_ijd(
     value_dtype: np.dtype,
     unique: bool,
     shape: tuple[int, int],
-    format: Literal["csc", "csr"],
+    format: Format,
     make_sorted: bool,
     context: soma.SOMATileDBContext,
 ) -> None:
@@ -387,7 +388,7 @@ def test_fastercsx_to_scipy(
     value_dtype: np.dtype,
     unique: bool,
     shape: tuple[int, int],
-    format: Literal["csc", "csr"],
+    format: Format,
     make_sorted: bool,
     context: soma.SOMATileDBContext,
 ) -> None:

--- a/apis/python/tests/test_fastercsx.py
+++ b/apis/python/tests/test_fastercsx.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
@@ -12,6 +12,7 @@ from typeguard import suppress_type_checks
 
 import tiledbsoma as soma
 import tiledbsoma._fastercsx as fastercsx
+from tiledbsoma._fastercsx import Format
 
 NP_VALUE_TYPES = [  # supported types - see fastercsx.h
     np.float32,
@@ -77,7 +78,7 @@ def assert_eq(sp: sparse.spmatrix, cm: fastercsx.CompressedMatrix) -> bool:
 def test_from_ijd(
     shape: tuple[int, int],
     value_dtype: np.dtype[Any],
-    format: Literal["csc", "csr"],
+    format: Format,
     context: soma.SOMATileDBContext,
     rng: np.random.Generator,
 ) -> None:
@@ -104,7 +105,7 @@ def test_from_soma_array(
     n_tables: int,
     shape: tuple[int, int],
     value_dtype: np.dtype[Any],
-    format: Literal["csc", "csr"],
+    format: Format,
     context: soma.SOMATileDBContext,
     rng: np.random.Generator,
 ) -> None:
@@ -151,7 +152,7 @@ def test_from_soma_chunked_array(
     n_chunks: int,
     shape: tuple[int, int],
     value_dtype: np.dtype[Any],
-    format: Literal["csc", "csr"],
+    format: Format,
     context: soma.SOMATileDBContext,
     rng: np.random.Generator,
 ) -> None:
@@ -193,7 +194,7 @@ def test_from_soma_chunked_array(
     "index", [None, slice(None), slice(0), slice(10), slice(0, 1), slice(1, -1)]
 )
 def test_to_scipy(
-    format: Literal["csc", "csr"],
+    format: Format,
     sorted: bool,
     index: slice | None,
     context: soma.SOMATileDBContext,
@@ -232,7 +233,7 @@ def test_to_scipy(
     "index", [None, slice(None), slice(0), slice(10), slice(0, 1), slice(1, -1)]
 )
 def test_to_numpy(
-    format: Literal["csc", "csr"],
+    format: Format,
     sorted: bool,
     shape: tuple[int, int],
     index: slice | None,
@@ -349,7 +350,7 @@ def test_bad_shapes(context: soma.SOMATileDBContext, rng: np.random.Generator) -
 @pytest.mark.parametrize("format", ["csr", "csc"])
 @pytest.mark.parametrize("make_sorted", [True, False])
 def test_duplicates(
-    format: Literal["csc", "csr"],
+    format: Format,
     make_sorted: bool,
     context: soma.SOMATileDBContext,
     rng: np.random.Generator,


### PR DESCRIPTION
**Issue and/or context:** factored out of #3740

**Changes:**
Add `Format = Literal["csc", "csr"]` alias (used in 3 files here, and more to come in #3740)
