### PR TITLE
[python] Remove some unreached code

### DIFF
--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -3,7 +3,6 @@ from concurrent import futures
 from contextlib import nullcontext
 from unittest import mock
 
-import attrs
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -954,11 +953,3 @@ def test_empty_categorical_query(conftest_pbmc_small_exp):
     with ctx:
         obs = q.obs().concat()
         assert len(obs) == 0
-
-
-@attrs.define(frozen=True)
-class IHaveObsVarStuff:
-    obs: int
-    var: int
-    the_obs_suf: str
-    the_var_suf: str


### PR DESCRIPTION
**Issue and/or context:** Found on a drive-by.

#3307 introduced, and used, `IHaveObsVarStuff`, along with a `test_axis_helpers`. The latter is no more (#3557) but the former is still there, and appears to not be used anywhere else.

**Changes:**

**Notes for Reviewer:**

