### PR TITLE
[python] Ensure `ndarray` byteorder is little-endian on matrix writes

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2043,7 +2043,7 @@ def _write_matrix_to_denseNDArray(
 
     add_metadata(soma_ndarray, additional_metadata)
 
-    # TileDB does not support big-endian so coerse to little-endian
+    # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
         matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
 
@@ -2442,7 +2442,7 @@ def _write_matrix_to_sparseNDArray(
 ) -> None:
     """Write a matrix to an empty DenseNDArray"""
 
-    # TileDB does not support big-endian so coerse to little-endian
+    # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
         matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2045,7 +2045,7 @@ def _write_matrix_to_denseNDArray(
 
     # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
-        matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
+        matrix = matrix.byteswap().view(matrix.dtype.newbyteorder("<"))
 
     # There is a chunk-by-chunk already-done check for resume mode, below.
     # This full-matrix-level check here might seem redundant, but in fact it's important:
@@ -2444,7 +2444,7 @@ def _write_matrix_to_sparseNDArray(
 
     # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
-        matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
+        matrix = matrix.byteswap().view(matrix.dtype.newbyteorder("<"))
 
     def _coo_to_table(
         mat_coo: sp.coo_matrix,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2043,6 +2043,10 @@ def _write_matrix_to_denseNDArray(
 
     add_metadata(soma_ndarray, additional_metadata)
 
+    # TileDB does not support big-endian so coerse to little-endian
+    if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
+        matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
+
     # There is a chunk-by-chunk already-done check for resume mode, below.
     # This full-matrix-level check here might seem redundant, but in fact it's important:
     # * By checking input bounds against storage NED here, we can see if the entire matrix
@@ -2437,6 +2441,10 @@ def _write_matrix_to_sparseNDArray(
     axis_1_mapping: AxisIDMapping,
 ) -> None:
     """Write a matrix to an empty DenseNDArray"""
+
+    # TileDB does not support big-endian so coerse to little-endian
+    if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
+        matrix = np.array(matrix, copy=False).byteswap().newbyteorder("<")
 
     def _coo_to_table(
         mat_coo: sp.coo_matrix,


### PR DESCRIPTION
**Issue and/or context:**

[[sc-63459](https://app.shortcut.com/tiledb-inc/story/63459/python-tiledbsoma-io-from-anndata-ignores-ndarray-byteorder-writes-incorrect-data-if-array-is-not-host-byteorder)]

**Changes:**

In `_write_matrix_to_{dense,sparse}NDArray`, ensure that the byteorder is little-endian.