### PR TITLE
h5py cleanup race fix

### DIFF
--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -176,9 +176,7 @@ class CachingReader:
     def close(self) -> None:
         """Close the file handle."""
         self._reset_cache()
-        if self._file is not None:
-            self._file.close()
-            self._file = None
+        self._file.close()
 
     def tell(self) -> int:
         """Return integer indicating the file object's current position in the file.

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -176,7 +176,9 @@ class CachingReader:
     def close(self) -> None:
         """Close the file handle."""
         self._reset_cache()
-        self._file.close()
+        if self._file is not None:
+            self._file.close()
+            self._file = None
 
     def tell(self) -> int:
         """Return integer indicating the file object's current position in the file.

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -58,6 +58,9 @@ def read_h5ad(
             anndata = ad.read_h5ad(_FSPathWrapper(input_handle, input_path), mode)
             yield anndata
     finally:
+        # This prevents a race condition with the REPL cleanup in ipython. See sc-65863
+        if anndata.file:
+            anndata.file.close()
         input_handle.close()
 
 


### PR DESCRIPTION
**Issue and/or context:**

There was a cleanup race which only manifested when:
* running in the `ipython` REPL
* an exception was thrown while an AnnData was open using the `soma.io.` anndata read proxy
* and the exception was caught and reported by the ipython REPL (which holds a latent reference to the stack traceback)

All of these together would cause a SEGV in h5py/hdf5.

Work-around is to manually break the race by closing the proxy handle when an exception occurs

**Changes:**

**Notes for Reviewer:**

[sc-65863]

