### PR TITLE
[c++] Some error-message regularization

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -549,7 +549,7 @@ bool ManagedQuery::_cast_column(
     if (has_attr && attr_has_enum(schema->name)) {
         if (schema->dictionary == nullptr || array->dictionary == nullptr) {
             throw std::invalid_argument(
-                "[SOMAArray] " + std::string(schema->name) +
+                "[ManagedQuery] " + std::string(schema->name) +
                 " requires dictionary entry");
         }
     }
@@ -988,7 +988,7 @@ bool ManagedQuery::_extend_and_write_enumeration(
                 value_schema, value_array, index_schema, index_array, enmr, se);
         default:
             throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
+                "[ManagedQuery] Unsupported TileDB dict datatype: {} ",
                 tiledb::impl::type_to_str(value_type)));
     }
 }
@@ -1288,8 +1288,8 @@ std::vector<uint8_t> ManagedQuery::_cast_bool_data(
     ArrowSchema* schema, ArrowArray* array) {
     if (strcmp(schema->format, "b") != 0) {
         throw TileDBSOMAError(fmt::format(
-            "_cast_bit_to_uint8 expected column format to be 'b' but saw "
-            "{}",
+            "[ManagedQuery::_cast_bool_data] expected column format to be 'b' "
+            "but saw {}",
             schema->format));
     }
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1034,8 +1034,7 @@ std::vector<int64_t> SOMAArray::_shape_via_tiledb_current_domain() {
     if (current_domain.is_empty()) {
         throw TileDBSOMAError(
             "Internal error: current domain requested for an array which "
-            "does "
-            "not support it");
+            "does not support it");
     }
 
     auto t = current_domain.type();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -973,7 +973,7 @@ class SOMAArray : public SOMAObject {
         if (new_lo_hi.size() != 2) {
             throw TileDBSOMAError(
                 "internal coding error detected at "
-                "_can_set_dataframe_domainish_slot_checker");
+                "_can_set_dataframe_domainish_slot_checker_non_string");
         }
 
         const T& old_lo = old_lo_hi.first;
@@ -1036,7 +1036,7 @@ class SOMAArray : public SOMAObject {
         if (new_lo_hi.size() != 2) {
             throw TileDBSOMAError(
                 "internal coding error detected at "
-                "_can_set_dataframe_domainish_slot_checker");
+                "_can_set_dataframe_domainish_slot_checker_string");
         }
 
         const std::string& new_lo = new_lo_hi[0];

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -1129,7 +1129,7 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema(
 
     if (array->length != 5) {
         throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
+            "[ArrowAdapter] unexpected length {} != 5 for name "
             "'{}'",
             array->length,
             col_name));
@@ -1177,7 +1177,7 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
 
     if (array->length != 5) {
         throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
+            "[ArrowAdapter] unexpected length {} != 5 for name "
             "'{}'",
             array->length,
             col_name));
@@ -1242,7 +1242,7 @@ ArrowAdapter::tiledb_attribute_from_arrow_schema(
 inline void exitIfError(const ArrowErrorCode ec, const std::string& msg) {
     if (ec != NANOARROW_OK)
         throw TileDBSOMAError(
-            fmt::format("ArrowAdapter: Arrow Error {} ", msg));
+            fmt::format("[ArrowAdapter] Arrow Error {} ", msg));
 }
 
 std::pair<std::unique_ptr<ArrowArray>, std::unique_ptr<ArrowSchema>>
@@ -1442,7 +1442,7 @@ std::string_view ArrowAdapter::to_arrow_format(
         return _to_arrow_format_map.at(tiledb_dtype);
     } catch (const std::out_of_range& e) {
         throw std::out_of_range(fmt::format(
-            "ArrowAdapter: Unsupported TileDB type: {} ",
+            "[ArrowAdapter] Unsupported TileDB type: {} ",
             tiledb::impl::type_to_str(tiledb_dtype)));
     }
 }
@@ -1476,7 +1476,7 @@ tiledb_datatype_t ArrowAdapter::to_tiledb_format(
         return dtype;
     } catch (const std::out_of_range& e) {
         throw std::out_of_range(fmt::format(
-            "ArrowAdapter: Unsupported Arrow type: {} ", arrow_dtype));
+            "[ArrowAdapter] Unsupported Arrow type: {} ", arrow_dtype));
     }
 }
 
@@ -1524,7 +1524,7 @@ enum ArrowType ArrowAdapter::to_nanoarrow_type(std::string_view sv) {
         return NANOARROW_TYPE_LARGE_BINARY;
     else
         throw TileDBSOMAError(
-            fmt::format("ArrowAdapter: Unsupported Arrow format: {} ", sv));
+            fmt::format("[ArrowAdapter] Unsupported Arrow format: {} ", sv));
 }
 
 std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
@@ -1535,7 +1535,8 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
 
     if (num_names != num_types) {
         throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter::make_arrow_schema: internal coding error: num_types "
+            "[ArrowAdapter::make_arrow_schema] internal coding error: "
+            "num_types "
             "{} != num_names {}",
             num_names,
             num_types));
@@ -1666,7 +1667,7 @@ void ArrowAdapter::_check_shapes(
     ArrowArray* arrow_array, ArrowSchema* arrow_schema) {
     if (arrow_array->n_children != arrow_schema->n_children) {
         throw std::runtime_error(
-            "ArrowAdapter::_check_shapes: internal coding error: data/schema "
+            "[ArrowAdapter::_check_shapes] internal coding error: data/schema "
             "mismatch");
     }
     for (int64_t i = 0; i < arrow_array->n_children; i++) {
@@ -1683,7 +1684,7 @@ int64_t ArrowAdapter::_get_column_index_from_name(
 
     if (arrow_schema->n_children == 0) {
         throw std::runtime_error(
-            "ArrowAdapter::_check_shapes: internal coding error: childless "
+            "[ArrowAdapter::_check_shapes] internal coding error: childless "
             "table");
     }
 
@@ -1694,7 +1695,7 @@ int64_t ArrowAdapter::_get_column_index_from_name(
     }
 
     throw std::runtime_error(fmt::format(
-        "ArrowAdapter::_check_shapes: column {} not found", column_name));
+        "[ArrowAdapter::_check_shapes] column {} not found", column_name));
 }
 
 ArrowArray* ArrowAdapter::_get_and_check_column(
@@ -1704,7 +1705,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     ArrowArray* arrow_array = arrow_table.first.get();
     if (column_index < 0 || column_index >= arrow_array->n_children) {
         throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: column index {} out of "
+            "[ArrowAdapter::_get_and_check_column] column index {} out of "
             "bounds {}..{}",
             column_index,
             0,
@@ -1715,7 +1716,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
 
     if (child->n_children != 0) {
         throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: column index {} is "
+            "[ArrowAdapter::_get_and_check_column] column index {} is "
             "non-terminal",
             column_index));
     }
@@ -1723,7 +1724,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     if (expected_n_buffers == 2) {
         if (child->n_buffers != 2) {
             throw std::runtime_error(fmt::format(
-                "ArrowAdapter::_get_and_check_column: column index {} "
+                "[ArrowAdapter::_get_and_check_column] column index {} "
                 "has buffer count {}; expected 2 for non-string data",
                 column_index,
                 child->n_buffers));
@@ -1732,7 +1733,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     } else if (expected_n_buffers == 3) {
         if (child->n_buffers != 3) {
             throw std::runtime_error(fmt::format(
-                "ArrowAdapter::_get_and_check_column: column index {} is "
+                "[ArrowAdapter::_get_and_check_column] column index {} is "
                 "has buffer count {}; expected 3 for string data",
                 column_index,
                 child->n_buffers));
@@ -1740,7 +1741,7 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
 
     } else {
         throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: internal coding error: "
+            "[ArrowAdapter::_get_and_check_column] internal coding error: "
             "expected_n_buffers {} is "
             "neither 2 nor 3.",
             expected_n_buffers));
@@ -1755,7 +1756,7 @@ std::unique_ptr<ArrowArray> ArrowAdapter::arrow_array_insert_at_index(
     int64_t index) {
     if (parent_array->n_children < index || index < 0) {
         throw std::runtime_error(
-            "[ArrowAdapter][arrow_array_insert_at_index] Invalid index to "
+            "[ArrowAdapter::arrow_array_insert_at_index] Invalid index to "
             "insert array");
     }
 
@@ -1790,7 +1791,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_insert_at_index(
     int64_t index) {
     if (parent_schema->n_children < index || index < 0) {
         throw std::runtime_error(
-            "[ArrowAdapter][arrow_schema_insert_at_index] Invalid index to "
+            "[ArrowAdapter::arrow_schema_insert_at_index] Invalid index to "
             "insert schema");
     }
 
@@ -1823,7 +1824,7 @@ std::unique_ptr<ArrowArray> ArrowAdapter::arrow_array_remove_at_index(
     std::unique_ptr<ArrowArray> array, int64_t index) {
     if (array->n_children <= index || index < 0) {
         throw std::runtime_error(
-            "[ArrowAdapter][arrow_array_remove_at_index] Invalid index to "
+            "[ArrowAdapter::arrow_array_remove_at_index] Invalid index to "
             "remove child array");
     }
 
@@ -1846,7 +1847,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_remove_at_index(
     std::unique_ptr<ArrowSchema> schema, int64_t index) {
     if (schema->n_children <= index || index < 0) {
         throw std::runtime_error(
-            "[ArrowAdapter][arrow_schema_remove_at_index] Invalid index to "
+            "[ArrowAdapter::arrow_schema_remove_at_index] Invalid index to "
             "remove child schema");
     }
 
@@ -1933,7 +1934,7 @@ size_t ArrowAdapter::_set_dictionary_buffers(
             return data_size / sizeof(double_t);
         default:
             throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
+                "[ArrowAdapter] Unsupported TileDB dict datatype: {} ",
                 tiledb::impl::type_to_str(enumeration.type())));
     }
 }

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -593,7 +593,8 @@ class ArrowAdapter {
         // if callsites don't use t.
         if (std::is_same_v<T, std::string>) {
             throw std::runtime_error(
-                "ArrowAdapter::make_arrow_array_child: template-specialization "
+                "[ArrowAdapter::make_arrow_array_child] "
+                "template-specialization "
                 "failure.");
         }
 
@@ -731,7 +732,7 @@ class ArrowAdapter {
 
         if (std::is_same_v<T, std::string>) {
             throw std::runtime_error(
-                "SOMAArray::get_table_non_string_column_by_index: "
+                "[ArrowAdapter::get_table_non_string_column_by_index] "
                 "template-specialization failure.");
         }
 
@@ -774,20 +775,19 @@ class ArrowAdapter {
         const ArrowArray* arrow_array) {
         if (arrow_array->n_children != 0) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: expected leaf "
+                "[ArrowAdapter::get_array_non_string_column] expected leaf "
                 "node");
         }
         if (arrow_array->n_buffers != 2) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: expected two "
+                "[ArrowAdapter::get_array_non_string_column] expected two "
                 "buffers");
         }
 
         if (std::is_same_v<T, std::string>) {
             throw std::runtime_error(
-                "SOMAArray::get_array_non_string_column: "
-                "template-specialization "
-                "failure.");
+                "[ArrowAdapter::get_array_non_string_column] "
+                "template-specialization failure.");
         }
 
         // Two-buffer model for non-string data:
@@ -800,18 +800,18 @@ class ArrowAdapter {
         // support arrow-nulls, we can work on that.
         if (arrow_array->buffers[0] != nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: validity buffer "
+                "[ArrowAdapter::get_array_non_string_column] validity buffer "
                 "unsupported here");
         }
         if (arrow_array->buffers[1] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: null data buffer");
+                "[ArrowAdapter::get_array_non_string_column] null data buffer");
         }
 
         const void* vdata = arrow_array->buffers[1];
         if (vdata == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_non_string_column: null data buffer");
+                "[ArrowAdapter::get_array_non_string_column] null data buffer");
         }
 
         const T* data = (T*)vdata;
@@ -834,12 +834,12 @@ class ArrowAdapter {
         const ArrowArray* arrow_array, const ArrowSchema* arrow_schema) {
         if (arrow_array->n_children != 0 || arrow_schema->n_children != 0) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: expected leaf "
+                "[ArrowAdapter::get_array_string_column] expected leaf "
                 "node");
         }
         if (arrow_array->n_buffers != 3) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: expected three "
+                "[ArrowAdapter::get_array_string_column] expected three "
                 "buffers");
         }
 
@@ -854,17 +854,17 @@ class ArrowAdapter {
         // support arrow-nulls, we can work on that.
         if (arrow_array->buffers[0] != nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: validity buffer "
+                "[ArrowAdapter::get_array_string_column] validity buffer "
                 "unsupported here");
         }
         if (arrow_array->buffers[1] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: null "
+                "[ArrowAdapter::get_array_string_column] null "
                 "offsets buffer");
         }
         if (arrow_array->buffers[2] == nullptr) {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: null data "
+                "[ArrowAdapter::get_array_string_column] null data "
                 "buffer");
         }
 
@@ -895,7 +895,7 @@ class ArrowAdapter {
 
         } else {
             throw std::runtime_error(
-                "ArrowAdapter::get_array_string_column: expected "
+                "[ArrowAdapter::get_array_string_column] expected "
                 "Arrow string, large_string, binary, or large_binary");
         }
     }
@@ -923,14 +923,15 @@ class ArrowAdapter {
 
         if (arrow_array->n_children == 0) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_any_column_by_index: expected "
+                "[ArrowAdapter::get_table_any_column_by_index] expected "
                 "non-leaf "
                 "node");
         }
 
         if (arrow_schema->n_children <= column_index) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_any_column_by_index: column index out "
+                "[ArrowAdapter::get_table_any_column_by_index] column index "
+                "out "
                 "of bounds.");
         }
 
@@ -997,13 +998,13 @@ class ArrowAdapter {
 
         if (array->n_children != 0) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_any_column: expected leaf "
+                "[ArrowAdapter::get_table_any_column] expected leaf "
                 "node");
         }
 
         if (array->length < static_cast<int64_t>(S + offset)) {
             throw std::runtime_error(
-                "ArrowAdapter::get_table_any_column: expected at least " +
+                "[ArrowAdapter::get_table_any_column] expected at least " +
                 std::to_string(S + offset) + " elements");
         }
 
@@ -1013,40 +1014,40 @@ class ArrowAdapter {
             strcmp(schema->format, "Z") == 0) {
             if (array->n_buffers != 3) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: expected three "
+                    "[ArrowAdapter::get_table_any_column] expected three "
                     "buffers");
             }
 
             if (array->buffers[0] != nullptr) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: validity buffer "
+                    "[ArrowAdapter::get_table_any_column] validity buffer "
                     "unsupported here");
             }
             if (array->buffers[1] == nullptr) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: null "
+                    "[ArrowAdapter::get_table_any_column] null "
                     "offsets buffer");
             }
             if (array->buffers[2] == nullptr) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: null data "
+                    "[ArrowAdapter::get_table_any_column] null data "
                     "buffer");
             }
         } else {
             if (array->n_buffers != 2) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: expected two "
+                    "[ArrowAdapter::get_table_any_column] expected two "
                     "buffers");
             }
 
             if (array->buffers[0] != nullptr) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: validity buffer "
+                    "[ArrowAdapter::get_table_any_column] validity buffer "
                     "unsupported here");
             }
             if (array->buffers[1] == nullptr) {
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: null data buffer");
+                    "[ArrowAdapter::get_table_any_column] null data buffer");
             }
         }
 
@@ -1156,7 +1157,7 @@ class ArrowAdapter {
                     return std::make_any<std::array<std::string, S>>(result);
                 } else {
                     throw std::runtime_error(
-                        "ArrowAdapter::get_table_any_column: Unknown "
+                        "[ArrowAdapter::get_table_any_column] Unknown "
                         "schema format '" +
                         std::string(schema->format) + "'");
                 }
@@ -1208,14 +1209,14 @@ class ArrowAdapter {
                         result);
                 } else {
                     throw std::runtime_error(
-                        "ArrowAdapter::get_table_any_column: Unknown "
+                        "[ArrowAdapter::get_table_any_column] Unknown "
                         "schema format '" +
                         std::string(schema->format) + "'");
                 }
             } break;
             default:
                 throw std::runtime_error(
-                    "ArrowAdapter::get_table_any_column: Unknown "
+                    "[ArrowAdapter::get_table_any_column] Unknown "
                     "datatype '" +
                     tiledb::impl::type_to_str(tdb_type) + "'");
                 break;


### PR DESCRIPTION
@jp-dark is, I believe, doing a more thorough audit of error messages. This is not that audit. In support of #3784 and 33815 for #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471), I thought I might check that function names within error messages matched the names of the functions they lie within, for a half-dozen source files.