### PR TITLE
[c++] Remove static deserializer map

### DIFF
--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -20,12 +20,6 @@
 
 namespace tiledbsoma {
 
-std::map<uint32_t, SOMAColumn::Factory> SOMAColumn::deserialiser_map = {
-    {soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE, SOMAAttribute::deserialize},
-    {soma_column_datatype_t::SOMA_COLUMN_DIMENSION, SOMADimension::deserialize},
-    {soma_column_datatype_t::SOMA_COLUMN_GEOMETRY,
-     SOMAGeometryColumn::deserialize}};
-
 std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
     const Context& ctx,
     const Array& array,
@@ -61,7 +55,26 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
             auto type = column[TILEDB_SOMA_SCHEMA_COL_TYPE_KEY]
                             .template get<uint32_t>();
 
-            auto col = deserialiser_map[type](column, ctx, array, metadata);
+            std::shared_ptr<SOMAColumn> col;
+
+            switch (static_cast<soma_column_datatype_t>(type)) {
+                case soma_column_datatype_t::SOMA_COLUMN_ATTRIBUTE:
+                    col = SOMAAttribute::deserialize(
+                        column, ctx, array, metadata);
+                    break;
+                case soma_column_datatype_t::SOMA_COLUMN_DIMENSION:
+                    col = SOMADimension::deserialize(
+                        column, ctx, array, metadata);
+                    break;
+                case soma_column_datatype_t::SOMA_COLUMN_GEOMETRY:
+                    col = SOMAGeometryColumn::deserialize(
+                        column, ctx, array, metadata);
+                    break;
+                default:
+                    throw TileDBSOMAError(fmt::format(
+                        "[SOMAColumn][deserialize] Unknown column type {}",
+                        type));
+            }
 
             if (col) {
                 // Deserialized column can be null in case the array is modified

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -523,8 +523,6 @@ class SOMAColumn {
         const Context&,
         const Array&,
         const std::map<std::string, tiledbsoma::MetadataValue>&);
-
-    static std::map<uint32_t, Factory> deserialiser_map;
 };
 
 template <>

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -516,13 +516,6 @@ class SOMAColumn {
         const SOMAContext& ctx, Array& array) const = 0;
 
     virtual std::any _core_current_domain_slot(NDRectangle& ndrect) const = 0;
-
-   private:
-    typedef std::shared_ptr<SOMAColumn> (*Factory)(
-        const nlohmann::json&,
-        const Context&,
-        const Array&,
-        const std::map<std::string, tiledbsoma::MetadataValue>&);
 };
 
 template <>


### PR DESCRIPTION
**Issue and/or context:** [conda-forge/tiledbsoma-feedstock/pull/7](https://github.com/conda-forge/tiledbsoma-feedstock/pull/7#issuecomment-2754852179)

**Changes:**
- Remove static deserializer map and replace it with a switch statement

**Notes for Reviewer:**
ASAN was reporting an ODR violation exporting the static map from libtiledbsoma shared library


