### PR TITLE
[python] Increase unit-test coverage for various metadata value-types

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -872,8 +872,10 @@ class MetadataWrapper(MutableMapping[str, Any]):
             for error in errors:
                 details.append(repr(error))
 
+            error_msg_details = "\n".join(details)
+
             raise SOMAError(
-                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk. Details: \n {"----\n".join(details)}"
+                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk. Details: \n {error_msg_details}"
             )
 
     def __repr__(self) -> str:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -868,8 +868,12 @@ class MetadataWrapper(MutableMapping[str, Any]):
         self._mods.clear()
 
         if errors:
+            details = []
+            for error in errors:
+                details.append(repr(error))
+
             raise SOMAError(
-                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk."
+                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk. Details: \n {"----\n".join(details)}"
             )
 
     def __repr__(self) -> str:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -875,7 +875,7 @@ class MetadataWrapper(MutableMapping[str, Any]):
             error_msg_details = "\n".join(details)
 
             raise SOMAError(
-                f"[MetadataWrapper][_write] {len(errors)} errors occured while writing metadata to disk. Details: \n {error_msg_details}"
+                f"[MetadataWrapper][_write] {len(errors)} error(s) occured while writing metadata to disk. Details: \n {error_msg_details}"
             )
 
     def __repr__(self) -> str:

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -187,11 +187,15 @@ def non_soma_metadata(obj) -> Dict[str, Any]:
         0,
         1.00000001,
         -3.1415,
+        np.float64(-3.1415),
         "",
         "\x00",
         "\U00000000",  # get's casted to \x00
         "\x10abc",
         "\U00081a63×\x84\x94𘪩a\U000a4f44Î\x10m",
+        "😀",
+        "¡ ¢ £ ¤ ¥ ¦ § ¨ © ª « ¬ ­ ® ¯ ° ± ² ³ ´ µ ¶ · ¸ ¹ º » ¼ ½ ¾ ¿",
+        "␀ ␁ ␂ ␃ ␄ ␅ ␆ ␇ ␈ ␉ ␊ ␋ ␌ ␍ ␎ ␏ ␐ ␑ ␒ ␓ ␔ ␕ ␖ ␗ ␘ ␙ ␚ ␛ ␜ ␝ ␞ ␟ ␠ ␡ ␢ ␣ ␤",
         np.str_("foo"),
         "a string",
         math.nan,
@@ -226,7 +230,22 @@ def test_metadata_marshalling_OK(soma_object, test_value):
 
 @pytest.mark.parametrize(
     "bad_value",
-    [["a", "b", "c"], {"a": False}, [1, 2, 3], np.arange(10)],
+    [
+        ["a", "b", "c"],
+        {"a": False},
+        [1, 2, 3],
+        np.arange(10),
+        np.bool(True),
+        np.int8(10),
+        np.int16(10),
+        np.int32(10),
+        np.int64(10),
+        np.uint8(10),
+        np.uint16(10),
+        np.uint32(10),
+        np.uint64(10),
+        np.float32(10),
+    ],
 )
 def test_metadata_marshalling_FAIL(soma_object, bad_value):
     """Verify that unsupported metadata types raise an error immediately."""
@@ -239,7 +258,15 @@ def test_metadata_marshalling_FAIL(soma_object, bad_value):
 
 @pytest.mark.parametrize(
     "good_key",
-    ["", "\x10abc", "\U00081a63×\x84\x94𘪩a\U000a4f44Î\x10m", "a string"],
+    [
+        "",
+        "\x10abc",
+        "\U00081a63×\x84\x94𘪩a\U000a4f44Î\x10m",
+        "a string",
+        "😀",
+        "¡ ¢ £ ¤ ¥ ¦ § ¨ © ª « ¬ ­ ® ¯ ° ± ² ³ ´ µ ¶ · ¸ ¹ º » ¼ ½ ¾ ¿",
+        "␀ ␁ ␂ ␃ ␄ ␅ ␆ ␇ ␈ ␉ ␊ ␋ ␌ ␍ ␎ ␏ ␐ ␑ ␒ ␓ ␔ ␕ ␖ ␗ ␘ ␙ ␚ ␛ ␜ ␝ ␞ ␟ ␠ ␡ ␢ ␣ ␤",
+    ],
 )
 def test_metadata_good_key(soma_object, good_key):
     """Verify that unsupported metadata types raise an error immediately."""
@@ -249,7 +276,14 @@ def test_metadata_good_key(soma_object, good_key):
 
 @pytest.mark.parametrize(
     "bad_key",
-    ["\x00", "AA\x00BB", "AA\U00000000BB"],
+    [
+        "\x00",
+        "AA\x00BB",
+        "AA\U00000000BB",
+        "😀\U00000000",
+        "¡ ¢ £ ¤ ¥ ¦ § ¨ © ª « ¬ ­ ® ¯\x00 ° ± ² ³ ´ µ ¶ · ¸ ¹ º » ¼ ½ ¾ ¿",
+        "␀ ␁ ␂ ␃ ␄ ␅ ␆ ␇ ␈ ␉ ␊ ␋ ␌ ␍ ␎\x00 ␏ ␐ ␑ ␒ ␓ ␔ ␕ ␖ ␗ ␘ ␙ ␚ ␛ ␜ ␝ ␞ ␟ ␠ ␡ ␢ ␣ ␤",
+    ],
 )
 def test_metadata_bad_key(soma_object, bad_key):
     """Verify that unsupported metadata types raise an error immediately."""
@@ -270,6 +304,9 @@ def test_metadata_bad_key(soma_object, bad_key):
         b"\xc2",
         b"\x00",
         np.bytes_("foo"),
+        "😀\U00000000",
+        "¡ ¢ £ ¤ ¥ ¦ § ¨ © ª « ¬ ­ ® ¯\x00 ° ± ² ³ ´ µ ¶ · ¸ ¹ º » ¼ ½ ¾ ¿",
+        "␀ ␁ ␂ ␃ ␄ ␅ ␆ ␇ ␈ ␉ ␊ ␋ ␌ ␍ ␎\x00 ␏ ␐ ␑ ␒ ␓ ␔ ␕ ␖ ␗ ␘ ␙ ␚ ␛ ␜ ␝ ␞ ␟ ␠ ␡ ␢ ␣ ␤",
     ],
 )
 def test_metadata_bad_string_value(soma_object, bad_value):

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -235,7 +235,7 @@ def test_metadata_marshalling_OK(soma_object, test_value):
         {"a": False},
         [1, 2, 3],
         np.arange(10),
-        np.bool(True),
+        np.bool_(True),
         np.int8(10),
         np.int16(10),
         np.int32(10),


### PR DESCRIPTION
**Issue and/or context:** [sc-62840](https://app.shortcut.com/tiledb-inc/story/62840/python-increase-unit-test-coverage-for-various-metadata-value-types)

**Changes:**
- Add more Unicode sequences to metadata unit test
- Add test for bitsized numpy scalars
- Improve error messages for metadata errors

**Notes for Reviewer:**

