### PR TITLE
[python] Update setuptools

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "pybind11[global]>=2.10.0",
-    "setuptools>=70.1",  # `setuptools.command.bdist_wheel`
+    "setuptools>=78.1",  # `setuptools.command.bdist_wheel`
     "cmake>=3.21,<4",  # CMake 4 builds are broken on ARM Linux: https://github.com/single-cell-data/TileDB-SOMA/issues/3890
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
**Issue and/or context:**

I noticed in build logs that we are getting a warning that `License classifiers are deprecated` (see #3944 for example).

**Changes:**

After some search, I saw that updating `setuptools` will likely fix the warnings (see bokeh/bokeh#14434).

**Notes for Reviewer:**