### PR TITLE
[r] Use exposed logger in C++ bindings

### DIFF
--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -29,9 +29,9 @@ void c_group_create(
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamp);
     if (timestamp.isNotNull()) {
         Rcpp::DatetimeVector v(timestamp);
-        spdl::debug("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]);
+        tdbs::LOG_DEBUG(fmt::format("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]));
     } else {
-        spdl::debug("[c_group_create] uri {}", uri);
+        tdbs::LOG_DEBUG(fmt::format("[c_group_create] uri {}", uri));
     }
 
     tdbs::SOMAGroup::create(sctx, uri, type, tsrng);

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -29,9 +29,9 @@ void c_group_create(
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamp);
     if (timestamp.isNotNull()) {
         Rcpp::DatetimeVector v(timestamp);
-        spdlog::debug("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]);
+        spdl::debug("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]);
     } else {
-        spdlog::debug("[c_group_create] uri {}", uri);
+        spdl::debug("[c_group_create] uri {}", uri);
     }
 
     tdbs::SOMAGroup::create(sctx, uri, type, tsrng);

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -193,7 +193,7 @@ void set_metadata(
     if (type == "character") {
         const tiledb_datatype_t value_type = TILEDB_STRING_UTF8;
         std::string value = Rcpp::as<std::string>(valuesxp);
-        spdlog::debug(
+        spdl::debug(
             "[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,
@@ -205,7 +205,7 @@ void set_metadata(
         const tiledb_datatype_t value_type = TILEDB_INT64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
-        spdlog::debug(
+        spdl::debug(
             "[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -193,24 +193,22 @@ void set_metadata(
     if (type == "character") {
         const tiledb_datatype_t value_type = TILEDB_STRING_UTF8;
         std::string value = Rcpp::as<std::string>(valuesxp);
-        spdl::debug(
-            "[set_metadata] key {} value {} is_array {} type {}",
+        tdbs::LOG_DEBUG(fmt::format("[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,
             is_array,
-            type);
+            type));
         soup->set_metadata(
             key, value_type, value.length(), (void*)value.c_str(), true);
     } else if (type == "integer64") {
         const tiledb_datatype_t value_type = TILEDB_INT64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
-        spdl::debug(
-            "[set_metadata] key {} value {} is_array {} type {}",
+        tdbs::LOG_DEBUG(fmt::format("[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,
             is_array,
-            type);
+            type));
         soup->set_metadata(key, value_type, 1, (void*)&value, true);
     } else {
         Rcpp::stop("Unsupported type '%s'", type);

--- a/apis/r/src/query_condition.cpp
+++ b/apis/r/src/query_condition.cpp
@@ -144,7 +144,7 @@ void libtiledbsoma_query_condition_from_triple(
     } else if (arrow_type_name == "timestamp_s") {
         int64_t v = static_cast<int64_t>(
             Rcpp::as<double>(condition_value));
-      spdl::debug("ts3 {}", v);
+        tdbs::LOG_DEBUG(fmt::format("ts3 {}", v));
         uint64_t cond_val_size = sizeof(int64_t);
         query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 

--- a/apis/r/src/query_condition.cpp
+++ b/apis/r/src/query_condition.cpp
@@ -144,7 +144,7 @@ void libtiledbsoma_query_condition_from_triple(
     } else if (arrow_type_name == "timestamp_s") {
         int64_t v = static_cast<int64_t>(
             Rcpp::as<double>(condition_value));
-      spdlog::debug("ts3 {}", v);
+      spdl::debug("ts3 {}", v);
         uint64_t cond_val_size = sizeof(int64_t);
         query_cond->init(attr_name, (void*)&v, cond_val_size, op);
 

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -69,12 +69,12 @@ SEXP soma_array_reader(
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;
 
-    spdlog::info("[soma_array_reader] Reading from {}", uri);
+    spdl::info("[soma_array_reader] Reading from {}", uri);
 
     std::vector<std::string> column_names = {};
     if (!colnames.isNull()) {  // If we have column names, select them
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
-        spdlog::debug(
+        spdl::debug(
             "[soma_array_reader] Selecting {} columns", column_names.size());
     }
 
@@ -85,7 +85,7 @@ SEXP soma_array_reader(
         timestamprange);
     if (timestamprange.isNotNull()) {
         Rcpp::DatetimeVector vec(timestamprange);
-        spdlog::debug(
+        spdl::debug(
             "[soma_array_reader] timestamprange ({},{})", vec[0], vec[1]);
     }
 
@@ -104,7 +104,7 @@ SEXP soma_array_reader(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        spdlog::info(
+        spdl::info(
             "[soma_array_reader] Dimension {} type {} domain {} extent {}",
             dim.name(),
             tiledb::impl::to_str(dim.type()),
@@ -116,7 +116,7 @@ SEXP soma_array_reader(
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdlog::info("[soma_array_reader_impl] Applying query condition");
+        spdl::info("[soma_array_reader_impl] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         mq.set_condition(*qcxp);
     }
@@ -146,7 +146,7 @@ SEXP soma_array_reader(
             "or using iterated partial reads.",
             uri);
     }
-    spdlog::info(
+    spdl::info(
         "[soma_array_reader] Read complete with {} rows and {} cols",
         sr_data->get()->num_rows(),
         sr_data->get()->names().size());
@@ -172,7 +172,7 @@ SEXP soma_array_reader(
 
     arr->length = 0;  // initial value
     for (size_t i = 0; i < ncol; i++) {
-        spdlog::info("[soma_array_reader] Accessing '{}' at pos {}", names[i], i);
+        spdl::info("[soma_array_reader] Accessing '{}' at pos {}", names[i], i);
 
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = sr_data->get()->at(names[i]);
@@ -186,13 +186,13 @@ SEXP soma_array_reader(
         ArrowArrayMove(pp.first.get(), arr->children[i]);
         ArrowSchemaMove(pp.second.get(), sch->children[i]);
 
-        spdlog::info(
+        spdl::info(
             "[soma_array_reader] Incoming name {} length {}",
             std::string(pp.second->name),
             pp.first->length);
 
         if (pp.first->length > arr->length) {
-            spdlog::debug(
+            spdl::debug(
                 "[soma_array_reader] Setting array length to {}",
                 pp.first->length);
             arr->length = pp.first->length;
@@ -404,7 +404,7 @@ SEXP c_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
         "Bad schema children alloc");
 
     for (size_t i = 0; i < static_cast<size_t>(lib_retval->n_children); i++) {
-        spdlog::info(
+        spdl::info(
             "[c_schema] Accessing name '{}' format '{}' at position {}",
             std::string(lib_retval->children[i]->name),
             std::string(lib_retval->children[i]->format),

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -69,13 +69,12 @@ SEXP soma_array_reader(
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;
 
-    spdl::info("[soma_array_reader] Reading from {}", uri);
+    tdbs::LOG_INFO(fmt::format("[soma_array_reader] Reading from {}", uri));
 
     std::vector<std::string> column_names = {};
     if (!colnames.isNull()) {  // If we have column names, select them
         column_names = Rcpp::as<std::vector<std::string>>(colnames);
-        spdl::debug(
-            "[soma_array_reader] Selecting {} columns", column_names.size());
+        tdbs::LOG_DEBUG(fmt::format("[soma_array_reader] Selecting {} columns", column_names.size()));
     }
 
     auto tdb_result_order = get_tdb_result_order(result_order);
@@ -85,8 +84,7 @@ SEXP soma_array_reader(
         timestamprange);
     if (timestamprange.isNotNull()) {
         Rcpp::DatetimeVector vec(timestamprange);
-        spdl::debug(
-            "[soma_array_reader] timestamprange ({},{})", vec[0], vec[1]);
+        tdbs::LOG_DEBUG(fmt::format("[soma_array_reader] timestamprange ({},{})", vec[0], vec[1]));
     }
 
     // Read selected columns from the uri (return is unique_ptr<SOMAArray>)
@@ -104,19 +102,18 @@ SEXP soma_array_reader(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        spdl::info(
-            "[soma_array_reader] Dimension {} type {} domain {} extent {}",
+        tdbs::LOG_INFO(fmt::format("[soma_array_reader] Dimension {} type {} domain {} extent {}",
             dim.name(),
             tiledb::impl::to_str(dim.type()),
             dim.domain_to_str(),
-            dim.tile_extent_to_str());
+            dim.tile_extent_to_str()));
         name2dim.emplace(std::make_pair(
             dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdl::info("[soma_array_reader_impl] Applying query condition");
+        tdbs::LOG_INFO("[soma_array_reader_impl] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         mq.set_condition(*qcxp);
     }
@@ -146,10 +143,9 @@ SEXP soma_array_reader(
             "or using iterated partial reads.",
             uri);
     }
-    spdl::info(
-        "[soma_array_reader] Read complete with {} rows and {} cols",
+    tdbs::LOG_INFO(fmt::format("[soma_array_reader] Read complete with {} rows and {} cols",
         sr_data->get()->num_rows(),
-        sr_data->get()->names().size());
+        sr_data->get()->names().size()));
 
     const std::vector<std::string> names = sr_data->get()->names();
     auto ncol = names.size();
@@ -172,7 +168,7 @@ SEXP soma_array_reader(
 
     arr->length = 0;  // initial value
     for (size_t i = 0; i < ncol; i++) {
-        spdl::info("[soma_array_reader] Accessing '{}' at pos {}", names[i], i);
+        tdbs::LOG_INFO(fmt::format("[soma_array_reader] Accessing '{}' at pos {}", names[i], i));
 
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = sr_data->get()->at(names[i]);
@@ -185,16 +181,13 @@ SEXP soma_array_reader(
         // pp.first.get(), sizeof(ArrowArray));
         ArrowArrayMove(pp.first.get(), arr->children[i]);
         ArrowSchemaMove(pp.second.get(), sch->children[i]);
-
-        spdl::info(
-            "[soma_array_reader] Incoming name {} length {}",
+        tdbs::LOG_INFO(fmt::format("[soma_array_reader] Incoming name {} length {}",
             std::string(pp.second->name),
-            pp.first->length);
+            pp.first->length));
 
         if (pp.first->length > arr->length) {
-            spdl::debug(
-                "[soma_array_reader] Setting array length to {}",
-                pp.first->length);
+            tdbs::LOG_DEBUG(fmt::format("[soma_array_reader] Setting array length to {}",
+                pp.first->length));
             arr->length = pp.first->length;
         }
     }
@@ -404,11 +397,10 @@ SEXP c_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
         "Bad schema children alloc");
 
     for (size_t i = 0; i < static_cast<size_t>(lib_retval->n_children); i++) {
-        spdl::info(
-            "[c_schema] Accessing name '{}' format '{}' at position {}",
+        tdbs::LOG_INFO(fmt::format("[c_schema] Accessing name '{}' format '{}' at position {}",
             std::string(lib_retval->children[i]->name),
             std::string(lib_retval->children[i]->format),
-            i);
+            i));
 
         ArrowSchemaMove(lib_retval->children[i], sch->children[i]);
     }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -90,7 +90,7 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
         tdbs::LOG_SET_LEVEL(loglevel);
     }
 
-    spdlog::debug("[mq_setup] Setting up {}", uri);
+    spdl::debug("[mq_setup] Setting up {}", uri);
 
     std::string_view name = "unnamed";
     std::vector<std::string> column_names = {};
@@ -128,7 +128,7 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        spdlog::debug(
+        spdl::debug(
             "[mq_setup] Dimension {} type {} domain {} extent {}",
             dim.name(),
             tiledb::impl::to_str(dim.type()),
@@ -140,7 +140,7 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        spdlog::debug("[mq_setup] Applying query condition");
+        spdl::debug("[mq_setup] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         mq->set_condition(*qcxp);
     }
@@ -205,7 +205,7 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
     check_xptr_tag<tdbs::ManagedQuery>(mq);
 
     if (mq_complete(mq)) {
-        spdlog::trace(
+        spdl::trace(
             "[mq_next] complete {} num_cells {}",
             mq->is_complete(true),
             mq->total_num_cells());
@@ -213,13 +213,13 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
     }
 
     auto mq_data = mq->read_next();
-    spdlog::debug(
+    spdl::debug(
         "[mq_next] Read {} rows and {} cols",
         mq_data->get()->num_rows(),
         mq_data->get()->names().size());
 
     if(!mq_data){
-        spdlog::trace("[mq_next] complete - mq_data read no data");
+        spdl::trace("[mq_next] complete - mq_data read no data");
         return create_empty_arrow_table();
     }
 
@@ -245,7 +245,7 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
     arr->length = 0;  // initial value
 
     for (size_t i = 0; i < ncol; i++) {
-        spdlog::trace("[mq_next] Accessing {} at {}", names[i], i);
+        spdl::trace("[mq_next] Accessing {} at {}", names[i], i);
 
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = mq_data->get()->at(names[i]);
@@ -257,14 +257,14 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
         ArrowSchemaMove(pp.second.get(), sch->children[i]);
 
         if (pp.first->length > arr->length) {
-            spdlog::debug(
+            spdl::debug(
                 "[soma_array_reader] Setting array length to {}",
                 pp.first->length);
             arr->length = pp.first->length;
         }
     }
 
-    spdlog::debug("[mq_next] Exporting chunk with {} rows", arr->length);
+    spdl::debug("[mq_next] Exporting chunk with {} rows", arr->length);
     // Nanoarrow special: stick schema into xptr tag to return single SEXP
     array_xptr_set_schema(arrayxp, schemaxp);  // embed schema in array
     return arrayxp;
@@ -274,7 +274,7 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
 void mq_reset(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
     check_xptr_tag<tdbs::ManagedQuery>(mq);
     mq->reset();
-    spdlog::debug("[mq_reset] Reset SOMAArray object");
+    spdl::debug("[mq_reset] Reset SOMAArray object");
 }
 
 // [[Rcpp::export]]
@@ -287,7 +287,7 @@ void mq_set_dim_points(
 
     std::vector<int64_t> vec = Rcpp::fromInteger64(points);
     mq->select_points<int64_t>(dim, vec);
-    spdlog::debug(
+    spdl::debug(
         "[mq_set_dim_points] Set on dim '{}' for {} points, first two are {} "
         "and {}",
         dim,

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -36,10 +36,9 @@ void apply_dim_points(
                 if (uv[i] >= pr.first && uv[i] <= pr.second) {
                     mq->select_point<uint64_t>(
                         nm, uv[i]);  // bonked when use with vector
-                    spdl::info(
-                        "[apply_dim_points] Applying dim point {} on {}",
+                    tdbs::LOG_INFO(fmt::format("[apply_dim_points] Applying dim point {} on {}",
                         uv[i],
-                        nm);
+                        nm));
                     suitable = true;
                 }
             }
@@ -50,10 +49,9 @@ void apply_dim_points(
             for (size_t i = 0; i < iv.size(); i++) {
                 if (iv[i] >= pr.first && iv[i] <= pr.second) {
                     mq->select_point<int64_t>(nm, iv[i]);
-                    spdl::debug(
-                        "[apply_dim_points] Applying dim point {} on {}",
+                    tdbs::LOG_DEBUG(fmt::format("[apply_dim_points] Applying dim point {} on {}",
                         iv[i],
-                        nm);
+                        nm));
                     suitable = true;
                 }
             }
@@ -64,10 +62,9 @@ void apply_dim_points(
                 float v = static_cast<float>(payload[i]);
                 if (v >= pr.first && v <= pr.second) {
                     mq->select_point<float>(nm, v);
-                    spdl::debug(
-                        "[apply_dim_points] Applying dim point {} on {}",
+                    tdbs::LOG_DEBUG(fmt::format("[apply_dim_points] Applying dim point {} on {}",
                         v,
-                        nm);
+                        nm));
                     suitable = true;
                 }
             }
@@ -77,10 +74,9 @@ void apply_dim_points(
             for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     mq->select_point<double>(nm, payload[i]);
-                    spdl::debug(
-                        "[apply_dim_points] Applying dim point {} on {}",
+                    tdbs::LOG_DEBUG(fmt::format("[apply_dim_points] Applying dim point {} on {}",
                         payload[i],
-                        nm);
+                        nm));
                     suitable = true;
                 }
             }
@@ -90,10 +86,9 @@ void apply_dim_points(
             for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     mq->select_point<int32_t>(nm, payload[i]);
-                    spdl::debug(
-                        "[apply_dim_points] Applying dim point {} on {}",
+                    tdbs::LOG_DEBUG(fmt::format("[apply_dim_points] Applying dim point {} on {}",
                         payload[i],
-                        nm);
+                        nm));
                     suitable = true;
                 }
             }
@@ -133,13 +128,12 @@ void apply_dim_ranges(
                 uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
                 vp[i] = std::make_pair(
                     std::max(l, pr.first), std::min(h, pr.second));
-                spdl::debug(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                tdbs::LOG_DEBUG(fmt::format("[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
                     nm,
                     l,
-                    h);
+                    h));
                 suitable = l < pr.second &&
                            h > pr.first;  // lower must be less than max, higher
                                           // more than min
@@ -155,13 +149,12 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdl::debug(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                tdbs::LOG_DEBUG(fmt::format("[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
                     nm,
                     lo[i],
-                    hi[i]);
+                    hi[i]));
                 suitable = lo[i] < pr.second &&
                            hi[i] > pr.first;  // lower must be less than max,
                                               // higher more than min
@@ -181,13 +174,12 @@ void apply_dim_ranges(
                 float h = static_cast<float>(hi[i]);
                 vp[i] = std::make_pair(
                     std::max(l, pr.first), std::min(h, pr.second));
-                spdl::debug(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                tdbs::LOG_DEBUG(fmt::format("[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
                     nm,
                     l,
-                    h);
+                    h));
                 suitable = l < pr.second &&
                            h > pr.first;  // lower must be less than max, higher
                                           // more than min
@@ -205,13 +197,12 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdl::debug(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                tdbs::LOG_DEBUG(fmt::format("[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
                     nm,
                     lo[i],
-                    hi[i]);
+                    hi[i]));
                 suitable = lo[i] < pr.second &&
                            hi[i] > pr.first;  // lower must be less than max,
                                               // higher more than min
@@ -229,13 +220,12 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdl::debug(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                tdbs::LOG_DEBUG(fmt::format("[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
                     nm[i],
                     lo[i],
-                    hi[i]);
+                    hi[i]));
                 suitable = lo[i] < pr.second &&
                            hi[i] > pr.first;  // lower must be less than max,
                                               // higher more than min
@@ -475,21 +465,19 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
             std::vector<std::string>
                 lohi = tiledbsoma::ArrowAdapter::get_array_string_column(
                     arrow_array->children[i], arrow_schema->children[i]);
-            spdl::info(
-                "[domainish] name {} format {} length {} lo {} hi {}",
+            tdbs::LOG_INFO(fmt::format("[domainish] name {} format {} length {} lo {} hi {}",
                 std::string(arrow_schema->children[i]->name),
                 std::string(arrow_schema->children[i]->format),
                 arrow_array->children[i]->length,
                 lohi[0],
-                lohi[1]);
+                lohi[1]));
         } else {
             // Arrow semantics: non-variable-length: buffers 0,1 are validity &
             // data
-            spdl::info(
-                "[domainish] name {} format {} length {}",
+            tdbs::LOG_INFO(fmt::format("[domainish] name {} format {} length {}",
                 std::string(arrow_schema->children[i]->name),
                 std::string(arrow_schema->children[i]->format),
-                arrow_array->children[i]->length);
+                arrow_array->children[i]->length));
         }
 
         ArrowArrayMove(arrow_array->children[i], arr->children[i]);

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -36,7 +36,7 @@ void apply_dim_points(
                 if (uv[i] >= pr.first && uv[i] <= pr.second) {
                     mq->select_point<uint64_t>(
                         nm, uv[i]);  // bonked when use with vector
-                    spdlog::info(
+                    spdl::info(
                         "[apply_dim_points] Applying dim point {} on {}",
                         uv[i],
                         nm);
@@ -50,7 +50,7 @@ void apply_dim_points(
             for (size_t i = 0; i < iv.size(); i++) {
                 if (iv[i] >= pr.first && iv[i] <= pr.second) {
                     mq->select_point<int64_t>(nm, iv[i]);
-                    spdlog::debug(
+                    spdl::debug(
                         "[apply_dim_points] Applying dim point {} on {}",
                         iv[i],
                         nm);
@@ -64,7 +64,7 @@ void apply_dim_points(
                 float v = static_cast<float>(payload[i]);
                 if (v >= pr.first && v <= pr.second) {
                     mq->select_point<float>(nm, v);
-                    spdlog::debug(
+                    spdl::debug(
                         "[apply_dim_points] Applying dim point {} on {}",
                         v,
                         nm);
@@ -77,7 +77,7 @@ void apply_dim_points(
             for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     mq->select_point<double>(nm, payload[i]);
-                    spdlog::debug(
+                    spdl::debug(
                         "[apply_dim_points] Applying dim point {} on {}",
                         payload[i],
                         nm);
@@ -90,7 +90,7 @@ void apply_dim_points(
             for (R_xlen_t i = 0; i < payload.size(); i++) {
                 if (payload[i] >= pr.first && payload[i] <= pr.second) {
                     mq->select_point<int32_t>(nm, payload[i]);
-                    spdlog::debug(
+                    spdl::debug(
                         "[apply_dim_points] Applying dim point {} on {}",
                         payload[i],
                         nm);
@@ -133,7 +133,7 @@ void apply_dim_ranges(
                 uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
                 vp[i] = std::make_pair(
                     std::max(l, pr.first), std::min(h, pr.second));
-                spdlog::debug(
+                spdl::debug(
                     "[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
@@ -155,7 +155,7 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdlog::debug(
+                spdl::debug(
                     "[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
@@ -181,7 +181,7 @@ void apply_dim_ranges(
                 float h = static_cast<float>(hi[i]);
                 vp[i] = std::make_pair(
                     std::max(l, pr.first), std::min(h, pr.second));
-                spdlog::debug(
+                spdl::debug(
                     "[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
@@ -205,7 +205,7 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdlog::debug(
+                spdl::debug(
                     "[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
@@ -229,7 +229,7 @@ void apply_dim_ranges(
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(
                     std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                spdlog::debug(
+                spdl::debug(
                     "[apply_dim_ranges] Applying dim point {} on {} with {} - "
                     "{}",
                     i,
@@ -475,7 +475,7 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
             std::vector<std::string>
                 lohi = tiledbsoma::ArrowAdapter::get_array_string_column(
                     arrow_array->children[i], arrow_schema->children[i]);
-            spdlog::info(
+            spdl::info(
                 "[domainish] name {} format {} length {} lo {} hi {}",
                 std::string(arrow_schema->children[i]->name),
                 std::string(arrow_schema->children[i]->format),
@@ -485,7 +485,7 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
         } else {
             // Arrow semantics: non-variable-length: buffers 0,1 are validity &
             // data
-            spdlog::info(
+            spdl::info(
                 "[domainish] name {} format {} length {}",
                 std::string(arrow_schema->children[i]->name),
                 std::string(arrow_schema->children[i]->format),

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -41,7 +41,7 @@ inline std::map<std::string, std::string> config_vector_to_map(Rcpp::Nullable<Rc
         size_t n = confvec.length();
         for (size_t i = 0; i<n; i++) {
             platform_config.emplace(std::make_pair(std::string(namesvec[i]), std::string(confvec[i])));
-            spdlog::trace("[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i]));
+            spdl::trace("[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i]));
         }
     }
 

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -41,7 +41,7 @@ inline std::map<std::string, std::string> config_vector_to_map(Rcpp::Nullable<Rc
         size_t n = confvec.length();
         for (size_t i = 0; i<n; i++) {
             platform_config.emplace(std::make_pair(std::string(namesvec[i]), std::string(confvec[i])));
-            spdl::trace("[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i]));
+            tdbs::LOG_TRACE(fmt::format("[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i])));
         }
     }
 


### PR DESCRIPTION
**Issue and/or context:**  [296](https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/296)

**Changes:**
Use exposed `tilesdbsoma` logging function instead of `spdlog` directly

**Notes for Reviewer:**

```
library(tiledbsoma)
tiledbsoma::set_log_level("<desired log level>")
tiledbsoma::SOMAExperimentOpen("/some/path")
```

