### PR TITLE
[r/ci] Test on both MacOS architectures

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -36,8 +36,11 @@ jobs:
           - name: linux
             os: ubuntu-24.04
             covr: 'no'
-          - name: macos
+          - name: macos (arm)
             os: macOS-latest
+            covr: 'no'
+          - name: macos (x86)
+            os: macOS-13
             covr: 'no'
           - name: coverage
             os: ubuntu-24.04


### PR DESCRIPTION
This reproduces the problem we see on r-universe when building for x86-64 macos, where `std::format`  is unavailable.

The [xcode cpp feature table](https://developer.apple.com/xcode/cpp/) shows that `std::format` requires `xcode 15.3`, which is [only available for MacOS-14 and up](https://developer.apple.com/support/xcode/) because the libc++ runtime version that ships with macos-13 is too old. However, macos-13 is [the last version of macos to run on x86 (Intel) architecture](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) on GitHub actions.  

So if you want to support Intel Mac, you need to some how condition `std::format` on the libc++ version.