### PR TITLE
[Backport release-1.16][ci] GHAs: don't file issues on re-run failures (#3820)

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -54,7 +54,7 @@ jobs:
   create_issue_on_fail:
     runs-on: ubuntu-24.04
     needs: [docker]
-    if: (failure() || cancelled()) && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule' && github.run_attempt == 1
     steps:
       - name: Checkout TileDB-SOMA `main`
         uses: actions/checkout@v4

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -248,10 +248,10 @@ jobs:
   create_issue_on_fail:
     runs-on: ubuntu-24.04
     needs: [smoke-test, publish-to-test-pypi, publish-to-pypi]
-    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
+    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch' && github.run_attempt == 1
     steps:
       - name: Checkout TileDB-SOMA `main`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Issue if Build Fails
         uses: JasonEtco/create-an-issue@v2
         env:

--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -113,10 +113,10 @@ jobs:
   create_issue_on_fail:
     runs-on: ubuntu-24.04
     needs: [ci]
-    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
+    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch' && github.run_attempt == 1
     steps:
       - name: Checkout TileDB-SOMA `main`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Issue if Build Fails
         uses: JasonEtco/create-an-issue@v2
         env:


### PR DESCRIPTION
When nightly GHAs fail, often our first move is to try re-running, but this can result in duplicate issues being filed, e.g.:

- https://github.com/single-cell-data/TileDB-SOMA/issues/3808
- https://github.com/single-cell-data/TileDB-SOMA/issues/3809
- https://github.com/single-cell-data/TileDB-SOMA/issues/3810

This only files an issue when the 1st "attempt" fails

**Issue and/or context:**

**Changes:**

**Notes for Reviewer:**

Backport of #3820 from `main` to `release-1.16`

