### PR TITLE
[python] Fix partition readers' naïve assumption that `nnz` is fast

### DIFF
--- a/apis/python/requirements_spatial.txt
+++ b/apis/python/requirements_spatial.txt
@@ -2,5 +2,6 @@ geopandas
 tifffile
 pillow
 spatialdata>=0.2.5
+numcodecs<0.16
 xarray
 dask<=2024.11.2

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -856,7 +856,7 @@ def _read_as_csr(
 
     approx_X_shape = tuple(b - a + 1 for a, b in matrix.non_empty_domain())
     # heuristically derived number (benchmarking). Thesis is that this is roughly 80% of a 1 GiB io buffer,
-    # which is the default for SOMA. If we have NNZ, use to partition based upon memory size. If we do not
+    # which is the default for SOMA. If we have fast NNZ, use to partition based upon memory size. If we do not
     # have fast NNZ, pick a default partition size which is large, but not so large as to rule out reasonable
     # parallelism (in this case, calculated based on typical scRNASeq assay density of 3-6K features).
     target_point_count = 96 * 1024**2

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -857,7 +857,7 @@ def _read_as_csr(
     approx_X_shape = tuple(b - a + 1 for a, b in matrix.non_empty_domain())
     # heuristically derived number (benchmarking). Thesis is that this is roughly 80% of a 1 GiB io buffer,
     # which is the default for SOMA. If we have NNZ, use to partition based upon memory size. If we do not
-    # have NNZ, pick a default partition size which is large, but not to large as to rule out reasonable
+    # have fast NNZ, pick a default partition size which is large, but not so large as to rule out reasonable
     # parallelism (in this case, calculated based on typical scRNASeq assay density of 3-6K features).
     target_point_count = 96 * 1024**2
     fallback_row_count = 32768

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -814,9 +814,9 @@ def _read_as_csr(
     d0_joinids = d0_joinids_arr.to_numpy()
     d1_joinids = d1_joinids_arr.to_numpy()
     try:
-        nnz = matrix._handle._handle.nnz(raise_if_slow=True)
+        nnz: int | None = matrix._handle._handle.nnz(raise_if_slow=True)
     except SOMAError:
-        nnz = -1
+        nnz = None
 
     # if able, downcast from int64 - reduces working memory
     index_dtype = (
@@ -864,7 +864,7 @@ def _read_as_csr(
     # compute partition size from array density and target point count, rounding to nearest 1024.
     partition_size = (
         max(1024 * round(approx_X_shape[0] * target_point_count / nnz / 1024), 1024)
-        if nnz > 0
+        if nnz is not None and nnz > 0
         else min(fallback_row_count, approx_X_shape[0])
     )
     splits = list(

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -106,7 +106,10 @@ def _read_partitioned_sparse(X: SparseNDArray, d0_size: int) -> pa.Table:
     # density of matrix. Magic number determined empirically, as a tradeoff
     # between concurrency and fixed query overhead.
     tgt_point_count = 96 * 1024**2
-    nnz = X.nnz
+    try:
+        nnz = X._handle._handle.nnz(raise_if_slow=True)
+    except SOMAError:
+        nnz = -1
     partition_sz = (
         max(1024 * round(d0_size * tgt_point_count / nnz / 1024), 1024)
         if nnz > 0

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -107,12 +107,12 @@ def _read_partitioned_sparse(X: SparseNDArray, d0_size: int) -> pa.Table:
     # between concurrency and fixed query overhead.
     tgt_point_count = 96 * 1024**2
     try:
-        nnz = X._handle._handle.nnz(raise_if_slow=True)
+        nnz: int | None = X._handle._handle.nnz(raise_if_slow=True)
     except SOMAError:
-        nnz = -1
+        nnz = None
     partition_sz = (
         max(1024 * round(d0_size * tgt_point_count / nnz / 1024), 1024)
-        if nnz > 0
+        if nnz is not None and nnz > 0
         else d0_size  # i.e, no partitioning
     )
     partitions = [

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -113,7 +113,7 @@ def _read_partitioned_sparse(X: SparseNDArray, d0_size: int) -> pa.Table:
     partition_sz = (
         max(1024 * round(d0_size * tgt_point_count / nnz / 1024), 1024)
         if nnz > 0
-        else d0_size
+        else d0_size  # i.e, no partitioning
     )
     partitions = [
         slice(st, min(st + partition_sz - 1, d0_size - 1))

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -153,7 +153,11 @@ void load_soma_array(py::module& m) {
             &SOMAArray::config_options_from_schema)
         .def("context", &SOMAArray::ctx)
 
-        .def("nnz", &SOMAArray::nnz, py::call_guard<py::gil_scoped_release>())
+        .def(
+            "nnz",
+            &SOMAArray::nnz,
+            py::arg("raise_if_slow") = false,
+            py::call_guard<py::gil_scoped_release>())
 
         .def_property_readonly("uri", &SOMAArray::uri)
 

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -559,10 +559,6 @@ uint64_t SOMAArray::nnz(bool raise_if_slow) {
         fragment_info.dump();
     }
 
-    if (!schema_->allows_dups() && fragment_info.fragment_num() == 1) {
-        return fragment_info.cell_num(0);
-    }
-
     // Find the subset of fragments contained within the read timestamp range
     // [if any]
     std::vector<uint32_t> relevant_fragments;

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -559,6 +559,10 @@ uint64_t SOMAArray::nnz() {
         fragment_info.dump();
     }
 
+    if (fragment_info.fragment_num() == 1) {
+        return fragment_info.cell_num(0);
+    }
+
     // Find the subset of fragments contained within the read timestamp range
     // [if any]
     std::vector<uint32_t> relevant_fragments;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -659,7 +659,7 @@ class SOMAArray : public SOMAObject {
      *
      * @return uint64_t Total number of unique cells
      */
-    uint64_t nnz();
+    uint64_t nnz(bool raise_if_slow = false);
 
     /**
      * @brief Get the current capacity of each dimension.
@@ -1164,7 +1164,7 @@ class SOMAArray : public SOMAObject {
     std::shared_ptr<Array> meta_cache_arr_;
 
     // Unoptimized method for computing nnz() (issue `count_cells` query)
-    uint64_t _nnz_slow();
+    uint64_t _nnz_slow(bool raise_if_slow);
 };
 
 }  // namespace tiledbsoma


### PR DESCRIPTION
**Issue and/or context:**

`tiledbsoma.io.to_anndata` and `ExperimentAxisQuery.to_anndata` contain a partitioned reader optimization. This code uses `nnz` to estimate partition sizes, and in doing so naively assumed `nnz` would always be fast (ie., would only use fragment metadata).  However, there are cases where this is not true, and `nnz` performs the very slow operation of reading and counting all data.

In this "slow" case, the end result is that the `to_anndata` methods will read the entire X array once to count `nnz`, and then read it again to construct the AnnData.

**Changes:**

1. Introduced a private, internal-only API to have `nnz` throw an exception if it is unable to use the "fast" path - ie.., compute nnz from fragment metadata.
2. Used this new hook in the partitioned readers to utilize nnz information when it is fast, and fall back on a non-partitioned read when nnz is unavailable.
3. Revised the fallback, when nnz is unavailable, to use a partition size that is reasonable for most ssRNAseq data (previously it fell back on no partitioning, which is not optimal).

**Notes for Reviewer:**

[[sc-65406]](https://app.shortcut.com/tiledb-inc/story/65406)
[[sc-65409]](https://app.shortcut.com/tiledb-inc/story/65409)