### PR TITLE
[python] `python-ci-full.yml`: fix `include` rules for compiler choice

### DIFF
--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -26,10 +26,10 @@ jobs:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1849
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         include:
-          - runs-on: ubuntu-24.04
+          - os: ubuntu-24.04
             cc: gcc-13
             cxx: g++-13
-          - runs-on: macos-latest
+          - os: macos-latest
             cc: clang
             cxx: clang++
     uses: ./.github/workflows/python-ci-single.yml


### PR DESCRIPTION
@bkmartinjr noticed our ubuntu GHAs had `cc`/`cxx` set to `clang` ([example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14184688749/job/39738791732#step:9:11)). This was [apparently](https://github.com/single-cell-data/TileDB-SOMA/pull/750/files#diff-9920b0afa17c2e73928b7fc1639e011370756aee90d805c32e76cffb5d0bbd58R19-R22) the case since `python-ci-full.yml` was added in #750.

With this PR, a [manually-dispatched GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14197589446/job/39776369369#step:9:11) shows GCC, as expected:
```
CC: gcc-13
CXX: g++-13
```

[sc-65188]