### PR TITLE
[r] Clean up `DESCRIPTION`

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -48,6 +48,7 @@ Imports:
     rlang (>= 1.1.5),
     spdl,
     stats,
+    tiledb (>= 0.31.1),
     tools,
     utils
 LinkingTo:

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -22,54 +22,54 @@ Authors@R: c(
     person(given = "TileDB, Inc.",
            role = c("cph", "fnd"))
     )
-URL: https://github.com/single-cell-data/TileDB-SOMA
+URL:
+    https://single-cell-data.github.io/TileDB-SOMA/,
+    https://github.com/single-cell-data/TileDB-SOMA
 BugReports: https://github.com/single-cell-data/TileDB-SOMA/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
-Depends:
-    R (>= 4.0.0)
-Imports:
-    R6,
-    methods,
-    Matrix,
-    stats,
-    bit64 (>= 4.6.0.1),
-    tiledb (>= 0.31.1),
-    arrow (>= 14.0.0),
-    utils,
-    fs,
-    glue,
-    Rcpp,
-    data.table,
-    spdl,
-    rlang,
-    tools,
-    tibble,
-    nanoarrow
-LinkingTo:
-    Rcpp,
-    RcppSpdlog (>= 0.0.20),
-    RcppInt64,
-    nanoarrow
 Additional_repositories: https://tiledb-inc.r-universe.dev
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+VignetteBuilder: knitr
+Depends:
+    R (>= 4.0.0)
+Imports:
+    arrow (>= 19.0.1),
+    bit64 (>= 4.6.0.1),
+    data.table,
+    fs,
+    glue,
+    Matrix (>= 1.7.3),
+    methods,
+    nanoarrow,
+    R6,
+    Rcpp,
+    rlang (>= 1.1.5),
+    spdl,
+    stats,
+    tools,
+    utils
+LinkingTo:
+    nanoarrow,
+    Rcpp,
+    RcppInt64,
+    RcppSpdlog (>= 0.0.20)
 Suggests:
-    rmarkdown,
-    knitr,
-    withr,
-    testthat (>= 3.0.0),
-    pbmc3k.tiledb,
-    SeuratObject (>= 4.1.0),
     datasets,
-    SingleCellExperiment (>= 1.20.0),
-    SummarizedExperiment (>= 1.28.0),
-    S4Vectors,
-    jsonlite,
     iterators,
     itertools,
-    pbmc3k
-VignetteBuilder: knitr
+    jsonlite,
+    knitr,
+    pbmc3k,
+    pbmc3k.tiledb,
+    rmarkdown,
+    S4Vectors,
+    SeuratObject (>= 4.1.0),
+    SingleCellExperiment (>= 1.20.0),
+    SummarizedExperiment (>= 1.28.0),
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 2
 OS_type: unix
 SystemRequirements: cmake, git


### PR DESCRIPTION
Let usethis manage dependencies (eg sorting)
Add a link to the docsite so that CRAN can link to it

Fixes [SOMA-46](https://linear.app/tiledb/issue/SOMA-46/clean-up-description)