### PR TITLE
[python] work around valgrind error in Pandas

### DIFF
--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -77,7 +77,7 @@ def test_query_condition(condition):
     pandas = pandas_query(uri, condition)
     soma_arrow = soma_query(uri, condition)
     assert len(pandas.index) == soma_arrow.num_rows
-    assert (
+    assert pandas.empty or (
         (pandas.reset_index(drop=True) == soma_arrow.to_pandas().reset_index(drop=True))
         .all()
         .all()


### PR DESCRIPTION
Fixes SOMA-129

Valgrind was reporting an error in a unit test. Root cause was calling Pandas DataFrame.all() on an empty dataframe. Worked around by testing first for the empty state.
