### PR TITLE
[python] Fix `to_anndata` with no `X`

### DIFF
--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -690,3 +690,16 @@ def _resolve_futures(unresolved: Dict[str, Any], deep: bool = False) -> Dict[str
         resolved[k] = v
 
     return resolved
+
+
+class Sentinel:
+    """This is used to help detect when a kwarg is supplied or not.  Often,
+    kwarg ``foo = None`` is adequate, and should be used. This helps for cases
+    when ``None`` is actually a valid option, and we want to distinguish between
+    the user passing ``foo=None`` and the user not passing any ``foo`` at all.
+    """
+
+    pass
+
+
+MISSING = Sentinel()

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -39,7 +39,7 @@ from .. import (
 from .._constants import SOMA_JOINID
 from .._exception import SOMAError
 from .._types import NPNDArray, Path
-from .._util import _resolve_futures
+from .._util import MISSING, Sentinel, _resolve_futures
 from . import conversions
 from ._common import (
     _DATAFRAME_ORIGINAL_INDEX_NAME_JSON,
@@ -222,14 +222,6 @@ def _read_dataframe(
             pdf.index.name = None
 
     return pdf
-
-
-# ----------------------------------------------------------------
-class Sentinel:
-    pass
-
-
-MISSING = Sentinel()
 
 
 def to_anndata(

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -856,8 +856,27 @@ def test_X_none(h5ad_file_X_none):
         assert exp.ms["RNA"].var.count == 1838
         assert list(exp.ms["RNA"].X.keys()) == []
 
-        tiledbsoma.io.to_anndata(exp, measurement_name="RNA", X_layer_name=None)
-        # TODO: more
+        adata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA", X_layer_name=None)
+        assert adata.obs is not None
+        assert adata.var is not None
+        assert adata.X is None
+
+        adata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
+        assert adata.obs is not None
+        assert adata.var is not None
+        assert adata.X is None
+
+        adata = tiledbsoma.io.to_anndata(
+            exp, measurement_name="RNA", X_layer_name="data"
+        )
+        assert adata.obs is not None
+        assert adata.var is not None
+        assert adata.X is None
+
+        with pytest.raises(ValueError):
+            adata = tiledbsoma.io.to_anndata(
+                exp, measurement_name="RNA", X_layer_name="nonesuch"
+            )
 
 
 # There exist in the wild AnnData files with categorical-int columns where "not in the category" is

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -693,6 +693,14 @@ def test_export_anndata(conftest_pbmc_small):
     for key in conftest_pbmc_small.varp.keys():
         assert readback.varp[key].shape == conftest_pbmc_small.varp[key].shape
 
+    with _factory.open(output_path) as exp:
+        readback = tiledbsoma.io.to_anndata(
+            exp, measurement_name="RNA", X_layer_name=None
+        )
+        assert readback.obs.shape == conftest_pbmc_small.obs.shape
+        assert readback.var.shape == conftest_pbmc_small.var.shape
+        assert readback.X is None
+
 
 def test_ingest_additional_metadata(conftest_pbmc_small):
     tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_additional_metadata_")
@@ -856,22 +864,18 @@ def test_X_none(h5ad_file_X_none):
         assert exp.ms["RNA"].var.count == 1838
         assert list(exp.ms["RNA"].X.keys()) == []
 
-        adata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA", X_layer_name=None)
-        assert adata.obs is not None
-        assert adata.var is not None
-        assert adata.X is None
-
         adata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
         assert adata.obs is not None
         assert adata.var is not None
         assert adata.X is None
 
-        adata = tiledbsoma.io.to_anndata(
-            exp, measurement_name="RNA", X_layer_name="data"
-        )
+        adata = tiledbsoma.io.to_anndata(exp, measurement_name="RNA", X_layer_name=None)
         assert adata.obs is not None
         assert adata.var is not None
         assert adata.X is None
+
+        with pytest.raises(ValueError):
+            tiledbsoma.io.to_anndata(exp, measurement_name="RNA", X_layer_name="data")
 
         with pytest.raises(ValueError):
             adata = tiledbsoma.io.to_anndata(


### PR DESCRIPTION
#3773 

[[sc-63400]](https://app.shortcut.com/tiledb-inc/story/63400/python-tiledbsoma-io-to-anndata-raises-error-when-x-layer-missing-but-not-requested)