### PR TITLE
[python] Harmonize/GC daily-GHA-failure issue-templates

### DIFF
--- a/.github/workflows/daily-python-dockers-issue-template.md
+++ b/.github/workflows/daily-python-dockers-issue-template.md
@@ -1,5 +1,5 @@
 ---
-title: Daily {{ tools.context.action }} run failing
+title: Daily `python-dockers.yml` build run failing
 labels: bug
 ---
 

--- a/.github/workflows/daily-python-dockers-issue-template.md
+++ b/.github/workflows/daily-python-dockers-issue-template.md
@@ -1,5 +1,5 @@
 ---
-title: Daily `python-dockers.yml` build run failing
+title: Daily `python-dockers.yml` build failing
 labels: bug
 ---
 

--- a/.github/workflows/daily-python-packaging-issue-template.md
+++ b/.github/workflows/daily-python-packaging-issue-template.md
@@ -1,6 +1,5 @@
 ---
-title: Daily GitHub Actions fail for remote tests on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: nguyenv, johnkerl
+title: Daily `python-packaging.yml` build failing
 labels: bug
 ---
 

--- a/.github/workflows/daily-test-build-issue-template.md
+++ b/.github/workflows/daily-test-build-issue-template.md
@@ -1,8 +1,0 @@
----
-title: Daily GitHub Actions build fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: nguyenv, ryan-williams, johnkerl
-labels: bug
----
-
-See run for more details:
-https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -253,4 +253,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: .github/workflows/daily-test-build-issue-template.md
+          filename: .github/workflows/daily-python-packaging-issue-template.md
+          assignees: nguyenv, ryan-williams, johnkerl
+          update_existing: true


### PR DESCRIPTION
**Issue and/or context:**
- Issue title was missing info on #3969 (`python-dockers.yml` failure)
- `python-packaging.yml`-failure issue-titles could be clearer about which daily build was failing  (cf. #3968)

**Changes:**
- Updated issue-template titles for `python-{dockers,packaging}.yml` to "Daily `XXX.yml` build failing"
- Removed unused `.github/workflows/daily-remote-tests-issue-template.md`
- Renamed issue templates to `daily-python-{dockers,packaging}-issue-template.md`
- Changed `python-packaging.yml` to update an existing issue (to consolidate consecutive-day failures onto one issue)
  - This also required removing the date from the issue title. "Daily `XXX.yml` build failing" should capture the spirit of the problem better.


**Notes for reviewer:**
Git{,Hub} are rendering the diff as:
```
 .github/workflows/{daily-remote-tests-issue-template.md => daily-python-packaging-issue-template.md} | 3 +--
 .github/workflows/daily-test-build-issue-template.md                                                 | 8 --------
```
which misunderstands which file was deleted vs. renamed, but the result is the same / correct afaict.