### PR TITLE
[python] Fix a spurious exception-class issue

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -155,9 +155,16 @@ void load_soma_array(py::module& m) {
 
         .def(
             "nnz",
-            &SOMAArray::nnz,
-            py::arg("raise_if_slow") = false,
-            py::call_guard<py::gil_scoped_release>())
+            [](SOMAArray& array, bool raise_if_slow = false) {
+                try {
+                    py::gil_scoped_release release;
+                    auto retval = array.nnz();
+                    py::gil_scoped_acquire acquire;
+                    return retval;
+                } catch (const std::exception& e) {
+                    TPY_ERROR_LOC(e.what());
+                }
+            })
 
         .def_property_readonly("uri", &SOMAArray::uri)
 

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -155,7 +155,7 @@ void load_soma_array(py::module& m) {
 
         .def(
             "nnz",
-            [](SOMAArray& array, bool raise_if_slow = false) {
+            [](SOMAArray& array, bool raise_if_slow) {
                 try {
                     py::gil_scoped_release release;
                     auto retval = array.nnz();
@@ -164,7 +164,8 @@ void load_soma_array(py::module& m) {
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }
-            })
+            },
+            py::arg("raise_if_slow") = false)
 
         .def_property_readonly("uri", &SOMAArray::uri)
 


### PR DESCRIPTION
**Issue and/or context:** Found interactively by @ryan-williams. Issue was `RuntimeError` was being seen at the Python level rather than `tiledbsoma.SOMAError`.

These are tricky to unit-test for, since in the past we've found that usually this works as intended: only on some platforms/installs does the exception get thrown as `RuntimeError`. In particular, I ran Ryan's exact repro script on my system, and it didn't throw `RuntimeError` for me as it did for him on his system. This meant I couldn't craft a unit-test case that failed without this PR's codemod but passed with this PR's codemod. Hence, no new unit-test cases are added on this PR; it suffices that existing unit-test cases continue to pass.

**Changes:** Explicit try-catch using the paradigm already established within `apis/python/src/tiledbsoma/*.cc`.

**Notes for Reviewer:**

The reasons this wasn't caught in code review for #3915 are:

* Before #3915, `nnz` did not throw; now it can (by design)
* It had no `pybind11` function body at all, letting `pybind11` auto-construct the body from `SOMAArray::nnz` -- so the author (and reviewer) wouldn't have seen a spot to put the try-catch in
* As noted above, on most systems most of the time we correctly get `tiledbsoma.SOMAError` instead of `RuntimeError` in our test suites
