### PR TITLE
[python] suppress insignificant overflow warning from numpy

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -1149,7 +1149,8 @@ def _find_extent_for_domain(
         return extent
 
     if np.issubdtype(dtype, NPInteger) or np.issubdtype(dtype, NPFloating):
-        return min(extent, hi - lo + 1)
+        with np.errstate(over='ignore'):
+            return min(extent, hi - lo + 1)
 
     if dtype in ("datetime64[s]", "datetime64[ms]", "datetime64[us]", "datetime64[ns]"):
         return min(extent, _util.to_unix_ts(hi) - _util.to_unix_ts(lo) + 1)

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -1149,7 +1149,7 @@ def _find_extent_for_domain(
         return extent
 
     if np.issubdtype(dtype, NPInteger) or np.issubdtype(dtype, NPFloating):
-        with np.errstate(over='ignore'):
+        with np.errstate(over="ignore"):
             return min(extent, hi - lo + 1)
 
     if dtype in ("datetime64[s]", "datetime64[ms]", "datetime64[us]", "datetime64[ns]"):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import struct
 import time
+import warnings
 from pathlib import Path
 from typing import Any, List
 
@@ -3688,3 +3689,25 @@ def test_dictionary_value_type_62364(tmp_path, dt_type):
         actual = A.read().concat()
         assert schema == A.schema == A.read().concat().schema
         assert actual["attr"] == expected["attr"]
+
+
+def test_no_extent_warning_61509(tmp_path):
+
+    schema = pa.schema(
+        [
+            pa.field("float_index", type=pa.float64(), nullable=False),
+            pa.field("soma_joinid", type=pa.int64(), nullable=False),
+            ("data", pa.float64()),
+        ]
+    )
+    fmax = np.finfo(np.float64).max
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        soma.DataFrame.create(
+            tmp_path.as_posix(),
+            schema=schema,
+            index_column_names=("float_index",),
+            domain=((-fmax, fmax),),
+        ).close()


### PR DESCRIPTION
DataFrame.create will raise numeric overflow warnings when it should not.  sc-61509

