### PR TITLE
[r] Replace tiledb attribute filter checks with `$attributes()`

### DIFF
--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -527,17 +527,12 @@ test_that("platform_config is respected", {
   expect_equal(tiledb::tiledb_filter_type(d3), "NONE")
   expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
 
-  expect_equal(length(tiledb::attrs(tsch)), 3)
-  i32_filters <- tiledb::filter_list(tiledb::attrs(tsch)$i32)
-  f64_filters <- tiledb::filter_list(tiledb::attrs(tsch)$f64)
-  expect_equal(tiledb::nfilters(i32_filters), 2)
-  expect_equal(tiledb::nfilters(f64_filters), 0)
-
-  i1 <- i32_filters[0] # C++ indexing here
-  i2 <- i32_filters[1] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(i1), "RLE")
-  expect_equal(tiledb::tiledb_filter_type(i2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(i2, "COMPRESSION_LEVEL"), 9)
+  expect_length(attrs <- sdf$attributes(), n = 3L)
+  expect_length(attrs$i32$filter_list, n = 2L)
+  expect_equal(attrs$i32$filter_list[[1L]]$filter_type, "RLE")
+  expect_equal(attrs$i32$filter_list[[2L]]$filter_type, "ZSTD")
+  expect_equal(attrs$i32$filter_list[[2L]]$compression_level, 9L)
+  expect_length(attrs$f64$filter_list, n = 0L)
 
   sdf$close()
 })

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -182,15 +182,11 @@ test_that("platform_config is respected", {
   d1 <- dim1_filters[0] # C++ indexing here
   expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
 
-  expect_equal(length(tiledb::attrs(tsch)), 1)
-  soma_data_filters <- tiledb::filter_list(tiledb::attrs(tsch)$soma_data)
-  expect_equal(tiledb::nfilters(soma_data_filters), 2)
-
-  a1 <- soma_data_filters[0] # C++ indexing here
-  a2 <- soma_data_filters[1] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(a1), "BITSHUFFLE")
-  expect_equal(tiledb::tiledb_filter_type(a2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(a2, "COMPRESSION_LEVEL"), 9)
+  expect_length(attrs <- dnda$attributes(), n = 1L)
+  expect_length(attrs$soma_data$filter_list, n = 2L)
+  expect_equal(attrs$soma_data$filter_list[[1L]]$filter_type, "BITSHUFFLE")
+  expect_equal(attrs$soma_data$filter_list[[2L]]$filter_type, "ZSTD")
+  expect_equal(attrs$soma_data$filter_list[[2L]]$compression_level, 9L)
 
   dnda$close()
 })

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -499,15 +499,11 @@ test_that("platform_config is respected", {
   d1 <- dim1_filters[0] # C++ indexing here
   expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
 
-  expect_equal(length(tiledb::attrs(tsch)), 1)
-  soma_data_filters <- tiledb::filter_list(tiledb::attrs(tsch)$soma_data)
-  expect_equal(tiledb::nfilters(soma_data_filters), 2)
-
-  a1 <- soma_data_filters[0] # C++ indexing here
-  a2 <- soma_data_filters[1] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(a1), "BITSHUFFLE")
-  expect_equal(tiledb::tiledb_filter_type(a2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(a2, "COMPRESSION_LEVEL"), 9)
+  expect_length(attrs <- snda$attributes(), n = 1L)
+  expect_length(attrs$soma_data$filter_list, n = 2L)
+  expect_equal(attrs$soma_data$filter_list[[1L]]$filter_type, "BITSHUFFLE")
+  expect_equal(attrs$soma_data$filter_list[[2L]]$filter_type, "ZSTD")
+  expect_equal(attrs$soma_data$filter_list[[2L]]$compression_level, 9L)
 
   snda$close()
 })


### PR DESCRIPTION
Replace calls to `tiledb::attrs()` with `$attributes()` accessor

[SC-64999](https://app.shortcut.com/tiledb-inc/story/64999)

continues work for #2406

Note: this PR is not going into main, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r