### PR TITLE
Format markdown with mdformat; add pre-commit hook for mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,8 @@ repos:
     rev: 0.7.22  # Use the ref you want to point at
     hooks:
     - id: mdformat
+      files: .*\.md|^apis/r/vignettes/.*\.Rmd
+      types: [file, text]
       exclude: ^.github/
+      additional_dependencies:
+        - "mdformat-frontmatter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,11 @@ repos:
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false
+
+# TODO: consider enabling this for all markdown files
+files: apis/python/HISTORY.md
+repos:
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22  # Use the ref you want to point at
+    hooks:
+    - id: mdformat

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,8 @@ repos:
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false
 
-# TODO: consider enabling this for all markdown files
-files: apis/python/HISTORY.md
-repos:
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22  # Use the ref you want to point at
     hooks:
     - id: mdformat
+      exclude: ^.github/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,21 +3,27 @@
 Thanks for your interest in TileDB-SOMA. The notes below give some pointers for filing issues and bug reports, or contributing to the code.
 
 ## Contribution Checklist
+
 - Reporting a bug? Please include the following information
   - operating system and version (windows, linux, macos, etc.)
   - TileDB and TileDB-SOMA version (for example, the output of `conda list` or `git status`).
   - if possible, a minimal working example demonstrating the bug or issue (along with any data to re-create, when feasible)
-- Please paste code blocks with triple backquotes (```) so that github will format it nicely. See [GitHub's guide on Markdown](https://guides.github.com/features/mastering-markdown) for more formatting tricks.
+- Please paste code blocks with triple backquotes (\`\`\`) so that github will format it nicely. See [GitHub's guide on Markdown](https://guides.github.com/features/mastering-markdown) for more formatting tricks.
 
 ## Contributing Code
+
 *By contributing code to TileDB-SOMA, you are agreeing to release it under the [MIT License](https://github.com/TileDB-Inc/TileDB/tree/dev/LICENSE).*
 
 ### Contribution Workflow
 
 - [Please follow these instructions to build from source](https://docs.tiledb.com/developer/tiledbsoma/installation)
+
 - Make changes locally, then rebuild as appropriate for the level of changes (e.g.: `make` for `libtilebsc` or `python setup.py develop` for `apis/python`).
+
 - Make sure to run `make check`, or `pytest` to verify changes against tests (add new tests where applicable).
+
 - Please submit [pull requests](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) against the default [`main` branch of TileDB-SOMA](https://github.com/TileDB-Inc/TileDB-SOMA/tree/master).
+
 - If you edit the Python files, please run the pre-commit hooks
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -16,38 +16,38 @@ Embedded](https://github.com/TileDB-Inc/TileDB) to implement the
 
 Get started on using TileDB-SOMA:
 
-* [Quick start](#quick-start).
-* Python [documentation](https://tiledbsoma.readthedocs.io/en/latest/python-api.html).
-* R [documentation](https://single-cell-data.github.io/TileDB-SOMA/).
+- [Quick start](#quick-start).
+- Python [documentation](https://tiledbsoma.readthedocs.io/en/latest/python-api.html).
+- R [documentation](https://single-cell-data.github.io/TileDB-SOMA/).
 
 ## What Can TileDB-SOMA Do?
 
 Intended to be used for single-cell data, TileDB-SOMA provides Python and R APIs to allow for storage and data access patterns at scale and for larger-than-memory operations:
 
-* Create and write large volumes of data.
-* Open and read data at low latency, locally and from the cloud.
-* Query and access interconnected arrays efficiently and at low latency.
+- Create and write large volumes of data.
+- Open and read data at low latency, locally and from the cloud.
+- Query and access interconnected arrays efficiently and at low latency.
 
 TileDB-SOMA provides interoperability with existing single-cell toolkits:
 
-* Load and create [AnnData](https://anndata.readthedocs.io/en/latest/) objects.
-* Load and create [Seurat](https://satijalab.org/seurat/) objects.
+- Load and create [AnnData](https://anndata.readthedocs.io/en/latest/) objects.
+- Load and create [Seurat](https://satijalab.org/seurat/) objects.
 
 TileDB-SOMA provides interoperability with existing Python or R data structures:
 
-* From Python create PyArrow objects, SciPy sparse matrices, NumPy arrays, and pandas data frames.
-* From R create R Arrow objects, sparse matrices (via the [Matrix](https://cran.r-project.org/package=Matrix) package), and standard data frames and (dense) matrices.
+- From Python create PyArrow objects, SciPy sparse matrices, NumPy arrays, and pandas data frames.
+- From R create R Arrow objects, sparse matrices (via the [Matrix](https://cran.r-project.org/package=Matrix) package), and standard data frames and (dense) matrices.
 
 ## Community
 
-* Please join the [TileDB Slack community](https://tiledb-community.slack.com/join/shared_invite/zt-ndq1ipwl-QcithaWG6j1BImtuQGSpag#/shared-invite/email) with dedicated channel `#genomics`.
-* Please join the [CZI Slack community](https://cziscience.slack.com/join/shared_invite/zt-czl1kp2v-sgGpY4RxO3bPYmFg2XlbZA#/shared-invite/email), with dedicated
-channel `#cellxgene-census-users`.
+- Please join the [TileDB Slack community](https://tiledb-community.slack.com/join/shared_invite/zt-ndq1ipwl-QcithaWG6j1BImtuQGSpag#/shared-invite/email) with dedicated channel `#genomics`.
+- Please join the [CZI Slack community](https://cziscience.slack.com/join/shared_invite/zt-czl1kp2v-sgGpY4RxO3bPYmFg2XlbZA#/shared-invite/email), with dedicated
+  channel `#cellxgene-census-users`.
 
 ## APIs Installation and Quick Start <a id="quick-start"></a>
 
-* [Python installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/Python-quick-start)
-* [R installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/R-quick-start)
+- [Python installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/Python-quick-start)
+- [R installation and quick start](https://github.com/single-cell-data/TileDB-SOMA/wiki/R-quick-start)
 
 ## API Documentation
 
@@ -59,40 +59,39 @@ Reference documentation can also be accessed directly from Python `help(tiledsom
 
 The capabilities of TileDB-SOMA lay on the different read, access, and query patterns that each of the main implementations of SOMA objects provide:
 
-* `DenseNDArray` is a dense, N-dimensional array, with offset (zero-based) integer indexing on each dimension.
-* `SparseNDArray` is the same as `DenseNDArray` but sparse, and supports point indexing (disjoint index access).
-* `DataFrame` is a multi-column table with a user-defined columns names and value types, with support for point indexing.
-* `Collection` is a persistent container of named SOMA objects.
-* `Experiment` is a class that represents a single-cell experiment. It always contains two objects:
- 	* `obs`: a  `DataFrame` with primary annotations on the observation axis.
- 	* `ms`: a  `Collection` of measurements, each composed of `X` matrices and axis annotation matrices or data frames (e.g. `var`, `varm`, `obsm`, etc).
+- `DenseNDArray` is a dense, N-dimensional array, with offset (zero-based) integer indexing on each dimension.
+- `SparseNDArray` is the same as `DenseNDArray` but sparse, and supports point indexing (disjoint index access).
+- `DataFrame` is a multi-column table with a user-defined columns names and value types, with support for point indexing.
+- `Collection` is a persistent container of named SOMA objects.
+- `Experiment` is a class that represents a single-cell experiment. It always contains two objects:
+  - `obs`: a `DataFrame` with primary annotations on the observation axis.
+  - `ms`: a `Collection` of measurements, each composed of `X` matrices and axis annotation matrices or data frames (e.g. `var`, `varm`, `obsm`, etc).
 
 ## Who Is Using SOMA?
 
-* [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) to build its [Census](https://github.com/chanzuckerberg/cellxgene-census/), which provides efficient access and querying to a corpus containing nearly 50 million cells, compiled from 700+ datasets.
+- [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) to build its [Census](https://github.com/chanzuckerberg/cellxgene-census/), which provides efficient access and querying to a corpus containing nearly 50 million cells, compiled from 700+ datasets.
 
 If you are interested in listing any projects here please contact us at [soma@chanzuckerberg.com](mailto:soma@chanzuckerberg.com).
 
 ## Issues and Contacts
 
-* Any/all questions, comments, and concerns are welcome at the [GitHub new-issue page](https://github.com/single-cell-data/TileDB-SOMA/issues/new/choose) -- or, you can also browse [existing issues](https://github.com/single-cell-data/TileDB-SOMA/issues).
-* If you believe you have found a security issue, in lieu of filing an issue please responsibly disclose it by contacting [security@tiledb.com](mailto:security@tiledb.com).
+- Any/all questions, comments, and concerns are welcome at the [GitHub new-issue page](https://github.com/single-cell-data/TileDB-SOMA/issues/new/choose) -- or, you can also browse [existing issues](https://github.com/single-cell-data/TileDB-SOMA/issues).
+- If you believe you have found a security issue, in lieu of filing an issue please responsibly disclose it by contacting [security@tiledb.com](mailto:security@tiledb.com).
 
 ## Branches
 
-This branch, `main`, implements the [updated specfication](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md).  Please also see the `main-old` branch which implements the [original specification](https://github.com/single-cell-data/TileDB-SOMA/blob/main-old/spec/specification.md).
+This branch, `main`, implements the [updated specfication](https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md). Please also see the `main-old` branch which implements the [original specification](https://github.com/single-cell-data/TileDB-SOMA/blob/main-old/spec/specification.md).
 
 ## Developer Information
 
-* [TileDB-SOMA wiki](https://github.com/single-cell-data/TileDB-SOMA/wiki).
-* [Build instructions for developers](libtiledbsoma/README.md).
+- [TileDB-SOMA wiki](https://github.com/single-cell-data/TileDB-SOMA/wiki).
+- [Build instructions for developers](libtiledbsoma/README.md).
 
 ## Code of Conduct
 
 All participants in TileDB spaces are expected to adhere to high standards of
 professionalism in all interactions. This repository is governed by the
 specific standards and reporting procedures detailed in depth in the
-[TileDB core repository Code Of Conduct](
-https://github.com/TileDB-Inc/TileDB/blob/dev/CODE_OF_CONDUCT.md).
+[TileDB core repository Code Of Conduct](https://github.com/TileDB-Inc/TileDB/blob/dev/CODE_OF_CONDUCT.md).
 
 <!-- links -->

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -1,0 +1,28 @@
+
+# TileDB-SOMA Python Changelog
+
+All notable changes to the Python TileDB-SOMA project will be documented in this file (related: [TileDB-SOMA R API changelog](../r/NEWS.md)).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- [[#4023](https://github.com/single-cell-data/TileDB-SOMA/pull/4023)] [c++] Use nanoarrow ArrowSchemaSetTypeDateTime for datetime values. Dictionary type with timestamp value type will raise error on read.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- [[#4040](https://github.com/single-cell-data/TileDB-SOMA/pull/4040)] [python] suppress insignificant overflow warning from numpy
+
+### Security
+
+## [Release prior to 1.17.0]
+
+TileDB-SOMA Python releases prior to 1.17.0 are documented in the [TileDB-SOMA Github Releases](https://github.com/single-cell-data/TileDB-SOMA/releases).

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -1,4 +1,3 @@
-
 # TileDB-SOMA Python Changelog
 
 All notable changes to the Python TileDB-SOMA project will be documented in this file (related: [TileDB-SOMA R API changelog](../r/NEWS.md)).
@@ -11,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- [[#4023](https://github.com/single-cell-data/TileDB-SOMA/pull/4023)] [c++] Use nanoarrow ArrowSchemaSetTypeDateTime for datetime values. Dictionary type with timestamp value type will raise error on read.
+- \[[#4023](https://github.com/single-cell-data/TileDB-SOMA/pull/4023)\] [c++] Use nanoarrow ArrowSchemaSetTypeDateTime for datetime values. Dictionary type with timestamp value type will raise error on read.
 
 ### Deprecated
 
@@ -19,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- [[#4040](https://github.com/single-cell-data/TileDB-SOMA/pull/4040)] [python] suppress insignificant overflow warning from numpy
+- \[[#4040](https://github.com/single-cell-data/TileDB-SOMA/pull/4040)\] [python] suppress insignificant overflow warning from numpy
 
 ### Security
 

--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -38,23 +38,23 @@ If this comes up empty for your system, you'll definitely need to build from sou
 
 ## From source
 
-* Clone [this repo](https://github.com/single-cell-data/TileDB-SOMA)
-* `cd` into your checkout and then `cd apis/python`
-* `python -m pip install .`
-* Or, if you wish to modify the code and run it, `python -m pip install -v -e .`
-* If the TileDB and TileDB-SOMA libraries are locally installed to a custom directory, such as `/usr/local`, set the path with environment variables `TILEDB_PATH` and `TILEDBSOMA_PATH`, `TILEDB_PATH=/usr/local python -m pip install -v -e .`
-* Optionally, if you prefer, you can run that inside `venv`:
+- Clone [this repo](https://github.com/single-cell-data/TileDB-SOMA)
+- `cd` into your checkout and then `cd apis/python`
+- `python -m pip install .`
+- Or, if you wish to modify the code and run it, `python -m pip install -v -e .`
+- If the TileDB and TileDB-SOMA libraries are locally installed to a custom directory, such as `/usr/local`, set the path with environment variables `TILEDB_PATH` and `TILEDBSOMA_PATH`, `TILEDB_PATH=/usr/local python -m pip install -v -e .`
+- Optionally, if you prefer, you can run that inside `venv`:
   ```shell
   $ python -m venv venv
   $ . ./venv/bin/activate
   $ python -m pip install -v -e .
   ```
-* In either case:
+- In either case:
   ```shell
   make data
   python -m pytest tests
   ```
-* A note about the `spdlog` package: If you encounter an install-time error like `fatal error: spdlog/spdlog.h: No such file or directory` you should additionally recursively remove `/usr/local/lib/cmake/spdlog `, since the system uninstall of `spdlog` fails to remove this properly.
+- A note about the `spdlog` package: If you encounter an install-time error like `fatal error: spdlog/spdlog.h: No such file or directory` you should additionally recursively remove `/usr/local/lib/cmake/spdlog `, since the system uninstall of `spdlog` fails to remove this properly.
 
 # Status
 

--- a/apis/python/notebooks/data/README.md
+++ b/apis/python/notebooks/data/README.md
@@ -1,8 +1,8 @@
 How to regenerate:
 
-* Source data -- download to local -- https://github.com/chanzuckerberg/cellxgene/raw/main/example-dataset/pbmc3k.h5ad
-* Use `tiledbsoma.io.from_h5ad`
-  * Remove previous `sparse/pbmc3k` and `dense/pbmc3k`
-  * Comment out the call to the uns-writing logic (we don't need it)
-  * Use default `X_kind` for `sparse/pbmc3k`
-  * Use `X_kind=DenseNDArray` for `dense/pbmc3k`
+- Source data -- download to local -- https://github.com/chanzuckerberg/cellxgene/raw/main/example-dataset/pbmc3k.h5ad
+- Use `tiledbsoma.io.from_h5ad`
+  - Remove previous `sparse/pbmc3k` and `dense/pbmc3k`
+  - Comment out the call to the uns-writing logic (we don't need it)
+  - Use default `X_kind` for `sparse/pbmc3k`
+  - Use `X_kind=DenseNDArray` for `dense/pbmc3k`

--- a/apis/python/remote_tests/README.md
+++ b/apis/python/remote_tests/README.md
@@ -38,11 +38,11 @@ aws s3 cp s3://tiledb-unittest/soma-prod-test-data/h5ad .
 
 Then use `tiledbsoma.io.from_h5ad` with the following sources and data:
 
-* Prefer a bare Docker image
-* Repeat for all desired TileDB-SOMA versions:
-  * `pip install tiledbsoma==1.15.7` (or whichever version)
-  * Ingest to `s3://tiledb-unittest/soma-prod-test-data/1.15.7/pbmc3k_unprocessed_1.15.7`
-  * Register this in the cloud UI
-    * Note: as of 2025-02-07 the cloud UI disallows `.` in group names so register with name like `1_15_7`.
-    * Tracked at [sc-63068](https://app.shortcut.com/tiledb-inc/story/63068/allow-in-registration-paths)
-  * Do not ingest directly to `tiledb://unittest/s3://tiledb-unittest/soma-prod-test-data/1.15.7/pbmc3k_unprocessed_1.15.7` since this will use today's version of core server-side, and what we want to really test is data written entirely by the pip-installed versions of tiledbsoma and core.
+- Prefer a bare Docker image
+- Repeat for all desired TileDB-SOMA versions:
+  - `pip install tiledbsoma==1.15.7` (or whichever version)
+  - Ingest to `s3://tiledb-unittest/soma-prod-test-data/1.15.7/pbmc3k_unprocessed_1.15.7`
+  - Register this in the cloud UI
+    - Note: as of 2025-02-07 the cloud UI disallows `.` in group names so register with name like `1_15_7`.
+    - Tracked at [sc-63068](https://app.shortcut.com/tiledb-inc/story/63068/allow-in-registration-paths)
+  - Do not ingest directly to `tiledb://unittest/s3://tiledb-unittest/soma-prod-test-data/1.15.7/pbmc3k_unprocessed_1.15.7` since this will use today's version of core server-side, and what we want to really test is data written entirely by the pip-installed versions of tiledbsoma and core.

--- a/apis/python/testdata/README.md
+++ b/apis/python/testdata/README.md
@@ -21,7 +21,7 @@ x = ad.read_h5ad('/Users/aaronwolen/Downloads/pbmc-small.h5ad')
 FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].
 ```
 
-But the Python `anndata` package (which we use for ingest) recognizes and fixes the problem.  The
+But the Python `anndata` package (which we use for ingest) recognizes and fixes the problem. The
 `pbmc-small.h5ad` file included here has that corrected by having read and written back the file
 using Python `anndata`.
 

--- a/apis/python/tests/ht/README.md
+++ b/apis/python/tests/ht/README.md
@@ -39,5 +39,4 @@ which enables a defect workaround, while the issue is being resolved.
 
 See the [Hypothesis documentation].
 
-
-[Hypothesis documentation]: https://hypothesis.readthedocs.io/
+[hypothesis documentation]: https://hypothesis.readthedocs.io/

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,333 +2,332 @@
 
 ## Removals
 
-* `TileDBURI` class has been removed
-* arrow <> TileDB-R helpers have been removed
-  * `arrow_field_from_tiledb_dim()`
-  * `arrow_field_from_tiledb_attr()`
-  * `arrow_schema_from_tiledb_schema()`
+- `TileDBURI` class has been removed
+- arrow \<> TileDB-R helpers have been removed
+  - `arrow_field_from_tiledb_dim()`
+  - `arrow_field_from_tiledb_attr()`
+  - `arrow_schema_from_tiledb_schema()`
 
 ## Additions
 
-* New function `get_tiledb_object_type()` to replace `tiledb::tiledb_object_type()`
-* New function `get_tiledb_version()` to replace `tiledb::tiledb_version()`
-* New method `SOMAArrayBase$is_sparse()` to replace `tiledb::is.sparse()`
-* New method `SOMAArrayBase$allows_duplicates()` to replace `tiledb::allows_dups()`
-* New method `SOMADataFrame$levels()` to replace tiledb-r enum accessors
+- New function `get_tiledb_object_type()` to replace `tiledb::tiledb_object_type()`
+- New function `get_tiledb_version()` to replace `tiledb::tiledb_version()`
+- New method `SOMAArrayBase$is_sparse()` to replace `tiledb::is.sparse()`
+- New method `SOMAArrayBase$allows_duplicates()` to replace `tiledb::allows_dups()`
+- New method `SOMADataFrame$levels()` to replace tiledb-r enum accessors
 
 ## Changes
 
-* `TileDBArray$attributes()` has been promoted to `SOMAArrayBase$attributes()` and returns a named list instead of an external pointer
+- `TileDBArray$attributes()` has been promoted to `SOMAArrayBase$attributes()` and returns a named list instead of an external pointer
 
 # tiledbsoma 1.16.0
 
-* Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII`
-* Use S3 method dispatch on `integer64` instead of directly calling the S3 methods
-* [c++] Replace `SOMAArray` read and write calls with `ManagedQuery` [#3678](https://github.com/single-cell-data/TileDB-SOMA/pull/3678)
-* Remove `used_shape`, which was deprecated in 1.15 with scheduled removal in 1.16 [#3723](https://github.com/single-cell-data/TileDB-SOMA/pull/3723)
+- Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII`
+- Use S3 method dispatch on `integer64` instead of directly calling the S3 methods
+- [c++] Replace `SOMAArray` read and write calls with `ManagedQuery` [#3678](https://github.com/single-cell-data/TileDB-SOMA/pull/3678)
+- Remove `used_shape`, which was deprecated in 1.15 with scheduled removal in 1.16 [#3723](https://github.com/single-cell-data/TileDB-SOMA/pull/3723)
 
 # tiledbsoma 1.15.7
 
-* This release contains Python-only bugfixes
+- This release contains Python-only bugfixes
 
 # tiledbsoma 1.15.6
 
-* This release contains Python-only bugfixes
+- This release contains Python-only bugfixes
 
 # tiledbsoma 1.15.5
 
-* This release contains a Python-only bugfix
+- This release contains a Python-only bugfix
 
 # tiledbsoma 1.15.4
 
-* This release contains Python-only updates for spatial transcriptomics
+- This release contains Python-only updates for spatial transcriptomics
 
 # tiledbsoma 1.15.3
 
-* This release contains Python-only bugfixes
+- This release contains Python-only bugfixes
 
 # tiledbsoma 1.15.2
 
-* This release contains a Python-only bugfix
+- This release contains a Python-only bugfix
 
 # tiledbsoma 1.15.1
 
-* Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII` [#3469](https://github.com/single-cell-data/TileDB-SOMA/pull/3469)
+- Encode string metadata as `TILEDB_STRING_UTF8` instead of `TILEDB_STRING_ASCII` [#3469](https://github.com/single-cell-data/TileDB-SOMA/pull/3469)
 
 # tiledbsoma 1.15.0
 
 ## Changes
 
-* Remove unused `fragment_count` accessor [#3054](https://github.com/single-cell-data/TileDB-SOMA/pull/3054)
-* Implement missing `domain` argument to `SOMADataFrame` `create` [#3032](https://github.com/single-cell-data/TileDB-SOMA/pull/3032)
-* Use `libtiledbsoma` for R schema evolution [#3100](https://github.com/single-cell-data/TileDB-SOMA/pull/3100)
-* Push `attrnames` down to C++ [#3121](https://github.com/single-cell-data/TileDB-SOMA/pull/3121)
-* Push `schema` accessor down to `libtiledbsoma` [#3079](https://github.com/single-cell-data/TileDB-SOMA/pull/3079)
-* Handle `numeric` coords properly when reading arrays
-* Remove two more `tiledb::schema` callsites [#3160](https://github.com/single-cell-data/TileDB-SOMA/pull/3160)
-* Add new Arrow-to-R type mapper
-* Add transitional/non-exported `parse_query_condition_new` [#3162](https://github.com/single-cell-data/TileDB-SOMA/pull/3162)
-* Apply new `parse_query_condition` [#3174](https://github.com/single-cell-data/TileDB-SOMA/pull/3174)
-* Apply new `non_empty_domain` [#3176](https://github.com/single-cell-data/TileDB-SOMA/pull/3176)
-* Support for dense current domain with core 2.27 [#3180](https://github.com/single-cell-data/TileDB-SOMA/pull/3180)
-* Fix `is_named_list` bug for half-named lists [#3183](https://github.com/single-cell-data/TileDB-SOMA/pull/3183)
-* Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
-* Min-sizing for dataframes/arrays with new shape feature [#3208](https://github.com/single-cell-data/TileDB-SOMA/pull/3208)
-* Proper prefixing for shape-related methods [#3237](https://github.com/single-cell-data/TileDB-SOMA/pull/3237)
-* Bindings for `upgrade_domain` [#3238](https://github.com/single-cell-data/TileDB-SOMA/pull/3238)
-* Apply `styler::style_pkg()` [#3239](https://github.com/single-cell-data/TileDB-SOMA/pull/3239)
-* Plumb old-style `SOMATileDBContext` into new-style `soma_context()` [#3252](https://github.com/single-cell-data/TileDB-SOMA/pull/3252)
-* Fixes for dense arrays and yet-to-be-released core 2.27 [#3270](https://github.com/single-cell-data/TileDB-SOMA/pull/3270)
-* More fixes for unit-test cases with dense + core 2.27 [#3280](https://github.com/single-cell-data/TileDB-SOMA/pull/3280)
-* Add initial support for ragged array writing for Seurat v5 by @mojaveazure in [#2523](https://github.com/single-cell-data/TileDB-SOMA/pull/2523)
-* Remove 2.27-related feature flag by @johnkerl in [#3368](https://github.com/single-cell-data/TileDB-SOMA/pull/3368)
-* Revert #3300 by @johnkerl in [#3358](https://github.com/single-cell-data/TileDB-SOMA/pull/3358)
-* Enforce dataframe domain lower bound == 0 by @johnkerl in [#3300](https://github.com/single-cell-data/TileDB-SOMA/pull/3300)
-* Data refresh for new shapes by @johnkerl in [#3303](https://github.com/single-cell-data/TileDB-SOMA/pull/3303)
-* Move beyond the new-shape feature flag by @johnkerl in [#3301](https://github.com/single-cell-data/TileDB-SOMA/pull/3301)
-* Note on dev installs and `spdlog` failures by @johnkerl in [#3324](https://github.com/single-cell-data/TileDB-SOMA/pull/3324)
-* Remove tiledb-r specific install by @mojaveazure in [#3319](https://github.com/single-cell-data/TileDB-SOMA/pull/3319)
-* Try to unbreak `r-valgrind` CI by @johnkerl in [#3318](https://github.com/single-cell-data/TileDB-SOMA/pull/3318)
-* Avoid log truncation with "Last 13 lines of output" by @johnkerl in [#3313](https://github.com/single-cell-data/TileDB-SOMA/pull/3313)
-* Run tests in closer to internal-dependency order by @johnkerl in [#3311](https://github.com/single-cell-data/TileDB-SOMA/pull/3311)
-* Use standard name `zzz.R` for init code by @johnkerl in [#3332](https://github.com/single-cell-data/TileDB-SOMA/pull/3332)
-* Address two more compiler warnings by @johnkerl in [#3320](https://github.com/single-cell-data/TileDB-SOMA/pull/3320)
-* Add support for writing Seurat v5 ragged arrays
-* Update docstrings for `domain` argument to `create` [#3396](https://github.com/single-cell-data/TileDB-SOMA/pull/3396)
-* Vignette for new-shape feature [#3302](https://github.com/single-cell-data/TileDB-SOMA/pull/3302)
-* Fix blockwise iterator + re-indexer to return re-indexed shape instead of full domain
-* Docstring audit for new shape [#3399](https://github.com/single-cell-data/TileDB-SOMA/pull/3399)
-* Add `check_only` support for domain/shape updates [#3400](https://github.com/single-cell-data/TileDB-SOMA/pull/3400)
-* Adjust blockwise + re-indexer to return condensed matrix, not full domain [#3395](https://github.com/single-cell-data/TileDB-SOMA/pull/3395)
-* [c++] Use core 2.27.0.rc5 [#3410](https://github.com/single-cell-data/TileDB-SOMA/pull/3410)
-* [c++] Use core 2.27.0 [#3422](https://github.com/single-cell-data/TileDB-SOMA/pull/3422)
+- Remove unused `fragment_count` accessor [#3054](https://github.com/single-cell-data/TileDB-SOMA/pull/3054)
+- Implement missing `domain` argument to `SOMADataFrame` `create` [#3032](https://github.com/single-cell-data/TileDB-SOMA/pull/3032)
+- Use `libtiledbsoma` for R schema evolution [#3100](https://github.com/single-cell-data/TileDB-SOMA/pull/3100)
+- Push `attrnames` down to C++ [#3121](https://github.com/single-cell-data/TileDB-SOMA/pull/3121)
+- Push `schema` accessor down to `libtiledbsoma` [#3079](https://github.com/single-cell-data/TileDB-SOMA/pull/3079)
+- Handle `numeric` coords properly when reading arrays
+- Remove two more `tiledb::schema` callsites [#3160](https://github.com/single-cell-data/TileDB-SOMA/pull/3160)
+- Add new Arrow-to-R type mapper
+- Add transitional/non-exported `parse_query_condition_new` [#3162](https://github.com/single-cell-data/TileDB-SOMA/pull/3162)
+- Apply new `parse_query_condition` [#3174](https://github.com/single-cell-data/TileDB-SOMA/pull/3174)
+- Apply new `non_empty_domain` [#3176](https://github.com/single-cell-data/TileDB-SOMA/pull/3176)
+- Support for dense current domain with core 2.27 [#3180](https://github.com/single-cell-data/TileDB-SOMA/pull/3180)
+- Fix `is_named_list` bug for half-named lists [#3183](https://github.com/single-cell-data/TileDB-SOMA/pull/3183)
+- Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
+- Min-sizing for dataframes/arrays with new shape feature [#3208](https://github.com/single-cell-data/TileDB-SOMA/pull/3208)
+- Proper prefixing for shape-related methods [#3237](https://github.com/single-cell-data/TileDB-SOMA/pull/3237)
+- Bindings for `upgrade_domain` [#3238](https://github.com/single-cell-data/TileDB-SOMA/pull/3238)
+- Apply `styler::style_pkg()` [#3239](https://github.com/single-cell-data/TileDB-SOMA/pull/3239)
+- Plumb old-style `SOMATileDBContext` into new-style `soma_context()` [#3252](https://github.com/single-cell-data/TileDB-SOMA/pull/3252)
+- Fixes for dense arrays and yet-to-be-released core 2.27 [#3270](https://github.com/single-cell-data/TileDB-SOMA/pull/3270)
+- More fixes for unit-test cases with dense + core 2.27 [#3280](https://github.com/single-cell-data/TileDB-SOMA/pull/3280)
+- Add initial support for ragged array writing for Seurat v5 by @mojaveazure in [#2523](https://github.com/single-cell-data/TileDB-SOMA/pull/2523)
+- Remove 2.27-related feature flag by @johnkerl in [#3368](https://github.com/single-cell-data/TileDB-SOMA/pull/3368)
+- Revert #3300 by @johnkerl in [#3358](https://github.com/single-cell-data/TileDB-SOMA/pull/3358)
+- Enforce dataframe domain lower bound == 0 by @johnkerl in [#3300](https://github.com/single-cell-data/TileDB-SOMA/pull/3300)
+- Data refresh for new shapes by @johnkerl in [#3303](https://github.com/single-cell-data/TileDB-SOMA/pull/3303)
+- Move beyond the new-shape feature flag by @johnkerl in [#3301](https://github.com/single-cell-data/TileDB-SOMA/pull/3301)
+- Note on dev installs and `spdlog` failures by @johnkerl in [#3324](https://github.com/single-cell-data/TileDB-SOMA/pull/3324)
+- Remove tiledb-r specific install by @mojaveazure in [#3319](https://github.com/single-cell-data/TileDB-SOMA/pull/3319)
+- Try to unbreak `r-valgrind` CI by @johnkerl in [#3318](https://github.com/single-cell-data/TileDB-SOMA/pull/3318)
+- Avoid log truncation with "Last 13 lines of output" by @johnkerl in [#3313](https://github.com/single-cell-data/TileDB-SOMA/pull/3313)
+- Run tests in closer to internal-dependency order by @johnkerl in [#3311](https://github.com/single-cell-data/TileDB-SOMA/pull/3311)
+- Use standard name `zzz.R` for init code by @johnkerl in [#3332](https://github.com/single-cell-data/TileDB-SOMA/pull/3332)
+- Address two more compiler warnings by @johnkerl in [#3320](https://github.com/single-cell-data/TileDB-SOMA/pull/3320)
+- Add support for writing Seurat v5 ragged arrays
+- Update docstrings for `domain` argument to `create` [#3396](https://github.com/single-cell-data/TileDB-SOMA/pull/3396)
+- Vignette for new-shape feature [#3302](https://github.com/single-cell-data/TileDB-SOMA/pull/3302)
+- Fix blockwise iterator + re-indexer to return re-indexed shape instead of full domain
+- Docstring audit for new shape [#3399](https://github.com/single-cell-data/TileDB-SOMA/pull/3399)
+- Add `check_only` support for domain/shape updates [#3400](https://github.com/single-cell-data/TileDB-SOMA/pull/3400)
+- Adjust blockwise + re-indexer to return condensed matrix, not full domain [#3395](https://github.com/single-cell-data/TileDB-SOMA/pull/3395)
+- [c++] Use core 2.27.0.rc5 [#3410](https://github.com/single-cell-data/TileDB-SOMA/pull/3410)
+- [c++] Use core 2.27.0 [#3422](https://github.com/single-cell-data/TileDB-SOMA/pull/3422)
 
 # tiledbsoma 1.14.5
 
 ## Changes
 
-* Fixes a Python-only bug [#3225](https://github.com/single-cell-data/TileDB-SOMA/pull/3225)
+- Fixes a Python-only bug [#3225](https://github.com/single-cell-data/TileDB-SOMA/pull/3225)
 
 # tiledbsoma 1.14.4
 
 ## Changes
 
-* Add new Arrow-to-R type mapper [#3161](https://github.com/single-cell-data/TileDB-SOMA/pull/3161)
-* Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
+- Add new Arrow-to-R type mapper [#3161](https://github.com/single-cell-data/TileDB-SOMA/pull/3161)
+- Expose block/random writer for sparse arrays [#3204](https://github.com/single-cell-data/TileDB-SOMA/pull/3204)
 
 # tiledbsoma 1.14.3
 
 ## Changes
 
-* Handle `numeric` coords properly when reading arrays [3145](https://github.com/single-cell-data/TileDB-SOMA/pull/3145)
+- Handle `numeric` coords properly when reading arrays [3145](https://github.com/single-cell-data/TileDB-SOMA/pull/3145)
 
 # tiledbsoma 1.14.2
 
 ## Changes
 
-* Fixes a Python-only bug [#3074](https://github.com/single-cell-data/TileDB-SOMA/pull/3074)
+- Fixes a Python-only bug [#3074](https://github.com/single-cell-data/TileDB-SOMA/pull/3074)
 
 # tiledbsoma 1.14.1
 
 ## Changes
 
-* Fixes a Python-only bug [#3013](https://github.com/single-cell-data/TileDB-SOMA/pull/3013)
+- Fixes a Python-only bug [#3013](https://github.com/single-cell-data/TileDB-SOMA/pull/3013)
 
 # tiledbsoma 1.14.0
 
 ## Changes
 
-* New `resize` and `tiledbsoma_upgrade_shape` accessors as part of the [new-shape project](https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
-* Make use of timestamp ranges in libtiledbsoma
-* Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
-* Use cached timestamps in `$write()` and `$create()`
-* Fix bug in blockwise iteration
-* Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
-* SOMA context objects are used throughout SOMA object creation
-* Add value-checking for `axis` parameter when initializing blockwise reads
+- New `resize` and `tiledbsoma_upgrade_shape` accessors as part of the [new-shape project](https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
+- Make use of timestamp ranges in libtiledbsoma
+- Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
+- Use cached timestamps in `$write()` and `$create()`
+- Fix bug in blockwise iteration
+- Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
+- SOMA context objects are used throughout SOMA object creation
+- Add value-checking for `axis` parameter when initializing blockwise reads
 
 # tiledbsoma 1.13.1
 
 ## Changes
 
-* Includes a fix for appended enumerations [#2903](https://github.com/single-cell-data/TileDB-SOMA/pull/2903)
+- Includes a fix for appended enumerations [#2903](https://github.com/single-cell-data/TileDB-SOMA/pull/2903)
 
 ## Changes
 
-* New `resize` and `tiledbsoma_upgrade_shape` accessors as part of the [new-shape project](https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
-* Make use of timestamp ranges in libtiledbsoma
-* Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
-* Use cached timestamps in `$write()` and `$create()`
-* Fix bug in blockwise iteration
-* Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
-* SOMA context objects are used throughout SOMA object creation
-* Add value-checking for `axis` parameter when initializing blockwise reads
+- New `resize` and `tiledbsoma_upgrade_shape` accessors as part of the [new-shape project](https://github.com/single-cell-data/TileDB-SOMA/issues/2407)
+- Make use of timestamp ranges in libtiledbsoma
+- Simplify timestamp ranges; strengthen assumptions about `tiledb_timestamp`
+- Use cached timestamps in `$write()` and `$create()`
+- Fix bug in blockwise iteration
+- Lay groundwork for cached SOMA contexts within objects rather than re-creating contexts
+- SOMA context objects are used throughout SOMA object creation
+- Add value-checking for `axis` parameter when initializing blockwise reads
 
 # tiledbsoma 1.13.0
 
 ## Changes
 
-* Updates the TileDB Core dependency to 2.25.0
-* The `used_shape` function is deprecated; `shape` mods are [upcoming](https://github.com/single-cell-data/TileDB-SOMA/issues/2407) scheduled for TileDB-SOMA 1.15
-* Change `$reopen(mode = )` default to not flip modes; require explicit `mode` parameter to be passed
-* Add `drop_levels` to `SOMAExperimentAxisQuery` -> ecosystem outgestors to drop unused factor levels
+- Updates the TileDB Core dependency to 2.25.0
+- The `used_shape` function is deprecated; `shape` mods are [upcoming](https://github.com/single-cell-data/TileDB-SOMA/issues/2407) scheduled for TileDB-SOMA 1.15
+- Change `$reopen(mode = )` default to not flip modes; require explicit `mode` parameter to be passed
+- Add `drop_levels` to `SOMAExperimentAxisQuery` -> ecosystem outgestors to drop unused factor levels
 
 # tiledbsoma 1.12.3
 
 ## Changes
 
-* Updates the TileDB Core dependency to 2.24.2
+- Updates the TileDB Core dependency to 2.24.2
 
 # tiledbsoma 1.12.2
 
 ## Changes
 
-* No R changes; only an update for Python
+- No R changes; only an update for Python
 
 # tiledbsoma 1.12.1
 
 ## Changes
 
-* Updates to TileDB Core 2.24.1
+- Updates to TileDB Core 2.24.1
 
 # tiledbsoma 1.12.0
 
 ## Changes
 
-* Updates to TileDB Core 2.24 and TileDB-R 0.28
-* Connect re-indexer to blockwise iterator to return re-indexed tables and matrices
+- Updates to TileDB Core 2.24 and TileDB-R 0.28
+- Connect re-indexer to blockwise iterator to return re-indexed tables and matrices
 
 # tiledbsoma 1.11.4
 
 ## Changes
 
-* Fixes a couple bugs observed in Python
+- Fixes a couple bugs observed in Python
 
 # tiledbsoma 1.11.3
 
 ## Changes
 
-* Fixes an intermittent segfault observed in Python
+- Fixes an intermittent segfault observed in Python
 
 # tiledbsoma 1.11.2
 
 ## Changes
 
-* New `reopen` method available from R
+- New `reopen` method available from R
 
 # tiledbsoma 1.11.1
 
 ## Changes
 
-* No R changes; only an update for Python
+- No R changes; only an update for Python
 
 # tiledbsoma 1.11.0
 
 ## Changes
 
-* Add support for ingestion of `SeuratCommand` logs
-* Add support for outgestion of `SeuratCommand` logs
-* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
-* Add support for blockwise iteration
-* Make `reopen()` a public method for all `TileDBObjects`
-* Add support for resume-mode in `write_soma()`
-* Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
-* Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
-* Have `SOMADataFrame$shape()` throw a not-yet-implemented error
-* Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
-* Clear timestamp when using `$reopen()` to reopen at the current time
-* Add support for the re-indexer
+- Add support for ingestion of `SeuratCommand` logs
+- Add support for outgestion of `SeuratCommand` logs
+- Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
+- Add support for blockwise iteration
+- Make `reopen()` a public method for all `TileDBObjects`
+- Add support for resume-mode in `write_soma()`
+- Push default-setting for `TileDBCreateOptions` to `$initialize()` instead of in the accessors
+- Muffle warnings for missing command logs when outgesting SOMA to `Seurat`
+- Have `SOMADataFrame$shape()` throw a not-yet-implemented error
+- Disable running `SeuratObject::.CalcN()` when outgesting from SOMA to `Seurat`
+- Clear timestamp when using `$reopen()` to reopen at the current time
+- Add support for the re-indexer
 
 # 1.10.2
 
-* Port resume-ingest mode from Python to R
+- Port resume-ingest mode from Python to R
 
 # 1.10.1
 
-* This release contains a single Python-only bug fix
+- This release contains a single Python-only bug fix
 
 # 1.10.0
 
 ## Changes
 
-* Add support for ingestion of `SeuratCommand` logs
-* Add support for outgestion of `SeuratCommand` logs
-* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
-* Add support for blockwise iteration
-* Make `reopen()` a public method for all `TileDBObjects`
-* Add support for resume-mode in `write_soma()`
+- Add support for ingestion of `SeuratCommand` logs
+- Add support for outgestion of `SeuratCommand` logs
+- Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
+- Add support for blockwise iteration
+- Make `reopen()` a public method for all `TileDBObjects`
+- Add support for resume-mode in `write_soma()`
 
 # 1.9.5
 
-* This release contains a single Python-only bug fix
+- This release contains a single Python-only bug fix
 
 # 1.9.4
 
-* This release contains an in-progress blockwise iterator, work on which will be completed in a subsequent release.
-* Reverted nanoarrow use to vendored versions and refactored the use throughout R and adjusted the build steps accordingly.
+- This release contains an in-progress blockwise iterator, work on which will be completed in a subsequent release.
+- Reverted nanoarrow use to vendored versions and refactored the use throughout R and adjusted the build steps accordingly.
 
 # 1.9.3
 
-* This release contains a single Python-only performance improvement
+- This release contains a single Python-only performance improvement
 
 # 1.9.2
 
-* This release contains a single Python-only modification for an API backward-compatibility update
+- This release contains a single Python-only modification for an API backward-compatibility update
 
 # 1.9.1
 
-* This release contains a single Python-only modification for its build process
+- This release contains a single Python-only modification for its build process
 
 # 1.9.0
 
 ## Changes
 
-* Add support for ingestion of `SeuratCommand` logs
-* Add support for outgestion of `SeuratCommand` logs
-* Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
+- Add support for ingestion of `SeuratCommand` logs
+- Add support for outgestion of `SeuratCommand` logs
+- Add support for reading `*m` and `*p` layers from `SOMAExperimentAxisQuery`
 
 # 1.8.1
 
 ## Changes
 
-* This is a release with Python changes only
+- This is a release with Python changes only
 
 # 1.8.0
 
 ## Changes
 
-* Add support for ingestion of `SeuratCommand` logs
-* Add support for outgestion of `SeuratCommand` logs
-
+- Add support for ingestion of `SeuratCommand` logs
+- Add support for outgestion of `SeuratCommand` logs
 
 # 1.7.0
 
 ## Changes
 
-* Add support for registering arrays with their parent collection in `write_soma()`
-* Add `write_soma.character()` to encode character vectors as SOMA arrays
+- Add support for registering arrays with their parent collection in `write_soma()`
+- Add `write_soma.character()` to encode character vectors as SOMA arrays
 
 # tiledbsoma 1.6.0
 
 ## Fixes
 
-* `SOMADataFrame`, `SOMASparseNDArray`, and `SOMADenseNDArray`'s `write()` method now correctly leaves the array open in write mode
+- `SOMADataFrame`, `SOMASparseNDArray`, and `SOMADenseNDArray`'s `write()` method now correctly leaves the array open in write mode
 
 # tiledbsoma 1.5.0
 
 ## Changes
 
-* Add support for I/O of R factors as enumerated types in `SOMADataFrame`
-* Add support for writing `SummarizedExperiment` and `SingleCellExperiment` object to SOMAs
-* Add support for bounding boxes for sparse arrays
-* Add support for creating `SOMADataFrames` with `ordered()` columns
-* Add support for I/O between SOMA and `SingleCellExperiment`
-* Add support for updating `obs` and `var`
-* Write string attrs as UTF-8 (Python compatibility)
-* Optimize export of obsm/varm arrays to Seurat
-* Add `axis_query()` method to `SOMAExperiment`
-* Add `to_sparse_matrix()` method to `SOMAExperimentAxisQuery`
-* Force exporting v3 assays with SeuratObject v5 installed
+- Add support for I/O of R factors as enumerated types in `SOMADataFrame`
+- Add support for writing `SummarizedExperiment` and `SingleCellExperiment` object to SOMAs
+- Add support for bounding boxes for sparse arrays
+- Add support for creating `SOMADataFrames` with `ordered()` columns
+- Add support for I/O between SOMA and `SingleCellExperiment`
+- Add support for updating `obs` and `var`
+- Write string attrs as UTF-8 (Python compatibility)
+- Optimize export of obsm/varm arrays to Seurat
+- Add `axis_query()` method to `SOMAExperiment`
+- Add `to_sparse_matrix()` method to `SOMAExperimentAxisQuery`
+- Force exporting v3 assays with SeuratObject v5 installed
 
 # tiledbsoma 1.4.0
 
@@ -336,23 +335,23 @@ This is the initial release of the tiledbsoma R package.
 
 ## Changes
 
-* Added a `NEWS.md` file to track changes to the package
-* `TileDBGroup` gains a `names` method to retrieve the names of group members
-* Added `SOMAMeasurement` and `SOMAExperiment` classes
-* spdl is now used for logging
-* TileDB performance statistics can now be collected for analysis
-* Added support for performing axis-based queries against a `SOMAExperiment` via the `SOMAExperimentAxisQuery` class
-* `TileDBArray` class gained a `colnames()` method that returns the names of both dimensions and attributes
-* Added internal helpers to centrally validate `coords` and `value_filter` arguments
-* All R6 classes' `create()` method now return `self` rather than nothing
-* Fixed calculating of relative paths when 1 of the URIs contains the `file://` prefix
-* Added `PlatformConfig` and `SOMATileDBContext` classes to handle SOMA and TileDB configuration
-* Add Seurat outgestors for `SOMAExperimentAxisQuery` objects
-* Numeric coordinates passed to SOMADataFrame$read() are now automatically upcast to int64 when necessary
-* Add ingestors to read data from `Seurat` objects
-* Add methods for listing and accessing bundled datasets, which now includes a `SOMAExperiment` containing the pbmc_small dataset from the SeuratObject package
-* New vignettes describing SOMA objects, reading data from them, and querying SOMA experiments
-* Objects added to `SOMACollection`-based classes using the `add_new_*()` methods now pass through their parent context and platform config
-* `SOMAExperimentAxisQuery` gained a `to_sparse_matrix()` method for retrieving data as a named sparse matrix
-* `SOMAExperiment` gained `axis_query()` to construct a `SOMAExperimentAxisQuery` object
-* Add SingleCellExperiment outgestor for `SOMAExperimentAxisQuery` objects
+- Added a `NEWS.md` file to track changes to the package
+- `TileDBGroup` gains a `names` method to retrieve the names of group members
+- Added `SOMAMeasurement` and `SOMAExperiment` classes
+- spdl is now used for logging
+- TileDB performance statistics can now be collected for analysis
+- Added support for performing axis-based queries against a `SOMAExperiment` via the `SOMAExperimentAxisQuery` class
+- `TileDBArray` class gained a `colnames()` method that returns the names of both dimensions and attributes
+- Added internal helpers to centrally validate `coords` and `value_filter` arguments
+- All R6 classes' `create()` method now return `self` rather than nothing
+- Fixed calculating of relative paths when 1 of the URIs contains the `file://` prefix
+- Added `PlatformConfig` and `SOMATileDBContext` classes to handle SOMA and TileDB configuration
+- Add Seurat outgestors for `SOMAExperimentAxisQuery` objects
+- Numeric coordinates passed to SOMADataFrame$read() are now automatically upcast to int64 when necessary
+- Add ingestors to read data from `Seurat` objects
+- Add methods for listing and accessing bundled datasets, which now includes a `SOMAExperiment` containing the pbmc_small dataset from the SeuratObject package
+- New vignettes describing SOMA objects, reading data from them, and querying SOMA experiments
+- Objects added to `SOMACollection`-based classes using the `add_new_*()` methods now pass through their parent context and platform config
+- `SOMAExperimentAxisQuery` gained a `to_sparse_matrix()` method for retrieving data as a named sparse matrix
+- `SOMAExperiment` gained `axis_query()` to construct a `SOMAExperimentAxisQuery` object
+- Add SingleCellExperiment outgestor for `SOMAExperimentAxisQuery` objects

--- a/apis/r/README.md
+++ b/apis/r/README.md
@@ -14,7 +14,7 @@ install.packages('tiledbsoma', repos = c('https://tiledb-inc.r-universe.dev',
                                          'https://cloud.r-project.org'))
 ```
 
-Installing from source on Unix-like platforms requires `cmake`, `git`, and a recent-enough C++ compiler (`g++` version 10.* or above).
+Installing from source on Unix-like platforms requires `cmake`, `git`, and a recent-enough C++ compiler (`g++` version 10.\* or above).
 
 Alternatively, tiledbsoma can be installed directly from [Conda](https://anaconda.org/tiledb/r-tiledbsoma), which serves binaries for multiple architectures.
 
@@ -31,33 +31,33 @@ To install the very latest tiledbsoma development version (our `main` branch), u
 ```r
 remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir = "apis/r")
 ```
+
 A note about the `fmt` and `spdlog` packages:
 
-* If you encounter an install-time error like `undefined symbol: _ZTIN3fmt2v912format_errorE` then you should uninstall your systemversions of `fmt` and `spdlog`. On Linux, this means `dpkg -l | egrep "lib(spdlog|fmt)"` should now come up empty.
-* If you encounter an install-time error like `fatal error: spdlog/spdlog.h: No such file or directory` you should additionally recursively remove `/usr/local/lib/cmake/spdlog `, since the system uninstall of `spdlog` fails to remove this properly.
+- If you encounter an install-time error like `undefined symbol: _ZTIN3fmt2v912format_errorE` then you should uninstall your systemversions of `fmt` and `spdlog`. On Linux, this means `dpkg -l | egrep "lib(spdlog|fmt)"` should now come up empty.
+- If you encounter an install-time error like `fatal error: spdlog/spdlog.h: No such file or directory` you should additionally recursively remove `/usr/local/lib/cmake/spdlog `, since the system uninstall of `spdlog` fails to remove this properly.
 
 ### Requirements
 
-* Source installation requires the [`tiledb` R package](https://github.com/TileDB-Inc/TileDB-R) -- which in turn depends on either a local installation of [TileDB Core library](https://github.com/TileDB-Inc/TileDB) or the provided build artifacts.
-* In general, source installation of TileDB Core and its packages requires `cmake` and `git` to be installed; these are common tools each operating system provides readily.
-* All other R package dependencies are listed in the [DESCRIPTION](https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/r/DESCRIPTION) file and can be installed via _e.g._
+- Source installation requires the [`tiledb` R package](https://github.com/TileDB-Inc/TileDB-R) -- which in turn depends on either a local installation of [TileDB Core library](https://github.com/TileDB-Inc/TileDB) or the provided build artifacts.
+- In general, source installation of TileDB Core and its packages requires `cmake` and `git` to be installed; these are common tools each operating system provides readily.
+- All other R package dependencies are listed in the [DESCRIPTION](https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/r/DESCRIPTION) file and can be installed via _e.g._
   `remotes::install_deps(".", dependencies=TRUE)` which will also install suggested packages. In order to build vignettes, `knitr` and `rmarkdown` are required (and will be installed), as is `testthat` for testing. If `testthat` is invoked directly then `pkgbuild` is also needed (but is not installed as not listed in `DESCRIPTION`).
-* In addition, this R package also depends on the [`libtiledbsoma` library](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma) from this repository. It is either installed with the package (as described in the next section), or can be used as a system library (if one is found). A system installation can be provided by following the steps in the [`libtiledbsoma` directory](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma).
-
+- In addition, this R package also depends on the [`libtiledbsoma` library](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma) from this repository. It is either installed with the package (as described in the next section), or can be used as a system library (if one is found). A system installation can be provided by following the steps in the [`libtiledbsoma` directory](https://github.com/single-cell-data/TileDB-SOMA/tree/main/libtiledbsoma).
 
 ### Development setup
 
 To set up and install from a local clone of this git repository:
 
-* Clone this repository: `git clone https://github.com/single-cell-data/TileDB-SOMA.git`.
-* Change into the R API package directory: `cd TileDB-SOMA/apis/r`.
-* Optionally, clean the files in the repo: `./cleanup` (this is not needed the first time).
-* Optionally, add on optional package with more more test data: `install.packages("pbmc3k.tiledb",  repos="https://ghrr.github.io/drat")`.
-* If you have edited any `src/*.cpp` files and changed any function signatures, then running `Rscript -e 'Rcpp::compileAttributes()'` will update the `Rcpp`-generated glue code.
-* If you have changed any C++ function header documentation, run `Rscript -e 'roxygen2::roxygenise()'` to update the corresponding R files.
-* Build the R package source tarball from the repository sources: `R CMD build .` (which will also include the `libtiledbsoma` source via a repository soft-link); other dependencies are required as described in the previous section).
-* Optionally, check and test the package from the tarball skipping vignettes and manuals (which need `texlive` or equivalent): `R CMD check --no-vignettes --no-manual tiledbsoma_*.tar.gz`.
-* Finally, install the package from the tarball: `R CMD INSTALL tiledbsoma_*.tar.gz`.  During this installation presence of the two C++ libraries (TileDB Core, TileDB-SOMA) is tested for. TileDB Core builds can be downloaded as needed, and the TileDB-SOMA library is built if needed. (We plan to provide a downloadable artifact for it too.)
+- Clone this repository: `git clone https://github.com/single-cell-data/TileDB-SOMA.git`.
+- Change into the R API package directory: `cd TileDB-SOMA/apis/r`.
+- Optionally, clean the files in the repo: `./cleanup` (this is not needed the first time).
+- Optionally, add on optional package with more more test data: `install.packages("pbmc3k.tiledb",  repos="https://ghrr.github.io/drat")`.
+- If you have edited any `src/*.cpp` files and changed any function signatures, then running `Rscript -e 'Rcpp::compileAttributes()'` will update the `Rcpp`-generated glue code.
+- If you have changed any C++ function header documentation, run `Rscript -e 'roxygen2::roxygenise()'` to update the corresponding R files.
+- Build the R package source tarball from the repository sources: `R CMD build .` (which will also include the `libtiledbsoma` source via a repository soft-link); other dependencies are required as described in the previous section).
+- Optionally, check and test the package from the tarball skipping vignettes and manuals (which need `texlive` or equivalent): `R CMD check --no-vignettes --no-manual tiledbsoma_*.tar.gz`.
+- Finally, install the package from the tarball: `R CMD INSTALL tiledbsoma_*.tar.gz`. During this installation presence of the two C++ libraries (TileDB Core, TileDB-SOMA) is tested for. TileDB Core builds can be downloaded as needed, and the TileDB-SOMA library is built if needed. (We plan to provide a downloadable artifact for it too.)
 
 Once installed successfully, the package sources can be edited and re-installed iteratively.
 The optional clean step ensures a full rebuild, and the optional copy of `libtiledbsoma` ensures it is updated too.

--- a/apis/r/inst/extdata/README.md
+++ b/apis/r/inst/extdata/README.md
@@ -1,8 +1,8 @@
 How to recreate these data files:
 
-* `soma-exp-pbmc-small.tar.gz`
-  * `data-raw/create-soma-exp-pbmc-small.R`
-* `soma-dataframe-pbmc3k-processed-obs.tar.gz`
-  * `data-raw/create-soma-dataframe-pbmc3k-processed-obs.R`
+- `soma-exp-pbmc-small.tar.gz`
+  - `data-raw/create-soma-exp-pbmc-small.R`
+- `soma-dataframe-pbmc3k-processed-obs.tar.gz`
+  - `data-raw/create-soma-dataframe-pbmc3k-processed-obs.R`
 
 Note for unit tests: if I unit-test case compares the length of `list_datasets()` to the length of `dir(example_data_dir())`, then that unit-test case should subtract 1 to account for this `README.md` file itself.

--- a/apis/r/vignettes/UsingPlatformConfig.Rmd
+++ b/apis/r/vignettes/UsingPlatformConfig.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Using PlatformConfig"
+title: Using PlatformConfig
 output: github_document
-vignette: |
+vignette: |-
   %\VignetteIndexEntry{Using PlatformConfig}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}

--- a/apis/r/vignettes/soma-experiment-queries.Rmd
+++ b/apis/r/vignettes/soma-experiment-queries.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Querying a SOMA experiment"
+title: Querying a SOMA experiment
 output: rmarkdown::html_vignette
-vignette: >
+vignette: >-
   %\VignetteIndexEntry{Querying a SOMA experiment}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
@@ -50,7 +50,6 @@ experiment <- SOMAExperimentOpen(experiment$uri, tiledbsoma_ctx = ctx)
 
 Alternatively, you can have in your environment `export TILEDB_SOMA_INIT_BUFFER_BYTES=2147483648` before loading the data.
 
-
 Now we can construct our query object.
 
 ```{r}
@@ -85,6 +84,7 @@ iterator <- query$obs()
 obs <- iterator$concat()
 obs
 ```
+
 As a reminder `arrow:Table` can be easily cast into a `tibble`
 
 ```{r}
@@ -108,6 +108,7 @@ Here we demonstrate by creating a new iterator.
 iterator <- experiment$obs$read()
 iterator$read_complete()
 ```
+
 ```{r}
 iterator$read_next()
 iterator$read_complete()
@@ -127,7 +128,7 @@ table_irerator$read_next()
 
 As in the `obs` example the data is small enough to fit in one chunk. For bigger data you can user `iterator$read_complete()` to check the status of iteration and `iterator$concat()` to concatenate the rest of the chunks.
 
-The iterator for  `Matrix::sparse_matrix` works in the same way. Keep in mind that the matrix format is `dgTMatrix` as it is the most memory-efficient and the only format type that can be easily iterated. And most importantly, the resulting object is a "view" of the full matrix with the original shape and indexes but only with data corresponding to the query coordinates or filters (see section below).
+The iterator for `Matrix::sparse_matrix` works in the same way. Keep in mind that the matrix format is `dgTMatrix` as it is the most memory-efficient and the only format type that can be easily iterated. And most importantly, the resulting object is a "view" of the full matrix with the original shape and indexes but only with data corresponding to the query coordinates or filters (see section below).
 
 ```{r}
 reader <- query$X(layer_name = "counts")

--- a/apis/r/vignettes/soma-objects.Rmd
+++ b/apis/r/vignettes/soma-objects.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "SOMA objects overview"
+title: SOMA objects overview
 output: rmarkdown::html_vignette
-vignette: >
+vignette: >-
   %\VignetteIndexEntry{SOMA objects overview}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
@@ -34,7 +34,7 @@ uri
 The `SOMAExperiment` class represents the top-level container for experiments that include one or more measurements across set of observations (e.g., cells or biospecimens). It always contains at least two objects:
 
 1. `obs`: A `SOMADataFrame` containing primary annotations on the observations.
-2. `ms`: A `SOMACollection` of the individual measurements (i.e., modalities).
+1. `ms`: A `SOMACollection` of the individual measurements (i.e., modalities).
 
 Open the `SOMAExperiment` using its file path and inspect the object:
 

--- a/apis/r/vignettes/soma-reading.Rmd
+++ b/apis/r/vignettes/soma-reading.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Reading from SOMA objects"
+title: Reading from SOMA objects
 output: rmarkdown::html_vignette
-vignette: >
+vignette: >-
   %\VignetteIndexEntry{Reading from SOMA objects}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
@@ -28,7 +28,6 @@ experiment <- load_dataset("soma-exp-pbmc-small")
 ## SOMA DataFrame
 
 We'll start with the `obs` dataframe. Simply calling the `read()$concat()` method will load all of the data in memory as an [Arrow Table](https://arrow.apache.org/docs/r/reference/table.html).
-
 
 ```{r}
 obs <- experiment$obs
@@ -128,7 +127,7 @@ Similar to `SOMADataFrame`, we can load the data into memory as an Arrow Table:
 counts$read()$tables()$concat()
 ```
 
-Or as a [`Matrix::sparseMatrix()`]:
+Or as a \[`Matrix::sparseMatrix()`\]:
 
 ```{r}
 counts$read()$sparse_matrix()$concat()

--- a/apis/r/vignettes/soma-shapes.Rmd
+++ b/apis/r/vignettes/soma-shapes.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "SOMA shapes"
+title: SOMA shapes
 output: rmarkdown::html_vignette
-vignette: >
+vignette: >-
   %\VignetteIndexEntry{SOMA shapes}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
@@ -33,7 +33,7 @@ exp
 
 The `obs` dataframe has a `domain`, which is a soft limit on what values can be written to it. (You'll get an error if you try to read or write `soma_joinid` values outside this range, which is an important data-integrity reassurance.)
 
-The `domain` we see here matches with the data populated inside of it.  (This will usually be the case. It might not, if you've created the dataframe but not written any data to it yet --- at that point it's empty but it still has a shape.)
+The `domain` we see here matches with the data populated inside of it. (This will usually be the case. It might not, if you've created the dataframe but not written any data to it yet --- at that point it's empty but it still has a shape.)
 
 If you have more data --- more cells --- to add to the experiment later, you will be able resize the obs, up to the maxdomain which is a hard limit.
 
@@ -121,11 +121,11 @@ In particular, the `X` array in this experiment --- and in most experiments --- 
 
 As a general rule you'll see the following:
 
-* An `X` array's shape is nobs x nvar
-* An `obsm` array's shape is `nobs` x some number, maybe 20
-* An `obsp` array's shape is `nobs` x `nobs`
-* A `varm` array's shape is `nvar` x some number, maybe 20
-* A `varp` array's shape is `nvar` x `nvar`
+- An `X` array's shape is nobs x nvar
+- An `obsm` array's shape is `nobs` x some number, maybe 20
+- An `obsp` array's shape is `nobs` x `nobs`
+- A `varm` array's shape is `nvar` x some number, maybe 20
+- A `varp` array's shape is `nvar` x `nvar`
 
 ## Advanced usage: dataframes with non-standard index columns
 
@@ -191,7 +191,7 @@ sdf1$index_column_names()
 
 Here we see the `soma_joinid` slot of the dataframe's domain is as requested.
 
-Another point is that domain cannot be specified for string-type index columns.  You can set them at create one of two ways:
+Another point is that domain cannot be specified for string-type index columns. You can set them at create one of two ways:
 
 ```{r, eval=FALSE}
 domain = list(soma_joinid = (0, 9), mystring = NULL)
@@ -247,8 +247,8 @@ In the TileDB-SOMA Python API, there is a method for resizing all the dataframes
 
 For N-dimensional arrays that have been upgraded, or that were created using TileDB-SOMA 1.15 or higher, simply do the following:
 
-* If the array's `$tiledbsoma_has_upgraded_shape()` reports `FALSE`, invoke the `$tiledbsoma_upgrade_shape()` method.
-* Otherwise invoke the `$.resize()` method.
+- If the array's `$tiledbsoma_has_upgraded_shape()` reports `FALSE`, invoke the `$tiledbsoma_upgrade_shape()` method.
+- Otherwise invoke the `$.resize()` method.
 
 Let's do a fresh unpack of a pre-1.15 experiment:
 

--- a/data/10x-pbmc-multiome-v1.0/README.md
+++ b/data/10x-pbmc-multiome-v1.0/README.md
@@ -6,6 +6,7 @@ Small sample dataset for testing.
   - https://www.10xgenomics.com/resources/datasets/10-k-human-pbm-cs-multiome-v-1-0-chromium-controller-1-standard-2-0-0
 - license: Creative Commons By-Attribution
 - subsetting from original, with scanpy:
+
 ```
 import scanpy
 

--- a/data/README.md
+++ b/data/README.md
@@ -15,7 +15,7 @@ Once you have verified the data works as intended, add it to a [TileDB-SOMA-Test
 The Makefile `data` target calls [scripts/prepare-test-data.sh](../scripts/prepare-test-data.sh). You will need to update the script to include a section to prepare your new data. Your update must do the following:
 
 1. Create a new file or folder in the `data/` directory (this directory) that includes the desired data if the data has not already been prepared.
-2. Gracefully skip preparing data that has already been added.
+1. Gracefully skip preparing data that has already been added.
 
 If you are including data from TileDB-SOMA-Test-Data, the easiest way to access the data is to download all necessary to a new directory using "wget". Extract any data that is compressed.
 
@@ -28,7 +28,7 @@ The Makefile `clean_data` target calls [scripts/clean-test-data.sh](../scripts/c
 Before committing your changes to `scripts/prepare-test-data.sh` verify the following:
 
 1. The command `make data` fully prepares your data so that if can be easily accessed in your new test and/or example.
-2. The command `make clean_data` fully removes your data.
-3. The data is being ignored by Git.
+1. The command `make clean_data` fully removes your data.
+1. The data is being ignored by Git.
 
 It is a good idea to include you new test or example in the same PR that adds the new data to help ensure you can check it has been successfully prepared.

--- a/data/simple/dim-uint64_attr-int64_10cells/README.md
+++ b/data/simple/dim-uint64_attr-int64_10cells/README.md
@@ -1,10 +1,12 @@
-  # Simple test data 1
+# Simple test data 1
 
 For ManagedQuery basic functionality tests.
 
 Creation of array:
+
 - TileDB-Py 0.12.2
 - Steps:
+
 ```
 import tiledb, numpy as np
 tiledb.from_numpy("simple/dim-uint64_attr-int64_10cells", np.arange(10))

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,15 +1,17 @@
 # Basic on-laptop setup
 
 Build the docs with:
+
 ```bash
 ./build.sh
 ```
 
 The first time you run this, it will:
+
 1. Create and activate a virtualenv (`venv/`)
-2. Install [`requirements_doc.txt`](requirements_doc.txt)
-3. Install `..apis/python` (editable)
-4. Build the docs (output to `doc/html/`)
+1. Install [`requirements_doc.txt`](requirements_doc.txt)
+1. Install `..apis/python` (editable)
+1. Build the docs (output to `doc/html/`)
 
 Subsequent runs will only perform the 4th step (unless `-r`/`--reinstall` is passed).
 
@@ -18,7 +20,9 @@ Once the docs are built, you can:
 ```bash
 open source/_build/html/index.html
 ```
+
 or e.g.:
+
 ```bash
 http-server source/_build/html &
 open http://localhost:8080/

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,10 +7,10 @@ Sample Dockerfiles that `pip install tiledbsoma` (including installing required 
 - [bookworm.dockerfile](bookworm.dockerfile): Debian 12, GCC 13, `pip install tiledbsoma==1.16.0`
 - [langchain.dockerfile](langchain.dockerfile): Debian 12, GCC 12, `pip install tiledbsoma==1.15.7`
 
-
 ## Debugging Tips
 
 ### `pip install --no-clean tiledbsoma` <a id="no-clean"></a>
+
 This keeps around various logs (example below), when a `pip install` fails.
 
 ### [vcpkg] requires `VCPKG_FORCE_SYSTEM_BINARIES=1` on ARM <a id="vcpkg"></a>
@@ -97,8 +97,8 @@ tail /TileDB-SOMA/build/externals/src/ep_tiledb-build/vcpkg-bootstrap.log
 ```
 
 This sequence of log files is commonly useful:
+
 - `ep_tiledb-configure-err.log`
 - `vcpkg-bootstrap.log`
-
 
 [vcpkg]: https://vcpkg.io/

--- a/encoding_specification.md
+++ b/encoding_specification.md
@@ -12,49 +12,49 @@
 
 A SOMA Collection is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value            | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### DataFrame encoding version 1.1.0
 
 A SOMA DataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value           | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"         | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### DenseNDArray encoding version 1.1.0
 
 A SOMA DenseNDArray is stored as a dense TileDB array. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value              | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"            | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### Experiment encoding version 1.1.0
 
 A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value            | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"          | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### MultiscaleImage encoding version 1.1.0
 
 A SOMA MultiscaleImage is stored as a TileDB group that contains a SOMA DenseNDArray for each resolution level. The group has the following metadata:
 
-| Metadata key                    | Datatype           | Value                                             | Description                                       | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :------------------------------ | :----------------- | :------------------------------------------------ | :------------------------------------------------ | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                             | SOMA type name                                    | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                           | general SOMA encoding version                     | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                           | type-specific SOMA encoding version               | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space        | JSON serialization of the coordinate space        | required |
-| "soma_multiscale_image_schema"  | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization of the multiscale image schema | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | general SOMA encoding version | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0" | type-specific SOMA encoding version | required |
+| "soma_coordinate_space" | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | required |
+| "soma_multiscale_image_schema" | TILEDB_STRING_UTF8 | JSON serialization fo the multiscale image schema | JSON serialization of the multiscale image schema | required |
 
 JSON serialization of the multiscale image schema is given by
 
@@ -76,49 +76,49 @@ JSON serialization of the multiscale image schema is given by
 }
 ```
 
-| Serialization Key       | Description                                                                                                               |
+| Serialization Key | Description |
 | :---------------------- | :------------------------------------------------------------------------------------------------------------------------ |
 | "data_axis_permutation" | The permutation of the coordinate space axis with the channel stored last to the order of the channels as stored on disk. |
-| "has_channel_axis"      | Whether the image has a dimension specifically for channel information.                                                   |
-| "shape"                 | The shape of the level 0 image.                                                                                           |
-| "datatype"              | The datatype of the image data stored using the PyArrow C-convention.                                                     |
+| "has_channel_axis" | Whether the image has a dimension specifically for channel information. |
+| "shape" | The shape of the level 0 image. |
+| "datatype" | The datatype of the image data stored using the PyArrow C-convention. |
 
 ### Measurement encoding version 1.1.0
 
 A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value             | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"           | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### PointCloudDataFrame encoding version 1.1.0
 
 The SOMA PointCloudDataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
-| Metadata key                    | Datatype           | Value                                      | Description                                                   | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :------------------------------ | :----------------- | :----------------------------------------- | :------------------------------------------------------------ | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAPointCloudDataFrame"                  | SOMA type name                                                | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version                                 | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version                           | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space                    | required |
-| "soma_geometry_type"            | TILEDB_STRING_UTF8 | string with possible values "radius"       | optional shape of the stored points                           | optional |
-| "soma_geometry"                 | TILEDB_FLOAT64     | floating-point value                       | the radius of circles centered at the points in the dataframe | optional |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAPointCloudDataFrame" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | general SOMA encoding version | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0" | type-specific SOMA encoding version | required |
+| "soma_coordinate_space" | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | required |
+| "soma_geometry_type" | TILEDB_STRING_UTF8 | string with possible values "radius" | optional shape of the stored points | optional |
+| "soma_geometry" | TILEDB_FLOAT64 | floating-point value | the radius of circles centered at the points in the dataframe | optional |
 
 ### Scene encoding version 1.1.0
 
 The SOMA Scene is stored as a TileDB group. It has the following group metadata:
 
-| Metadata key                    | Datatype           | Value                                      | Description                                | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :------------------------------ | :----------------- | :----------------------------------------- | :----------------------------------------- | :------- |
-| "soma_datatype"                 | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage"                      | SOMA type name                             | required |
-| "soma_encoding_version"         | TILEDB_STRING_UTF8 | "1.1.0"                                    | general SOMA encoding version              | required |
-| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0"                                    | type-specific SOMA encoding version        | required |
-| "soma_coordinate_space"         | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAMultiscaleImage" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | general SOMA encoding version | required |
+| "soma_spatial_encoding_version" | TILEDB_STRING_UTF8 | "0.2.0" | type-specific SOMA encoding version | required |
+| "soma_coordinate_space" | TILEDB_STRING_UTF8 | JSON serialization of the coordinate space | JSON serialization of the coordinate space | optional |
 
 Collections inside the SOMA Scene may store transformation data from the Scene to the elements inside the collections. In addition to the standard group metadata, these collections have the following metadata:
 
-| Metadata key                        | Datatype           | Value                                          | Description                                                                                            | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------------------- | :----------------- | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------- | :------- |
 | "soma*scene_registry*{object_name}" | TILEDB_STRING_UTF8 | JSON serialization of the coordinate transform | The coordinate transform from a SOMA Scene to the element names `{object_name}` inside the collection. | optional |
 
@@ -187,6 +187,7 @@ The SOMA CoordinateTransform are serialized using the following JSON schemas:
   ```
 
 - AffineTransform serializaton
+
   ```
   {
       "type": "object",
@@ -207,23 +208,23 @@ The SOMA CoordinateTransform are serialized using the following JSON schemas:
   }
   ```
 
-| Serialization Key | Description                                                                                                                                      |
+| Serialization Key | Description |
 | :---------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
-| "transform_type"  | The type of the coordinate space transform. Must be one of "IdentityTransform", "UniformScaleTransform", "ScaleTransform", or "AffineTransform". |
-| "input_axes"      | The names of the axes of the input coordinate space to the transform.                                                                            |
-| "output_axes"     | The names of the axes of the output coordinate space to the transform.                                                                           |
-| "scale"           | The scale factor for the "UniformScaleTransform".                                                                                                |
-| "scale_factors"   | An array of the scale factors for the "ScaleTransform" in order or the axis they are applied to."                                                |
-| "maxtrix"         | The matrix representation of the "AffineTransform", flattened in row-major order.                                                                |
+| "transform_type" | The type of the coordinate space transform. Must be one of "IdentityTransform", "UniformScaleTransform", "ScaleTransform", or "AffineTransform". |
+| "input_axes" | The names of the axes of the input coordinate space to the transform. |
+| "output_axes" | The names of the axes of the output coordinate space to the transform. |
+| "scale" | The scale factor for the "UniformScaleTransform". |
+| "scale_factors" | An array of the scale factors for the "ScaleTransform" in order or the axis they are applied to." |
+| "maxtrix" | The matrix representation of the "AffineTransform", flattened in row-major order. |
 
 ### SparseNDArray encoding version 1.1.0
 
 A SOMA SparseNDArray is stored as a sparse TileDB array. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value               | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0"             | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1.1.0" | SOMA encoding version | required |
 
 ### CoordinateSpace serialization encoding version 1.1.0
 
@@ -243,10 +244,10 @@ The SOMA CoordinateSpace is serialized to JSON as an array of axes, stored in or
 }
 ```
 
-| Serialization Key | Description                                                            |
+| Serialization Key | Description |
 | :---------------- | :--------------------------------------------------------------------- |
-| "name"            | Name of the axis.                                                      |
-| "unit"            | The name of the units for the axis, or null if no units are specified. |
+| "name" | Name of the axis. |
+| "unit" | The name of the units for the axis, or null if no units are specified. |
 
 ## TileDB-SOMA encoding version 1.0.0
 
@@ -258,52 +259,52 @@ TileDB-SOMA encoding version 1.0.0 satisfies the SOMA abstract specification 0.1
 
 A SOMA Collection is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value            | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMACollection" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |
 
 ### DataFrame encoding version 1.0.0
 
 A SOMA DataFrame is stored as a sparse TileDB array. Index columns are stored as TileDB dimensions. All other columns are stored as TileDB attributes. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value           | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :-------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"             | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMADataFrame" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |
 
 ### DenseNDArray encoding version 1.0.0
 
 A SOMA DenseNDArray is stored as a dense TileDB array. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value              | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :----------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"                | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMADenseNDArray" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |
 
 ### Experiment encoding version 1.0.0
 
 A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value            | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :--------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"              | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAExperiment" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |
 
 ### Measurement encoding version 1.0.0
 
 A SOMA Experiment is stored as a TileDB group. The group has the following metadata.
 
-| Metadata key            | Datatype           | Value             | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :---------------- | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"               | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMAMeasurement" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |
 
 ### SparseNDArray encoding version 1.0.0
 
 A SOMA SparseNDArray is stored as a sparse TileDB array. The array has the following metadata.
 
-| Metadata key            | Datatype           | Value               | Description           | Required |
+| Metadata key | Datatype | Value | Description | Required |
 | :---------------------- | :----------------- | :------------------ | :-------------------- | :------- |
-| "soma_datatype"         | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name        | required |
-| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1"                 | SOMA encoding version | required |
+| "soma_datatype" | TILEDB_STRING_UTF8 | "SOMASparseNDArray" | SOMA type name | required |
+| "soma_encoding_version" | TILEDB_STRING_UTF8 | "1" | SOMA encoding version | required |

--- a/libtiledbsoma/README.md
+++ b/libtiledbsoma/README.md
@@ -2,32 +2,44 @@
 
 ## System Dependencies
 
-* C++20 compiler
-* Python 3.9+
+- C++20 compiler
+- Python 3.9+
 
 Run these commands to setup a fresh Ubuntu 22.04 instance (tested on x86 and Arm):
+
 ```
 sudo apt update
 sudo apt install -y g++ make pkg-config
 sudo apt install -y python3 python-is-python3 python3.10-venv python-dev-is-python3
 ```
----
+
+______________________________________________________________________
+
 ## Clone the source code
+
 ```
 git clone https://github.com/single-cell-data/TileDB-SOMA.git
 cd TileDB-SOMA
 ```
----
+
+______________________________________________________________________
+
 ## Set up a Python Virtual Environment
+
 Create a python virtual environment and install the [developer requirements](../apis/python/requirements_dev.txt):
+
 ```
 python -m venv test/tiledbsoma
 source test/tiledbsoma/bin/activate
 pip install -r apis/python/requirements_dev.txt
 ```
----
+
+______________________________________________________________________
+
 ## Python-only Development
+
 Developers who do not need to modify the C++ code must use these build commands:
+
 ```
 # remove old build artifacts
 make clean
@@ -38,11 +50,12 @@ pip install -v -e apis/python
 # test
 pytest apis/python
 ```
+
 This approach leverages the build-system defined in [pyproject.toml](../apis/python/pyproject.toml) to reduce the number of dependencies required to build `tiledbsoma`.
 
 > **Note** - Running `python setup.py develop` is not supported.
 
----
+______________________________________________________________________
 
 ## Python and C++ Development
 
@@ -99,7 +112,7 @@ Examples:
     make update
 ```
 
----
+______________________________________________________________________
 
 ## Notes
 

--- a/libtiledbsoma/doc/README.md
+++ b/libtiledbsoma/doc/README.md
@@ -1,4 +1,5 @@
 Generate diagrams with [PlantUML](https://github.com/plantuml/plantuml), for example:
+
 ```
 java -jar plantuml.jar -tsvg reader.uml
 ```

--- a/overview.md
+++ b/overview.md
@@ -8,13 +8,13 @@ The [data model and API](https://github.com/single-cell-data) -- here as impleme
 
 Features:
 
-* flexible, extensible, and open-source API
-* supports access to persistent, cloud-resident annotated 2D matrix datasets
-* enables use within popular data science environments (e.g., R, Python), using the tools of that environment (e.g., Python Pandas integration), with the same storage regardless of language
-* allows interop with multiple tools including AnnData, Scanpy, Seurat, and Bioconductor
-* cloud-native TileDB arrays allow you to slice straight from remote storage
-* reduces costs and processing time by utilizing cost-efficient object storage services like S3
-* enables out-of-core access to data aggregations much larger than single-host main memory
-* enables distributed computation over datasets
+- flexible, extensible, and open-source API
+- supports access to persistent, cloud-resident annotated 2D matrix datasets
+- enables use within popular data science environments (e.g., R, Python), using the tools of that environment (e.g., Python Pandas integration), with the same storage regardless of language
+- allows interop with multiple tools including AnnData, Scanpy, Seurat, and Bioconductor
+- cloud-native TileDB arrays allow you to slice straight from remote storage
+- reduces costs and processing time by utilizing cost-efficient object storage services like S3
+- enables out-of-core access to data aggregations much larger than single-host main memory
+- enables distributed computation over datasets
 
 ![](./images/cover.png)

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -3,6 +3,7 @@ This tool is a profiler for [SOMA](https://github.com/single-cell-data/SOMA/tree
 Here's an example for how to profile a SOMA script (here `tests/objects.py`)
 
 This example shows how to generate the profile data for a given SOMA run (here `tests/objects.py`)
+
 ```shell
 python -m profiler python tests/objects.py
 ```
@@ -10,54 +11,55 @@ python -m profiler python tests/objects.py
 This will capture the following context information and metrics in a databased, stored under `profiling_runs`:
 
 Context info:
-* command
-* timestamp
-* stdout
-* stderr
-* tiledb_stats
-* somacore_version
-* tiledbsoma_version
-* host_context
-* custom_out
+
+- command
+- timestamp
+- stdout
+- stderr
+- tiledb_stats
+- somacore_version
+- tiledbsoma_version
+- host_context
+- custom_out
 
 Metrics captured:
-* user_time_sec
-* system_time_sec
-* pct_of_cpu
-* elapsed_time_sec
-* avg_shared_text_sz_kb
-* avg_unshared_text_sz_kb
-* avg_stack_sz_kb
-* avg_total_sz_kb
-* max_res_set_sz_kb
-* avg_res_set_sz_kb
-* major_page_faults
-* minor_page_faults
-* voluntary_context_switches
-* involuntary_context_switches
-* swaps
-* file_system_inputs
-* file_system_outputs
-* socket_messages_sent
-* socket_messages_received
-* signals_delivered
-* page_size_bytes
-* exit_status
 
+- user_time_sec
+- system_time_sec
+- pct_of_cpu
+- elapsed_time_sec
+- avg_shared_text_sz_kb
+- avg_unshared_text_sz_kb
+- avg_stack_sz_kb
+- avg_total_sz_kb
+- max_res_set_sz_kb
+- avg_res_set_sz_kb
+- major_page_faults
+- minor_page_faults
+- voluntary_context_switches
+- involuntary_context_switches
+- swaps
+- file_system_inputs
+- file_system_outputs
+- socket_messages_sent
+- socket_messages_received
+- signals_delivered
+- page_size_bytes
+- exit_status
 
 To report the metrics from multiple runs of the profiled script as JSON output:
+
 ```shell
 python -m profiler.report -j "python tests/objects.py"
 ```
 
 To report on a metric from multiple runs of the profiled script with a graphical plot:
+
 ```shell
 python -m profiler.report  -m <metric_name> "python tests/objects.py"
 ```
 
 The profiling data includes the following metrics:
-
- 
 
 To capture TileDB stats, you must instrument your command script as follows:
 
@@ -67,7 +69,9 @@ from profiler import data
 db = data.FileBasedProfileDB()
 db.extract('python tests/objects.py', 'peak_memory')
 ```
+
 If you want TileDB stats to also be added to the profile, please surround your code as follows:
+
 ```code
 tiledb.stats_enable()
 tiledb.stats_reset()
@@ -82,7 +86,5 @@ with open("tiledb_stats.json", "w") as f:
     json.dump(tiledb.stats_dump(json=True), f)
 
 ```
+
 The profiler automatically reads and stores the content of `tiledb_stats.txt` file.
-
-
-

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,4 +3,3 @@
 **Changes:**
 
 **Notes for Reviewer:**
-


### PR DESCRIPTION
Changes:
1. Add pre-commit hook to run mdformat on all markdown, including R vignettes
2. Ran hook and commit formatting changes

Excluded `.github` directory as several of those files are space-sensitive when presented in GH issue editor, etc.
