### PR TITLE
[python] Remove `pre-commit/mirrors-prettier` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,3 @@ repos:
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.5.3
-    hooks:
-      - id: prettier
-        files: "encoding_specification.md"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.3
     hooks:
       - id: prettier
         files: "encoding_specification.md"


### PR DESCRIPTION
**Issue and/or context:**
- [#3724] added [pre-commit/mirrors-prettier](http://github.com/pre-commit/mirrors-prettier) hook
- [#3842] bumped it from `v3.0.3` to `v4.0.0-alpha.8`
- [pre-commit/mirrors-prettier] was archived in April '24.
- `v4.0.0-alpha.8` fails for me, locally:

```
prettier.................................................................Failed
- hook id: prettier
- duration: 0.36s
- exit code: 1

node:internal/event_target:1101
  process.nextTick(() => { throw err; });
                           ^

TypeError [ERR_INVALID_ARG_TYPE]: The "event" argument must be an instance of Event. Received an instance of SyntaxError
    at WorkerShim.dispatchEvent (node:internal/event_target:757:13)
    at Worker.<anonymous> (file:///Users/ryan/.cache/pre-commit/repo97q9xrl6/node_env-default/lib/node_modules/prettier/node_modules/webworker-shim/dist/node.js:38:18)
    at Worker.emit (node:events:507:28)
    at [kOnErrorMessage] (node:internal/worker:327:10)
    at [kOnMessage] (node:internal/worker:338:37)
    at MessagePort.<anonymous> (node:internal/worker:233:57)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)
    at [kOnExit] (node:internal/worker:304:5)
    at Worker.<computed>.onexit (node:internal/worker:230:20) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v23.11.0
```

It may have to do with the Node.js version, but I've not found a way to control which version `pre-commit` installs/uses.

**Changes:**
- ~Use [rbubley/mirrors-prettier], which seems to be [the most maintained/starred fork][forks].~
- ~Bump to latest (non-alpha) version, `v3.5.3` (works for me locally).~

Per offline discussion, we're just going to remove this hook.

[#3724]: https://github.com/single-cell-data/TileDB-SOMA/pull/3724
[#3842]: https://github.com/single-cell-data/TileDB-SOMA/pull/3842

[pre-commit/mirrors-prettier]: http://github.com/pre-commit/mirrors-prettier
[rbubley/mirrors-prettier]: https://github.com/rbubley/mirrors-prettier
[forks]: https://github.com/pre-commit/mirrors-prettier/forks