### PR TITLE
[python] Remove `numcodecs<0.16` pin

### DIFF
--- a/apis/python/requirements_spatial.txt
+++ b/apis/python/requirements_spatial.txt
@@ -2,7 +2,5 @@ geopandas
 tifffile
 pillow
 spatialdata>=0.2.5
-# spatialdata 0.3.0 pins `zarr<3`, which is incompatible with numcodecs 0.16.0. See also: https://github.com/single-cell-data/TileDB-SOMA/issues/3917
-numcodecs<0.16
 xarray
 dask<=2024.11.2

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -5,7 +5,6 @@ docutils==0.20.1
 ipython==8.24.0
 jinja2==3.1.6
 nbsphinx==0.9.3
-numcodecs<0.16  # https://github.com/single-cell-data/TileDB-SOMA/issues/3917
 pandoc==2.3
 pybind11==2.12.0
 setuptools==75.1.0


### PR DESCRIPTION
`zarr==2.18.7` removes the need for it.

**Issue and/or context:**
- https://github.com/zarr-developers/zarr-python/issues/2963
- #3917
- #3922 
