### PR TITLE
[python] Improve UX for `extend_enumeration_values` with non-Arrow types

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -416,7 +416,12 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         # These assertions could be done in C++. However, it's easier here
         # to do the exception-type multiplexing, raising ValueError for one
         # thing, TileDBSOMAError for another.
-        for column_name in values.keys():
+        for column_name, values_for_column in values.items():
+            if not isinstance(values_for_column, pa.Array):
+                raise ValueError(
+                    f"value for column name '{column_name}' must be pyarrow.Array: got '{type(values_for_column)}'"
+                )
+
             # As with get_enumeration_values: we are trusting pyarrow to raise
             # KeyError, and raise it with a sufficiently clear error message,
             # when the column name is not present within the schema.
@@ -425,7 +430,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 raise KeyError(
                     f"schema column name '{column_name}' is not of dictionary type"
                 )
-            if pa.types.is_dictionary(values[column_name].type):
+            if pa.types.is_dictionary(values_for_column.type):
                 raise ValueError(
                     f"value column name '{column_name}' is of dictionary type: pass its dictionary array instead"
                 )

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -14,6 +14,7 @@ import pytest
 import somacore
 from numpy.testing import assert_array_equal
 from pandas.api.types import union_categoricals
+from typeguard import suppress_type_checks
 
 import tiledbsoma as soma
 
@@ -576,6 +577,13 @@ def test_extend_enumeration_values(tmp_path, extend_not_write, ordered):
             match=r"is of dictionary type: pass its dictionary array instead",
         ):
             sdf.extend_enumeration_values(xvalues)
+
+        # The values provided must be Arrow arrays. Our unit tests run with typeguard,
+        # but our end users nominally do not -- so we have to ask typeguard to take
+        # a breather here so we can test the UX our users will have.
+        with suppress_type_checks():
+            with pytest.raises(ValueError):
+                sdf.extend_enumeration_values({"string_enum1": ["plain", "strings"]})
 
         # The values provided must all be non-null
         for nvalues in [


### PR DESCRIPTION
**Issue and/or context:** Improve error-handling UX for #3785 / [[sc-63930]](https://app.shortcut.com/tiledb-inc/story/63930/dataframe-need-api-to-extend-column-enum-values-without-doing-a-write#activity-64471). 


**Changes:**

Before:

```
with tiledbsoma.Experiment.open(uri, "w") as exp:
    exp.obs.extend_enumeration_values({'louvain':["three-eyed-alien cells"]})
```

fails with

```
AttributeError: 'list' object has no attribute 'type' 
```

This is confusing and doesn't clearly tell the user what they did wrong, nor how to fix it.

After:

```
ValueError: value column name 'louvain' must be pyarrow.Array: got '<class 'list'>'
```

**Notes for Reviewer:**

