### PR TITLE
[Backport release-1.16][python] Ingest performance improvements (#3865)

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -344,6 +344,7 @@ setuptools.setup(
     install_requires=[
         "anndata>=0.10.1",
         "attrs>=22.2",
+        "more-itertools",
         "numpy",
         "pandas",
         "pyarrow",

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -4,54 +4,82 @@
 
 from __future__ import annotations
 
-import json
-from typing import Any, Dict, Sequence
+import warnings
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence, cast
 
 import anndata as ad
 import attrs
+import numpy as np
+import numpy.typing as npt
 import pandas as pd
-from typing_extensions import Self
+import pyarrow as pa
+from typing_extensions import Self, TypeAlias
 
 import tiledbsoma
-import tiledbsoma.logging
-from tiledbsoma.io._util import read_h5ad  # Allow us to read over S3 in backed mode
+import tiledbsoma.io
+import tiledbsoma.logging as logging
+from tiledbsoma import DataFrame, Experiment, SOMAError
 from tiledbsoma.options import SOMATileDBContext
+from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_context
 
+from .._util import read_h5ad
+from .enum import extend_enumerations, get_enumerations
 from .id_mappings import AxisIDMapping, ExperimentIDMapping, get_dataframe_values
 
+MeasurementName: TypeAlias = str
+ColumnName: TypeAlias = str
 
-@attrs.define(kw_only=True)
+
+@attrs.define(kw_only=True, frozen=True)
 class AxisAmbientLabelMapping:
-    """
-    For all the to-be-appended AnnData/H5AD inputs in SOMA multi-file append-mode ingestion, this
+    """For all the to-be-appended AnnData/H5AD inputs in SOMA multi-file append-mode ingestion, this
     class tracks the mapping of input-data ``obs`` or ``var`` ID-column name (barcode ID, gene
-    symbol) to SOMA join IDs for SOMA experiment ``obs`` or ``var``.
+    symbol) to SOMA join IDs for SOMA experiment ``obs`` or ``var``, as well as any dictionary/enumeration
+    values.
 
     See module-level comments for more information.
     """
 
-    data: Dict[str, int]
     field_name: str
+    joinid_map: pd.DataFrame  # id -> soma_joinid
+    enum_values: dict[str, pd.CategoricalDtype]
 
-    def get_next_start_soma_joinid(self) -> int:
-        """Once some number of input files have been registered for an ``obs`` or ``var``
-        axis, this returned the next as-yet-unused SOMA join ID for the axis."""
-        if len(self.data) == 0:
-            return 0
-        else:
-            return max(self.data.values()) + 1
+    shape: int = attrs.field(init=False)
 
-    def id_mapping_from_values(self, input_ids: Sequence[Any]) -> AxisIDMapping:
+    def __attrs_post_init__(self) -> None:
+        assert self.joinid_map.empty or self.joinid_map.soma_joinid.dtype == np.int64
+        object.__setattr__(
+            self,
+            "shape",
+            (
+                int(self.joinid_map.soma_joinid.max() + 1)
+                if len(self.joinid_map) > 0
+                else 0
+            ),
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, AxisAmbientLabelMapping):
+            raise NotImplementedError("Cannot compare to non-AxisAmbientLabelMapping")
+        return (
+            self.field_name == other.field_name
+            and self.joinid_map.equals(other.joinid_map)
+            and self.enum_values == other.enum_values
+        )
+
+    def id_mapping_from_values(self, input_ids: npt.ArrayLike) -> AxisIDMapping:
         """Given registered label-to-SOMA-join-ID mappings for all registered input files for an
         ``obs`` or ``var`` axis, and a list of input-file 0-up offsets, this returns an int-to-int
         mapping from a single input file's ``obs`` or ``var`` axis to the registered SOMA join IDs.
         """
-        soma_joinids = []
-        for i, input_id in enumerate(input_ids):
-            if input_id not in self.data:
-                raise ValueError(f"input_id {input_id} not found in registration data")
-            soma_joinids.append(self.data[input_id])
-        return AxisIDMapping(data=tuple(soma_joinids))
+        new_joinid_map = self.joinid_map.reindex(labels=input_ids, fill_value=-1)
+        if new_joinid_map.soma_joinid.isin([-1]).any():
+            raise ValueError(
+                f"The input_ids for {self.field_name} [{input_ids[:10]}...] were not found in registration data."
+            )
+        return AxisIDMapping(data=new_joinid_map.soma_joinid.to_numpy())
 
     def id_mapping_from_dataframe(self, df: pd.DataFrame) -> AxisIDMapping:
         """Given registered label-to-SOMA-join-ID mappings for all registered input files for an
@@ -62,490 +90,607 @@ class AxisAmbientLabelMapping:
         values = get_dataframe_values(df, self.field_name)
         return self.id_mapping_from_values(values)
 
-    @classmethod
-    def from_isolated_dataframe(
-        cls,
-        df: pd.DataFrame,
-        *,
-        index_field_name: str | None = None,
-    ) -> Self:
-        """Factory method to compute an axis label-to-SOMA-join-ID mapping for a single dataframe in
-        isolation. This is used when a user is ingesting a single AnnData/H5AD to a single SOMA
-        experiment, not in append mode, but allowing us to still have the bulk of the ingestor code
-        to be non-duplicated between non-append mode and append mode.
-        """
-        tiledbsoma.logging.logger.info("Registration: registering AnnData dataframe.")
 
-        index_field_name = index_field_name or df.index.name or "index"
-        df = df.reset_index()
-
-        data = {}
-        next_soma_joinid = 0
-        for index in df[index_field_name]:
-            data[index] = next_soma_joinid
-            next_soma_joinid += 1
-        return cls(data=data, field_name=index_field_name)
-
-    def get_shape(self) -> int:
-        if len(self.data.values()) == 0:
-            return 0
-        else:
-            return 1 + max(self.data.values())
-
-    def to_json(self) -> str:
-        """The ``to_json`` and ``from_json`` methods allow you to persist
-        the registration mappings to disk."""
-        return json.dumps(self, default=attrs.asdict, sort_keys=True, indent=4)
-
-    @classmethod
-    def from_json(cls, s: str) -> Self:
-        """The ``to_json`` and ``from_json`` methods allow you to persist
-        the registration mappings to disk."""
-        dikt = json.loads(s)
-        return cls(**dikt)
-
-
-@attrs.define(kw_only=True)
+@attrs.define(kw_only=True, frozen=True)
 class ExperimentAmbientLabelMapping:
-    """
-    For all the to-be-appended AnnData/H5AD inputs in SOMA multi-file append-mode ingestion, this
-    class contains an ``AxisAmbientLabelMapping`` for ``obs``, and an ``AxisAmbientLabelMapping``
-    for ``var`` in each measurement.
+    """For all the to-be-appended AnnData/H5AD inputs in SOMA multi-file append-mode ingestion, this
+    class contains information required to perform ingestion via ``from_h5ad`` or ``from_anndata``.
+
+    This class tracks the mapping from input-data ``obs`` or ``var`` ID-column name (barcode ID, gene
+    symbol) to SOMA join IDs for SOMA experiment ``obs`` or ``var``, as well as any dictionary/enumeration
+    values.
     """
 
     obs_axis: AxisAmbientLabelMapping
-    var_axes: Dict[str, AxisAmbientLabelMapping]
+    var_axes: dict[str, AxisAmbientLabelMapping]
+    prepared: bool = False
 
     def id_mappings_for_anndata(
-        self,
-        adata: ad.AnnData,
-        *,
-        measurement_name: str = "RNA",
-        obs_field_name: str = "obs_id",
-        var_field_name: str = "var_id",
+        self, adata: ad.AnnData, *, measurement_name: str = "RNA"
     ) -> ExperimentIDMapping:
-        """
-        Given label-to-SOMA-join-ID mappings for all to-be-appended input files, this selects
-        out the offset-to-SOMA-join-ID mappings for a single input file.
-        """
-        obs_axis = self.obs_axis.id_mapping_from_dataframe(adata.obs)
-        var_axes = {}
-        var_axes[measurement_name] = self.var_axes[
-            measurement_name
-        ].id_mapping_from_dataframe(adata.var)
+
+        obs_axis = AxisIDMapping(
+            data=self.obs_axis.joinid_map.loc[adata.obs.index].soma_joinid.to_numpy()
+        )
+        var_axes = {
+            measurement_name: AxisIDMapping(
+                data=self.var_axes[measurement_name]
+                .joinid_map.loc[adata.var.index]
+                .soma_joinid.to_numpy()
+            )
+        }
         if adata.raw is not None:
-            var_axes["raw"] = self.var_axes["raw"].id_mapping_from_dataframe(
-                adata.raw.var
+            var_axes["raw"] = AxisIDMapping(
+                data=self.var_axes["raw"]
+                .joinid_map.loc[adata.raw.var.index]
+                .soma_joinid.to_numpy()
             )
 
-        return ExperimentIDMapping(
-            obs_axis=obs_axis,
-            var_axes=var_axes,
-        )
+        return ExperimentIDMapping(obs_axis=obs_axis, var_axes=var_axes)
 
-    @classmethod
-    def from_isolated_anndata(
-        cls,
-        adata: ad.AnnData,
-        *,
-        measurement_name: str,
-        obs_field_name: str | None = None,
-        var_field_name: str | None = None,
-    ) -> Self:
-        """Factory method to compute the label-to-SOMA-join-ID mappings for a single input file in
-        isolation. This is used when a user is ingesting a single AnnData/H5AD to a single SOMA
-        experiment, not in append mode, but allowing us to still have the bulk of the ingestor code
-        to be non-duplicated between non-append mode and append mode.
-        """
-        tiledbsoma.logging.logger.info("Registration: registering AnnData object.")
+    def get_obs_shape(self) -> int:
+        return self.obs_axis.shape
 
-        obs_axis = AxisAmbientLabelMapping.from_isolated_dataframe(
-            adata.obs, index_field_name=obs_field_name
-        )
-        tiledbsoma.logging.logger.info(
-            f"Registration: accumulated to nobs={len(obs_axis.data)}"
-        )
+    def get_var_shapes(self) -> dict[str, int]:
+        return {ms_name: self.var_axes[ms_name].shape for ms_name in self.var_axes}
 
-        var_axes = {}
-        var_axis = AxisAmbientLabelMapping.from_isolated_dataframe(
-            adata.var,
-            index_field_name=var_field_name,
-        )
-        var_axes[measurement_name] = var_axis
-        tiledbsoma.logging.logger.info(
-            f"Registration: accumulated to nvar={len(var_axis.data)}"
-        )
-        if adata.raw is not None:
-            raw_var_axis = AxisAmbientLabelMapping.from_isolated_dataframe(
-                adata.raw.var,
-                index_field_name=var_field_name,
-            )
-            var_axes["raw"] = raw_var_axis
-            tiledbsoma.logging.logger.info(
-                f"Registration: accumulated to nvar={len(raw_var_axis.data)}"
-            )
+    def subset_for_anndata(self, adata: ad.AnnData) -> Self:
+        """Return a copy of this object containing only the information necessary to ingest
+        the specified AnnData.
 
-        return cls(
-            obs_axis=obs_axis,
-            var_axes=var_axes,
-        )
+        This is an optional step, used to improve the performance of multi-process or
+        distributed ingestion. It reduces the registration information transmitted to
+        the worker process performing the call to ``from_anndata`` or ``from_h5ad``.
 
-    @classmethod
-    def from_isolated_h5ad(
-        cls,
-        h5ad_file_name: str,
-        *,
-        measurement_name: str,
-        obs_field_name: str | None = None,
-        var_field_name: str | None = None,
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Factory method to compute label-to-SOMA-join-ID mappings for a single input file in
-        isolation. This is used when a user is ingesting a single AnnData/H5AD to a single SOMA
-        experiment, not in append mode, but allowing us to still have the bulk of the ingestor code
-        to be non-duplicated between non-append mode and append mode.
-        """
-        with read_h5ad(h5ad_file_name, mode="r", ctx=context) as adata:
-            return cls.from_isolated_anndata(
-                adata,
-                measurement_name=measurement_name,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-            )
+        Args:
+            h5ad_path: an ``anndata.AnnData``, previously registered in this ``ExperimentAmbientLabelMapping``.
 
-    @classmethod
-    def from_isolated_soma_experiment(
-        cls,
-        experiment_uri: str | None = None,
-        *,
-        obs_field_name: str = "obs_id",
-        var_field_name: str = "var_id",
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Factory method to compute label-to-SOMA-join-ID mappings for a single SOMA experiment in
-        isolation. These are already committed to SOMA storage, so they are the unchangeable inputs
-        for a multi-file append-mode ingest to that experiment. The label-to-SOMA-join-ID mappings
-        for the input files will be computed on top of this foundation.
+        Returns:
+            A new ``ExperimentAmbientLabelMapping`` scoped specifically for the AnnData.
         """
 
-        obs_map = {}
-        var_maps = {}
+        # Only subset obs - provides largest benefit with simple implementation.
+        return attrs.evolve(
+            self,
+            obs_axis=attrs.evolve(
+                self.obs_axis, joinid_map=self.obs_axis.joinid_map.loc[adata.obs.index]
+            ),
+        )
 
-        if experiment_uri is None:
-            tiledbsoma.logging.logger.info(
-                "Registration: starting with empty experiment."
+    def subset_for_h5ad(self, h5ad_path: str) -> Self:
+        """Subset this plan to only contain ID maps useful for this H5AD.
+
+        See ``subset_for_anndata`` for more information.
+
+        Args:
+            h5ad_path: path to H5AD
+
+        Returns:
+            A new ``ExperimentAmbientLabelMapping`` scoped specifically for the H5AD.
+        """
+        with read_h5ad(h5ad_path, mode="r") as adata:
+            return self.subset_for_anndata(adata)
+
+    def prepare_experiment(
+        self, experiment_uri: str, context: SOMATileDBContext | None = None
+    ) -> None:
+        """Prepare experiment for ingestion.
+
+        Currently performs two operations:
+        1. Resize experiment to a shape sufficient to contain all registered AnnData/H5AD inputs
+        2. Evolve schema on all dict/enum/categorical columns to include any new values defined in registered AnnData (e.g., Pandas Categoricals with additional categories).
+
+        This makes subsequent data writes race safe, for workflows using concurrent dataset writers
+        (ie., parallel calls to `to_anndata` or `from_h5ad`).
+
+        This operation must be performed after the experiment is created, and before any writes
+        to the experiment.
+
+        Args:
+            experiment_uri: the Experiment to prepare for ingestion.
+
+            context: a SOMA context
+
+        Returns:
+            None
+        """
+        context = _validate_soma_tiledb_context(context)
+
+        def _check_experiment_structure(exp: tiledbsoma.Experiment) -> None:
+            # Verify that the experiment has been created correctly - check for existence of obs & var
+            # and raise error if Experiment does not contain expected structure.
+            did_you_create = (
+                "Did you create the Experiment using `from_anndata` or `from_h5ad`?"
+            )
+            if "obs" not in exp:
+                raise ValueError(
+                    f"SOMA Experiment is missing required 'obs' DataFrame. {did_you_create}"
+                )
+            for ms_name in self.var_axes:
+                if len(self.var_axes[ms_name].joinid_map) > 0:
+                    if ms_name not in exp.ms:
+                        raise ValueError(
+                            f"SOMA Experiment is missing required Measurement '{ms_name}'. {did_you_create}"
+                        )
+                    if "var" not in exp.ms[ms_name]:
+                        raise ValueError(
+                            f"SOMA Experiment is missing required `var` Dataframe in Measurement '{ms_name}'. {did_you_create}"
+                        )
+
+        with Experiment.open(experiment_uri, context=context) as E:
+
+            _check_experiment_structure(E)
+
+            # Resize is done only if we have an Experiment supporting current domain.
+            # Code assumes that if obs is of a given era (i.e. pre/post current domain change),
+            # so are all other arrays in the experiment.
+            ok_to_resize, _ = E.obs.tiledbsoma_resize_soma_joinid_shape(
+                self.get_obs_shape(), check_only=True
+            )
+            if ok_to_resize:
+                tiledbsoma.io.resize_experiment(
+                    experiment_uri,
+                    nobs=self.get_obs_shape(),
+                    nvars=self.get_var_shapes(),
+                    context=context,
+                )
+            else:
+                warnings.warn(
+                    "Experiment does not support resizing. Please consider upgrading the dataset "
+                    "using 'tiledbsoma.io.upgrade_experiment_shapes'."
+                )
+
+        with Experiment.open(experiment_uri, context=context, mode="w") as E:
+
+            # Enumerations schema evolution
+            extend_enumerations(E.obs, self.obs_axis.enum_values)
+
+            for ms_name, var_axis in self.var_axes.items():
+                if var_axis.enum_values:
+                    extend_enumerations(E.ms[ms_name].var, var_axis.enum_values)
+
+        # The class is a frozen `attrs` instance, to protect from user modification of the data.
+        # This is the "blessed" way for an implementation to modify itself (per attrs docs).
+        object.__setattr__(self, "prepared", True)
+
+    @staticmethod
+    def _load_axes_metadata_from_anndatas(
+        adatas: Iterable[ad.AnnData],
+        obs_field_name: str,
+        var_field_name: str,
+        validate_anndata: Callable[[ad.AnnData], None],
+    ) -> tuple[AnnDataAxisMetadata, AnnDataAxisMetadata, AnnDataAxisMetadata | None]:
+        """Private helper to load axis metadata for obs, var and raw.var (if present) from AnnData,
+        in an intermediate form.
+
+        Return (obs, var, raw.var)
+        """
+        obs_metadata: list[AnnDataAxisMetadata] = []
+        var_metadata: list[AnnDataAxisMetadata] = []
+        raw_var_metadata: list[AnnDataAxisMetadata] = []
+
+        def categorical_columns(df: pd.DataFrame) -> dict[Any, pd.CategoricalDtype]:
+            return cast(
+                dict[str, pd.CategoricalDtype],
+                {k: v.dtype for k, v in df.items() if v.dtype == "category"},
             )
 
-        else:
-            tiledbsoma.logging.logger.info(
-                f"Registration: starting with experiment {experiment_uri}"
+        for adata in adatas:
+
+            validate_anndata(adata)  # may throw
+
+            obs_metadata.append(
+                AnnDataAxisMetadata(
+                    field_name=obs_field_name,
+                    field_index=adata.obs.index,
+                    enum_values=categorical_columns(adata.obs),
+                )
+            )
+            var_metadata.append(
+                AnnDataAxisMetadata(
+                    field_name=var_field_name,
+                    field_index=adata.var.index,
+                    enum_values=categorical_columns(adata.var),
+                )
+            )
+            if adata.raw is not None:
+                raw_var_metadata.append(
+                    AnnDataAxisMetadata(
+                        field_name=var_field_name,
+                        field_index=adata.raw.var.index,
+                        enum_values=categorical_columns(adata.raw.var),
+                    )
+                )
+
+        obs, var, raw_var = (
+            AnnDataAxisMetadata.reduce(obs_metadata),
+            AnnDataAxisMetadata.reduce(var_metadata),
+            AnnDataAxisMetadata.reduce(raw_var_metadata),
+        )
+        assert obs is not None
+        assert var is not None
+        return obs, var, raw_var
+
+    @staticmethod
+    def _load_axes_metadata_from_h5ads(
+        paths: Sequence[str | Path],
+        obs_field_name: str,
+        var_field_name: str,
+        validate_anndata: Callable[[ad.AnnData], None],
+    ) -> tuple[AnnDataAxisMetadata, AnnDataAxisMetadata, AnnDataAxisMetadata | None]:
+        """Private helper to load axis metadata for obs, var and raw.var (if present) from H5ADs.
+
+        Return (obs, var, raw.var).
+        """
+        obs_metadata: list[AnnDataAxisMetadata] = []
+        var_metadata: list[AnnDataAxisMetadata] = []
+        raw_var_metadata: list[AnnDataAxisMetadata] = []
+
+        for p in paths:
+            with read_h5ad(p, mode="r") as adata:
+                obs, var, raw_var = (
+                    ExperimentAmbientLabelMapping._load_axes_metadata_from_anndatas(
+                        [adata], obs_field_name, var_field_name, validate_anndata
+                    )
+                )
+            obs_metadata.append(obs)
+            var_metadata.append(var)
+            if raw_var is not None:
+                raw_var_metadata.append(raw_var)
+
+        obs, var, raw_var = (
+            AnnDataAxisMetadata.reduce(obs_metadata),
+            AnnDataAxisMetadata.reduce(var_metadata),
+            AnnDataAxisMetadata.reduce(raw_var_metadata),
+        )
+        assert obs is not None
+        assert var is not None
+        return obs, var, raw_var
+
+    @staticmethod
+    def _load_existing_experiment_metadata(
+        uri: str, obs_field_name: str, var_field_name: str, context: SOMATileDBContext
+    ) -> tuple[
+        pd.DataFrame,
+        dict[ColumnName, pd.DataFrame],
+        dict[ColumnName, pd.CategoricalDtype],
+        dict[MeasurementName, dict[ColumnName, pd.CategoricalDtype]],
+    ]:
+        """Private helper to load any joinid/enum metadata from an existing experiment.
+
+        Returns (obs_joinid_map, var_joinid_maps, obs_enum_values, var_enum_values).
+        """
+
+        def _get_enum_values(df: DataFrame) -> dict[str, pd.CategoricalDtype]:
+            return get_enumerations(
+                df, [f.name for f in df.schema if pa.types.is_dictionary(f.type)]
             )
 
-            with tiledbsoma.Experiment.open(experiment_uri, context=context) as exp:
-                for batch in exp.obs.read(column_names=["soma_joinid", obs_field_name]):
-                    obs_ids = [e.as_py() for e in batch[1]]
-                    soma_joinids = [e.as_py() for e in batch[0]]
-                    obs_map.update(dict(zip(obs_ids, soma_joinids)))
+        def _get_joinid_map(df: DataFrame, field_name: str) -> pd.DataFrame:
+            return cast(
+                pd.DataFrame,
+                df.read(column_names=["soma_joinid", field_name])
+                .concat()
+                .to_pandas()
+                .set_index(field_name),
+            )
 
-                for measurement_name in exp.ms:
-                    meas = exp.ms[measurement_name]
-                    if "var" not in meas:
-                        continue
-                    expvar = meas.var
-                    if var_field_name not in expvar.schema.names:
-                        continue
-                    var_map = {}
-                    for batch in expvar.read(
-                        column_names=["soma_joinid", var_field_name]
-                    ):
-                        var_ids = [e.as_py() for e in batch[1]]
-                        soma_joinids = [e.as_py() for e in batch[0]]
-                        var_map.update(dict(zip(var_ids, soma_joinids)))
-                    var_maps[measurement_name] = var_map
-
-                    tiledbsoma.logging.logger.info(
-                        f"Registration: found nobs={len(obs_map)} nvar={len(var_map)} from experiment."
+        with Experiment.open(uri, context=context) as E:
+            existing_obs_joinid_map = _get_joinid_map(E.obs, obs_field_name)
+            existing_obs_enum_values = _get_enum_values(E.obs)
+            existing_var_joinid_maps = {}
+            existing_var_enum_values = {}
+            for ms_name in E.ms.keys():
+                if (
+                    "var" in E.ms[ms_name]
+                    and var_field_name in E.ms[ms_name].var.keys()
+                ):
+                    existing_var_joinid_maps[ms_name] = _get_joinid_map(
+                        E.ms[ms_name].var, var_field_name
+                    )
+                    existing_var_enum_values[ms_name] = _get_enum_values(
+                        E.ms[ms_name].var
                     )
 
-        return cls(
-            obs_axis=AxisAmbientLabelMapping(data=obs_map, field_name=obs_field_name),
-            var_axes={
-                ms_name: AxisAmbientLabelMapping(data=data, field_name=var_field_name)
-                for ms_name, data in var_maps.items()
-            },
+        return (
+            existing_obs_joinid_map,
+            existing_var_joinid_maps,
+            existing_obs_enum_values,
+            existing_var_enum_values,
         )
 
-    @classmethod
-    def from_anndata_append_on_experiment(
-        cls,
-        adata: ad.AnnData,
-        previous: Self,
+    @staticmethod
+    def _register_common(
+        experiment_uri: str | None,
+        axes_metadata: list[
+            tuple[AnnDataAxisMetadata, AnnDataAxisMetadata, AnnDataAxisMetadata | None]
+        ],
         *,
         measurement_name: str,
-        obs_field_name: str = "obs_id",
-        var_field_name: str = "var_id",
-        append_obsm_varm: bool = False,
-    ) -> Self:
-        """Extends registration data to one more AnnData input."""
-        tiledbsoma.logging.logger.info("Registration: registering AnnData object.")
+        obs_field_name: str,
+        var_field_name: str,
+        context: SOMATileDBContext,
+    ) -> ExperimentAmbientLabelMapping:
+        """
+        Private method used by various constructor paths -- shared code for registration.
 
-        # Pre-checks
+        Four-step process common to all ingestion plans. Given AnnData axis metadata (joinid map
+        and enum definitions):
+        1. Load plan info from existing Experiment, if available
+        2. Reduce all AnnData axis metadata
+        3. Create a joinid map for ingestion
+        4. Create enum evolution
+        5. Create and return the plan.
+
+        [sc-65318]: the current design assumes that the join column for `var` is the same across
+        all measurements. For simple cases (e.g., single modality) this is normally true.
+        It is less likely to be true for multi-modal data. Future rework should address this
+        by allowing a per-measurement var join column.
+        """
+
+        tp = context.threadpool
+        existing_obs_joinid_map: pd.DataFrame
+        existing_var_joinid_maps: dict[str, pd.DataFrame]
+        existing_obs_enum_values: dict[str, pd.CategoricalDtype]
+        existing_var_enum_values: dict[str, dict[str, pd.CategoricalDtype]]
+
+        #
+        # Step 1: load all existing Experiment info.
+        #
+        if experiment_uri is not None:
+            logging.log_io_same("Loading existing experiment joinid map")
+            experiment_metadata_ft = tp.submit(
+                ExperimentAmbientLabelMapping._load_existing_experiment_metadata,
+                experiment_uri,
+                obs_field_name,
+                var_field_name,
+                context,
+            )
+
+        #
+        # Step 2: reduce axis metadata
+        #
+        logging.log_io_same("Reducing axis metadata")
+        obs_axis_metadata, var_axis_metadata, raw_var_axis_metadata = tp.map(
+            AnnDataAxisMetadata.reduce,
+            [
+                [t[0] for t in axes_metadata if t[0] is not None],  # obs
+                [t[1] for t in axes_metadata if t[1] is not None],  # var
+                [t[2] for t in axes_metadata if t[2] is not None],  # raw.var
+            ],
+        )
+        logging.log_io_same("Finished reducing axis metadata")
+
+        # And, grab the result of step 1 from the futures
+        if experiment_uri is not None:
+            (
+                existing_obs_joinid_map,
+                existing_var_joinid_maps,
+                existing_obs_enum_values,
+                existing_var_enum_values,
+            ) = experiment_metadata_ft.result()
+            logging.log_io_same("Existing joinid maps are loaded.")
+        else:
+            existing_obs_joinid_map = pd.DataFrame()
+            existing_var_joinid_maps = {
+                measurement_name: pd.DataFrame(),
+                "raw": pd.DataFrame(),
+            }
+            existing_obs_enum_values = {}
+            existing_var_enum_values = {measurement_name: {}, "raw": {}}
+
+        #
+        # Step 3: create a joinid map for each axis
+        #
+        def _make_joinid_map(
+            joinids_index: pd.Index,  # type:ignore[type-arg]
+            prev_joinid_map: pd.DataFrame,
+        ) -> pd.DataFrame:
+            maps = []
+            if len(prev_joinid_map) > 0:
+                joinids_index = joinids_index.difference(
+                    prev_joinid_map.index, sort=False
+                )
+                next_soma_joinid = prev_joinid_map.soma_joinid.max() + 1
+                maps.append(prev_joinid_map)
+            else:
+                next_soma_joinid = 0
+
+            logging.log_io_same(f"next soma_joinid={next_soma_joinid}")
+            maps.append(
+                pd.DataFrame(
+                    index=joinids_index,
+                    data={
+                        "soma_joinid": np.arange(
+                            next_soma_joinid,
+                            next_soma_joinid + len(joinids_index),
+                            dtype=np.int64,
+                        )
+                    },
+                )
+            )
+            return pd.concat(maps)
+
+        obs_joinid_map_future = tp.submit(
+            _make_joinid_map, obs_axis_metadata.field_index, existing_obs_joinid_map
+        )
+        var_joinid_maps_future = {
+            measurement_name: tp.submit(
+                _make_joinid_map,
+                var_axis_metadata.field_index,
+                existing_var_joinid_maps.get(measurement_name, pd.DataFrame()),
+            )
+        }
+        if len(raw_var_axis_metadata.field_index) > 0:
+            var_joinid_maps_future["raw"] = tp.submit(
+                _make_joinid_map,
+                raw_var_axis_metadata.field_index,
+                existing_var_joinid_maps.get("raw", pd.DataFrame()),
+            )
+
+        obs_joinid_map = obs_joinid_map_future.result()
+        var_joinid_maps = existing_var_joinid_maps | {
+            k: f.result() for k, f in var_joinid_maps_future.items()
+        }
+
+        #
+        # Step 4: create merged enum values for all axis dataframes
+        #
+        obs_enum_values = AnnDataAxisMetadata.reduce_enum_values(
+            [existing_obs_enum_values, obs_axis_metadata.enum_values]
+        )
+        var_enum_values = existing_var_enum_values.copy()
+        var_enum_values[measurement_name] = AnnDataAxisMetadata.reduce_enum_values(
+            [
+                existing_var_enum_values.get(measurement_name, {}),
+                var_axis_metadata.enum_values,
+            ]
+        )
+        if len(raw_var_axis_metadata.enum_values) > 0:
+            var_enum_values["raw"] = AnnDataAxisMetadata.reduce_enum_values(
+                [
+                    existing_var_enum_values.get("raw", {}),
+                    raw_var_axis_metadata.enum_values,
+                ]
+            )
+
+        #
+        # Step 5: create and return the ingestion plan
+        #
+        obs_axis = AxisAmbientLabelMapping(
+            field_name=obs_field_name,
+            joinid_map=obs_joinid_map,
+            enum_values=obs_enum_values,
+        )
+        var_axes = {
+            k: AxisAmbientLabelMapping(
+                field_name=var_field_name,
+                joinid_map=(
+                    var_joinid_maps[k] if k in var_joinid_maps else pd.DataFrame()
+                ),
+                enum_values=var_enum_values[k] if k in var_enum_values else {},
+            )
+            for k in set(var_joinid_maps.keys()) | set(var_enum_values.keys())
+        }
+        return ExperimentAmbientLabelMapping(obs_axis=obs_axis, var_axes=var_axes)
+
+    @staticmethod
+    def _validate_anndata(append_obsm_varm: bool, adata: ad.AnnData) -> None:
+        """Pre-checks performed on all AnnData"""
+
+        def check_df(df: pd.DataFrame | None, df_name: str) -> None:
+            if df is None or df.index.empty:
+                raise ValueError(
+                    f"Unable to ingest AnnData with empty {df_name} dataframe."
+                )
+            elif not df.index.is_unique:
+                raise ValueError(
+                    f"Non-unique registration values have been provided in {df_name} dataframe."
+                )
+
+        check_df(adata.obs, "obs")
+        check_df(adata.var, "var")
+        if adata.raw is not None:
+            check_df(adata.raw.var, "raw.var")
+
         if not append_obsm_varm:
             if len(adata.obsm) > 0 or len(adata.varm) > 0:
                 raise ValueError(
-                    "append-mode ingest of obsm and varm is only supported via explicit opt-in. Please drop them from the inputs, or retry with append_obsm_varm=True."
+                    "The append-mode ingest of obsm and varm is only supported via explicit opt-in. Please drop them from the inputs, or retry with append_obsm_varm=True."
                 )
 
         if len(adata.obsp) > 0 or len(adata.varp) > 0:
             raise ValueError(
-                "append-mode ingest of obsp and varp is not supported. Please retry without them."
+                "The append-mode ingest of obsp and varp is not supported. Please retry without them."
             )
 
-        obs_next_soma_joinid = previous.obs_axis.get_next_start_soma_joinid()
-        obs_map = dict(previous.obs_axis.data)
-        obs_ids = get_dataframe_values(adata.obs, obs_field_name)
-        for obs_id in obs_ids:
-            if obs_id not in obs_map:
-                obs_map[obs_id] = obs_next_soma_joinid
-                obs_next_soma_joinid += 1
+        if adata.uns:
+            warnings.warn(
+                "The append-mode ingest of 'uns' is typically an error due to uns key collisions "
+                "across multiple AnnData. Drop 'uns' from AnnData to remove this warning, or if you "
+                "intend for 'uns' to merge, ensure each AnnData uses unique keys."
+            )
 
-        var_map = {}
-        var_next_soma_joinid = 0
-        if measurement_name in previous.var_axes:
-            var_map = dict(previous.var_axes[measurement_name].data)
-            var_next_soma_joinid = previous.var_axes[
-                measurement_name
-            ].get_next_start_soma_joinid()
-        var_ids = get_dataframe_values(adata.var, var_field_name)
-        for var_id in var_ids:
-            if var_id not in var_map:
-                var_map[var_id] = var_next_soma_joinid
-                var_next_soma_joinid += 1
 
-        var_maps = {measurement_name: var_map}
+@attrs.define(kw_only=True, frozen=True)
+class AnnDataAxisMetadata:
+    """Private class encapsulating _intermediate_ information extracted from registered
+    H5ADs/AnnData. Other than data storage, this also provides a reducer for the type.
+    """
 
-        if adata.raw is None:
-            if "raw" in previous.var_axes:
-                var_maps["raw"] = dict(previous.var_axes["raw"].data)
+    field_name: str  # user-specified join field name
+    field_index: pd.Index[Any]  # index of join field values
+    enum_values: dict[ColumnName, pd.CategoricalDtype]
 
-        else:
-            # One input may not have a raw while the next may have one
-            raw_var_map = {}
-            raw_var_next_soma_joinid = 0
-            if "raw" in previous.var_axes:
-                raw_var_axis = previous.var_axes["raw"]
-                raw_var_map = raw_var_axis.data
-                raw_var_next_soma_joinid = raw_var_axis.get_next_start_soma_joinid()
-            raw_var_ids = get_dataframe_values(adata.raw.var, var_field_name)
-            for raw_var_id in raw_var_ids:
-                if raw_var_id not in raw_var_map:
-                    raw_var_map[raw_var_id] = raw_var_next_soma_joinid
-                    raw_var_next_soma_joinid += 1
+    @classmethod
+    def reduce(cls, ams: list[Self]) -> AnnDataAxisMetadata:
+        assert all(isinstance(a, cls) for a in ams)
+        assert all([a.field_name == ams[0].field_name for a in ams])
+        if not all(a.field_index.dtype == ams[0].field_index.dtype for a in ams):
+            raise SOMAError("All AnnData must have a common dtype for their index.")
 
-            var_maps["raw"] = raw_var_map
+        if len(ams) == 0:
+            return cls(field_name="", field_index=pd.Index([]), enum_values={})
+        if len(ams) == 1:
+            return ams[0]
 
-        tiledbsoma.logging.logger.info(
-            f"Registration: accumulated to nobs={len(obs_map)} nvar={len(var_map)}."
-        )
+        def _reduce_field_index(indices: list[pd.Index]) -> pd.Index:  # type: ignore[type-arg]
+            """reducer for joinid indices"""
+            if len(indices) == 0:
+                return pd.Index([])
+            if len(indices) == 1:
+                return indices[0]
+            return cast("pd.Index[Any]", indices[0].append(indices[1:]).drop_duplicates())  # type: ignore[no-untyped-call]
+
         return cls(
-            obs_axis=AxisAmbientLabelMapping(data=obs_map, field_name=obs_field_name),
-            var_axes={
-                ms_name: AxisAmbientLabelMapping(data=data, field_name=var_field_name)
-                for ms_name, data in var_maps.items()
-            },
+            field_name=ams[0].field_name,
+            field_index=_reduce_field_index(
+                [a.field_index for a in ams if not a.field_index.empty]
+            ),
+            enum_values=cls.reduce_enum_values([a.enum_values for a in ams]),
         )
 
-    @classmethod
-    def _acquire_experiment_mappings(
-        cls,
-        experiment_uri: str | None,
-        *,
-        measurement_name: str,
-        obs_field_name: str,
-        var_field_name: str,
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Acquires label-to-ID mappings from the baseline, already-written SOMA experiment."""
+    @staticmethod
+    def reduce_enum_values(
+        enum_values: list[dict[ColumnName, pd.CategoricalDtype]],
+    ) -> dict[ColumnName, pd.CategoricalDtype]:
+        """reducer for enum values"""
 
-        if experiment_uri is not None:
-            if not tiledbsoma.Experiment.exists(experiment_uri, context=context):
-                raise ValueError(f"cannot find experiment at URI {experiment_uri}")
+        def _merge_categoricals(
+            col_name: str,
+            enums: list[pd.CategoricalDtype],
+        ) -> pd.CategoricalDtype:
+            assert len(enums) > 0
+            if len(enums) == 1:
+                return enums[0]
 
-            # Pre-check
-            with tiledbsoma.Experiment.open(experiment_uri, context=context) as exp:
-                if measurement_name not in exp.ms:
-                    raise ValueError(
-                        f"cannot append: target measurement {measurement_name} is not in experiment {experiment_uri}"
+            ordered = enums[0].ordered
+            if not all(e.ordered == ordered for e in enums[1:]):
+                raise SOMAError(
+                    f"Unable to register AnnData -- for column `{col_name}`, all AnnData dtype must have the same categorical ordering."
+                )
+
+            if not ordered:
+                return pd.CategoricalDtype(
+                    enums[0]
+                    .categories.append([e.categories for e in enums[1:]])  # type: ignore[no-untyped-call]
+                    .drop_duplicates(),
+                    ordered=False,
+                )
+
+            # Ordered enums are tricky - handle the simple case where all are identical
+            # and error on anything else.
+            for e in enums[1:]:
+                if e != enums[0]:
+                    raise SOMAError(
+                        f"Unable to register AnnData -- for column `{col_name}`, all AnnData must have the same dtype."
                     )
-            registration_data = cls.from_isolated_soma_experiment(
-                experiment_uri,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-                context=context,
-            )
-        else:
-            registration_data = cls(
-                obs_axis=AxisAmbientLabelMapping(data={}, field_name=obs_field_name),
-                var_axes={
-                    measurement_name: AxisAmbientLabelMapping(
-                        data={}, field_name=var_field_name
-                    ),
-                    "raw": AxisAmbientLabelMapping(data={}, field_name=var_field_name),
-                },
-            )
-        return registration_data
+            return enums[0]
 
-    @classmethod
-    def from_anndata_appends_on_experiment(
-        cls,
-        experiment_uri: str | None,
-        adatas: Sequence[ad.AnnData] | ad.AnnData,
-        *,
-        measurement_name: str,
-        obs_field_name: str,
-        var_field_name: str,
-        append_obsm_varm: bool = False,
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Extends registration data from the baseline, already-written SOMA
-        experiment to include multiple H5AD input files. If ``experiment_uri``
-        is ``None`` then you will be computing registrations only for the input
-        ``AnnData`` objects. If ``experiment_uri`` is not ``None`` then it is
-        an error if the experiment is not accessible."""
-        # typeguard doesn't help at runtime. Check this crucial user-facing API.
-        if isinstance(adatas, ad.AnnData):
-            adatas = [adatas]
-        elif not isinstance(adatas, (list, tuple)):
-            raise ValueError(
-                f"adatas must be list or tuple of AnnData, or a single AnnData; got {type(adatas)}"
-            )
+        # invert the enum maps from list[dict[str, pd.Categorical]] to dict[str, list[pd.Categorical]]
+        inverted_enum_values: dict[str, list[pd.CategoricalDtype]] = defaultdict(list)
+        for e in enum_values:
+            for k, v in e.items():
+                inverted_enum_values[k].append(v)
 
-        registration_data = cls._acquire_experiment_mappings(
-            experiment_uri,
-            measurement_name=measurement_name,
-            obs_field_name=obs_field_name,
-            var_field_name=var_field_name,
-            context=context,
-        )
-
-        for adata in adatas:
-            registration_data = cls.from_anndata_append_on_experiment(
-                adata,
-                registration_data,
-                measurement_name=measurement_name,
-                append_obsm_varm=append_obsm_varm,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-            )
-
-        tiledbsoma.logging.logger.info("Registration: complete.")
-        return registration_data
-
-    @classmethod
-    def from_h5ad_append_on_experiment(
-        cls,
-        h5ad_file_name: str,
-        previous: Self,
-        *,
-        measurement_name: str,
-        obs_field_name: str = "obs_id",
-        var_field_name: str = "var_id",
-        append_obsm_varm: bool = False,
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Extends registration data to one more H5AD input file."""
-        tiledbsoma.logging.logger.info(f"Registration: registering {h5ad_file_name}.")
-
-        with read_h5ad(h5ad_file_name, mode="r", ctx=context) as adata:
-            return cls.from_anndata_append_on_experiment(
-                adata,
-                previous,
-                measurement_name=measurement_name,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-                append_obsm_varm=append_obsm_varm,
-            )
-
-    @classmethod
-    def from_h5ad_appends_on_experiment(
-        cls,
-        experiment_uri: str | None,
-        h5ad_file_names: Sequence[str] | str,
-        *,
-        measurement_name: str,
-        obs_field_name: str,
-        var_field_name: str,
-        append_obsm_varm: bool = False,
-        context: SOMATileDBContext | None = None,
-    ) -> Self:
-        """Extends registration data from the baseline, already-written SOMA
-        experiment to include multiple H5AD input files."""
-        # typeguard doesn't help at runtime. Check this crucial user-facing API.
-        if isinstance(h5ad_file_names, str):
-            h5ad_file_names = [h5ad_file_names]
-        elif not isinstance(h5ad_file_names, (list, tuple)):
-            raise ValueError(
-                f"h5ad_file_names must be list or tuple of string, or a single string; got {type(h5ad_file_names)}"
-            )
-
-        registration_data = cls._acquire_experiment_mappings(
-            experiment_uri,
-            measurement_name=measurement_name,
-            obs_field_name=obs_field_name,
-            var_field_name=var_field_name,
-            context=context,
-        )
-
-        for h5ad_file_name in h5ad_file_names:
-            registration_data = cls.from_h5ad_append_on_experiment(
-                h5ad_file_name,
-                registration_data,
-                measurement_name=measurement_name,
-                append_obsm_varm=append_obsm_varm,
-                obs_field_name=obs_field_name,
-                var_field_name=var_field_name,
-                context=context,
-            )
-
-        tiledbsoma.logging.logger.info("Registration: complete.")
-        return registration_data
-
-    def __str__(self) -> str:
-        lines = [f"obs:{len(self.obs_axis.data)}"]
-        for k, v in self.var_axes.items():
-            lines.append(f"{k}/var:{len(v.data)}")
-        return "\n".join(lines)
-
-    def get_obs_shape(self) -> int:
-        """Reports the new obs shape which the experiment will need to be
-        resized to in order to accommodate the data contained within the
-        registration."""
-        return self.obs_axis.get_shape()
-
-    def get_var_shapes(self) -> Dict[str, int]:
-        """Reports the new var shapes, one per measurement, which the experiment
-        will need to be resized to in order to accommodate the data contained
-        within the registration."""
-        retval: Dict[str, int] = {}
-        for key, axis in self.var_axes.items():
-            retval[key] = axis.get_shape()
-        return retval
-
-    def to_json(self) -> str:
-        """The ``to_json`` and ``from_json`` methods allow you to persist
-        the registration mappings to disk."""
-        return json.dumps(self, default=attrs.asdict, sort_keys=True, indent=4)
-
-    @classmethod
-    def from_json(cls, s: str) -> Self:
-        """The ``to_json`` and ``from_json`` methods allow you to persist
-        the registration mappings to disk."""
-        dikt = json.loads(s)
-        obs_axis = AxisAmbientLabelMapping(
-            data=dikt["obs_axis"]["data"], field_name=dikt["obs_axis"]["field_name"]
-        )
-        var_axes = {
-            k: AxisAmbientLabelMapping(data=v["data"], field_name=v["field_name"])
-            for k, v in dikt["var_axes"].items()
-        }
-        return cls(obs_axis=obs_axis, var_axes=var_axes)
+        return {k: _merge_categoricals(k, v) for k, v in inverted_enum_values.items()}

--- a/apis/python/src/tiledbsoma/io/_registration/enum.py
+++ b/apis/python/src/tiledbsoma/io/_registration/enum.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+import pyarrow as pa
+
+from tiledbsoma import DataFrame
+
+
+def get_enumerations(
+    df: DataFrame, column_names: Sequence[str]
+) -> dict[str, pd.CategoricalDtype]:
+    """Look up enum info in schema, and return as a Pandas CategoricalDType. This
+    is a convenience wrapper around ``DataFrame.get_enumeration_values``, for use
+    in the registration module."""
+
+    # skip columns which are not of type dictionary
+    column_names = [
+        c for c in column_names if pa.types.is_dictionary(df.schema.field(c).type)
+    ]
+    return {
+        k: pd.CategoricalDtype(categories=v, ordered=df.schema.field(k).type.ordered)
+        for k, v in df.get_enumeration_values(column_names).items()
+    }
+
+
+def extend_enumerations(df: DataFrame, columns: dict[str, pd.CategoricalDtype]) -> None:
+    """
+    Extend enumerations as needed, starting with a CategoricalDType for each
+    cat/enum/dict column. A convenience wrapper around ``DataFrame.extend_enumeration_values``,
+    for use in the registration module.
+
+    DataFrame must be open for write.
+    """
+
+    current_enums = get_enumerations(df, list(columns.keys()))
+    columns_to_extend = {}
+    for column_name, cat_dtype in columns.items():
+
+        # first confirm this is a dictionary. If it has been decategorical-ized, i.e.,
+        # are an array of the value type, don't extend.
+        if column_name not in current_enums:
+            assert not pa.types.is_dictionary(df.schema.field(column_name).type)
+            continue
+
+        # determine if we have any new enum values in this column
+        existing_dtype = current_enums[column_name]
+        new_enum_values = pd.Index(cat_dtype.categories).difference(
+            existing_dtype.categories, sort=False
+        )
+        if len(new_enum_values) == 0:
+            continue
+
+        # if there are new values, extend the array schema enum
+        new_enum_values = pa.array(new_enum_values.to_numpy())
+        columns_to_extend[column_name] = new_enum_values
+
+    # and evolve the schema
+    df.extend_enumeration_values(columns_to_extend, deduplicate=False)

--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -1,42 +1,44 @@
 # Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
 #
 # Licensed under the MIT License.
+from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import cast
 
 import anndata as ad
 import attrs
+import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from typing_extensions import Self
 
-import tiledbsoma
-import tiledbsoma.logging
 
-
-@attrs.define(kw_only=True)
+@attrs.define(kw_only=True, frozen=True)
 class AxisIDMapping:
-    """
-    For a single to-be-appended AnnData/H5AD input in SOMA multi-file append-mode ingestion, this
+    """For a single to-be-appended AnnData/H5AD input in SOMA multi-file append-mode ingestion, this
     class tracks the mapping of input-data ``obs`` or ``var`` 0-up offsets to SOMA join ID values
     for the destination SOMA experiment.
 
-    See module-level comments for more information.
+    Private class
     """
 
-    # Tuple not List so this can't be modified by accident when passed into some function somewhere
-    data: Tuple[int, ...]
+    data: npt.NDArray[np.int64]
 
-    def is_identity(self) -> bool:
-        for i, data in enumerate(self.data):
-            if data != i:
-                return False
-        return True
+    def __attrs_post_init__(self) -> None:
+        self.data.setflags(write=False)
 
     def get_shape(self) -> int:
         if len(self.data) == 0:
             return 0
         else:
-            return 1 + max(self.data)
+            return int(self.data.max() + 1)
+
+    def is_identity(self) -> bool:
+        # fast rejection first
+        if self.get_shape() != len(self.data) or self.data[0] != 0:
+            return False
+
+        return np.array_equal(self.data, np.arange(0, len(self.data)))
 
     @classmethod
     def identity(cls, n: int) -> Self:
@@ -44,59 +46,47 @@ class AxisIDMapping:
         important for uns arrays which we never grow on ingest --- rather, we
         sub-nest the entire recursive ``uns`` data structure.
         """
-        return cls(data=tuple(range(n)))
+        return cls(data=np.arange(n, dtype=np.int64))
 
 
-@attrs.define(kw_only=True)
+@attrs.define(kw_only=True, frozen=True)
 class ExperimentIDMapping:
-    """
-    For a single to-be-appended AnnData/H5AD input in SOMA multi-file append-mode ingestion, this
-    class contains an ``ExperimentIDMapping`` for ``obs``, and one ``ExperimentIDMapping`` for
+    """For a single to-be-appended AnnData/H5AD input in SOMA multi-file append-mode ingestion, this
+    class contains an ``AxisIDMapping`` for ``obs``, and one ``AxisIDMapping`` for
     ``var`` in each measurement.
 
-    See module-level comments for more information.
+    Private class
     """
 
     obs_axis: AxisIDMapping
-    var_axes: Dict[str, AxisIDMapping]
+    var_axes: dict[str, AxisIDMapping]
 
     @classmethod
-    def from_isolated_anndata(
-        cls,
-        adata: ad.AnnData,
-        measurement_name: str,
-    ) -> Self:
-        """Factory method to compute offset-to-SOMA-join-ID mappings for a single input file in
-        isolation. This is used when a user is ingesting a single AnnData/H5AD to a single SOMA
-        experiment, not in append mode, allowing us to still have the bulk of the ingestor code to
-        be non-duplicated between non-append mode and append mode.
+    def from_anndata(cls, adata: ad.AnnData, *, measurement_name: str = "RNA") -> Self:
+        """Create a new ID mapping from an AnnData.
+
+        This is useful for creating a new Experiment from a single AnnData.
         """
-        tiledbsoma.logging.logger.info(
-            "Registration: registering isolated AnnData object."
-        )
-
-        obs_mapping = AxisIDMapping(data=tuple(range(len(adata.obs))))
-        var_axes = {}
-        var_axes[measurement_name] = AxisIDMapping(data=tuple(range(len(adata.var))))
+        obs_axis = AxisIDMapping.identity(len(adata.obs))
+        var_axes = {measurement_name: AxisIDMapping.identity(len(adata.var))}
         if adata.raw is not None:
-            var_axes["raw"] = AxisIDMapping(data=tuple(range(len(adata.raw.var))))
+            var_axes["raw"] = AxisIDMapping.identity(len(adata.raw.var))
+        return cls(obs_axis=obs_axis, var_axes=var_axes)
 
-        return cls(obs_axis=obs_mapping, var_axes=var_axes)
 
-
-def get_dataframe_values(df: pd.DataFrame, field_name: str) -> List[str]:
+def get_dataframe_values(df: pd.DataFrame, field_name: str) -> pd.Series:  # type: ignore[type-arg]
     """Extracts the label values (e.g. cell barcode, gene symbol) from an AnnData/H5AD
     ``obs`` or ``var`` dataframe."""
     if field_name in df:
-        values = [str(e) for e in df[field_name]]
+        values = cast(pd.Series, df[field_name].astype(str))  # type: ignore[type-arg]
     elif df.index.name in (field_name, "index", None):
-        values = list(df.index)
+        values = cast(pd.Series, df.index.to_series().astype(str))  # type: ignore[type-arg]
     else:
-        raise ValueError(f"could not find field name {field_name} in dataframe")
+        raise ValueError(f"Could not find field name {field_name} in dataframe.")
 
     # Check the values are unique.
-    if len(values) != len(set(values)):
+    if not values.is_unique:
         raise ValueError(
-            f"non-unique registration values have been provided in field {field_name}"
+            f"Non-unique registration values have been provided in field {field_name}."
         )
     return values

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -113,7 +113,8 @@ def _hack_patch_anndata() -> ContextManager[object]:
 
     @file_backing.AnnDataFileManager.filename.setter  # type: ignore[misc]
     def filename(
-        self: file_backing.AnnDataFileManager, filename: Union[Path, _FSPathWrapper]
+        self: file_backing.AnnDataFileManager,
+        filename: Union[Path, _FSPathWrapper, None],
     ) -> None:
         self._filename = filename
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -10,12 +10,20 @@ other formats. Currently only ``.h5ad`` (`AnnData <https://anndata.readthedocs.i
 
 from __future__ import annotations
 
+import contextlib
 import json
 import math
+import multiprocessing
+import os
 import time
+import warnings
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from functools import partial
+from itertools import repeat
 from typing import (
     Any,
     Dict,
+    Iterable,
     List,
     Literal,
     Mapping,
@@ -36,6 +44,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
+from more_itertools import batched
 
 # As of anndata 0.11 we get a warning importing anndata.experimental.
 # But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
@@ -105,7 +114,6 @@ from ._registration import (
     AxisIDMapping,
     ExperimentAmbientLabelMapping,
     ExperimentIDMapping,
-    get_dataframe_values,
 )
 from ._util import get_arrow_str_format, read_h5ad
 
@@ -135,7 +143,7 @@ class IngestionParams:
     ) -> None:
         if ingest_mode == "schema_only":
             self.write_schema_no_data = True
-            self.error_if_already_exists = True
+            self.error_if_already_exists = False
             self.skip_existing_nonempty_domain = False
             self.appending = False
 
@@ -190,24 +198,71 @@ def register_h5ads(
     var_field_name: str,
     append_obsm_varm: bool = False,
     context: SOMATileDBContext | None = None,
+    use_multiprocessing: bool = False,
 ) -> ExperimentAmbientLabelMapping:
     """Extends registration data from the baseline, already-written SOMA
     experiment to include multiple H5AD input files. See ``from_h5ad`` and
-    ``from_anndata`` on-line help."""
-    return ExperimentAmbientLabelMapping.from_h5ad_appends_on_experiment(
-        experiment_uri=experiment_uri,
-        h5ad_file_names=h5ad_file_names,
+    ``from_anndata`` on-line help.
+
+    If enabled via the ``use_multiprocessing`` parameter, this function will use multiprocessing
+    to register each H5AD in parallel. In cases with many files, this can produce a performance
+    benefit. Regardless of ``use_multiprocessing``, H5ADs will be registered concurrently -- you
+    can control the concurrency using the ``soma.compute_concurrency_level`` configuration
+    parameter in the ``context`` argument.
+    """
+
+    if isinstance(h5ad_file_names, str):
+        h5ad_file_names = [h5ad_file_names]
+
+    context = _validate_soma_tiledb_context(context)
+    concurrency_level = _concurrency_level(context)
+
+    logging.log_io(None, f"Loading per-axis metadata for {len(h5ad_file_names)} files.")
+    executor_context: contextlib.AbstractContextManager[
+        ProcessPoolExecutor | ThreadPoolExecutor
+    ]
+    if use_multiprocessing:
+        if multiprocessing.get_start_method() == "fork":
+            warnings.warn(
+                "Multiprocessing `fork` start method is inherently unsafe -- use `spawn`. See `multiprocessing.set_start_method()`",
+            )
+        executor_context = ProcessPoolExecutor(max_workers=concurrency_level)
+    else:
+        executor_context = contextlib.nullcontext(enter_result=context.threadpool)
+
+    with executor_context as executor:
+        axes_metadata = list(
+            executor.map(
+                ExperimentAmbientLabelMapping._load_axes_metadata_from_h5ads,
+                batched(
+                    h5ad_file_names,
+                    math.ceil(len(h5ad_file_names) / concurrency_level),
+                ),
+                repeat(obs_field_name),
+                repeat(var_field_name),
+                repeat(
+                    partial(
+                        ExperimentAmbientLabelMapping._validate_anndata,
+                        append_obsm_varm,
+                    )
+                ),
+            )
+        )
+    logging.log_io(None, "Loaded per-axis metadata")
+
+    return ExperimentAmbientLabelMapping._register_common(
+        experiment_uri,
+        axes_metadata,
         measurement_name=measurement_name,
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
-        append_obsm_varm=append_obsm_varm,
         context=context,
     )
 
 
 def register_anndatas(
     experiment_uri: str | None,
-    adatas: Sequence[ad.AnnData] | ad.AnnData,
+    adatas: Iterable[ad.AnnData] | ad.AnnData,
     *,
     measurement_name: str,
     obs_field_name: str,
@@ -218,13 +273,27 @@ def register_anndatas(
     """Extends registration data from the baseline, already-written SOMA
     experiment to include multiple H5AD input files. See ``from_h5ad`` and
     ``from_anndata`` on-line help."""
-    return ExperimentAmbientLabelMapping.from_anndata_appends_on_experiment(
-        experiment_uri=experiment_uri,
-        adatas=adatas,
+
+    if isinstance(adatas, ad.AnnData):
+        adatas = [adatas]
+
+    context = _validate_soma_tiledb_context(context)
+
+    axes_metadata = [
+        ExperimentAmbientLabelMapping._load_axes_metadata_from_anndatas(
+            adatas,
+            obs_field_name,
+            var_field_name,
+            partial(ExperimentAmbientLabelMapping._validate_anndata, append_obsm_varm),
+        )
+    ]
+
+    return ExperimentAmbientLabelMapping._register_common(
+        experiment_uri,
+        axes_metadata,
         measurement_name=measurement_name,
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
-        append_obsm_varm=append_obsm_varm,
         context=context,
     )
 
@@ -470,10 +539,14 @@ def from_anndata(
     #
     # * Here we select out the renumberings for the obs, var, X, etc. array indices
     if registration_mapping is None:
-        joinid_maps = ExperimentIDMapping.from_isolated_anndata(
+        joinid_maps = ExperimentIDMapping.from_anndata(
             anndata, measurement_name=measurement_name
         )
     else:
+        if not registration_mapping.prepared and Experiment.exists(experiment_uri):
+            raise SOMAError(
+                "Experiment must be prepared prior to ingestion. Please call ``registration_map.prepare_experiment`` method."
+            )
         joinid_maps = registration_mapping.id_mappings_for_anndata(
             anndata, measurement_name=measurement_name
         )
@@ -1114,11 +1187,15 @@ def _extract_new_values_for_append_aux(
     previous_sjids_table = previous_soma_dataframe.read(
         column_names=["soma_joinid"]
     ).concat()
-    previous_join_ids = set(
-        int(e)
-        for e in get_dataframe_values(previous_sjids_table.to_pandas(), SOMA_JOINID)
+    # use numpy.isin over pyarrow.compute.is_in, as it is MUCH faster
+    mask = pa.array(
+        np.isin(
+            arrow_table[SOMA_JOINID].to_numpy(),
+            previous_sjids_table[SOMA_JOINID].to_numpy(),
+            invert=True,
+        )
     )
-    mask = [e.as_py() not in previous_join_ids for e in arrow_table[SOMA_JOINID]]
+
     arrow_table = arrow_table.filter(mask)
 
     # Check if any new data.
@@ -2372,13 +2449,9 @@ def _write_matrix_to_sparseNDArray(
         soma_dim_1 = mat_coo.col + base if base > 0 and axis == 1 else mat_coo.col
 
         # Apply registration mappings: e.g. columns 0,1,2,3 in an AnnData file might
-        # have been assigned gene-ID labels 22,197,438,988. Don't do this for
-        # identity mappings, as this is a needless (and expensive) data copy.
-        if not axis_0_mapping.is_identity():
-            soma_dim_0 = [axis_0_mapping.data[e] for e in soma_dim_0]
-        if not axis_1_mapping.is_identity():
-            soma_dim_1 = [axis_1_mapping.data[e] for e in soma_dim_1]
-
+        # have been assigned gene-ID labels 22,197,438,988.
+        soma_dim_0 = axis_0_mapping.data[soma_dim_0]
+        soma_dim_1 = axis_1_mapping.data[soma_dim_1]
         pydict = {
             "soma_data": mat_coo.data,
             "soma_dim_0": soma_dim_0,
@@ -3022,3 +3095,24 @@ def _ingest_uns_ndarray(
 
     msg = f"Wrote   {soma_arr.uri} (uns ndarray)"
     logging.log_io(msg, msg)
+
+
+def _concurrency_level(context: SOMATileDBContext) -> int:
+    """
+    Private helper function to determine appropriate concurrency level for
+    ingestion of H5AD when use_multiprocessing is enabled.
+
+    Functionally, this just allows the user to control concurrency via the
+    context configuration ``soma.compute_concurrency_level``, with error checking.
+    """
+    concurrency_level: int = os.cpu_count() or 1
+    if context is not None:
+        concurrency_level = min(
+            concurrency_level,
+            int(
+                context.tiledb_config.get(
+                    "soma.compute_concurrency_level", concurrency_level
+                )
+            ),
+        )
+    return concurrency_level

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -471,8 +471,8 @@ def from_visium(
     # for spatial indexing.
     if registration_mapping is None:
         joinid_maps = ExperimentIDMapping(
-            obs_axis=AxisIDMapping(data=tuple(range(nobs))),
-            var_axes={measurement_name: AxisIDMapping(data=tuple(range(nvar)))},
+            obs_axis=AxisIDMapping.identity(nobs),
+            var_axes={measurement_name: AxisIDMapping.identity(nvar)},
         )
     else:
         raise NotImplementedError("Support for appending is not yet implemented.")

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1354,9 +1354,7 @@ def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids):
         var_field_name="var_id",
     )
 
-    nobs = rd.get_obs_shape()
-    nvars = rd.get_var_shapes()
-    tiledbsoma.io.resize_experiment(SOMA_URI, nobs=nobs, nvars=nvars)
+    rd.prepare_experiment(experiment_uri=SOMA_URI)
 
     # Append the second anndata object
     tiledbsoma.io.from_anndata(
@@ -1488,16 +1486,8 @@ def test_decat_append(tmp_path):
         var_field_name="var_id",
     )
 
-    tiledbsoma.io.resize_experiment(
-        path_under,
-        nobs=rd_under_over.get_obs_shape(),
-        nvars=rd_under_over.get_var_shapes(),
-    )
-    tiledbsoma.io.resize_experiment(
-        path_over,
-        nobs=rd_over_under.get_obs_shape(),
-        nvars=rd_over_under.get_var_shapes(),
-    )
+    rd_under_over.prepare_experiment(experiment_uri=path_under)
+    rd_over_under.prepare_experiment(experiment_uri=path_over)
 
     tiledbsoma.io.from_anndata(
         path_under, adata_over, "RNA", registration_mapping=rd_under_over

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -183,7 +183,7 @@ def test_df_io_roundtrips(
         uri,
         original_df,
         id_column_name=ingest_id_column_name,
-        axis_mapping=AxisIDMapping(data=tuple(range(len(original_df)))),
+        axis_mapping=AxisIDMapping.identity(len(original_df)),
         ingestion_params=IngestionParams("write", None),
     ).close()
 

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -47,3 +47,20 @@ Functions
     tiledbsoma.io.show_experiment_shapes
     tiledbsoma.io.upgrade_experiment_shapes
     tiledbsoma.io.resize_experiment
+
+
+Classes
+-------
+
+.. currentmodule:: tiledbsoma.io
+
+.. autoclass:: ExperimentAmbientLabelMapping
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: _generated
+
+      ~ExperimentAmbientLabelMapping.prepare_experiment
+      ~ExperimentAmbientLabelMapping.subset_for_anndata
+      ~ExperimentAmbientLabelMapping.subset_for_h5ad


### PR DESCRIPTION
Manual backport of #3865 since backport bot failed here https://github.com/single-cell-data/TileDB-SOMA/pull/3865#issuecomment-2787456227 which, in turn, happened because #3835 hadn't been backported yet and overlapped. Now that #3835 has been backported to #3931 and merged to `release-1.16`, this backport goes in cleanly following the instructions at https://github.com/single-cell-data/TileDB-SOMA/pull/3865#issuecomment-2787456227.