### PR TITLE
[c++,python] Correct SOMA type for collection members

### DIFF
--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -279,9 +279,23 @@ class GroupEntry:
     @classmethod
     def from_soma_group_entry(cls, obj: tuple[str, str]) -> "GroupEntry":
         uri, type = obj[0], obj[1]
-        if type == "SOMAArray":
+        if type in (
+            "SOMAArray",
+            "SOMADataFrame",
+            "SOMADenseNDArray",
+            "SOMAGeometryDataFrame",
+            "SOMAPointCloudDataFrame",
+            "SOMASparseNDArray",
+        ):
             return GroupEntry(uri, SOMAArrayWrapper)
-        if type == "SOMAGroup":
+        if type in (
+            "SOMAGroup",
+            "SOMACollection",
+            "SOMAExperiment",
+            "SOMAMeasurement",
+            "SOMAScene",
+            "SOMAMultiscaleImage",
+        ):
             return GroupEntry(uri, SOMAGroupWrapper)
         raise SOMAError(f"internal error: unknown object type {uri}")
 

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -112,6 +112,11 @@ def test_collection_basic(tmp_path):
     with pytest.raises(soma.SOMAError):
         soma.MultiscaleImage.open(collection.uri)
 
+    with soma.Collection.open(basedir) as collection:
+        mems = collection.members()
+        assert mems["sdf"][1] == "SOMADataFrame"
+        assert mems["snda"][1] == "SOMASparseNDArray"
+
 
 @pytest.fixture(
     scope="function",

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -211,6 +211,16 @@ SOMACollectionBase <- R6::R6Class(
         SOMAArray = TileDBArray$new,
         GROUP = TileDBGroup$new,
         SOMAGroup = TileDBGroup$new,
+        SOMADataFrame = TileDBArray$new,
+        SOMADenseNDArray = TileDBArray$new,
+        SOMAGeometryDataFrame = TileDBArray$new,
+        SOMAPointCloudDataFrame = TileDBArray$new,
+        SOMASparseNDArray = TileDBArray$new,
+        SOMACollection = TileDBGroup$new,
+        SOMAExperiment = TileDBGroup$new,
+        SOMAMeasurement = TileDBGroup$new,
+        SOMAScene = TileDBGroup$new,
+        SOMAMultiscaleImage = TileDBGroup$new,
         stop(sprintf("Unknown member TileDB type: %s", type), call. = FALSE)
       )
 

--- a/apis/r/R/TileDBGroup.R
+++ b/apis/r/R/TileDBGroup.R
@@ -352,6 +352,16 @@ TileDBGroup <- R6::R6Class(
         SOMAArray = TileDBArray$new,
         GROUP = TileDBGroup$new,
         SOMAGroup = TileDBGroup$new,
+        SOMADataFrame = TileDBArray$new,
+        SOMADenseNDArray = TileDBArray$new,
+        SOMAGeometryDataFrame = TileDBArray$new,
+        SOMAPointCloudDataFrame = TileDBArray$new,
+        SOMASparseNDArray = TileDBArray$new,
+        SOMACollection = TileDBGroup$new,
+        SOMAExperiment = TileDBGroup$new,
+        SOMAMeasurement = TileDBGroup$new,
+        SOMAScene = TileDBGroup$new,
+        SOMAMultiscaleImage = TileDBGroup$new,
         stop(sprintf("Unknown member type: %s", type), call. = FALSE)
       )
       obj <- constructor(uri,

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -90,7 +90,8 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMACollection> member = SOMACollection::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }
@@ -116,7 +117,8 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }
@@ -142,7 +144,8 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }
@@ -168,7 +171,8 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }
@@ -194,7 +198,8 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }
@@ -220,7 +225,8 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::open(
         uri, OpenMode::read, ctx, timestamp);
-    this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
+    this->set(
+        std::string(uri), uri_type, std::string(key), member->type().value());
     children_[std::string(key)] = member;
     return member;
 }

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -138,32 +138,29 @@ void SOMAGroup::fill_caches() {
         auto mem = cache_group_->member(i);
         std::string parent_soma_type = util::soma_type_from_tiledb_type(
             mem.type());
-        std::optional<std::string> soma_type = std::nullopt;
+        std::string soma_type;
 
         if (parent_soma_type == "SOMAArray") {
             try {
                 soma_type = SOMAArray::open(OpenMode::read, mem.uri(), ctx_)
-                                ->type();
+                                ->type()
+                                .value_or("SOMAArray");
             } catch (std::exception& e) {
                 soma_type = "SOMAArray";
             }
         } else if (parent_soma_type == "SOMAGroup") {
             try {
                 soma_type = SOMAGroup::open(OpenMode::read, mem.uri(), ctx_)
-                                ->type();
+                                ->type()
+                                .value_or("SOMAGroup");
             } catch (std::exception& e) {
                 soma_type = "SOMAGroup";
             }
         }
 
-        if (!soma_type.has_value()) {
-            throw TileDBSOMAError(fmt::format(
-                "Group member '{}' has invalid SOMA type", mem.uri()));
-        }
-
         std::string key = mem.name().has_value() ? mem.name().value() :
                                                    mem.uri();
-        members_map_[key] = SOMAGroupEntry(mem.uri(), *soma_type);
+        members_map_[key] = SOMAGroupEntry(mem.uri(), soma_type);
     }
 }
 

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -50,7 +50,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     auto index_columns = helper::create_column_index_info(dim_infos);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
+        {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMASparseNDArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -102,7 +102,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
     auto index_columns = helper::create_column_index_info(dim_infos);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
+        {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMADenseNDArray")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -161,7 +161,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         helper::create_arrow_schema_and_index_columns(dim_infos, attr_infos);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
+        {"dataframe", SOMAGroupEntry(sub_uri, "SOMADataFrame")}};
 
     auto soma_collection = SOMACollection::open(
         base_uri, OpenMode::write, ctx, ts);
@@ -200,7 +200,7 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     SOMACollection::create(base_uri, ctx);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
+        {"subcollection", SOMAGroupEntry(sub_uri, "SOMACollection")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
@@ -239,7 +239,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
         helper::create_arrow_schema_and_index_columns(dim_infos, attr_infos);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
+        {"experiment", SOMAGroupEntry(sub_uri, "SOMAExperiment")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
@@ -284,7 +284,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
         helper::create_arrow_schema_and_index_columns(dim_infos, attr_infos);
 
     std::map<std::string, SOMAGroupEntry> expected_map{
-        {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
+        {"measurement", SOMAGroupEntry(sub_uri, "SOMAMeasurement")}};
 
     auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -131,10 +131,10 @@ TEST_CASE("SOMAGroup: basic") {
     auto ctx = std::make_shared<SOMAContext>();
 
     std::string uri_main_group = "mem://main-group";
-    SOMAGroup::create(ctx, uri_main_group, "NONE");
+    SOMAGroup::create(ctx, uri_main_group, "SOMAGroup");
 
     std::string uri_sub_group = "mem://sub-group";
-    SOMAGroup::create(ctx, uri_sub_group, "NONE");
+    SOMAGroup::create(ctx, uri_sub_group, "SOMAGroup");
 
     auto [uri_sub_array, expected_nnz] = create_array(
         "mem://sub-array", *ctx->tiledb_ctx());
@@ -153,6 +153,8 @@ TEST_CASE("SOMAGroup: basic") {
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->count() == 2);
+    std::cout << soma_group->members_map()["subgroup"].second << std::endl;
+    std::cout << soma_group->members_map()["subarray"].second << std::endl;
     REQUIRE(expected_map == soma_group->members_map());
     REQUIRE(soma_group->get("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get("subarray").type() == Object::Type::Array);

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -153,8 +153,6 @@ TEST_CASE("SOMAGroup: basic") {
     REQUIRE(soma_group->ctx() == ctx);
     REQUIRE(soma_group->uri() == uri_main_group);
     REQUIRE(soma_group->count() == 2);
-    std::cout << soma_group->members_map()["subgroup"].second << std::endl;
-    std::cout << soma_group->members_map()["subarray"].second << std::endl;
     REQUIRE(expected_map == soma_group->members_map());
     REQUIRE(soma_group->get("subgroup").type() == Object::Type::Group);
     REQUIRE(soma_group->get("subarray").type() == Object::Type::Array);


### PR DESCRIPTION
**Issue and/or context:**

[[sc-65770](https://app.shortcut.com/tiledb-inc/story/65770/python-somacollection-members-returns-incorrect-soma-type-for-collection-members)]

**Changes:**

Previously, the code would return `SOMAArray` for `tiledb::Object::Array` and `SOMAGroup` for `tiledb::Object::Group`. Now we use `SOMAArray::open` and `SOMAGroup::open` and use `SOMAObject::type` to get the derived class.
