### PR TITLE
[c++/python] Improve error-handling for enum-getter and modes

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -428,7 +428,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Lifecycle:
             Maturing.
         """
-        self._check_open_read()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a DataFrameWrapper
         return cast(DataFrameWrapper, self._handle).count
 
@@ -745,7 +745,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._check_open_read()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -204,7 +204,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             Maturing.
         """
         del partitions  # Currently unused.
-        self._check_open_read()
+        self._verify_open_for_reading()
         result_order = somacore.ResultOrder(result_order)
 
         # The dense_indices_to_shape includes, as one of its roles, how to handle default

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -322,7 +322,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the geometry dataframe."""
-        self._check_open_read()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a GeometryDataFrameWrapper
         return cast(GeometryDataFrameWrapper, self._handle).count
 
@@ -360,7 +360,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._check_open_read()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -299,7 +299,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the dataframe."""
-        self._check_open_read()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a PointCloudDataFrameWrapper
         return cast(PointCloudDataFrameWrapper, self._handle).count
 
@@ -337,7 +337,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._check_open_read()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -267,7 +267,18 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             )
         if self.mode != "w":
             raise SOMAError(
-                f"{self.__class__.__name__} ({self.uri}) must be open for writing (open for reading)"
+                f"{self.__class__.__name__} ({self.uri}) must be open for writing"
+            )
+
+    def _verify_open_for_reading(self) -> None:
+        """Raises an error if the object is not open for reading."""
+        if self.closed:
+            raise SOMAError(
+                f"{self.__class__.__name__} ({self.uri}) must be open for reading (closed)"
+            )
+        if self.mode != "r":
+            raise SOMAError(
+                f"{self.__class__.__name__} ({self.uri}) must be open for writing"
             )
 
     @property
@@ -328,10 +339,6 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 return md_type.lower() == cls.soma_type.lower()
         except (RuntimeError, SOMAError):
             return False
-
-    def _check_open_read(self) -> None:
-        if self.mode != "r":
-            raise ValueError(f"{self} is not open reading")
 
 
 AnySOMAObject = SOMAObject[_tdb_handles.AnyWrapper]

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -331,7 +331,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     def _check_open_read(self) -> None:
         if self.mode != "r":
-            raise ValueError(f"{self} is open for writing, not reading")
+            raise ValueError(f"{self} is not open reading")
 
 
 AnySOMAObject = SOMAObject[_tdb_handles.AnyWrapper]

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -216,7 +216,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         Lifecycle:
             Maturing.
         """
-        self._check_open_read()
+        self._verify_open_for_reading()
         return cast(SparseNDArrayWrapper, self._handle).nnz
 
     def read(
@@ -263,7 +263,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             * Negative indexing is unsupported.
         """
         del batch_size  # Currently unused.
-        self._check_open_read()
+        self._verify_open_for_reading()
         _util.check_unpartitioned(partitions)
 
         return SparseNDArrayRead(

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -140,8 +140,12 @@ void load_soma_array(py::module& m) {
                 auto pa = py::module::import("pyarrow");
                 auto pa_schema_import = pa.attr("Schema").attr(
                     "_import_from_c");
-                return pa_schema_import(
-                    py::capsule(array.arrow_schema().get()));
+                try {
+                    return pa_schema_import(
+                        py::capsule(array.arrow_schema().get()));
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
             })
         .def("schema_config_options", &SOMAArray::schema_config_options)
         .def(

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -302,6 +302,10 @@ def test_get_enumeration_values(tmp_path, ordered, mode):
         }
         assert actual == expect
 
+    # Check with the dataframe closed
+    with pytest.raises(soma.SOMAError):
+        sdf.get_enumeration_values(["bool_enum"])
+
     # Write once
     pd_data = {
         "soma_joinid": [0, 1, 2, 3, 4],


### PR DESCRIPTION
**Issue and/or context:** Split out from 3815 for #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471).  See in particular [this comment](https://github.com/single-cell-data/TileDB-SOMA/pull/3815/files#r2013014784).

**Changes:**

* Update the wording of the existing `_check_open_read` as suggested
* Re-raise the core error when doing `get_enumeration_values` on a closed array as `SOMAError`
* Unit-test that
* Find the existing check-open-for-read and check-open-for-write, colocate them within the source file, and change the name of the existing private read-check method to be similar to the existing public write-check method

**Notes for Reviewer:**

