### PR TITLE
[c++] Colocate another pair of template instantiations [trivial]

### DIFF
--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -433,16 +433,34 @@ def test_sparse_nd_array_shaping(tmp_path, shape_is_nones, element_type):
     with soma.SparseNDArray.open(uri) as snda:
         assert snda.nnz == 0
 
+    soma_dim_0 = pa.array([0, 0, 0, 1, 1, 1], type=pa.int64())
+    soma_dim_1 = pa.array([0, 1, 2, 0, 1, 2], type=pa.int64())
+    soma_data = None
+
+    if element_type == pa.bool_():
+        soma_data = pa.array([True, False, False, True, True, False], type=element_type)
+    else:
+        soma_data = pa.array([1, 2, 3, 4, 5, 6], type=element_type)
+
     batch1 = pa.Table.from_pydict(
         {
-            "soma_dim_0": [0, 0, 0, 1, 1, 1],
-            "soma_dim_1": [0, 1, 2, 0, 1, 2],
-            "soma_data": [1, 2, 3, 4, 5, 6],
+            "soma_dim_0": soma_dim_0,
+            "soma_dim_1": soma_dim_1,
+            "soma_data": soma_data,
         }
     )
 
+    soma_dim_0 = pa.array([2, 2, 2], type=pa.int64())
+    soma_dim_1 = pa.array([0, 1, 2], type=pa.int64())
+    soma_data = None
+
+    if element_type == pa.bool_():
+        soma_data = pa.array([False, True, False], type=element_type)
+    else:
+        soma_data = pa.array([7, 8, 9], type=element_type)
+
     batch2 = pa.Table.from_pydict(
-        {"soma_dim_0": [2, 2, 2], "soma_dim_1": [0, 1, 2], "soma_data": [7, 8, 9]}
+        {"soma_dim_0": soma_dim_0, "soma_dim_1": soma_dim_1, "soma_data": soma_data}
     )
 
     with soma.SparseNDArray.open(uri, "w") as snda:

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -852,6 +852,22 @@ bool ManagedQuery::_cast_column_aux<std::string>(
     return false;
 }
 
+template <>
+bool ManagedQuery::_cast_column_aux<bool>(
+    ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
+    (void)se;  // se is unused in bool specialization
+
+    auto casted = _cast_bool_data(schema, array);
+
+    setup_write_column(
+        schema->name,
+        array->length,
+        (const void*)casted.data(),
+        (uint64_t*)nullptr,
+        _cast_validity_buffer(array));
+    return false;
+}
+
 template <typename UserType>
 bool ManagedQuery::_cast_column_aux(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
@@ -919,22 +935,6 @@ bool ManagedQuery::_cast_column_aux(
                 "column: " +
                 tiledb::impl::type_to_str(disk_type));
     }
-}
-
-template <>
-bool ManagedQuery::_cast_column_aux<bool>(
-    ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
-    (void)se;  // se is unused in bool specialization
-
-    auto casted = _cast_bool_data(schema, array);
-
-    setup_write_column(
-        schema->name,
-        array->length,
-        (const void*)casted.data(),
-        (uint64_t*)nullptr,
-        _cast_validity_buffer(array));
-    return false;
 }
 
 bool ManagedQuery::_extend_and_write_enumeration(

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -888,12 +888,15 @@ bool ManagedQuery::_cast_column_aux(
     // false
     switch (disk_type) {
         case TILEDB_BOOL:
+            throw TileDBSOMAError(
+                "internal coding error: template-specialization failure for "
+                "boolean in _cast_column_aux");
         case TILEDB_STRING_ASCII:
         case TILEDB_STRING_UTF8:
         case TILEDB_CHAR:
             throw TileDBSOMAError(
                 "internal coding error: template-specialization failure for "
-                "boolean in _cast_column_aux");
+                "string in _cast_column_aux");
 
         case TILEDB_INT8:
             return _set_column<UserType, int8_t>(schema, array, se);

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -795,7 +795,8 @@ void ManagedQuery::_cast_dictionary_values<bool>(
     auto value_array = array->dictionary;
 
     std::vector<int64_t> indexes = _get_index_vector(schema, array);
-    std::vector<uint8_t> values = _cast_bool_data(value_schema, value_array);
+    std::vector<uint8_t> values = _bool_data_bits_to_bytes(
+        value_schema, value_array);
     std::vector<uint8_t> index_to_value;
 
     for (auto i : indexes) {
@@ -857,7 +858,7 @@ bool ManagedQuery::_cast_column_aux<bool>(
     ArrowSchema* schema, ArrowArray* array, ArraySchemaEvolution se) {
     (void)se;  // se is unused in bool specialization
 
-    auto casted = _cast_bool_data(schema, array);
+    auto casted = _bool_data_bits_to_bytes(schema, array);
 
     setup_write_column(
         schema->name,
@@ -887,6 +888,13 @@ bool ManagedQuery::_cast_column_aux(
     // false
     switch (disk_type) {
         case TILEDB_BOOL:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_CHAR:
+            throw TileDBSOMAError(
+                "internal coding error: template-specialization failure for "
+                "boolean in _cast_column_aux");
+
         case TILEDB_INT8:
             return _set_column<UserType, int8_t>(schema, array, se);
         case TILEDB_UINT8:
@@ -1219,8 +1227,9 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     if (strcmp(value_schema->format, "b") == 0) {
         // Specially handle Boolean types as their representation in Arrow (bit)
         // is different from what is in TileDB (uint8_t)
-        auto casted = _cast_bool_data(value_schema, value_array);
-        enum_values_in_write.assign(casted.data(), casted.data() + num_elems);
+        auto expanded = _bool_data_bits_to_bytes(value_schema, value_array);
+        enum_values_in_write.assign(
+            expanded.data(), expanded.data() + num_elems);
     } else {
         // General case
         ValueType* data;
@@ -1284,7 +1293,7 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     }
 }
 
-std::vector<uint8_t> ManagedQuery::_cast_bool_data(
+std::vector<uint8_t> ManagedQuery::_bool_data_bits_to_bytes(
     ArrowSchema* schema, ArrowArray* array) {
     if (strcmp(schema->format, "b") != 0) {
         throw TileDBSOMAError(fmt::format(

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -1011,7 +1011,7 @@ class ManagedQuery {
      * @param array the ArrowArray holding Boolean data
      * @return std::vector<uint8_t>
      */
-    std::vector<uint8_t> _cast_bool_data(
+    std::vector<uint8_t> _bool_data_bits_to_bytes(
         ArrowSchema* schema, ArrowArray* array);
 
     /**


### PR DESCRIPTION
**Issue and/or context:** On commit https://github.com/single-cell-data/TileDB-SOMA/commit/32ba743cfdbca91a4eff64fe4647387941636ae0 of PR #3823 I moved the `<std::string>` specialization of `_cast_column_aux` above the generic implementation. I missed, and thus neglected to do the same, for the `<bool>` specialization. This PR fixes that.

**Changes:** As above. Also, rename a helper method to have a clearer name for TileDB <-> Arrow / bytemap <-> bitmap conversions.

**Notes for Reviewer:**

Existing unit-test cases suffices to verify nothing is broken, as I'm simply moving one method higher up in a source file.