### PR TITLE
[python] Fix a venial typo in a unit-test case

### DIFF
--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -309,7 +309,7 @@ def test_get_enumeration_values(tmp_path, ordered, mode):
     # Write once
     pd_data = {
         "soma_joinid": [0, 1, 2, 3, 4],
-        "not_an_enum": pd.Categorical(["a", "nn", "zzz", "nn", "a"]),
+        "not_an_enum": ["a", "nn", "zzz", "nn", "a"],
         "string_enum": pd.Categorical(["a", "nn", "zzz", "nn", "a"], ordered=ordered),
         "int64_enum": pd.Categorical(
             [111111111, 99999, 3333333, 111111111, 99999], ordered=ordered
@@ -358,7 +358,7 @@ def test_get_enumeration_values(tmp_path, ordered, mode):
     # Write again
     pd_data = {
         "soma_joinid": [5, 6, 7],
-        "not_an_enum": pd.Categorical(["dddd", "nn", "zzz"]),
+        "not_an_enum": ["dddd", "nn", "zzz"],
         "string_enum": pd.Categorical(["dddd", "nn", "zzz"], ordered=ordered),
         "int64_enum": pd.Categorical([555555555, 111111111, 99999], ordered=ordered),
         "float64_enum": pd.Categorical(


### PR DESCRIPTION
**Issue and/or context:** I had a `not_an_enum` column defined in the schema as `pa.large_string()`. Then writing it with `pd.Categorical`. That surfaces no error, which is by design as implemented on #3354. However, #3354 isn't being tested here; this was a copy/paste error, not intentional; and it adds needless confusion.

Surrounding context: #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471).


**Changes:** Write non-enum string data to the non-enum string column.

**Notes for Reviewer:**

