### PR TITLE
[python] Pin `build-system.requires`, ARM Linux Docker-builds to `cmake<4`

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -17,25 +17,32 @@ jobs:
           - runs-on: ubuntu-24.04
             suffix: ''
           - runs-on: ubuntu-24.04-arm
-            suffix: ' (ARM)'
+            suffix: ' ARM'
           # TODO: currently impossible(?) to build Docker images on macOS runners: https://github.com/single-cell-data/TileDB-SOMA/issues/3781
           # - macos-15
           # TODO: try x86 macOS builds, once https://github.com/single-cell-data/TileDB-SOMA/issues/3787 is resolved
           # - macos-13
         img:
-          - name: ubuntu-src
-          - name: ubuntu
+          - name: Ubuntu src
+            file: ubuntu-src
+          - name: Ubuntu 1.15.7
+            file: ubuntu
             args: v=1.15.7
-          - name: ubuntu
+          - name: Ubuntu 1.16.0
+            file: ubuntu
             args: v=1.16.0
-          - name: bookworm
+          - name: Debian 1.15.7 gcc12
+            file: bookworm
             args: gcc=12 v=1.15.7
-          - name: bookworm
+          - name: Debian 1.15.7 gcc13
+            file: bookworm
             args: gcc=13 v=1.15.7
-          - name: bookworm
+          - name: Debian 1.16.0 gcc13
+            file: bookworm
             args: gcc=13 v=1.16.0
-          - name: langchain
-    name: ${{ matrix.img.name }} ${{ matrix.img.args }}${{ matrix.os.suffix }}
+          - name: Langchain
+            file: langchain
+    name: ${{ matrix.img.name }}${{ matrix.os.suffix }}
     runs-on: ${{ matrix.os.runs-on }}
     steps:
       - uses: actions/checkout@v4
@@ -45,11 +52,11 @@ jobs:
           for arg in ${{ matrix.img.args }}; do
             args+=(--build-arg $arg)
           done
-          cmd=(docker build -f ${{ matrix.img.name }}.dockerfile -t ${{ matrix.img.name }} "${args[@]}" .)
+          cmd=(docker build -f ${{ matrix.img.file }}.dockerfile -t ${{ matrix.img.file }} "${args[@]}" .)
           echo "Running: ${cmd[*]}"
           "${cmd[@]}"
         working-directory: docker
-      - run: docker run ${{ matrix.img.name }}
+      - run: docker run ${{ matrix.img.file }}
         working-directory: docker
   # File an issue if anything fails, but only for scheduled ones (not manual "workflow_dispatch" runs).
   create_issue_on_fail:

--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   docker:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - runs-on: ubuntu-24.04

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "pybind11[global]>=2.10.0",
     "setuptools>=70.1",  # `setuptools.command.bdist_wheel`
-    "cmake>=3.21",
+    "cmake>=3.21,<4",  # CMake 4 builds are broken on ARM Linux: https://github.com/single-cell-data/TileDB-SOMA/issues/3890
 ]
 build-backend = "setuptools.build_meta"
 

--- a/docker/bookworm.dockerfile
+++ b/docker/bookworm.dockerfile
@@ -2,12 +2,18 @@
 ARG gcc=13
 FROM gcc:$gcc-bookworm
 
-ENV DEBIAN_FRONTEND=noninteractive VCPKG_FORCE_SYSTEM_BINARIES=1
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y \
  && apt install -y cmake curl g++ git make ninja-build pkg-config tar unzip zip \
  && apt install -y python3 python-is-python3 python3-pip python3-venv \
  && python -m venv .venv
 ENV PATH=/.venv/bin:$PATH
+
+# Require CMake<4 on ARM Linux: https://github.com/single-cell-data/TileDB-SOMA/issues/3890
+RUN if [ "$(uname -m)" = aarch64 ]; then echo 'cmake<4' > constraints.txt; else touch constraints.txt; fi
+ENV PIP_CONSTRAINT=/constraints.txt
+# vcpkg requires this on ARM, elsewhere it's a no-op (as `pip install tiledbsoma` below installs wheels, skips vcpkg bootstrap)
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 
 # tiledbsoma>=1.16 requires GCC 13
 ARG v=''

--- a/docker/langchain.dockerfile
+++ b/docker/langchain.dockerfile
@@ -1,9 +1,15 @@
 # Example Debian 12 image, comes with GCC 12 and Python 3.12
 FROM langchain/langgraph-api:3.12
 
-ENV DEBIAN_FRONTEND=noninteractive VCPKG_FORCE_SYSTEM_BINARIES=1
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y \
  && apt install -y cmake curl g++ git make ninja-build pkg-config tar unzip zip
+
+# Require CMake<4 on ARM Linux: https://github.com/single-cell-data/TileDB-SOMA/issues/3890
+RUN if [ "$(uname -m)" = aarch64 ]; then echo 'cmake<4' > constraints.txt; else touch constraints.txt; fi
+ENV PIP_CONSTRAINT=/api/constraints.txt
+# vcpkg requires this on ARM, elsewhere it's a no-op (as `pip install tiledbsoma` below installs wheels, skips vcpkg bootstrap)
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 
 # tiledbsoma>=1.16 requires GCC 13, which is more involved to install on this base image; see bookworm-pypi for an
 # example that works with both GCC 12 and 13

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -13,7 +13,13 @@ RUN apt update -y \
  && apt install -y python${python}-dev python${python}-venv python3-pip \
  && update-alternatives --install /usr/bin/python python /usr/bin/python${python} 1 \
  && python -m venv .venv
-ENV PATH="/.venv/bin:$PATH" VCPKG_FORCE_SYSTEM_BINARIES=1
+ENV PATH="/.venv/bin:$PATH"
+
+# Require CMake<4 on ARM Linux: https://github.com/single-cell-data/TileDB-SOMA/issues/3890
+RUN if [ "$(uname -m)" = aarch64 ]; then echo 'cmake<4' > constraints.txt; else touch constraints.txt; fi
+ENV PIP_CONSTRAINT=/constraints.txt
+# vcpkg requires this on ARM, elsewhere it's a no-op (as `pip install tiledbsoma` below installs wheels, skips vcpkg bootstrap)
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 
 ARG v=''
 RUN if [ -z $v ]; then pip install tiledbsoma; else pip install tiledbsoma==$v; fi


### PR DESCRIPTION
**Issue and/or context:**

CMake 4 (released [Friday, 3/27](https://pypi.org/project/cmake/4.0.0/)) broke our vcpkg-source build:

- #3890
- #3867
- #2482
- #2413

**Changes:**
- Pin `cmake<4` in `pyproject.toml` `build-system.requirements`
- Use a pip ["constraints" file](https://pip.pypa.io/en/stable/user_guide/#constraints-files) in Docker builds, to force setuptools to use `cmake<4`.

**Notes for Reviewer:**
- This makes [python-dockers.yml] work again, but the ARM Linux jobs still take 25-35mins building wheels (vs. 1-2mins on other platforms).
- It also remains a mystery why we're not getting vcpkg binaries, and why our vcpkg source build is getting an [old/broken cmrc][CMakeRC.cmake#L37].

[![GitHub Actions screenshot showing job timings; ARM jobs take 25-35mins (vs. 1-2mins for x86 jobs)](https://github.com/user-attachments/assets/d26c0ab7-d668-431a-8ce9-a5eec6a7e894)][GHA]
([GHA])

[GHA]: https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14220200288
[python-dockers.yml]: https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-dockers.yml
[CMakeRC.cmake#L37]: https://github.com/vector-of-bool/cmrc/blob/2.0.1/CMakeRC.cmake#L37