### PR TITLE
[python] Ingest from S3 performance

### DIFF
--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -118,6 +118,9 @@ jobs:
     - name: Show XCode version
       run: clang --version
 
+    - name: Log pip dependencies
+      run: pip list
+
     - name: Run libtiledbsoma unit tests
       run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
       env:

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import ctypes
 import io
+import sys
 import threading
 from collections import OrderedDict
-from typing import Any, cast
+from typing import Any, Union, cast
 
 import attrs
 import pyarrow as pa
-from typing_extensions import Buffer
+from typing_extensions import Buffer, TypeAlias
+
+# typeguard and cython memoryview incompat in older versions
+if sys.version_info >= (3, 12):
+    WritableBuffer: TypeAlias = Union[memoryview, Buffer]
+else:
+    WritableBuffer: TypeAlias = Any
 
 
 @attrs.define
@@ -132,7 +139,7 @@ class CachingReader:
         self._pos += len(b)
         return cast(bytes, b)
 
-    def readinto(self, buf: Buffer | memoryview) -> int | None:
+    def readinto(self, buf: WritableBuffer) -> int | None:
         if not isinstance(buf, memoryview):
             buf = memoryview(buf)
         if buf.nbytes == 0:

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -194,22 +194,20 @@ class CachingReader:
           os.SEEK_END or 2 - end of the stream; offset is usually negative
 
         """
-
-        if whence not in [io.SEEK_SET, io.SEEK_CUR, io.SEEK_END]:
+        if whence == io.SEEK_SET:
+            new_pos = 0 + offset
+        elif whence == io.SEEK_CUR:
+            new_pos = self._pos + offset
+        elif whence == io.SEEK_END:
+            new_pos = self._file_length + offset
+        else:
             raise ValueError("Invalid whence value {whence})")
 
-        if whence == io.SEEK_END:
-            offset = self._file_length + offset
-        elif whence == io.SEEK_CUR:
-            offset += self._pos
-        elif whence == io.SEEK_SET:
-            offset = offset
-
-        if offset < 0:
+        if new_pos < 0:
             raise OSError("seek() returned invalid position")
 
-        self._pos = offset
-        return offset
+        self._pos = new_pos
+        return new_pos
 
     @property
     def closed(self) -> bool:

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -173,7 +173,7 @@ class CachingReader:
 
     def seek(self, offset: int, whence: int = 0) -> int:
         if whence not in [io.SEEK_SET, io.SEEK_CUR, io.SEEK_END]:
-            raise ValueError("Invalid whence value")
+            raise ValueError("Invalid whence value {whence})")
 
         if whence == io.SEEK_END:
             offset = self._file_length + offset

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import ctypes
+import io
+import threading
+from collections import OrderedDict
+from typing import Any, cast
+
+import pyarrow as pa
+from typing_extensions import Buffer
+
+
+class CachingReader:
+    """Buffering reader which will maintain an LRU cache of previously read data, wrapping
+    and presenting a file-like interface.
+
+    Much like ``io.BufferedReader``, wraps file-like object. Class assumes that the underlying
+    file is not changing concurrent with read. Any read to the file-like object will be a
+    minimum of "cache block" size bytes.
+
+    Primary use case is wrapping a VFS FileBuffer object, to improve performance of read
+    operations by doing fewer, larger reads.
+
+    Cached read bytes are stored as PyArrow arrays, primarily to benefit from the
+    easy, minimal-copy concat and slice operations upon underlying buffers.
+    """
+
+    def __init__(
+        self,
+        file: Any,  # file-like object. Unfortunately, Python lacks a good typing signature for this concept.
+        *,
+        memory_budget: int = 128 * 1024**2,
+        cache_block_size: int = 1024**2,
+    ):
+        if not file.readable():
+            raise io.UnsupportedOperation("file must be readable")
+        if memory_budget < cache_block_size:
+            raise ValueError("memory_budget must be >= cache_block_size")
+
+        self._file = file
+        self._file_length = file.seek(0, io.SEEK_END)
+        file.seek(0)
+        self._offset = 0
+
+        self._cache_block_size = cache_block_size
+        self._max_cache_blocks = max(1, memory_budget // cache_block_size)
+        self._n_blocks = (self._file_length + cache_block_size - 1) // cache_block_size
+
+        self._cache_lock = threading.Lock()
+        self._cached_blocks: list[bytes | None] = [None] * self._n_blocks
+        self._cache_lru: OrderedDict[int, None] = OrderedDict()
+
+    def _read_block(self, block: int) -> pa.UInt8Array:
+        nbytes = min(
+            self._cache_block_size,
+            self._file_length - block * self._cache_block_size,
+        )
+        assert nbytes > 0
+        buffer = pa.allocate_buffer(nbytes)
+        ctypes.memset(buffer.address, 0, len(buffer))  # better safe than sorry
+        self._file.seek(block * self._cache_block_size)
+        bytes_read = self._file.readinto(memoryview(buffer))
+        assert nbytes == bytes_read == len(buffer)
+        a = pa.UInt8Array.from_buffers(pa.uint8(), len(buffer), [None, buffer])
+        return a
+
+    def _load_cache(self, start: int, end: int) -> list[pa.UInt8Array]:
+        end = min(end, self._file_length)
+        start_block = start // self._cache_block_size
+        end_block = (end + self._cache_block_size - 1) // self._cache_block_size
+        with self._cache_lock:
+            missing_blocks = [
+                i
+                for i in range(start_block, end_block)
+                if self._cached_blocks[i] is None
+            ]
+            for block in missing_blocks:
+                self._cached_blocks[block] = self._read_block(block)
+
+            requested_blocks = [
+                self._cached_blocks[i] for i in range(start_block, end_block)
+            ]
+
+            self._mark_and_sweep_blocks(start_block, end_block)
+
+        assert all(b is not None for b in requested_blocks)
+        return cast(list[pa.UInt8Array], requested_blocks)
+
+    def _mark_and_sweep_blocks(self, start: int, stop: int) -> None:
+        for block_idx in range(start, stop):
+            if block_idx in self._cache_lru:
+                self._cache_lru.move_to_end(block_idx)
+
+            elif len(self._cache_lru) < self._max_cache_blocks:
+                self._cache_lru[block_idx] = None
+
+            else:
+                remove_idx = self._cache_lru.popitem(last=False)
+                self._cache_lru[block_idx] = None
+                self._cached_blocks[remove_idx[0]] = None
+
+    def _reset_cache(self) -> None:
+        with self._cache_lock:
+            self._cached_blocks = [None] * self._n_blocks
+            self._cache_lru.clear()
+
+    def read(self, size: int = -1) -> bytes:
+        if size == -1:
+            size = self._file_length - self._offset
+        blocks = self._load_cache(self._offset, self._offset + size)
+
+        start = self._offset % self._cache_block_size
+        end = start + size
+        arr = pa.chunked_array(blocks)[start:end].combine_chunks()  # NB: copy
+        assert arr.offset == 0
+        b = arr.buffers()[1].to_pybytes()  # NB: copy
+        self._offset += size
+        return cast(bytes, b)
+
+    def readinto(self, buf: Buffer) -> int:
+        buf = memoryview(buf)
+        size = len(buf)
+        blocks = self._load_cache(self._offset, self._offset + size)
+        start = self._offset % self._cache_block_size
+        end = start + size
+        carr = pa.chunked_array(blocks)[start:end]
+
+        dst = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+        dstidx = 0
+        for c in carr.chunks:
+            src = c.buffers()[1].address + c.offset
+            count = len(c)
+            ctypes.memmove(dst + dstidx, src, count)
+            dstidx += count
+
+        assert dstidx == len(carr)
+        self._offset += dstidx
+        return dstidx
+
+    def close(self) -> None:
+        self._reset_cache()
+        self._file.close()
+
+    def tell(self) -> int:
+        return self._offset
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        if whence not in [io.SEEK_SET, io.SEEK_CUR, io.SEEK_END]:
+            raise ValueError("Invalid whence value")
+
+        if whence == io.SEEK_END:
+            offset = self._file_length + offset
+        elif whence == io.SEEK_CUR:
+            offset += self._offset
+        elif whence == io.SEEK_SET:
+            offset = offset
+
+        if offset < 0:
+            raise OSError("seek() returned invalid position")
+
+        self._offset = offset
+        return offset

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -132,7 +132,7 @@ class CachingReader:
         self._pos += len(b)
         return cast(bytes, b)
 
-    def readinto(self, buf: Buffer) -> int | None:
+    def readinto(self, buf: Buffer | memoryview) -> int | None:
         if not isinstance(buf, memoryview):
             buf = memoryview(buf)
         if buf.nbytes == 0:

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -53,7 +53,9 @@ def read_h5ad(
     ctx = ctx or SOMATileDBContext()
     vfs = clib.SOMAVFS(ctx.native_context)
     input_handle = CachingReader(
-        clib.SOMAVFSFilebuf(vfs).open(str(input_path)), memory_budget=128 * 1024**2
+        clib.SOMAVFSFilebuf(vfs).open(str(input_path)),
+        memory_budget=1024**3,
+        cache_block_size=8 * 1024**2,
     )
     try:
         with _hack_patch_anndata():

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -54,7 +54,7 @@ def read_h5ad(
     vfs = clib.SOMAVFS(ctx.native_context)
     input_handle = CachingReader(
         clib.SOMAVFSFilebuf(vfs).open(str(input_path)),
-        memory_budget=1024**3,
+        memory_budget=64 * 1024**2,
         cache_block_size=8 * 1024**2,
     )
     try:

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -22,6 +22,7 @@ from .. import pytiledbsoma as clib
 from .._exception import SOMAError
 from .._types import Path
 from ..options import SOMATileDBContext
+from ._caching_reader import CachingReader
 
 _pa_type_to_str_fmt = {
     pa.string(): "U",
@@ -51,7 +52,9 @@ def read_h5ad(
     """
     ctx = ctx or SOMATileDBContext()
     vfs = clib.SOMAVFS(ctx.native_context)
-    input_handle = clib.SOMAVFSFilebuf(vfs).open(str(input_path))
+    input_handle = CachingReader(
+        clib.SOMAVFSFilebuf(vfs).open(str(input_path)), memory_budget=128 * 1024**2
+    )
     try:
         with _hack_patch_anndata():
             anndata = ad.read_h5ad(_FSPathWrapper(input_handle, input_path), mode)

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -75,7 +75,6 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
             return py::bytes("");
         }
 
-        auto oldoffset = offset_;
         py::gil_scoped_release release;
         std::string buffer(nbytes, '\0');
         offset_ += xsgetn(&buffer[0], nbytes);

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -39,7 +39,7 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
    public:
     SOMAVFSFilebuf(const VFS& vfs)
         : tiledb::impl::VFSFilebuf(vfs)
-        , vfs_(vfs) {};
+        , vfs_(vfs){};
 
     SOMAVFSFilebuf* open(const std::string& uri, std::ios::openmode openmode) {
         openmode_ = openmode;

--- a/apis/python/tests/ht/test_ht_caching_reader.py
+++ b/apis/python/tests/ht/test_ht_caching_reader.py
@@ -1,0 +1,118 @@
+import io
+
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    initialize,
+    invariant,
+    precondition,
+    rule,
+)
+
+from tiledbsoma.io._caching_reader import CachingReader
+
+from .._util import TESTDATA
+
+
+class CachingReaderStateMachine(RuleBasedStateMachine):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fname = TESTDATA / "pbmc3k.h5ad"
+
+    @initialize()
+    def _setup(self):
+        self._closed = True
+
+        # the two file handles that are compared
+        self.raw = None
+        self.cached = None
+
+    def teardown(self) -> None:
+        if not self._closed:
+            self.raw.close()
+            self.cached.close()
+            self.raw = None
+            self.cache = None
+
+        super().teardown()
+
+    @invariant()
+    @precondition(lambda self: self.raw is not None and self._closed)
+    def check_closed_state(self) -> None:
+        """Invariants that should be true when we have a file handle (in any state)"""
+        assert self.raw is not None and self.cached is not None
+        assert self.raw.closed == self.cached.closed
+
+    @invariant()
+    @precondition(lambda self: self.raw is not None and not self._closed)
+    def check_open_state(self) -> None:
+        """Invariants that should be true if we have an open handle"""
+        assert self.raw is not None and not self._closed
+        assert self.raw.closed == self.cached.closed
+        assert self.raw.readable() == self.cached.readable()
+        assert self.raw.tell() == self.cached.tell()
+
+    @precondition(lambda self: self._closed)
+    @rule()
+    def open(self) -> None:
+        self._closed = False
+        self.raw = open(self._fname, "rb")
+        self.cached = CachingReader(open(self._fname, "rb"))
+
+    @precondition(lambda self: not self._closed)
+    @rule()
+    def close(self) -> None:
+        self._closed = True
+        self.raw.close()
+        self.cached.close()
+        assert self.raw.closed == self.cached.closed
+
+    @precondition(lambda self: not self._closed)
+    @rule(size=st.integers(min_value=-1, max_value=8192))
+    def read(self, size: int) -> None:
+        raw_buf = self.raw.read(size)
+        cached_buf = self.cached.read(size)
+
+        assert raw_buf == cached_buf
+        assert self.raw.tell() == self.cached.tell()
+
+    @precondition(lambda self: not self._closed)
+    @rule(size=st.integers(min_value=0, max_value=8192))
+    def readinto(self, size: int) -> None:
+        raw_buf = bytearray(size)
+        cached_buf = bytearray(size)
+
+        raw_nbytes = self.raw.readinto(raw_buf)
+        cached_nbytes = self.cached.readinto(cached_buf)
+
+        assert raw_nbytes == cached_nbytes
+        assert raw_buf == cached_buf
+        assert self.raw.tell() == self.cached.tell()
+
+    @precondition(lambda self: not self._closed)
+    @rule(
+        offset=st.integers(min_value=-8192, max_value=8192),
+        whence=st.sampled_from([io.SEEK_SET, io.SEEK_CUR, io.SEEK_END]),
+    )
+    def seek(self, offset: int, whence: int) -> None:
+        raw_offset: int | None = None
+        cached_offset: int | None = None
+        try:
+            raw_err = False
+            raw_offset = self.raw.seek(offset, whence)
+        except Exception:
+            raw_err = True
+
+        try:
+            cached_err = False
+            cached_offset = self.cached.seek(offset, whence)
+        except Exception:
+            cached_err = True
+
+        assert raw_offset == cached_offset
+        assert self.raw.tell() == self.cached.tell()
+        assert raw_err == cached_err
+
+
+TestCachingReader = CachingReaderStateMachine.TestCase


### PR DESCRIPTION
**Issue and/or context:**

`soma.io.from_h5ad` will read H5ADs from any path VFS supports. However, performance on S3 is extremely slow.

Analysis shows that this is caused by two issues:
* `h5py` (which underpins AnnData) assumes it is reading from a file system (eg, issues many small reads, does not read the object sequentially, etc)
* The current implementation translates those requests directly to VFS read calls, which is a documented antipattern (see vfs.h header where it recommends issuing fewer, larger reads)

**Changes:**

This PR introduces a Python caching reader, similar in concept to `io.BufferedReader`, to mediate between `h5Py` and VFS. It introduces several changes in behavior:
* the minimum read size is increased significantly (configurable)
* previously read blocks are maintained in an LRU cache (size configurable)
* the file-like object API `readinto` is added, reducing memory copies (h5py will preferentially use this API if it exists)

The PR also adds `SOMAVFS` python bindings required for common usage as a "file-like" object (i.e., those features of `RawIOBase`, necessary to wrap in buffering classes like `io.BufferedReader`), including `readinto`, `closed`, `readable` and other methods.

Benchmarking on a wide variety of H5ADs resident on S3 have resulted in the current configuration of 8MiB blocks, and a total cache size of 64MiB.

Benchmarking on EC2/S3 across a wide range of H5AD sizes show that this PR provides a 30-60X speed up in  total time to perform `from_h5ad` (this time _includes_ writing the Experiment).  I also compared `from_h5ad` to the time required to download and perform the same operation on the local file system - it is now within a factor of 2X of the "make a local copy" time.

**Notes for Reviewer:**

This is one of two PRs relating to ingestion performance.  Related: [sc-43827]

This PR also made a small change to GH CI.  Previously, the installed python packages were logged prior to running tests.  At some point, this was removed and they were only logged prior to running pre-commits.  I added the logging back, as an aid to solving dependency related failures.