### PR TITLE
[ci/python] `python-ci-packaging.yml`: only run on `push` events to `main`

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -5,6 +5,7 @@ name: TileDB-SOMA Python CI (Packaging)
 
 on:
   push:
+    branches: [ main ]
     paths:
       - '.github/workflows/python-ci-packaging.yml'
       - 'apis/python/MANIFEST.in'


### PR DESCRIPTION
Otherwise it runs on any branch push that touches relevant `paths`, which is not necessary (given the `paths` are already tested for `pull_request` events).

Example: I canceled [this run](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14222818216) on a non-PR branch (where I'm testing `python-packaging.yml` by manually-dispatching runs).