### PR TITLE
[c++] Correctly handle NaN category values

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2370,9 +2370,7 @@ def test_enum_handling_category_of_nan_62449(tmp_path):
             "soma_joinid": [4, 5],
             "A": pa.DictionaryArray.from_arrays(
                 indices=pa.array([1, 0], type=pa.int32()),
-                dictionary=pa.array(
-                    [quiet_nan, signaling_nan], type=pa.float32()
-                ),
+                dictionary=pa.array([quiet_nan, signaling_nan], type=pa.float32()),
             ),
         }
     )

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2365,6 +2365,7 @@ def test_enum_handling_category_of_nan_62449(tmp_path):
         assert len(actual_dict_vals) == 3
         assert nan_check(quiet_nan, actual_dict_vals)
         assert nan_check(negative_nan, actual_dict_vals)
+        assert nan_check(signaling_nan, actual_dict_vals)
         assert_array_equal(expected_data1["A"], actual_data)
 
     # Ensure that the dictionary indexes get shifted correctly when appending

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2322,6 +2322,7 @@ def test_enum_regression_62887(tmp_path):
 def test_enum_handling_category_of_nan_62449(tmp_path):
     uri = tmp_path.as_posix()
 
+    # Different representations of single-precision NaNs
     quiet_nan = struct.unpack(">f", b"\x7f\xc0\x00\x00")[0]
     negative_nan = struct.unpack(">f", b"\xff\xc0\x00\x00")[0]
     signaling_nan = struct.unpack(">f", b"\x7f\x80\x00\x01")[0]

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1,6 +1,7 @@
 import contextlib
 import datetime
 import json
+import math
 import time
 from pathlib import Path
 from typing import Any, Dict, List
@@ -2332,7 +2333,7 @@ def test_enum_handling_category_of_nan_62449(tmp_path):
             "soma_joinid": [0, 1, 2, 3],
             "A": pa.DictionaryArray.from_arrays(
                 indices=pa.array([0, 1, 2, 0], type=pa.int32()),
-                dictionary=pa.array([0.0, 1.0, np.math.nan], type=pa.float32()),
+                dictionary=pa.array([0.0, 1.0, math.nan], type=pa.float32()),
             ),
         }
     )

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1239,20 +1239,11 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     // Find any new enumeration values
     std::vector<ValueType> enum_values_to_add;
     for (auto enum_val : enum_values_in_write) {
-        // Check if the value already exists using bitwise comparison.
-        // - We cannot use std::find because NaN != NaN
-        // - We cannot use std::isnan because TileDB and Arrow treat NaNs with 
-        //   different bit patterns as distinct values
-        bool is_new_value = std::none_of(
-            enum_values_existing.begin(),
-            enum_values_existing.end(),
-            [enum_val](ValueType existing_val) {
-                return std::memcmp(
-                           &enum_val, &existing_val, sizeof(ValueType)) == 0;
-            });
+        // Find the value in the list of already existing enums
+        auto it = _find_enum_match(enum_val, enum_values_existing);
 
-        // If it is a new enumeration value, add to the list
-        if (is_new_value) {
+        // If not found, append to the to-add list
+        if (it == enum_values_existing.end()) {
             enum_values_to_add.push_back(enum_val);
         }
     }

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1239,10 +1239,30 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     // Find any new enumeration values
     std::vector<ValueType> enum_values_to_add;
     for (auto enum_val : enum_values_in_write) {
-        if (std::find(
-                enum_values_existing.begin(),
-                enum_values_existing.end(),
-                enum_val) == enum_values_existing.end()) {
+        bool is_new_value = false;
+
+        if (std::isnan(enum_val)) {
+            // Special case: check if the value is NaN. We cannot use std::find
+            // below because NaN != NaN
+            for (auto existing_val : enum_values_existing) {
+                if (std::isnan(existing_val)) {
+                    is_new_value = true;
+                    break;
+                }
+            }
+
+        } else {
+            // Typical case: use std::find to check if the value already exists
+            if (std::find(
+                    enum_values_existing.begin(),
+                    enum_values_existing.end(),
+                    enum_val) != enum_values_existing.end()) {
+                is_new_value = true;
+            }
+        }
+
+        // If it is a new enumeration value, add to the list
+        if (!is_new_value) {
             enum_values_to_add.push_back(enum_val);
         }
     }

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1240,7 +1240,7 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     std::vector<ValueType> enum_values_to_add;
     for (auto enum_val : enum_values_in_write) {
         // Find the value in the list of already existing enums
-        auto it = _find_enum_match(enum_val, enum_values_existing);
+        auto it = _find_enum_match(enum_values_existing, enum_val);
 
         // If not found, append to the to-add list
         if (it == enum_values_existing.end()) {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1241,17 +1241,17 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     for (auto enum_val : enum_values_in_write) {
         // Check if the value already exists using bitwise comparison.
         // - We cannot use std::find because NaN != NaN
-        // - We cannot use std::isnan because multiple bit representations
-        //   exist for NaN. For example, in float32 (little-endian), both
-        //   0x7fc00000 and 0x7fc00100 represent NaN
+        // - We cannot use std::isnan because multiple bit representations exist
+        //   for NaN. For example, in float32 (little-endian), both 0x7fc00000
+        //   and 0x7fc00100 represent NaN
         // - TileDB and Arrow treat NaNs with different bit patterns as distinct
         //   values
         bool is_new_value = std::none_of(
             enum_values_existing.begin(),
             enum_values_existing.end(),
-            [enum_val](float existing_val) {
-                return std::memcmp(&enum_val, &existing_val, sizeof(float)) ==
-                       0;
+            [enum_val](ValueType existing_val) {
+                return std::memcmp(
+                           &enum_val, &existing_val, sizeof(ValueType)) == 0;
             });
 
         // If it is a new enumeration value, add to the list

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -1241,11 +1241,8 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     for (auto enum_val : enum_values_in_write) {
         // Check if the value already exists using bitwise comparison.
         // - We cannot use std::find because NaN != NaN
-        // - We cannot use std::isnan because multiple bit representations exist
-        //   for NaN. For example, in float32 (little-endian), both 0x7fc00000
-        //   and 0x7fc00100 represent NaN
-        // - TileDB and Arrow treat NaNs with different bit patterns as distinct
-        //   values
+        // - We cannot use std::isnan because TileDB and Arrow treat NaNs with 
+        //   different bit patterns as distinct values
         bool is_new_value = std::none_of(
             enum_values_existing.begin(),
             enum_values_existing.end(),

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -831,7 +831,7 @@ class ManagedQuery {
             if (0 > i) {
                 shifted_indexes.push_back(i);
             } else {
-                auto it = _find_enum_match(enums_in_write[i], enmr_vec);
+                auto it = _find_enum_match(enmr_vec, enums_in_write[i]);
                 shifted_indexes.push_back(it - enmr_vec.begin());
             }
         }

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1043,7 +1043,7 @@ class ManagedQuery {
      */
     template <typename T>
     typename std::vector<T>::const_iterator _find_enum_match(
-        const T& target, const std::vector<T>& values) {
+        const std::vector<T>& values, const T& target) {
         return std::find_if(
             values.begin(), values.end(), [&target](const T& candidate) {
                 return std::memcmp(&target, &candidate, sizeof(T)) == 0;


### PR DESCRIPTION
**Issue and/or context:**

[[sc-62449](https://app.shortcut.com/tiledb-inc/story/62449/python-c-enum-evolution-does-not-correctly-handle-category-value-of-nan)]

`std::find` does not work "as expected" for NaN values, since NaN != NaN (which is the correct behavior for floating-point comparisons, but not what is intended in this context).

**Changes:**

Add `ManagedQuery::_find_enum_match` which uses bitwise comparison. Like `std::find`, the method returns an iterator that points to the match value in the container; if not found, returns an iterator to the end of the container.