### PR TITLE
[python] More docstring content for `extend_enumeration_values` [WIP]

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -406,6 +406,16 @@ class DataFrame(SOMAArray, somacore.DataFrame):
     ) -> None:
         """Extend enumeration values for each column defined in `values`.
 
+        You can do ``write`` with columns of Arrow dictionary type, without
+        calling this method, and that works fine for non-parallel data ingestion
+        into the same dataframe.  If, however, you are running multiple
+        parallelized writes into the same dataframe, you can use this method to
+        help avoid a race condition. Call this method with all the unique values
+        from all the your inputs.
+
+        Nominally this will be called for you by the experiment-level ingestion
+        logic.
+
         Raises ``ValueError`` if any of the the specified column names is not in
         the schema, or if any is not of Arrow dictionary type. May only contain
         values that already exist in the schema (see the output of


### PR DESCRIPTION
**Issue and/or context:**  For issue #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471). Follow-on to #3815.

**Changes:** Add some more docstring content re why/when users would want to call this.

**Notes for Reviewer:**

I'm still deciding what to say here. This method isn't really a top-level/user-facing method. Rather, #3865 will be. And `extend_enumeration_values` will be called by `tiledbsoma.io` on behalf of the user.

Some options for the docstring:

* Leave it as-is without this PR.
* As in this PR as of the first commit.
* Add a sentence saying it isn't really intended to be called directly, and point the user at the mods on #3865.
* Add a sentence saying it isn't _usually_ intended to be called directly, but add something like the contents of this PR as of the first commit.
* Add a link to Academy documentation, which I'm working on now.

I'm leaving this in draft for now, but I'm leaning toward the last bullet.