### PR TITLE
[python] treat timestamp of zero as equivalent to None

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- \[[#4071](https://github.com/single-cell-data/TileDB-SOMA/pull/4071)\] [python] A `tiledb_timestamp` with value of zero is now equivalent to an unspecified timestamp (or `None`), and will be a synonym for "current time". Prior to this fix, a zero-valued timestamp would generate errors or unpredictable results.
+
 ### Security
 
 ## [Release 1.17.0]

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -354,10 +354,14 @@ class SOMATileDBContext(ContextBase):
         )
 
     def _open_timestamp_ms(self, in_timestamp: OpenTimestamp | None) -> int:
-        """Returns the real timestamp that should be used to open an object."""
-        if in_timestamp is not None:
+        """Returns the real timestamp that should be used to open an object.
+        
+        Timestamp values of zero or None are treated as "use default". This is
+        consistent with other TileDB API (e.g., TileDB-Py).
+        """
+        if in_timestamp is not None and in_timestamp != 0:
             return to_timestamp_ms(in_timestamp)
-        if self.timestamp_ms is not None:
+        if self.timestamp_ms is not None and self.timestamp_ms != 0:
             return self.timestamp_ms
         return int(time.time() * 1000)
 

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -355,10 +355,14 @@ class SOMATileDBContext(ContextBase):
 
     def _open_timestamp_ms(self, in_timestamp: OpenTimestamp | None) -> int:
         """Returns the real timestamp that should be used to open an object.
-        
+
         Timestamp values of zero or None are treated as "use default". This is
-        consistent with other TileDB API (e.g., TileDB-Py).
+        consistent with other TileDB API (e.g., TileDB-Py). The datetime.datetime
+        epoch is treated as zero/default.
         """
+        if isinstance(in_timestamp, datetime.datetime):
+            # if a datetime, convert to int/ms
+            in_timestamp = to_timestamp_ms(in_timestamp)
         if in_timestamp is not None and in_timestamp != 0:
             return to_timestamp_ms(in_timestamp)
         if self.timestamp_ms is not None and self.timestamp_ms != 0:


### PR DESCRIPTION
**Issue and/or context:**

Fixes SOMA-72

A timestamp value of zero is not a legal timestamp in TileDB. TileDB APIs treat `None` and `0` as equivalent to the default time of `now`.  As of TileDB-SOMA 1.15 this package regressed and treated zero as a specific time, which will raise inscrutable errors in various code paths.

**Changes:**

A timestamp value of zero (int) or epoch (datetime.datetime) is equivalent to `now`.

