### PR TITLE
Publish ARM Linux wheels

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -59,6 +59,9 @@ jobs:
           - cibw_build: manylinux_aarch64
             os: ubuntu-24.04-arm
             wheel-name: manylinux_2_28-aarch64
+            CIBW_BEFORE_BUILD_LINUX: dnf install -y ninja-build perl-IPC-Cmd zip
+            # vcpkg source build requires this on ARM, for some reason; cf. https://github.com/NixOS/nixpkgs/issues/335868
+            CIBW_ENVIRONMENT_LINUX: VCPKG_FORCE_SYSTEM_BINARIES=1
           - cibw_build: macosx_x86_64
             os: macos-latest
             cibw_archs_macos: x86_64
@@ -93,29 +96,23 @@ jobs:
         with:
           xcode-version: '15.4'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           package-dir: tiledbsoma.tar.gz
           only: cp${{ matrix.python-version }}-${{ matrix.cibw_build }}
         env:
-          CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-toolset-13 ninja-build perl-IPC-Cmd zip; bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
-          # ^ Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
-          #   run CMake build or not. Otherwise it'll keep reusing the library file built in the
-          #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
-          #   built for the wrong python version.
+          # Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
+          # run CMake build or not. Otherwise it'll keep reusing the library file built in the
+          # first iteration of cibuildwheel's outer loop, resulting in wheels with the library
+          # built for the wrong python version.
           CIBW_BEFORE_BUILD: bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
-          # ^ Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
-          #   run CMake build or not. Otherwise it'll keep reusing the library file built in the
-          #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
-          #   built for the wrong python version.
+          CIBW_BEFORE_BUILD_LINUX: ${{ matrix.CIBW_BEFORE_BUILD_LINUX || '' }}
+          CIBW_ENVIRONMENT_LINUX: ${{ matrix.CIBW_ENVIRONMENT_LINUX || '' }}
+          # Most recent tags with no listed security issues at https://quay.io/repository/pypa/manylinux_2_28_aarch64?tab=tags, ca. 2025-04-03
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:2025.03.22-2
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64:2025.03.22-2
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          # vcpkg source build requires VCPKG_FORCE_SYSTEM_BINARIES=1 on ARM
-          CIBW_ENVIRONMENT_LINUX: CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++ VCPKG_FORCE_SYSTEM_BINARIES=1
-          CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
           MACOSX_DEPLOYMENT_TARGET: "13.3"
 

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -211,7 +211,6 @@ jobs:
           ls -l dist
       - name: Publish packages to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
         with:
           repository-url: https://test.pypi.org/legacy/
           packages_dir: dist

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -130,6 +130,8 @@ jobs:
     strategy:
       matrix:
         python:
+          - undotted-version: '39'
+            dotted-version: '3.9'
           - undotted-version: '310'
             dotted-version: '3.10'
           - undotted-version: '311'

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -51,11 +51,14 @@ jobs:
     strategy:
       matrix:
         python-version: [ '39', '310', '311', '312', '313' ]
-        cibw_build: [ manylinux_x86_64, macosx_x86_64, macosx_arm64 ]
+        cibw_build: [ manylinux_x86_64, manylinux_aarch64, macosx_x86_64, macosx_arm64 ]
         include:
           - cibw_build: manylinux_x86_64
             os: ubuntu-24.04
-            wheel-name: manylinux_2_28
+            wheel-name: manylinux_2_28-x86_64
+          - cibw_build: manylinux_aarch64
+            os: ubuntu-24.04-arm
+            wheel-name: manylinux_2_28-aarch64
           - cibw_build: macosx_x86_64
             os: macos-latest
             cibw_archs_macos: x86_64
@@ -98,7 +101,8 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_BUILD_LINUX: yum -y remove gcc-toolset-12\*; yum -y install gcc-toolset-13; bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_BEFORE_BUILD_LINUX: yum -y install gcc-toolset-13 ninja-build perl-IPC-Cmd zip; bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'
           # ^ Delete lib folder that apis/python/setup.py:find_or_build() looks for in deciding to
           #   run CMake build or not. Otherwise it'll keep reusing the library file built in the
           #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
@@ -109,7 +113,8 @@ jobs:
           #   first iteration of cibuildwheel's outer loop, resulting in wheels with the library
           #   built for the wrong python version.
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          CIBW_ENVIRONMENT_LINUX : CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
+          # vcpkg source build requires VCPKG_FORCE_SYSTEM_BINARIES=1 on ARM
+          CIBW_ENVIRONMENT_LINUX: CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++ VCPKG_FORCE_SYSTEM_BINARIES=1
           CIBW_TEST_SKIP: "*_arm64"
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cibw_archs_macos }}
           MACOSX_DEPLOYMENT_TARGET: "13.3"
@@ -137,13 +142,19 @@ jobs:
           - undotted-version: '313'
             dotted-version: '3.13'
         wheel-name:
-          - manylinux_2_28
+          - manylinux_2_28-x86_64
+          - manylinux_2_28-aarch64
           - macos-x86_64
           - macos-arm64
         include:
-          - wheel-name: manylinux_2_28
+          - wheel-name: manylinux_2_28-x86_64
             os: ubuntu-24.04
             arch: x86_64
+            cc: gcc-13
+            cxx: g++-13
+          - wheel-name: manylinux_2_28-aarch64
+            os: ubuntu-24.04-arm
+            arch: aarch64
             cc: gcc-13
             cxx: g++-13
           - wheel-name: macos-x86_64

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -147,23 +147,15 @@ jobs:
           - wheel-name: manylinux_2_28-x86_64
             os: ubuntu-24.04
             arch: x86_64
-            cc: gcc-13
-            cxx: g++-13
           - wheel-name: manylinux_2_28-aarch64
             os: ubuntu-24.04-arm
             arch: aarch64
-            cc: gcc-13
-            cxx: g++-13
           - wheel-name: macos-x86_64
             os: macos-13
             arch: x86_64
-            cc: clang
-            cxx: clang++
           - wheel-name: macos-arm64
             os: macos-14
             arch: arm64
-            cc: clang
-            cxx: clang++
       fail-fast: false
     steps:
       - name: Set up Python ${{ matrix.python.dotted-version }}


### PR DESCRIPTION
## Issue and/or context
- #2482
- #3867
- #3890

`pip install tiledbsoma` can take [over 40mins]() on ARM Linux, building TileDB-SOMA, TileDB, and vcpkg from source. The former two take most of the time, but the latter broke us from Friday to Weds (#3867), and we've still not root-caused some of what went wrong (#3890).

`pip install` takes <2mins on other platforms, by installing wheels; publishing ARM Linux wheels brings that same performance to e.g. Graviton EC2 instances, and Linux Docker builds on ARM Macs.

## Changes
- Add `manylinux_aarch64` as a 4th set of os/arch wheels (so we now publish {linux,mac} x {x86,arm}).
- Audit/GC CIBW configs:
  - Pin `CIBW_MANYLINUX_{X86_,AARCH}64_IMAGE=quay.io/pypa/manylinux_2_28_*:2025.03.22-2` ([options](https://quay.io/repository/pypa/manylinux_2_28_aarch64?tab=tags))
  - Remove unused `CIBW_BUILD` var
  - Remove unnecessary GCC-version munging
  - Remove unnecessary `CIBW_TEST_SKIP: "*_arm64"`
  - Remove a redundant `bash -x -c 'rm -rf tiledbsoma*/dist_links/dist/lib*'`
- Restore `smoke-test` job for Python 3.9 (related: #2640)
- Fix Test PyPI publish silent failure (e.g. when hitting quota; [example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/13913129586/job/38931629454))
- Remove unused `matrix.{cc,cxx}` entries

## Notes for Reviewer
- [Latest GHA run](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14251626772) (in progress)
- Previous test.pypi.org releases and GHA runs:
  - [1.15.0rc0.post386.dev1013776864] ([GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14245910996), 2h20m)
  - [1.15.0rc0.post387.dev4100197019] ([GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14248317927), 1h31m)
  - [1.15.0rc0.post388.dev2177748919] ([GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14250576038), 32m)
  The timing variance is mostly due to jobs waiting in "pending" state, afaict.

### Release-size math
Most recent prod release was ≈354M total:
```bash
pypi wheels tiledbsoma 1.16.1 \
| perl -ne 'print "$1$2\n" while /Size: ([\d.]+) ([KM])iB/g' \
| numfmt --from=iec \
| jq -n '[inputs]|add' \
| numfmt --to=iec
# 354M
```
(cf. [pypi-command-line#29](https://github.com/wasi-master/pypi-command-line/issues/29))

This PR adds 5 new aarch64 wheels per release (for Python 3.9 through 3.13), which are 17MB each / +85MB overall, so these new test releases (and future prod releases) look to be ≈438MiB:
```bash
pypi --repository testpypi wheels tiledbsoma 1.15.0rc0.post386.dev1013776864 \
| perl -ne 'print "$1$2\n" while /Size: ([\d.]+) ([KM])iB/g' \
| numfmt --from=iec \
| jq -n '[inputs]|add' \
| numfmt --to=iec
# 438M
```

We're currently using 9.3GiB of 20GiB of prod PyPI quota, so this change reduces expected "releases until quota" from 33 down to 27.


[1.15.0rc0.post386.dev1013776864]: https://test.pypi.org/project/tiledbsoma/1.15.0rc0.post386.dev1013776864
[1.15.0rc0.post387.dev4100197019]: https://test.pypi.org/project/tiledbsoma/1.15.0rc0.post387.dev4100197019
[1.15.0rc0.post388.dev2177748919]: https://test.pypi.org/project/tiledbsoma/1.15.0rc0.post388.dev2177748919