### PR TITLE
[python] Fix a typo on #3949

### DIFF
--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -11,7 +11,6 @@ https://github.com/single-cell-data/TileDB-SOMA/issues/2407."""
 from __future__ import annotations
 
 import io
-import json
 import sys
 from collections.abc import Callable
 from typing import Any, Dict, Tuple, TypeVar, Union, cast
@@ -195,7 +194,6 @@ def show_experiment_shapes(
         output_handle=output_handle,
         context=context,
     )
-    print(json.dumps(retval, indent=2))
     return _check_statuses(retval)
 
 


### PR DESCRIPTION
**Issue and/or context:** As noted on #3962:

> By accident I merged https://github.com/single-cell-data/TileDB-SOMA/pull/3949 first, not this one. So while the two were reviewed independently, they'll appear in revision history as a single squashed commit. My apologies!

This PR removes a debug-print I meant not to keep.

**Changes:** Only that.

**Notes for Reviewer:** #3966 includes this. So if 3966 is OK, we can merge 3966 & be done. But if there's any doubt/delay with 3966 let's merge this PR instead. 

