### PR TITLE
[c++,python] Flush the `Array` object in `SOMAArray::reopen`

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -212,6 +212,7 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
                 f"Invalid mode '{mode}' passed. " "Valid modes are 'r' and 'w'."
             )
         ts = self.context._open_timestamp_ms(timestamp)
+        self.metadata._write()
         return self._handle.reopen(
             clib.OpenMode.read if mode == "r" else clib.OpenMode.write, (0, ts)
         )

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2053,3 +2053,11 @@ def test_sparse_nd_array_null(tmp_path):
         # any null values present in non-nullable attributes get casted to
         # fill values. In the case for float64, the fill value is 0
         np.testing.assert_array_equal(pdf["soma_data"], table["soma_data"].fill_null(0))
+
+
+def test_reopen_metadata_sc61118(tmp_path):
+    uri = tmp_path.as_posix()
+    with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A1:
+        A1.metadata["foo"] = "bar"
+        with A1.reopen(mode="r") as A2:
+            assert dict(A1.metadata) == dict(A2.metadata)

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -210,6 +210,12 @@ void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
 
 std::unique_ptr<SOMAArray> SOMAArray::reopen(
     OpenMode mode, std::optional<TimestampRange> timestamp) {
+    if (arr_->query_type() == TILEDB_READ) {
+        arr_->reopen();
+    } else {
+        arr_->close();
+        arr_->open(TILEDB_WRITE);
+    }
     return std::make_unique<SOMAArray>(mode, uri_, ctx_, timestamp);
 }
 


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61118](https://app.shortcut.com/tiledb-inc/story/61118/python-reopen-loses-metadata-modifications)]

**Changes:**

Previously, the `reopen` method only opened and returned a new `SOMAArray` object without actually performing a flush operation. 