### PR TITLE
[python] Add pydocstyle lint & fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: "25.1.0"
     hooks:
     - id: black
+      args: ["--config=apis/python/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -18,11 +18,13 @@ module = "tiledbsoma._query_condition"
 ignore_errors = true
 
 [tool.ruff]
-lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
 target-version = "py39"
-line-length = 120
+line-length = 88
+
+[tool.ruff.lint]
+extend-select = ["I001"]  # unsorted-imports
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
@@ -33,10 +35,13 @@ no-lines-before = ["tiledb"]
 "tiledbsoma" = ["tiledbsoma"]
 "tiledb" = ["tiledb"]
 
-
 [tool.pytest.ini_options]
 filterwarnings = ["ignore:Support for spatial types is experimental"]
 markers = [
     "slow: mark test as slow",
     "spatialdata: test of SpatialData integration",
 ]
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -18,11 +18,11 @@ module = "tiledbsoma._query_condition"
 ignore_errors = true
 
 [tool.ruff]
-lint.ignore = ["E501"]  # line too long
 lint.extend-select = ["I001"]  # unsorted-imports
 fix = true
 exclude = ["*.cc"]
 target-version = "py39"
+line-length = 120
 
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -26,6 +26,28 @@ line-length = 88
 [tool.ruff.lint]
 extend-select = ["I001"]  # unsorted-imports
 
+# Enable all `pydocstyle` rules, limiting to those that adhere to the
+# Google convention via `convention = "google"`, below.
+select = ["D"]
+ignore = [
+    "D417",  # disable documentation for every function parameter
+    "D205",  # disable blank line requirement between summary and description
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `D` rules everywhere except for the `src/` directory.
+"!apis/python/src/**.py" = ["D"]
+
+# Temporarily disable checks in the io and io.spatial modules.
+"apis/python/src/tiledbsoma/io/**/*.py" = [
+    "D100",  # Missing docstring in public module (TEMP disable)
+    "D101",  # Missing docstring in public class (TEMP disable)
+    "D102",  # Missing docstring in public method (TEMP disable)
+    "D103",  # Missing docstring in public function (TEMP disable)
+    "D104",  # Missing docstring in private module (TEMP disable)
+    "D107",  # Missing docstring in `__init__` (TEMP disable)
+]
+
 [tool.ruff.lint.isort]
 # HACK: tiledb needs to come after tiledbsoma: https://github.com/single-cell-data/TileDB-SOMA/issues/2293
 section-order = ["future", "standard-library", "third-party", "tiledbsoma", "tiledb", "first-party", "local-folder"]
@@ -34,6 +56,9 @@ no-lines-before = ["tiledb"]
 [tool.ruff.lint.isort.sections]
 "tiledbsoma" = ["tiledbsoma"]
 "tiledb" = ["tiledb"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore:Support for spatial types is experimental"]

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""SOMA powered by TileDB
+"""SOMA powered by TileDB.
 
 SOMA --- stack of matrices, annotated --- is a flexible, extensible, and
 open-source API enabling access to data in a variety of formats, and is

--- a/apis/python/src/tiledbsoma/_arrow_types.py
+++ b/apis/python/src/tiledbsoma/_arrow_types.py
@@ -2,8 +2,9 @@
 #
 # Licensed under the MIT License.
 
-"""Conversion to/from Arrow and TileDB type systems. Must be capable
-of representing full type semantics, and correctly performing a
+"""Conversion to/from Arrow and TileDB type systems.
+
+Must be capable of representing full type semantics, and correctly performing a
 round trip conversion (e.g., T == to_arrow(to_tiledb(T)))
 
 Most primitive types are simple -- e.g., uint8. Of particular challenge

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""Implementation of a SOMA Collection"""
+"""Implementation of a SOMA Collection."""
 from __future__ import annotations
 
 import itertools
@@ -386,7 +386,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         )
 
     def members(self) -> dict[str, tuple[str, str]]:
-        """Get a mapping of {member_name: (uri, soma_object_type)}"""
+        """Get a mapping of {member_name: (uri, soma_object_type)}."""
         handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
         return handle.members()
 
@@ -432,7 +432,6 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
             value:
                 The reified SOMA object to store locally.
         """
-
         self._check_allows_child(key, type(soma_object))
         super()._set_element(key, uri=uri, relative=relative, soma_object=soma_object)
 

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -40,7 +40,6 @@ class NDArray(SOMAArray, somacore.NDArray):
         """Creates a SOMA ``NDArray`` at the given URI.
 
         Args:
-
             type:
                 The Arrow type to be stored in the NDArray.
                 If the type is unsupported, an error will be raised.

--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""Global package constants"""
+"""Global package constants."""
 
 
 SOMA_JOINID = "soma_joinid"

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -2,9 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""
-Implementation of a SOMA DataFrame
-"""
+"""Implementation of a SOMA DataFrame."""
 
 from __future__ import annotations
 
@@ -380,8 +378,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """Returns an Arrow array of the specified columns'
         enumeration/dictionary/categorical values. Raises ``ValueError`` if any
         of the the specified column names is not in the schema, or if any is not
-        of Arrow dictionary type."""
-
+        of Arrow dictionary type.
+        """
         # These assertions could be done in C++. However, it's easier here
         # to do the exception-type multiplexing, raising ValueError for one
         # thing, TileDBSOMAError for another.
@@ -407,7 +405,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Raises ``ValueError`` if any of the the specified column names is not in
         the schema, or if any is not of Arrow dictionary type. May only contain
         values that already exist in the schema (see the output of
-        ``get_enumeration_values``)  unless ``deduplicate=True``."""
+        ``get_enumeration_values``)  unless ``deduplicate=True``.
+        """
         self.verify_open_for_writing()
 
         # These assertions could be done in C++. However, it's easier here
@@ -568,7 +567,6 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         self, newdomain: Domain, function_name_for_messages: str
     ) -> Any:
         """Converts the user-level tuple of low/high pairs into a pyarrow table suitable for calling libtiledbsoma."""
-
         # Check user-provided domain against dataframe domain.
         dim_names = self._tiledb_dim_names()
         if len(dim_names) != len(newdomain):

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -2,9 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""
-Implementation of SOMA DenseNDArray.
-"""
+"""Implementation of SOMA DenseNDArray."""
 
 from __future__ import annotations
 
@@ -38,8 +36,9 @@ from .options._tiledb_create_write_options import (
 
 class DenseNDArray(NDArray, somacore.DenseNDArray):
     """:class:`DenseNDArray` is a dense, N-dimensional array, with offset (zero-based)
-    integer indexing on each dimension. :class:`DenseNDArray` has a user-defined
-    schema, which includes:
+    integer indexing on each dimension.
+
+    :class:`DenseNDArray` has a user-defined schema, which includes:
 
     * The element type, expressed as an
       `Arrow type <https://arrow.apache.org/docs/python/api/datatypes.html>`_
@@ -335,7 +334,6 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         int64 is returned for the capacity -- which is particularly suitable for
         maxdomain.
         """
-
         # Old news: for dense n-dimensional arrays, the number of bytes for each
         # core cell is the product of the following:
         #

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -27,7 +27,7 @@ class DoesNotExistError(SOMAError):
 
 def is_does_not_exist_error(e: RuntimeError | SOMAError) -> bool:
     """Given a RuntimeError or SOMAError, return true if it indicates the object
-    does not exist
+    does not exist.
 
     Lifecycle: Maturing.
 
@@ -65,7 +65,7 @@ class AlreadyExistsError(SOMAError):
 
 
 def is_already_exists_error(e: SOMAError) -> bool:
-    """Given a SOMAError, return true if it indicates the object already exists
+    """Given a SOMAError, return true if it indicates the object already exists.
 
     Lifecycle: Maturing.
 

--- a/apis/python/src/tiledbsoma/_fastercsx.py
+++ b/apis/python/src/tiledbsoma/_fastercsx.py
@@ -256,8 +256,7 @@ class CompressedMatrix:
         is_sorted: bool,
         no_duplicates: bool | None,
     ) -> scipy.sparse.csr_matrix | scipy.sparse.csc_matrix:
-        """
-        This is to bypass the O(N) scan that :meth:`sparse._cs_matrix.__init__`
+        """This is to bypass the O(N) scan that :meth:`sparse._cs_matrix.__init__`
         performs when a new compressed matrix is created.
 
         See `SciPy bug 11496 <https://github.com/scipy/scipy/issues/11496>` for details.

--- a/apis/python/src/tiledbsoma/_funcs.py
+++ b/apis/python/src/tiledbsoma/_funcs.py
@@ -39,7 +39,6 @@ def forwards_kwargs_to(
     """Decorator function to update the signature with ``dst``'s kwargs.
 
     Example:
-
         def _internal(__it, a, b, c=3, *d, e=6, **f) -> None:
             ...
 

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -33,7 +33,6 @@ def get_implementation_version() -> str:
 
     Lifecycle: Maturing.
     """
-
     try:
         return importlib.metadata.version("tiledbsoma")
     except importlib.metadata.PackageNotFoundError:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -1,9 +1,7 @@
 # Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
 #
 # Licensed under the MIT License.
-"""
-Implementation of a SOMA Geometry DataFrame
-"""
+"""Implementation of a SOMA Geometry DataFrame."""
 
 from __future__ import annotations
 
@@ -355,6 +353,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
                 The default of ``None`` represents no filter. Value filter
                 syntax is implementation-defined; see the documentation
                 for the particular SOMA implementation for details.
+
         Returns:
             A :class:`ReadIter` of :class:`pa.Table`s.
 
@@ -549,7 +548,6 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         Returns: ``self``, to enable method chaining.
 
         """
-
         outline_transformer = clib.OutlineTransformer(
             coordinate_space_to_json(self._coord_space)
         )

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -44,7 +44,6 @@ def tiledbsoma_build_index(
     Lifecycle:
         Deprecated.
     """
-
     return IntIndexer(data, context=context)
 
 

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -1,9 +1,7 @@
 # Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
 #
 # Licensed under the MIT License.
-"""
-Implementation of a SOMA MultiscaleImage.
-"""
+"""Implementation of a SOMA MultiscaleImage."""
 
 from __future__ import annotations
 

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -1,9 +1,7 @@
 # Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
 #
 # Licensed under the MIT License.
-"""
-Implementation of a SOMA Point Cloud DataFrame
-"""
+"""Implementation of a SOMA Point Cloud DataFrame."""
 
 from __future__ import annotations
 
@@ -112,6 +110,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
                 particular reason not to, you should always provide the desired
                 `domain` at create time: this is an optional but strongly
                 recommended parameter.
+
         Returns:
             The newly created point cloud, opened for writing.
 
@@ -329,6 +328,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
                 The default of ``None`` represents no filter. Value filter
                 syntax is implementation-defined; see the documentation
                 for the particular SOMA implementation for details.
+
         Returns:
             A :class:`ReadIter` of :class:`pa.Table`s.
 

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -88,8 +88,7 @@ class AxisName(enum.Enum):
 
 @attrs.define
 class AxisIndexer(query.AxisIndexer):
-    """
-    Given a query, provides index-building services for obs/var axis.
+    """Given a query, provides index-building services for obs/var axis.
 
     Lifecycle: maturing
     """
@@ -328,6 +327,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
 
     def obsm(self, layer: str) -> SparseRead:
         """Returns an ``obsm`` layer as a sparse read.
+
         Lifecycle: maturing
         """
         return self._get_annotation_layer("obsm", layer).read(
@@ -336,6 +336,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
 
     def varm(self, layer: str) -> SparseRead:
         """Returns a ``varm`` layer as a sparse read.
+
         Lifecycle: maturing
         """
         return self._get_annotation_layer("varm", layer).read(
@@ -343,8 +344,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
         )
 
     def obs_scene_ids(self) -> pa.Array:
-        """Returns a pyarrow array with scene ids that contain obs from this
-        query.
+        """Returns a pyarrow array with scene ids that contain obs from this query.
 
         Lifecycle: experimental
         """
@@ -428,7 +428,6 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
                 If true, drop unused categories from the ``obs`` and ``var`` dataframes.
                 Defaults to ``False``.
         """
-
         if column_names is None:
             column_names = AxisColumnNames(obs=None, var=None)
 
@@ -549,7 +548,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
         drop_levels: bool = False,
         scene_presence_mode: str = "obs",
     ):
-        """Returns a SpatialData object containing the query results
+        """Returns a SpatialData object containing the query results.
 
         This is a low-level routine intended to be used by loaders for other
         in-core formats, such as AnnData, which can be created from the
@@ -571,7 +570,6 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
                 dataframe) and ``var`` (use ``var_spatial_presence`` dataframe).
                 Defaults to ``obs``.
         """
-
         from .io.spatial._spatialdata_util import _spatial_to_spatialdata
 
         warnings.warn(SPATIAL_DISCLAIMER)
@@ -715,9 +713,9 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
 
     @property
     def _threadpool(self) -> ThreadPoolExecutor:
+        """Returns the threadpool provided by the experiment's context.
+        If not available, creates a thread pool just in time.
         """
-        Returns the threadpool provided by the experiment's context.
-        If not available, creates a thread pool just in time."""
         return self.experiment.context.threadpool
 
 

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -1,9 +1,7 @@
 # Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
 #
 # Licensed under the MIT License.
-"""
-Implementation of a SOMA Scene
-"""
+"""Implementation of a SOMA Scene."""
 
 from __future__ import annotations
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -106,8 +106,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         return self._handle.config_options_from_schema()
 
     def non_empty_domain(self) -> tuple[tuple[Any, Any], ...]:
-        """
-        Retrieves the non-empty domain for each dimension, namely the smallest
+        """Retrieves the non-empty domain for each dimension, namely the smallest
         and largest indices in each dimension for which the array/dataframe has
         data occupied.  This is nominally the same as the domain used at
         creation time, but if for example only a portion of the available domain

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -73,7 +73,7 @@ class SOMAGroup(
         self._mutated_keys: set[str] = set()
 
     def __len__(self) -> int:
-        """Return the number of members in the collection"""
+        """Return the number of members in the collection."""
         return len(self._contents)
 
     def __getitem__(self, key: str) -> CollectionElementType:
@@ -101,7 +101,7 @@ class SOMAGroup(
         return cast(CollectionElementType, entry.soma)
 
     def __setitem__(self, key: str, value: CollectionElementType) -> None:
-        """Default collection __setattr__"""
+        """Default collection __setattr__."""
         self.set(key, value, use_relative_uri=None)
 
     def __delitem__(self, key: str) -> None:
@@ -150,7 +150,6 @@ class SOMAGroup(
             value:
                 The reified SOMA object to store locally.
         """
-
         if key in self._mutated_keys.union(self._contents):
             # TileDB groups currently do not support replacing elements.
             # If we use a hack to flush writes, corruption is possible.

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -151,8 +151,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
     def reopen(
         self, mode: options.OpenMode, tiledb_timestamp: OpenTimestamp | None = None
     ) -> Self:
-        """
-        Return a new copy of the SOMAObject with the given mode at the current
+        """Return a new copy of the SOMAObject with the given mode at the current
         Unix timestamp.
 
         Args:
@@ -199,8 +198,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @property
     def uri(self) -> str:
-        """
-        Accessor for the object's storage URI.
+        """Accessor for the object's storage URI.
 
         Examples:
             >>> soma_object.uri
@@ -212,8 +210,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         return self._handle.uri
 
     def close(self) -> None:
-        """
-        Release any resources held while the object is open.
+        """Release any resources held while the object is open.
         Closing an already-closed object is a no-op.
 
         Examples:
@@ -226,8 +223,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @property
     def closed(self) -> bool:
-        """
-        True if the object has been closed. False if it is still open.
+        """True if the object has been closed. False if it is still open.
 
         Examples:
             >>> with tiledbsoma.open("an_object") as soma_object:
@@ -244,8 +240,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @property
     def mode(self) -> options.OpenMode:
-        """
-        The mode this object was opened in, either ``r`` or ``w``.
+        """The mode this object was opened in, either ``r`` or ``w``.
 
         Examples:
             >>> with tiledbsoma.open("an_object") as soma_object:
@@ -297,8 +292,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         context: SOMATileDBContext | None = None,
         tiledb_timestamp: OpenTimestamp | None = None,
     ) -> bool:
-        """
-        Finds whether an object of this type exists at the given URI.
+        """Finds whether an object of this type exists at the given URI.
 
         Args:
             uri:

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -2,9 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""
-Implementation of SOMA SparseNDArray.
-"""
+"""Implementation of SOMA SparseNDArray."""
 
 from __future__ import annotations
 
@@ -46,8 +44,8 @@ _UNBATCHED = options.BatchSize()
 
 
 class SparseNDArray(NDArray, somacore.SparseNDArray):
-    """:class:`SparseNDArray` is a sparse, N-dimensional array, with offset
-    (zero-based) integer indexing on each dimension.
+    """:class:`SparseNDArray` is a sparse, N-dimensional array, with offset (zero-based) integer indexing on each dimension.
+
     :class:`SparseNDArray` has a user-defined schema, which includes:
 
     * The element type, expressed as an
@@ -205,8 +203,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
     @property
     def nnz(self) -> int:
-        """
-        The number of stored values in the array, including explicitly stored zeros.
+        """The number of stored values in the array, including explicitly stored zeros.
 
         Lifecycle:
             Maturing.
@@ -274,8 +271,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         *,
         platform_config: PlatformConfig | None = None,
     ) -> Self:
-        """
-        Writes an Arrow object to the SparseNDArray.
+        """Writes an Arrow object to the SparseNDArray.
 
         `Arrow SparseTensor <https://arrow.apache.org/docs/cpp/api/tensor.html>`_:
         the coordinates in the Arrow SparseTensor are interpreted as the
@@ -296,7 +292,6 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         Lifecycle:
             Maturing.
         """
-
         write_options: TileDBCreateOptions | TileDBWriteOptions
         sort_coords = None
         if isinstance(platform_config, TileDBCreateOptions):
@@ -416,7 +411,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
 
 
 class _SparseNDArrayReadBase(somacore.SparseRead):
-    """Base class for sparse reads"""
+    """Base class for sparse reads."""
 
     def __init__(
         self,
@@ -425,9 +420,8 @@ class _SparseNDArrayReadBase(somacore.SparseRead):
         result_order: clib.ResultOrder,
         platform_config: options.PlatformConfig | None,
     ):
-        """
-        Lifecycle:
-            Maturing.
+        """Lifecycle:
+        Maturing.
         """
         self.array = array
         self.coords = coords
@@ -446,7 +440,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
     complete "blocks" for any given user-specified dimension, eg., all coordinates in a given row in one
     iteration step. NB: `blockwise` iterators may utilize additional disk or network IO.
 
-    See also:
+    See Also:
         somacore.data.SparseRead
 
     Lifecycle:
@@ -454,8 +448,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
     """
 
     def coos(self, shape: NTuple | None = None) -> SparseCOOTensorReadIter:
-        """
-        Returns an iterator of
+        """Returns an iterator of
         `Arrow SparseCOOTensor <https://arrow.apache.org/docs/cpp/api/tensor.html>`_.
 
         Args:
@@ -476,8 +469,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
         )
 
     def tables(self) -> TableReadIter:
-        """
-        Returns an iterator of
+        """Returns an iterator of
         `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_.
 
         Lifecycle:
@@ -500,8 +492,7 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
         reindex_disable_on_axis: int | Sequence[int] | None = None,
         eager: bool = True,
     ) -> SparseNDArrayBlockwiseRead:
-        """
-        Returns an intermediate type to choose a blockwise iterator of a specific format.
+        """Returns an intermediate type to choose a blockwise iterator of a specific format.
 
         Blockwise iterators yield results grouped by a user-specified axis. For example, a
         blockwise iterator with `axis=0` will yield results containing all coordinates for
@@ -535,7 +526,6 @@ class SparseNDArrayRead(_SparseNDArrayReadBase):
                 consumption, at the cost of additional processing time.
 
         Examples:
-
             A simple example iterating over the first 10000 elements of the first dimension, into
             blocks of SciPy sparse matrices:
 
@@ -593,9 +583,7 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
         self.eager = eager
 
     def tables(self) -> BlockwiseTableReadIter:
-        """
-        Returns a blockwise iterator of
-        `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_.
+        """Returns a blockwise iterator of `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_.
 
         Yields:
             The iterator will yield a tuple of:
@@ -618,18 +606,16 @@ class SparseNDArrayBlockwiseRead(_SparseNDArrayReadBase):
         )
 
     def coos(self) -> somacore.ReadIter[None]:
-        """
-        Unimplemented due to ARROW-17933, https://issues.apache.org/jira/browse/ARROW-17933,
-        which causes failure on empty tensors (which are commonly yielded by blockwise
-        iterators). Also tracked as https://github.com/single-cell-data/TileDB-SOMA/issues/668
+        """Unimplemented due to ARROW-17933, https://issues.apache.org/jira/browse/ARROW-17933, which causes failure on empty tensors (which are commonly yielded by blockwise iterators).
+
+        Also tracked as https://github.com/single-cell-data/TileDB-SOMA/issues/668
         """
         raise NotImplementedError(
             "Blockwise SparseCOOTensor not implemented due to ARROW-17933."
         )
 
     def scipy(self, *, compress: bool = True) -> BlockwiseScipyReadIter:
-        """
-        Returns a blockwise iterator of
+        """Returns a blockwise iterator of
         `SciPy sparse matrix` <https://docs.scipy.org/doc/scipy/reference/sparse.html>
         over a 2D SparseNDArray.
 

--- a/apis/python/src/tiledbsoma/_spatial_dataframe.py
+++ b/apis/python/src/tiledbsoma/_spatial_dataframe.py
@@ -2,9 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""
-Implementation of a base class shared between GeometryDataFrame and PointCloudDataFrame
-"""
+"""Implementation of a base class shared between GeometryDataFrame and PointCloudDataFrame."""
 
 from __future__ import annotations
 
@@ -93,6 +91,7 @@ class SpatialDataFrame(SOMAArray):
                 The default of ``None`` represents no filter. Value filter
                 syntax is implementation-defined; see the documentation
                 for the particular SOMA implementation for details.
+
         Returns:
             A :class:`ReadIter` of :class:`pa.Table`s.
 

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -32,8 +32,7 @@ def coordinate_space_to_json(coord_space: somacore.CoordinateSpace) -> str:
 
 
 def transform_from_json(data: str) -> somacore.CoordinateTransform:
-    """Convert a JSON string representing a CoordinateTransform"""
-
+    """Convert a JSON string representing a CoordinateTransform."""
     raw = json.loads(data)
 
     try:
@@ -66,8 +65,7 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
 
 
 def transform_to_json(transform: somacore.CoordinateTransform) -> str:
-    """Representing a CoordinateTransform as a JSON string"""
-
+    """Representing a CoordinateTransform as a JSON string."""
     kwargs: dict[str, Any] = {
         "input_axes": transform.input_axes,
         "output_axes": transform.output_axes,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -567,29 +567,29 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
 
     @property
     def maybe_soma_joinid_shape(self) -> int | None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(Union[int, None], self._handle.maybe_soma_joinid_shape)
 
     @property
     def maybe_soma_joinid_maxshape(self) -> int | None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(Union[int, None], self._handle.maybe_soma_joinid_maxshape)
 
     @property
     def tiledbsoma_has_upgraded_domain(self) -> bool:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_domain)
 
     def resize_soma_joinid_shape(
         self, newshape: int, function_name_for_messages: str
     ) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.resize_soma_joinid_shape(newshape, function_name_for_messages)
 
     def can_resize_soma_joinid_shape(
         self, newshape: int, function_name_for_messages: str
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason,
             self._handle.can_resize_soma_joinid_shape(
@@ -600,13 +600,13 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def upgrade_soma_joinid_shape(
         self, newshape: int, function_name_for_messages: str
     ) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.upgrade_soma_joinid_shape(newshape, function_name_for_messages)
 
     def can_upgrade_soma_joinid_shape(
         self, newshape: int, function_name_for_messages: str
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason,
             self._handle.can_upgrade_soma_joinid_shape(
@@ -617,26 +617,26 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def upgrade_domain(
         self, newdomain: Domain, function_name_for_messages: str
     ) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.upgrade_domain(newdomain, function_name_for_messages)
 
     def can_upgrade_domain(
         self, newdomain: Domain, function_name_for_messages: str
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason,
             self._handle.can_upgrade_domain(newdomain, function_name_for_messages),
         )
 
     def change_domain(self, newdomain: Domain, function_name_for_messages: str) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.change_domain(newdomain, function_name_for_messages)
 
     def can_change_domain(
         self, newdomain: Domain, function_name_for_messages: str
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason,
             self._handle.can_change_domain(newdomain, function_name_for_messages),
@@ -676,25 +676,25 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[int | None]) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.resize(newshape)
 
     def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
 
     def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.tiledbsoma_upgrade_shape(newshape)
 
     def tiledbsoma_can_upgrade_shape(
         self, newshape: Sequence[int | None]
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape)
         )
@@ -711,25 +711,25 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[int | None]) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.resize(newshape)
 
     def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(StatusAndReason, self._handle.can_resize(newshape))
 
     def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         self._handle.tiledbsoma_upgrade_shape(newshape)
 
     def tiledbsoma_can_upgrade_shape(
         self, newshape: Sequence[int | None]
     ) -> StatusAndReason:
-        """Wrapper-class internals"""
+        """Wrapper-class internals."""
         return cast(
             StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape)
         )

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -324,9 +324,7 @@ def pa_types_is_string_or_bytes(dtype: pa.DataType) -> bool:
 def build_clib_platform_config(
     platform_config: options.PlatformConfig | None,
 ) -> clib.PlatformConfig:
-    """
-    Copy over Python PlatformConfig values to the C++ clib.PlatformConfig
-    """
+    """Copy over Python PlatformConfig values to the C++ clib.PlatformConfig."""
     plt_cfg = clib.PlatformConfig()
 
     if platform_config is None:

--- a/apis/python/src/tiledbsoma/eta.py
+++ b/apis/python/src/tiledbsoma/eta.py
@@ -2,6 +2,7 @@
 #
 # Licensed under the MIT License.
 
+"""Estimated time helpers."""
 
 import numpy as np
 
@@ -13,6 +14,7 @@ class Tracker:
     cumulative_seconds: list[float]
 
     def __init__(self) -> None:
+        """Initialize."""
         self.chunk_percents = []
         self.cumulative_seconds = []
 
@@ -72,7 +74,9 @@ class Tracker:
             return "%.2f seconds" % (seconds)
 
     def __str__(self) -> str:
+        """User-friendly string."""
         return str(self.chunk_percents) + " " + str(self.cumulative_seconds)
 
     def __repr__(self) -> str:
+        """User-friendly string."""
         return self.__str__()

--- a/apis/python/src/tiledbsoma/experiment_query.py
+++ b/apis/python/src/tiledbsoma/experiment_query.py
@@ -2,6 +2,8 @@
 #
 # Licensed under the MIT License.
 
+"""Read utilities."""
+
 from typing import cast
 
 import pandas as pd
@@ -39,7 +41,6 @@ def X_as_series(tbl: pa.Table) -> PDSeries:
     Lifecycle:
         Maturing.
     """
-
     data = tbl["soma_data"].to_numpy()
     dim_0 = tbl["soma_dim_0"].to_numpy()
     dim_1 = tbl["soma_dim_1"].to_numpy()

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -27,7 +27,9 @@ class CacheStats:
 
 class CachingReader:
     """Buffering reader which maintains a LRU cache of previously read data, wrapping
-    and presenting a file-like interface. Typical use is similar to ``io.BufferedReader``:
+    and presenting a file-like interface.
+
+    Typical use is similar to ``io.BufferedReader``:
 
         f = CachingReader(open("a file", mode="rb"), memory_budget=64*1024**2, cache_block_size=1024**2)
 
@@ -128,7 +130,8 @@ class CachingReader:
         is unspecified or -1, all bytes until EOF are returned. Fewer than size bytes may be
         returned if the operating system call returns fewer than size bytes.
 
-        If 0 bytes are returned, and size was not 0, this indicates end of file."""
+        If 0 bytes are returned, and size was not 0, this indicates end of file.
+        """
         if size is None:
             size = -1  # type: ignore[unreachable]
         if size < 0:
@@ -148,7 +151,8 @@ class CachingReader:
 
     def readinto(self, buf: WritableBuffer) -> int | None:
         """Read bytes into a pre-allocated, writable bytes-like object b,
-        and return the number of bytes read."""
+        and return the number of bytes read.
+        """
         if not isinstance(buf, memoryview):
             buf = memoryview(buf)
         if buf.nbytes == 0:
@@ -180,15 +184,16 @@ class CachingReader:
 
     def tell(self) -> int:
         """Return integer indicating the file object's current position in the file.
+
         See ``io.RawIOBase.tell``
         """
         return self._pos
 
     def seek(self, offset: int, whence: int = 0) -> int:
-        """
-        Change the stream position to the given byte offset, interpreted relative to the position
-        indicated by whence, and return the new absolute position. Values for whence are:
+        """Change the stream position to the given byte offset, interpreted relative to the position
+        indicated by whence, and return the new absolute position.
 
+        Values for whence are:
           os.SEEK_SET or 0 - start of the stream (the default); offset should be zero or positive
           os.SEEK_CUR or 1 - current stream position; offset may be negative
           os.SEEK_END or 2 - end of the stream; offset is usually negative

--- a/apis/python/src/tiledbsoma/io/_registration/__init__.py
+++ b/apis/python/src/tiledbsoma/io/_registration/__init__.py
@@ -2,8 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""
-Support for soma_joinid remapping for append-mode ingestion.
+"""Support for soma_joinid remapping for append-mode ingestion.
 
 This is an internal-use class; none of it is user-facing API. The user-facing API is
 ``tiledbsoma.io.register``.
@@ -43,7 +42,6 @@ There are two kinds of mappings: _ambient mappings_ which contain string-to-int 
 for _all_ inputs, and ID mappings which contain int-to-int offset-to-join-ID mappings for each _single_ input.
 
 Example:
-
 - Input 1 has obs IDs ``["AAAT", "ACTG", "AGAG"]`` numbered 0, 1, 2 within input 1.
 - Input 1 has var IDs ``["AKT1", "APOE", "ESR1", "TP53", "VEGFA"]`` numbered 0, 1, 2, 3, 4 within input 1.
 - Input 2 has obs IDs ``["CAAT", "CCTG", "CGAG"]`` numbered 0, 1, 2 within input 2.

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -158,7 +158,6 @@ class ExperimentAmbientLabelMapping:
         Returns:
             A new ``ExperimentAmbientLabelMapping`` scoped specifically for the AnnData.
         """
-
         # Only subset obs - provides largest benefit with simple implementation.
         return attrs.evolve(
             self,
@@ -426,8 +425,7 @@ class ExperimentAmbientLabelMapping:
         var_field_name: str,
         context: SOMATileDBContext,
     ) -> ExperimentAmbientLabelMapping:
-        """
-        Private method used by various constructor paths -- shared code for registration.
+        """Private method used by various constructor paths -- shared code for registration.
 
         Four-step process common to all ingestion plans. Given AnnData axis metadata (joinid map
         and enum definitions):
@@ -442,7 +440,6 @@ class ExperimentAmbientLabelMapping:
         It is less likely to be true for multi-modal data. Future rework should address this
         by allowing a per-measurement var join column.
         """
-
         tp = context.threadpool
         existing_obs_joinid_map: pd.DataFrame
         existing_var_joinid_maps: dict[str, pd.DataFrame]
@@ -591,7 +588,7 @@ class ExperimentAmbientLabelMapping:
 
     @staticmethod
     def _validate_anndata(append_obsm_varm: bool, adata: ad.AnnData) -> None:
-        """Pre-checks performed on all AnnData"""
+        """Pre-checks performed on all AnnData."""
 
         def check_df(df: pd.DataFrame | None, df_name: str) -> None:
             if df is None or df.index.empty:
@@ -630,7 +627,9 @@ class ExperimentAmbientLabelMapping:
 @attrs.define(kw_only=True, frozen=True)
 class AnnDataAxisMetadata:
     """Private class encapsulating _intermediate_ information extracted from registered
-    H5ADs/AnnData. Other than data storage, this also provides a reducer for the type.
+    H5ADs/AnnData.
+
+    Other than data storage, this also provides a reducer for the type.
     """
 
     field_name: str  # user-specified join field name
@@ -650,7 +649,7 @@ class AnnDataAxisMetadata:
             return ams[0]
 
         def _reduce_field_index(indices: list[pd.Index]) -> pd.Index:  # type: ignore[type-arg]
-            """reducer for joinid indices"""
+            """Reducer for joinid indices."""
             if len(indices) == 0:
                 return pd.Index([])
             if len(indices) == 1:
@@ -669,7 +668,7 @@ class AnnDataAxisMetadata:
     def reduce_enum_values(
         enum_values: list[dict[ColumnName, pd.CategoricalDtype]],
     ) -> dict[ColumnName, pd.CategoricalDtype]:
-        """reducer for enum values"""
+        """Reducer for enum values."""
 
         def _merge_categoricals(
             col_name: str,

--- a/apis/python/src/tiledbsoma/io/_registration/enum.py
+++ b/apis/python/src/tiledbsoma/io/_registration/enum.py
@@ -13,8 +13,8 @@ def get_enumerations(
 ) -> dict[str, pd.CategoricalDtype]:
     """Look up enum info in schema, and return as a Pandas CategoricalDType. This
     is a convenience wrapper around ``DataFrame.get_enumeration_values``, for use
-    in the registration module."""
-
+    in the registration module.
+    """
     # skip columns which are not of type dictionary
     column_names = [
         c for c in column_names if pa.types.is_dictionary(df.schema.field(c).type)
@@ -26,14 +26,12 @@ def get_enumerations(
 
 
 def extend_enumerations(df: DataFrame, columns: dict[str, pd.CategoricalDtype]) -> None:
-    """
-    Extend enumerations as needed, starting with a CategoricalDType for each
+    """Extend enumerations as needed, starting with a CategoricalDType for each
     cat/enum/dict column. A convenience wrapper around ``DataFrame.extend_enumeration_values``,
     for use in the registration module.
 
     DataFrame must be open for write.
     """
-
     current_enums = get_enumerations(df, list(columns.keys()))
     columns_to_extend = {}
     for column_name, cat_dtype in columns.items():

--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -76,7 +76,8 @@ class ExperimentIDMapping:
 
 def get_dataframe_values(df: pd.DataFrame, field_name: str) -> pd.Series:  # type: ignore[type-arg]
     """Extracts the label values (e.g. cell barcode, gene symbol) from an AnnData/H5AD
-    ``obs`` or ``var`` dataframe."""
+    ``obs`` or ``var`` dataframe.
+    """
     if field_name in df:
         values = cast(pd.Series, df[field_name].astype(str))  # type: ignore[type-arg]
     elif df.index.name in (field_name, "index", None):

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -43,9 +43,7 @@ _pa_type_to_str_fmt = {
 def read_h5ad(
     input_path: Path, *, mode: str = "r", ctx: SOMATileDBContext | None = None
 ) -> Iterator[ad.AnnData]:
-    """
-    This lets us ingest H5AD with "r" (backed mode) from S3 URIs.
-    """
+    """This lets us ingest H5AD with "r" (backed mode) from S3 URIs."""
     ctx = ctx or SOMATileDBContext()
     input_handle = CachingReader(
         clib.SOMAFileHandle(str(input_path), ctx.native_context),

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -47,7 +47,6 @@ def _string_dict_from_arrow_schema(schema: pa.Schema) -> dict[str, str]:
     This is easier on the eyes, easier to convert from/to JSON for distributed logging,
     and easier to do del-key on.
     """
-
     _EQUIVALENCES = {
         "large_string": "string",
         "large_binary": "binary",
@@ -166,8 +165,7 @@ def _prepare_df_for_ingest(df: pd.DataFrame, id_column_name: str | None) -> str 
 
 
 def obs_or_var_to_tiledb_supported_array_type(obs_or_var: pd.DataFrame) -> pd.DataFrame:
-    """
-    Performs a typecast into types that TileDB can persist.  This includes, as a
+    """Performs a typecast into types that TileDB can persist.  This includes, as a
     performance improvement, converting high-cardinality categorical-of-string
     columns (cardinality > 4096) to plain string.
     """
@@ -221,9 +219,7 @@ def csr_from_coo_table(
 
 
 def df_to_arrow_table(df: pd.DataFrame) -> pa.Table:
-    """
-    Handle special cases where pa.Table.from_pandas is not sufficient.
-    """
+    """Handle special cases where pa.Table.from_pandas is not sufficient."""
     nullable_fields = set()
     # Not for name, col in df.items() since we need df[k] on the left-hand sides
     for key in df:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -205,7 +205,6 @@ def register_h5ads(
     can control the concurrency using the ``soma.compute_concurrency_level`` configuration
     parameter in the ``context`` argument.
     """
-
     if isinstance(h5ad_file_names, str):
         h5ad_file_names = [h5ad_file_names]
 
@@ -267,8 +266,8 @@ def register_anndatas(
 ) -> ExperimentAmbientLabelMapping:
     """Extends registration data from the baseline, already-written SOMA
     experiment to include multiple H5AD input files. See ``from_h5ad`` and
-    ``from_anndata`` on-line help."""
-
+    ``from_anndata`` on-line help.
+    """
     if isinstance(adatas, ad.AnnData):
         adatas = [adatas]
 
@@ -311,7 +310,7 @@ def from_h5ad(
     uns_keys: Sequence[str] | None = None,
     additional_metadata: AdditionalMetadata = None,
 ) -> str:
-    """Reads an ``.h5ad`` file and writes it to an :class:`Experiment`.
+    r"""Reads an ``.h5ad`` file and writes it to an :class:`Experiment`.
 
     Measurement data is stored in a :class:`Measurement` in the experiment's
     ``ms`` field, with the key provided by ``measurement_name``. Data elements
@@ -464,7 +463,8 @@ class IngestCtx(TypedDict):
 class IngestPlatformCtx(IngestCtx):
     """Convenience type-alias for kwargs passed to ingest functions.
 
-    Extends :class:`IngestCtx`, adds ``platform_config``."""
+    Extends :class:`IngestCtx`, adds ``platform_config``.
+    """
 
     platform_config: PlatformConfig | None
 
@@ -825,9 +825,8 @@ def append_obs(
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> str:
-    """
-    Writes new rows to an existing ``obs`` dataframe. (This is distinct from ``update_obs``
-    which mutates the entirety of the ``obs`` dataframe, e.g. to add/remove columns.)
+    """Writes new rows to an existing ``obs`` dataframe (this is distinct from ``update_obs``
+    which mutates the entirety of the ``obs`` dataframe, e.g. to add/remove columns).
 
     Example::
 
@@ -884,9 +883,8 @@ def append_var(
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> str:
-    """
-    Writes new rows to an existing ``var`` dataframe. (This is distinct from ``update_var``
-    which mutates the entirety of the ``var`` dataframe, e.g. to add/remove columns.)
+    """Writes new rows to an existing ``var`` dataframe (this is distinct from ``update_var``
+    which mutates the entirety of the ``var`` dataframe, e.g. to add/remove columns).
 
     Example::
 
@@ -953,8 +951,7 @@ def append_X(
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> str:
-    """
-    Appends new data to an existing ``X`` matrix. Nominally to be used in conjunction
+    """Appends new data to an existing ``X`` matrix. Nominally to be used in conjunction
     with ``update_obs`` and ``update_var``, as an itemized alternative to doing
     ``from_anndata`` with a registration mapping supplied.
 
@@ -1141,8 +1138,7 @@ def _extract_new_values_for_append_aux(
     previous_soma_dataframe: DataFrame,
     arrow_table: pa.Table,
 ) -> pa.Table:
-    """
-    Helper function for _extract_new_values_for_append.
+    """Helper function for _extract_new_values_for_append.
 
     This does two things:
 
@@ -1177,7 +1173,6 @@ def _extract_new_values_for_append_aux(
     enough cardinality that we would keep it as categorical, but the existing
     storage has non-categorical, we must write the new data as non-categorical.
     """
-
     # Retain only the new rows.
     previous_sjids_table = previous_soma_dataframe.read(
         column_names=["soma_joinid"]
@@ -1269,8 +1264,8 @@ def _extract_new_values_for_append(
     arrow_table: pa.Table,
     context: SOMATileDBContext | None = None,
 ) -> pa.Table:
-    """
-    For append mode: mostly we just go ahead and write the data, except var.
+    """For append mode: mostly we just go ahead and write the data, except var.
+
     Nominally:
 
     * Cell IDs (obs IDs) are distinct per input
@@ -1343,8 +1338,7 @@ def _write_dataframe(
     axis_mapping: AxisIDMapping,
     must_exist: bool = False,
 ) -> DataFrame:
-    """
-    Convert and save a pd.DataFrame as a SOMA DataFrame.
+    """Convert and save a pd.DataFrame as a SOMA DataFrame.
 
     This function adds a ``soma_joinid`` index to the provided ``pd.DataFrame``, as that is
     required by libtiledbsoma; the original ``pd.DataFrame`` index is "reset" to a column, with its
@@ -1501,8 +1495,7 @@ def create_from_matrix(
     ingest_mode: IngestMode = "write",
     context: SOMATileDBContext | None = None,
 ) -> _NDArr:
-    """
-    Create and populate the ``soma_matrix`` from the contents of ``matrix``.
+    """Create and populate the ``soma_matrix`` from the contents of ``matrix``.
 
     Lifecycle:
         Maturing.
@@ -1532,9 +1525,7 @@ def _create_from_matrix(
     axis_1_mapping: AxisIDMapping,
     must_exist: bool = False,
 ) -> _NDArr:
-    """
-    Internal helper for user-facing ``create_from_matrix``.
-    """
+    """Internal helper for user-facing ``create_from_matrix``."""
     # Older SparseDataset has no ndim but it has a shape
     if len(matrix.shape) != 2:
         raise ValueError(f"expected matrix.shape == 2; got {matrix.shape}")
@@ -1632,10 +1623,9 @@ def update_obs(
     platform_config: PlatformConfig | None = None,
     default_index_name: str = "obs_id",
 ) -> None:
-    """
-    Given a new Pandas dataframe with desired contents, updates the SOMA experiment's
-    entire ``obs`` to incorporate the changes. (This is distinct from ``append_obs``
-    which adds new rows, while allowing no schema/column changes.)
+    """Given a new Pandas dataframe with desired contents, updates the SOMA experiment's
+    entire ``obs`` to incorporate the changes (this is distinct from ``append_obs``
+    which adds new rows, while allowing no schema/column changes).
 
     All columns present in current SOMA-experiment storage but absent from the new
     dataframe will be dropped.  All columns absent in current SOMA-experiment storage
@@ -1662,7 +1652,6 @@ def update_obs(
     Lifecycle:
         Maturing.
     """
-
     _update_dataframe(
         exp.obs,
         new_data,
@@ -1682,10 +1671,9 @@ def update_var(
     platform_config: PlatformConfig | None = None,
     default_index_name: str = "var_id",
 ) -> None:
-    """
-    Given a new Pandas dataframe with desired contents, updates the SOMA experiment's
-    specified measurement's entire ``var`` to incorporate the changes. (This is distinct
-    from ``append_var`` which adds new rows, while allowing no schema/column changes.)
+    """Given a new Pandas dataframe with desired contents, updates the SOMA experiment's
+    specified measurement's entire ``var`` to incorporate the changes (this is distinct
+    from ``append_var`` which adds new rows, while allowing no schema/column changes).
 
     All columns present in current SOMA-experiment storage but absent from the new
     dataframe will be dropped.  All columns absent in current SOMA-experiment storage
@@ -1740,10 +1728,7 @@ def _update_dataframe(
     platform_config: PlatformConfig | None,
     default_index_name: str,
 ) -> None:
-    """
-    See ``update_obs`` and ``update_var``. This is common helper code shared by both.
-    """
-
+    """See ``update_obs`` and ``update_var``. This is common helper code shared by both."""
     sdf.verify_open_for_writing()
     old_sig = conversions._string_dict_from_arrow_schema(sdf.schema)
     new_schema = conversions.df_to_arrow_schema(new_data, default_index_name)
@@ -1840,8 +1825,7 @@ def update_matrix(
     context: SOMATileDBContext | None = None,
     platform_config: PlatformConfig | None = None,
 ) -> None:
-    """
-    Given a ``SparseNDArray`` or ``DenseNDArray`` already opened for write,
+    """Given a ``SparseNDArray`` or ``DenseNDArray`` already opened for write,
     writes the new data. It is the caller's responsibility to ensure that the
     intended shape of written contents of the array match those of the existing
     data. The intended use-case is to replace updated numerical values.
@@ -1872,7 +1856,6 @@ def update_matrix(
     Lifecycle:
         Maturing.
     """
-
     # More developer-level information on why we do not -- and cannot -- check
     # shape/bounding box:
     #
@@ -1980,7 +1963,6 @@ def add_matrix_to_collection(
     Lifecycle:
         Maturing.
     """
-
     ingestion_params = IngestionParams(ingest_mode, None)
 
     # For local disk and S3, creation and storage URIs are identical.  For
@@ -2034,8 +2016,7 @@ def _write_matrix_to_denseNDArray(
     ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
-    """Write a matrix to an empty DenseNDArray"""
-
+    """Write a matrix to an empty DenseNDArray."""
     add_metadata(soma_ndarray, additional_metadata)
 
     # TileDB does not support big-endian so coerce to little-endian
@@ -2254,7 +2235,7 @@ def _find_sparse_chunk_size_non_backed(
 
 
 def _find_mean_nnz(matrix: Matrix, axis: int) -> int:
-    """Helper for _find_sparse_chunk_size_backed"""
+    """Helper for _find_sparse_chunk_size_backed."""
     extent = matrix.shape[axis]
     if extent == 0:
         return 0
@@ -2352,7 +2333,6 @@ def _find_sparse_chunk_size_backed(
     * On the very last bit of the matrix, there can be no sizing up --
       if there are only 7 rows remaining, that's that, end of story.
     """
-
     # Parameters as noted above and below.
     lower_ratio = 0.7
     upper_ratio = 1.0
@@ -2435,8 +2415,7 @@ def _write_matrix_to_sparseNDArray(
     axis_0_mapping: AxisIDMapping,
     axis_1_mapping: AxisIDMapping,
 ) -> None:
-    """Write a matrix to an empty DenseNDArray"""
-
+    """Write a matrix to an empty DenseNDArray."""
     # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
         matrix = matrix.byteswap().view(matrix.dtype.newbyteorder("<"))
@@ -2666,8 +2645,7 @@ def _chunk_is_contained_in(
     chunk_bounds: Sequence[tuple[int, int]],
     storage_nonempty_domain: Sequence[tuple[int | None, int | None]],
 ) -> bool:
-    """
-    Determines if a dim range is included within the array's non-empty domain.  Ranges are inclusive
+    """Determines if a dim range is included within the array's non-empty domain.  Ranges are inclusive
     on both endpoints.  This is a helper for resume-ingest mode.
 
     We say "bounds" not "MBR" with the "M" for minimum: a sparse matrix might not _have_ any
@@ -2906,15 +2884,13 @@ def _ingest_uns_string_array(
     ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
-    """
-    Ingest an uns string array. In the SOMA data model, we have NDArrays _of number only_ ...
+    """Ingest an uns string array. In the SOMA data model, we have NDArrays _of number only_ ...
     so we need to make this a SOMADataFrame.
 
     Ideally we don't want to add an index column "soma_joinid" -- "index", maybe.
     However, ``SOMADataFrame`` _requires_ that soma_joinid be present, either
     as an index column, or as a data column. The former is less confusing.
     """
-
     if len(value.shape) == 1:
         helper = _ingest_uns_1d_string_array
     elif len(value.shape) == 2:
@@ -2950,7 +2926,7 @@ def _ingest_uns_1d_string_array(
     ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
-    """Helper for ``_ingest_uns_string_array``"""
+    """Helper for ``_ingest_uns_string_array``."""
     n = len(value)
     # An array like ["a", "b", "c"] becomes a DataFrame like
     # soma_joinid value
@@ -2998,7 +2974,8 @@ def _ingest_uns_2d_string_array(
     """Helper for ``_ingest_uns_string_array``. Even if the 2D array is 1xN or Nx1, we
     must nonetheless keep this as 2D rather than flattening to length-N 1D. That's because
     this ``uns`` data is solely of interest for AnnData ingest/outgest, and it must go
-    back out the way it came in."""
+    back out the way it came in.
+    """
     num_rows, num_cols = value.shape
     data: dict[str, Any] = {"soma_joinid": np.arange(num_rows, dtype=np.int64)}
     # An array like [["a", "b", "c"], ["d", "e", "f"]] becomes a DataFrame like
@@ -3101,8 +3078,7 @@ def _ingest_uns_ndarray(
 
 
 def _concurrency_level(context: SOMATileDBContext) -> int:
-    """
-    Private helper function to determine appropriate concurrency level for
+    """Private helper function to determine appropriate concurrency level for
     ingestion of H5AD when use_multiprocessing is enabled.
 
     Functionally, this just allows the user to control concurrency via the

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -135,7 +135,7 @@ def _read_partitioned_sparse(X: SparseNDArray, d0_size: int) -> pa.Table:
 def _extract_X_key(
     measurement: Measurement, X_layer_name: str, nobs: int, nvar: int
 ) -> Future[Matrix]:
-    """Helper function for to_anndata"""
+    """Helper function for to_anndata."""
     if X_layer_name not in measurement.X:
         raise ValueError(
             f"X_layer_name {X_layer_name} not found in data: {measurement.X.keys()}"
@@ -287,7 +287,6 @@ def to_anndata(
     Lifecycle:
         Maturing.
     """
-
     s = _util.get_start_stamp()
     logging.log_io(None, "START  Experiment.to_anndata")
 
@@ -474,10 +473,7 @@ def _extract_obsm_or_varm(
     num_rows: int,
     width_configs: dict[str, int],
 ) -> Matrix:
-    """
-    This is a helper function for ``to_anndata`` of ``obsm`` and ``varm`` elements.
-    """
-
+    """This is a helper function for ``to_anndata`` of ``obsm`` and ``varm`` elements."""
     # SOMA shape is capacity/domain -- not what AnnData wants.
     # But here do check the array is truly 2D.
     shape = soma_nd_array.shape
@@ -558,9 +554,7 @@ def _extract_uns(
     uns_keys: Sequence[str] | None = None,
     level: int = 0,
 ) -> dict[str, FutureUnsDictNode]:
-    """
-    This is a helper function for ``to_anndata`` of ``uns`` elements.
-    """
+    """This is a helper function for ``to_anndata`` of ``uns`` elements."""
     extracted: dict[str, FutureUnsDictNode] = {}
     tp = collection.context.threadpool
     for key in collection.keys():
@@ -613,7 +607,7 @@ def _extract_uns(
 
 
 def _outgest_uns_1d_string_array(pdf: pd.DataFrame, uri_for_logging: str) -> NPNDArray:
-    """Helper methods for _extract_uns"""
+    """Helper methods for _extract_uns."""
     num_rows, num_cols = pdf.shape
     # An array like ["a", "b", "c"] had become a DataFrame like
     # soma_joinid value
@@ -628,7 +622,7 @@ def _outgest_uns_1d_string_array(pdf: pd.DataFrame, uri_for_logging: str) -> NPN
 
 
 def _outgest_uns_2d_string_array(pdf: pd.DataFrame, uri_for_logging: str) -> NPNDArray:
-    """Helper methods for _extract_uns"""
+    """Helper methods for _extract_uns."""
     num_rows, num_cols = pdf.shape
     if num_cols < 2:
         raise SOMAError(f"Expected 2 columns in {uri_for_logging}; got {num_cols}")

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -2,11 +2,11 @@
 #
 # Licensed under the MIT License.
 
-"""
-Provides support for the new shape feature in TileDB-SOMA 1.15, including the
+"""Provides support for the new shape feature in TileDB-SOMA 1.15, including the
 ability to process all dataframes/arrays contained within a TileDB-SOMA
 Experiment. Please also see
-https://github.com/single-cell-data/TileDB-SOMA/issues/2407."""
+https://github.com/single-cell-data/TileDB-SOMA/issues/2407.
+"""
 
 from __future__ import annotations
 
@@ -97,7 +97,6 @@ def get_experiment_shapes(
 
     Returns: a nested Python dict.
     """
-
     # Developer note: it would be a well-intentioned mistake to refactor
     # show_experiment_shapes to call get_experiment_shapes and then print the
     # result. The crucial issue is that for complex experiments on remote object
@@ -180,7 +179,6 @@ def show_experiment_shapes(
         ``True`` if outputting the shape works for elements. ``False`` if any element
         fails to successfully output its shape.
     """
-
     retval = _treewalk(
         uri,
         leaf_visitor=_leaf_visitor_show_shapes,
@@ -361,7 +359,6 @@ def resize_experiment(
         ``True`` if all resize operations succeed. ``False`` if any resize operation
         fails.
     """
-
     # Extra user-provided keys not relevant to the experiment are ignored.  This
     # is important for the case when a new measurement, which is registered from
     # AnnData/H5AD inputs, is registered and is about to be created but does not

--- a/apis/python/src/tiledbsoma/io/spatial/__init__.py
+++ b/apis/python/src/tiledbsoma/io/spatial/__init__.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the MIT License.
 
-"""Experimental SOMA features
+"""Experimental SOMA features.
 
 This module is for experimental features. Support for these features
 may be dropped.

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -137,7 +137,6 @@ def to_spatialdata_points(
             cloud is in to the coordinate space of the point cloud.
         soma_joinid: The name to use for the SOMA joinid.
     """
-
     # Get the axis names for the spatial data shapes.
     orig_axis_names = points.coordinate_space.axis_names
     new_axis_names, points_dim_map = _convert_axis_names(orig_axis_names)
@@ -182,7 +181,6 @@ def to_spatialdata_shapes(
             cloud is in to the coordinate space of the point cloud.
         soma_joinid: The name to use for the SOMA joinid.
     """
-
     # Get the radius for the point cloud.
     try:
         radius = points.metadata["soma_geometry"]
@@ -345,7 +343,6 @@ def to_spatialdata_multiscale_image(
         transform: The transformation from the coordinate space of the scene this
             multiscale image is in to the coordinate space of the image itself.
     """
-
     # Check for channel axis.
     if not image.has_channel_axis:
         raise NotImplementedError(

--- a/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
@@ -52,7 +52,6 @@ class DenseNDArrayWrapper:
 
     def __getitem__(self, key: tuple[slice | int, ...]) -> np.typing.NDArray[Any]:
         """Returns a numpy array containing data from a requested tuple."""
-
         # Compute the expected Xarray output shape.
         output_shape = tuple(
             len(range(dim_size)[index])  # type: ignore
@@ -141,7 +140,6 @@ def dense_nd_array_to_data_array(
         attrs: The attributes (metadata) to set on the :class:`xarray.DataArray`.
         context: Optional :class:`SOMATileDBContext` containing storage parameters, etc.
     """
-
     array_wrapper = DenseNDArrayWrapper(uri=uri, context=context)
 
     if chunks is None:

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -372,7 +372,6 @@ def from_visium(
     Lifecycle:
         Experimental
     """
-
     # Disclaimer about the experimental nature of the generated experiment.
     warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 

--- a/apis/python/src/tiledbsoma/io/update_uns.py
+++ b/apis/python/src/tiledbsoma/io/update_uns.py
@@ -74,8 +74,7 @@ def _update_uns(
     default_index_name: str | None = None,
     strict: Strict = True,
 ) -> None:
-    """
-    Update the given experiment/measurement's ``uns`` Collection.
+    """Update the given experiment/measurement's ``uns`` Collection.
 
     ``uns`` (short for unstructured data) is conceptually a dictionary; values can be scalars,
     DataFrames, arrays (dense or sparse), or recursively-nested dictionaries.

--- a/apis/python/src/tiledbsoma/logging.py
+++ b/apis/python/src/tiledbsoma/logging.py
@@ -2,6 +2,8 @@
 #
 # Licensed under the MIT License.
 
+"""Logging configuration helpers."""
+
 from __future__ import annotations
 
 import logging
@@ -52,6 +54,7 @@ def _set_level(level: int) -> None:
 
 
 def log_io_same(message: str) -> None:
+    """Log message to both INFO and DEBUG."""
     log_io(message, message)
 
 

--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -2,6 +2,8 @@
 #
 # Licensed under the MIT License.
 
+"""TileDB-SOMA configuration options."""
+
 from ._soma_tiledb_context import ConfigDict, SOMATileDBContext
 from ._tiledb_create_write_options import TileDBCreateOptions, TileDBWriteOptions
 

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -186,17 +186,14 @@ class SOMATileDBContext(ContextBase):
 
     @property
     def timestamp_ms(self) -> int | None:
-        """
-        The default timestamp for SOMA operations, as milliseconds since
+        """The default timestamp for SOMA operations, as milliseconds since
         the Unix epoch, or ``None`` if not provided.
         """
         return self._timestamp_ms
 
     @property
     def timestamp(self) -> datetime.datetime | None:
-        """
-        The default timestamp for SOMA operations, or ``None`` if not provided.
-        """
+        """The default timestamp for SOMA operations, or ``None`` if not provided."""
         if self.timestamp_ms is None:
             return None
         return ms_to_datetime(self.timestamp_ms)
@@ -372,7 +369,6 @@ def _validate_soma_tiledb_context(context: Any) -> SOMATileDBContext:
     easy for users to pass a ``tiledb.Ctx`` when a ``SOMATileDBContext`` is
     expected, we should offer a helpful redirect when they do.
     """
-
     if context is None:
         return SOMATileDBContext()
 

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -2,6 +2,8 @@
 #
 # Licensed under the MIT License.
 
+"""TileDB query stats helpers."""
+
 import json
 from typing import Literal, Union, cast
 

--- a/apis/python/tests/test_fastercsx.py
+++ b/apis/python/tests/test_fastercsx.py
@@ -276,7 +276,9 @@ def test_bad_arguments(
     """Test various bad argument types/values are caught."""
     sp = sparse.random(970, 31, density=0.01, dtype=np.float32, random_state=rng)
 
-    with suppress_type_checks():  # w/o this, typeguard raises, which defeats the point of the test
+    with (
+        suppress_type_checks()
+    ):  # w/o this, typeguard raises, which defeats the point of the test
 
         # context - bad type
         with pytest.raises(AttributeError):

--- a/apis/python/tests/test_metadata.py
+++ b/apis/python/tests/test_metadata.py
@@ -110,7 +110,9 @@ def test_metadata(soma_object):
         assert "'foobar': " in meta_repr
         assert "'my': 'enemies'" in meta_repr
     # ...but closed metadata does not.
-    with suppress_type_checks():  # type checking eagerly evaluates properties including `len`, which fails on a closed object
+    with (
+        suppress_type_checks()
+    ):  # type checking eagerly evaluates properties including `len`, which fails on a closed object
         meta_repr_closed = repr(second_read.metadata)
     assert "foobar" not in meta_repr_closed
 


### PR DESCRIPTION
Changes:
* Add Ruff's pydocstyle lint
* Run automated reformatting
* Manually fix unsafe lint errors (e.g., D405)

NB: tiledbsoma.io has many missing docstrings.  The D100 family of errors are temporarily disabled in this code path (see pyproject.toml).

Fixes SOMA-35
