### PR TITLE
[r] Roll back minimum version of Matrix

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     data.table,
     fs,
     glue,
-    Matrix (>= 1.7.3),
+    Matrix (>= 1.6.4),
     methods,
     nanoarrow,
     R6,


### PR DESCRIPTION
Allow building on Conda against R 4.3

Fixes [SOMA-68](https://linear.app/tiledb/issue/SOMA-68/r-roll-back-minimum-version-of-rmatrix)

resolves TileDB-Inc/tiledbsoma-feedstock#313
