### PR TITLE
[r] Move package startup messages to attach hook

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.17.99
+Version: 1.17.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = "aut", email = "aaron@tiledb.com",

--- a/apis/r/R/zzz.R
+++ b/apis/r/R/zzz.R
@@ -7,7 +7,11 @@
 .onLoad <- function(libname, pkgname) {
   ## create a slot for somactx in per-package enviroment, do no fill it yet to allow 'lazy load'
   .pkgenv[["somactx"]] <- NULL
+}
 
+## An .onAttach() function is not allowed to use cat() etc but _must_ communicate via
+## packageStartupMessage() as this function can be 'muzzled' as desired. See Writing R Extensions.
+.onAttach <- function(libname, pkgname) {
   rpkg_lib <- tiledb::tiledb_version(compact = FALSE)
   # Check major and minor but not micro: sc-50464
   rpkg_lib_version <- paste(rpkg_lib[["major"]], rpkg_lib[["minor"]], sep = ".")
@@ -19,11 +23,6 @@
     )
     packageStartupMessage(msg)
   }
-}
-
-## An .onAttach() function is not allowed to use cat() etc but _must_ communicate via
-## packageStartupMessage() as this function can be 'muzzled' as desired. See Writing R Extensions.
-.onAttach <- function(libname, pkgname) {
   if (interactive()) {
     packageStartupMessage(
       "TileDB-SOMA R package ", packageVersion(pkgname),


### PR DESCRIPTION
Package startup messages are not allowed in load hook; move them to the attach hook to follow CRAN's policies

Fixes [SOMA-24](https://linear.app/tiledb/issue/SOMA-24)