### PR TITLE
[python] Test `get_experiment_shapes` for underpopulated experiments

### DIFF
--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -11,7 +11,6 @@ https://github.com/single-cell-data/TileDB-SOMA/issues/2407."""
 from __future__ import annotations
 
 import io
-import json
 import sys
 from collections.abc import Callable
 from typing import Any, Dict, Tuple, TypeVar, Union, cast
@@ -195,7 +194,6 @@ def show_experiment_shapes(
         output_handle=output_handle,
         context=context,
     )
-    print(json.dumps(retval, indent=2))
     return _check_statuses(retval)
 
 
@@ -473,14 +471,17 @@ def _treewalk(
         # Non-terminal
         if isinstance(item, tiledbsoma.Experiment):
             retval = {}
-            retval["obs"] = _recurse(item, node_name="obs", **kwargs)
-            retval["ms"] = _recurse(item, node_name="ms", **kwargs)
+            if "obs" in item:
+                retval["obs"] = _recurse(item, node_name="obs", **kwargs)
+            if "ms" in item:
+                retval["ms"] = _recurse(item, node_name="ms", **kwargs)
             return retval
 
         # Non-terminal
         if isinstance(item, tiledbsoma.Measurement):
             retval = {}
-            retval["var"] = _recurse(item, node_name="var", **kwargs)
+            if "var" in item:
+                retval["var"] = _recurse(item, node_name="var", **kwargs)
             for iter_coll_name in ["X", "obsm", "obsp", "varm", "varp"]:
                 kwargs["coll_name"] = iter_coll_name
                 children_dict = _recurse(item, node_name=iter_coll_name, **kwargs)

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -826,6 +826,43 @@ def test_canned_experiments(tmp_path, has_shapes):
     assert dict_output == expect
 
 
+@pytest.mark.parametrize("level", [1, 2, 3, 4])
+def test_get_experiment_shapes_corner_cases(tmp_path, level):
+    path1 = tmp_path
+    path2 = path1 / "ms"
+    path3 = path2 / "RNA"
+    path4 = path3 / "X"
+
+    uri1 = path1.as_posix()
+    uri2 = path2.as_posix()
+    uri3 = path3.as_posix()
+    uri4 = path4.as_posix()
+
+    with tiledbsoma.Experiment.create(uri1) as exp:
+        if level >= 2:
+            with tiledbsoma.Collection.create(uri2) as ms:
+                if level >= 3:
+                    with tiledbsoma.Measurement.create(uri3) as RNA:
+                        if level >= 4:
+                            with tiledbsoma.Collection.create(uri4) as X:
+                                pass
+                            RNA.set("X", X, use_relative_uri=False)
+                    ms.set("RNA", RNA, use_relative_uri=False)
+            exp.set("ms", ms, use_relative_uri=False)
+
+    actual = tiledbsoma.io.get_experiment_shapes(uri1)
+    expect = {}
+    if level == 1:
+        expect = {}
+    elif level == 2:
+        expect = {"ms": {}}
+    elif level == 3:
+        expect = {"ms": {"RNA": {}}}
+    elif level == 4:
+        expect = {"ms": {"RNA": {}}}
+    assert actual == expect
+
+
 def test_canned_nonstandard_dataframe_upgrade(tmp_path):
     uri = tmp_path.as_posix()
 


### PR DESCRIPTION
**Issue and/or context:** Implements https://github.com/single-cell-data/TileDB-SOMA/pull/3949#discussion_r2040234927

[sc-64098](https://app.shortcut.com/tiledb-inc/story/64098/get-output-of-tiledbsoma-io-show-experiment-shapes)

**Changes:**

**Notes for Reviewer:**

