### PR TITLE
[python] `SOMAObject.open`: rm unused `clib_type` kwarg

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -76,7 +76,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             tiledb_timestamp:
                 The TileDB timestamp to open this object at,
                 either an int representing milliseconds since the Unix epoch
-                or a datetime.dateime object.
+                or a datetime.datetime object.
                 When not provided (the default), the current time is used.
 
         Returns:
@@ -163,7 +163,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             tiledb_timestamp:
                 The TileDB timestamp to open this object at,
                 either an int representing milliseconds since the Unix epoch
-                or a datetime.dateime object.
+                or a datetime.datetime object.
                 When not provided (the default), the current time is used.
 
         Raises:

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -63,7 +63,6 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         tiledb_timestamp: OpenTimestamp | None = None,
         context: SOMATileDBContext | None = None,
         platform_config: options.PlatformConfig | None = None,
-        clib_type: str | None = None,
     ) -> Self:
         """Opens this specific type of SOMA object.
 

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -277,7 +277,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
             )
         if self.mode != "r":
             raise SOMAError(
-                f"{self.__class__.__name__} ({self.uri}) must be open for writing"
+                f"{self.__class__.__name__} ({self.uri}) must be open for reading"
             )
 
     @property


### PR DESCRIPTION
**Issue and/or context:**
[#3402] [changed](https://github.com/single-cell-data/TileDB-SOMA/pull/3402/files#diff-37c77dc8fe14164529674bc6d4155c68329b4283443501554195bde86b027488L100-R104) `SOMAObject.open` to not use the `clib_type` kwarg. AFAICT:
- Calling `SOMAObject.open` with the default `clib_type=None` will error (`cls._wrapper_type` will raise `AttributeError: type object 'SOMAObject' has no attribute '_wrapper_type'`).
- We never do that; [_tdb_handles.py:89](https://github.com/single-cell-data/TileDB-SOMA/blob/8b8183bfc87bd3b09ebe7c022bb359004400bb9f/apis/python/src/tiledbsoma/_tdb_handles.py#L89) is the only direct reference I see to `SOMAObject.open`; I guess we never call that without explicit `clib_type` either?
  - Maybe `clib_type` type-annotation should be modified to indicate it's required?

[#3402]: https://github.com/single-cell-data/TileDB-SOMA/pull/3402

**Changes:**
This PR currently removes the unused `clib_type` kwarg.

~However, I guess it's part of a public API; should we instead document it as deprecated (and verify that, if present, it matches the inferred `clib_type=cls._wrapper_type._WRAPPED_TYPE.__name__`)?~

Edit: `_soma_object.SOMAObject.open` is not a public API; maybe removing the kwarg is fine.

I also added a couple unrelated comment/message typo fixes.