### PR TITLE
[python] Cast object to child class in pybind11 `SOMAArray.reopen`

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -94,7 +94,7 @@ void load_soma_array(py::module& m) {
                         "Unreachable code: The missing soma_object_type case "
                         "is already handled. This indicates an "
                         "unexpected failure to catch exceptions by "
-                        "SOMAArray::reopenopen");
+                        "SOMAArray::reopen");
                 }
 
                 std::transform(

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -89,8 +89,7 @@ void load_soma_array(py::module& m) {
                 }
 
                 if (!soma_obj_type) {
-                    assert(
-                        false &&
+                    throw TileDBSOMAError(
                         "Unreachable code: The missing soma_object_type case "
                         "is already handled. This indicates an "
                         "unexpected failure to catch exceptions by "
@@ -114,8 +113,7 @@ void load_soma_array(py::module& m) {
                 else if (soma_obj_type == "somadensendarray")
                     return py::cast(SOMADenseNDArray(*new_array));
 
-                assert(
-                    false &&
+                throw TileDBSOMAError(
                     "Unreachable code: All possible SOMA object types are "
                     "already handled. This indicates a logic error or an "
                     "unexpected failure to catch exceptions by "

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2061,3 +2061,11 @@ def test_reopen_metadata_sc61118(tmp_path):
         A1.metadata["foo"] = "bar"
         with A1.reopen(mode="r") as A2:
             assert dict(A1.metadata) == dict(A2.metadata)
+
+
+def test_reopen_shape_sc61123(tmp_path):
+    uri = tmp_path.as_posix()
+    with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A:
+        assert A.shape == (10,)
+        A = A.reopen(mode="r")
+        assert A.shape == (10,)

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2067,5 +2067,7 @@ def test_reopen_shape_sc61123(tmp_path):
     uri = tmp_path.as_posix()
     with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A:
         assert A.shape == (10,)
+        assert isinstance(A, soma.SparseNDArray)
         A = A.reopen(mode="r")
         assert A.shape == (10,)
+        assert isinstance(A, soma.SparseNDArray)


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61123](https://app.shortcut.com/tiledb-inc/story/61123/python-reopening-sparsendarray-removes-shape-attribute)]

The `reopen` method returns a `SOMAArray`. The `shape` attribute exists only on the `NDArray` classes, not for all `SOMArray` classes. Calling `reopen` on a `SparseNDArray` returned a `SOMAArray`, so calling `shape` yielded this error: 
```
AttributeError: 'tiledbsoma.pytiledbsoma.SOMAArray' object has no attribute 'shape'
```

**Changes:**

Refactor the Pybind11 `SOMAArray.reopen` to be a factory method which correctly casts the `SOMAArray` object to the correct child class according to the `soma_object_type` metadata value.

**Notes for Reviewer:**

On top of https://github.com/single-cell-data/TileDB-SOMA/pull/3775.