### PR TITLE
[ci/python] `python-dockers.yml`: improve issue template

### DIFF
--- a/.github/workflows/daily-python-dockers-issue-template.md
+++ b/.github/workflows/daily-python-dockers-issue-template.md
@@ -1,0 +1,7 @@
+---
+title: Daily {{ tools.context.action }} run failing
+labels: bug
+---
+
+See run for more details:
+https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -63,4 +63,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: .github/workflows/daily-test-build-issue-template.md
+          filename: .github/workflows/daily-python-dockers-issue-template.md
+          assignees: ryan-williams, johnkerl
+          update_existing: true

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -41,7 +41,7 @@ jobs:
 
   # This step builds wheels and uploads them to GitHub Actions storage.
   # See also https://github.com/single-cell-data/TileDB-SOMA/issues/700.
-  # See also https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-WIP
+  # See also https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-notes
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py


### PR DESCRIPTION
**Issue and/or context:**
`python-docker.yml` began failing Friday (#3867), then continued failing for several days, generating a new issue each day (#3870, #3871, #3874, #3880, #3892).

**Changes:**
- `update_existing: true`: update any existing open issue with the same title as the one about to be filed
  - Requires removing the date from the title, but I think that makes sense; #3867 turned into a rolling/tracking issue about a build break that lasted multiple days.
- Move assignees from issue-template to `JasonEtco/create-an-issue@v2` invocation (seems a bit nicer)
- Fix an unrelated broken wiki link

**Notes for Reviewer:**
I haven't tested this, seems likely correct / we can troubleshoot if/when the next failure occurs. Alternative is I can manually-dispatch it to create a test issue, and verify that subsequent runs update the existing issue (rather than create a new issue each time).

I've `[skip ci]`'d because Docker-build GHA is failing (until #3891 lands), and it wouldn't file an issue anyway (since it's not a `scheduled` run).