### PR TITLE
[c++] Some name-clarifies in `managed_query.cc`

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -698,7 +698,7 @@ class ManagedQuery {
                 ctx_, array_, schema, schema->dictionary);
 
             // Return whether we extended the enumeration for this attribute
-            return _extend_enumeration(
+            return _extend_and_write_enumeration(
                 schema->dictionary,  // value schema
                 array->dictionary,   // value array
                 schema,              // index schema
@@ -725,7 +725,7 @@ class ManagedQuery {
     }
 
     template <typename ValueType>
-    bool _extend_and_evolve_schema(
+    bool _extend_and_evolve_schema_and_write(
         ArrowSchema* value_schema,
         ArrowArray* value_array,
         ArrowSchema* index_schema,
@@ -938,7 +938,7 @@ class ManagedQuery {
             _cast_validity_buffer(index_array));
     }
 
-    bool _extend_enumeration(
+    bool _extend_and_write_enumeration(
         ArrowSchema* value_schema,
         ArrowArray* value_array,
         ArrowSchema* index_schema,
@@ -1039,7 +1039,7 @@ bool ManagedQuery::_cast_column_aux<bool>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se);
 
 template <>
-bool ManagedQuery::_extend_and_evolve_schema<std::string>(
+bool ManagedQuery::_extend_and_evolve_schema_and_write<std::string>(
     ArrowSchema* value_schema,
     ArrowArray* value_array,
     ArrowSchema* index_schema,


### PR DESCRIPTION
**Issue and/or context:** Split out from #3815 for #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471)

**Changes:**

* Commit 1:
  * Rename `_extend_and_evolve_schema` to `_extend_and_evolve_schema_and_write`, since this is what it does
    * On #3815 there will be a method `_extend_and_evolve_schema` which will extend and evolve the schema without doing a write
  * Similarly, `_extend_enumeration` to `_extend_and_write_enumeration`
  * Change the name of some local variables which operate only on enum values (e.g. vector of string) to have the name `enum_values` -- as a confusion-reducer since `enums` are mappings from things like int to string
* Commit 2:
  * Within `managed_query.cc`, put the `<std::string>` template specializations before the generic `<ValueType>` variant. This is important for cognitive load, since enum-of-string is by far the most important case. The reader must encounter our hash-map-accelerated lookup for strings on first read.

**Notes for Reviewer:**

