### PR TITLE
[r] Replace tiledb-r enum accessors with libtiledb/Rcpp

### DIFF
--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -266,6 +266,14 @@ c_attributes <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_c_attributes`, uri, ctxxp)
 }
 
+c_attribute_enumerated <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_attribute_enumerated`, uri, ctxxp)
+}
+
+c_attribute_enumeration_levels <- function(uri, ctxxp, name) {
+    .Call(`_tiledbsoma_c_attribute_enumeration_levels`, uri, ctxxp, name)
+}
+
 resize <- function(uri, new_shape, function_name_for_messages, check_only, ctxxp) {
     .Call(`_tiledbsoma_resize`, uri, new_shape, function_name_for_messages, check_only, ctxxp)
 }

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -266,8 +266,8 @@ c_attributes <- function(uri, ctxxp) {
     .Call(`_tiledbsoma_c_attributes`, uri, ctxxp)
 }
 
-c_attribute_enumerated <- function(uri, ctxxp) {
-    .Call(`_tiledbsoma_c_attribute_enumerated`, uri, ctxxp)
+c_attributes_enumerated <- function(uri, ctxxp) {
+    .Call(`_tiledbsoma_c_attributes_enumerated`, uri, ctxxp)
 }
 
 c_attribute_enumeration_levels <- function(uri, ctxxp, name) {

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -221,7 +221,7 @@ Furthermore, \code{values} must contain the same number of rows as the current
 \subsection{Method \code{levels()}}{
 Get the levels for an enumerated (\code{factor}) column
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$levels(column_names = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$levels(column_names = NULL, simplify = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -229,13 +229,21 @@ Get the levels for an enumerated (\code{factor}) column
 \describe{
 \item{\code{column_names}}{Optional character vector of column names to pull
 enumeration levels for; defaults to all enumerated columns}
+
+\item{\code{simplify}}{Simplify the result down to a vector or matrix}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-If \code{column_names} is a single string value, a character
-vector of enumeration levels; otherwise, a named list where each name is
-a column name and each value is the enumeration levels for said column
+If \code{simplify} returns one of the following:
+\itemize{
+\item a vector of there is only one enumerated column
+\item a matrix if there are multiple enumerated columns with the same
+number of levels
+\item a named list if there are multiple enumerated columns with
+differing numbers of levels
+}
+Otherwise, returns a named list
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -19,6 +19,7 @@ row and is intended to act as a join key for other objects, such as
 \item \href{#method-SOMADataFrame-write}{\code{SOMADataFrame$write()}}
 \item \href{#method-SOMADataFrame-read}{\code{SOMADataFrame$read()}}
 \item \href{#method-SOMADataFrame-update}{\code{SOMADataFrame$update()}}
+\item \href{#method-SOMADataFrame-levels}{\code{SOMADataFrame$levels()}}
 \item \href{#method-SOMADataFrame-shape}{\code{SOMADataFrame$shape()}}
 \item \href{#method-SOMADataFrame-maxshape}{\code{SOMADataFrame$maxshape()}}
 \item \href{#method-SOMADataFrame-domain}{\code{SOMADataFrame$domain()}}
@@ -213,6 +214,29 @@ Furthermore, \code{values} must contain the same number of rows as the current
 \code{SOMADataFrame}.
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMADataFrame-levels"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMADataFrame-levels}{}}}
+\subsection{Method \code{levels()}}{
+Get the levels for an enumerated (\code{factor}) column
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMADataFrame$levels(column_names = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{column_names}}{Optional character vector of column names to pull
+enumeration levels for; defaults to all enumerated columns}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+If \code{column_names} is a single string value, a character
+vector of enumeration levels; otherwise, a named list where each name is
+a column name and each value is the enumeration levels for said column
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMADataFrame-shape"></a>}}

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -636,6 +636,31 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// c_attribute_enumerated
+Rcpp::LogicalVector c_attribute_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_attribute_enumerated(SEXP uriSEXP, SEXP ctxxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_attribute_enumerated(uri, ctxxp));
+    return rcpp_result_gen;
+END_RCPP
+}
+// c_attribute_enumeration_levels
+Rcpp::CharacterVector c_attribute_enumeration_levels(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp, const std::string& name);
+RcppExport SEXP _tiledbsoma_c_attribute_enumeration_levels(SEXP uriSEXP, SEXP ctxxpSEXP, SEXP nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_attribute_enumeration_levels(uri, ctxxp, name));
+    return rcpp_result_gen;
+END_RCPP
+}
 // resize
 std::string resize(const std::string& uri, Rcpp::NumericVector new_shape, std::string function_name_for_messages, bool check_only, Rcpp::XPtr<somactx_wrap_t> ctxxp);
 RcppExport SEXP _tiledbsoma_resize(SEXP uriSEXP, SEXP new_shapeSEXP, SEXP function_name_for_messagesSEXP, SEXP check_onlySEXP, SEXP ctxxpSEXP) {
@@ -931,6 +956,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_c_cell_order", (DL_FUNC) &_tiledbsoma_c_cell_order, 2},
     {"_tiledbsoma_c_schema_filters", (DL_FUNC) &_tiledbsoma_c_schema_filters, 2},
     {"_tiledbsoma_c_attributes", (DL_FUNC) &_tiledbsoma_c_attributes, 2},
+    {"_tiledbsoma_c_attribute_enumerated", (DL_FUNC) &_tiledbsoma_c_attribute_enumerated, 2},
+    {"_tiledbsoma_c_attribute_enumeration_levels", (DL_FUNC) &_tiledbsoma_c_attribute_enumeration_levels, 3},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 5},
     {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 4},
     {"_tiledbsoma_tiledbsoma_upgrade_shape", (DL_FUNC) &_tiledbsoma_tiledbsoma_upgrade_shape, 5},

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -636,15 +636,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// c_attribute_enumerated
-Rcpp::LogicalVector c_attribute_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
-RcppExport SEXP _tiledbsoma_c_attribute_enumerated(SEXP uriSEXP, SEXP ctxxpSEXP) {
+// c_attributes_enumerated
+Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp);
+RcppExport SEXP _tiledbsoma_c_attributes_enumerated(SEXP uriSEXP, SEXP ctxxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
-    rcpp_result_gen = Rcpp::wrap(c_attribute_enumerated(uri, ctxxp));
+    rcpp_result_gen = Rcpp::wrap(c_attributes_enumerated(uri, ctxxp));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -956,7 +956,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_c_cell_order", (DL_FUNC) &_tiledbsoma_c_cell_order, 2},
     {"_tiledbsoma_c_schema_filters", (DL_FUNC) &_tiledbsoma_c_schema_filters, 2},
     {"_tiledbsoma_c_attributes", (DL_FUNC) &_tiledbsoma_c_attributes, 2},
-    {"_tiledbsoma_c_attribute_enumerated", (DL_FUNC) &_tiledbsoma_c_attribute_enumerated, 2},
+    {"_tiledbsoma_c_attributes_enumerated", (DL_FUNC) &_tiledbsoma_c_attributes_enumerated, 2},
     {"_tiledbsoma_c_attribute_enumeration_levels", (DL_FUNC) &_tiledbsoma_c_attribute_enumeration_levels, 3},
     {"_tiledbsoma_resize", (DL_FUNC) &_tiledbsoma_resize, 5},
     {"_tiledbsoma_resize_soma_joinid_shape", (DL_FUNC) &_tiledbsoma_resize_soma_joinid_shape, 4},

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -654,7 +654,7 @@ Rcpp::List c_attributes(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp
 // adapted from tiledb-r
 // https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L3027-L3042
 // [[Rcpp::export]]
-Rcpp::LogicalVector c_attribute_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
     std::shared_ptr<tiledb::ArraySchema> sch = sr->tiledb_schema();
     sr->close();
@@ -663,7 +663,6 @@ Rcpp::LogicalVector c_attribute_enumerated(const std::string& uri, Rcpp::XPtr<so
     Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(nattrs);
     Rcpp::CharacterVector names = Rcpp::CharacterVector(nattrs);
     for (int i = 0; i < nattrs; i++) {
-        //
         auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(sch->attribute(i)));
         auto enmr = tiledb::AttributeExperimental::get_enumeration_name(
             // credit to this monstrosity goes to Beka Davis
@@ -685,7 +684,7 @@ Rcpp::CharacterVector c_attribute_enumeration_levels(
         const std::string& name
 ) {
     auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
-    auto enum_values = sr->get_enumeration_values_for_column(name);
+    std::pair<ArrowArray*, ArrowSchema*> enum_values = sr->get_enumeration_values_for_column(name);
     sr->close();
 
     if (enum_values.first->length > std::numeric_limits<int32_t>::max()) {
@@ -705,7 +704,6 @@ Rcpp::CharacterVector c_attribute_enumeration_levels(
             ArrowStringView item = ArrowArrayViewGetStringUnsafe(enum_view.get(), i);
             enumerations(i) = std::string(item.data, item.size_bytes);
         }
-        Rcpp::Rcerr << "i " << i << " " << enumerations(i) << std::endl;
     }
 
     return enumerations;

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -693,7 +693,7 @@ Rcpp::CharacterVector c_attribute_enumeration_levels(
     }
 
     nanoarrow::UniqueArrayView enum_view;
-    ArrowArrayViewInitFromType(enum_view.get(), NANOARROW_TYPE_STRING);
+    ArrowArrayViewInitFromType(enum_view.get(), NANOARROW_TYPE_LARGE_STRING);
     NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(enum_view.get(), enum_values.first, nullptr));
 
     int nlevels = static_cast<int32_t>(enum_values.first->length);

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -666,7 +666,7 @@ Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<s
         auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(sch->attribute(i)));
         auto enmr = tiledb::AttributeExperimental::get_enumeration_name(
             // credit to this monstrosity goes to Beka Davis
-            const_cast<const tiledb::Context&>(*(ctxxp.get()->ctxptr.get()->tiledb_ctx())),
+            *(ctxxp->ctxptr->tiledb_ctx()),
             *attr.get()
         );
         has_enum(i) = enmr != std::nullopt;

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -651,6 +651,66 @@ Rcpp::List c_attributes(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp
     return result;
 }
 
+// adapted from tiledb-r
+// https://github.com/TileDB-Inc/TileDB-R/blob/525bdfc0f34aadb74a312a5d8428bd07819a8f83/src/libtiledb.cpp#L3027-L3042
+// [[Rcpp::export]]
+Rcpp::LogicalVector c_attribute_enumerated(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
+    std::shared_ptr<tiledb::ArraySchema> sch = sr->tiledb_schema();
+    sr->close();
+
+    int nattrs = sch->attribute_num();
+    Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(nattrs);
+    Rcpp::CharacterVector names = Rcpp::CharacterVector(nattrs);
+    for (int i = 0; i < nattrs; i++) {
+        //
+        auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(sch->attribute(i)));
+        auto enmr = tiledb::AttributeExperimental::get_enumeration_name(
+            // credit to this monstrosity goes to Beka Davis
+            const_cast<const tiledb::Context&>(*(ctxxp.get()->ctxptr.get()->tiledb_ctx())),
+            *attr.get()
+        );
+        has_enum(i) = enmr != std::nullopt;
+        names(i) = attr->name();
+    }
+
+    has_enum.attr("names") = names;
+    return has_enum;
+}
+
+// [[Rcpp::export]]
+Rcpp::CharacterVector c_attribute_enumeration_levels(
+        const std::string& uri,
+        Rcpp::XPtr<somactx_wrap_t> ctxxp,
+        const std::string& name
+) {
+    auto sr = tdbs::SOMAArray::open(OpenMode::read, uri, ctxxp->ctxptr);
+    auto enum_values = sr->get_enumeration_values_for_column(name);
+    sr->close();
+
+    if (enum_values.first->length > std::numeric_limits<int32_t>::max()) {
+        Rcpp::stop("too many enumeration levels for R");
+    }
+
+    nanoarrow::UniqueArrayView enum_view;
+    ArrowArrayViewInitFromType(enum_view.get(), NANOARROW_TYPE_STRING);
+    NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(enum_view.get(), enum_values.first, nullptr));
+
+    int nlevels = static_cast<int32_t>(enum_values.first->length);
+    Rcpp::CharacterVector enumerations = Rcpp::CharacterVector(nlevels);
+    for (int i = 0; i < nlevels; i++) {
+        if (ArrowArrayViewIsNull(enum_view.get(), i)) {
+            enumerations(i) = R_NaString;
+        } else {
+            ArrowStringView item = ArrowArrayViewGetStringUnsafe(enum_view.get(), i);
+            enumerations(i) = std::string(item.data, item.size_bytes);
+        }
+        Rcpp::Rcerr << "i " << i << " " << enumerations(i) << std::endl;
+    }
+
+    return enumerations;
+}
+
 // [[Rcpp::export]]
 std::string resize(
     const std::string& uri,

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -665,7 +665,6 @@ Rcpp::LogicalVector c_attributes_enumerated(const std::string& uri, Rcpp::XPtr<s
     for (int i = 0; i < nattrs; i++) {
         auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(sch->attribute(i)));
         auto enmr = tiledb::AttributeExperimental::get_enumeration_name(
-            // credit to this monstrosity goes to Beka Davis
             *(ctxxp->ctxptr->tiledb_ctx()),
             *attr.get()
         );

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -348,7 +348,7 @@ test_that("creation with ordered factors", {
 
   expect_length(lvls <- sdf$levels(), n = 1L)
   expect_named(lvls, "ord")
-  expect_identical(lvs$ord, levels(df$ord))
+  expect_identical(lvls$ord, levels(df$ord))
   expect_identical(sdf$levels("ord"), levels(df$ord))
 
   expect_s3_class(ord <- sdf$object[]$ord, c("ordered", "factor"), exact = TRUE)

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -879,7 +879,10 @@ test_that("missing levels in enums", {
 
   # Test missingness is preserved
   expect_s3_class(sdf <- SOMADataFrameOpen(uri), "SOMADataFrame")
-  expect_true(tiledb::tiledb_array_has_enumeration(sdf$object)["enum"])
+  expect_true(c_attribute_enumerated(
+    sdf$uri,
+    sdf$.__enclos_env__$private$.soma_context
+  )["enum"])
   expect_s4_class(
     attr <- tiledb::attrs(sdf$tiledb_schema())$enum,
     "tiledb_attr"
@@ -888,7 +891,7 @@ test_that("missing levels in enums", {
     tiledb::tiledb_attribute_get_enumeration(attr, sdf$object),
     levels(df$enum)
   )
-  expect_true(tiledb::tiledb_attribute_get_nullable(attr))
+  expect_true(sdf$attributes()$enum$nullable)
 
   # Test reading preserves missingness
   expect_identical(sdf$object[]$enum, df$enum)

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -346,7 +346,7 @@ test_that("creation with ordered factors", {
     )
   )
 
-  expect_length(lvls <- sdf$levels(), n = 1L)
+  expect_length(lvls <- sdf$levels(simplify = FALSE), n = 1L)
   expect_named(lvls, "ord")
   expect_identical(lvls$ord, levels(df$ord))
   expect_identical(sdf$levels("ord"), levels(df$ord))


### PR DESCRIPTION
Replace tiledb-r enum accessors with new libtiledb/Rcpp accessors; also add new `SOMADataFrame$levels()` method to fetch enumeration levels

New SOMA methods:
- `SOMADataFrame$levels()`: get the enumeration levels from one or more enumerated columns. By default `column_names = NULL`: returns a named list of all enumerated columns with their enumeration levels

[SC-65002](https://app.shortcut.com/tiledb-inc/story/65002)

continues work for #2406

Note: this PR is not going into main, but into a separate branch to accumulate all of these little PRs before filing the larger one to remove tiledb-r
