### PR TITLE
[python] Use `typeguard==4.4.2`

### DIFF
--- a/apis/python/requirements_dev.txt
+++ b/apis/python/requirements_dev.txt
@@ -3,7 +3,7 @@ pytest
 pytest-cov
 ruff
 sparse
-typeguard==4.4.0
+typeguard==4.4.2
 types-setuptools
 more-itertools
 hypothesis


### PR DESCRIPTION
**Issue and/or context:** From #3865, to isolate dependency changes from application changes

**Changes:**

**Notes for Reviewer:**

