### PR TITLE
Include 1.16.1 datasets in soma-experiment-versions tests

### DIFF
--- a/scripts/prepare-test-data.sh
+++ b/scripts/prepare-test-data.sh
@@ -74,7 +74,7 @@ if [ -d $name ]; then
     echo "-- Skipping dataset 'data/$name'; directory 'data/$name' already exists."
 else
     if [ ! -f $name.tgz ]; then
-        wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-02-24/$name.tgz
+        wget https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/download/dataset-2025-04-04/$name.tgz
     fi
     tar zxf $name.tgz
 fi


### PR DESCRIPTION
**Issue and/or context:** [[sc-65354]](https://app.shortcut.com/tiledb-inc/story/65354/extend-older-versions-test-cases)

**Changes:** https://github.com/single-cell-data/TileDB-SOMA-Test-Data/releases/tag/dataset-2025-04-04 has 1.16.1 data in it

**Notes for Reviewer:**

