### PR TITLE
[python] Fix memory usage in `nnz_slow`

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -518,6 +518,7 @@ uint64_t SOMAArray::_nnz_slow() {
     uint64_t total_cell_num = 0;
     auto sr = SOMAArray::open(OpenMode::read, uri_, ctx_, timestamp_);
     auto mq = ManagedQuery(*sr, ctx_->tiledb_ctx(), "count_cells");
+    mq.select_columns({schema_->domain().dimension(0).name()});
     while (auto batch = mq.read_next()) {
         total_cell_num += (*batch)->num_rows();
     }


### PR DESCRIPTION
**Issue and/or context:** Fixes a scaling issue found on an 800K x 38K experiment. [[sc-64476]](https://app.shortcut.com/tiledb-inc/story/64476/exp-obs-count-yields-error-with-1-16-0#activity-64528)


**Changes:**

PR #3735 had an unintended omission:

* Before: a column-select to reduce memory consumption https://github.com/single-cell-data/TileDB-SOMA/blob/96e08e8ca9e379b42b0df97de4b46235d4facdb5/libtiledbsoma/src/soma/soma_array.cc#L632 
* After: the column-select was omitted https://github.com/single-cell-data/TileDB-SOMA/blob/d8a60e6192116f8e867f82ebaffcc50e4caf75b5/libtiledbsoma/src/soma/soma_array.cc#L512-L517

This PR restores the column-select statement. (Solution thanks to @nguyenv .)

**Notes for Reviewer:**

