### PR TITLE
[ci] Backport 3894

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -71,4 +71,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: .github/workflows/daily-test-build-issue-template.md
+          filename: .github/workflows/daily-python-dockers-issue-template.md
+          assignees: ryan-williams, johnkerl
+          update_existing: true

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -41,7 +41,7 @@ jobs:
 
   # This step builds wheels and uploads them to GitHub Actions storage.
   # See also https://github.com/single-cell-data/TileDB-SOMA/issues/700.
-  # See also https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-WIP
+  # See also https://github.com/single-cell-data/TileDB-SOMA/wiki/PyPI-packaging-notes
   # for important transitional context.
   wheels:
     # Note: tries all supported Python versions as specified in apis/python/setup.py


### PR DESCRIPTION
**Issue and/or context:** Backport #3894 from `main` to `release-1.16` since the backport bot silently did nothing

**Changes:**

**Notes for Reviewer:**

