### PR TITLE
[python] Implement `tiledbsoma.io.get_experiment_shapes`

### DIFF
--- a/apis/python/remote_tests/test_03_versions.py
+++ b/apis/python/remote_tests/test_03_versions.py
@@ -190,3 +190,93 @@ def test_resize_experiment_ok(conftest_context, uri_and_info):
         assert "dataframe currently has no domain set" in body
     else:
         assert ok
+
+
+@pytest.mark.parametrize(
+    "uri_and_info",
+    util_pbmc3k_unprocessed_versions(),
+)
+def test_get_experiment_shapes(conftest_context, uri_and_info):
+    uri, info = uri_and_info
+
+    dict_output = tiledbsoma.io.get_experiment_shapes(uri, context=conftest_context)
+
+    # Mask out the URIs for which we needn't compare the exact UUID values.
+    dict_output["obs"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["var"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["X"]["data"]["uri"] = "test"
+
+    if info["shape"] == "old":
+
+        expect = {
+            "obs": {
+                "uri": "test",
+                "type": "DataFrame",
+                "count": 2700,
+                "non_empty_domain": ((0, 2699),),
+                "domain": ((0, 2147483646),),
+                "maxdomain": ((0, 2147483646),),
+                "upgraded": False,
+            },
+            "ms": {
+                "RNA": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 13714,
+                        "non_empty_domain": ((0, 13713),),
+                        "domain": ((0, 2147483646),),
+                        "maxdomain": ((0, 2147483646),),
+                        "upgraded": False,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2699), (0, 13713)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        }
+                    },
+                }
+            },
+        }
+        assert dict_output == expect
+
+    else:
+        expect = {
+            "obs": {
+                "uri": "test",
+                "type": "DataFrame",
+                "count": 2700,
+                "non_empty_domain": ((0, 2699),),
+                "domain": ((0, 2699),),
+                "maxdomain": ((0, 9223372036854773758),),
+                "upgraded": True,
+            },
+            "ms": {
+                "RNA": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 13714,
+                        "non_empty_domain": ((0, 13713),),
+                        "domain": ((0, 13713),),
+                        "maxdomain": ((0, 9223372036854773758),),
+                        "upgraded": True,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2699), (0, 13713)),
+                            "shape": (2700, 13714),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        }
+                    },
+                }
+            },
+        }
+        assert dict_output == expect

--- a/apis/python/src/tiledbsoma/io/__init__.py
+++ b/apis/python/src/tiledbsoma/io/__init__.py
@@ -29,6 +29,7 @@ from .outgest import (
     to_h5ad,
 )
 from .shaping import (
+    get_experiment_shapes,
     resize_experiment,
     show_experiment_shapes,
     upgrade_experiment_shapes,
@@ -60,6 +61,7 @@ __all__ = (
     "update_obs",
     "update_var",
     "upgrade_experiment_shapes",
+    "get_experiment_shapes",
     "show_experiment_shapes",
     "resize_experiment",
     "ExperimentAmbientLabelMapping",

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -678,6 +678,153 @@ def test_canned_experiments(tmp_path, has_shapes):
         _check_ndarray(exp.ms["RNA"].obsp["connectivities"], True, (2639, 2639))
         _check_ndarray(exp.ms["RNA"].varm["PCs"], True, (1839, 50))
 
+    # Test get_experiment_shapes.
+    # The output includes URIs which vary randomly from one test run to another;
+    # mask out the URIs.
+    dict_output = tiledbsoma.io.get_experiment_shapes(uri)
+
+    assert "obs" in dict_output
+    assert "ms" in dict_output
+    assert "RNA" in dict_output["ms"]
+
+    dict_output["obs"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["var"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["X"]["data"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_draw_graph_fr"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_pca"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_tsne"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_umap"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsp"]["connectivities"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsp"]["distances"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["varm"]["PCs"]["uri"] = "test"
+    dict_output["ms"]["raw"]["var"]["uri"] = "test"
+    dict_output["ms"]["raw"]["X"]["data"]["uri"] = "test"
+
+    if has_shapes:
+        var_max_domain_hi = 9223372036854773968
+    else:
+        var_max_domain_hi = 9223372036854773758
+
+    expect = {
+        "obs": {
+            "uri": "test",
+            "type": "DataFrame",
+            "count": 2638,
+            "non_empty_domain": ((0, 2637),),
+            "domain": ((0, 2638),),
+            "maxdomain": ((0, 9223372036854773758),),
+            "upgraded": True,
+        },
+        "ms": {
+            "RNA": {
+                "var": {
+                    "uri": "test",
+                    "type": "DataFrame",
+                    "count": 1838,
+                    "non_empty_domain": ((0, 1837),),
+                    "domain": ((0, 1838),),
+                    "maxdomain": ((0, var_max_domain_hi),),
+                    "upgraded": True,
+                },
+                "X": {
+                    "data": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 1837)),
+                        "shape": (2639, 1839),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    }
+                },
+                "obsm": {
+                    "X_draw_graph_fr": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 1)),
+                        "shape": (2639, 2),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                    "X_pca": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 49)),
+                        "shape": (2639, 50),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                    "X_tsne": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 1)),
+                        "shape": (2639, 2),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                    "X_umap": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 1)),
+                        "shape": (2639, 2),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                },
+                "obsp": {
+                    "connectivities": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 2637)),
+                        "shape": (2639, 2639),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                    "distances": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (1, 2637)),
+                        "shape": (2639, 2639),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    },
+                },
+                "varm": {
+                    "PCs": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 1837), (0, 49)),
+                        "shape": (1839, 50),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    }
+                },
+            },
+            "raw": {
+                "var": {
+                    "uri": "test",
+                    "type": "DataFrame",
+                    "count": 13714,
+                    "non_empty_domain": ((0, 13713),),
+                    "domain": ((0, 13719),),
+                    "maxdomain": ((0, 9223372036854773758),),
+                    "upgraded": True,
+                },
+                "X": {
+                    "data": {
+                        "uri": "test",
+                        "type": "SparseNDArray",
+                        "non_empty_domain": ((0, 2637), (0, 13713)),
+                        "shape": (2639, 13720),
+                        "maxshape": (9223372036854773759, 9223372036854773759),
+                        "upgraded": True,
+                    }
+                },
+            },
+        },
+    }
+
+    assert dict_output == expect
+
 
 def test_canned_nonstandard_dataframe_upgrade(tmp_path):
     uri = tmp_path.as_posix()

--- a/apis/python/tests/test_soma_experiment_versions.py
+++ b/apis/python/tests/test_soma_experiment_versions.py
@@ -54,3 +54,284 @@ def test_to_anndata(version, name_and_expected_shape):
                 assert adata.obsp[key].shape == (expected_nobs, expected_nobs)
 
             assert adata.varm["PCs"].shape == (expected_nvar, 50)
+
+
+@pytest.mark.parametrize(
+    "version_and_upgraded",
+    [
+        ["1.7.3", False],
+        ["1.12.3", False],
+        ["1.14.5", False],
+        ["1.15.0", True],
+        ["1.15.7", True],
+    ],
+)
+def test_get_experiment_shapes(version_and_upgraded):
+    """Checks that experiments written by older versions are still readable,
+    in the particular form of doing an outgest."""
+
+    version, upgraded = version_and_upgraded
+    name = "pbmc3k_processed"
+    path = ROOT_DATA_DIR / "soma-experiment-versions-2025-04-04" / version / name
+    uri = str(path)
+    if not os.path.isdir(uri):
+        raise RuntimeError(
+            f"Missing '{uri}' directory. Try running `make data` "
+            "from the TileDB-SOMA project root directory."
+        )
+
+    # The output includes URIs which vary randomly from one test run to another;
+    # mask out the URIs.
+    dict_output = tiledbsoma.io.get_experiment_shapes(uri)
+
+    dict_output["obs"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["var"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["X"]["data"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_draw_graph_fr"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_pca"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_tsne"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsm"]["X_umap"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsp"]["connectivities"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["obsp"]["distances"]["uri"] = "test"
+    dict_output["ms"]["RNA"]["varm"]["PCs"]["uri"] = "test"
+    dict_output["ms"]["raw"]["var"]["uri"] = "test"
+    dict_output["ms"]["raw"]["X"]["data"]["uri"] = "test"
+
+    if not upgraded:
+        expect = {
+            "obs": {
+                "uri": "test",
+                "type": "DataFrame",
+                "count": 2638,
+                "non_empty_domain": ((0, 2637),),
+                "domain": ((0, 2147483646),),
+                "maxdomain": ((0, 2147483646),),
+                "upgraded": False,
+            },
+            "ms": {
+                "RNA": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 1838,
+                        "non_empty_domain": ((0, 1837),),
+                        "domain": ((0, 2147483646),),
+                        "maxdomain": ((0, 2147483646),),
+                        "upgraded": False,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1837)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        }
+                    },
+                    "obsm": {
+                        "X_draw_graph_fr": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                        "X_pca": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 49)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                        "X_tsne": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                        "X_umap": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                    },
+                    "obsp": {
+                        "connectivities": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 2637)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                        "distances": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (1, 2637)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        },
+                    },
+                    "varm": {
+                        "PCs": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 1837), (0, 49)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        }
+                    },
+                },
+                "raw": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 13714,
+                        "non_empty_domain": ((0, 13713),),
+                        "domain": ((0, 2147483646),),
+                        "maxdomain": ((0, 2147483646),),
+                        "upgraded": False,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 13713)),
+                            "shape": (2147483646, 2147483646),
+                            "maxshape": (2147483646, 2147483646),
+                            "upgraded": False,
+                        }
+                    },
+                },
+            },
+        }
+    else:
+        expect = {
+            "obs": {
+                "uri": "test",
+                "type": "DataFrame",
+                "count": 2638,
+                "non_empty_domain": ((0, 2637),),
+                "domain": ((0, 2637),),
+                "maxdomain": ((0, 9223372036854773758),),
+                "upgraded": True,
+            },
+            "ms": {
+                "RNA": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 1838,
+                        "non_empty_domain": ((0, 1837),),
+                        "domain": ((0, 1837),),
+                        "maxdomain": ((0, 9223372036854773968),),
+                        "upgraded": True,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1837)),
+                            "shape": (2638, 1838),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        }
+                    },
+                    "obsm": {
+                        "X_draw_graph_fr": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2638, 2),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                        "X_pca": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 49)),
+                            "shape": (2638, 50),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                        "X_tsne": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2638, 2),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                        "X_umap": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 1)),
+                            "shape": (2638, 2),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                    },
+                    "obsp": {
+                        "connectivities": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 2637)),
+                            "shape": (2638, 2638),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                        "distances": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (1, 2637)),
+                            "shape": (2638, 2638),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        },
+                    },
+                    "varm": {
+                        "PCs": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 1837), (0, 49)),
+                            "shape": (1838, 50),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        }
+                    },
+                },
+                "raw": {
+                    "var": {
+                        "uri": "test",
+                        "type": "DataFrame",
+                        "count": 13714,
+                        "non_empty_domain": ((0, 13713),),
+                        "domain": ((0, 13713),),
+                        "maxdomain": ((0, 9223372036854773758),),
+                        "upgraded": True,
+                    },
+                    "X": {
+                        "data": {
+                            "uri": "test",
+                            "type": "SparseNDArray",
+                            "non_empty_domain": ((0, 2637), (0, 13713)),
+                            "shape": (2638, 13714),
+                            "maxshape": (9223372036854773759, 9223372036854773759),
+                            "upgraded": True,
+                        }
+                    },
+                },
+            },
+        }
+
+    assert dict_output == expect

--- a/doc/source/python-tiledbsoma-io.rst
+++ b/doc/source/python-tiledbsoma-io.rst
@@ -44,6 +44,7 @@ Functions
     tiledbsoma.io.append_X
     tiledbsoma.io.append_obs
     tiledbsoma.io.append_var
+    tiledbsoma.io.get_experiment_shapes
     tiledbsoma.io.show_experiment_shapes
     tiledbsoma.io.upgrade_experiment_shapes
     tiledbsoma.io.resize_experiment


### PR DESCRIPTION
**Issue and/or context:** Analog of `tiledbsoma.io.show_experiment_shapes` for programmatic use as requested on [[sc-64098]](https://app.shortcut.com/tiledb-inc/story/64098/get-output-of-tiledbsoma-io-show-experiment-shapes).

**Changes:**

**Notes for Reviewer:**

Example outputs can be found in the unit-test files.

Stacked atop #3962.
