### PR TITLE
[python] Remove `typing.{Dict,List,Optional,Set,Tuple,Type,Union}` references

### DIFF
--- a/apis/python/remote_tests/util.py
+++ b/apis/python/remote_tests/util.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import pathlib
 import shutil
-from typing import Tuple
 
 import tiledb.cloud
 
@@ -20,7 +19,7 @@ def util_make_uri(
     basename: str,
     namespace: str,
     default_s3_path: str,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     if os.getenv("TILEDB_SOMA_CLOUD_TEST_LOCAL_PATHS") is None:
 
         # The default_s3_path contains the "s3://..." prefix and a trailing slash.

--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -25,13 +25,13 @@ ASCII-only dimensions will be relaxed in a future release. Unicode/UTF-8 is
 fully supported in SOMA DataFrame non-indexed columns.
 """
 
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 
-_ARROW_TO_TDB_ATTR: Dict[Any, Union[str, TypeError]] = {
+_ARROW_TO_TDB_ATTR: dict[Any, Union[str, TypeError]] = {
     pa.string(): "U1",
     pa.large_string(): "U1",
     pa.binary(): "bytes",
@@ -54,7 +54,7 @@ If the value is an instance of Exception, it will be raised.
 IMPORTANT: ALL non-primitive types supported by TileDB must be in this table.
 """
 
-_PYARROW_TO_CARROW: Dict[pa.DataType, str] = {
+_PYARROW_TO_CARROW: dict[pa.DataType, str] = {
     pa.bool_(): "b",
     pa.int8(): "c",
     pa.int16(): "s",
@@ -72,7 +72,7 @@ _PYARROW_TO_CARROW: Dict[pa.DataType, str] = {
     pa.timestamp("ns"): "tsn:",
 }
 
-_CARROW_TO_PYARROW: Dict[pa.DataType, str] = {
+_CARROW_TO_PYARROW: dict[pa.DataType, str] = {
     "c": pa.int8(),
     "s": pa.int16(),
     "i": pa.int32(),
@@ -91,7 +91,7 @@ _CARROW_TO_PYARROW: Dict[pa.DataType, str] = {
 
 # Same as _ARROW_TO_TDB_ATTR, but used for DataFrame indexed columns, aka TileDB Dimensions.
 # Any type system differences from the base-case Attr should be added here.
-_ARROW_TO_TDB_DIM: Dict[Any, Union[str, TypeError]] = _ARROW_TO_TDB_ATTR.copy()
+_ARROW_TO_TDB_DIM: dict[Any, Union[str, TypeError]] = _ARROW_TO_TDB_ATTR.copy()
 """Same as _ARROW_TO_TDB_ATTR, but used for DataFrame indexed columns, aka TileDB Dimensions.
 Any type system differences from the base-case Attr should be added here.
 """

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     Type,
     TypeVar,
     cast,
@@ -120,7 +119,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
 
     # Subclass protocol to constrain which SOMA objects types  may be set on a
     # particular collection key. Used by Experiment and Measurement.
-    _subclass_constrained_soma_types: ClassVar[Dict[str, tuple[str, ...]]] = {}
+    _subclass_constrained_soma_types: ClassVar[dict[str, tuple[str, ...]]] = {}
     """A map limiting what types may be set to certain keys.
 
     Map keys are the key of the collection to constrain; values are the SOMA
@@ -387,7 +386,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             key, kind=kind, factory=factory, user_uri=user_uri
         )
 
-    def members(self) -> Dict[str, tuple[str, str]]:
+    def members(self) -> dict[str, tuple[str, str]]:
         """Get a mapping of {member_name: (uri, soma_object_type)}"""
         handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
         return handle.members()

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -11,7 +11,6 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    Tuple,
     Type,
     TypeVar,
     cast,
@@ -121,7 +120,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
 
     # Subclass protocol to constrain which SOMA objects types  may be set on a
     # particular collection key. Used by Experiment and Measurement.
-    _subclass_constrained_soma_types: ClassVar[Dict[str, Tuple[str, ...]]] = {}
+    _subclass_constrained_soma_types: ClassVar[Dict[str, tuple[str, ...]]] = {}
     """A map limiting what types may be set to certain keys.
 
     Map keys are the key of the collection to constrain; values are the SOMA
@@ -388,7 +387,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             key, kind=kind, factory=factory, user_uri=user_uri
         )
 
-    def members(self) -> Dict[str, Tuple[str, str]]:
+    def members(self) -> Dict[str, tuple[str, str]]:
         """Get a mapping of {member_name: (uri, soma_object_type)}"""
         handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
         return handle.members()

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Type,
     TypeVar,
     cast,
     overload,
@@ -151,7 +150,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     def add_new_collection(
         self,
         key: str,
-        kind: Type[_Coll],
+        kind: type[_Coll],
         *,
         uri: str | None = ...,
         platform_config: options.PlatformConfig | None = ...,
@@ -161,7 +160,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     def add_new_collection(
         self,
         key: str,
-        kind: Type[CollectionBase] | None = None,  # type: ignore[type-arg]
+        kind: type[CollectionBase] | None = None,  # type: ignore[type-arg]
         *,
         uri: str | None = None,
         platform_config: options.PlatformConfig | None = None,
@@ -272,7 +271,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
 
     @_funcs.forwards_kwargs_to(NDArray.create, exclude=("context", "tiledb_timestamp"))
     def _add_new_ndarray(
-        self, cls: Type[_NDArr], key: str, *, uri: str | None = None, **kwargs: Any
+        self, cls: type[_NDArr], key: str, *, uri: str | None = None, **kwargs: Any
     ) -> _NDArr:
         """Internal implementation of common NDArray-adding operations."""
         return self._add_new_element(
@@ -362,7 +361,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
     def _add_new_element(
         self,
         key: str,
-        kind: Type[_TDBO],
+        kind: type[_TDBO],
         factory: Callable[[str], _TDBO],
         user_uri: str | None,
     ) -> _TDBO:
@@ -504,7 +503,7 @@ class Collection(  # type: ignore[misc]  # __eq__ false positive
 
 
 @typeguard_ignore
-def _real_class(cls: Type[Any]) -> type:
+def _real_class(cls: type[Any]) -> type:
     """Extracts the real class from a generic alias.
 
     Generic aliases like ``Collection[whatever]`` cannot be used in instance or

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple, cast
+from typing import Sequence, cast
 
 import pyarrow as pa
 import somacore
@@ -119,7 +119,7 @@ class NDArray(SOMAArray, somacore.NDArray):
             return (True, "")
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Returns capacity of each dimension, always a list of length ``ndim``.
         This will not necessarily match the bounds of occupied cells within the array.
         Rather, it is the bounds outside of which no data may be read or written.
@@ -127,10 +127,10 @@ class NDArray(SOMAArray, somacore.NDArray):
         Lifecycle:
             Maturing.
         """
-        return cast(Tuple[int, ...], tuple(self._handle.shape))
+        return cast(tuple[int, ...], tuple(self._handle.shape))
 
     @property
-    def maxshape(self) -> Tuple[int, ...]:
+    def maxshape(self) -> tuple[int, ...]:
         """Returns the maximum resizable capacity of each dimension, always a list of length
         ``ndim``.  This will not necessarily match the bounds of occupied cells within the array.
         It is the upper limit for ``resize`` on the array.
@@ -138,7 +138,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         Lifecycle:
             Maturing.
         """
-        return cast(Tuple[int, ...], tuple(self._handle.maxshape))
+        return cast(tuple[int, ...], tuple(self._handle.maxshape))
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
@@ -158,5 +158,5 @@ class NDArray(SOMAArray, somacore.NDArray):
         dim_shape: int | None,
         ndim: int,
         create_options: TileDBCreateOptions,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         raise NotImplementedError("must be implemented by child class.")

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple, Union, cast
+from typing import Sequence, Tuple, cast
 
 import pyarrow as pa
 import somacore
@@ -32,7 +32,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         uri: str,
         *,
         type: pa.DataType,
-        shape: Sequence[Union[int, None]],
+        shape: Sequence[int | None],
         platform_config: options.PlatformConfig | None = None,
         context: SOMATileDBContext | None = None,
         tiledb_timestamp: OpenTimestamp | None = None,
@@ -86,7 +86,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         raise NotImplementedError("must be implemented by child class.")
 
     def resize(
-        self, newshape: Sequence[Union[int, None]], check_only: bool = False
+        self, newshape: Sequence[int | None], check_only: bool = False
     ) -> StatusAndReason:
         """Increases the shape of the array as specfied. Raises an error if the new
         shape is less than the current shape in any dimension. Raises an error if
@@ -106,7 +106,7 @@ class NDArray(SOMAArray, somacore.NDArray):
             return (True, "")
 
     def tiledbsoma_upgrade_shape(
-        self, newshape: Sequence[Union[int, None]], check_only: bool = False
+        self, newshape: Sequence[int | None], check_only: bool = False
     ) -> StatusAndReason:
         """Allows the array to have a resizeable shape as described in the TileDB-SOMA
         1.15 release notes.  Raises an error if the new shape exceeds maxshape in

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -950,7 +950,7 @@ def _fill_out_slot_soma_domain(
     index_column_name: str,
     pa_type: pa.DataType,
     dtype: Any,
-) -> tuple[tuple[Any, Any], Union[bool, tuple[bool, ...]]]:
+) -> tuple[tuple[Any, Any], bool | tuple[bool, ...]]:
     """Helper function for _build_tiledb_schema. Given a user-specified domain for a
     dimension slot -- which may be ``None``, or a two-tuple of which either element
     may be ``None`` -- return either what the user specified (if adequate) or
@@ -1165,7 +1165,7 @@ def _find_extent_for_domain(
 # extent exceeds max value representable by domain type. Reduce domain max
 # by 1 tile extent to allow for expansion.
 def _revise_domain_for_extent(
-    domain: tuple[Any, Any], extent: Any, saturated_range: Union[bool, tuple[bool, ...]]
+    domain: tuple[Any, Any], extent: Any, saturated_range: bool | tuple[bool, ...]
 ) -> tuple[Any, Any]:
     if isinstance(domain[0], (np.datetime64, pa.TimestampScalar)):
         domain = cast(

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -12,7 +12,6 @@ import inspect
 from typing import (
     Any,
     Dict,
-    List,
     Literal,
     Sequence,
     Union,
@@ -48,7 +47,7 @@ from .options._tiledb_create_write_options import (
 )
 
 _UNBATCHED = options.BatchSize()
-AxisDomain = Union[None, tuple[Any, Any], List[Any]]
+AxisDomain = Union[None, tuple[Any, Any], list[Any]]
 Domain = Sequence[AxisDomain]
 
 

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -15,7 +15,6 @@ from typing import (
     List,
     Literal,
     Sequence,
-    Tuple,
     Union,
     cast,
 )
@@ -49,7 +48,7 @@ from .options._tiledb_create_write_options import (
 )
 
 _UNBATCHED = options.BatchSize()
-AxisDomain = Union[None, Tuple[Any, Any], List[Any]]
+AxisDomain = Union[None, tuple[Any, Any], List[Any]]
 Domain = Sequence[AxisDomain]
 
 
@@ -353,7 +352,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 
-    def keys(self) -> Tuple[str, ...]:
+    def keys(self) -> tuple[str, ...]:
         """Returns the names of the columns when read back as a dataframe.
 
         Examples:
@@ -369,7 +368,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         return self._tiledb_array_keys()
 
     @property
-    def index_column_names(self) -> Tuple[str, ...]:
+    def index_column_names(self) -> tuple[str, ...]:
         """Returns index (dimension) column names.
 
         Lifecycle:
@@ -438,7 +437,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         self._handle.extend_enumeration_values(values, deduplicate)
 
     @property
-    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def domain(self) -> tuple[tuple[Any, Any], ...]:
         """Returns tuples of minimum and maximum values, one tuple per index column, currently storable
         on each index column of the dataframe. These can be resized up to ``maxdomain``.
 
@@ -448,7 +447,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         return self._domain()
 
     @property
-    def maxdomain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def maxdomain(self) -> tuple[tuple[Any, Any], ...]:
         """Returns tuples of minimum and maximum values, one tuple per index column, to which the dataframe
         can have its domain resized.
 
@@ -951,7 +950,7 @@ def _fill_out_slot_soma_domain(
     index_column_name: str,
     pa_type: pa.DataType,
     dtype: Any,
-) -> Tuple[Tuple[Any, Any], Union[bool, Tuple[bool, ...]]]:
+) -> tuple[tuple[Any, Any], Union[bool, tuple[bool, ...]]]:
     """Helper function for _build_tiledb_schema. Given a user-specified domain for a
     dimension slot -- which may be ``None``, or a two-tuple of which either element
     may be ``None`` -- return either what the user specified (if adequate) or
@@ -1111,7 +1110,7 @@ def _find_extent_for_domain(
     index_column_name: str,
     tiledb_create_write_options: TileDBCreateOptions,
     dtype: np.typing.DTypeLike | str,
-    slot_domain: Tuple[Any, Any],
+    slot_domain: tuple[Any, Any],
 ) -> int | float | Literal["", b""]:
     """Helper function for _build_tiledb_schema. Returns a tile extent that is
     small enough for the index-column type, and that also fits within the
@@ -1166,11 +1165,11 @@ def _find_extent_for_domain(
 # extent exceeds max value representable by domain type. Reduce domain max
 # by 1 tile extent to allow for expansion.
 def _revise_domain_for_extent(
-    domain: Tuple[Any, Any], extent: Any, saturated_range: Union[bool, Tuple[bool, ...]]
-) -> Tuple[Any, Any]:
+    domain: tuple[Any, Any], extent: Any, saturated_range: Union[bool, tuple[bool, ...]]
+) -> tuple[Any, Any]:
     if isinstance(domain[0], (np.datetime64, pa.TimestampScalar)):
         domain = cast(
-            Tuple[Any, Any], (_util.to_unix_ts(domain[0]), _util.to_unix_ts(domain[1]))
+            tuple[Any, Any], (_util.to_unix_ts(domain[0]), _util.to_unix_ts(domain[1]))
         )
 
     if isinstance(saturated_range, tuple):

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import inspect
 from typing import (
     Any,
-    Dict,
     Literal,
     Sequence,
     Union,
@@ -590,7 +589,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         dim_schema = pa.schema(dim_schema_list)
 
         # Convert the user's tuple of low/high pairs into a dict keyed by index-column name.
-        new_domain_dict: Dict[str, Domain] = {}
+        new_domain_dict: dict[str, Domain] = {}
         for dim_name, new_dom in zip(dim_names, newdomain):
             # Domain can't be specified for strings (core constraint) so let them keystroke that easily.
             if (

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -830,7 +830,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         _util.check_type("values", values, (pa.Table,))
 
-        write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
+        write_options: TileDBCreateOptions | TileDBWriteOptions
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(
                 "As of TileDB-SOMA 1.13, the write method takes "

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -9,7 +9,7 @@ Implementation of SOMA DenseNDArray.
 from __future__ import annotations
 
 import warnings
-from typing import List, Sequence, Tuple
+from typing import List, Sequence
 
 import numpy as np
 import pyarrow as pa
@@ -328,7 +328,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         dim_shape: int | None,
         ndim: int,
         create_options: TileDBCreateOptions,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Given a user-specified shape (maybe ``None``) along a particular dimension,
         returns a tuple of the TileDB capacity and extent for that dimension, suitable
         for schema creation. If the user-specified shape is None, the largest possible

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -9,7 +9,7 @@ Implementation of SOMA DenseNDArray.
 from __future__ import annotations
 
 import warnings
-from typing import List, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -94,7 +94,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         uri: str,
         *,
         type: pa.DataType,
-        shape: Sequence[Union[int, None]],
+        shape: Sequence[int | None],
         platform_config: options.PlatformConfig | None = None,
         context: SOMATileDBContext | None = None,
         tiledb_timestamp: OpenTimestamp | None = None,
@@ -291,7 +291,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         clib_handle = self._handle._handle
 
         # Compute the coordinates for the dense array.
-        new_coords: List[Union[int, Slice[int], None]] = []
+        new_coords: List[int | Slice[int] | None] = []
         for c in coords:
             if isinstance(c, slice) and isinstance(c.stop, int):
                 new_coords.append(slice(c.start, c.stop, c.step))

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -9,7 +9,7 @@ Implementation of SOMA DenseNDArray.
 from __future__ import annotations
 
 import warnings
-from typing import List, Sequence
+from typing import Sequence
 
 import numpy as np
 import pyarrow as pa
@@ -291,7 +291,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         clib_handle = self._handle._handle
 
         # Compute the coordinates for the dense array.
-        new_coords: List[int | Slice[int] | None] = []
+        new_coords: list[int | Slice[int] | None] = []
         for c in coords:
             if isinstance(c, slice) and isinstance(c.stop, int):
                 new_coords.append(slice(c.start, c.stop, c.step))

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -4,7 +4,7 @@
 
 """Exceptions."""
 
-from typing import Union
+from __future__ import annotations
 
 
 class SOMAError(Exception):
@@ -25,7 +25,7 @@ class DoesNotExistError(SOMAError):
     pass
 
 
-def is_does_not_exist_error(e: Union[RuntimeError, SOMAError]) -> bool:
+def is_does_not_exist_error(e: RuntimeError | SOMAError) -> bool:
     """Given a RuntimeError or SOMAError, return true if it indicates the object
     does not exist
 

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import (
     Callable,
-    Dict,
     Type,
     TypeVar,
     cast,
@@ -212,7 +211,7 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
 
 @no_type_check
 def _type_name_to_cls(type_name: str) -> Type[AnySOMAObject]:
-    type_map: Dict[str, Type[AnySOMAObject]] = {
+    type_map: dict[str, Type[AnySOMAObject]] = {
         t.soma_type.lower(): t
         for t in (
             _collection.Collection,

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import (
     Callable,
-    Type,
     TypeVar,
     cast,
     no_type_check,
@@ -64,7 +63,7 @@ def open(
     uri: str,
     mode: options.OpenMode,
     *,
-    soma_type: Type[_Obj],
+    soma_type: type[_Obj],
     context: SOMATileDBContext | None = None,
     tiledb_timestamp: OpenTimestamp | None = None,
 ) -> _Obj: ...
@@ -75,7 +74,7 @@ def open(
     uri: str,
     mode: options.OpenMode = "r",
     *,
-    soma_type: Type[SOMAObject] | str | None = None,  # type: ignore[type-arg]
+    soma_type: type[SOMAObject] | str | None = None,  # type: ignore[type-arg]
     context: SOMATileDBContext | None = None,
     tiledb_timestamp: OpenTimestamp | None = None,
 ) -> AnySOMAObject:
@@ -210,8 +209,8 @@ def _read_soma_type(hdl: _tdb_handles.AnyWrapper) -> str:
 
 
 @no_type_check
-def _type_name_to_cls(type_name: str) -> Type[AnySOMAObject]:
-    type_map: dict[str, Type[AnySOMAObject]] = {
+def _type_name_to_cls(type_name: str) -> type[AnySOMAObject]:
+    type_map: dict[str, type[AnySOMAObject]] = {
         t.soma_type.lower(): t
         for t in (
             _collection.Collection,

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -13,7 +13,6 @@ from typing import (
     Dict,
     Type,
     TypeVar,
-    Union,
     cast,
     no_type_check,
     overload,
@@ -77,7 +76,7 @@ def open(
     uri: str,
     mode: options.OpenMode = "r",
     *,
-    soma_type: Union[Type[SOMAObject], str, None] = None,  # type: ignore[type-arg]
+    soma_type: Type[SOMAObject] | str | None = None,  # type: ignore[type-arg]
     context: SOMATileDBContext | None = None,
     tiledb_timestamp: OpenTimestamp | None = None,
 ) -> AnySOMAObject:

--- a/apis/python/src/tiledbsoma/_fastercsx.py
+++ b/apis/python/src/tiledbsoma/_fastercsx.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import collections.abc
 import math
-from typing import Any, List, Literal, Sequence, Union, cast
+from typing import Any, Literal, Sequence, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -126,9 +126,9 @@ class CompressedMatrix:
             else tables
         )
 
-        def chunks(a: pa.Array | pa.ChunkedArray) -> List[pa.Array]:
+        def chunks(a: pa.Array | pa.ChunkedArray) -> list[pa.Array]:
             return (
-                list(a) if isinstance(a, pa.Array) else cast(List[pa.Array], a.chunks)
+                list(a) if isinstance(a, pa.Array) else cast(list[pa.Array], a.chunks)
             )
 
         if len(tbl) > 0:

--- a/apis/python/src/tiledbsoma/_fastercsx.py
+++ b/apis/python/src/tiledbsoma/_fastercsx.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import collections.abc
 import math
-from typing import Any, List, Literal, Sequence, Tuple, Union, cast
+from typing import Any, List, Literal, Sequence, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -45,7 +45,7 @@ class CompressedMatrix:
         indptr: NDArrayIndex,
         indices: NDArrayIndex,
         data: NDArrayNumber,
-        shape: Tuple[int, int],
+        shape: tuple[int, int],
         format: Format,
         is_sorted: bool,
         no_duplicates: bool | None,
@@ -73,7 +73,7 @@ class CompressedMatrix:
         i: NDArrayIndex | Sequence[NDArrayIndex],
         j: NDArrayIndex | Sequence[NDArrayIndex],
         d: NDArrayNumber | Sequence[NDArrayNumber],
-        shape: Tuple[int, int],
+        shape: tuple[int, int],
         format: Format,
         make_sorted: bool,
         context: SOMATileDBContext,
@@ -109,7 +109,7 @@ class CompressedMatrix:
     @staticmethod
     def from_soma(
         tables: pa.Table | Sequence[pa.Table],
-        shape: Tuple[int, int],
+        shape: tuple[int, int],
         format: Format,
         make_sorted: bool,
         context: SOMATileDBContext,
@@ -251,7 +251,7 @@ class CompressedMatrix:
         indptr: NDArrayNumber,
         indices: NDArrayNumber,
         data: NDArrayNumber,
-        shape: Tuple[int, int],
+        shape: tuple[int, int],
         format: Format,
         is_sorted: bool,
         no_duplicates: bool | None,

--- a/apis/python/src/tiledbsoma/_funcs.py
+++ b/apis/python/src/tiledbsoma/_funcs.py
@@ -9,7 +9,6 @@ from typing import (
     Any,
     Callable,
     Collection,
-    List,
     TypeVar,
 )
 
@@ -61,7 +60,7 @@ def forwards_kwargs_to(
 
     def wrap(me: _CT) -> _CT:
         my_sig = inspect.Signature.from_callable(me)
-        merged: List[inspect.Parameter] = []
+        merged: list[inspect.Parameter] = []
         claimed_names = set(exclude)
         for param in my_sig.parameters.values():
             if param.kind == inspect.Parameter.VAR_KEYWORD:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Geometry DataFrame
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, Tuple, Union, cast
+from typing import Any, Sequence, Tuple, cast
 
 import pyarrow as pa
 import somacore
@@ -73,7 +73,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         uri: str,
         *,
         schema: pa.Schema,
-        coordinate_space: Union[Sequence[str], CoordinateSpace] = ("x", "y"),
+        coordinate_space: Sequence[str] | CoordinateSpace = ("x", "y"),
         domain: Domain | None = None,
         platform_config: options.PlatformConfig | None = None,
         context: SOMATileDBContext | None = None,
@@ -479,7 +479,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
 
     def write(
         self,
-        values: Union[pa.RecordBatch, pa.Table],
+        values: pa.RecordBatch | pa.Table,
         *,
         platform_config: options.PlatformConfig | None = None,
     ) -> Self:
@@ -500,7 +500,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         """
         _util.check_type("values", values, (pa.Table,))
 
-        write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
+        write_options: TileDBCreateOptions | TileDBWriteOptions
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(
@@ -526,7 +526,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
 
     def from_outlines(
         self,
-        values: Union[pa.RecordBatch, pa.Table],
+        values: pa.RecordBatch | pa.Table,
         *,
         platform_config: options.PlatformConfig | None = None,
     ) -> Self:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Geometry DataFrame
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, Tuple, cast
+from typing import Any, Sequence, cast
 
 import pyarrow as pa
 import somacore
@@ -191,7 +191,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         index_column_schema = []
 
         # TODO this requires fixing the return type for _revise_domain_for_extent
-        # which is currently Tuple[Any, Any]
+        # which is currently tuple[Any, Any]
         index_column_data: dict[str, Any] = {}
 
         for index_column_name, slot_soma_domain in zip(index_column_names, soma_domain):
@@ -567,7 +567,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
     # Metadata operations
 
     @property
-    def axis_names(self) -> Tuple[str, ...]:
+    def axis_names(self) -> tuple[str, ...]:
         """The names of the axes of the coordinate space the data is defined on.
 
         Lifecycle:

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -24,7 +24,7 @@ IndexerDataType = Union[
     PDSeries,
     pd.arrays.IntegerArray,
     pa.ChunkedArray,
-    List[int],
+    list[int],
 ]
 
 

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence
 
 import attrs
 import pyarrow as pa
@@ -51,16 +51,16 @@ class _LevelProperties:
     """Properties for a single resolution level in a multiscale image."""
 
     name: str
-    shape: Tuple[int, ...] = attrs.field(converter=tuple)
+    shape: tuple[int, ...] = attrs.field(converter=tuple)
 
 
 @attrs.define(frozen=True)
 class _MultiscaleImageMetadata:
     """Helper class for reading/writing multiscale image metadata."""
 
-    data_axis_permutation: Tuple[int, ...] = attrs.field(converter=tuple)
+    data_axis_permutation: tuple[int, ...] = attrs.field(converter=tuple)
     has_channel_axis: bool
-    shape: Tuple[int, ...] = attrs.field(converter=tuple)
+    shape: tuple[int, ...] = attrs.field(converter=tuple)
     datatype: pa.DataType
 
     def to_json(self) -> str:
@@ -606,7 +606,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         self._coord_space = value
 
     @property
-    def data_axis_order(self) -> Tuple[str, ...]:
+    def data_axis_order(self) -> tuple[str, ...]:
         """The order of the axes for the resolution levels.
 
         Lifecycle:
@@ -678,7 +678,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._has_channel_axis
 
-    def levels(self) -> Dict[str, Tuple[str, Tuple[int, ...]]]:
+    def levels(self) -> Dict[str, tuple[str, tuple[int, ...]]]:
         """Returns a mapping of {member_name: (uri, shape)}."""
         return {
             level.name: (self._contents[level.name].entry.uri, level.shape)
@@ -694,7 +694,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         return len(self._levels)
 
-    def level_shape(self, level: int | str) -> Tuple[int, ...]:
+    def level_shape(self, level: int | str) -> tuple[int, ...]:
         """The shape of the image at the specified resolution level.
 
         Lifecycle: experimental

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple
 
 import attrs
 import pyarrow as pa
@@ -119,7 +119,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         level_shape: Sequence[int],
         level_key: str = "level0",
         level_uri: str | None = None,
-        coordinate_space: Union[Sequence[str], CoordinateSpace] = (
+        coordinate_space: Sequence[str] | CoordinateSpace = (
             "x",
             "y",
         ),
@@ -418,7 +418,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     def read_spatial_region(
         self,
-        level: Union[int, str],
+        level: int | str,
         region: options.SpatialRegion | None = None,
         *,
         channel_coords: options.DenseCoord = None,
@@ -553,7 +553,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         )
 
     # Metadata operations
-    def _level_properties(self, level: Union[int, str]) -> _LevelProperties:
+    def _level_properties(self, level: int | str) -> _LevelProperties:
         """The properties of an image at the specified level."""
         # by name
         # TODO could dynamically create a dictionary whenever a name-based
@@ -621,7 +621,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             for index in self._data_axis_permutation
         )
 
-    def get_transform_from_level(self, level: Union[int, str]) -> ScaleTransform:
+    def get_transform_from_level(self, level: int | str) -> ScaleTransform:
         """Returns the transformation from user requested level to the image reference
         level.
 
@@ -645,7 +645,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             scale_factors=scale_factors,
         )
 
-    def get_transform_to_level(self, level: Union[int, str]) -> ScaleTransform:
+    def get_transform_to_level(self, level: int | str) -> ScaleTransform:
         """Returns the transformation from the image reference level to the user
         requested level.
 
@@ -694,7 +694,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         return len(self._levels)
 
-    def level_shape(self, level: Union[int, str]) -> Tuple[int, ...]:
+    def level_shape(self, level: int | str) -> Tuple[int, ...]:
         """The shape of the image at the specified resolution level.
 
         Lifecycle: experimental
@@ -709,7 +709,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         # by index
         return self._levels[level].shape
 
-    def level_uri(self, level: Union[int, str]) -> str:
+    def level_uri(self, level: int | str) -> str:
         """The URI of the image at the specified resolution level.
 
         Lifecycle: experimental

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 import attrs
 import pyarrow as pa
@@ -678,7 +678,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         return self._has_channel_axis
 
-    def levels(self) -> Dict[str, tuple[str, tuple[int, ...]]]:
+    def levels(self) -> dict[str, tuple[str, tuple[int, ...]]]:
         """Returns a mapping of {member_name: (uri, shape)}."""
         return {
             level.name: (self._contents[level.name].entry.uri, level.shape)

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, Sequence
 
 import attrs
 import pyarrow as pa
@@ -568,7 +568,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         # by index
         return self._levels[level]
 
-    def _axis_order(self) -> List[int]:
+    def _axis_order(self) -> list[int]:
         """Indices for accessing the data order for spatial axes."""
         axes = [
             index

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Point Cloud DataFrame
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, Tuple, cast
+from typing import Any, Sequence, cast
 
 import pyarrow as pa
 import somacore
@@ -524,7 +524,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         self._coord_space = value
 
     @property
-    def axis_names(self) -> Tuple[str, ...]:
+    def axis_names(self) -> tuple[str, ...]:
         """The names of the axes of the coordinate space the data is defined on.
 
         Lifecycle:

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Point Cloud DataFrame
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, Tuple, Union, cast
+from typing import Any, Sequence, Tuple, cast
 
 import pyarrow as pa
 import somacore
@@ -70,7 +70,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         uri: str,
         *,
         schema: pa.Schema,
-        coordinate_space: Union[Sequence[str], CoordinateSpace] = ("x", "y"),
+        coordinate_space: Sequence[str] | CoordinateSpace = ("x", "y"),
         domain: Domain | None = None,
         platform_config: options.PlatformConfig | None = None,
         context: SOMATileDBContext | None = None,
@@ -450,7 +450,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
 
     def write(
         self,
-        values: Union[pa.RecordBatch, pa.Table],
+        values: pa.RecordBatch | pa.Table,
         *,
         platform_config: options.PlatformConfig | None = None,
     ) -> Self:
@@ -471,7 +471,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         """
         _util.check_type("values", values, (pa.Table,))
 
-        write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
+        write_options: TileDBCreateOptions | TileDBWriteOptions
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -9,7 +9,7 @@ filtering query results on attribute values.
 from __future__ import annotations
 
 import ast
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, List, Union
 
 import attrs
 import numpy as np
@@ -336,7 +336,7 @@ class QueryConditionTree(ast.NodeVisitor):
         att: QueryConditionNodeElem,
         val: QueryConditionNodeElem,
         op: clib.tiledb_query_condition_op_t,
-    ) -> Tuple[
+    ) -> tuple[
         QueryConditionNodeElem,
         QueryConditionNodeElem,
         clib.tiledb_query_condition_op_t,

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -411,9 +411,9 @@ class QueryConditionTree(ast.NodeVisitor):
 
     def cast_val_to_dtype(
         self,
-        val: Union[str, int, float, bytes, np.int32, np.int64, np.float32],
+        val: str | int | float | bytes | np.int32 | np.int64 | np.float32,
         dtype: str,
-    ) -> Union[str, int, float, bytes, np.int32, np.int64, np.float32]:
+    ) -> str | int | float | bytes | np.int32 | np.int64 | np.float32:
         if dtype != "string":
             try:
                 # this prevents numeric strings ("1", '123.32') from getting

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -9,7 +9,7 @@ filtering query results on attribute values.
 from __future__ import annotations
 
 import ast
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, Union
 
 import attrs
 import numpy as np
@@ -130,7 +130,7 @@ class QueryCondition:
     def init_query_condition(
         self,
         schema: pa.Schema,
-        query_attrs: List[str] | None,
+        query_attrs: list[str] | None,
     ):
         try:
             qctree = QueryConditionTree(schema, query_attrs)
@@ -150,7 +150,7 @@ class QueryCondition:
 @attrs.define
 class QueryConditionTree(ast.NodeVisitor):
     schema: pa.Schema
-    query_attrs: List[str]
+    query_attrs: list[str]
 
     def visit_BitOr(self, node):
         return clib.TILEDB_OR

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -68,9 +68,7 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
     def __init__(
         self,
         array: SOMAArray,
-        coords: Union[
-            options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
-        ],
+        coords: options.SparseDFCoords | options.SparseNDCoords | options.DenseNDCoords,
         column_names: Sequence[str] | None,
         result_order: clib.ResultOrder,
         value_filter: str | None,
@@ -78,7 +76,7 @@ class TableReadIter(somacore.ReadIter[pa.Table]):
         *,
         coord_space: CoordinateSpace | None = None,
     ):
-        """Initalizes a new TableReadIter for SOMAArrays.
+        """Initializes a new TableReadIter for SOMAArrays.
 
         Args:
             array (SOMAArray):

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -136,7 +136,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         self,
         array: SOMAArray,
         coords: options.SparseNDCoords,
-        axis: Union[int, Sequence[int]],
+        axis: int | Sequence[int],
         result_order: clib.ResultOrder,
         platform_config: options.PlatformConfig | None,
         *,
@@ -197,8 +197,8 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
     @classmethod
     def _validate_args(
         cls,
-        shape: Union[NTuple, Sequence[int]],
-        axis: Union[int, Sequence[int]],
+        shape: NTuple | Sequence[int],
+        axis: int | Sequence[int],
         size: int | Sequence[int] | None = None,
         reindex_disable_on_axis: int | Sequence[int] | None = None,
     ) -> Tuple[List[int], List[int], List[int]]:
@@ -340,7 +340,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
         self,
         array: SOMAArray,
         coords: options.SparseNDCoords,
-        axis: Union[int, Sequence[int]],
+        axis: int | Sequence[int],
         result_order: clib.ResultOrder,
         platform_config: options.PlatformConfig | None,
         *,
@@ -454,7 +454,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
     def _cs_reader(
         self, _pool: ThreadPoolExecutor | None = None
-    ) -> Iterator[Tuple[Union[sparse.csr_matrix, sparse.csc_matrix], IndicesType],]:
+    ) -> Iterator[Tuple[sparse.csr_matrix | sparse.csc_matrix, IndicesType],]:
         """Private. Compressed sparse variants"""
         assert self.compress
         assert self.major_axis not in self.reindex_disable_on_axis

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -13,7 +13,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Iterator,
-    List,
     Sequence,
     TypeVar,
     Union,
@@ -169,7 +168,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         self.coords = _pad_with_none(coords, self.ndim)
 
         # materialize all indexing info.
-        self.joinids: List[pa.Array] = [
+        self.joinids: list[pa.Array] = [
             pa.array(
                 np.concatenate(
                     list(_coords_strider(self.coords[d], self.shape[d], self.shape[d]))
@@ -198,7 +197,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         axis: int | Sequence[int],
         size: int | Sequence[int] | None = None,
         reindex_disable_on_axis: int | Sequence[int] | None = None,
-    ) -> tuple[List[int], List[int], List[int]]:
+    ) -> tuple[list[int], list[int], list[int]]:
         """
         Class method to validate and normalize common user-provided arguments axis, size and reindex_disable_on_axis.
         * normalize args to fully specify the arg per dimension, for convenience in later usage
@@ -418,7 +417,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
         """Private. Make shape of this iterator step"""
         shape = cast(tuple[int, int], tuple(self.shape))
         assert len(shape) == 2
-        _sp_shape: List[int] = list(shape)
+        _sp_shape: list[int] = list(shape)
 
         if self.major_axis not in self.reindex_disable_on_axis:
             _sp_shape[self.major_axis] = len(major_coords)
@@ -562,9 +561,7 @@ class ArrowTableRead(Iterator[pa.Table]):
     def __init__(
         self,
         array: SOMAArray,
-        coords: Union[
-            options.SparseDFCoords, options.SparseNDCoords, options.DenseNDCoords
-        ],
+        coords: options.SparseDFCoords | options.SparseNDCoords | options.DenseNDCoords,
         column_names: Sequence[str] | None,
         result_order: clib.ResultOrder,
         value_filter: str | None,

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -15,7 +15,6 @@ from typing import (
     Iterator,
     List,
     Sequence,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -48,17 +47,17 @@ if TYPE_CHECKING:
 
 # Convenience types
 _RT = TypeVar("_RT")
-BlockwiseTableReadIterResult = Tuple[pa.Table, Tuple[pa.Array, ...]]
+BlockwiseTableReadIterResult = tuple[pa.Table, tuple[pa.Array, ...]]
 BlockwiseSingleAxisTableIter = Iterator[BlockwiseTableReadIterResult]
 
-BlockwiseScipyReadIterResult = Tuple[
+BlockwiseScipyReadIterResult = tuple[
     Union[sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix],
-    Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
+    tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
 ]
 
-IndicesType = Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]
-IJDType = Tuple[
-    Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
+IndicesType = tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]
+IJDType = tuple[
+    tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]],
     npt.NDArray[Union[np.integer[Any], np.floating[Any]]],
 ]
 
@@ -201,7 +200,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         axis: int | Sequence[int],
         size: int | Sequence[int] | None = None,
         reindex_disable_on_axis: int | Sequence[int] | None = None,
-    ) -> Tuple[List[int], List[int], List[int]]:
+    ) -> tuple[List[int], List[int], List[int]]:
         """
         Class method to validate and normalize common user-provided arguments axis, size and reindex_disable_on_axis.
         * normalize args to fully specify the arg per dimension, for convenience in later usage
@@ -398,7 +397,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
     def _sorted_tbl_reader(
         self, _pool: ThreadPoolExecutor | None = None
-    ) -> Iterator[Tuple[IJDType, IndicesType]]:
+    ) -> Iterator[tuple[IJDType, IndicesType]]:
         """Private. Read reindexed tables and sort them. Yield as ((i,j),d)"""
         for coo_tbl, indices in self._maybe_eager_iterator(
             self._reindexed_table_reader(_pool), _pool
@@ -417,9 +416,9 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
     def _mk_shape(
         self, major_coords: npt.NDArray[np.int64], minor_coords: npt.NDArray[np.int64]
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Private. Make shape of this iterator step"""
-        shape = cast(Tuple[int, int], tuple(self.shape))
+        shape = cast(tuple[int, int], tuple(self.shape))
         assert len(shape) == 2
         _sp_shape: List[int] = list(shape)
 
@@ -428,11 +427,11 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
         if self.minor_axis not in self.reindex_disable_on_axis:
             _sp_shape[self.minor_axis] = len(minor_coords)
 
-        return cast(Tuple[int, int], tuple(_sp_shape))
+        return cast(tuple[int, int], tuple(_sp_shape))
 
     def _coo_reader(
         self, _pool: ThreadPoolExecutor | None = None
-    ) -> Iterator[Tuple[sparse.coo_matrix, IndicesType]]:
+    ) -> Iterator[tuple[sparse.coo_matrix, IndicesType]]:
         """Private. Uncompressed variants"""
         assert not self.compress
         for ((i, j), d), indices in self._maybe_eager_iterator(
@@ -454,7 +453,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
     def _cs_reader(
         self, _pool: ThreadPoolExecutor | None = None
-    ) -> Iterator[Tuple[sparse.csr_matrix | sparse.csc_matrix, IndicesType],]:
+    ) -> Iterator[tuple[sparse.csr_matrix | sparse.csc_matrix, IndicesType],]:
         """Private. Compressed sparse variants"""
         assert self.compress
         assert self.major_axis not in self.reindex_disable_on_axis
@@ -647,6 +646,6 @@ def _coords_strider(
 _ElemT = TypeVar("_ElemT")
 
 
-def _pad_with_none(s: Sequence[_ElemT], to_length: int) -> Tuple[_ElemT | None, ...]:
+def _pad_with_none(s: Sequence[_ElemT], to_length: int) -> tuple[_ElemT | None, ...]:
     """Given a sequence, pad length to a user-specified length, with None values"""
     return tuple(s[i] if i < len(s) else None for i in range(to_length))

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -147,7 +147,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
             self._coord_space = coordinate_space_from_json(coord_space)
 
     def _open_subcollection(
-        self, subcollection: Union[str, Sequence[str]]
+        self, subcollection: str | Sequence[str]
     ) -> CollectionBase[AnySOMAObject]:
         if len(subcollection) == 0:
             raise ValueError("Invalid subcollection: value cannot be empty.")
@@ -174,7 +174,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         *,
         key: str,
         transform: CoordinateTransform,
-        subcollection: Union[str, Sequence[str]],
+        subcollection: str | Sequence[str],
         coordinate_space: CoordinateSpace | None,
     ) -> _SE:
         # Check the transform is compatible with the coordinate spaces of the scene
@@ -251,7 +251,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def add_new_geometry_dataframe(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]],
+        subcollection: str | Sequence[str],
         *,
         transform: CoordinateTransform | None,
         uri: str | None = None,
@@ -295,11 +295,11 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def add_new_multiscale_image(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]],
+        subcollection: str | Sequence[str],
         *,
         transform: CoordinateTransform | None,
         uri: str | None = None,
-        coordinate_space: Union[Sequence[str], CoordinateSpace] = ("x", "y"),
+        coordinate_space: Sequence[str] | CoordinateSpace = ("x", "y"),
         **kwargs: Any,
     ) -> MultiscaleImage:
         """Adds a ``MultiscaleImage`` to the scene and sets a coordinate transform
@@ -386,11 +386,11 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def add_new_point_cloud_dataframe(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]],
+        subcollection: str | Sequence[str],
         *,
         transform: CoordinateTransform | None,
         uri: str | None = None,
-        coordinate_space: Union[Sequence[str], CoordinateSpace] = ("x", "y"),
+        coordinate_space: Sequence[str] | CoordinateSpace = ("x", "y"),
         **kwargs: Any,
     ) -> PointCloudDataFrame:
         """Adds a point cloud to the scene and sets a coordinate transform
@@ -477,7 +477,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def set_transform_to_geometry_dataframe(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]] = "obsl",
+        subcollection: str | Sequence[str] = "obsl",
         *,
         transform: CoordinateTransform,
         coordinate_space: CoordinateSpace | None = None,
@@ -512,7 +512,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def set_transform_to_multiscale_image(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]] = "img",
+        subcollection: str | Sequence[str] = "img",
         *,
         transform: CoordinateTransform,
         coordinate_space: CoordinateSpace | None = None,
@@ -549,7 +549,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     def set_transform_to_point_cloud_dataframe(
         self,
         key: str,
-        subcollection: Union[str, Sequence[str]] = "obsl",
+        subcollection: str | Sequence[str] = "obsl",
         *,
         transform: CoordinateTransform,
         coordinate_space: CoordinateSpace | None = None,
@@ -589,7 +589,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         )
 
     def get_transform_from_geometry_dataframe(
-        self, key: str, subcollection: Union[str, Sequence[str]] = "obsl"
+        self, key: str, subcollection: str | Sequence[str] = "obsl"
     ) -> CoordinateTransform:
         """Returns the coordinate transformation from the requested geometry dataframe
         to the scene.
@@ -678,7 +678,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         return transform.inverse_transform()
 
     def get_transform_to_geometry_dataframe(
-        self, key: str, subcollection: Union[str, Sequence[str]] = "obsl"
+        self, key: str, subcollection: str | Sequence[str] = "obsl"
     ) -> CoordinateTransform:
         """Returns the coordinate transformation from the scene to a requested
         geometery dataframe.

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Scene
 from __future__ import annotations
 
 import warnings
-from typing import Any, List, Sequence, Type, TypeVar, Union
+from typing import Any, Sequence, Type, TypeVar, Union
 
 import somacore
 from somacore import (
@@ -157,7 +157,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
             subcollection = tuple(subcollection)
         coll: CollectionBase[AnySOMAObject] = self
         # Keep track of collection hierarchy for informative error reporting
-        parent_name: List[str] = []
+        parent_name: list[str] = []
         for name in subcollection:
             try:
                 coll = coll[name]  # type: ignore[assignment]

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Scene
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, Type, TypeVar, Union
+from typing import Any, Sequence, TypeVar, Union
 
 import somacore
 from somacore import (
@@ -170,7 +170,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
 
     def _set_transform_to_element(
         self,
-        kind: Type[_SE],
+        kind: type[_SE],
         *,
         key: str,
         transform: CoordinateTransform,

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -8,7 +8,7 @@ Implementation of a SOMA Scene
 from __future__ import annotations
 
 import warnings
-from typing import Any, List, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, List, Sequence, Type, TypeVar, Union
 
 import somacore
 from somacore import (
@@ -213,7 +213,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         # Either set the new coordinate space or check the axes of the current
         # coordinate space the element is defined on.
         if coordinate_space is None:
-            elem_axis_names: Tuple[str, ...] = elem.coordinate_space.axis_names
+            elem_axis_names: tuple[str, ...] = elem.coordinate_space.axis_names
             if elem_axis_names != transform.output_axes:
                 raise ValueError(
                     f"The name of transform output axes, {transform.output_axes}, do "

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 import warnings
-from typing import Any, Tuple
+from typing import Any
 
 import pyarrow as pa
 
@@ -105,7 +105,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         )
         return self._handle.config_options_from_schema()
 
-    def non_empty_domain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def non_empty_domain(self) -> tuple[tuple[Any, Any], ...]:
         """
         Retrieves the non-empty domain for each dimension, namely the smallest
         and largest indices in each dimension for which the array/dataframe has
@@ -116,21 +116,21 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.non_empty_domain()
 
-    def _tiledb_array_keys(self) -> Tuple[str, ...]:
+    def _tiledb_array_keys(self) -> tuple[str, ...]:
         """Return all dim and attr names."""
         return self._tiledb_dim_names() + self._tiledb_attr_names()
 
-    def _tiledb_dim_names(self) -> Tuple[str, ...]:
+    def _tiledb_dim_names(self) -> tuple[str, ...]:
         """Reads the dimension names from the schema: for example, ['obs_id', 'var_id']."""
         return self._handle.dim_names
 
-    def _tiledb_attr_names(self) -> Tuple[str, ...]:
+    def _tiledb_attr_names(self) -> tuple[str, ...]:
         """Reads the attribute names from the schema:
         for example, the list of column names in a dataframe.
         """
         return self._handle.attr_names
 
-    def _domain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def _domain(self) -> tuple[tuple[Any, Any], ...]:
         """This is the SOMA domain, not the core domain.
         * For arrays with core current-domain support:
           o soma domain is core current domain
@@ -145,7 +145,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.domain
 
-    def _maxdomain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def _maxdomain(self) -> tuple[tuple[Any, Any], ...]:
         """This is the SOMA maxdomain, not the core domain.
         * For arrays with core current-domain support:
           o soma domain is core current domain

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -12,7 +12,6 @@ from typing import (
     Iterable,
     Iterator,
     Set,
-    Type,
     TypeVar,
     cast,
 )
@@ -186,7 +185,7 @@ class SOMAGroup(
     def _add_new_element(
         self,
         key: str,
-        kind: Type[_TDBO],
+        kind: type[_TDBO],
         factory: Callable[[str], _TDBO],
         user_uri: str | None,
     ) -> _TDBO:

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -11,7 +11,6 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
-    Set,
     TypeVar,
     cast,
 )
@@ -71,7 +70,7 @@ class SOMAGroup(
 
         This is loaded at startup when we have a read handle.
         """
-        self._mutated_keys: Set[str] = set()
+        self._mutated_keys: set[str] = set()
 
     def __len__(self) -> int:
         """Return the number of members in the collection"""

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from contextlib import ExitStack
-from typing import Any, Generic, MutableMapping, Type, TypeVar, Union
+from typing import Any, Generic, MutableMapping, Type, TypeVar
 
 import somacore
 from somacore import options
@@ -39,17 +39,17 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Maturing.
     """
 
-    _wrapper_type: Union[
-        Type[_WrapperType_co],
-        Type[_tdb_handles.DataFrameWrapper],
-        Type[_tdb_handles.DenseNDArrayWrapper],
-        Type[_tdb_handles.SparseNDArrayWrapper],
-        Type[_tdb_handles.CollectionWrapper],
-        Type[_tdb_handles.ExperimentWrapper],
-        Type[_tdb_handles.MeasurementWrapper],
-        Type[_tdb_handles.SceneWrapper],
-        Type[_tdb_handles.MultiscaleImageWrapper],
-    ]
+    _wrapper_type: (
+        Type[_WrapperType_co]
+        | Type[_tdb_handles.DataFrameWrapper]
+        | Type[_tdb_handles.DenseNDArrayWrapper]
+        | Type[_tdb_handles.SparseNDArrayWrapper]
+        | Type[_tdb_handles.CollectionWrapper]
+        | Type[_tdb_handles.ExperimentWrapper]
+        | Type[_tdb_handles.MeasurementWrapper]
+        | Type[_tdb_handles.SceneWrapper]
+        | Type[_tdb_handles.MultiscaleImageWrapper]
+    )
     """Class variable of the Wrapper class used to open this object type."""
 
     __slots__ = ("_close_stack", "_handle")
@@ -113,12 +113,12 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     def __init__(
         self,
-        handle: Union[
-            _WrapperType_co,
-            _tdb_handles.DataFrameWrapper,
-            _tdb_handles.DenseNDArrayWrapper,
-            _tdb_handles.SparseNDArrayWrapper,
-        ],
+        handle: (
+            _WrapperType_co
+            | _tdb_handles.DataFrameWrapper
+            | _tdb_handles.DenseNDArrayWrapper
+            | _tdb_handles.SparseNDArrayWrapper
+        ),
         *,
         _dont_call_this_use_create_or_open_instead: str = "unset",
     ):

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from contextlib import ExitStack
-from typing import Any, Generic, MutableMapping, Type, TypeVar
+from typing import Any, Generic, MutableMapping, TypeVar
 
 import somacore
 from somacore import options
@@ -40,15 +40,15 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     """
 
     _wrapper_type: (
-        Type[_WrapperType_co]
-        | Type[_tdb_handles.DataFrameWrapper]
-        | Type[_tdb_handles.DenseNDArrayWrapper]
-        | Type[_tdb_handles.SparseNDArrayWrapper]
-        | Type[_tdb_handles.CollectionWrapper]
-        | Type[_tdb_handles.ExperimentWrapper]
-        | Type[_tdb_handles.MeasurementWrapper]
-        | Type[_tdb_handles.SceneWrapper]
-        | Type[_tdb_handles.MultiscaleImageWrapper]
+        type[_WrapperType_co]
+        | type[_tdb_handles.DataFrameWrapper]
+        | type[_tdb_handles.DenseNDArrayWrapper]
+        | type[_tdb_handles.SparseNDArrayWrapper]
+        | type[_tdb_handles.CollectionWrapper]
+        | type[_tdb_handles.ExperimentWrapper]
+        | type[_tdb_handles.MeasurementWrapper]
+        | type[_tdb_handles.SceneWrapper]
+        | type[_tdb_handles.MultiscaleImageWrapper]
     )
     """Class variable of the Wrapper class used to open this object type."""
 

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import (
     Sequence,
-    Tuple,
     Union,
     cast,
 )
@@ -400,7 +399,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         dim_shape: int | None,
         ndim: int,  # not needed for sparse
         create_options: TileDBCreateOptions,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Given a user-specified shape (maybe ``None``) along a particular dimension,
         returns a tuple of the TileDB capacity and extent for that dimension, suitable
         for schema creation. If the user-specified shape is None, the largest possible

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -112,7 +112,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         uri: str,
         *,
         type: pa.DataType,
-        shape: Sequence[Union[int, None]],
+        shape: Sequence[int | None],
         platform_config: options.PlatformConfig | None = None,
         context: SOMATileDBContext | None = None,
         tiledb_timestamp: OpenTimestamp | None = None,
@@ -307,7 +307,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             Maturing.
         """
 
-        write_options: Union[TileDBCreateOptions, TileDBWriteOptions]
+        write_options: TileDBCreateOptions | TileDBWriteOptions
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
             raise ValueError(
@@ -504,7 +504,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
 
     def blockwise(
         self,
-        axis: Union[int, Sequence[int]],
+        axis: int | Sequence[int],
         *,
         size: int | Sequence[int] | None = None,
         reindex_disable_on_axis: int | Sequence[int] | None = None,
@@ -587,7 +587,7 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
         self,
         array: SparseNDArray,
         coords: options.SparseNDCoords,
-        axis: Union[int, Sequence[int]],
+        axis: int | Sequence[int],
         result_order: clib.ResultOrder,
         platform_config: options.PlatformConfig | None,
         *,

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -8,11 +8,7 @@ Implementation of SOMA SparseNDArray.
 
 from __future__ import annotations
 
-from typing import (
-    Sequence,
-    Union,
-    cast,
-)
+from typing import Sequence, cast
 
 import numpy as np
 import pyarrow as pa
@@ -274,12 +270,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
     def write(
         self,
-        values: Union[
-            pa.SparseCOOTensor,
-            pa.SparseCSRMatrix,
-            pa.SparseCSCMatrix,
-            pa.Table,
-        ],
+        values: pa.SparseCOOTensor | pa.SparseCSRMatrix | pa.SparseCSCMatrix | pa.Table,
         *,
         platform_config: PlatformConfig | None = None,
     ) -> Self:

--- a/apis/python/src/tiledbsoma/_spatial_dataframe.py
+++ b/apis/python/src/tiledbsoma/_spatial_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a base class shared between GeometryDataFrame and PointCloudDa
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Tuple
+from typing import Any, Sequence
 
 import pyarrow as pa
 import somacore
@@ -25,7 +25,7 @@ class SpatialDataFrame(SOMAArray):
 
     __slots__ = ()
 
-    def keys(self) -> Tuple[str, ...]:
+    def keys(self) -> tuple[str, ...]:
         """Returns the names of the columns when read back as a spatial dataframe.
 
         Examples:
@@ -41,7 +41,7 @@ class SpatialDataFrame(SOMAArray):
         return self._tiledb_array_keys()
 
     @property
-    def index_column_names(self) -> Tuple[str, ...]:
+    def index_column_names(self) -> tuple[str, ...]:
         """Returns index (dimension) column names.
 
         Lifecycle:
@@ -50,7 +50,7 @@ class SpatialDataFrame(SOMAArray):
         return self._tiledb_dim_names()
 
     @property
-    def axis_names(self) -> Tuple[str, ...]:
+    def axis_names(self) -> tuple[str, ...]:
         """The names of the axes of the coordinate space the data is defined on.
 
         Lifecycle: experimental
@@ -58,7 +58,7 @@ class SpatialDataFrame(SOMAArray):
         raise NotImplementedError("Must be implemented by the child class")
 
     @property
-    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+    def domain(self) -> tuple[tuple[Any, Any], ...]:
         """Returns a tuple of minimum and maximum values, inclusive, storable
         on each index column of the dataframe.
 

--- a/apis/python/src/tiledbsoma/_spatial_dataframe.py
+++ b/apis/python/src/tiledbsoma/_spatial_dataframe.py
@@ -8,7 +8,7 @@ Implementation of a base class shared between GeometryDataFrame and PointCloudDa
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Tuple, Union
+from typing import Any, Sequence, Tuple
 
 import pyarrow as pa
 import somacore
@@ -151,7 +151,7 @@ class SpatialDataFrame(SOMAArray):
 
     def write(
         self,
-        values: Union[pa.RecordBatch, pa.Table],
+        values: pa.RecordBatch | pa.Table,
         *,
         platform_config: options.PlatformConfig | None = None,
     ) -> Self:

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Type
+from typing import Any, Type
 
 import numpy as np
 import pyarrow as pa
@@ -52,7 +52,7 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
             "convert JSON to CoordinateTransform child class"
         )
 
-    coord_transform_init: Dict[str, Type[somacore.CoordinateTransform]] = {
+    coord_transform_init: dict[str, Type[somacore.CoordinateTransform]] = {
         "AffineTransform": somacore.AffineTransform,
         "ScaleTransform": somacore.ScaleTransform,
         "UniformScaleTransform": somacore.UniformScaleTransform,
@@ -68,7 +68,7 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
 def transform_to_json(transform: somacore.CoordinateTransform) -> str:
     """Representing a CoordinateTransform as a JSON string"""
 
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "input_axes": transform.input_axes,
         "output_axes": transform.output_axes,
     }
@@ -181,7 +181,7 @@ def process_image_region(
 def process_spatial_df_region(
     region: options.SpatialRegion | None,
     transform: somacore.CoordinateTransform,
-    coords_by_name: Dict[str, options.SparseDFCoord],
+    coords_by_name: dict[str, options.SparseDFCoord],
     index_columns: tuple[str, ...],
     axis_names: tuple[str, ...],
     schema: pa.Schema,

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict, Type
 
 import numpy as np
 import pyarrow as pa
@@ -122,8 +122,8 @@ def process_image_region(
     region: options.SpatialRegion | None,
     transform: somacore.CoordinateTransform,
     channel_coords: options.DenseCoord,
-    data_order: Tuple[int, ...],
-) -> Tuple[
+    data_order: tuple[int, ...],
+) -> tuple[
     options.DenseNDCoords, options.SpatialRegion | None, somacore.CoordinateTransform
 ]:
 
@@ -182,11 +182,11 @@ def process_spatial_df_region(
     region: options.SpatialRegion | None,
     transform: somacore.CoordinateTransform,
     coords_by_name: Dict[str, options.SparseDFCoord],
-    index_columns: Tuple[str, ...],
-    axis_names: Tuple[str, ...],
+    index_columns: tuple[str, ...],
+    axis_names: tuple[str, ...],
     schema: pa.Schema,
     spatial_column: str | None = None,
-) -> Tuple[
+) -> tuple[
     options.SparseDFCoords,
     options.SpatialRegion | None,
     somacore.CoordinateTransform,

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Type
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
@@ -52,7 +52,7 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
             "convert JSON to CoordinateTransform child class"
         )
 
-    coord_transform_init: dict[str, Type[somacore.CoordinateTransform]] = {
+    coord_transform_init: dict[str, type[somacore.CoordinateTransform]] = {
         "AffineTransform": somacore.AffineTransform,
         "ScaleTransform": somacore.ScaleTransform,
         "UniformScaleTransform": somacore.UniformScaleTransform,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -480,22 +480,20 @@ class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
         """Only implemented for DataFrame."""
         raise NotImplementedError
 
-    def resize(self, newshape: Sequence[Union[int, None]]) -> None:
+    def resize(self, newshape: Sequence[int | None]) -> None:
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
-    def tiledbsoma_can_resize(
-        self, newshape: Sequence[Union[int, None]]
-    ) -> StatusAndReason:
+    def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
-    def tiledbsoma_upgrade_shape(self, newshape: Sequence[Union[int, None]]) -> None:
+    def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
         """Not implemented for DataFrame."""
         raise NotImplementedError
 
     def tiledbsoma_can_upgrade_shape(
-        self, newshape: Sequence[Union[int, None]]
+        self, newshape: Sequence[int | None]
     ) -> StatusAndReason:
         """Not implemented for DataFrame."""
         raise NotImplementedError
@@ -685,22 +683,20 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
         """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
-    def resize(self, newshape: Sequence[Union[int, None]]) -> None:
+    def resize(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals"""
         self._handle.resize(newshape)
 
-    def tiledbsoma_can_resize(
-        self, newshape: Sequence[Union[int, None]]
-    ) -> StatusAndReason:
+    def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
 
-    def tiledbsoma_upgrade_shape(self, newshape: Sequence[Union[int, None]]) -> None:
+    def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals"""
         self._handle.tiledbsoma_upgrade_shape(newshape)
 
     def tiledbsoma_can_upgrade_shape(
-        self, newshape: Sequence[Union[int, None]]
+        self, newshape: Sequence[int | None]
     ) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(
@@ -722,22 +718,20 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
         """Wrapper-class internals"""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
-    def resize(self, newshape: Sequence[Union[int, None]]) -> None:
+    def resize(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals"""
         self._handle.resize(newshape)
 
-    def tiledbsoma_can_resize(
-        self, newshape: Sequence[Union[int, None]]
-    ) -> StatusAndReason:
+    def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(StatusAndReason, self._handle.can_resize(newshape))
 
-    def tiledbsoma_upgrade_shape(self, newshape: Sequence[Union[int, None]]) -> None:
+    def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals"""
         self._handle.tiledbsoma_upgrade_shape(newshape)
 
     def tiledbsoma_can_upgrade_shape(
-        self, newshape: Sequence[Union[int, None]]
+        self, newshape: Sequence[int | None]
     ) -> StatusAndReason:
         """Wrapper-class internals"""
         return cast(

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -16,7 +16,6 @@ from typing import (
     Dict,
     Generic,
     Iterator,
-    List,
     Mapping,
     MutableMapping,
     Sequence,
@@ -37,7 +36,7 @@ from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import SOMATileDBContext
 
-AxisDomain = Union[None, tuple[Any, Any], List[Any]]
+AxisDomain = Union[None, tuple[Any, Any], list[Any]]
 Domain = Sequence[AxisDomain]
 
 RawHandle = Union[

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -18,7 +18,6 @@ from typing import (
     Mapping,
     MutableMapping,
     Sequence,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -275,7 +274,7 @@ AnyWrapper = Wrapper[RawHandle]
 @attrs.define(frozen=True)
 class GroupEntry:
     uri: str
-    wrapper_type: Type[AnyWrapper]
+    wrapper_type: type[AnyWrapper]
 
     @classmethod
     def from_soma_group_entry(cls, obj: tuple[str, str]) -> "GroupEntry":
@@ -290,7 +289,7 @@ class GroupEntry:
 class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
     """Base class for Pybind11 SOMAGroupWrapper handles."""
 
-    _WRAPPED_TYPE: Type[_SOMAObjectType]
+    _WRAPPED_TYPE: type[_SOMAObjectType]
 
     clib_type = "SOMAGroup"
 
@@ -359,7 +358,7 @@ class SceneWrapper(SOMAGroupWrapper[clib.SOMAScene]):
 class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
     """Base class for Pybind11 SOMAArrayWrapper handles."""
 
-    _WRAPPED_TYPE: Type[_SOMAObjectType]
+    _WRAPPED_TYPE: type[_SOMAObjectType]
 
     clib_type = "SOMAArray"
 

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -20,7 +20,6 @@ from typing import (
     Mapping,
     MutableMapping,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -38,7 +37,7 @@ from ._exception import DoesNotExistError, SOMAError, is_does_not_exist_error
 from ._types import METADATA_TYPES, Metadatum, OpenTimestamp, StatusAndReason
 from .options._soma_tiledb_context import SOMATileDBContext
 
-AxisDomain = Union[None, Tuple[Any, Any], List[Any]]
+AxisDomain = Union[None, tuple[Any, Any], List[Any]]
 Domain = Sequence[AxisDomain]
 
 RawHandle = Union[
@@ -281,7 +280,7 @@ class GroupEntry:
     wrapper_type: Type[AnyWrapper]
 
     @classmethod
-    def from_soma_group_entry(cls, obj: Tuple[str, str]) -> "GroupEntry":
+    def from_soma_group_entry(cls, obj: tuple[str, str]) -> "GroupEntry":
         uri, type = obj[0], obj[1]
         if type == "SOMAArray":
             return GroupEntry(uri, SOMAArrayWrapper)
@@ -325,8 +324,8 @@ class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
     def meta(self) -> "MetadataWrapper":
         return self.metadata
 
-    def members(self) -> Dict[str, Tuple[str, str]]:
-        return cast(Dict[str, Tuple[str, str]], self._handle.members())
+    def members(self) -> Dict[str, tuple[str, str]]:
+        return cast(Dict[str, tuple[str, str]], self._handle.members())
 
 
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
@@ -414,41 +413,41 @@ class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
         return len(self._handle.dimension_names)
 
     @property
-    def domain(self) -> Tuple[Tuple[object, object], ...]:
+    def domain(self) -> tuple[tuple[object, object], ...]:
         from ._util import _cast_domainish
 
         return _cast_domainish(self._handle.domain())
 
     @property
-    def maxdomain(self) -> Tuple[Tuple[object, object], ...]:
+    def maxdomain(self) -> tuple[tuple[object, object], ...]:
         from ._util import _cast_domainish
 
         return _cast_domainish(self._handle.maxdomain())
 
-    def non_empty_domain(self) -> Tuple[Tuple[object, object], ...]:
+    def non_empty_domain(self) -> tuple[tuple[object, object], ...]:
         from ._util import _cast_domainish
 
         return _cast_domainish(self._handle.non_empty_domain())
 
     @property
-    def attr_names(self) -> Tuple[str, ...]:
+    def attr_names(self) -> tuple[str, ...]:
         return tuple(
             f.name for f in self.schema if f.name not in self._handle.dimension_names
         )
 
     @property
-    def dim_names(self) -> Tuple[str, ...]:
+    def dim_names(self) -> tuple[str, ...]:
         return tuple(self._handle.dimension_names)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Not implemented for DataFrame."""
-        return cast(Tuple[int, ...], tuple(self._handle.shape))
+        return cast(tuple[int, ...], tuple(self._handle.shape))
 
     @property
-    def maxshape(self) -> Tuple[int, ...]:
+    def maxshape(self) -> tuple[int, ...]:
         """Not implemented for DataFrame."""
-        return cast(Tuple[int, ...], tuple(self._handle.maxshape))
+        return cast(tuple[int, ...], tuple(self._handle.maxshape))
 
     @property
     def maybe_soma_joinid_shape(self) -> int | None:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -13,7 +13,6 @@ import abc
 import enum
 from typing import (
     Any,
-    Dict,
     Generic,
     Iterator,
     Mapping,
@@ -323,8 +322,8 @@ class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
     def meta(self) -> "MetadataWrapper":
         return self.metadata
 
-    def members(self) -> Dict[str, tuple[str, str]]:
-        return cast(Dict[str, tuple[str, str]], self._handle.members())
+    def members(self) -> dict[str, tuple[str, str]]:
+        return cast(dict[str, tuple[str, str]], self._handle.members())
 
 
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
@@ -799,8 +798,8 @@ class MetadataWrapper(MutableMapping[str, Any]):
     """
 
     owner: Wrapper[RawHandle]
-    cache: Dict[str, Any]
-    _mods: Dict[str, "_DictMod"] = attrs.field(init=False, factory=dict)
+    cache: dict[str, Any]
+    _mods: dict[str, "_DictMod"] = attrs.field(init=False, factory=dict)
     """Tracks the modifications we have made to cache entries."""
 
     def __len__(self) -> int:

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
-from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union, get_args
+from typing import TYPE_CHECKING, Any, List, Sequence, Union, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -51,7 +51,7 @@ Ids = Union[List[str], List[bytes], List[int]]
 
 Labels = Union[Sequence[str], PDIndex]
 
-NTuple = Tuple[int, ...]
+NTuple = tuple[int, ...]
 
 IngestMode = Literal["write", "schema_only", "resume"]  # for static-analysis checks
 INGEST_MODES = get_args(IngestMode)  # for run-time checks
@@ -84,6 +84,6 @@ is_slice_of = types.is_slice_of
 Metadatum = Union[bytes, float, int, str]
 METADATA_TYPES = (bytes, float, int, str)
 
-StatusAndReason = Tuple[bool, str]
+StatusAndReason = tuple[bool, str]
 """Information for whether an upgrade-shape or resize would succeed
 if attempted, along with a reason why not."""

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
-from typing import TYPE_CHECKING, Any, List, Sequence, Union, get_args
+from typing import TYPE_CHECKING, Any, Sequence, Union, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -47,7 +47,7 @@ else:
 
 Path = Union[str, pathlib.Path]
 
-Ids = Union[List[str], List[bytes], List[int]]
+Ids = Union[list[str], list[bytes], list[int]]
 
 Labels = Union[Sequence[str], PDIndex]
 

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -16,7 +16,6 @@ from typing import (
     Any,
     Mapping,
     Sequence,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -243,7 +242,7 @@ def dense_index_to_shape(coord: options.DenseCoord, array_length: int) -> int:
 def check_type(
     name: str,
     actual_value: Any,
-    expected_types: tuple[Type[Any], ...],
+    expected_types: tuple[type[Any], ...],
 ) -> None:
     """Verifies the type of an argument, or produces a useful error message."""
     if not isinstance(actual_value, expected_types):

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -18,7 +18,6 @@ from typing import (
     List,
     Mapping,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -162,8 +161,8 @@ class NonNumericDimensionError(TypeError):
 
 
 def slice_to_numeric_range(
-    slc: Slice[Any], domain: Tuple[_T, _T]
-) -> Tuple[_T, _T] | None:
+    slc: Slice[Any], domain: tuple[_T, _T]
+) -> tuple[_T, _T] | None:
     """Constrains the given slice to the ``domain`` for numeric dimensions.
 
     We assume the slice has already been validated by validate_slice.
@@ -196,9 +195,9 @@ def slice_to_numeric_range(
 
 def dense_indices_to_shape(
     coords: options.DenseNDCoords,
-    array_shape: Tuple[int, ...],
+    array_shape: tuple[int, ...],
     result_order: somacore.ResultOrder,
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     """Given a subarray index specified as a tuple of per-dimension slices or scalars
     (e.g., ``([:], 1, [1:2])``), and the shape of the array, return the shape of
     the subarray. Note that the number of coordinates may be less than or equal
@@ -246,7 +245,7 @@ def dense_index_to_shape(coord: options.DenseCoord, array_length: int) -> int:
 def check_type(
     name: str,
     actual_value: Any,
-    expected_types: Tuple[Type[Any], ...],
+    expected_types: tuple[Type[Any], ...],
 ) -> None:
     """Verifies the type of an argument, or produces a useful error message."""
     if not isinstance(actual_value, expected_types):
@@ -371,7 +370,7 @@ def _build_column_config(col: Mapping[str, _ColumnConfig] | None) -> str:
 
 
 def _build_filter_list(
-    filters: Tuple[_DictFilterSpec, ...] | None, return_json: bool = True
+    filters: tuple[_DictFilterSpec, ...] | None, return_json: bool = True
 ) -> _JSONFilterList:
     _convert_filter = {
         "GzipFilter": "GZIP",
@@ -446,7 +445,7 @@ def _build_filter_list(
     return json.dumps(filter_list) if return_json else filter_list
 
 
-def _cast_domainish(domainish: List[Any]) -> Tuple[Tuple[object, object], ...]:
+def _cast_domainish(domainish: List[Any]) -> tuple[tuple[object, object], ...]:
     result = []
     for slot in domainish:
         arrow_type = slot[0].type
@@ -509,7 +508,7 @@ def _set_coord(
             _set_geometry_coord(
                 mq,
                 dim,
-                cast(Tuple[Mapping[str, float], Mapping[str, float]], dom),
+                cast(tuple[Mapping[str, float], Mapping[str, float]], dom),
                 coord,
                 axis_names,
             )
@@ -580,7 +579,7 @@ def _set_coord(
 def _set_geometry_coord(
     mq: ManagedQuery,
     dim: pa.Field,
-    dom: Tuple[Mapping[str, float], Mapping[str, float]],
+    dom: tuple[Mapping[str, float], Mapping[str, float]],
     coord: object,
     axis_names: Sequence[str],
 ) -> None:
@@ -656,7 +655,7 @@ def _set_coord_by_py_seq_or_np_array(
 
 
 def _set_coord_by_numeric_slice(
-    mq: ManagedQuery, dim: pa.Field, dom: Tuple[object, object], coord: Slice[Any]
+    mq: ManagedQuery, dim: pa.Field, dom: tuple[object, object], coord: Slice[Any]
 ) -> None:
     try:
         lo_hi = slice_to_numeric_range(coord, dom)

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -14,7 +14,6 @@ from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Mapping,
     Sequence,
     Type,
@@ -39,7 +38,7 @@ from .options._tiledb_create_write_options import (
 if TYPE_CHECKING:
     from ._read_iters import ManagedQuery
 
-_JSONFilter = Union[str, Dict[str, Union[str, Union[int, float]]]]
+_JSONFilter = Union[str, dict[str, Union[str, Union[int, float]]]]
 _JSONFilterList = Union[str, list[_JSONFilter]]
 
 
@@ -352,13 +351,13 @@ def build_clib_platform_config(
 
 
 def _build_column_config(col: Mapping[str, _ColumnConfig] | None) -> str:
-    column_config: Dict[str, Dict[str, _JSONFilterList | int]] = dict()
+    column_config: dict[str, dict[str, _JSONFilterList | int]] = dict()
 
     if col is None:
         return ""
 
     for k in col:
-        dikt: Dict[str, _JSONFilterList | int] = {}
+        dikt: dict[str, _JSONFilterList | int] = {}
         if col[k].filters is not None:
             dikt["filters"] = _build_filter_list(col[k].filters, False)
         if col[k].tile is not None:
@@ -674,7 +673,7 @@ def _set_coord_by_numeric_slice(
         return
 
 
-def _resolve_futures(unresolved: Dict[str, Any], deep: bool = False) -> Dict[str, Any]:
+def _resolve_futures(unresolved: dict[str, Any], deep: bool = False) -> dict[str, Any]:
     """Resolves any futures found in the dict."""
     resolved = {}
     for k, v in unresolved.items():

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -15,7 +15,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    List,
     Mapping,
     Sequence,
     Type,
@@ -41,7 +40,7 @@ if TYPE_CHECKING:
     from ._read_iters import ManagedQuery
 
 _JSONFilter = Union[str, Dict[str, Union[str, Union[int, float]]]]
-_JSONFilterList = Union[str, List[_JSONFilter]]
+_JSONFilterList = Union[str, list[_JSONFilter]]
 
 
 def get_start_stamp() -> float:
@@ -426,7 +425,7 @@ def _build_filter_list(
         return ""
 
     filter: _JSONFilter
-    filter_list: List[_JSONFilter] = []
+    filter_list: list[_JSONFilter] = []
 
     for info in filters:
         if len(info) == 1:
@@ -445,7 +444,7 @@ def _build_filter_list(
     return json.dumps(filter_list) if return_json else filter_list
 
 
-def _cast_domainish(domainish: List[Any]) -> tuple[tuple[object, object], ...]:
+def _cast_domainish(domainish: list[Any]) -> tuple[tuple[object, object], ...]:
     result = []
     for slot in domainish:
         arrow_type = slot[0].type

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -354,13 +354,13 @@ def build_clib_platform_config(
 
 
 def _build_column_config(col: Mapping[str, _ColumnConfig] | None) -> str:
-    column_config: Dict[str, Dict[str, Union[_JSONFilterList, int]]] = dict()
+    column_config: Dict[str, Dict[str, _JSONFilterList | int]] = dict()
 
     if col is None:
         return ""
 
     for k in col:
-        dikt: Dict[str, Union[_JSONFilterList, int]] = {}
+        dikt: Dict[str, _JSONFilterList | int] = {}
         if col[k].filters is not None:
             dikt["filters"] = _build_filter_list(col[k].filters, False)
         if col[k].tile is not None:

--- a/apis/python/src/tiledbsoma/eta.py
+++ b/apis/python/src/tiledbsoma/eta.py
@@ -2,7 +2,6 @@
 #
 # Licensed under the MIT License.
 
-from typing import List
 
 import numpy as np
 
@@ -10,8 +9,8 @@ import numpy as np
 class Tracker:
     """Computes estimated time to completion for chunked writes."""
 
-    chunk_percents: List[float]
-    cumulative_seconds: List[float]
+    chunk_percents: list[float]
+    cumulative_seconds: list[float]
 
     def __init__(self) -> None:
         self.chunk_percents = []

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Union
+from typing import Mapping, Union
 
 import h5py
 import numpy as np
@@ -34,10 +34,10 @@ UnsNode = Union[UnsLeaf, Mapping[str, "UnsNode"]]
 UnsMapping = Mapping[str, UnsNode]
 # Specialize `UnsNode` to `Dict` instead of `Mapping`
 # `Mapping` doesn't expose `__set__`, so this is useful for building `uns` dictionaries.
-UnsDictNode = Union[UnsLeaf, Dict[str, "UnsDictNode"]]
-UnsDict = Dict[str, UnsDictNode]
+UnsDictNode = Union[UnsLeaf, dict[str, "UnsDictNode"]]
+UnsDict = dict[str, UnsDictNode]
 
-AdditionalMetadata = Union[Dict[str, Metadatum], None]
+AdditionalMetadata = Union[dict[str, Metadatum], None]
 
 # Arrays of strings from AnnData's uns are stored in SOMA as SOMADataFrame,
 # since SOMA ND arrays are necessarily arrays *of numbers*. This is okay since

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Union
+from typing import Dict, Mapping, Union
 
 import h5py
 import numpy as np
@@ -29,7 +29,7 @@ Matrix = Union[DenseMatrix, SparseMatrix]
 
 UnsScalar = Union[str, int, float, np.generic]
 # TODO: support sparse matrices in `uns`
-UnsLeaf = Union[UnsScalar, List[UnsScalar], pd.DataFrame, NPNDArray]
+UnsLeaf = Union[UnsScalar, list[UnsScalar], pd.DataFrame, NPNDArray]
 UnsNode = Union[UnsLeaf, Mapping[str, "UnsNode"]]
 UnsMapping = Mapping[str, UnsNode]
 # Specialize `UnsNode` to `Dict` instead of `Mapping`

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -7,11 +7,7 @@ from __future__ import annotations
 import pathlib
 import sys
 from contextlib import contextmanager
-from typing import (
-    ContextManager,
-    Iterator,
-    Union,
-)
+from typing import ContextManager, Iterator
 from unittest import mock
 
 import anndata as ad
@@ -114,7 +110,7 @@ def _hack_patch_anndata() -> ContextManager[object]:
     @file_backing.AnnDataFileManager.filename.setter  # type: ignore[misc]
     def filename(
         self: file_backing.AnnDataFileManager,
-        filename: Union[Path, _FSPathWrapper, None],
+        filename: Path | _FSPathWrapper | None,
     ) -> None:
         self._filename = filename
 

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, TypeVar, Union, cast
+from typing import TypeVar, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -41,7 +41,7 @@ See also https://github.com/single-cell-data/TileDB-SOMA/pull/3415.
 OriginalIndexMetadata = Union[None, str]
 
 
-def _string_dict_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]:
+def _string_dict_from_arrow_schema(schema: pa.Schema) -> dict[str, str]:
     """Converts an Arrow schema to a string/string dict.
 
     This is easier on the eyes, easier to convert from/to JSON for distributed logging,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -22,7 +22,6 @@ from functools import partial
 from itertools import repeat
 from typing import (
     Any,
-    Dict,
     Iterable,
     Literal,
     Mapping,
@@ -2994,7 +2993,7 @@ def _ingest_uns_2d_string_array(
     this ``uns`` data is solely of interest for AnnData ingest/outgest, and it must go
     back out the way it came in."""
     num_rows, num_cols = value.shape
-    data: Dict[str, Any] = {"soma_joinid": np.arange(num_rows, dtype=np.int64)}
+    data: dict[str, Any] = {"soma_joinid": np.arange(num_rows, dtype=np.int64)}
     # An array like [["a", "b", "c"], ["d", "e", "f"]] becomes a DataFrame like
     # soma_joinid values_0 values_1 values_2
     # 0           a        b        c

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -28,7 +28,6 @@ from typing import (
     Literal,
     Mapping,
     Sequence,
-    Tuple,
     Type,
     TypedDict,
     TypeVar,
@@ -2659,8 +2658,8 @@ def _write_matrix_to_sparseNDArray(
 
 
 def _chunk_is_contained_in(
-    chunk_bounds: Sequence[Tuple[int, int]],
-    storage_nonempty_domain: Sequence[Tuple[int | None, int | None]],
+    chunk_bounds: Sequence[tuple[int, int]],
+    storage_nonempty_domain: Sequence[tuple[int | None, int | None]],
 ) -> bool:
     """
     Determines if a dim range is included within the array's non-empty domain.  Ranges are inclusive
@@ -2692,8 +2691,8 @@ def _chunk_is_contained_in(
 
 
 def _chunk_is_contained_in_axis(
-    chunk_bounds: Sequence[Tuple[int, int]],
-    storage_nonempty_domain: Sequence[Tuple[int | None, int | None]],
+    chunk_bounds: Sequence[tuple[int, int]],
+    storage_nonempty_domain: Sequence[tuple[int | None, int | None]],
     stride_axis: int,
 ) -> bool:
     """Helper function for ``_chunk_is_contained_in``."""

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -24,7 +24,6 @@ from typing import (
     Any,
     Dict,
     Iterable,
-    List,
     Literal,
     Mapping,
     Sequence,
@@ -2237,7 +2236,7 @@ def _find_sparse_chunk_size_non_backed(
     """
     chunk_size = 0
     sum_nnz = 0
-    coords: List[slice | int] = [slice(None), slice(None)]
+    coords: list[slice | int] = [slice(None), slice(None)]
     for index in range(start_index, matrix.shape[axis]):
         coords[axis] = index
         candidate_sum_nnz = sum_nnz + matrix[tuple(coords)].nnz
@@ -2268,7 +2267,7 @@ def _find_mean_nnz(matrix: Matrix, axis: int) -> int:
     #   total_nnz = matrix[:, :].nnz
     # So instead we break it up. Testing over a variety of H5AD sizes
     # shows that the performance is fine here.
-    coords: List[slice] = [slice(None), slice(None)]  # type: ignore[unreachable]
+    coords: list[slice] = [slice(None), slice(None)]  # type: ignore[unreachable]
     bsz = 1000
     total_nnz = 0
     for lo in range(0, extent, bsz):
@@ -2376,7 +2375,7 @@ def _find_sparse_chunk_size_backed(
 
     # This is just matrix[0:m, :] or matrix[:, 0:m], but spelt out flexibly
     # given that the axis (0 or 1) is a variable.
-    coords: List[slice] = [slice(None), slice(None)]
+    coords: list[slice] = [slice(None), slice(None)]
     coords[axis] = slice(start_index, start_index + chunk_size)
     chunk_nnz = int(matrix[tuple(coords)].nnz)
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -26,7 +26,6 @@ from typing import (
     Literal,
     Mapping,
     Sequence,
-    Type,
     TypedDict,
     TypeVar,
     cast,
@@ -307,7 +306,7 @@ def from_h5ad(
     raw_X_layer_name: str = "data",
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
-    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
+    X_kind: type[SparseNDArray] | type[DenseNDArray] = SparseNDArray,
     registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
@@ -484,7 +483,7 @@ def from_anndata(
     raw_X_layer_name: str = "data",
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
-    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
+    X_kind: type[SparseNDArray] | type[DenseNDArray] = SparseNDArray,
     registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
@@ -950,7 +949,7 @@ def append_X(
     var_ids: Sequence[str],
     *,
     registration_mapping: ExperimentAmbientLabelMapping,
-    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
+    X_kind: type[SparseNDArray] | type[DenseNDArray] = SparseNDArray,
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> str:
@@ -1040,7 +1039,7 @@ def _maybe_set(
 
 @overload
 def _create_or_open_collection(
-    cls: Type[Experiment],
+    cls: type[Experiment],
     uri: str,
     *,
     ingestion_params: IngestionParams,
@@ -1051,7 +1050,7 @@ def _create_or_open_collection(
 
 @overload
 def _create_or_open_collection(
-    cls: Type[Measurement],
+    cls: type[Measurement],
     uri: str,
     *,
     ingestion_params: IngestionParams,
@@ -1062,7 +1061,7 @@ def _create_or_open_collection(
 
 @overload
 def _create_or_open_collection(
-    cls: Type[Collection[_TDBO]],
+    cls: type[Collection[_TDBO]],
     uri: str,
     *,
     ingestion_params: IngestionParams,
@@ -1073,7 +1072,7 @@ def _create_or_open_collection(
 
 @no_type_check
 def _create_or_open_collection(
-    cls: Type[CollectionBase[_TDBO]],
+    cls: type[CollectionBase[_TDBO]],
     uri: str,
     *,
     ingestion_params: IngestionParams,
@@ -1095,7 +1094,7 @@ def _create_or_open_collection(
 # Spellings compatible with 1.2.7:
 @overload
 def _create_or_open_coll(
-    cls: Type[Experiment],
+    cls: type[Experiment],
     uri: str,
     *,
     ingest_mode: IngestMode,
@@ -1105,7 +1104,7 @@ def _create_or_open_coll(
 
 @overload
 def _create_or_open_coll(
-    cls: Type[Measurement],
+    cls: type[Measurement],
     uri: str,
     *,
     ingest_mode: IngestMode,
@@ -1115,7 +1114,7 @@ def _create_or_open_coll(
 
 @overload
 def _create_or_open_coll(
-    cls: Type[Collection[_TDBO]],
+    cls: type[Collection[_TDBO]],
     uri: str,
     *,
     ingest_mode: IngestMode,
@@ -1124,7 +1123,7 @@ def _create_or_open_coll(
 
 
 def _create_or_open_coll(
-    cls: Type[Any],
+    cls: type[Any],
     uri: str,
     *,
     ingest_mode: IngestMode,
@@ -1495,7 +1494,7 @@ def _write_dataframe_impl(
 
 
 def create_from_matrix(
-    cls: Type[_NDArr],
+    cls: type[_NDArr],
     uri: str,
     matrix: Matrix | h5py.Dataset,
     platform_config: PlatformConfig | None = None,
@@ -1521,7 +1520,7 @@ def create_from_matrix(
 
 
 def _create_from_matrix(
-    cls: Type[_NDArr],
+    cls: type[_NDArr],
     uri: str,
     matrix: Matrix | h5py.Dataset,
     *,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -32,7 +32,6 @@ from typing import (
     Type,
     TypedDict,
     TypeVar,
-    Union,
     cast,
     no_type_check,
     overload,
@@ -311,7 +310,7 @@ def from_h5ad(
     raw_X_layer_name: str = "data",
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
-    X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
+    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
     registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
@@ -488,7 +487,7 @@ def from_anndata(
     raw_X_layer_name: str = "data",
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
-    X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
+    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
     registration_mapping: ExperimentAmbientLabelMapping | None = None,
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
@@ -947,14 +946,14 @@ def append_var(
 
 def append_X(
     exp: Experiment,
-    new_X: Union[Matrix, h5py.Dataset],
+    new_X: Matrix | h5py.Dataset,
     measurement_name: str,
     X_layer_name: str,
     obs_ids: Sequence[str],
     var_ids: Sequence[str],
     *,
     registration_mapping: ExperimentAmbientLabelMapping,
-    X_kind: Union[Type[SparseNDArray], Type[DenseNDArray]] = SparseNDArray,
+    X_kind: Type[SparseNDArray] | Type[DenseNDArray] = SparseNDArray,
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> str:
@@ -1309,7 +1308,7 @@ def _extract_new_values_for_append(
 
 def _write_arrow_table(
     arrow_table: pa.Table,
-    handle: Union[DataFrame, SparseNDArray, PointCloudDataFrame],
+    handle: DataFrame | SparseNDArray | PointCloudDataFrame,
     tiledb_create_options: TileDBCreateOptions,
     tiledb_write_options: TileDBWriteOptions,
 ) -> None:
@@ -1501,7 +1500,7 @@ def _write_dataframe_impl(
 def create_from_matrix(
     cls: Type[_NDArr],
     uri: str,
-    matrix: Union[Matrix, h5py.Dataset],
+    matrix: Matrix | h5py.Dataset,
     platform_config: PlatformConfig | None = None,
     ingest_mode: IngestMode = "write",
     context: SOMATileDBContext | None = None,
@@ -1527,7 +1526,7 @@ def create_from_matrix(
 def _create_from_matrix(
     cls: Type[_NDArr],
     uri: str,
-    matrix: Union[Matrix, h5py.Dataset],
+    matrix: Matrix | h5py.Dataset,
     *,
     ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata = None,
@@ -1555,7 +1554,7 @@ def _create_from_matrix(
         )
     else:
         try:
-            shape: Sequence[Union[int, None]] = ()
+            shape: Sequence[int | None] = ()
             # A SparseNDArray must be appendable in soma.io.
 
             # Instead of
@@ -1839,8 +1838,8 @@ def _update_dataframe(
 
 
 def update_matrix(
-    soma_ndarray: Union[SparseNDArray, DenseNDArray],
-    new_data: Union[Matrix, h5py.Dataset],
+    soma_ndarray: SparseNDArray | DenseNDArray,
+    new_data: Matrix | h5py.Dataset,
     *,
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
@@ -1939,7 +1938,7 @@ def add_X_layer(
     measurement_name: str,
     X_layer_name: str,
     # E.g. a scipy.csr_matrix from scanpy analysis:
-    X_layer_data: Union[Matrix, h5py.Dataset],
+    X_layer_data: Matrix | h5py.Dataset,
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
     context: SOMATileDBContext | None = None,
@@ -1972,7 +1971,7 @@ def add_matrix_to_collection(
     collection_name: str,
     matrix_name: str,
     # E.g. a scipy.csr_matrix from scanpy analysis:
-    matrix_data: Union[Matrix, h5py.Dataset],
+    matrix_data: Matrix | h5py.Dataset,
     ingest_mode: IngestMode = "write",
     use_relative_uri: bool | None = None,
     context: SOMATileDBContext | None = None,
@@ -2033,7 +2032,7 @@ def add_matrix_to_collection(
 
 def _write_matrix_to_denseNDArray(
     soma_ndarray: DenseNDArray,
-    matrix: Union[Matrix, h5py.Dataset],
+    matrix: Matrix | h5py.Dataset,
     tiledb_create_options: TileDBCreateOptions,
     tiledb_write_options: TileDBWriteOptions,
     ingestion_params: IngestionParams,
@@ -2239,7 +2238,7 @@ def _find_sparse_chunk_size_non_backed(
     """
     chunk_size = 0
     sum_nnz = 0
-    coords: List[Union[slice, int]] = [slice(None), slice(None)]
+    coords: List[slice | int] = [slice(None), slice(None)]
     for index in range(start_index, matrix.shape[axis]):
         coords[axis] = index
         candidate_sum_nnz = sum_nnz + matrix[tuple(coords)].nnz

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -468,7 +468,7 @@ def to_anndata(
 
 
 def _extract_obsm_or_varm(
-    soma_nd_array: Union[SparseNDArray, DenseNDArray],
+    soma_nd_array: SparseNDArray | DenseNDArray,
     collection_name: str,
     element_name: str,
     num_rows: int,

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 import io
 import json
 import sys
-from collections.abc import Callable
-from typing import Any, Dict, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, TypeVar, Union, cast
 
 import tiledbsoma
 
@@ -293,7 +292,7 @@ def resize_experiment(
     uri: str,
     *,
     nobs: int,
-    nvars: Dict[str, int],
+    nvars: dict[str, int],
     verbose: bool = False,
     check_only: bool = False,
     context: tiledbsoma.SOMATileDBContext | None = None,
@@ -507,7 +506,7 @@ def _leaf_visitor_show_shapes(
     *,
     node_name: str,
     nobs: int | None,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
     coll_name: str | None,
     verbose: bool,
@@ -644,7 +643,7 @@ def _leaf_visitor_upgrade(
     *,
     node_name: str,
     nobs: int | None,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
     coll_name: str | None,
     verbose: bool,
@@ -773,7 +772,7 @@ def _leaf_visitor_resize(
     *,
     node_name: str,
     nobs: int | None,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
     coll_name: str | None,
     verbose: bool,
@@ -961,7 +960,7 @@ def _print_dry_run_result(
 
 def _get_new_var_shape(
     *,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
 ) -> int:
     """Maps from experiment-level nobs and per-measurement nvar to the correct resizes
@@ -982,12 +981,12 @@ def _get_new_var_shape(
 
 def _get_new_ndarray_shape(
     *,
-    current_shape: Tuple[int, ...],
+    current_shape: tuple[int, ...],
     nobs: int | None,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
     coll_name: str | None,
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     """Maps from experiment-level nobs and per-measurement nvar to the correct resizes
     for various kinds of n-d array within a SOMA Experiment.
     """
@@ -1032,7 +1031,7 @@ def _leaf_visitor_get_shapes(
     *,
     node_name: str,
     nobs: int | None,
-    nvars: Dict[str, int] | None,
+    nvars: dict[str, int] | None,
     ms_name: str | None,
     coll_name: str | None,
     verbose: bool,

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Mapping
 
 import pandas as pd
 import somacore
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
 
 
 def _convert_axis_names(
-    coord_axis_names: Tuple[str, ...],
-    data_axis_names: Tuple[str, ...] | None = None,
-) -> Tuple[Tuple[str, ...], Dict[str, str]]:
+    coord_axis_names: tuple[str, ...],
+    data_axis_names: tuple[str, ...] | None = None,
+) -> tuple[tuple[str, ...], Dict[str, str]]:
     """Convert SOMA axis names to SpatialData axis names.
 
     Args:

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 import pandas as pd
 import somacore
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 def _convert_axis_names(
     coord_axis_names: tuple[str, ...],
     data_axis_names: tuple[str, ...] | None = None,
-) -> tuple[tuple[str, ...], Dict[str, str]]:
+) -> tuple[tuple[str, ...], dict[str, str]]:
     """Convert SOMA axis names to SpatialData axis names.
 
     Args:
@@ -84,8 +84,8 @@ def _get_transform_from_collection(
 
 def _transform_to_spatialdata(
     transform: somacore.CoordinateTransform,
-    input_dim_map: Dict[str, str],
-    output_dim_map: Dict[str, str],
+    input_dim_map: dict[str, str],
+    output_dim_map: dict[str, str],
 ) -> sd.transformations.BaseTransformation:
     """Returns the equivalent SpatialData transform for a SOMA transform.
 
@@ -120,7 +120,7 @@ def to_spatialdata_points(
     *,
     key: str,
     scene_id: str,
-    scene_dim_map: Dict[str, str],
+    scene_dim_map: dict[str, str],
     transform: somacore.CoordinateTransform | None,
     soma_joinid_name: str = SOMA_JOINID,
 ) -> dd.DataFrame:
@@ -165,7 +165,7 @@ def to_spatialdata_shapes(
     *,
     key: str,
     scene_id: str,
-    scene_dim_map: Dict[str, str],
+    scene_dim_map: dict[str, str],
     transform: somacore.CoordinateTransform | None,
     soma_joinid_name: str = SOMA_JOINID,
 ) -> gpd.GeoDataFrame:
@@ -330,7 +330,7 @@ def to_spatialdata_multiscale_image(
     *,
     key: str,
     scene_id: str,
-    scene_dim_map: Dict[str, str],
+    scene_dim_map: dict[str, str],
     transform: somacore.CoordinateTransform | None,
 ) -> "DataTree":
     """Export a MultiscaleImage to a DataTree.

--- a/apis/python/src/tiledbsoma/io/spatial/_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_util.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import h5py
 import numpy as np
@@ -74,7 +74,7 @@ def _version_less_than(version: str, upper_bound: tuple[int, int, int]) -> bool:
 
 
 def _read_visium_software_version(
-    gene_expression_path: Union[str, Path],
+    gene_expression_path: str | Path,
 ) -> tuple[int, int, int]:
     with TenXCountMatrixReader(gene_expression_path) as reader:
         version = reader.software_version

--- a/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Mapping, Sequence, Tuple, Union
+from typing import Any, Mapping, Sequence, Tuple
 
 import dask.array as da
 import numpy as np
@@ -50,7 +50,7 @@ class DenseNDArrayWrapper:
             "soma_data"
         ).type.to_pandas_dtype()
 
-    def __getitem__(self, key: Tuple[Union[slice, int], ...]) -> np.typing.NDArray[Any]:
+    def __getitem__(self, key: Tuple[slice | int, ...]) -> np.typing.NDArray[Any]:
         """Returns a numpy array containing data from a requested tuple."""
 
         # Compute the expected Xarray output shape.

--- a/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Mapping, Sequence, Tuple
+from typing import Any, Mapping, Sequence
 
 import dask.array as da
 import numpy as np
@@ -50,7 +50,7 @@ class DenseNDArrayWrapper:
             "soma_data"
         ).type.to_pandas_dtype()
 
-    def __getitem__(self, key: Tuple[slice | int, ...]) -> np.typing.NDArray[Any]:
+    def __getitem__(self, key: tuple[slice | int, ...]) -> np.typing.NDArray[Any]:
         """Returns a numpy array containing data from a requested tuple."""
 
         # Compute the expected Xarray output shape.
@@ -107,7 +107,7 @@ class DenseNDArrayWrapper:
         """Numpy dtype of the array data."""
         return self._dtype
 
-    def recommend_chunks(self) -> Tuple[int, ...]:
+    def recommend_chunks(self) -> tuple[int, ...]:
         """Returns recommended chunk sizes for chunking this array."""
         dim_info = json.loads(self._array.schema_config_options().dims)
         return tuple(
@@ -116,7 +116,7 @@ class DenseNDArrayWrapper:
         )
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Shape of the wrapped SOMA DenseNDArray."""
         return self._array.shape
 
@@ -124,8 +124,8 @@ class DenseNDArrayWrapper:
 def dense_nd_array_to_data_array(
     uri: str,
     *,
-    dim_names: Tuple[str, ...],
-    chunks: Tuple[int, ...] | None = None,
+    dim_names: tuple[str, ...],
+    chunks: tuple[int, ...] | None = None,
     attrs: Mapping[str, Any] | None = None,
     context: SOMATileDBContext | None = None,
 ) -> xr.DataArray:

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import warnings
 from pathlib import Path
-from typing import Sequence, Type, TypeVar
+from typing import Sequence, TypeVar
 
 import attrs
 import numpy as np
@@ -737,7 +737,7 @@ def _write_arrow_to_dataframe(
 
 
 def _write_X_layer(
-    cls: Type[_NDArr],
+    cls: type[_NDArr],
     uri: str,
     reader: TenXCountMatrixReader,
     axis_0_mapping: AxisIDMapping,

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -9,7 +9,6 @@ from typing import (
     Iterable,
     Mapping,
     Sequence,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -232,7 +231,7 @@ _T = TypeVar("_T")
 
 
 def _dig_platform_config(
-    input: object, typ: Type[_T], full_path: tuple[str, ...]
+    input: object, typ: type[_T], full_path: tuple[str, ...]
 ) -> dict[str, object] | _T:
     """Looks for an object of the given type in dictionaries.
 

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -10,7 +10,6 @@ from typing import (
     Iterable,
     Mapping,
     Sequence,
-    Tuple,
     Type,
     TypedDict,
     TypeVar,
@@ -56,7 +55,7 @@ class _DictColumnSpec(TypedDict, total=False):
 
 # These functions have to appear first because they're used in the definition
 # of TileDBCreateOptions.
-def _normalize_filters(inputs: Iterable[_FilterSpec]) -> Tuple[_DictFilterSpec, ...]:
+def _normalize_filters(inputs: Iterable[_FilterSpec]) -> tuple[_DictFilterSpec, ...]:
     if isinstance(inputs, str):
         raise TypeError(
             "filters must be a list of strings (or dicts), not a single string"
@@ -72,13 +71,13 @@ def _normalize_filters(inputs: Iterable[_FilterSpec]) -> Tuple[_DictFilterSpec, 
 # like converters.optional(inner_converter).
 def _normalize_filters_optional(
     inputs: Iterable[_FilterSpec] | None,
-) -> Tuple[_DictFilterSpec, ...] | None:
+) -> tuple[_DictFilterSpec, ...] | None:
     return None if inputs is None else _normalize_filters(inputs)
 
 
 @attrs_.define(frozen=True, slots=True)
 class _ColumnConfig:
-    filters: Tuple[_DictFilterSpec, ...] | None = attrs_.field(
+    filters: tuple[_DictFilterSpec, ...] | None = attrs_.field(
         converter=_normalize_filters_optional
     )
     tile: int | None = attrs_.field(validator=vld.optional(vld.instance_of(int)))
@@ -129,7 +128,7 @@ class TileDBCreateOptions:
         validator=vld.instance_of(int), default=2_400_000_000
     )
     capacity: int = attrs_.field(validator=vld.instance_of(int), default=100_000)
-    offsets_filters: Tuple[_DictFilterSpec, ...] = attrs_.field(
+    offsets_filters: tuple[_DictFilterSpec, ...] = attrs_.field(
         converter=_normalize_filters,
         default=(
             "DoubleDeltaFilter",
@@ -137,7 +136,7 @@ class TileDBCreateOptions:
             "ZstdFilter",
         ),
     )
-    validity_filters: Tuple[_DictFilterSpec, ...] | None = attrs_.field(
+    validity_filters: tuple[_DictFilterSpec, ...] | None = attrs_.field(
         converter=_normalize_filters_optional, default=None
     )
     allows_duplicates: bool = attrs_.field(
@@ -172,7 +171,7 @@ class TileDBCreateOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "create"))
         if isinstance(create_entry, dict):
-            attrs: Tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
+            attrs: tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filtered_create_entry: Dict[str, Any] = {
@@ -181,7 +180,7 @@ class TileDBCreateOptions:
             return cls(**filtered_create_entry)
         return create_entry
 
-    def cell_tile_orders(self) -> Tuple[str | None, str | None]:
+    def cell_tile_orders(self) -> tuple[str | None, str | None]:
         """Returns the cell and tile orders that should be used.
 
         If *neither* ``cell_order`` nor ``tile_order`` is present, only in this
@@ -224,7 +223,7 @@ class TileDBWriteOptions:
         """
         create_entry = _dig_platform_config(platform_config, cls, ("tiledb", "write"))
         if isinstance(create_entry, dict):
-            attrs: Tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
+            attrs: tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
             filered_create_entry: Dict[str, Any] = {
@@ -238,7 +237,7 @@ _T = TypeVar("_T")
 
 
 def _dig_platform_config(
-    input: object, typ: Type[_T], full_path: Tuple[str, ...]
+    input: object, typ: Type[_T], full_path: tuple[str, ...]
 ) -> Union[Dict[str, object], _T]:
     """Looks for an object of the given type in dictionaries.
 

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import (
     Any,
-    Dict,
     Iterable,
     Mapping,
     Sequence,
@@ -172,7 +171,7 @@ class TileDBCreateOptions:
             attrs: tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
-            filtered_create_entry: Dict[str, Any] = {
+            filtered_create_entry: dict[str, Any] = {
                 key: value for (key, value) in create_entry.items() if key in attr_names
             }
             return cls(**filtered_create_entry)
@@ -222,7 +221,7 @@ class TileDBWriteOptions:
             attrs: tuple[attrs_.Attribute, ...] = cls.__attrs_attrs__  # type: ignore[type-arg]
             attr_names = frozenset(a.name for a in attrs)
             # Explicitly opt out of type-checking for these kwargs.
-            filered_create_entry: Dict[str, Any] = {
+            filered_create_entry: dict[str, Any] = {
                 key: value for (key, value) in create_entry.items() if key in attr_names
             }
             return cls(**filered_create_entry)
@@ -234,7 +233,7 @@ _T = TypeVar("_T")
 
 def _dig_platform_config(
     input: object, typ: Type[_T], full_path: tuple[str, ...]
-) -> Dict[str, object] | _T:
+) -> dict[str, object] | _T:
     """Looks for an object of the given type in dictionaries.
 
     This is used to extract a valid object out of ``platform_config``. If an

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -49,7 +49,7 @@ _FilterSpec = Union[str, _DictFilterSpec]
 class _DictColumnSpec(TypedDict, total=False):
     """Type specification for the dictionary used to configure a column."""
 
-    filters: Union[Sequence[str], Mapping[str, Union[_FilterSpec]]]
+    filters: Sequence[str] | Mapping[str, _FilterSpec]
     tile: int
 
 
@@ -159,9 +159,7 @@ class TileDBCreateOptions:
     @classmethod
     def from_platform_config(
         cls,
-        platform_config: Union[
-            options.PlatformConfig, "TileDBCreateOptions", None
-        ] = None,
+        platform_config: options.PlatformConfig | "TileDBCreateOptions" | None = None,
     ) -> Self:
         """Creates the object from a value passed in ``platform_config``.
 
@@ -211,9 +209,7 @@ class TileDBWriteOptions:
     @classmethod
     def from_platform_config(
         cls,
-        platform_config: Union[
-            options.PlatformConfig, "TileDBWriteOptions", None
-        ] = None,
+        platform_config: options.PlatformConfig | "TileDBWriteOptions" | None = None,
     ) -> Self:
         """Creates the object from a value passed in ``platform_config``.
 
@@ -238,7 +234,7 @@ _T = TypeVar("_T")
 
 def _dig_platform_config(
     input: object, typ: Type[_T], full_path: tuple[str, ...]
-) -> Union[Dict[str, object], _T]:
+) -> Dict[str, object] | _T:
     """Looks for an object of the given type in dictionaries.
 
     This is used to extract a valid object out of ``platform_config``. If an

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License.
 
 import json
-from typing import Dict, List, Literal, Union, cast
+from typing import Dict, Literal, Union, cast
 
 from .pytiledbsoma import tiledbsoma_stats_string
 
-ParsedStats = List[Dict[Literal["counters", "timers"], Dict[str, Union[float, int]]]]
+ParsedStats = list[Dict[Literal["counters", "timers"], Dict[str, Union[float, int]]]]
 
 
 def tiledbsoma_stats_json() -> str:

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License.
 
 import json
-from typing import Dict, Literal, Union, cast
+from typing import Literal, Union, cast
 
 from .pytiledbsoma import tiledbsoma_stats_string
 
-ParsedStats = list[Dict[Literal["counters", "timers"], Dict[str, Union[float, int]]]]
+ParsedStats = list[dict[Literal["counters", "timers"], dict[str, Union[float, int]]]]
 
 
 def tiledbsoma_stats_json() -> str:

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Type, Union
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -140,7 +140,7 @@ ROOT_DATA_DIR = PROJECT_ROOT / "data"
 
 
 @contextmanager
-def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
+def raises_no_typeguard(exc: type[Exception], *args: Any, **kwargs: Any):
     """
     Temporarily suppress typeguard checks in order to verify a runtime exception is raised.
 
@@ -153,7 +153,7 @@ def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
 
 
 # Alias for several types that can be used to specify expected exceptions in `maybe_raises`
-Err = Union[str, Type[E], tuple[Type[E], str]]
+Err = Union[str, type[E], tuple[type[E], str]]
 
 
 def maybe_raises(

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, List, Tuple, Type, Union
+from typing import Any, List, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -103,7 +103,7 @@ def assert_transform_equal(
         assert False
 
 
-def parse_col(col_str: str) -> Tuple[str | None, List[str]]:
+def parse_col(col_str: str) -> tuple[str | None, List[str]]:
     """Parse a "column string" of the form ``val1,val2,...`` or ``name=val1,val2,...``."""
     pcs = col_str.split("=")
     if len(pcs) == 1:
@@ -153,7 +153,7 @@ def raises_no_typeguard(exc: Type[Exception], *args: Any, **kwargs: Any):
 
 
 # Alias for several types that can be used to specify expected exceptions in `maybe_raises`
-Err = Union[str, Type[E], Tuple[Type[E], str]]
+Err = Union[str, Type[E], tuple[Type[E], str]]
 
 
 def maybe_raises(

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, List, Type, Union
+from typing import Any, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -103,7 +103,7 @@ def assert_transform_equal(
         assert False
 
 
-def parse_col(col_str: str) -> tuple[str | None, List[str]]:
+def parse_col(col_str: str) -> tuple[str | None, list[str]]:
     """Parse a "column string" of the form ``val1,val2,...`` or ``name=val1,val2,...``."""
     pcs = col_str.split("=")
     if len(pcs) == 1:
@@ -185,7 +185,7 @@ def maybe_raises(
         return nullcontext()
 
 
-def verify_logs(caplog: LogCaptureFixture, expected_logs: List[str] | None) -> None:
+def verify_logs(caplog: LogCaptureFixture, expected_logs: list[str] | None) -> None:
     """Verify that expected log messages are present in a pytest "caplog" (captured logs) fixture."""
     if not expected_logs:
         return

--- a/apis/python/tests/ht/test_ht_indexer.py
+++ b/apis/python/tests/ht/test_ht_indexer.py
@@ -1,6 +1,6 @@
 """Hypothesis tests for IntIndexer module."""
 
-from typing import Any, List, Union
+from typing import Any, Union
 
 import hypothesis as ht
 import hypothesis.extra.numpy as ht_np
@@ -63,7 +63,7 @@ def test_IntIndexer_arrow_lookup(
     )
 
 
-@given(data=st.from_type(Union[np.ndarray[Any, Any], List[int]]))
+@given(data=st.from_type(Union[np.ndarray[Any, Any], list[int]]))
 @settings(suppress_health_check=(ht.HealthCheck.function_scoped_fixture,))
 def test_fuzz_IntIndexer(
     data: npt.NDArray[Any], context: soma.SOMATileDBContext

--- a/apis/python/tests/ht/test_ht_sparsendarray.py
+++ b/apis/python/tests/ht/test_ht_sparsendarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import shutil
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 import hypothesis as ht
 import numpy as np
@@ -195,7 +195,7 @@ class SOMASparseNDArrayStateMachine(SOMANDArrayStateMachine):
         super().__init__(shapes_factory=sparse_array_shape)
 
     @initialize(type=ndarray_datatype(), shape=sparse_array_shape(allow_none=True))
-    def setup(self, type: pa.DataType, shape: Tuple[int | None, ...]) -> None:
+    def setup(self, type: pa.DataType, shape: tuple[int | None, ...]) -> None:
         super().setup(
             type,
             shape,

--- a/apis/python/tests/ht/test_ht_sparsendarray.py
+++ b/apis/python/tests/ht/test_ht_sparsendarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import shutil
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Sequence, Union
 
 import hypothesis as ht
 import numpy as np
@@ -161,7 +161,7 @@ def test_fuzz_SparseNDArray_create(
     tmp_path,
     uri: str,
     type: pa.DataType,
-    shape: Sequence[Optional[int]],
+    shape: Sequence[int | None],
     platform_config: dict[str, Mapping[str, Any]] | object | None,
     context: tiledbsoma.SOMATileDBContext | None,
     tiledb_timestamp: int | datetime.datetime | None,

--- a/apis/python/tests/ht/test_ht_sparsendarray.py
+++ b/apis/python/tests/ht/test_ht_sparsendarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import shutil
-from typing import Any, Dict, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import hypothesis as ht
 import numpy as np
@@ -162,7 +162,7 @@ def test_fuzz_SparseNDArray_create(
     uri: str,
     type: pa.DataType,
     shape: Sequence[Optional[int]],
-    platform_config: Dict[str, Mapping[str, Any]] | object | None,
+    platform_config: dict[str, Mapping[str, Any]] | object | None,
     context: tiledbsoma.SOMATileDBContext | None,
     tiledb_timestamp: int | datetime.datetime | None,
 ) -> None:

--- a/apis/python/tests/parametrize_cases.py
+++ b/apis/python/tests/parametrize_cases.py
@@ -1,11 +1,10 @@
 from dataclasses import asdict, fields
 from inspect import getfullargspec
-from typing import List
 
 import pytest
 
 
-def parametrize_cases(cases: List):
+def parametrize_cases(cases: list):
     """Parametrize a test with a list of test cases (each an instance of a dataclass).
 
     The cases are expected to have an ``id: str`` field, which is used as the test-case "ID".

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import pathlib
 import textwrap
-from typing import List, TypeVar, Union
+from typing import TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -377,7 +377,7 @@ def test_cascading_close(tmp_path: pathlib.Path):
     un_corvid.close()
     assert un_corvid.closed
 
-    all_elements: List[_soma_object.AnySOMAObject] = []
+    all_elements: list[_soma_object.AnySOMAObject] = []
 
     def crawl(obj: _soma_object.AnySOMAObject):
         all_elements.append(obj)
@@ -409,7 +409,7 @@ def test_cascading_close(tmp_path: pathlib.Path):
 @pytest.mark.parametrize(
     ("in_type", "want"),
     [
-        (List[int], list),
+        (list[int], list),
         (set, set),
         (soma.Collection[object], soma.Collection),
     ],
@@ -420,7 +420,7 @@ def test_real_class(in_type, want):
 
 
 @pytest.mark.parametrize(
-    "in_type", (Union[int, str], Literal["bacon"], TypeVar("_T", bound=List))
+    "in_type", (Union[int, str], Literal["bacon"], TypeVar("_T", bound=list))
 )
 def test_real_class_fail(in_type):
     with raises_no_typeguard(TypeError):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -7,7 +7,7 @@ import shutil
 import struct
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, List
 
 import numpy as np
 import pandas as pd
@@ -1240,7 +1240,7 @@ def make_multiply_indexed_dataframe(
         domain=domain,
     )
 
-    data: Dict[str, list] = {
+    data: dict[str, list] = {
         "0_thru_5": [0, 1, 2, 3, 4, 5],
         "strings_aaa": ["aaa", "aaa", "bbb", "bbb", "ccc", "ccc"],
         "zero_one": [0, 1, 0, 1, 0, 1],

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1614,7 +1614,7 @@ def test_read_indexing(tmp_path, io):
             {k: io[k] for k in ("coords", "partitions", "value_filter") if k in io}
         )
 
-        # `throws` can be `Type[Exception]`, or `(Type[Exception], bool)` indicating explicitly
+        # `throws` can be `type[Exception]`, or `(type[Exception], bool)` indicating explicitly
         # whether Typeguard should be enabled during the `with raises` check.
         throws = io.get("throws", None)
         if throws:

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -1214,7 +1214,7 @@ def test_index_types(tmp_path, make_dataframe):
 
 
 def make_multiply_indexed_dataframe(
-    tmp_path, index_column_names: List[str], domain: List[Any]
+    tmp_path, index_column_names: list[str], domain: List[Any]
 ):
     """
     Creates a variably-indexed DataFrame for use in tests below.

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from os.path import join
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -38,7 +37,7 @@ class RoundTrip:
     # Columns that should be persisted; all are expected to be of type "large string" (for the purposes of these test
     # cases); the required `soma_joinid` (with type `int64 not null`) is excluded from this list, but always verified to
     # also exist.
-    persisted_column_names: List[str]
+    persisted_column_names: list[str]
     # Expected "original index metadata" (attached to the persisted SOMA DataFrame)
     persisted_metadata: str | None = None
     # Argument passed to `_write_dataframe` on ingest (default here matches `from_anndata`'s "obs" path)
@@ -110,7 +109,7 @@ ROUND_TRIPS = [
 
 
 def verify_metadata(
-    sdf: DataFrame, persisted_column_names: List[str], persisted_metadata: str | None
+    sdf: DataFrame, persisted_column_names: list[str], persisted_metadata: str | None
 ):
     # Verify column names and types
     schema = sdf.schema
@@ -131,7 +130,7 @@ def verify_metadata(
 def test_adata_io_roundtrips(
     tmp_path: Path,
     original_df: pd.DataFrame,
-    persisted_column_names: List[str],
+    persisted_column_names: list[str],
     persisted_metadata: str | None,
     ingest_id_column_name: str | None,
     outgested_df: pd.DataFrame,
@@ -173,7 +172,7 @@ def test_adata_io_roundtrips(
 def test_df_io_roundtrips(
     tmp_path: Path,
     original_df: pd.DataFrame,
-    persisted_column_names: List[str],
+    persisted_column_names: list[str],
     persisted_metadata: str | None,
     ingest_id_column_name: str | None,
     outgested_df: pd.DataFrame,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -2,7 +2,6 @@ import contextlib
 import datetime
 import json
 import pathlib
-from typing import Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -20,7 +19,7 @@ from ._util import raises_no_typeguard
 )
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
 def test_dense_nd_array_create_ok(
-    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+    tmp_path, shape: tuple[int, ...], element_type: pa.DataType
 ):
     """
     Test all cases we expect "create" to succeed.
@@ -133,14 +132,14 @@ def test_dense_nd_array_reopen(tmp_path):
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
 def test_dense_nd_array_create_fail(
-    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+    tmp_path, shape: tuple[int, ...], element_type: pa.DataType
 ):
     with pytest.raises(TypeError):
         soma.DenseNDArray.create(tmp_path.as_posix(), type=element_type, shape=shape)
 
 
 @pytest.mark.parametrize("shape", [(10,), (10, 20), (10, 20, 2), (2, 4, 6, 8)])
-def test_dense_nd_array_read_write_tensor(tmp_path, shape: Tuple[int, ...]):
+def test_dense_nd_array_read_write_tensor(tmp_path, shape: tuple[int, ...]):
     uri = tmp_path.as_posix()
 
     a = soma.DenseNDArray.create(uri, type=pa.float64(), shape=shape)

--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Dict, List
+from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -51,7 +51,7 @@ def add_presence_dataframe(
     key: str,
     max_joinids: int,
     joinids: np.ndarray,
-    scene_ids: List[str],
+    scene_ids: list[str],
 ) -> None:
     df = coll.add_new_dataframe(
         key,
@@ -78,7 +78,7 @@ def add_presence_dataframe(
 
 def add_point_cloud_dataframe(
     scene: soma.Scene,
-    subcoll: str | List[str],
+    subcoll: str | list[str],
     key: str,
     data: Dict[str, np.ndarray],
     circles: bool,
@@ -218,7 +218,7 @@ def soma_spatial_experiment(tmp_path_factory) -> soma.Experiment:
     return exp
 
 
-def check_for_scene_data(sdata, has_scenes: List[bool]):
+def check_for_scene_data(sdata, has_scenes: list[bool]):
     for index, has_scene in enumerate(has_scenes):
         if not has_scene:
             continue

--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -80,7 +79,7 @@ def add_point_cloud_dataframe(
     scene: soma.Scene,
     subcoll: str | list[str],
     key: str,
-    data: Dict[str, np.ndarray],
+    data: dict[str, np.ndarray],
     circles: bool,
 ):
     with scene.add_new_point_cloud_dataframe(
@@ -102,9 +101,9 @@ def add_scene(
     coll: soma.Collection,
     key: str,
     *,
-    points: Dict[tuple[str | tuple[str, ...], str], Dict[str, np.ndarray]],
-    circles: Dict[tuple[str | tuple[str, ...], str], Dict[str, np.ndarray]],
-    images: Dict[str, tuple[tuple[int, ...]]],
+    points: dict[tuple[str | tuple[str, ...], str], dict[str, np.ndarray]],
+    circles: dict[tuple[str | tuple[str, ...], str], dict[str, np.ndarray]],
+    images: dict[str, tuple[tuple[int, ...]]],
 ) -> None:
     with coll.add_new_collection(key, soma.Scene, coordinate_space=("x", "y")) as scene:
         scene.add_new_collection("obsl")

--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import itertools
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
@@ -76,7 +78,7 @@ def add_presence_dataframe(
 
 def add_point_cloud_dataframe(
     scene: soma.Scene,
-    subcoll: Union[str, List[str]],
+    subcoll: str | List[str],
     key: str,
     data: Dict[str, np.ndarray],
     circles: bool,
@@ -100,8 +102,8 @@ def add_scene(
     coll: soma.Collection,
     key: str,
     *,
-    points: Dict[tuple[Union[str, tuple[str, ...]], str], Dict[str, np.ndarray]],
-    circles: Dict[tuple[Union[str, tuple[str, ...]], str], Dict[str, np.ndarray]],
+    points: Dict[tuple[str | tuple[str, ...], str], Dict[str, np.ndarray]],
+    circles: Dict[tuple[str | tuple[str, ...], str], Dict[str, np.ndarray]],
     images: Dict[str, tuple[tuple[int, ...]]],
 ) -> None:
     with coll.add_new_collection(key, soma.Scene, coordinate_space=("x", "y")) as scene:

--- a/apis/python/tests/test_experiment_query_spatial.py
+++ b/apis/python/tests/test_experiment_query_spatial.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,7 @@ sd = pytest.importorskip("spatialdata")
 def add_multiscale_image(
     scene: soma.Scene,
     key: str,
-    shapes: Tuple[Tuple[int, ...]],
+    shapes: tuple[tuple[int, ...]],
 ):
     with scene.add_new_multiscale_image(
         key,
@@ -100,9 +100,9 @@ def add_scene(
     coll: soma.Collection,
     key: str,
     *,
-    points: Dict[Tuple[Union[str, Tuple[str, ...]], str], Dict[str, np.ndarray]],
-    circles: Dict[Tuple[Union[str, Tuple[str, ...]], str], Dict[str, np.ndarray]],
-    images: Dict[str, Tuple[Tuple[int, ...]]],
+    points: Dict[tuple[Union[str, tuple[str, ...]], str], Dict[str, np.ndarray]],
+    circles: Dict[tuple[Union[str, tuple[str, ...]], str], Dict[str, np.ndarray]],
+    images: Dict[str, tuple[tuple[int, ...]]],
 ) -> None:
     with coll.add_new_collection(key, soma.Scene, coordinate_space=("x", "y")) as scene:
         scene.add_new_collection("obsl")

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import threading
-from typing import List, Union
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -19,9 +21,7 @@ from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_contex
         (np.tile(np.array([-1, 1, 2, 3, 4, 5]), 4), [-10000, 1, 2, 3, 5, 6]),
     ],
 )
-def test_duplicate_key_indexer_error(
-    keys: Union[np.array, List[int]], lookups: np.array
-):
+def test_duplicate_key_indexer_error(keys: np.array | List[int], lookups: np.array):
     context = _validate_soma_tiledb_context(SOMATileDBContext())
     with pytest.raises(SOMAError, match="There are duplicate keys."):
         IntIndexer(keys, context=context)

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -21,7 +20,7 @@ from tiledbsoma.options._soma_tiledb_context import _validate_soma_tiledb_contex
         (np.tile(np.array([-1, 1, 2, 3, 4, 5]), 4), [-10000, 1, 2, 3, 5, 6]),
     ],
 )
-def test_duplicate_key_indexer_error(keys: np.array | List[int], lookups: np.array):
+def test_duplicate_key_indexer_error(keys: np.array | list[int], lookups: np.array):
     context = _validate_soma_tiledb_context(SOMATileDBContext())
     with pytest.raises(SOMAError, match="There are duplicate keys."):
         IntIndexer(keys, context=context)

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
@@ -175,7 +175,7 @@ def test_set_delete_metadata(soma_object):
         assert non_soma_metadata(reader) == {}
 
 
-def non_soma_metadata(obj) -> Dict[str, Any]:
+def non_soma_metadata(obj) -> dict[str, Any]:
     return {k: v for (k, v) in obj.metadata.items() if not k.startswith("soma_")}
 
 

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import math
 import tempfile
 from contextlib import nullcontext
-from typing import List, Sequence, Tuple, Union
+from typing import List, Sequence, Union
 
 import anndata as ad
 import numpy as np
@@ -243,9 +243,9 @@ PANDAS_INDEXING_TEST_DF = pd.DataFrame(
     ]
 )
 def test_pandas_indexing(
-    index_col_and_name: Union[Tuple[str | None], Tuple[str, str | None]],
+    index_col_and_name: Union[tuple[str | None], tuple[str, str | None]],
     default_index_name: str,
-    signature_col_names: List[Union[str, Tuple[str, str]]],
+    signature_col_names: List[Union[str, tuple[str, str]]],
 ):
     """
     The `default_index_name` for registration can interact with column- and

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import math
 import tempfile
 from contextlib import nullcontext
-from typing import List, Sequence, Union
+from typing import List, Sequence
 
 import anndata as ad
 import numpy as np
@@ -243,9 +243,9 @@ PANDAS_INDEXING_TEST_DF = pd.DataFrame(
     ]
 )
 def test_pandas_indexing(
-    index_col_and_name: Union[tuple[str | None], tuple[str, str | None]],
+    index_col_and_name: tuple[str | None] | tuple[str, str | None],
     default_index_name: str,
-    signature_col_names: List[Union[str, tuple[str, str]]],
+    signature_col_names: List[str | tuple[str, str]],
 ):
     """
     The `default_index_name` for registration can interact with column- and

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import math
 import tempfile
 from contextlib import nullcontext
-from typing import List, Sequence
+from typing import Sequence
 
 import anndata as ad
 import numpy as np
@@ -245,7 +245,7 @@ PANDAS_INDEXING_TEST_DF = pd.DataFrame(
 def test_pandas_indexing(
     index_col_and_name: tuple[str | None] | tuple[str, str | None],
     default_index_name: str,
-    signature_col_names: List[str | tuple[str, str]],
+    signature_col_names: list[str | tuple[str, str]],
 ):
     """
     The `default_index_name` for registration can interact with column- and

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -9,7 +9,7 @@ import operator
 import pathlib
 import sys
 from concurrent import futures
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Union
 from unittest import mock
 
 import numpy as np
@@ -32,7 +32,7 @@ AnySparseTensor = Union[pa.SparseCOOTensor, pa.SparseCSRMatrix, pa.SparseCSCMatr
 )
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_SUPPORTED)
 def test_sparse_nd_array_create_ok(
-    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+    tmp_path, shape: tuple[int, ...], element_type: pa.DataType
 ):
     """
     Test all cases we expect "create" to succeed.
@@ -156,7 +156,7 @@ def test_sparse_nd_array_reopen(tmp_path):
 @pytest.mark.parametrize("shape", [(10,)])
 @pytest.mark.parametrize("element_type", NDARRAY_ARROW_TYPES_NOT_SUPPORTED)
 def test_sparse_nd_array_create_fail(
-    tmp_path, shape: Tuple[int, ...], element_type: pa.DataType
+    tmp_path, shape: tuple[int, ...], element_type: pa.DataType
 ):
     with pytest.raises(TypeError):
         soma.SparseNDArray.create(tmp_path.as_posix(), type=element_type, shape=shape)
@@ -164,7 +164,7 @@ def test_sparse_nd_array_create_fail(
 
 def create_random_tensor(
     format: str,
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     dtype: np.dtype,
     density: float = 0.33,
 ):
@@ -320,7 +320,7 @@ def tables_are_same_value(a: pa.Table, b: pa.Table) -> bool:
 @pytest.mark.parametrize("test_enumeration", range(10))
 def test_sparse_nd_array_read_write_sparse_tensor(
     tmp_path,
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     format: str,
     test_enumeration: int,
 ):
@@ -367,7 +367,7 @@ def test_sparse_nd_array_read_write_sparse_tensor(
 @pytest.mark.parametrize("shape", [(10,), (23, 4), (5, 3, 1), (8, 4, 2, 30)])
 @pytest.mark.parametrize("test_enumeration", range(10))
 def test_sparse_nd_array_read_write_table(
-    tmp_path, shape: Tuple[int, ...], test_enumeration: int
+    tmp_path, shape: tuple[int, ...], test_enumeration: int
 ):
     a = soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float32(), shape=shape)
     assert a.shape == shape
@@ -391,7 +391,7 @@ def test_sparse_nd_array_read_write_table(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 @pytest.mark.parametrize("shape", [(1,), (23, 14), (35, 3, 2), (8, 4, 2, 30)])
 def test_sparse_nd_array_read_as_pandas(
-    tmp_path, dtype: np.dtype, shape: Tuple[int, ...]
+    tmp_path, dtype: np.dtype, shape: tuple[int, ...]
 ):
     dtype = np.dtype(dtype)
     with soma.SparseNDArray.create(
@@ -1276,7 +1276,7 @@ def a_soma_context() -> SOMATileDBContext:
 
 @pytest.fixture
 def a_random_sparse_nd_array(
-    tmp_path, a_soma_context: SOMATileDBContext, shape: Tuple[int, ...], density: float
+    tmp_path, a_soma_context: SOMATileDBContext, shape: tuple[int, ...], density: float
 ) -> str:
     uri = tmp_path.as_posix()
     dtype = np.float32
@@ -1325,8 +1325,8 @@ def a_random_sparse_nd_array(
 )
 def test_blockwise_table_iter(
     a_random_sparse_nd_array: str,
-    shape: Tuple[int, ...],
-    coords: Tuple[Any, ...],
+    shape: tuple[int, ...],
+    coords: tuple[Any, ...],
     a_soma_context: SOMATileDBContext,
 ) -> None:
     """Check blockwise iteration over non-reindexed results"""
@@ -1385,7 +1385,7 @@ def test_blockwise_table_iter(
 )
 @pytest.mark.parametrize("size", (999, 2**16, 2**20))
 def test_blockwise_table_iter_size(
-    a_random_sparse_nd_array: str, shape: Tuple[int, ...], size: int
+    a_random_sparse_nd_array: str, shape: tuple[int, ...], size: int
 ) -> None:
     """
     Verify that blockwise iteration correctly obeys size param.
@@ -1456,8 +1456,8 @@ def test_blockwise_table_iter_size(
 )
 def test_blockwise_table_iter_reindex(
     a_random_sparse_nd_array: str,
-    shape: Tuple[int, ...],
-    coords: Tuple[Any, ...],
+    shape: tuple[int, ...],
+    coords: tuple[Any, ...],
     a_soma_context: SOMATileDBContext,
 ) -> None:
     """Test blockwise table iteration with reindexing"""
@@ -1513,7 +1513,7 @@ def test_blockwise_table_iter_reindex(
 
 @pytest.mark.parametrize("density,shape", [(0.1, (100, 100))])
 def test_blockwise_table_iter_error_checks(
-    a_random_sparse_nd_array: str, shape: Tuple[int, ...]
+    a_random_sparse_nd_array: str, shape: tuple[int, ...]
 ) -> None:
     with soma.open(a_random_sparse_nd_array, mode="r") as A:
         with pytest.raises(NotImplementedError):
@@ -1550,7 +1550,7 @@ def test_blockwise_table_iter_error_checks(
 @pytest.mark.parametrize("size", [777, 1001, 2**16])
 def test_blockwise_scipy_iter(
     a_random_sparse_nd_array: str,
-    coords: Tuple[Any, ...],
+    coords: tuple[Any, ...],
     size: int,
     a_soma_context: SOMATileDBContext,
 ) -> None:
@@ -1559,7 +1559,7 @@ def test_blockwise_scipy_iter(
     """
 
     def _slice_sp(
-        coo: sparse.coo_matrix, _coords: Tuple[Any, ...]
+        coo: sparse.coo_matrix, _coords: tuple[Any, ...]
     ) -> sparse.coo_matrix:
         """
         Slice from the COO, accomodating conversion from closed range to half-open range
@@ -1653,7 +1653,7 @@ def test_blockwise_scipy_iter(
 
 @pytest.mark.parametrize("density,shape", [(0.1, (100, 100))])
 def test_blockwise_scipy_iter_error_checks(
-    a_random_sparse_nd_array: str, shape: Tuple[int, ...]
+    a_random_sparse_nd_array: str, shape: tuple[int, ...]
 ) -> None:
     with soma.open(a_random_sparse_nd_array, mode="r") as A:
         with pytest.raises(ValueError):
@@ -1668,7 +1668,7 @@ def test_blockwise_scipy_iter_error_checks(
 
 @pytest.mark.parametrize("density,shape", [(0.1, (4, 8, 16))])
 def test_blockwise_scipy_iter_not_2D(
-    a_random_sparse_nd_array: str, shape: Tuple[int, ...]
+    a_random_sparse_nd_array: str, shape: tuple[int, ...]
 ) -> None:
     with soma.open(a_random_sparse_nd_array, mode="r") as A:
         with pytest.raises(soma.SOMAError):
@@ -1678,7 +1678,7 @@ def test_blockwise_scipy_iter_not_2D(
 @pytest.mark.parametrize("density,shape", [(0.01, (10_000, 1230))])
 def test_blockwise_scipy_iter_eager(
     a_random_sparse_nd_array: str,
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     a_soma_context: SOMATileDBContext,
 ) -> None:
     """Should get same results with any eager setting"""
@@ -1753,8 +1753,8 @@ def test_blockwise_scipy_iter_result_order(a_random_sparse_nd_array: str) -> Non
 )
 def test_blockwise_indices(
     a_random_sparse_nd_array: str,
-    coords: Tuple[Any, ...],
-    expected_indices: Tuple[Any, ...],
+    coords: tuple[Any, ...],
+    expected_indices: tuple[Any, ...],
 ) -> None:
     """Verify indices look reasonable"""
     size = 1111
@@ -1815,7 +1815,7 @@ def test_blockwise_indices(
 @pytest.mark.parametrize("density,shape", [(0.1, (100, 100))])
 @pytest.mark.parametrize("coords", [(slice(0, 10),), (slice(1, 10),)])
 def test_blockwise_scipy_reindex_disable_major_dim(
-    a_random_sparse_nd_array: str, coords: Tuple[Any, ...]
+    a_random_sparse_nd_array: str, coords: tuple[Any, ...]
 ) -> None:
     """
     Disable reindexing on major axis. Expected behavior:
@@ -1844,7 +1844,7 @@ def test_blockwise_scipy_reindex_disable_major_dim(
 
 @pytest.mark.parametrize("density,shape", [(0.1, (100, 100))])
 def test_blockwise_iterator_uses_thread_pool_from_context(
-    a_random_sparse_nd_array: str, shape: Tuple[int, ...]
+    a_random_sparse_nd_array: str, shape: tuple[int, ...]
 ) -> None:
     pool = mock.Mock(wraps=futures.ThreadPoolExecutor(max_workers=2))
     pool.submit.assert_not_called()

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -9,7 +9,7 @@ import operator
 import pathlib
 import sys
 from concurrent import futures
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 from unittest import mock
 
 import numpy as np
@@ -1021,7 +1021,7 @@ def test_sparse_nd_array_table_slicing(tmp_path, io, write_format, read_format):
     ],
 )
 def test_result_order(
-    tmp_path: pathlib.Path, result_order, want: Dict[str, List[float]]
+    tmp_path: pathlib.Path, result_order, want: Dict[str, list[float]]
 ):
     arrow_tensor = create_random_tensor("table", (5, 7), np.float32(), density=1)
 

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -9,7 +9,7 @@ import operator
 import pathlib
 import sys
 from concurrent import futures
-from typing import Any, Dict, Union
+from typing import Any, Union
 from unittest import mock
 
 import numpy as np
@@ -1021,7 +1021,7 @@ def test_sparse_nd_array_table_slicing(tmp_path, io, write_format, read_format):
     ],
 )
 def test_result_order(
-    tmp_path: pathlib.Path, result_order, want: Dict[str, list[float]]
+    tmp_path: pathlib.Path, result_order, want: dict[str, list[float]]
 ):
     arrow_tensor = create_random_tensor("table", (5, 7), np.float32(), density=1)
 

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import tempfile
 from dataclasses import dataclass
-from typing import Type
 
 import numpy as np
 import pandas as pd
@@ -131,7 +130,7 @@ def verify_updates(
     experiment_path,
     obs,
     var,
-    exc: Type[ValueError] | None = None,
+    exc: type[ValueError] | None = None,
 ):
     """
     Calls `update_obs` and `update_var` on the experiment. Also verifies that the

--- a/apis/python/tests/test_update_uns.py
+++ b/apis/python/tests/test_update_uns.py
@@ -4,7 +4,7 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 import numpy as np
 from _pytest.logging import LogCaptureFixture
@@ -18,8 +18,8 @@ from tests._util import Err, assert_uns_equal, make_pd_df, maybe_raises, verify_
 from tests.parametrize_cases import parametrize_cases
 from tests.test_basic_anndata_io import TEST_UNS, make_uns_adata
 
-ValidUpdates = Union[None, str, List[str], Dict[str, "ValidUpdates"]]
-Logs = Union[List[str], None]
+ValidUpdates = Union[None, str, list[str], Dict[str, "ValidUpdates"]]
+Logs = Union[list[str], None]
 
 
 @dataclass

--- a/apis/python/tests/test_update_uns.py
+++ b/apis/python/tests/test_update_uns.py
@@ -4,7 +4,7 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Union
+from typing import Union
 
 import numpy as np
 from _pytest.logging import LogCaptureFixture
@@ -18,7 +18,7 @@ from tests._util import Err, assert_uns_equal, make_pd_df, maybe_raises, verify_
 from tests.parametrize_cases import parametrize_cases
 from tests.test_basic_anndata_io import TEST_UNS, make_uns_adata
 
-ValidUpdates = Union[None, str, list[str], Dict[str, "ValidUpdates"]]
+ValidUpdates = Union[None, str, list[str], dict[str, "ValidUpdates"]]
 Logs = Union[list[str], None]
 
 

--- a/apis/python/version.py
+++ b/apis/python/version.py
@@ -77,7 +77,6 @@ import sys
 from datetime import date
 from os.path import basename, dirname, join, relpath
 from subprocess import DEVNULL, CalledProcessError, check_output
-from typing import List
 
 GIT_RELPATH = "apis/python/version.py"
 RELEASE_VERSION_FILE = join(dirname(__file__), "RELEASE-VERSION")
@@ -97,7 +96,7 @@ def err(*args, **kwargs):
 
 def lines(
     *cmd, drop_trailing_newline: bool = True, stderr=DEVNULL, **kwargs
-) -> List[str] | None:
+) -> list[str] | None:
     """Run a command, return its stdout as a list of lines.
 
     Strip each line's trailing newline, and drop the last line if it's empty, by default.

--- a/profiler/src/profiler/context_generator.py
+++ b/profiler/src/profiler/context_generator.py
@@ -1,13 +1,12 @@
 import json
 import os
 import sys
-from typing import Dict
 
 import psutil
 from git import Repo
 
 
-def host_context() -> Dict[str, str]:
+def host_context() -> dict[str, str]:
     physical_mem_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
 
     def get_git_revision_hash() -> str:

--- a/profiler/src/profiler/data.py
+++ b/profiler/src/profiler/data.py
@@ -5,7 +5,7 @@ import json
 import os
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import attr
 import boto3
@@ -46,7 +46,7 @@ class ProfileData:
     signals_delivered: int
     page_size_bytes: int
     exit_status: int
-    custom_out: List[Optional[str]]
+    custom_out: list[Optional[str]]
 
     command_key: str = attr.field()
 
@@ -106,7 +106,7 @@ class FileBasedProfileDB(ProfileDB):
             return result
         return ""
 
-    def find(self, command) -> List[ProfileData]:
+    def find(self, command) -> list[ProfileData]:
         key = _command_key(command)
         if not os.path.exists(f"{self.path}/{key}"):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), key)
@@ -141,10 +141,10 @@ class S3ProfileDB(ProfileDB):
     Each run is stored as a separate S3 object under a key with the structure `<bucket>/<command>/<timestamp>`.
     """
 
-    def read_object_keys(self, prefix: str, suffix: str) -> List[str]:
+    def read_object_keys(self, prefix: str, suffix: str) -> list[str]:
         # return all the objects kets starting with prefix and ending with suffix
         result = self.s3.list_objects(Bucket=self.bucket_name, Prefix=prefix)
-        keys: List[str] = []
+        keys: list[str] = []
         for o in result.get("Contents"):
             object_key = o.get("Key")
             if object_key.endswith(suffix):
@@ -196,7 +196,7 @@ class S3ProfileDB(ProfileDB):
             f"Bucket {self.bucket_name} does not exist or access is not granted."
         )
 
-    def find(self, command) -> List[ProfileData]:
+    def find(self, command) -> list[ProfileData]:
         key = _command_key(command)
         result = []
         # Extract all data files associated with this command

--- a/profiler/src/profiler/data.py
+++ b/profiler/src/profiler/data.py
@@ -5,7 +5,7 @@ import json
 import os
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import attr
 import boto3
@@ -46,7 +46,7 @@ class ProfileData:
     signals_delivered: int
     page_size_bytes: int
     exit_status: int
-    custom_out: list[Optional[str]]
+    custom_out: list[str | None]
 
     command_key: str = attr.field()
 

--- a/profiler/src/profiler/data.py
+++ b/profiler/src/profiler/data.py
@@ -5,7 +5,7 @@ import json
 import os
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import attr
 import boto3
@@ -20,10 +20,10 @@ class ProfileData:
     timestamp: float
     stdout: str
     stderr: str
-    tiledb_stats: Dict[str, Any]
+    tiledb_stats: dict[str, Any]
     somacore_version: str
     tiledbsoma_version: str
-    host_context: Dict[str, str]
+    host_context: dict[str, str]
     user_time_sec: float
     system_time_sec: float
     pct_of_cpu: float

--- a/profiler/src/profiler/profiler.py
+++ b/profiler/src/profiler/profiler.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from subprocess import PIPE
 from sys import stderr
-from typing import Any, Optional
+from typing import Any
 
 import somacore
 
@@ -76,7 +76,7 @@ TILEDB_STATS_FILE_PATH = "./tiledb_stats.json"
 
 
 def build_profile_data(
-    stderr_: str, stdout_: str, prof1: Optional[str], prof2: Optional[str]
+    stderr_: str, stdout_: str, prof1: str | None, prof2: str | None
 ) -> ProfileData:
     """Parse the time utility output to extract performance and memory metrics"""
     gnu_time_output_values = GNU_TIME_OUTPUT_REGEXP.search(stderr_)

--- a/profiler/src/profiler/profiler.py
+++ b/profiler/src/profiler/profiler.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from subprocess import PIPE
 from sys import stderr
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import somacore
 
@@ -103,7 +103,7 @@ def build_profile_data(
     return data
 
 
-def read_tiledb_stats_output() -> Dict[str, Any]:
+def read_tiledb_stats_output() -> dict[str, Any]:
     if not os.path.isfile(TILEDB_STATS_FILE_PATH):
         return {}
 

--- a/profiler/src/profiler/report.py
+++ b/profiler/src/profiler/report.py
@@ -2,7 +2,7 @@ import argparse
 import re
 from collections import OrderedDict
 from sys import stderr
-from typing import Dict, Union
+from typing import Union
 
 import attr
 import matplotlib.pyplot as plt
@@ -11,7 +11,7 @@ import pandas as pd
 from .data import FileBasedProfileDB, ProfileData
 
 
-def collect_tiledb_stats(data: ProfileData) -> Dict[str, Union[int, float]]:
+def collect_tiledb_stats(data: ProfileData) -> dict[str, Union[int, float]]:
     """Extract all TileDB stats as dictionary"""
     result = {}
     tiledb_stats = data.tiledb_stats

--- a/profiler/src/profiler/report.py
+++ b/profiler/src/profiler/report.py
@@ -2,7 +2,7 @@ import argparse
 import re
 from collections import OrderedDict
 from sys import stderr
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 import attr
 import matplotlib.pyplot as plt
@@ -63,7 +63,7 @@ def extract_context_data(data: ProfileData, metric: str) -> Union[int, float, No
         raise Exception(f"context does not have the following metric {metric}")
 
 
-def create_pandas_df(profile_datas: List[ProfileData]) -> pd.DataFrame:
+def create_pandas_df(profile_datas: list[ProfileData]) -> pd.DataFrame:
     """Create pandas dataframe for all the runs of a given command
     Columns are metric names and rows are the runs
     """
@@ -108,7 +108,7 @@ def main():
 
     # extract profiling command run data
     db = FileBasedProfileDB()
-    profile_datas: List[ProfileData] = db.find(" ".join(args.command))
+    profile_datas: list[ProfileData] = db.find(" ".join(args.command))
 
     if args.json:
         output_as_json(profile_datas)
@@ -141,7 +141,7 @@ def main():
     plt.show()
 
 
-def output_as_json(profile_datas: List[ProfileData]) -> None:
+def output_as_json(profile_datas: list[ProfileData]) -> None:
     print(create_pandas_df(profile_datas).to_json(orient="columns"))
 
 


### PR DESCRIPTION
**Issue and/or context:**
- {`Dict`,`List`,`Set`,`Tuple`,`Type`} [are deprecated since Python 3.9](https://docs.python.org/3/library/typing.html), to be replaced with lowercase counterparts (which don't require dedicated `import`s).
- `Union` can be replaced with the pipe `|` operator [since Python 3.10](https://docs.python.org/3/library/typing.html#typing.Union), but in most cases can be replaced in Python 3.9 as long as `from __future__ import annotations` is present. Explicit `Union` is still needed in top-level type-alias declarations, and `cast` and `st.from_type` functions.
- Similarly, `Optional[T]` can usually be replaced with `T | None`, except in e.g. `cast` calls, so I've done more of that here (was mostly done in #3453).

**Changes:**
- Remove all references to {`Dict`,`List`,`Set`,`Tuple`,`Type`}
- Remove most references to {`Optional`,`Union`}