### PR TITLE
[python] Prepare `io.shaping` for spatial additions

### DIFF
--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -98,7 +98,7 @@ def show_experiment_shapes(
         output_handle: The handle to print the output to.
 
     Returns:
-        ``True`` if outputing the shape works for elements. ``False`` if any element
+        ``True`` if outputting the shape works for elements. ``False`` if any element
         fails to successfully output its shape.
     """
     args: SizingArgs = dict(
@@ -133,13 +133,13 @@ def upgrade_experiment_shapes(
     ``shape`` feature introduced in TileDB-SOMA 1.15.
 
     A new shape feature was introduced in TileDB-SOMA in release 1.15. This
-    will update the main elements in TileDB-SOMA to use the new feature. It  makes
+    updates the main elements in TileDB-SOMA to use the new feature. It  makes
     an experiment created before TileDB-SOMA 1.15 look like an experiment created by
     TileDB-SOMA 1.15 or later. You can use ``tiledbsoma.io.show_experiment_shapes``
     before and after to see the difference.
 
     For each dataframe and N-D array that is being upgraded, if the dataframe does
-    not currently support the new shape feature, upgrade to add the feature and set
+    not currently support the new shape feature, upgrades to add the feature and sets
     the domain to the dataframe's current ``non_empty_domain``. If the new ``shape``
     feature is already enable, nothing is changed.
 
@@ -233,7 +233,7 @@ def resize_experiment(
     size.  If the new domain of the ``soma_joinid`` column does not fit inside the
     ``maxshape``, the resize fails.
 
-    An N-D matrix will be resized if either dimension of the new ``shape`` is larger
+    An N-D array will be resized if either dimension of the new ``shape`` is larger
     than the current shape. If either dimension of the new ``shape`` is larger
     than ``maxshape``, the resize fails.
 
@@ -242,7 +242,7 @@ def resize_experiment(
       * ``obs`` dataframe: ``soma_joinid`` resized to fit ``nobs``.
 
     For each ``measurement_name`` in the experiment the elements are resized as follows
-    where ``nvar[measurement_name]`` is the current size if ``measurement_name`` if
+    where ``nvar[measurement_name]`` is the current size if ``measurement_name`` or
     no value is provided by the user:
 
       * ``var`` dataframe: ``soma_joinid`` resized to fit ``nvar[measurement_name]``.

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -51,11 +51,26 @@ def show_experiment_shapes(
     context: tiledbsoma.SOMATileDBContext | None = None,
     output_handle: Printable = cast(Printable, sys.stdout),
 ) -> bool:
-    """Outputs the current shapes of the main elements in the ``Experiment``.
+    """Outputs the current shapes of the elements in the ``Experiment``.
 
-    For main dataframes and arrays contained within the SOMA ``Experiment``, shows
-    the ``non_empty_domain`` (for dataframes), along with the ``shape`` and ``maxshape``
-    (for arrays) or ``domain`` and ``maxdomain`` (for dataframes).
+    Outputs the ``non_empty_domain``, ``domain``, and ``maxdomain`` of dataframes and
+    the ``non_empty_domain``, ``shape``, and ``maxshape`` of arrays. This method is
+    applied to the following elements inside the SOMA ``Experiment``:
+
+    The shapes of the following elements are output:
+
+      * the ``obs`` dataframe in the experiment,
+
+    and for each measurement:
+
+      * the ``var`` dataframe,
+      * all ``X`` arrays,
+      * all ``obsm`` arrays,
+      * all ``varm`` arrays,
+      * all ``obsp`` arrays,
+      * all ``varm`` arrays,
+      * all ``varp`` arrays.
+
 
     Example::
 
@@ -77,20 +92,6 @@ def show_experiment_shapes(
           shape                (2700, 13714)
           maxshape             (9223372036854773759, 9223372036854773759)
           upgraded             True
-
-    The shapes of the following elements are output:
-
-      * the ``obs`` dataframe in the experiment,
-
-    for each measurement:
-
-      * the ``var`` dataframe,
-      * all ``X`` arrays,
-      * all ``obsm`` arrays,
-      * all ``varm`` arrays,
-      * all ``obsp`` arrays,
-      * all ``varm`` arrays,
-      * all ``varp`` arrays.
 
     Args:
         uri: The URI of a SOMA :class:`Experiment`.
@@ -129,14 +130,14 @@ def upgrade_experiment_shapes(
     context: tiledbsoma.SOMATileDBContext | None = None,
     output_handle: Printable = cast(Printable, sys.stdout),
 ) -> bool:
-    """Upgrade the main elements inside a SOMA ``Experiment`` to use the
-    ``shape`` feature introduced in TileDB-SOMA 1.15.
+    """Upgrade the elements inside a SOMA ``Experiment`` to use the ``shape`` feature
+    introduced in TileDB-SOMA 1.15.
 
-    A new shape feature was introduced in TileDB-SOMA in release 1.15. This
-    updates the main elements in TileDB-SOMA to use the new feature. It  makes
-    an experiment created before TileDB-SOMA 1.15 look like an experiment created by
-    TileDB-SOMA 1.15 or later. You can use ``tiledbsoma.io.show_experiment_shapes``
-    before and after to see the difference.
+    A new shape feature was introduced in TileDB-SOMA in release 1.15. This updates
+    the elements in TileDB-SOMA to use the new feature. It makes an experiment created
+    before TileDB-SOMA 1.15 look like an experiment created by TileDB-SOMA 1.15 or
+    later. You can use ``tiledbsoma.io.show_experiment_shapes`` before and after to see
+    the difference.
 
     For each dataframe and N-D array that is being upgraded, if the dataframe does
     not currently support the new shape feature, upgrades to add the feature and sets
@@ -331,7 +332,21 @@ def _treewalk(
     args: SizingArgs,
     context: tiledbsoma.SOMATileDBContext | None,
 ) -> bool:
-    """Apply visitor function to the main ``Experiment`` elements.
+    """Apply visitor function to the ``Experiment`` elements.
+
+    The following elements are visited:
+
+      * the ``obs`` dataframe in the experiment,
+
+    for each measurement:
+
+      * the ``var`` dataframe,
+      * all ``X`` arrays,
+      * all ``obsm`` arrays,
+      * all ``varm`` arrays,
+      * all ``obsp`` arrays,
+      * all ``varm`` arrays,
+      * all ``varp`` arrays.
 
     Args:
         uri: URI of the element to visit and visit the children of.

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -51,14 +51,11 @@ def show_experiment_shapes(
     context: tiledbsoma.SOMATileDBContext | None = None,
     output_handle: Printable = cast(Printable, sys.stdout),
 ) -> bool:
-    """For each dataframe/array contained within the SOMA ``Experiment`` pointed
-    to by the given URI, shows the ``non_empty_domain`` (for dataframes), along
-    with the ``shape`` and ``maxshape`` (for arrays) or ``domain`` and
-    ``maxdomain`` (for dataframes).
+    """Outputs the current shapes of the main elements in the ``Experiment``.
 
-    Args:
-        uri: The URI of a SOMA :class:`Experiment`.
-        context: Optional :class:`SOMATileDBContext`.
+    For main dataframes and arrays contained within the SOMA ``Experiment``, shows
+    the ``non_empty_domain`` (for dataframes), along with the ``shape`` and ``maxshape``
+    (for arrays) or ``domain`` and ``maxdomain`` (for dataframes).
 
     Example::
 
@@ -80,6 +77,29 @@ def show_experiment_shapes(
           shape                (2700, 13714)
           maxshape             (9223372036854773759, 9223372036854773759)
           upgraded             True
+
+    The shapes of the following elements are output:
+
+      * the ``obs`` dataframe in the experiment,
+
+    for each measurement:
+
+      * the ``var`` dataframe,
+      * all ``X`` arrays,
+      * all ``obsm`` arrays,
+      * all ``varm`` arrays,
+      * all ``obsp`` arrays,
+      * all ``varm`` arrays,
+      * all ``varp`` arrays.
+
+    Args:
+        uri: The URI of a SOMA :class:`Experiment`.
+        context: Optional :class:`SOMATileDBContext`.
+        output_handle: The handle to print the output to.
+
+    Returns:
+        ``True`` if outputing the shape works for elements. ``False`` if any element
+        fails to successfully output its shape.
     """
     args: SizingArgs = dict(
         nobs=None,
@@ -109,24 +129,33 @@ def upgrade_experiment_shapes(
     context: tiledbsoma.SOMATileDBContext | None = None,
     output_handle: Printable = cast(Printable, sys.stdout),
 ) -> bool:
-    """For each dataframe contained within the SOMA ``Experiment`` pointed to by
-    the given URI, sets the ``domain`` to match the dataframe's current
-    ``non_empty_domain``.  For each N-D array, sets the ``shape`` to match the array's
-    ``non_empty_domain``. If ``verbose`` is set to ``True``, an activity log
-    is printed. If ``check_only`` is true, only does a dry run and reports any
-    reasons the upgrade would fail.
+    """Upgrade the main elements inside a SOMA ``Experiment`` to use the
+    ``shape`` feature introduced in TileDB-SOMA 1.15.
 
-    This makes an experiment created before TileDB-SOMA 1.15 look like an
-    experiment created by TileDB-SOMA 1.15 or later. You can use
-    ``tiledbsoma.io.show_experiment_shapes`` before and after to see
-    the difference.
+    A new shape feature was introduced in TileDB-SOMA in release 1.15. This
+    will update the main elements in TileDB-SOMA to use the new feature. It  makes
+    an experiment created before TileDB-SOMA 1.15 look like an experiment created by
+    TileDB-SOMA 1.15 or later. You can use ``tiledbsoma.io.show_experiment_shapes``
+    before and after to see the difference.
 
-    Args:
-        uri: The URI of a SOMA :class:`Experiment`.
-        verbose: If ``True``, produce per-array output as the upgrade runs.
-        check_only: If ``True``,  don't apply the upgrades, but show what would
-            be attempted, and show why each one would fail.
-        context: Optional :class:`SOMATileDBContext`.
+    For each dataframe and N-D array that is being upgraded, if the dataframe does
+    not currently support the new shape feature, upgrade to add the feature and set
+    the domain to the dataframe's current ``non_empty_domain``. If the new ``shape``
+    feature is already enable, nothing is changed.
+
+    The following elements are updated:
+
+      * the ``obs`` dataframe in the experiment,
+
+    for each measurement:
+
+      * the ``var`` dataframe,
+      * all ``X`` arrays,
+      * all ``obsm`` arrays,
+      * all ``varm`` arrays,
+      * all ``obsp`` arrays,
+      * all ``varm`` arrays,
+      * all ``varp`` arrays.
 
     Example::
 
@@ -143,6 +172,17 @@ def upgrade_experiment_shapes(
           URI file:///data/pbmc3k_unprocessed_old/ms/RNA/X/data
           Dry run for: tiledbsoma_upgrade_shape((2700, 13714))
           OK
+
+    Args:
+        uri: The URI of a SOMA :class:`Experiment`.
+        verbose: If ``True``, produce per-array output as the upgrade runs.
+        check_only: If ``True``,  don't apply the upgrades, but show what would
+            be attempted, and show why each one would fail.
+        context: Optional :class:`SOMATileDBContext`.
+
+    Returns:
+        ``True`` if all upgrade operations succeed. ``False`` if any upgrade
+        operation fails.
     """
     # For resize, nobs and nvars are from the user. But for upgrade,
     # they're from the experiment as-is.
@@ -247,7 +287,7 @@ def resize_experiment(
         context: Optional :class:`SOMATileDBContext`.
 
     Returns:
-        ``True`` if all resize operations succeed. ``False`` if any resize operations
+        ``True`` if all resize operations succeed. ``False`` if any resize operation
         fails.
     """
     args: SizingArgs = dict(

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -446,7 +446,7 @@ def test_canned_experiments(tmp_path, has_shapes):
         tgz = TESTDATA / "pbmc-exp-with-shapes.tgz"
 
     with tarfile.open(tgz) as handle:
-        handle.extractall(uri, filter="data")
+        handle.extractall(uri)
 
     def _assert_huge_domainish(d):
         assert len(d) == 1
@@ -685,7 +685,7 @@ def test_canned_nonstandard_dataframe_upgrade(tmp_path):
     tgz = TESTDATA / "nonstandard-dataframe-without-shapes.tgz"
 
     with tarfile.open(tgz) as handle:
-        handle.extractall(uri, filter="data")
+        handle.extractall(uri)
 
     # ----------------------------------------------------------------
     # As of tiledbsoma 1.15 we no longer write dataframes/arrays without

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -446,7 +446,7 @@ def test_canned_experiments(tmp_path, has_shapes):
         tgz = TESTDATA / "pbmc-exp-with-shapes.tgz"
 
     with tarfile.open(tgz) as handle:
-        handle.extractall(uri)
+        handle.extractall(uri, filter="data")
 
     def _assert_huge_domainish(d):
         assert len(d) == 1
@@ -685,7 +685,7 @@ def test_canned_nonstandard_dataframe_upgrade(tmp_path):
     tgz = TESTDATA / "nonstandard-dataframe-without-shapes.tgz"
 
     with tarfile.open(tgz) as handle:
-        handle.extractall(uri)
+        handle.extractall(uri, filter="data")
 
     # ----------------------------------------------------------------
     # As of tiledbsoma 1.15 we no longer write dataframes/arrays without


### PR DESCRIPTION
**Issue and/or context:** [sc-65008](https://app.shortcut.com/tiledb-inc/story/65008/prepare-io-shaping-for-spatial-additions)

**Changes:**

* Update docstrings to reflect which elements inside the experiment are being accessed.
* Refactor `_treewalk` to make adding more elements easier.


