### PR TITLE
[python] prepare for ruff/black line length change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: "25.1.0"
     hooks:
     - id: black
+      args: ["--config=apis/python/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -18,11 +18,13 @@ module = "tiledbsoma._query_condition"
 ignore_errors = true
 
 [tool.ruff]
-lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
 target-version = "py39"
-line-length = 120
+line-length = 88
+
+[tool.ruff.lint]
+extend-select = ["I001"]  # unsorted-imports
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
@@ -33,10 +35,13 @@ no-lines-before = ["tiledb"]
 "tiledbsoma" = ["tiledbsoma"]
 "tiledb" = ["tiledb"]
 
-
 [tool.pytest.ini_options]
 filterwarnings = ["ignore:Support for spatial types is experimental"]
 markers = [
     "slow: mark test as slow",
     "spatialdata: test of SpatialData integration",
 ]
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -18,11 +18,11 @@ module = "tiledbsoma._query_condition"
 ignore_errors = true
 
 [tool.ruff]
-lint.ignore = ["E501"]  # line too long
 lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
 target-version = "py39"
+line-length = 120
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293

--- a/apis/python/tests/test_fastercsx.py
+++ b/apis/python/tests/test_fastercsx.py
@@ -276,7 +276,9 @@ def test_bad_arguments(
     """Test various bad argument types/values are caught."""
     sp = sparse.random(970, 31, density=0.01, dtype=np.float32, random_state=rng)
 
-    with suppress_type_checks():  # w/o this, typeguard raises, which defeats the point of the test
+    with (
+        suppress_type_checks()
+    ):  # w/o this, typeguard raises, which defeats the point of the test
 
         # context - bad type
         with pytest.raises(AttributeError):

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -110,7 +110,9 @@ def test_metadata(soma_object):
         assert "'foobar': " in meta_repr
         assert "'my': 'enemies'" in meta_repr
     # ...but closed metadata does not.
-    with suppress_type_checks():  # type checking eagerly evaluates properties including `len`, which fails on a closed object
+    with (
+        suppress_type_checks()
+    ):  # type checking eagerly evaluates properties including `len`, which fails on a closed object
         meta_repr_closed = repr(second_read.metadata)
     assert "foobar" not in meta_repr_closed
 


### PR DESCRIPTION
Changes in preparation for changing default line length:
* Wire up `black` configuration so we can use non-default line length
* Explicitly set python line length to 88 in ruff and black
* Remove skip line too long warning
* run pre-commits (which triggered a couple of small reformats)

Note to reviewers: at a later date, we will move to 120 character line length and reformat the code base.

