### PR TITLE
`setup.py`: remove deprecated `License ::` from `classifiers`

### DIFF
--- a/apis/python/requirements_spatial.txt
+++ b/apis/python/requirements_spatial.txt
@@ -2,5 +2,7 @@ geopandas
 tifffile
 pillow
 spatialdata>=0.2.5
+# spatialdata 0.3.0 pins `zarr<3`, which is incompatible with numcodecs 0.16.0. See also: https://github.com/single-cell-data/TileDB-SOMA/issues/3917
+numcodecs<0.16
 xarray
 dask<=2024.11.2

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -291,7 +291,6 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Operating System :: Unix",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
**Issue and/or context:**

`pip install tiledbsoma` was issuing a warning like:
```
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved :: MIT License

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
```

([GHA example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14276171882/job/40019409594#step:9:52); compare to lack of warning in [GHA for this PR](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14312394947/job/40110373749#step:9:51))

**Changes:**
Our MIT license is already specified in the `license` field, can be removed from `classifiers`.

Also fixes #3917 by pinning `numcodecs<0.16`.

[sc-65131]