### PR TITLE
[c++] Follow-up to #3873 and #3928

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -308,12 +308,10 @@ class SOMAArray : public SOMAObject {
         return schema;
     }
 
-    std::unique_ptr<ArrowSchema> arrow_schema_for_column(
-        std::string column_name) const {
+    ArrowSchema* arrow_schema_for_column(std::string column_name) const {
         for (size_t i = 0; i < columns_.size(); ++i) {
             if (columns_[i]->name() == column_name) {
-                return std::unique_ptr<ArrowSchema>(
-                    columns_[i]->arrow_schema_slot(*ctx_, *arr_));
+                return columns_[i]->arrow_schema_slot(*ctx_, *arr_);
             }
         }
         throw TileDBSOMAError(


### PR DESCRIPTION
**Issue and/or context:** [[sc-65594]](https://app.shortcut.com/tiledb-inc/story/65594)

As of #3873 and #3928 the method `ArrowAdapter::arrow_schema_from_tiledb_attribute` the `ArrowSchema*` is now allocated using `malloc`:
https://github.com/single-cell-data/TileDB-SOMA/blob/d65892d3fb23e423cfe77b7193c9785291424fe0/libtiledbsoma/src/utils/arrow_adapter.cc#L497

This is used by `SOMAAttribute::arrow_schema_slot` here, and passed through:
https://github.com/single-cell-data/TileDB-SOMA/blob/d65892d3fb23e423cfe77b7193c9785291424fe0/libtiledbsoma/src/soma/soma_attribute.cc#L145-L149

That is converted into `std::unique_ptr` by `SOMAArray::arrow_schema_for_column` here:
https://github.com/single-cell-data/TileDB-SOMA/blob/d65892d3fb23e423cfe77b7193c9785291424fe0/libtiledbsoma/src/soma/soma_array.h#L315-L316

The `SOMAArray::arrow_schema_for_column` method is only used here:
https://github.com/single-cell-data/TileDB-SOMA/blob/d65892d3fb23e423cfe77b7193c9785291424fe0/libtiledbsoma/src/soma/soma_array.cc#L396-L407
and it is only needed for the duration of that check.

When that `std::unique_ptr` goes out of scope, `delete` is called as revealed by
```
valgrind --trace-children=yes --max-threads=20000 --leak-check=no \
  pytest -s -x -v \
    'apis/python/tests/test_registration_mappings.py::test_multiples_with_experiment[False-var_id-obs_id]'
```

as follows:

<details>

```
==3385== Mismatched free() / delete / delete []
==3385==    at 0x484A61D: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3385==    by 0x347BFB9F: std::default_delete<ArrowSchema>::operator()(ArrowSchema*) const (unique_ptr.h:99)
==3385==    by 0x347BA599: std::unique_ptr<ArrowSchema, std::default_delete<ArrowSchema> >::~unique_ptr() (unique_ptr.h:404)
==3385==    by 0x347A68D6: tiledbsoma::SOMAArray::get_enumeration_values_for_column(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (soma_array.cc:477)
==3385==    by 0x347A6154: tiledbsoma::SOMAArray::get_enumeration_values(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) (soma_array.cc:386)
==3385==    by 0x33F25315: libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}::operator()(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) const [clone .isra.0] (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x33F2988B: pybind11::cpp_function::initialize<libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}, pybind11::dict, tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, pybind11::name, pybind11::is_method, pybind11::sibling, pybind11::arg>(libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}&&, pybind11::dict (*)(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >), pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&, pybind11::arg const&)::{lambda(pybind11::detail::function_call&)#1}::_FUN(pybind11::detail::function_call&) (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x33BFA9CF: pybind11::cpp_function::dispatcher(_object*, _object*, _object*) (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x4A0F272: cfunction_call (methodobject.c:542)
==3385==    by 0x49BA340: _PyObject_MakeTpCall (call.c:214)
==3385==    by 0x495D47B: _PyEval_EvalFrameDefault (ceval.c:4769)
==3385==    by 0x4ABB667: _PyEval_EvalFrame (pycore_ceval.h:73)
==3385==    by 0x4ABB667: _PyEval_Vector (ceval.c:6434)
==3385==  Address 0x38548c30 is 0 bytes inside a block of size 72 alloc'd
==3385==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3385==    by 0x3487EB1F: tiledbsoma::ArrowAdapter::arrow_schema_from_tiledb_attribute(tiledb::Attribute const&, tiledb::Context const&, tiledb::Array const&) (arrow_adapter.cc:497)
==3385==    by 0x347F274C: tiledbsoma::SOMAAttribute::arrow_schema_slot(tiledbsoma::SOMAContext const&, tiledb::Array&) const (soma_attribute.cc:147)
==3385==    by 0x347B8A96: tiledbsoma::SOMAArray::arrow_schema_for_column(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) const (soma_array.h:316)
==3385==    by 0x347A632B: tiledbsoma::SOMAArray::get_enumeration_values_for_column(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (soma_array.cc:398)
==3385==    by 0x347A6154: tiledbsoma::SOMAArray::get_enumeration_values(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) (soma_array.cc:386)
==3385==    by 0x33F25315: libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}::operator()(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) const [clone .isra.0] (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x33F2988B: pybind11::cpp_function::initialize<libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}, pybind11::dict, tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, pybind11::name, pybind11::is_method, pybind11::sibling, pybind11::arg>(libtiledbsomacpp::load_soma_dataframe(pybind11::module_&)::{lambda(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)#1}&&, pybind11::dict (*)(tiledbsoma::SOMADataFrame&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >), pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&, pybind11::arg const&)::{lambda(pybind11::detail::function_call&)#1}::_FUN(pybind11::detail::function_call&) (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x33BFA9CF: pybind11::cpp_function::dispatcher(_object*, _object*, _object*) (in /home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/pytiledbsoma.cpython-311-x86_64-linux-gnu.so)
==3385==    by 0x4A0F272: cfunction_call (methodobject.c:542)
==3385==    by 0x49BA340: _PyObject_MakeTpCall (call.c:214)
==3385==    by 0x495D47B: _PyEval_EvalFrameDefault (ceval.c:4769)

```

</details>

**Changes:**

Use `column_schema->release(column_schema)`, then `free` the struct.

**Notes for Reviewer:**

We need more and thorough careful audits as tracked on #3860 before we continue to change memory-allocation techniques (once we get valgrind-clean, of course).