### PR TITLE
[r] Replace `tiledb::domain()` with Rcpp `c_domain()`

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -274,6 +274,10 @@ c_attribute_enumeration_levels <- function(uri, ctxxp, name) {
     .Call(`_tiledbsoma_c_attribute_enumeration_levels`, uri, ctxxp, name)
 }
 
+c_domain <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_domain`, uri, ctxxp)
+}
+
 resize <- function(uri, new_shape, function_name_for_messages, check_only, ctxxp) {
     .Call(`_tiledbsoma_resize`, uri, new_shape, function_name_for_messages, check_only, ctxxp)
 }
@@ -438,4 +442,3 @@ get_soma_object_type <- function(uri, ctxxp) {
 get_tiledb_object_type <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_get_tiledb_object_type`, uri, ctxxp)
 }
-

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -442,3 +442,4 @@ get_soma_object_type <- function(uri, ctxxp) {
 get_tiledb_object_type <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_get_tiledb_object_type`, uri, ctxxp)
 }
+

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -639,9 +639,6 @@ END_RCPP
 // c_attributes_enumerated
 Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_c_attributes_enumerated(SEXP uriSEXP, SEXP ctxxpSEXP) {
-// c_domain
-Rcpp::List c_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
-RcppExport SEXP _tiledbsoma_c_domain(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -661,6 +658,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
     rcpp_result_gen = Rcpp::wrap(c_attribute_enumeration_levels(uri, ctxxp, name));
+    return rcpp_result_gen;
+END_RCPP
+}
+// c_domain
+Rcpp::List c_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_domain(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     rcpp_result_gen = Rcpp::wrap(c_domain(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -639,6 +639,9 @@ END_RCPP
 // c_attributes_enumerated
 Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_c_attributes_enumerated(SEXP uriSEXP, SEXP ctxxpSEXP) {
+// c_domain
+Rcpp::List c_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_domain(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -658,6 +661,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
     rcpp_result_gen = Rcpp::wrap(c_attribute_enumeration_levels(uri, ctxxp, name));
+    rcpp_result_gen = Rcpp::wrap(c_domain(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -958,6 +962,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_c_attributes", (DL_FUNC) &_tiledbsoma_c_attributes, 2},
     {"_tiledbsoma_c_attributes_enumerated", (DL_FUNC) &_tiledbsoma_c_attributes_enumerated, 2},
     {"_tiledbsoma_c_attribute_enumeration_levels", (DL_FUNC) &_tiledbsoma_c_attribute_enumeration_levels, 3},
+    {"_tiledbsoma_c_domain", (DL_FUNC) &_tiledbsoma_c_domain, 2},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 5},
     {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 4},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 5},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -726,9 +726,8 @@ Rcpp::List c_domain(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
             Rcpp::Named("name") = name,
             Rcpp::Named("type") = _tiledb_datatype_to_string(dim->type()),
             Rcpp::Named("ncells") = _get_ncells<Rcpp::XPtr<tiledb::Dimension>>(dim),
-            // TODO: add domain and tile to return value
-            // Rcpp::Named("domain") = "",
-            // Rcpp::Named("tile") = "",
+            Rcpp::Named("domain") = _get_dim_domain(dim),
+            Rcpp::Named("tile") = _get_dim_tile(dim),
             Rcpp::Named("filters") = filters
         );
     }

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -582,22 +582,6 @@ const char *_tiledb_datatype_to_string(tiledb_datatype_t dtype) {
     }
 }
 
-// identify ncells
-// taken from tiledb-r
-// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L1590-L1599
-template <typename AttrOrDim>
-int _get_ncells(AttrOrDim x) {
-    int ncells;
-    if (x->cell_val_num() == TILEDB_VAR_NUM) {
-        ncells = R_NaInt;
-    } else if (x->cell_val_num() > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
-    } else {
-        ncells = static_cast<int32_t>(x->cell_val_num());
-    }
-    return ncells;
-}
-
 // [[Rcpp::export]]
 Rcpp::List c_attributes(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -545,6 +545,22 @@ const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
     }
 }
 
+// identify ncells
+// taken from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L1590-L1599
+template <typename AttrOrDim>
+int _get_ncells(AttrOrDim x) {
+    int ncells;
+    if (x->cell_val_num() == TILEDB_VAR_NUM) {
+        ncells = R_NaInt;
+    } else if (x->cell_val_num() > std::numeric_limits<int32_t>::max()) {
+        Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
+    } else {
+        ncells = static_cast<int32_t>(x->cell_val_num());
+    }
+    return ncells;
+}
+
 // internal helper function for
 // `_get_filter_options()`
 // <Numeric> should be `int32_t` or `double`

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -592,3 +592,171 @@ Rcpp::List _get_filter_options(Rcpp::XPtr<tiledb::Filter> filter) {
         Rcpp::Named("float_offset") = _get_filter_option<double>(filter, TILEDB_SCALE_FLOAT_OFFSET)
     );
 }
+
+// adapted from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/57d3d929a5cd6d6e9bc4bf5bda0036c736ca46dc/src/libtiledb.cpp#L927-L1039
+SEXP _get_dim_domain(Rcpp::XPtr<tiledb::Dimension> dim) {
+    auto dim_type = dim->type();
+    switch (dim_type) {
+    case TILEDB_FLOAT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+        return Rcpp::NumericVector({dim->domain<DataType>().first, dim->domain<DataType>().second});
+    }
+    case TILEDB_FLOAT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        if (d1 == R_NaReal || d2 == R_NaReal) {
+            Rcpp::stop("tiledb_dim domain FLOAT64 value not representable as an R double");
+        }
+        return Rcpp::NumericVector({d1, d2});
+    }
+    case TILEDB_INT8: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+        return Rcpp::IntegerVector({dim->domain<DataType>().first, dim->domain<DataType>().second});
+    }
+    case TILEDB_UINT8: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+        return Rcpp::IntegerVector({dim->domain<DataType>().first, dim->domain<DataType>().second});
+    }
+    case TILEDB_INT16: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+        return Rcpp::IntegerVector({dim->domain<DataType>().first, dim->domain<DataType>().second});
+    }
+    case TILEDB_UINT16: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+        return Rcpp::IntegerVector({dim->domain<DataType>().first, dim->domain<DataType>().second});
+    }
+    case TILEDB_INT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        if (d1 == R_NaInt || d2 == R_NaInt) {
+            Rcpp::stop("tiledb_dim domain INT32 value not representable as an R integer");
+        }
+        return Rcpp::IntegerVector({d1, d2});
+    }
+    case TILEDB_UINT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        auto uint_max = std::numeric_limits<uint32_t>::max();
+        if (d1 > uint_max ||d2 > uint_max) {
+            Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
+        }
+        return Rcpp::NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+    }
+    case TILEDB_INT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        return Rcpp::NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+    }
+    case TILEDB_UINT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        return Rcpp::NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+    }
+    case TILEDB_DATETIME_YEAR:
+    case TILEDB_DATETIME_MONTH:
+    case TILEDB_DATETIME_WEEK:
+    case TILEDB_DATETIME_DAY:
+    case TILEDB_DATETIME_HR:
+    case TILEDB_DATETIME_MIN:
+    case TILEDB_DATETIME_SEC:
+    case TILEDB_DATETIME_MS:
+    case TILEDB_DATETIME_US:
+    case TILEDB_DATETIME_NS:
+    case TILEDB_DATETIME_PS:
+    case TILEDB_DATETIME_FS:
+    case TILEDB_DATETIME_AS: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+        auto d1 = dim->domain<DataType>().first;
+        auto d2 = dim->domain<DataType>().second;
+        auto int32_max = std::numeric_limits<int32_t>::max();
+        if (d1 <= R_NaInt || d1 > int32_max || d2 <= R_NaInt || d2 > int32_max) {
+            return Rcpp::NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+        }
+        return Rcpp::IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
+    }
+    default:
+        Rcpp::stop("invalid tiledb_dim domain type (%s)", tiledb::impl::to_str(dim_type));
+    }
+}
+
+// adapted from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/57d3d929a5cd6d6e9bc4bf5bda0036c736ca46dc/src/libtiledb.cpp#L1042-L1137
+SEXP _get_dim_tile(Rcpp::XPtr<tiledb::Dimension> dim) {
+    auto dim_type = dim->type();
+    switch (dim_type) {
+    case TILEDB_FLOAT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+        return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_FLOAT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+        auto t = dim->tile_extent<DataType>();
+        if (t == R_NaReal) {
+            Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
+        }
+        return Rcpp::wrap(static_cast<double>(t));
+    }
+    case TILEDB_INT8: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+        return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_UINT8: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+        return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_INT16: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+        return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_UINT16: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+        return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_INT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+        auto t = dim->tile_extent<DataType>();
+        if (t == R_NaInt) {
+            Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
+        }
+        return Rcpp::wrap(static_cast<int32_t>(t));
+    }
+    case TILEDB_UINT32: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+        auto t = dim->tile_extent<DataType>();
+        if (t > std::numeric_limits<int32_t>::max()) {
+            Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R integer, returning double");
+            return Rcpp::wrap(static_cast<double>(t));
+        }
+        return Rcpp::wrap(static_cast<int32_t>(t));
+    }
+    case TILEDB_DATETIME_YEAR:
+    case TILEDB_DATETIME_MONTH:
+    case TILEDB_DATETIME_WEEK:
+    case TILEDB_DATETIME_DAY:
+    case TILEDB_DATETIME_HR:
+    case TILEDB_DATETIME_MIN:
+    case TILEDB_DATETIME_SEC:
+    case TILEDB_DATETIME_MS:
+    case TILEDB_DATETIME_US:
+    case TILEDB_DATETIME_NS:
+    case TILEDB_DATETIME_PS:
+    case TILEDB_DATETIME_FS:
+    case TILEDB_DATETIME_AS:
+    case TILEDB_INT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+        return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+    }
+    case TILEDB_UINT64: {
+        using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+        return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+    }
+    default:
+        Rcpp::stop("invalid tiledb_dim domain type (%s)", tiledb::impl::to_str(dim_type));
+    }
+}

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -545,22 +545,6 @@ const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
     }
 }
 
-// identify ncells
-// taken from tiledb-r
-// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L1590-L1599
-template <typename AttrOrDim>
-int _get_ncells(AttrOrDim x) {
-    int ncells;
-    if (x->cell_val_num() == TILEDB_VAR_NUM) {
-        ncells = R_NaInt;
-    } else if (x->cell_val_num() > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
-    } else {
-        ncells = static_cast<int32_t>(x->cell_val_num());
-    }
-    return ncells;
-}
-
 // internal helper function for
 // `_get_filter_options()`
 // <Numeric> should be `int32_t` or `double`

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -84,10 +84,5 @@ std::string remap_arrow_type_code_r_to_c(std::string input);
 // Maps tiledb layouts to string identifiers
 const char *_tiledb_layout_to_string(tiledb_layout_t layout);
 
-// Get the cell_val_num from a `Rcpp::XPtr<tiledb::Attribute>`
-// or `Rcpp::XPtr<tiledb::Dimension>`
-template <typename AttrOrDim>
-int _get_ncells(AttrOrDim x);
-
 // Get options for a TileDB filter
 Rcpp::List _get_filter_options(Rcpp::XPtr<tiledb::Filter> filter);

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -86,3 +86,9 @@ const char *_tiledb_layout_to_string(tiledb_layout_t layout);
 
 // Get options for a TileDB filter
 Rcpp::List _get_filter_options(Rcpp::XPtr<tiledb::Filter> filter);
+
+// Get domain from a TileDB dimension
+SEXP _get_dim_domain(Rcpp::XPtr<tiledb::Dimension> dim);
+
+// Get tiling from a TileDB dimension
+SEXP _get_dim_tile(Rcpp::XPtr<tiledb::Dimension> dim);

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -84,5 +84,10 @@ std::string remap_arrow_type_code_r_to_c(std::string input);
 // Maps tiledb layouts to string identifiers
 const char *_tiledb_layout_to_string(tiledb_layout_t layout);
 
+// Get the cell_val_num from a `Rcpp::XPtr<tiledb::Attribute>`
+// or `Rcpp::XPtr<tiledb::Dimension>`
+template <typename AttrOrDim>
+int _get_ncells(AttrOrDim x);
+
 // Get options for a TileDB filter
 Rcpp::List _get_filter_options(Rcpp::XPtr<tiledb::Filter> filter);

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -604,20 +604,19 @@ test_that("platform_config defaults", {
     platform_config = cfg
   )
 
-  # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   # Here we're snooping on the default dim filter that's used when no other is specified.
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 1)
-  dim <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim), "soma_joinid")
-  dim_filters <- tiledb::filter_list(dim)
-  expect_equal(tiledb::nfilters(dim_filters), 1)
-  d1 <- dim_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(d1, "COMPRESSION_LEVEL"), 3)
+  expect_length(
+    domain <- c_domain(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    n = 1L
+  )
+  expect_named(domain, "soma_joinid")
+  expect_equal(domain[[1L]]$name, "soma_joinid")
+
+  dim <- domain$soma_joinid
+  expect_length(dim$filters, n = 1L)
+  expect_equal(dim$filters[[1L]]$filter_type, "ZSTD")
+  expect_equal(dim$filters[[1L]]$compression_level, 3L)
+
   sdf$close()
 })
 

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -523,9 +523,6 @@ test_that("platform_config is respected", {
   )
 
   # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   expect_equal(
     c_capacity(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
     8000L

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -556,21 +556,19 @@ test_that("platform_config is respected", {
   expect_equal(coord_filters$validity[[1L]]$filter_type, "RLE")
   expect_equal(coord_filters$validity[[2L]]$filter_type, "NOOP")
 
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 1)
-  dim <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim), "soma_joinid")
+  expect_length(
+    domain <- c_domain(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    n = 1L
+  )
+  dim <- domain[[1]]
+  expect_equal(dim$name, "soma_joinid")
   # TODO: As noted above, check this when we are able to.
   # expect_equal(tiledb::tile(dim), 999)
-  dim_filters <- tiledb::filter_list(dim)
-  expect_equal(tiledb::nfilters(dim_filters), 3)
-  d1 <- dim_filters[0] # C++ indexing here
-  d2 <- dim_filters[1] # C++ indexing here
-  d3 <- dim_filters[2] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
-  expect_equal(tiledb::tiledb_filter_type(d2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_type(d3), "NONE")
-  expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
+  expect_length(dim$filters, n = 3L)
+  expect_equal(dim$filters[[1L]]$filter_type, "RLE")
+  expect_equal(dim$filters[[2L]]$filter_type, "ZSTD")
+  expect_equal(dim$filters[[2L]]$compression_level, 8L)
+  expect_equal(dim$filters[[3L]]$filter_type, "NONE")
 
   expect_length(attrs <- sdf$attributes(), n = 3L)
   expect_length(attrs$i32$filter_list, n = 2L)

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -568,7 +568,7 @@ test_that("platform_config is respected", {
   expect_equal(dim$filters[[1L]]$filter_type, "RLE")
   expect_equal(dim$filters[[2L]]$filter_type, "ZSTD")
   expect_equal(dim$filters[[2L]]$compression_level, 8L)
-  expect_equal(dim$filters[[3L]]$filter_type, "NONE")
+  expect_equal(dim$filters[[3L]]$filter_type, "NOOP")
 
   expect_length(attrs <- sdf$attributes(), n = 3L)
   expect_length(attrs$i32$filter_list, n = 2L)

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -183,7 +183,7 @@ test_that("platform_config is respected", {
   d3 <- dim0_filters[2] # C++ indexing here
   expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
   expect_equal(tiledb::tiledb_filter_type(d2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_type(d3), "NONE")
+  expect_equal(tiledb::tiledb_filter_type(d3), "NOOP")
   expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
 
   dim1 <- tiledb::dimensions(dom)[[2]]

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -170,30 +170,30 @@ test_that("platform_config is respected", {
   expect_equal(coord_filters$validity[[1L]]$filter_type, "RLE")
   expect_equal(coord_filters$validity[[2L]]$filter_type, "NOOP")
 
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 2)
-  dim0 <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim0), "soma_dim_0")
+  expect_length(
+    domain <- c_domain(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
+    n = 2L
+  )
+  expect_named(
+    domain,
+    dims <- sprintf("soma_dim_%i", 0:1)
+  )
+  expect_equal(
+    vapply(domain, FUN = '[[', FUN.VALUE = character(1L), "name", USE.NAMES = FALSE),
+    dims
+  )
   # TODO: As noted above, check this when we are able to.
   # expect_equal(tiledb::tile(dim0), 999)
-  dim0_filters <- tiledb::filter_list(dim0)
-  expect_equal(tiledb::nfilters(dim0_filters), 3)
-  d1 <- dim0_filters[0] # C++ indexing here
-  d2 <- dim0_filters[1] # C++ indexing here
-  d3 <- dim0_filters[2] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
-  expect_equal(tiledb::tiledb_filter_type(d2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_type(d3), "NOOP")
-  expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
+  dim0 <- domain$soma_dim_0
+  expect_length(dim0$filters, n = 3L)
+  expect_equal(dim0$filters[[1L]]$filter_type, "RLE")
+  expect_equal(dim0$filters[[2L]]$filter_type, "ZSTD")
+  expect_equal(dim0$filters[[2L]]$compression_level, 8L)
+  expect_equal(dim0$filters[[3L]]$filter_type, "NOOP")
 
-  dim1 <- tiledb::dimensions(dom)[[2]]
-  expect_equal(tiledb::name(dim1), "soma_dim_1")
-  # TODO: As noted above, check this when we are able to.
-  # expect_equal(tiledb::tile(dim1), 999)
-  dim1_filters <- tiledb::filter_list(dim1)
-  expect_equal(tiledb::nfilters(dim1_filters), 1)
-  d1 <- dim1_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
+  dim1 <- domain$soma_dim_1
+  expect_length(dim1$filters, n = 1L)
+  expect_equal(dim1$filters[[1L]]$filter_type, "RLE")
 
   expect_length(attrs <- dnda$attributes(), n = 1L)
   expect_length(attrs$soma_data$filter_list, n = 2L)
@@ -214,29 +214,28 @@ test_that("platform_config defaults", {
   # Create the SOMADenseNDArray
   dnda <- SOMADenseNDArrayCreate(uri = uri, type = arrow::int32(), shape = c(100, 100), platform_config = cfg)
 
-  # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   # Here we're snooping on the default dim filter that's used when no other is specified.
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 2)
+  expect_length(
+    domain <- c_domain(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
+    n = 2L
+  )
+  expect_named(
+    domain,
+    dims <- sprintf("soma_dim_%i", 0:1)
+  )
+  expect_equal(
+    vapply(domain, FUN = '[[', FUN.VALUE = character(1L), "name", USE.NAMES = FALSE),
+    dims
+  )
+  dim0 <- domain$soma_dim_0
+  expect_length(dim0$filters, n = 1L)
+  expect_equal(dim0$filters[[1L]]$filter_type, "ZSTD")
+  expect_equal(dim0$filters[[1L]]$compression_level, 3L)
 
-  dim0 <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim0), "soma_dim_0")
-  dim0_filters <- tiledb::filter_list(dim0)
-  expect_equal(tiledb::nfilters(dim0_filters), 1)
-  d1 <- dim0_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(d1, "COMPRESSION_LEVEL"), 3)
-
-  dim1 <- tiledb::dimensions(dom)[[2]]
-  expect_equal(tiledb::name(dim1), "soma_dim_1")
-  dim1_filters <- tiledb::filter_list(dim1)
-  expect_equal(tiledb::nfilters(dim1_filters), 1)
-  d1 <- dim1_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(d1, "COMPRESSION_LEVEL"), 3)
+  dim1 <- domain$soma_dim_1
+  expect_length(dim1$filters, n = 1L)
+  expect_equal(dim1$filters[[1L]]$filter_type, "ZSTD")
+  expect_equal(dim1$filters[[1L]]$compression_level, 3L)
 
   dnda$close()
 })

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -135,12 +135,14 @@ test_that("platform_config is respected", {
   ))
 
   # Create the SOMADenseNDArray
-  dnda <- SOMADenseNDArrayCreate(uri = uri, type = arrow::int32(), shape = c(100, 100), platform_config = cfg)
+  dnda <- SOMADenseNDArrayCreate(
+    uri = uri,
+    type = arrow::int32(),
+    shape = c(100, 100),
+    platform_config = cfg
+  )
 
   # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   expect_equal(
     c_capacity(dnda$uri, dnda$.__enclos_env__$private$.soma_context),
     8000L

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -452,12 +452,14 @@ test_that("platform_config is respected", {
   ))
 
   # Create the SOMASparseNDArray
-  snda <- SOMASparseNDArrayCreate(uri = uri, type = arrow::int32(), shape = c(100, 100), platform_config = cfg)
+  snda <- SOMASparseNDArrayCreate(
+    uri = uri,
+    type = arrow::int32(),
+    shape = c(100, 100),
+    platform_config = cfg
+  )
 
   # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   expect_equal(
     c_capacity(snda$uri, snda$.__enclos_env__$private$.soma_context),
     8000L

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -487,30 +487,19 @@ test_that("platform_config is respected", {
   expect_equal(coord_filters$validity[[1L]]$filter_type, "RLE")
   expect_equal(coord_filters$validity[[2L]]$filter_type, "NOOP")
 
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 2)
-  dim0 <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim0), "soma_dim_0")
+  expect_length(
+    domain <- c_domain(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
+    n = 1L
+  )
+  dim <- domain[[1]]
+  expect_equal(dim$name, "soma_joinid")
   # TODO: As noted above, check this when we are able to.
-  # expect_equal(tiledb::tile(dim0), 999)
-  dim0_filters <- tiledb::filter_list(dim0)
-  expect_equal(tiledb::nfilters(dim0_filters), 3)
-  d1 <- dim0_filters[0] # C++ indexing here
-  d2 <- dim0_filters[1] # C++ indexing here
-  d3 <- dim0_filters[2] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
-  expect_equal(tiledb::tiledb_filter_type(d2), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_type(d3), "NONE")
-  expect_equal(tiledb::tiledb_filter_get_option(d2, "COMPRESSION_LEVEL"), 8)
-
-  dim1 <- tiledb::dimensions(dom)[[2]]
-  expect_equal(tiledb::name(dim1), "soma_dim_1")
-  # TODO: As noted above, check this when we are able to.
-  # expect_equal(tiledb::tile(dim1), 999)
-  dim1_filters <- tiledb::filter_list(dim1)
-  expect_equal(tiledb::nfilters(dim1_filters), 1)
-  d1 <- dim1_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "RLE")
+  # expect_equal(tiledb::tile(dim), 999)
+  expect_length(dim$filters, n = 3L)
+  expect_equal(dim$filters[[1L]]$filter_type, "RLE")
+  expect_equal(dim$filters[[2L]]$filter_type, "ZSTD")
+  expect_equal(dim$filters[[2L]]$compression_level, 8L)
+  expect_equal(dim$filters[[3L]]$filter_type, "NONE")
 
   expect_length(attrs <- snda$attributes(), n = 1L)
   expect_length(attrs$soma_data$filter_list, n = 2L)

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -488,11 +488,14 @@ test_that("platform_config is respected", {
   expect_equal(coord_filters$validity[[2L]]$filter_type, "NOOP")
 
   expect_length(
-    domain <- c_domain(sdf$uri, sdf$.__enclos_env__$private$.soma_context),
-    n = 1L
+    domain <- c_domain(snda$uri, snda$.__enclos_env__$private$.soma_context),
+    n = 2L
   )
-  dim <- domain[[1]]
-  expect_equal(dim$name, "soma_joinid")
+  expect_named(domain, dims <- sprintf("soma_dim_%i", 0:1))
+  expect_equal(
+    vapply(domain, FUN = '[[', FUN.VALUE = character(1L), "name", USE.NAMES = FALSE),
+    dims
+  )
   # TODO: As noted above, check this when we are able to.
   # expect_equal(tiledb::tile(dim), 999)
   expect_length(dim$filters, n = 3L)

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -528,29 +528,28 @@ test_that("platform_config defaults", {
   # Create the SOMASparseNDArray
   snda <- SOMASparseNDArrayCreate(uri = uri, type = arrow::int32(), shape = c(100, 100), platform_config = cfg)
 
-  # Read back and check the array schema against the tiledb create options
-  arr <- tiledb::tiledb_array(uri)
-  tsch <- tiledb::schema(arr)
-
   # Here we're snooping on the default dim filter that's used when no other is specified.
-  dom <- tiledb::domain(tsch)
-  expect_equal(tiledb::tiledb_ndim(dom), 2)
+  expect_length(
+    domain <- c_domain(snda$uri, snda$.__enclos_env__$private$.soma_context),
+    n = 2L
+  )
+  expect_named(
+    domain,
+    dims <- sprintf("soma_dim_%i", 0:1)
+  )
+  expect_equal(
+    vapply(domain, FUN = '[[', FUN.VALUE = character(1L), "name", USE.NAMES = FALSE),
+    dims
+  )
+  dim0 <- domain$soma_dim_0
+  expect_length(dim0$filters, n = 1L)
+  expect_equal(dim0$filters[[1L]]$filter_type, "ZSTD")
+  expect_equal(dim0$filters[[1L]]$compression_level, 3L)
 
-  dim0 <- tiledb::dimensions(dom)[[1]]
-  expect_equal(tiledb::name(dim0), "soma_dim_0")
-  dim0_filters <- tiledb::filter_list(dim0)
-  expect_equal(tiledb::nfilters(dim0_filters), 1)
-  d1 <- dim0_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(d1, "COMPRESSION_LEVEL"), 3)
-
-  dim1 <- tiledb::dimensions(dom)[[2]]
-  expect_equal(tiledb::name(dim1), "soma_dim_1")
-  dim1_filters <- tiledb::filter_list(dim1)
-  expect_equal(tiledb::nfilters(dim1_filters), 1)
-  d1 <- dim1_filters[0] # C++ indexing here
-  expect_equal(tiledb::tiledb_filter_type(d1), "ZSTD")
-  expect_equal(tiledb::tiledb_filter_get_option(d1, "COMPRESSION_LEVEL"), 3)
+  dim1 <- domain$soma_dim_1
+  expect_length(dim1$filters, n = 1L)
+  expect_equal(dim1$filters[[1L]]$filter_type, "ZSTD")
+  expect_equal(dim1$filters[[1L]]$compression_level, 3L)
 
   snda$close()
 })

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -503,7 +503,7 @@ test_that("platform_config is respected", {
   expect_equal(dim0$filters[[1L]]$filter_type, "RLE")
   expect_equal(dim0$filters[[2L]]$filter_type, "ZSTD")
   expect_equal(dim0$filters[[2L]]$compression_level, 8L)
-  expect_equal(dim0$filters[[3L]]$filter_type, "NONE")
+  expect_equal(dim0$filters[[3L]]$filter_type, "NOOP")
 
   dim1 <- domain$soma_dim_1
   expect_length(dim1$filters, n = 1L)

--- a/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMASparseNDArray.R
@@ -498,11 +498,16 @@ test_that("platform_config is respected", {
   )
   # TODO: As noted above, check this when we are able to.
   # expect_equal(tiledb::tile(dim), 999)
-  expect_length(dim$filters, n = 3L)
-  expect_equal(dim$filters[[1L]]$filter_type, "RLE")
-  expect_equal(dim$filters[[2L]]$filter_type, "ZSTD")
-  expect_equal(dim$filters[[2L]]$compression_level, 8L)
-  expect_equal(dim$filters[[3L]]$filter_type, "NONE")
+  dim0 <- domain$soma_dim_0
+  expect_length(dim0$filters, n = 3L)
+  expect_equal(dim0$filters[[1L]]$filter_type, "RLE")
+  expect_equal(dim0$filters[[2L]]$filter_type, "ZSTD")
+  expect_equal(dim0$filters[[2L]]$compression_level, 8L)
+  expect_equal(dim0$filters[[3L]]$filter_type, "NONE")
+
+  dim1 <- domain$soma_dim_1
+  expect_length(dim1$filters, n = 1L)
+  expect_equal(dim1$filters[[1L]]$filter_type, "RLE")
 
   expect_length(attrs <- snda$attributes(), n = 1L)
   expect_length(attrs$soma_data$filter_list, n = 2L)

--- a/apis/r/tests/testthat/test-11-OrderedAndFactor.R
+++ b/apis/r/tests/testthat/test-11-OrderedAndFactor.R
@@ -103,15 +103,12 @@ test_that("SOMADataFrame round-trip with factor and ordered", {
   turi <- tempfile()
   expect_silent(tiledb::fromDataFrame(ett, turi, col_index = "soma_joinid"))
 
-  tsch <- tiledb::schema(turi)
-  expect_true(inherits(tsch, "tiledb_array_schema"))
-
   att <- arrow::as_arrow_table(ett)
   expect_true(inherits(att, "Table"))
 
   lvls <- tiledbsoma:::extract_levels(att)
   expect_true(is.list(lvls))
-  expect_equal(length(lvls), ncol(et)) # et, not ett or tsch or sch as no soma_joinid
+  expect_equal(length(lvls), ncol(et)) # et, not ett
   expect_equal(names(lvls), colnames(et))
 
   # sdf <- SOMADataFrameCreate(uri, sch)


### PR DESCRIPTION
Replace calls to `tiledb::domain()` and other domain accessors with libtiledbsom/Rcpp `c_domain()`

[SC-65000](https://app.shortcut.com/tiledb-inc/story/65000)

continues work for #2406

Requires #3851

Note: this PR is not going into main, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r