### PR TITLE
[python] Have `SOMAFileHandle` encapsulate both `VFS` and `VFSFilebuf`

### DIFF
--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -48,7 +48,7 @@ def read_h5ad(
     """
     ctx = ctx or SOMATileDBContext()
     input_handle = CachingReader(
-        clib.SOMAVFS(ctx.native_context).open(str(input_path)),
+        clib.SOMAFileHandle(str(input_path), ctx.native_context),
         memory_budget=64 * 1024**2,
         cache_block_size=8 * 1024**2,
     )

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -47,9 +47,8 @@ def read_h5ad(
     This lets us ingest H5AD with "r" (backed mode) from S3 URIs.
     """
     ctx = ctx or SOMATileDBContext()
-    vfs = clib.SOMAVFS(ctx.native_context)
     input_handle = CachingReader(
-        clib.SOMAVFSFilebuf(vfs).open(str(input_path)),
+        clib.SOMAVFS(ctx.native_context).open(str(input_path)),
         memory_budget=64 * 1024**2,
         cache_block_size=8 * 1024**2,
     )

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -23,8 +23,15 @@ using namespace tiledbsoma;
 // TODO This temporary workaround prevents namespace clash with tiledb-py.
 // Bind tiledb::VFS directly once tiledb-py dependency is removed
 class SOMAVFS : public tiledb::VFS {
+   private:
+    std::shared_ptr<SOMAContext> ctx_;
+
    public:
-    using tiledb::VFS::VFS;
+    SOMAVFS(std::shared_ptr<SOMAContext> ctx)
+        : tiledb::VFS(*ctx->tiledb_ctx())
+        , ctx_(ctx) {
+    }
+
     SOMAVFS(const tiledb::VFS& vfs)
         : tiledb::VFS(vfs) {
     }
@@ -127,7 +134,7 @@ void load_soma_vfs(py::module& m) {
     py::class_<SOMAVFS, std::shared_ptr<SOMAVFS>>(m, "SOMAVFS")
         .def(
             py::init([](std::shared_ptr<SOMAContext> context) {
-                return SOMAVFS(*context->tiledb_ctx());
+                return SOMAVFS(context);
             }),
             "ctx"_a);
 

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -14,45 +14,43 @@
 
 #include "common.h"
 
+#include <streambuf>
+
 namespace libtiledbsomacpp {
 
 namespace py = pybind11;
 using namespace py::literals;
 using namespace tiledbsoma;
 
-// TODO This temporary workaround prevents namespace clash with tiledb-py.
-// Bind tiledb::VFS directly once tiledb-py dependency is removed
-class SOMAVFS : public tiledb::VFS {
+class SOMAVFS {
+   public:
+    class SOMAFilebuf : public tiledb::impl::VFSFilebuf {
+       public:
+        using tiledb::impl::VFSFilebuf::seekoff;
+        using tiledb::impl::VFSFilebuf::showmanyc;
+        using tiledb::impl::VFSFilebuf::VFSFilebuf;
+        using tiledb::impl::VFSFilebuf::xsgetn;
+    };
+
    private:
+    std::streamsize offset_ = 0;
+    std::ios::openmode openmode_ = std::ios::in;  // hardwired to read-only
+
+    // Ensure proper order of destruction
+    SOMAFilebuf buf_;
+    tiledb::VFS vfs_;
     std::shared_ptr<SOMAContext> ctx_;
 
    public:
     SOMAVFS(std::shared_ptr<SOMAContext> ctx)
-        : tiledb::VFS(*ctx->tiledb_ctx())
+        : vfs_(tiledb::VFS(*ctx->tiledb_ctx()))
+        , buf_(SOMAFilebuf(vfs_))
         , ctx_(ctx) {
     }
 
-    SOMAVFS(const tiledb::VFS& vfs)
-        : tiledb::VFS(vfs) {
-    }
-};
-
-class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
-   private:
-    std::streamsize offset_ = 0;
-    std::shared_ptr<SOMAVFS> vfs_;
-    std::ios::openmode openmode_;
-
-   public:
-    SOMAVFSFilebuf(std::shared_ptr<SOMAVFS> vfs)
-        : tiledb::impl::VFSFilebuf(*vfs)
-        , vfs_(vfs){};
-
-    SOMAVFSFilebuf* open(const std::string& uri, std::ios::openmode openmode) {
-        openmode_ = openmode;
-        if (tiledb::impl::VFSFilebuf::open(uri, openmode) == nullptr) {
-            // No std::format in C++17, and fmt::format is overkill
-            // here
+    SOMAVFS* open(const std::string& uri) {
+        if (buf_.open(uri, openmode_) == nullptr) {
+            // No std::format in C++17, and fmt::format is overkill here
             std::stringstream ss;
             ss << "URI " << uri << " is not a valid URI";
             TPY_ERROR_LOC(ss.str());
@@ -62,12 +60,12 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
 
     std::streamsize seek(std::streamsize offset, uint64_t whence) {
         if (whence == 0) {
-            offset_ = seekoff(offset, std::ios::beg, std::ios::in);
+            offset_ = buf_.seekoff(offset, std::ios::beg, std::ios::in);
         } else if (whence == 1) {
-            offset_ += seekoff(offset, std::ios::cur, std::ios::in);
+            offset_ += buf_.seekoff(offset, std::ios::cur, std::ios::in);
         } else if (whence == 2) {
-            offset_ = vfs_->file_size(get_uri()) -
-                      seekoff(offset, std::ios::end, std::ios::in);
+            offset_ = vfs_.file_size(buf_.get_uri()) -
+                      buf_.seekoff(offset, std::ios::end, std::ios::in);
         } else {
             TPY_ERROR_LOC(
                 "whence must be equal to SEEK_SET, SEEK_CUR, SEEK_END");
@@ -77,14 +75,16 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
     }
 
     py::bytes read(std::streamsize size) {
-        int64_t nbytes = (size < 0 || size > showmanyc()) ? showmanyc() : size;
+        int64_t nbytes = (size < 0 || size > buf_.showmanyc()) ?
+                             buf_.showmanyc() :
+                             size;
         if (nbytes <= 0) {
             return py::bytes("");
         }
 
         py::gil_scoped_release release;
         std::string buffer(nbytes, '\0');
-        offset_ += xsgetn(&buffer[0], nbytes);
+        offset_ += buf_.xsgetn(&buffer[0], nbytes);
         py::gil_scoped_acquire acquire;
 
         return py::bytes(buffer);
@@ -102,7 +102,7 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
             return 0;
 
         py::gil_scoped_release release;
-        auto bytes_read = xsgetn(static_cast<char*>(info.ptr), nbytes);
+        auto bytes_read = buf_.xsgetn(static_cast<char*>(info.ptr), nbytes);
         offset_ += bytes_read;
         py::gil_scoped_acquire acquire;
 
@@ -111,6 +111,10 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
 
     std::streamsize tell() {
         return offset_;
+    }
+
+    void close(bool should_throw) {
+        buf_.close(should_throw);
     }
 
     bool readable() {
@@ -122,7 +126,7 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
     }
 
     bool closed() {
-        return !is_open();
+        return !buf_.is_open();
     }
 
     bool seekable() {
@@ -131,35 +135,27 @@ class SOMAVFSFilebuf : public tiledb::impl::VFSFilebuf {
 };
 
 void load_soma_vfs(py::module& m) {
-    py::class_<SOMAVFS, std::shared_ptr<SOMAVFS>>(m, "SOMAVFS")
-        .def(
-            py::init([](std::shared_ptr<SOMAContext> context) {
-                return SOMAVFS(context);
-            }),
-            "ctx"_a);
-
-    py::class_<SOMAVFSFilebuf>(m, "SOMAVFSFilebuf")
-        .def(py::init<const std::shared_ptr<SOMAVFS>&>())
+    py::class_<SOMAVFS>(m, "SOMAVFS")
+        .def(py::init<std::shared_ptr<SOMAContext>>(), "ctx"_a)
         .def(
             "open",
-            [](SOMAVFSFilebuf& buf, const std::string& uri) {
-                return buf.open(uri, std::ios::in);  // hardwired to read-only
-            },
+            &SOMAVFS::open,
+            "uri"_a,
             py::call_guard<py::gil_scoped_release>())
-        .def("read", &SOMAVFSFilebuf::read, "size"_a = -1)
-        .def("readinto", &SOMAVFSFilebuf::readinto, "buffer"_a)
-        .def("flush", [](SOMAVFSFilebuf& buf) {})
-        .def("tell", &SOMAVFSFilebuf::tell)
-        .def("readable", &SOMAVFSFilebuf::readable)
-        .def("writable", &SOMAVFSFilebuf::writable)
-        .def_property_readonly("closed", &SOMAVFSFilebuf::closed)
-        .def("seekable", &SOMAVFSFilebuf::seekable)
+        .def("read", &SOMAVFS::read, "size"_a = -1)
+        .def("readinto", &SOMAVFS::readinto, "buffer"_a)
+        .def("flush", [](SOMAVFS& buf) {})
+        .def("tell", &SOMAVFS::tell)
+        .def("readable", &SOMAVFS::readable)
+        .def("writable", &SOMAVFS::writable)
+        .def_property_readonly("closed", &SOMAVFS::closed)
+        .def("seekable", &SOMAVFS::seekable)
         .def(
             "seek",
-            &SOMAVFSFilebuf::seek,
+            &SOMAVFS::seek,
             "offset"_a,
             "whence"_a = 0,
             py::call_guard<py::gil_scoped_release>())
-        .def("close", &SOMAVFSFilebuf::close, "should_throw"_a = true);
+        .def("close", &SOMAVFS::close, "should_throw"_a = true);
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -37,7 +37,6 @@ class SOMAFileHandle {
     std::ios::openmode openmode_ = std::ios::in;  // hardwired to read-only
 
     // Ensure proper order of destruction
-    const std::string& uri_;
     SOMAFilebuf buf_;
     tiledb::VFS vfs_;
     std::shared_ptr<SOMAContext> ctx_;
@@ -46,8 +45,7 @@ class SOMAFileHandle {
     SOMAFileHandle(const std::string& uri, std::shared_ptr<SOMAContext> ctx)
         : vfs_(tiledb::VFS(*ctx->tiledb_ctx()))
         , buf_(SOMAFilebuf(vfs_))
-        , ctx_(ctx)
-        , uri_(uri) {
+        , ctx_(ctx) {
         if (buf_.open(uri, openmode_) == nullptr) {
             // No std::format in C++17, and fmt::format is overkill here
             std::stringstream ss;
@@ -66,7 +64,7 @@ class SOMAFileHandle {
         } else if (whence == 1) {
             offset_ += buf_.seekoff(offset, std::ios::cur, std::ios::in);
         } else if (whence == 2) {
-            offset_ = vfs_.file_size(uri_) -
+            offset_ = vfs_.file_size(buf_.get_uri()) -
                       buf_.seekoff(offset, std::ios::end, std::ios::in);
         } else {
             TPY_ERROR_LOC(

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1562,8 +1562,8 @@ def test_from_anndata_byteorder_63459(tmp_path, conftest_pbmc_small):
 
 def test_vfs_lifetime_65831_65864():
     context = tiledbsoma.SOMATileDBContext()
-    fb = tiledbsoma.pytiledbsoma.SOMAVFS(context.native_context).open(
-        str(TESTDATA / "pbmc-small.h5ad")
+    fb = tiledbsoma.pytiledbsoma.SOMAFileHandle(
+        str(TESTDATA / "pbmc-small.h5ad"), context.native_context
     )
     del context  # https://app.shortcut.com/tiledb-inc/story/65864/
     gc.collect()  # Make sure that context is freed

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1560,14 +1560,14 @@ def test_from_anndata_byteorder_63459(tmp_path, conftest_pbmc_small):
         assert ad.uns["X"] == new_ad.uns["X"]
 
 
-def test_vfs_lifetime_65831():
-    # https://app.shortcut.com/tiledb-inc/story/65831/python-c-segv-memory-issues-in-somavfs-somavfsfilebuf
+def test_vfs_lifetime_65831_65864():
     context = tiledbsoma.SOMATileDBContext()
     vfs = tiledbsoma.pytiledbsoma.SOMAVFS(context.native_context)
+    del context  # https://app.shortcut.com/tiledb-inc/story/65864/
     fb = tiledbsoma.pytiledbsoma.SOMAVFSFilebuf(vfs).open(
         str(TESTDATA / "pbmc-small.h5ad")
     )
-    del vfs
+    del vfs  # https://app.shortcut.com/tiledb-inc/story/65831/
     gc.collect()  # Make sure that vfs is freed
     fb.read(100)  # Implicitly ensure that read does not segfault
     fb.close()

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1560,7 +1560,7 @@ def test_from_anndata_byteorder_63459(tmp_path, conftest_pbmc_small):
         assert ad.uns["X"] == new_ad.uns["X"]
 
 
-def test_vfs_lifetime_65831_65864():
+def test_soma_file_handling_65831_65864():
     context = tiledbsoma.SOMATileDBContext()
     fb = tiledbsoma.pytiledbsoma.SOMAFileHandle(
         str(TESTDATA / "pbmc-small.h5ad"), context.native_context
@@ -1569,3 +1569,19 @@ def test_vfs_lifetime_65831_65864():
     gc.collect()  # Make sure that context is freed
     fb.read(100)  # Implicitly ensure that read does not segfault
     fb.close()
+
+    with pytest.raises(
+        tiledbsoma.SOMAError, match="File must be open before performing read"
+    ):
+        fb.read(100)
+
+    with pytest.raises(
+        tiledbsoma.SOMAError, match="File must be open before performing seek"
+    ):
+        fb.seek(100, 1)
+
+    with pytest.raises(
+        tiledbsoma.SOMAError, match="File must be open before performing readinto"
+    ):
+        arr = np.zeros(100, dtype=np.uint8)
+        fb.readinto(arr)

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1562,12 +1562,10 @@ def test_from_anndata_byteorder_63459(tmp_path, conftest_pbmc_small):
 
 def test_vfs_lifetime_65831_65864():
     context = tiledbsoma.SOMATileDBContext()
-    vfs = tiledbsoma.pytiledbsoma.SOMAVFS(context.native_context)
-    del context  # https://app.shortcut.com/tiledb-inc/story/65864/
-    fb = tiledbsoma.pytiledbsoma.SOMAVFSFilebuf(vfs).open(
+    fb = tiledbsoma.pytiledbsoma.SOMAVFS(context.native_context).open(
         str(TESTDATA / "pbmc-small.h5ad")
     )
-    del vfs  # https://app.shortcut.com/tiledb-inc/story/65831/
-    gc.collect()  # Make sure that vfs is freed
+    del context  # https://app.shortcut.com/tiledb-inc/story/65864/
+    gc.collect()  # Make sure that context is freed
     fb.read(100)  # Implicitly ensure that read does not segfault
     fb.close()


### PR DESCRIPTION
**Issue and/or context:**

[[sc-65864](https://app.shortcut.com/tiledb-inc/story/65864/python-c-valgrind-reports-bad-ref-in-somavfs)]

**Changes:**

Fix lifetime issues with the `Context` by encapsulating `VFS` and `VFSFilebuf` into a single `SOMAFileHandle` Pybind11 class.
