### PR TITLE
[Backport release-1.16][python] Fix a typo on #3949

### DIFF
--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -11,7 +11,6 @@ https://github.com/single-cell-data/TileDB-SOMA/issues/2407."""
 from __future__ import annotations
 
 import io
-import json
 import sys
 from collections.abc import Callable
 from typing import Any, Dict, Tuple, TypeVar, Union, cast
@@ -195,7 +194,6 @@ def show_experiment_shapes(
         output_handle=output_handle,
         context=context,
     )
-    print(json.dumps(retval, indent=2))
     return _check_statuses(retval)
 
 


### PR DESCRIPTION
**Issue and/or context:** Backports #3965 to `release-1.16` following https://github.com/single-cell-data/TileDB-SOMA/pull/3965#issuecomment-2798093586

**Changes:**

**Notes for Reviewer:**

