### PR TITLE
[c++] Extract `get_enumeration` helper

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -950,17 +950,9 @@ bool ManagedQuery::_extend_enumeration(
     // {index name}_{value dtype}. Prior to 1.16, enum labels are the same as
     // the index name. If the new format doesn't work then fall back to the old
     // format
-    Enumeration enmr = [&]() {
-        try {
-            return ArrayExperimental::get_enumeration(
-                *ctx_,
-                *array_,
-                util::get_enmr_label(index_schema, value_schema));
-        } catch (const std::exception& e) {
-            return ArrayExperimental::get_enumeration(
-                *ctx_, *array_, index_schema->name);
-        }
-    }();
+    Enumeration enmr = util::get_enumeration(
+        ctx_, array_, index_schema, value_schema);
+
     auto value_type = enmr.type();
 
     switch (value_type) {
@@ -1043,17 +1035,8 @@ bool ManagedQuery::_extend_and_evolve_schema(
     // {index name}_{value dtype}. Prior to 1.16, enum labels are the same as
     // the index name. If the new format doesn't work then fall back to the old
     // format
-    Enumeration enmr = [&]() {
-        try {
-            return ArrayExperimental::get_enumeration(
-                *ctx_,
-                *array_,
-                util::get_enmr_label(index_schema, value_schema));
-        } catch (const std::exception& e) {
-            return ArrayExperimental::get_enumeration(
-                *ctx_, *array_, index_schema->name);
-        }
-    }();
+    Enumeration enmr = util::get_enumeration(
+        ctx_, array_, index_schema, value_schema);
     std::vector<ValueType> enums_existing = enmr.as_vector<ValueType>();
 
     // Find any new enumeration values
@@ -1150,17 +1133,8 @@ bool ManagedQuery::_extend_and_evolve_schema<std::string>(
     // {index name}_{value dtype}. Prior to 1.16, enum labels are the same as
     // the index name. If the new format doesn't work then fall back to the old
     // format
-    Enumeration enmr = [&]() {
-        try {
-            return ArrayExperimental::get_enumeration(
-                *ctx_,
-                *array_,
-                util::get_enmr_label(index_schema, value_schema));
-        } catch (const std::exception& e) {
-            return ArrayExperimental::get_enumeration(
-                *ctx_, *array_, index_schema->name);
-        }
-    }();
+    Enumeration enmr = util::get_enumeration(
+        ctx_, array_, index_schema, value_schema);
     std::vector<std::string_view> extend_values;
     size_t total_size = 0;
 

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -92,4 +92,22 @@ std::string get_enmr_label(
     return std::string(index_schema->name) + "_" + format;
 }
 
+Enumeration get_enumeration(
+    std::shared_ptr<Context> ctx,
+    std::shared_ptr<Array> arr,
+    ArrowSchema* index_schema,
+    ArrowSchema* value_schema) {
+    try {
+        // New-style names of the form {attr_name}_{arrow_format}, e.g. "foo_U"
+        // for attributes written by tiledbsoma >= 1.16.0
+        return ArrayExperimental::get_enumeration(
+            *ctx, *arr, util::get_enmr_label(index_schema, value_schema));
+    } catch (const std::exception& e) {
+        // Old-style names of the form {attr_name}, e.g. "foo"
+        // for attributes written by tiledbsoma < 1.16.0
+        return ArrayExperimental::get_enumeration(
+            *ctx, *arr, index_schema->name);
+    }
+}
+
 };  // namespace tiledbsoma::util

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -80,6 +80,20 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
 std::string get_enmr_label(
     ArrowSchema* index_schema, ArrowSchema* value_schema);
 
+/**
+ * Given the Arrow index and value schemas for a column of enumerated
+ * type, returns the core enumeration for that column. Throws if this
+ * cannot be found. Handles new-style names of the form
+ * {attr_name}_{arrow_format}, e.g. "foo_U" for columns written by
+ * tiledbsoma >= 1.16.0 as well as old-style names of the form {attr_name},
+ * e.g. "foo" for attributes written by tiledbsoma < 1.16.0.
+ */
+Enumeration get_enumeration(
+    std::shared_ptr<Context> ctx_,
+    std::shared_ptr<Array> array_,
+    ArrowSchema* index_schema,
+    ArrowSchema* value_schema);
+
 }  // namespace tiledbsoma::util
 
 #endif


### PR DESCRIPTION
**Issue and/or context:** In the vein of #3783: a line-count-reducing PR split out from #3784.

**Changes:** Consolidate the three try-catch blocks into a single helper. On #3784 there will be a fourth callsite, and I didn't want a fourth try-catch.

**Notes for Reviewer:**

