### PR TITLE
[r] Skip {testthat} test if SeuratObject is not installed

### DIFF
--- a/apis/r/tests/testthat/test-13-write-soma-objects.R
+++ b/apis/r/tests/testthat/test-13-write-soma-objects.R
@@ -377,6 +377,8 @@ test_that("write_soma.character scalar", {
 })
 
 test_that("get_{some,tiledb}_object_type", {
+  skip_if_not_installed("SeuratObject", minimum_version = .MINIMUM_SEURAT_VERSION("c"))
+
   suppressMessages({
     library(SeuratObject)
     library(tiledbsoma)


### PR DESCRIPTION
**Issue and/or context:**
While adding the R tests to the conda feedstock (https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/294, https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/295), I discovered a single test that requires {SeuratObject} to be installed but wasn't protected by `skip_if_not_installed()`. The test was added in https://github.com/single-cell-data/TileDB-SOMA/commit/0c9be67f1fad7f2ed0a2f3a065951f61ad3238ac via https://github.com/single-cell-data/TileDB-SOMA/pull/2833.

**Changes:**

I added the missing `skip_if_not_installed()`

**Notes for Reviewer:**

I tested this by installing r-tiledbsoma into a conda env and then running the local tests in `apis/r/tests/`

```sh
mamba create --yes -n soma-testthat -c conda-forge -c tiledb \
  r-testthat r-tiledbsoma
mamba activate soma-testthat
mamba list | grep tiledb
## libtiledbsoma                     1.16.1        he4be59c_0            tiledb
## r-tiledb                          0.31.0        r44h84d6215_0         conda-forge
## r-tiledbsoma                      1.16.1        r44hd2a4b20_0         tiledb
## tiledb                            2.27.2        h9edfc3c_3            conda-forge
R
```
```R
testthat::test_file("apis/r/tests/testthat.R")
## ── Failed tests ──────────────────────────────────────────────────────────────────────────────────────────────
## Error (test-13-write-soma-objects.R:381:5): get_{some,tiledb}_object_type
## <packageNotFoundError/error/condition>
## Error in `library(SeuratObject)`: there is no package called ‘SeuratObject’
## Backtrace:
##     ▆
##  1. ├─base::suppressMessages(...) at test-13-write-soma-objects.R:380:3
##  2. │ └─base::withCallingHandlers(...)
##  3. └─base::library(SeuratObject) at test-13-write-soma-objects.R:381:5
##
## [ FAIL 1 | WARN 0 | SKIP 143 | PASS 1043 ]
## [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
##
## ── Error (testthat.R:5:1): (code run outside of `test_that()`) ─────────────────
## Error: Test failures
## Backtrace:
##     ▆
##  1. └─testthat::test_check("tiledbsoma", reporter = ParallelProgressReporter) at testthat.R:5:1
##  2.   └─testthat::test_dir(...)
##  3.     └─testthat:::test_files(...)
##  4.       └─testthat:::test_files_serial(...)
##  5.         └─testthat:::test_files_check(...)
## [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]

# Skipped via skip_if_not_installed()
testthat::test_file("apis/r/tests/testthat.R")
## • {SeuratObject} is not installed (1): test-13-write-soma-objects.R:380:3
##
## [ FAIL 0 | WARN 0 | SKIP 144 | PASS 1043 ]
##  Done!
```


