### PR TITLE
[python] `numcodecs<0.16` in docs build

### DIFF
--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -5,6 +5,7 @@ docutils==0.20.1
 ipython==8.24.0
 jinja2==3.1.6
 nbsphinx==0.9.3
+numcodecs<0.16  # https://github.com/single-cell-data/TileDB-SOMA/issues/3917
 pandoc==2.3
 pybind11==2.12.0
 setuptools==75.1.0


### PR DESCRIPTION
**Issue and/or context:**
- #3917 
- RTD build [still failing](https://app.readthedocs.com/projects/tiledb-inc-tiledb-soma/builds/2947815/#33747619--713), need `numcodecs<0.16` in `requirements_doc.txt` as well.

[RTD build](https://app.readthedocs.com/projects/tiledb-inc-tiledb-soma/builds/2948417/) passed.