### PR TITLE
[python] Add `python-uv.dockerfile`

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -42,6 +42,12 @@ jobs:
             args: gcc=13 v=1.16.0
           - name: Langchain
             file: langchain
+          - name: Python 3.12 + uv
+            file: python-uv
+            args: python=3.12
+          - name: Python 3.13 + uv
+            file: python-uv
+            args: python=3.13
     name: ${{ matrix.img.name }}${{ matrix.os.suffix }}
     runs-on: ${{ matrix.os.runs-on }}
     steps:

--- a/docker/python-uv.dockerfile
+++ b/docker/python-uv.dockerfile
@@ -1,0 +1,31 @@
+ARG python=3.13
+FROM python:$python
+
+# Required by vcpkg source build on ARM
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+# Required by vcpkg source build
+RUN apt update -y && apt install -y curl ninja-build tar unzip zip
+
+# `tiledbsoma>=1.16` requires GCC ≥13
+RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list && \
+    echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
+    echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease && \
+    apt update -y && \
+    apt install -y -t unstable gcc-13 g++-13 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 && \
+    update-alternatives --set gcc /usr/bin/gcc-13 && \
+    update-alternatives --set g++ /usr/bin/g++-13
+
+RUN pip install --upgrade pip \
+  && pip install uv \
+  && uv init example
+
+WORKDIR example
+# Required on ARM, until ARM Linux wheels are published:
+# - https://github.com/single-cell-data/TileDB-SOMA/issues/3890
+# - https://github.com/single-cell-data/TileDB-SOMA/issues/3909
+RUN echo "cmake<4" > constraints.txt
+RUN uv pip install --system --build-constraints constraints.txt tiledbsoma
+
+ENTRYPOINT [ "python", "-c", "import tiledbsoma; tiledbsoma.show_package_versions()" ]


### PR DESCRIPTION
**Issue and/or context:**
- #3944
- #3890
- #3909

**Changes:**
- Add `python-uv.dockerfile`, verifying using `uv` to `pip install tiledbsoma` in `python:<version>` Docker images (Debian 12 / bookworm-based, but need GCC 13 installed for TileDB-SOMA ≥1.16).
- Add `python:3.{12,13}` x {x86,ARM} builds to `python-dockers.yml` [GHA](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-dockers.yml)
