### PR TITLE
[python] unit tests temp file cleanup

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import gc
 import json
 import random
-import tempfile
 from copy import deepcopy
 from pathlib import Path
 
@@ -90,14 +89,13 @@ def h5ad_file_X_none(request):
     "X_kind",
     [tiledbsoma.SparseNDArray, tiledbsoma.DenseNDArray],
 )
-def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
+def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind, tmp_path):
     original = conftest_pbmc_small.copy()
     conftest_pbmc_small = conftest_pbmc_small.copy()
 
     have_ingested = False
 
-    tempdir = tempfile.TemporaryDirectory(prefix="test_import_anndata_")
-    output_path = tempdir.name
+    output_path = tmp_path.as_posix()
 
     conftest_pbmc_small.layers["plus1"] = conftest_pbmc_small.X + 1
     orig = conftest_pbmc_small.copy()
@@ -221,8 +219,6 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
 
         # pbmc-small has no varp
 
-        tempdir.cleanup()
-
 
 @pytest.mark.parametrize(
     "X_layer_name",
@@ -232,9 +228,8 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind):
         "othername",
     ],
 )
-def test_named_X_layers(conftest_pbmc_small_h5ad_path, X_layer_name):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_named_X_layers_")
-    soma_path = tempdir.name
+def test_named_X_layers(conftest_pbmc_small_h5ad_path, X_layer_name, tmp_path):
+    soma_path = tmp_path.as_posix()
 
     if X_layer_name is None:
         tiledbsoma.io.from_h5ad(
@@ -275,20 +270,18 @@ def _get_fragment_count(array_uri):
         TESTDATA / "pbmc-small-x-csc.h5ad",
     ],
 )
-def test_resume_mode(resume_mode_h5ad_file):
+def test_resume_mode(resume_mode_h5ad_file, tmp_path):
     """
     Makes sure resume-mode ingest after successful ingest of the same input data does not write
     anything new
     """
 
-    tempdir1 = tempfile.TemporaryDirectory(prefix="test_resume_mode_1_")
-    output_path1 = tempdir1.name
+    output_path1 = (tmp_path / "test_resume_mode_1_").as_posix()
     tiledbsoma.io.from_h5ad(
         output_path1, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write"
     )
 
-    tempdir2 = tempfile.TemporaryDirectory(prefix="test_resume_mode_2_")
-    output_path2 = tempdir2.name
+    output_path2 = (tmp_path / "test_resume_mode_2_").as_posix()
     tiledbsoma.io.from_h5ad(
         output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write"
     )
@@ -333,9 +326,8 @@ def test_resume_mode(resume_mode_h5ad_file):
 
 
 @pytest.mark.parametrize("use_relative_uri", [False, True, None])
-def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_relative_")
-    output_path = tempdir.name
+def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri, tmp_path):
+    output_path = tmp_path.as_posix()
 
     tiledbsoma.io.from_h5ad(
         output_path,
@@ -431,9 +423,8 @@ def test_ingest_uns(
             assert set(uns) == set(ingest_uns_keys)
 
 
-def test_ingest_uns_string_arrays(h5ad_file_uns_string_arrays):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_uns_string_arrays_")
-    output_path = tempdir.name
+def test_ingest_uns_string_arrays(h5ad_file_uns_string_arrays, tmp_path):
+    output_path = tmp_path.as_posix()
 
     tiledbsoma.io.from_h5ad(
         output_path,
@@ -457,9 +448,8 @@ def test_ingest_uns_string_arrays(h5ad_file_uns_string_arrays):
             assert contents["values_0"][0].as_py() == "#1f77b4"
 
 
-def test_add_matrix_to_collection(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_add_matrix_to_collection_")
-    output_path = tempdir.name
+def test_add_matrix_to_collection(conftest_pbmc_small, tmp_path):
+    output_path = tmp_path.as_posix()
 
     original = conftest_pbmc_small.copy()
 
@@ -518,7 +508,7 @@ def test_add_matrix_to_collection(conftest_pbmc_small):
 # modules or methods -- those whose names start with an underscore.  For this single case we are
 # making an exception. For future code-imitation purposes, please be aware this is a pattern to be
 # avoided in the future, not imitated.
-def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
+def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small, tmp_path):
     def add_X_layer(
         exp: tiledbsoma.Experiment,
         measurement_name: str,
@@ -589,8 +579,7 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
                         use_relative_uri=use_relative_uri,
                     )
 
-    tempdir = tempfile.TemporaryDirectory(prefix="test_add_matrix_to_collection_1_2_7_")
-    output_path = tempdir.name
+    output_path = tmp_path.as_posix()
     original = conftest_pbmc_small.copy()
 
     uri = tiledbsoma.io.from_anndata(
@@ -653,9 +642,8 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small):
         assert sorted(list(exp_r.ms["RNA"]["newthing"].keys())) == ["X_pcd"]
 
 
-def test_export_anndata(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_export_anndata_")
-    output_path = tempdir.name
+def test_export_anndata(conftest_pbmc_small, tmp_path):
+    output_path = tmp_path.as_posix()
 
     original = conftest_pbmc_small.copy()
 
@@ -703,9 +691,8 @@ def test_export_anndata(conftest_pbmc_small):
         assert readback.X is None
 
 
-def test_ingest_additional_metadata(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_ingest_additional_metadata_")
-    output_path = tempdir.name
+def test_ingest_additional_metadata(conftest_pbmc_small, tmp_path):
+    output_path = tmp_path.as_posix()
 
     additional_metadata = {"key1": "val1", "key2": "val2"}
 
@@ -836,9 +823,8 @@ def test_export_obsm_with_holes(h5ad_file_with_obsm_holes, tmp_path):
         assert try4.obsm["X_pca"].shape == (2638, 50)
 
 
-def test_X_empty(h5ad_file_X_empty):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_X_empty_")
-    output_path = tempdir.name
+def test_X_empty(h5ad_file_X_empty, tmp_path):
+    output_path = tmp_path.as_posix()
     tiledbsoma.io.from_h5ad(
         output_path, h5ad_file_X_empty.as_posix(), measurement_name="RNA"
     )
@@ -853,9 +839,8 @@ def test_X_empty(h5ad_file_X_empty):
         # TODO: more
 
 
-def test_X_none(h5ad_file_X_none):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_X_none_")
-    output_path = tempdir.name
+def test_X_none(h5ad_file_X_none, tmp_path):
+    output_path = tmp_path.as_posix()
     tiledbsoma.io.from_h5ad(
         output_path, h5ad_file_X_none.as_posix(), measurement_name="RNA"
     )
@@ -1167,9 +1152,8 @@ def test_index_names_io(tmp_path, obs_index_name, var_index_name):
         assert adata.var.index.name == bdata.var.index.name
 
 
-def test_obsm_data_type(conftest_pbmc_small):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_obsm_data_type_")
-    soma_path = tempdir.name
+def test_obsm_data_type(conftest_pbmc_small, tmp_path):
+    soma_path = tmp_path.as_posix()
     bdata = anndata.AnnData(
         X=conftest_pbmc_small.X,
         obs=conftest_pbmc_small.obs,
@@ -1299,7 +1283,7 @@ def test_outgest_X_layers(tmp_path):
 @pytest.mark.parametrize("nans", ["all", "none", "some"])         # how many `nan`s in new column?
 @pytest.mark.parametrize("new_obs_ids", ["all", "none", "half"])  # how many new obs IDs?
 # fmt: on
-def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids):
+def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids, tmp_path):
     """Test append-ingesting an AnnData object, including a new `obs` column with various properties:
 
     - {all,some,none} of its values are `nan`
@@ -1341,7 +1325,7 @@ def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids):
         obs2.index = obs2.index[:half].tolist() + (obs2.index[half:] + "_2").tolist()
 
     # Initial ingest
-    SOMA_URI = tempfile.mkdtemp(prefix="soma-exp-")
+    SOMA_URI = tmp_path.as_posix()
     tiledbsoma.io.from_anndata(
         experiment_uri=SOMA_URI, anndata=conftest_pbmc_small, measurement_name="RNA"
     )

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -5,7 +5,6 @@ Test join-id registrations for ingesting multiple AnnData objects into a single 
 from __future__ import annotations
 
 import math
-import tempfile
 from contextlib import nullcontext
 from typing import Sequence
 
@@ -172,19 +171,17 @@ def create_anndata_canned(which: int, obs_field_name: str, var_field_name: str):
     )
 
 
-def create_h5ad_canned(which: int, obs_field_name: str, var_field_name: str):
-    tmp_path = tempfile.TemporaryDirectory(prefix="create_h5ad_canned_")
+def create_h5ad_canned(which: int, obs_field_name: str, var_field_name: str, tmp_path):
     anndata = create_anndata_canned(which, obs_field_name, var_field_name)
     return create_h5ad(
         anndata,
-        (tmp_path.name + f"{which}.h5ad"),
+        (tmp_path / f"{which}.h5ad").as_posix(),
     )
 
 
-def create_soma_canned(which: int, obs_field_name, var_field_name):
-    tmp_path = tempfile.TemporaryDirectory(prefix="create_soma_canned_")
-    h5ad = create_h5ad_canned(which, obs_field_name, var_field_name)
-    uri = tmp_path.name + f"soma{which}"
+def create_soma_canned(which: int, obs_field_name, var_field_name, tmp_path):
+    h5ad = create_h5ad_canned(which, obs_field_name, var_field_name, tmp_path)
+    uri = (tmp_path / f"soma{which}").as_posix()
     tiledbsoma.io.from_h5ad(uri, h5ad, "measname")
     return uri
 
@@ -200,10 +197,9 @@ def anndata_larger():
     )
 
 
-@pytest.fixture
-def soma_larger(anndata_larger):
-    tmp_path = tempfile.TemporaryDirectory(prefix="soma_larger_")
-    uri = tmp_path.name + "soma-larger"
+@pytest.fixture()
+def soma_larger(anndata_larger, tmp_path):
+    uri = (tmp_path / "soma-larger").as_posix()
     tiledbsoma.io.from_anndata(uri, anndata_larger, "measname")
     return uri
 
@@ -267,7 +263,7 @@ def test_pandas_indexing(
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
-def test_axis_mappings(obs_field_name, var_field_name):
+def test_axis_mappings(obs_field_name, var_field_name, tmp_path):
     anndata1 = create_anndata_canned(1, obs_field_name, var_field_name)
     mapping = registration.AxisIDMapping.identity(10)
     assert_array_equal(mapping.data, np.arange(10))
@@ -341,8 +337,8 @@ def test_isolated_anndata_mappings(obs_field_name, var_field_name):
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
-def test_isolated_h5ad_mappings(obs_field_name, var_field_name):
-    h5ad1 = create_h5ad_canned(1, obs_field_name, var_field_name)
+def test_isolated_h5ad_mappings(obs_field_name, var_field_name, tmp_path):
+    h5ad1 = create_h5ad_canned(1, obs_field_name, var_field_name, tmp_path)
     rd = tiledbsoma.io.register_h5ads(
         None,
         h5ad1,
@@ -372,8 +368,8 @@ def test_isolated_h5ad_mappings(obs_field_name, var_field_name):
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
-def test_isolated_soma_experiment_mappings(obs_field_name, var_field_name):
-    soma1 = create_soma_canned(1, obs_field_name, var_field_name)
+def test_isolated_soma_experiment_mappings(obs_field_name, var_field_name, tmp_path):
+    soma1 = create_soma_canned(1, obs_field_name, var_field_name, tmp_path)
     rd = tiledbsoma.io.register_anndatas(
         soma1,
         [],
@@ -414,10 +410,10 @@ def test_multiples_without_experiment(
     solo_experiment_first,
     use_multiprocessing,
 ):
-    h5ad1 = create_h5ad_canned(1, obs_field_name, var_field_name)
-    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name)
-    h5ad3 = create_h5ad_canned(3, obs_field_name, var_field_name)
-    h5ad4 = create_h5ad_canned(4, obs_field_name, var_field_name)
+    h5ad1 = create_h5ad_canned(1, obs_field_name, var_field_name, tmp_path)
+    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name, tmp_path)
+    h5ad3 = create_h5ad_canned(3, obs_field_name, var_field_name, tmp_path)
+    h5ad4 = create_h5ad_canned(4, obs_field_name, var_field_name, tmp_path)
 
     experiment_uri = (tmp_path / "exp").as_posix()
     h5ad_file_names = [h5ad1, h5ad2, h5ad3, h5ad4]
@@ -720,11 +716,13 @@ def test_multiples_without_experiment(
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
 @pytest.mark.parametrize("use_multiprocessing", [False, True])
-def test_multiples_with_experiment(obs_field_name, var_field_name, use_multiprocessing):
-    soma1 = create_soma_canned(1, obs_field_name, var_field_name)
-    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name)
-    h5ad3 = create_h5ad_canned(3, obs_field_name, var_field_name)
-    h5ad4 = create_h5ad_canned(4, obs_field_name, var_field_name)
+def test_multiples_with_experiment(
+    obs_field_name, var_field_name, use_multiprocessing, tmp_path
+):
+    soma1 = create_soma_canned(1, obs_field_name, var_field_name, tmp_path)
+    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name, tmp_path)
+    h5ad3 = create_h5ad_canned(3, obs_field_name, var_field_name, tmp_path)
+    h5ad4 = create_h5ad_canned(4, obs_field_name, var_field_name, tmp_path)
 
     rd = tiledbsoma.io.register_h5ads(
         soma1,
@@ -817,9 +815,9 @@ def test_multiples_with_experiment(obs_field_name, var_field_name, use_multiproc
 
 @pytest.mark.parametrize("obs_field_name", ["obs_id", "cell_id"])
 @pytest.mark.parametrize("var_field_name", ["var_id", "gene_id"])
-def test_append_items_with_experiment(obs_field_name, var_field_name):
-    soma1 = create_soma_canned(1, obs_field_name, var_field_name)
-    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name)
+def test_append_items_with_experiment(obs_field_name, var_field_name, tmp_path):
+    soma1 = create_soma_canned(1, obs_field_name, var_field_name, tmp_path)
+    h5ad2 = create_h5ad_canned(2, obs_field_name, var_field_name, tmp_path)
     rd = tiledbsoma.io.register_h5ads(
         soma1,
         [h5ad2],
@@ -1444,9 +1442,9 @@ def test_registration_lists_and_tuples(tmp_path):
     obs_field_name = "cell_id"
     var_field_name = "gene_id"
 
-    exp_uri = create_soma_canned(1, obs_field_name, var_field_name)
+    exp_uri = create_soma_canned(1, obs_field_name, var_field_name, tmp_path)
     adata = create_anndata_canned(2, obs_field_name, var_field_name)
-    h5ad_file_name = create_h5ad_canned(2, obs_field_name, var_field_name)
+    h5ad_file_name = create_h5ad_canned(2, obs_field_name, var_field_name, tmp_path)
 
     rd1 = tiledbsoma.io.register_anndatas(
         experiment_uri=exp_uri,

--- a/apis/python/tests/test_update_matrix.py
+++ b/apis/python/tests/test_update_matrix.py
@@ -1,12 +1,9 @@
-import tempfile
-
 import tiledbsoma
 import tiledbsoma.io
 
 
-def test_update_matrix_X(conftest_pbmc3k_adata):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_update_matrix_X_")
-    output_path = tempdir.name
+def test_update_matrix_X(conftest_pbmc3k_adata, tmp_path):
+    output_path = tmp_path.as_posix()
 
     tiledbsoma.io.from_anndata(
         output_path, conftest_pbmc3k_adata, measurement_name="RNA"
@@ -38,9 +35,8 @@ def test_update_matrix_X(conftest_pbmc3k_adata):
 
 
 # Magical conftest.py fixture
-def test_update_matrix_obsm(conftest_pbmc3k_adata):
-    tempdir = tempfile.TemporaryDirectory(prefix="test_update_matrix_obsm_")
-    output_path = tempdir.name
+def test_update_matrix_obsm(conftest_pbmc3k_adata, tmp_path):
+    output_path = tmp_path.as_posix()
 
     tiledbsoma.io.from_anndata(
         output_path, conftest_pbmc3k_adata, measurement_name="RNA"


### PR DESCRIPTION
**Issue and/or context:**

A number of python unit tests were leaving temp files after a run. Most simply needed to be converted to use the preferred `tmp_path` pytest fixture.

Fixes SOMA-194

There are no change to test semantics, just how those tests create/cleanup temporary files.