### PR TITLE
[python] skip redundant metadata writes for improved performance

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1455,6 +1455,11 @@ def _write_dataframe_impl(
                 platform_config=platform_config,
                 context=context,
             )
+            # Save the original index name for outgest. We use JSON for elegant indication of index name
+            # being None (in Python anyway).
+            soma_df.metadata[_DATAFRAME_ORIGINAL_INDEX_NAME_JSON] = json.dumps(
+                original_index_metadata
+            )
         except (AlreadyExistsError, NotCreateableError):
             if ingestion_params.error_if_already_exists:
                 raise SOMAError(f"{df_uri} already exists")
@@ -1479,11 +1484,6 @@ def _write_dataframe_impl(
             arrow_table, soma_df, tiledb_create_options, tiledb_write_options
         )
 
-    # Save the original index name for outgest. We use JSON for elegant indication of index name
-    # being None (in Python anyway).
-    soma_df.metadata[_DATAFRAME_ORIGINAL_INDEX_NAME_JSON] = json.dumps(
-        original_index_metadata
-    )
     add_metadata(soma_df, additional_metadata)
 
     logging.log_io(


### PR DESCRIPTION
**Issue and/or context:**

tiledbsoma.io.from_anndata writes metadata on the obs and var DataFrame to indicate the original index name for the ingested dataframe. This is essentially schema information, as it known at create time, and must never change (i.e., even in append mode, the incoming AnnData must share obs/var structure).

The current code sets this metadata, to the same value, for each AnnData ingested.  This will create a new metadata fragment, containing identical data, for each AnnData ingested. 

**Changes:**

Set the metadata value at create time, rather than at data write time. End result is one fragment, rather than one per AnnData.
