### PR TITLE
[c++] Replace deprecated `FragmentInfo.dump` function

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -556,7 +556,11 @@ uint64_t SOMAArray::nnz() {
 
     LOG_DEBUG(fmt::format("[SOMAArray] Fragment info for array '{}'", uri_));
     if (LOG_DEBUG_ENABLED()) {
-        fragment_info.dump();
+        std::ostringstream fragment_info_dump;
+        fragment_info_dump << fragment_info;
+        fragment_info_dump.flush();
+
+        LOG_DEBUG(fragment_info_dump.str());
     }
 
     // Find the subset of fragments contained within the read timestamp range


### PR DESCRIPTION
**Issue and/or context:** [sc-65364](https://app.shortcut.com/tiledb-inc/story/65364/c-logging-broken-in-nnz)

**Changes:**

**Notes for Reviewer:**

