### PR TITLE
[r] Replace calls to tiledb-r schema checkers with libtiledbsoma

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -246,6 +246,18 @@ c_allows_dups <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_c_allows_dups`, uri, ctxxp)
 }
 
+c_capacity <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_capacity`, uri, ctxxp)
+}
+
+c_tile_order <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_tile_order`, uri, ctxxp)
+}
+
+c_cell_order <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_cell_order`, uri, ctxxp)
+}
+
 c_attributes <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_c_attributes`, uri, ctxxp)
 }

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -576,6 +576,42 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// c_capacity
+double c_capacity(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_capacity(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_capacity(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// c_tile_order
+std::string c_tile_order(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_tile_order(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_tile_order(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// c_cell_order
+std::string c_cell_order(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_cell_order(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_cell_order(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
 // c_attributes
 Rcpp::List c_attributes(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_c_attributes(SEXP uriSEXP, SEXP ctxxpSEXP) {
@@ -878,6 +914,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_c_schema", (DL_FUNC) &_tiledbsoma_c_schema, 2},
     {"_tiledbsoma_c_is_sparse", (DL_FUNC) &_tiledbsoma_c_is_sparse, 2},
     {"_tiledbsoma_c_allows_dups", (DL_FUNC) &_tiledbsoma_c_allows_dups, 2},
+    {"_tiledbsoma_c_capacity", (DL_FUNC) &_tiledbsoma_c_capacity, 2},
+    {"_tiledbsoma_c_tile_order", (DL_FUNC) &_tiledbsoma_c_tile_order, 2},
+    {"_tiledbsoma_c_cell_order", (DL_FUNC) &_tiledbsoma_c_cell_order, 2},
     {"_tiledbsoma_c_attributes", (DL_FUNC) &_tiledbsoma_c_attributes, 2},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 5},
     {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 4},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -444,25 +444,6 @@ double c_capacity(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     return static_cast<double>(cap);
 }
 
-// Taken from tiledb-r
-// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L246C1-L261C2
-const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
-    switch (layout) {
-    case TILEDB_ROW_MAJOR:
-        return "ROW_MAJOR";
-    case TILEDB_COL_MAJOR:
-        return "COL_MAJOR";
-    case TILEDB_GLOBAL_ORDER:
-        return "GLOBAL_ORDER";
-    case TILEDB_UNORDERED:
-        return "UNORDERED";
-    case TILEDB_HILBERT:
-        return "HILBERT";
-    default:
-        Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
-    }
-}
-
 // [[Rcpp::export]]
 std::string c_tile_order(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -434,6 +434,55 @@ bool c_allows_dups(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     return sch->allows_dups();
 }
 
+// [[Rcpp::export]]
+double c_capacity(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
+    std::shared_ptr<tiledb::ArraySchema> sch = sr->tiledb_schema();
+    sr->close();
+
+    uint64_t cap = sch->capacity();
+    return static_cast<double>(cap);
+}
+
+// Taken from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L246C1-L261C2
+const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
+    switch (layout) {
+    case TILEDB_ROW_MAJOR:
+        return "ROW_MAJOR";
+    case TILEDB_COL_MAJOR:
+        return "COL_MAJOR";
+    case TILEDB_GLOBAL_ORDER:
+        return "GLOBAL_ORDER";
+    case TILEDB_UNORDERED:
+        return "UNORDERED";
+    case TILEDB_HILBERT:
+        return "HILBERT";
+    default:
+        Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
+    }
+}
+
+// [[Rcpp::export]]
+std::string c_tile_order(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
+    std::shared_ptr<tiledb::ArraySchema> sch = sr->tiledb_schema();
+    sr->close();
+
+    auto order = sch->tile_order();
+    return _tiledb_layout_to_string(order);
+}
+
+// [[Rcpp::export]]
+std::string c_cell_order(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
+    std::shared_ptr<tiledb::ArraySchema> sch = sr->tiledb_schema();
+    sr->close();
+
+    auto order = sch->cell_order();
+    return _tiledb_layout_to_string(order);
+}
+
 // Taken from tiledb-r
 // https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L31C1-L110C2
 const char *_tiledb_datatype_to_string(tiledb_datatype_t dtype) {

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -525,3 +525,22 @@ std::string remap_arrow_type_code_r_to_c(std::string input) {
         return it->second;
     }
 }
+
+// Taken from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L246C1-L261C2
+const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
+    switch (layout) {
+    case TILEDB_ROW_MAJOR:
+        return "ROW_MAJOR";
+    case TILEDB_COL_MAJOR:
+        return "COL_MAJOR";
+    case TILEDB_GLOBAL_ORDER:
+        return "GLOBAL_ORDER";
+    case TILEDB_UNORDERED:
+        return "UNORDERED";
+    case TILEDB_HILBERT:
+        return "HILBERT";
+    default:
+        Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
+    }
+}

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -80,3 +80,6 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table);
 
 // Maps e.g. "int8" and "float32" to "c" and "f".
 std::string remap_arrow_type_code_r_to_c(std::string input);
+
+// Maps tiledb layouts to string identifiers
+const char *_tiledb_layout_to_string(tiledb_layout_t layout);

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -495,9 +495,19 @@ test_that("platform_config is respected", {
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
-  expect_equal(tiledb::capacity(tsch), 8000)
-  expect_equal(tiledb::tile_order(tsch), "COL_MAJOR")
-  expect_equal(tiledb::cell_order(tsch), "ROW_MAJOR")
+  expect_equal(
+    c_capacity(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    8000L
+  )
+  expect_equal(
+    c_tile_order(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    "COL_MAJOR"
+  )
+  expect_equal(
+    c_cell_order(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    "ROW_MAJOR"
+  )
+
 
   offsets_filters <- tiledb::filter_list(tsch)$offsets
   expect_equal(tiledb::nfilters(offsets_filters), 1)

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -141,9 +141,18 @@ test_that("platform_config is respected", {
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
-  expect_equal(tiledb::capacity(tsch), 8000)
-  expect_equal(tiledb::tile_order(tsch), "COL_MAJOR")
-  expect_equal(tiledb::cell_order(tsch), "ROW_MAJOR")
+  expect_equal(
+    c_capacity(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
+    8000L
+  )
+  expect_equal(
+    c_tile_order(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
+    "COL_MAJOR"
+  )
+  expect_equal(
+    c_cell_order(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
+    "ROW_MAJOR"
+  )
 
   offsets_filters <- tiledb::filter_list(tsch)$offsets
   expect_equal(tiledb::nfilters(offsets_filters), 1)

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -458,9 +458,18 @@ test_that("platform_config is respected", {
   arr <- tiledb::tiledb_array(uri)
   tsch <- tiledb::schema(arr)
 
-  expect_equal(tiledb::capacity(tsch), 8000)
-  expect_equal(tiledb::tile_order(tsch), "COL_MAJOR")
-  expect_equal(tiledb::cell_order(tsch), "ROW_MAJOR")
+  expect_equal(
+    c_capacity(snda$uri, snda$.__enclos_env__$private$.soma_context),
+    8000L
+  )
+  expect_equal(
+    c_tile_order(snda$uri, snda$.__enclos_env__$private$.soma_context),
+    "COL_MAJOR"
+  )
+  expect_equal(
+    c_cell_order(snda$uri, snda$.__enclos_env__$private$.soma_context),
+    "ROW_MAJOR"
+  )
 
   offsets_filters <- tiledb::filter_list(tsch)$offsets
   expect_equal(tiledb::nfilters(offsets_filters), 1)


### PR DESCRIPTION
Replace calls the following tiledb-r schema accessors with new libtiledbsoma functions:
 - `tiledb::capacity()` replaced with `c_capacity()`
 - `tiledb::tile_order()` replaced with `c_tile_order()`
 - `tiledb::cell_order()` replaced with `c_cell_order()`

[SC-64997](https://app.shortcut.com/tiledb-inc/story/64997)

continues work for #2406

Note: this PR is not going into main, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r

