### PR TITLE
[c++] Fix some compiler warnings

### DIFF
--- a/libtiledbsoma/src/soma/soma_transformers.cc
+++ b/libtiledbsoma/src/soma/soma_transformers.cc
@@ -90,9 +90,8 @@ OutlineTransformer::_cast_polygon_vertex_list_to_wkb(
         const auto axis = coordinate_space.axis(i);
 
         // Min spatial axis
-        arrays.push_back(std::move(std::make_unique<ArrowArray>(ArrowArray{})));
-        schemas.push_back(
-            std::move(std::make_unique<ArrowSchema>(ArrowSchema{})));
+        arrays.push_back(std::make_unique<ArrowArray>(ArrowArray{}));
+        schemas.push_back(std::make_unique<ArrowSchema>(ArrowSchema{}));
         NANOARROW_THROW_NOT_OK(ArrowArrayInitFromType(
             arrays.back().get(), ArrowType::NANOARROW_TYPE_DOUBLE));
         NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -156,7 +156,7 @@ void ArrowAdapter::release_array(struct ArrowArray* array) {
         // Dictionary arrays are allocated differently than data arrays
         // We need to free the buffers one at a time, then we can call the
         // release schema to continue the cleanup properly
-        for (size_t i = 0; i < array->dictionary->n_buffers; ++i) {
+        for (int64_t i = 0; i < array->dictionary->n_buffers; ++i) {
             if (array->dictionary->buffers[i] != nullptr) {
                 free(const_cast<void*>(array->dictionary->buffers[i]));
                 array->dictionary->buffers[i] = nullptr;


### PR DESCRIPTION
**Issue and/or context:** Drive-by improvements found while working on #3784 for #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471)

**Changes:**

Eliminate these warnings (found with `clang` on MacOS):

```
/Users/kerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/soma/soma_transformers.cc:93:26: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
   93 |         arrays.push_back(std::move(std::make_unique<ArrowArray>(ArrowArray{})));
      |                          ^
/Users/kerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/soma/soma_transformers.cc:93:26: note: remove std::move call here
   93 |         arrays.push_back(std::move(std::make_unique<ArrowArray>(ArrowArray{})));
      |                          ^~~~~~~~~~                                          ~
/Users/kerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/soma/soma_transformers.cc:95:13: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
   95 |             std::move(std::make_unique<ArrowSchema>(ArrowSchema{})));
      |             ^
/Users/kerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/soma/soma_transformers.cc:95:13: note: remove std::move call here
   95 |             std::move(std::make_unique<ArrowSchema>(ArrowSchema{})));
      |             ^~~~~~~~~~                                            ~
2 warnings generated.
...
/Users/kerl/git/single-cell-data/TileDB-SOMA/libtiledbsoma/src/utils/arrow_adapter.cc:159:30: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int64_t' (aka 'long long') [-Wsign-compare]
  159 |         for (size_t i = 0; i < array->dictionary->n_buffers; ++i) {
      |                            ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

**Notes for Reviewer:**

