### PR TITLE
[ci] Run remote-storage workflow on all commits

### DIFF
--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -1,18 +1,19 @@
 name: TileDB-SOMA Python CI (remote storage)
 
 on:
-  # Not for regular use, but you can uncomment this when putting up PRs on this
-  # file. Just remember to take it back out. There's no need to run
-  # remote-storage tests on every single PR push to our repo.
-  #
-  # pull_request:
-  #
-  # Allows for 'as needed' manual trigger:
+  push:
+    branches:
+      - main
+      - 'release-*'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'apis/r/**'
+      - 'docker/**'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/python-remote-storage.yml'
   workflow_dispatch:
-  #
-  # Use a regular nightly build as well (time is UTC):
-  schedule:
-    - cron: "25 5 * * *"
 
 env:
   # Don't name this "TILEDB_REST_TOKEN" since that will map into a core


### PR DESCRIPTION
**Issue and/or context:** Follow-on to PR #3884 given that issue #3879 revealed a defect in #3764 that was detected by the nightly remote-storage CI but not pre-merge CI. See also [[sc-65205]](https://app.shortcut.com/tiledb-inc/story/65205/apparent-umr-in-offsets-returned-on-remote-write).

**Changes:**

**Notes for Reviewer:**

Wall times for these two are comparable:

* https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml
* https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-remote-storage.yml

Note that the first uses many runners, and the latter only one -- so this PR won't double our per-commit CI time.