### PR TITLE
[python] Timestamp-test for #3958

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -5,6 +5,7 @@ import random
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import anndata
 import numpy as np
@@ -23,6 +24,7 @@ from tiledbsoma._soma_object import SOMAObject
 from tiledbsoma.io._common import _TILEDBSOMA_TYPE, UnsDict, UnsMapping
 
 from ._util import TESTDATA, assert_adata_equal, make_pd_df
+from .test_sparse_nd_array import create_random_tensor
 
 
 @pytest.fixture
@@ -1537,3 +1539,31 @@ def test_decat_append(tmp_path):
 def test_from_h5ad_bad_uri():
     with pytest.raises(tiledbsoma.SOMAError, match="URI /nonesuch is not a valid URI"):
         next(tiledbsoma.io._util.read_h5ad("/nonesuch").gen)
+
+
+def test_dask_query_to_anndata_timestamp(conftest_pbmc_small_h5ad_path):
+    with TemporaryDirectory("conftest_pbmc_small_exp_") as exp_path:
+        tiledbsoma.io.from_h5ad(
+            exp_path,
+            conftest_pbmc_small_h5ad_path,
+            measurement_name="RNA",
+        )
+        with Experiment.open(exp_path, mode="w") as exp:
+            ts0 = exp.tiledb_timestamp_ms
+            X = exp.ms["RNA"].X["data"]
+            arrow_tensor = create_random_tensor(
+                format="csr",
+                shape=X.shape,
+                dtype=np.float32(),
+                seed=1111,
+            )
+            assert arrow_tensor.non_zero_length == 528
+            X.write(arrow_tensor)
+
+        with Experiment.open(exp_path, tiledb_timestamp=ts0 - 1) as exp:
+            ad = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
+            assert ad.X.nnz == 1600
+
+        with Experiment.open(exp_path) as exp:
+            ad = tiledbsoma.io.to_anndata(exp, measurement_name="RNA")
+            assert ad.X.nnz == 528

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -167,6 +167,7 @@ def create_random_tensor(
     shape: Tuple[int, ...],
     dtype: np.dtype,
     density: float = 0.33,
+    seed: int | None = None,
 ):
     """
     Create a random tensor/table of specified format, shape and dtype.
@@ -174,7 +175,7 @@ def create_random_tensor(
     Guarantee: there will be NO duplicate values in the tensor, which makes
     it simpler to validate (see `tensors_are_same_value`)
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=seed)
     ndim = len(shape)
     assert 0 < density <= 1
 


### PR DESCRIPTION
**Issue and/or context:**
- Before [#3958], this test fails with a `RuntimeError: NNZ slow path called with 'raise_if_slow==true'`
  - [GHA example](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/14391316075/job/40358791869#step:14:156), from https://github.com/single-cell-data/TileDB-SOMA/commit/c4ecc305af5657f1411c021e723dda56a1002255.
- This PR adds a test, to catch possible regressions, but the test is not returning the expected NNZ counts at both timestamps.
  - I'm either using the `open`/`write` APIs incorrectly, or there's another bug.
- It's also confusing that there wasn't already a test to catch the issue from [#3958]; we should figure out why that's the case, or why this test is so unique.

[#3958]: https://github.com/single-cell-data/TileDB-SOMA/pull/3958