### PR TITLE
[c++] Optimize `nnz` computation

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -155,9 +155,17 @@ void load_soma_array(py::module& m) {
 
         .def(
             "nnz",
-            &SOMAArray::nnz,
-            py::arg("raise_if_slow") = false,
-            py::call_guard<py::gil_scoped_release>())
+            [](SOMAArray& array, bool raise_if_slow) {
+                try {
+                    py::gil_scoped_release release;
+                    auto retval = array.nnz(raise_if_slow);
+                    py::gil_scoped_acquire acquire;
+                    return retval;
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            },
+            py::arg("raise_if_slow") = false)
 
         .def_property_readonly("uri", &SOMAArray::uri)
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -648,7 +648,7 @@ uint64_t SOMAArray::nnz(bool raise_if_slow) {
             return non_empty_domains[lhs][0] < non_empty_domains[rhs][0];
         });
 
-    auto permutate =
+    auto permute =
         []<typename T>(
             const std::vector<T>& data,
             const std::vector<size_t>& permutation) -> std::vector<T> {

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -668,9 +668,9 @@ uint64_t SOMAArray::nnz(bool raise_if_slow) {
     bool overlap = false;
     for (uint32_t i = 1; i < fragment_count; ++i) {
         if (current_range[1] < non_empty_domains[i][0]) {
-            // Fragment is not overlapping
+            // Fragment is non-overlapping.
             // Current range was overlapping with previous tiles
-            // and we need to add it to the ovelapping ranges
+            // and we need to add it to the overlapping ranges.
             if (overlap) {
                 overlapping_ranges.push_back(
                     std::make_pair(current_range[0], current_range[1]));

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -661,6 +661,8 @@ uint64_t SOMAArray::nnz(bool raise_if_slow) {
     // the next non-empty domain, there is an overlap
 
     // TODO: We only need to apply the ``_nzz_slow`` on overlapping fragments
+    // Tracking issue:
+    // https://github.com/single-cell-data/TileDB-SOMA/issues/3908
     std::vector<std::pair<int64_t, int64_t>> overlapping_ranges;
     std::array<uint64_t, 2> current_range = non_empty_domains[0];
     uint64_t cell_count = fragment_info.cell_num(relevant_fragments[0]);

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -679,7 +679,7 @@ uint64_t SOMAArray::nnz(bool raise_if_slow) {
             }
 
             current_range = non_empty_domains[i];
-            cell_count = fragment_info.cell_num(relevant_fragments[0]);
+            cell_count = fragment_info.cell_num(relevant_fragments[i]);
             overlap = false;
         } else if (current_range[1] >= non_empty_domains[i][1]) {
             // Check if range is included completely

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1162,7 +1162,9 @@ class SOMAArray : public SOMAObject {
     std::shared_ptr<Array> meta_cache_arr_;
 
     // Unoptimized method for computing nnz() (issue `count_cells` query)
-    uint64_t _nnz_slow(bool raise_if_slow);
+    uint64_t _nnz_slow(
+        bool raise_if_slow,
+        const std::vector<std::pair<int64_t, int64_t>>& ranges = {});
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -418,12 +418,10 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
     auto index_columns = helper::create_column_index_info(dim_infos);
 
-    SOMASparseNDArray::create(
-        uri,
-        attr_arrow_format,
-        ArrowTable(
-            std::move(index_columns.first), std::move(index_columns.second)),
-        ctx);
+    SOMASparseNDArray::create(uri, attr_arrow_format, index_columns, ctx);
+
+    index_columns.first->release(index_columns.first.get());
+    index_columns.second->release(index_columns.second.get());
 
     // Create vectors of data for writing.
     std::vector<int64_t> d0 = {1, 2, 3};


### PR DESCRIPTION
**Issue and/or context:** [sc-64438](https://app.shortcut.com/tiledb-inc/story/64438/c-sparsendarray-nnz-is-missing-useful-optimization), [sc-64677](https://app.shortcut.com/tiledb-inc/story/64677/c-sparsendarray-nnz-could-use-core-s-count-aggregator)

**Changes:**
- Use the `COUNT` aggregate instead or doing a read and returning the number of rows
- Use the `COUNT` aggregate only on overlapping fragments

**Notes for Reviewer:**

Closes #3908 
