### PR TITLE
[python] Ensure schema is explicitly passed to `pa.Table.from*` converters

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -186,7 +186,6 @@ bool is_tdb_str(tiledb_datatype_t type) {
  * @brief Convert ArrayBuffers to Arrow table.
  *
  * @param buffers ArrayBuffers
- * @param schema ArraySchema
  * @return py::object pa.Table
  */
 py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -182,32 +182,6 @@ bool is_tdb_str(tiledb_datatype_t type) {
     }
 }
 
-py::object c_to_pyarrow_dtype(std::string_view c_arrow_type) {
-    auto pa = py::module::import("pyarrow");
-    std::map<std::string_view, py::object> _c_to_pyarrow_dtype = {
-        {"u", pa.attr("large_string")()},
-        {"U", pa.attr("large_string")()},
-        {"z", pa.attr("large_string")()},
-        {"Z", pa.attr("large_string")()},
-        {"c", pa.attr("int8")()},
-        {"C", pa.attr("uint8")()},
-        {"s", pa.attr("int16")()},
-        {"S", pa.attr("uint16")()},
-        {"i", pa.attr("int32")()},
-        {"I", pa.attr("uint32")()},
-        {"l", pa.attr("int64")()},
-        {"L", pa.attr("uint64")()},
-        {"f", pa.attr("float32")()},
-        {"g", pa.attr("float64")()},
-        {"b", pa.attr("bool_")()},
-        {"tss:", pa.attr("timestamp")("s")},
-        {"tsm:", pa.attr("timestamp")("ms")},
-        {"tsu:", pa.attr("timestamp")("us")},
-        {"tsn:", pa.attr("timestamp")("ns")},
-    };
-    return _c_to_pyarrow_dtype.at(c_arrow_type);
-}
-
 /**
  * @brief Convert ArrayBuffers to Arrow table.
  *

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -13,6 +13,8 @@
 
 #include "common.h"
 
+using namespace pybind11::literals;  // to bring in the `_a` literal
+
 namespace tiledbsoma {
 
 std::unordered_map<tiledb_datatype_t, std::string> _tdb_to_np_name_dtype = {
@@ -180,31 +182,57 @@ bool is_tdb_str(tiledb_datatype_t type) {
     }
 }
 
+py::object c_to_pyarrow_dtype(std::string_view c_arrow_type) {
+    auto pa = py::module::import("pyarrow");
+    std::map<std::string_view, py::object> _c_to_pyarrow_dtype = {
+        {"u", pa.attr("large_string")()},
+        {"U", pa.attr("large_string")()},
+        {"z", pa.attr("large_string")()},
+        {"Z", pa.attr("large_string")()},
+        {"c", pa.attr("int8")()},
+        {"C", pa.attr("uint8")()},
+        {"s", pa.attr("int16")()},
+        {"S", pa.attr("uint16")()},
+        {"i", pa.attr("int32")()},
+        {"I", pa.attr("uint32")()},
+        {"l", pa.attr("int64")()},
+        {"L", pa.attr("uint64")()},
+        {"f", pa.attr("float32")()},
+        {"g", pa.attr("float64")()},
+        {"b", pa.attr("bool_")()},
+        {"tss:", pa.attr("timestamp")("s")},
+        {"tsm:", pa.attr("timestamp")("ms")},
+        {"tsu:", pa.attr("timestamp")("us")},
+        {"tsn:", pa.attr("timestamp")("ns")},
+    };
+    return _c_to_pyarrow_dtype.at(c_arrow_type);
+}
+
 /**
  * @brief Convert ArrayBuffers to Arrow table.
  *
- * @param cbs ArrayBuffers
- * @return py::object
+ * @param buffers ArrayBuffers
+ * @param schema ArraySchema
+ * @return py::object pa.Table
  */
 py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {
     auto pa = py::module::import("pyarrow");
-    auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
     auto pa_array_import = pa.attr("Array").attr("_import_from_c");
-    auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");
+    auto pa_dtype_import = pa.attr("DataType").attr("_import_from_c");
+    auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
 
     py::list array_list;
-    py::list names;
+    py::list field_list;
 
     for (auto& name : buffers->names()) {
-        auto column = buffers->at(name);
-        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(column);
-        auto array = pa_array_import(
-            py::capsule(pa_array.get()), py::capsule(pa_schema.get()));
-        array_list.append(array);
-        names.append(name);
+        auto [pa_array, pa_schema] = ArrowAdapter::to_arrow(buffers->at(name));
+        auto nullable = (pa_schema->flags & ARROW_FLAG_NULLABLE) != 0;
+        auto dtype = pa_dtype_import(py::capsule(pa_schema.get()));
+        array_list.append(pa_array_import(py::capsule(pa_array.get()), dtype));
+        field_list.append(pa.attr("field")(name, dtype, nullable));
     }
-
-    return pa_table_from_arrays(array_list, names);
+    return pa_table_from_arrays(
+        array_list, "schema"_a = pa.attr("schema")(field_list));
 }
 
 std::optional<py::object> to_table(

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -102,10 +102,10 @@ void load_managed_query(py::module& m) {
                 std::optional<std::shared_ptr<ArrayBuffers>> tbl;
                 try {
                     tbl = mq.read_next();
-                    // Acquire python GIL before accessing python objects
                 } catch (const std::exception& e) {
                     throw TileDBSOMAError(e.what());
                 }
+                // Acquire python GIL before accessing python objects
                 py::gil_scoped_acquire acquire;
 
                 if (!tbl) {

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -898,7 +898,7 @@ def test_DataFrame_read_column_names(simple_data_frame, ids, col_names):
     _check_tbl(sdf.read(ids, column_names=col_names).concat(), col_names, ids)
     _check_tbl(sdf.read(column_names=col_names).concat(), col_names, None)
 
-    # pa.Table.from_pandas infers nullability from the data if a schema is not 
+    # pa.Table.from_pandas infers nullability from the data if a schema is not
     # provided. If there are no null values in the data, then the data is marked
     # as non-nullable. To ensure nullability is preserved, explicitly pass in
     # the schema

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -82,7 +82,7 @@ def test_sparse_nd_array_basics(
         dikt = {"soma_data": [4, 5]}
         for i in range(ndim):
             dikt[dim_names[i]] = coords[i]
-        table = pa.Table.from_pydict(dikt)
+        table = pa.Table.from_pydict(dikt, schema=snda.schema)
         snda.write(table)
 
     # Test the various accessors
@@ -104,7 +104,7 @@ def test_sparse_nd_array_basics(
         with pytest.raises(tiledbsoma.SOMAError):
             dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
             dikt["soma_data"] = [30]
-            table = pa.Table.from_pydict(dikt)
+            table = pa.Table.from_pydict(dikt, schema=snda.schema)
             snda.write(table)
 
     with tiledbsoma.SparseNDArray.open(uri) as snda:
@@ -152,7 +152,7 @@ def test_sparse_nd_array_basics(
         for i in range(ndim):
             dikt[dim_names[i]] = [arg_shape[i] + 20]
         dikt["soma_data"] = pa.array([34.5], type=element_dtype)
-        table = pa.Table.from_pydict(dikt)
+        table = pa.Table.from_pydict(dikt, schema=snda.schema)
 
         # Re-test writes out of old bounds, within new bounds
         with tiledbsoma.SparseNDArray.open(uri, "w") as snda:

--- a/apis/python/tests/test_unicode.py
+++ b/apis/python/tests/test_unicode.py
@@ -12,6 +12,16 @@ Test read/write of unicode, ascii and binary
 
 @pytest.fixture
 def sample_arrow_table():
+    schema = pa.schema(
+        [
+            pa.field("soma_joinid", pa.int64(), False),
+            pa.field("unicode", pa.large_string()),
+            pa.field("ascii", pa.large_string()),
+            pa.field("bytes", pa.large_binary()),
+            pa.field("float32", pa.float32()),
+        ]
+    )
+
     df = pd.DataFrame(
         data={
             "soma_joinid": np.arange(3, dtype=np.int64),
@@ -25,17 +35,6 @@ def sample_arrow_table():
             "float32": np.array([0.0, 1.0, 2.0], np.float32),
         }
     )
-
-    # We "know" that tiledbsoma will promote string->large_string and
-    # binary->large_binary, so generate a table with that latent expectation.
-    tbl = pa.Table.from_pandas(df)
-    schema = tbl.schema
-    for i in range(len(tbl.schema)):
-        fld = schema.field(i)
-        if fld.type == pa.string():
-            schema = schema.set(i, fld.with_type(pa.large_string()))
-        if fld.type == pa.binary():
-            schema = schema.set(i, fld.with_type(pa.large_binary()))
 
     return pa.Table.from_pandas(df, schema)
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -401,11 +401,11 @@ class ManagedQuery {
     void submit_write(bool sort_coords = true);
 
     /**
-     * @brief Get the schema of the array.
+     * @brief Get the schema of the array as a TileDB ArraySchema.
      *
      * @return std::shared_ptr<ArraySchema> Schema
      */
-    std::shared_ptr<ArraySchema> schema() {
+    std::shared_ptr<ArraySchema> schema() const {
         return schema_;
     }
 


### PR DESCRIPTION
**Issue and/or context:**

[[sc-61222](https://app.shortcut.com/tiledb-inc/story/61222/python-somasparsearray-read-returns-arrow-table-not-matching-array-schema-nullability#activity-65401)]

This PR fixes several problems when we do not explicitly pass a schema to `pa.Table.from_{arrays,pydict,pandas}` converters:

1. In the Pybind11 [utility function `_buffer_to_table`](https://github.com/single-cell-data/TileDB-SOMA/compare/viviannguyen/sc-61222/python-somasparsearray-read-returns-arrow?expand=1#diff-d123499d8c03fff7d820bb52ab295e45080a15c7a815123ae43cdd2d8bdf0674R218-R235) which takes an `ArrayBuffer` and converts it to a Python `pa.Table` using `pa.Table.from_arrays`, we were taking in a list of names which meant it was inferring the schema from the data in the arrays. We now generate a list of `pa.Field` objects for each column and generate the `pa.Schema` to explicitly pass in instead of names. This fixes the issue reported in the shortcut story linked.
2. Several unit tests utilize `pa.Table.from_pydict` and `pa.Table.from_pandas` and took in only a `dict` or `pd.DataFrame`. Without explicitly passing in a `pa.Schema` argument, columns without `NULL` values would be inferred to be non-nullable. 

**Would strongly recommend to always pass the `schema` for all Arrow converter methods to preserve nullability.**