### PR TITLE
[python] Directly read Visium table instead of filtering through AnnData

### DIFF
--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -455,14 +455,8 @@ def from_visium(
         )
     logging.log_io(None, _util.format_elapsed(start_time, "FINISHED READING"))
 
-    # Deduplicate obs and var names.
-    start_time = _util.get_start_stamp()
-    logging.log_io(None, "START  DECATEGORICALIZING")
-    anndata.obs_names_make_unique()
-    anndata.var_names_make_unique()
-    logging.log_io(None, _util.format_elapsed(start_time, "FINISH DECATEGORICALIZING"))
-
-    # Create registration mapping if none was provided.
+    # Create registration mapping if none was provided and get obs/var data needed
+    # for spatial indexing.
     if registration_mapping is None:
         joinid_maps = ExperimentIDMapping.from_isolated_anndata(
             anndata, measurement_name=measurement_name

--- a/apis/python/tests/test_from_visium.py
+++ b/apis/python/tests/test_from_visium.py
@@ -97,7 +97,7 @@ def test_visium_paths_v2(visium_v2_path):
 def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
     """Test `from_visium` runs without error."""
     PIL = pytest.importorskip("PIL")
-    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_v2"
+    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_v1"
     exp_uri = spatial_io.from_visium(
         uri,
         visium_v1_path,
@@ -108,10 +108,26 @@ def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
     )
     with soma.Experiment.open(exp_uri) as exp:
 
-        # Check for the existance of obs, RNA/X, and RNA/var
+        # Check obs schema and domain.
         assert isinstance(exp.obs, soma.DataFrame)
+        obs_data = exp.obs.read().concat().to_pandas()
+        assert obs_data.columns.tolist() == ["soma_joinid", "obs_id"]
+        assert len(obs_data) == 4035
+
+        # Check RNA/X.
         assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
+
+        # Check RNA/var.
         assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
+        var_data = exp.ms["RNA"].var.read().concat().to_pandas()
+        assert var_data.columns.tolist() == [
+            "soma_joinid",
+            "var_id",
+            "gene_ids",
+            "feature_types",
+            "genome",
+        ]
+        len(var_data) == 1
 
         # Check for the existance of the presence matrices.
         assert isinstance(exp.obs_spatial_presence, soma.DataFrame)
@@ -193,14 +209,26 @@ def test_from_visium_for_visium_v2(tmp_path, visium_v2_path):
     )
     with soma.Experiment.open(exp_uri) as exp:
 
-        # Check for the existance of obs, RNA/X, and RNA/var
+        # Check obs schema and domain.
         assert isinstance(exp.obs, soma.DataFrame)
-        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
-        assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
+        obs_data = exp.obs.read().concat().to_pandas()
+        assert obs_data.columns.tolist() == ["soma_joinid", "obs_id"]
+        assert len(obs_data) == 2797
 
-        # Check for the existance of the presence matrices.
-        assert isinstance(exp.obs_spatial_presence, soma.DataFrame)
-        assert isinstance(exp.ms["RNA"].var_spatial_presence, soma.DataFrame)
+        # Check RNA/X.
+        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
+
+        # Check RNA/var.
+        assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
+        var_data = exp.ms["RNA"].var.read().concat().to_pandas()
+        assert var_data.columns.tolist() == [
+            "soma_joinid",
+            "var_id",
+            "gene_ids",
+            "feature_types",
+            "genome",
+        ]
+        len(var_data) == 19465
 
         # Define some expected data.
         pixel_coord_space = soma.CoordinateSpace(

--- a/apis/python/tests/test_from_visium.py
+++ b/apis/python/tests/test_from_visium.py
@@ -3,6 +3,8 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+import scanpy
+import scipy.sparse as sp
 
 import tiledbsoma as soma
 
@@ -94,28 +96,62 @@ def test_visium_paths_v2(visium_v2_path):
 
 
 @pytest.mark.slow
-def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_from_visium(tmp_path, version, visium_v1_path, visium_v2_path):
     """Test `from_visium` runs without error."""
     PIL = pytest.importorskip("PIL")
-    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_v1"
+
+    if version == "v1":
+        scene_name = "human_lymph_node"
+        expected_scale_factors = np.array([0.170105, 0.170111], dtype=np.float64)
+        visium_dir_path = visium_v1_path
+        loc_path = visium_v1_path / "filtered_visium1_loc.csv"
+    elif version == "v2":
+        scene_name = "fresh_frozen_mouse_brain"
+        expected_scale_factors = np.array([0.150015, 0.150015], dtype=np.float64)
+        visium_dir_path = visium_v2_path
+        loc_path = visium_v2_path / "filtered_visium2_loc.csv"
+    else:
+        raise AssertionError(f"Version should be 'v1' or 'v2': got {version}")
+
+    # Get input data and open AnnData for comparisons.
+    visium_paths = spatial_io.VisiumPaths.from_base_folder(visium_dir_path)
+    adata = scanpy.read_10x_h5(visium_paths.gene_expression)
+
+    # Set URI for output data.
+    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_{version}"
+    visium_paths = spatial_io.VisiumPaths.from_base_folder(visium_dir_path)
+
+    # Create Visium Experiment for testing.
     exp_uri = spatial_io.from_visium(
         uri,
-        visium_v1_path,
+        visium_paths,
         "RNA",
-        "human_lymph_node",
+        scene_name,
         write_obs_spatial_presence=True,
         write_var_spatial_presence=True,
     )
+
+    # Verify Visium Experiment has expected data.
     with soma.Experiment.open(exp_uri) as exp:
+
+        # Check a chunk of RNA/X.
+        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
+        X_data = exp.ms["RNA"].X["data"].read().coos().concat().to_numpy()
+        X_actual = sp.csr_matrix(
+            (X_data[0][:, 0], (X_data[1][:, 0], X_data[1][:, 1])),
+            shape=exp.ms["RNA"].X["data"].shape,
+        )
+        np.testing.assert_equal(X_actual.data, adata.X.data)
+        np.testing.assert_equal(X_actual.indices, adata.X.indices)
+        np.testing.assert_equal(X_actual.indptr, adata.X.indptr)
 
         # Check obs schema and domain.
         assert isinstance(exp.obs, soma.DataFrame)
         obs_data = exp.obs.read().concat().to_pandas()
         assert obs_data.columns.tolist() == ["soma_joinid", "obs_id"]
-        assert len(obs_data) == 4035
-
-        # Check RNA/X.
-        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
+        assert len(obs_data) == len(adata.obs)
+        assert set(obs_data.obs_id) == set(adata.obs.index)
 
         # Check RNA/var.
         assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
@@ -127,7 +163,11 @@ def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
             "feature_types",
             "genome",
         ]
-        len(var_data) == 1
+        assert len(var_data) == len(adata.var)
+        # assert set(var_data.var_id) == set(adata.var.index) # anndata chances the names
+        assert set(var_data.gene_ids) == set(adata.var.gene_ids)
+        assert set(var_data.feature_types) == set(adata.var.feature_types)
+        assert set(var_data.genome) == set(adata.var.genome)
 
         # Check for the existance of the presence matrices.
         assert isinstance(exp.obs_spatial_presence, soma.DataFrame)
@@ -139,8 +179,8 @@ def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
         )
 
         # Check the scene exists and has the desired metadata.
-        assert isinstance(exp.spatial["human_lymph_node"], soma.Scene)
-        scene = exp.spatial["human_lymph_node"]
+        assert isinstance(exp.spatial[scene_name], soma.Scene)
+        scene = exp.spatial[scene_name]
         assert scene.coordinate_space == pixel_coord_space
 
         # Check the scene subcollections:
@@ -165,127 +205,24 @@ def test_from_visium_for_visium_v1(tmp_path, visium_v1_path):
         assert img_transform.input_axes == ("x", "y")
         assert img_transform.output_axes == ("x", "y")
         np.testing.assert_allclose(
-            img_transform.scale_factors,
-            np.array([0.170105, 0.170111], dtype=np.float64),
-            atol=0.000001,
+            img_transform.scale_factors, expected_scale_factors, atol=0.000001
         )
 
         # Check spot locations.
         loc = scene.obsl["loc"]
         assert loc.coordinate_space == pixel_coord_space
         actual_loc_data = loc.read().concat().to_pandas()
-        expected_loc_data = pd.read_csv(visium_v1_path / "filtered_visium1_loc.csv")
+        expected_loc_data = pd.read_csv(loc_path)
         pd.testing.assert_frame_equal(actual_loc_data, expected_loc_data)
 
         # Check tissue image.
         image = scene.img["tissue"]
         assert image.coordinate_space == pixel_coord_space
         hires_data = np.moveaxis(image["hires"].read().to_numpy(), 0, -1)
-        with PIL.Image.open(
-            visium_v1_path / "spatial" / "tissue_hires_image.png"
-        ) as input_hires:
+        with PIL.Image.open(visium_paths.hires_image) as input_hires:
             expected = np.array(input_hires)
             np.testing.assert_equal(expected, hires_data)
         lowres_data = np.moveaxis(image["lowres"].read().to_numpy(), 0, -1)
-        with PIL.Image.open(
-            visium_v1_path / "spatial" / "tissue_lowres_image.png"
-        ) as input_lowres:
-            expected = np.array(input_lowres)
-            np.testing.assert_equal(expected, lowres_data)
-
-
-@pytest.mark.slow
-def test_from_visium_for_visium_v2(tmp_path, visium_v2_path):
-    """Test `from_visium` runs without error."""
-    PIL = pytest.importorskip("PIL")
-    uri = f"{tmp_path.as_uri()}/from_visium_for_visium_v2"
-    exp_uri = spatial_io.from_visium(
-        uri,
-        visium_v2_path,
-        "RNA",
-        "fresh_frozen_mouse_brain",
-        write_obs_spatial_presence=True,
-        write_var_spatial_presence=True,
-    )
-    with soma.Experiment.open(exp_uri) as exp:
-
-        # Check obs schema and domain.
-        assert isinstance(exp.obs, soma.DataFrame)
-        obs_data = exp.obs.read().concat().to_pandas()
-        assert obs_data.columns.tolist() == ["soma_joinid", "obs_id"]
-        assert len(obs_data) == 2797
-
-        # Check RNA/X.
-        assert isinstance(exp.ms["RNA"].X["data"], soma.SparseNDArray)
-
-        # Check RNA/var.
-        assert isinstance(exp.ms["RNA"].var, soma.DataFrame)
-        var_data = exp.ms["RNA"].var.read().concat().to_pandas()
-        assert var_data.columns.tolist() == [
-            "soma_joinid",
-            "var_id",
-            "gene_ids",
-            "feature_types",
-            "genome",
-        ]
-        len(var_data) == 19465
-
-        # Define some expected data.
-        pixel_coord_space = soma.CoordinateSpace(
-            (soma.Axis("x", "pixels"), soma.Axis("y", "pixels"))
-        )
-
-        # Check the scene exists and has the desired metadata.
-        assert isinstance(exp.spatial["fresh_frozen_mouse_brain"], soma.Scene)
-        scene = exp.spatial["fresh_frozen_mouse_brain"]
-        assert scene.coordinate_space == pixel_coord_space
-
-        # Check the scene subcollections:
-        # - `obsl` only has a point cloud dataframe named `loc`,
-        # - `varl` is empty,
-        # - `img` only has a multiscale image named `tissue`.
-        assert len(scene.obsl.items()) == 1
-        assert isinstance(scene.obsl["loc"], soma.PointCloudDataFrame)
-        assert len(scene.varl.items()) == 0
-        assert len(scene.img.items()) == 1
-        assert isinstance(scene.img["tissue"], soma.MultiscaleImage)
-
-        # Check transform to `loc`.
-        loc_transform = scene.get_transform_to_point_cloud_dataframe("loc", "obsl")
-        assert isinstance(loc_transform, soma.IdentityTransform)
-        assert loc_transform.input_axes == ("x", "y")
-        assert loc_transform.output_axes == ("x", "y")
-
-        # Check transform to `img`.
-        img_transform = scene.get_transform_to_multiscale_image("tissue", "img")
-        assert isinstance(img_transform, soma.ScaleTransform)
-        assert img_transform.input_axes == ("x", "y")
-        assert img_transform.output_axes == ("x", "y")
-        np.testing.assert_allclose(
-            img_transform.scale_factors,
-            np.array([0.150015, 0.150015], dtype=np.float64),
-            atol=0.000001,
-        )
-
-        # Check point cloud dataframe data.
-        loc = scene.obsl["loc"]
-        assert loc.coordinate_space == pixel_coord_space
-        actual_loc_data = loc.read().concat().to_pandas()
-        expected_loc_data = pd.read_csv(visium_v2_path / "filtered_visium2_loc.csv")
-        pd.testing.assert_frame_equal(actual_loc_data, expected_loc_data)
-
-        # Check image.
-        image = scene.img["tissue"]
-        assert image.coordinate_space == pixel_coord_space
-        hires_data = np.moveaxis(image["hires"].read().to_numpy(), 0, -1)
-        with PIL.Image.open(
-            visium_v2_path / "spatial" / "tissue_hires_image.png"
-        ) as input_hires:
-            expected = np.array(input_hires)
-            np.testing.assert_equal(expected, hires_data)
-        lowres_data = np.moveaxis(image["lowres"].read().to_numpy(), 0, -1)
-        with PIL.Image.open(
-            visium_v2_path / "spatial" / "tissue_lowres_image.png"
-        ) as input_lowres:
+        with PIL.Image.open(visium_paths.lowres_image) as input_lowres:
             expected = np.array(input_lowres)
             np.testing.assert_equal(expected, lowres_data)


### PR DESCRIPTION
**Issue and/or context:** 
* [sc-63795](https://app.shortcut.com/tiledb-inc/story/63795/remove-anndata-generation-step)
* [sc-56837](https://app.shortcut.com/tiledb-inc/story/56837/add-logging-to-the-visium-ingestor)

**Changes:**
* Directly read data from 10x HDF5 instead of opening it with AnnData.
* (bug fix) Add `platform_config` to spatial array creation.

