### PR TITLE
[python] Address memory leak in domain accessor

### DIFF
--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -28,22 +28,13 @@ py::list domainish_to_list(ArrowArray* arrow_array, ArrowSchema* arrow_schema) {
 
     py::list array_list;
     for (int i = 0; i < arrow_array->n_children; i++) {
-        // Note that this runs the release callbacks within the ArrowArray and
-        // the ArrowSchema, freeing memory.
         auto array = pa_array_import(
             py::capsule(arrow_array->children[i]),
             py::capsule(arrow_schema->children[i]));
         array_list.append(array);
-
-        // Already released: ensure there is no attempt at second free.
-        arrow_array->children[i] = nullptr;
-        arrow_schema->children[i] = nullptr;
     }
-    // Already released: ensure there is no attempt at second free.
-    arrow_array->n_children = 0;
-    arrow_array->children = nullptr;
-    arrow_schema->n_children = 0;
-    arrow_schema->children = nullptr;
+    arrow_schema->release(arrow_schema);
+    arrow_array->release(arrow_array);
 
     return array_list;
 }


### PR DESCRIPTION
**Issue and/or context:** https://linear.app/tiledb/issue/SOMA-169/c-memory-leak-in-somaarray-get-core-domainish

**Changes:**

**Notes for Reviewer:**

I ran this from @bkmartinjr on SOMA-169:

`cat 169.py`
```
import tiledbsoma as soma


def main():
    uri = "data/soma-experiment-versions-2025-04-04/1.15.7/pbmc3k_processed/ms/RNA/X/data/"
    with soma.SparseNDArray.open(uri) as arr:
        for i in range(100):
            d = arr._handle._handle.domain()


main()
```

```
valgrind --error-limit=no --trace-children=yes -s --leak-check=full $(which python) 169.py
```
