### PR TITLE
[c++] Use raw pointer for child `Attribute` Arrow schema

### DIFF
--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -145,8 +145,7 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAAttribute::arrow_domain_slot(
 ArrowSchema* SOMAAttribute::arrow_schema_slot(
     const SOMAContext& ctx, Array& array) const {
     return ArrowAdapter::arrow_schema_from_tiledb_attribute(
-               attribute, *ctx.tiledb_ctx(), array)
-        .release();
+        attribute, *ctx.tiledb_ctx(), array);
 }
 
 void SOMAAttribute::serialize(nlohmann::json& columns_schema) const {

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -532,8 +532,7 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAGeometryColumn::arrow_domain_slot(
 ArrowSchema* SOMAGeometryColumn::arrow_schema_slot(
     const SOMAContext& ctx, Array& array) const {
     return ArrowAdapter::arrow_schema_from_tiledb_attribute(
-               attribute, *ctx.tiledb_ctx(), array)
-        .release();
+        attribute, *ctx.tiledb_ctx(), array);
 }
 
 void SOMAGeometryColumn::serialize(nlohmann::json& columns_schema) const {

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -492,9 +492,9 @@ ArrowSchema* ArrowAdapter::arrow_schema_from_tiledb_dimension(
     return arrow_schema;
 }
 
-std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
+ArrowSchema* ArrowAdapter::arrow_schema_from_tiledb_attribute(
     const Attribute& attribute, const Context& ctx, const Array& tiledb_array) {
-    std::unique_ptr<ArrowSchema> arrow_schema = std::make_unique<ArrowSchema>();
+    ArrowSchema* arrow_schema = (ArrowSchema*)malloc(sizeof(ArrowSchema));
     arrow_schema->format = strdup(
         ArrowAdapter::to_arrow_format(attribute.type()).data());
     arrow_schema->name = strdup(attribute.name().c_str());
@@ -519,7 +519,7 @@ std::unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_attribute(
             ArrowCharView("dtype"),
             ArrowCharView("WKB"));
         ArrowSchemaSetMetadata(
-            arrow_schema.get(), reinterpret_cast<char*>(metadata_buffer->data));
+            arrow_schema, reinterpret_cast<char*>(metadata_buffer->data));
     }
 
     LOG_TRACE(fmt::format(

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -366,7 +366,7 @@ class ArrowAdapter {
      *
      * @return ArrowSchema
      */
-    static std::unique_ptr<ArrowSchema> arrow_schema_from_tiledb_attribute(
+    static ArrowSchema* arrow_schema_from_tiledb_attribute(
         const Attribute& attribute,
         const Context& ctx,
         const Array& tiledb_array);


### PR DESCRIPTION
**Issue and/or context:** [sc-65508](https://app.shortcut.com/tiledb-inc/story/65512/c-valgrind-error-when-running-unit-tests-test-basic-anndata-io-py-k-test-decat-append)

**Changes:**
Use a `malloc`-allocated raw pointer instead of an `std::unique_ptr` (which implicitly does `new`) for child Arrow schema generated by a TileDB attribute.

**Notes for Reviewer:** Continuation of #3873.

On https://github.com/single-cell-data/TileDB-SOMA/pull/3873/files this changed to `malloc`:
https://github.com/single-cell-data/TileDB-SOMA/blob/1c6a0570936928efcaa32bbc3825e9de2ae28c95/libtiledbsoma/src/utils/arrow_adapter.cc#L475
but this use of `std::make_unique` is an implicit `new`:
https://github.com/single-cell-data/TileDB-SOMA/blob/1c6a0570936928efcaa32bbc3825e9de2ae28c95/libtiledbsoma/src/utils/arrow_adapter.cc#L497
