### PR TITLE
[c++] Show errant value in not-array-not-group error messages

### DIFF
--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -13,6 +13,7 @@
 
 #include "soma_group.h"
 #include "../soma/logger_public.h"
+#include "../utils/logger.h"  // for fmt::format
 #include "../utils/util.h"
 
 namespace tiledbsoma {
@@ -134,17 +135,7 @@ void SOMAGroup::fill_caches() {
 
     for (uint64_t i = 0; i < cache_group_->member_count(); ++i) {
         auto mem = cache_group_->member(i);
-        std::string soma_type;
-        switch (mem.type()) {
-            case Object::Type::Array:
-                soma_type = "SOMAArray";
-                break;
-            case Object::Type::Group:
-                soma_type = "SOMAGroup";
-                break;
-            default:
-                throw TileDBSOMAError("Saw invalid TileDB type");
-        }
+        std::string soma_type = util::soma_type_from_tiledb_type(mem.type());
         std::string key = mem.name().has_value() ? mem.name().value() :
                                                    mem.uri();
         members_map_[key] = SOMAGroupEntry(mem.uri(), soma_type);

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -3,6 +3,7 @@
 #include <tiledb/tiledb>
 
 #include "../utils/logger.h"
+#include "../utils/util.h"
 #include "soma_array.h"
 #include "soma_collection.h"
 #include "soma_dataframe.h"
@@ -28,17 +29,7 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
     if (soma_type == std::nullopt) {
         auto tiledb_type = Object::object(*ctx->tiledb_ctx(), std::string(uri))
                                .type();
-        switch (tiledb_type) {
-            case Object::Type::Array:
-                soma_type = "SOMAArray";
-                break;
-            case Object::Type::Group:
-                soma_type = "SOMAGroup";
-                break;
-            default:
-                throw TileDBSOMAError(
-                    "[SOMAObject::open] Saw invalid TileDB type");
-        }
+        soma_type = util::soma_type_from_tiledb_type(tiledb_type);
     }
 
     if (soma_type == "SOMAArray") {

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -14,6 +14,7 @@
 #include "utils/util.h"
 #include <cstring>
 #include "logger.h"
+#include "utils/logger.h"  // for fmt::format
 
 namespace tiledbsoma::util {
 
@@ -115,6 +116,35 @@ Enumeration get_enumeration(
                 new_way,
                 old_way));
         }
+    }
+}
+
+/**
+ * Maps core Array/Group type enums to SOMA-style strings "SOMAArray" and
+ * "SOMAGroup". Throws if the input value is neither one of those.
+ */
+std::string soma_type_from_tiledb_type(tiledb::Object::Type tiledb_type) {
+    switch (tiledb_type) {
+        case Object::Type::Array:
+            return "SOMAArray";
+        case Object::Type::Group:
+            return "SOMAGroup";
+        case Object::Type::Invalid:
+            throw TileDBSOMAError(fmt::format(
+                "[SOMAObject::open] Saw TileDB type Invalid ({}), which is "
+                "neither Array ({}) "
+                "nor Group ({})",
+                static_cast<int>(tiledb_type),
+                static_cast<int>(Object::Type::Array),
+                static_cast<int>(Object::Type::Group)));
+            throw TileDBSOMAError(fmt::format(
+                "[SOMAObject::open] Saw unrecognized TileDB type {}",
+                static_cast<int>(tiledb_type)));
+            throw TileDBSOMAError(fmt::format(
+                "[SOMAObject::open] Saw unrecognized TileDB type {}", 3));
+        default:
+            throw TileDBSOMAError(
+                fmt::format("[SOMAObject::open] Saw unrecognized TileDB type"));
     }
 }
 

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -132,19 +132,14 @@ std::string soma_type_from_tiledb_type(tiledb::Object::Type tiledb_type) {
         case Object::Type::Invalid:
             throw TileDBSOMAError(fmt::format(
                 "[SOMAObject::open] Saw TileDB type Invalid ({}), which is "
-                "neither Array ({}) "
-                "nor Group ({})",
+                "neither Array ({}) nor Group ({})",
                 static_cast<int>(tiledb_type),
                 static_cast<int>(Object::Type::Array),
                 static_cast<int>(Object::Type::Group)));
+        default:
             throw TileDBSOMAError(fmt::format(
                 "[SOMAObject::open] Saw unrecognized TileDB type {}",
                 static_cast<int>(tiledb_type)));
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAObject::open] Saw unrecognized TileDB type {}", 3));
-        default:
-            throw TileDBSOMAError(
-                fmt::format("[SOMAObject::open] Saw unrecognized TileDB type"));
     }
 }
 

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -138,8 +138,12 @@ std::string soma_type_from_tiledb_type(tiledb::Object::Type tiledb_type) {
                 static_cast<int>(Object::Type::Group)));
         default:
             throw TileDBSOMAError(fmt::format(
-                "[SOMAObject::open] Saw unrecognized TileDB type {}",
-                static_cast<int>(tiledb_type)));
+                "[SOMAObject::open] Saw unrecognized TileDB type ({}), which "
+                "is neither Array ({}) nor Group ({}) nor Invalid ({})",
+                static_cast<int>(tiledb_type),
+                static_cast<int>(Object::Type::Array),
+                static_cast<int>(Object::Type::Group),
+                static_cast<int>(Object::Type::Invalid)));
     }
 }
 

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -94,6 +94,12 @@ Enumeration get_enumeration(
     ArrowSchema* index_schema,
     ArrowSchema* value_schema);
 
+/**
+ * Maps core Array/Group type enums to SOMA-style strings "SOMAArray" and
+ * "SOMAGroup". Throws if the input value is neither one of those.
+ */
+std::string soma_type_from_tiledb_type(tiledb::Object::Type tiledb_type);
+
 }  // namespace tiledbsoma::util
 
 #endif


### PR DESCRIPTION
**Issue and/or context:** [[sc-65212]](https://app.shortcut.com/tiledb-inc/story/65212)

**Changes:** The only legitimate thing this type can be is  `Object::Type::Invalid`, and the existing error message already says "Invalid". So, strictly speaking, there's no new information here -- but, it will feel to the user less like we're hiding information: the infamous "Invalid value" error message antipattern wherein we say something is _bad_ without saying what it _was_. (Also, if the value is indeed anything other than `Array`, `Group`, or `Invalid` -- that would likely be memory corruption or an uninitialized memory read, and we this message will help surface that fact as well.)

**Notes for Reviewer:**

