### PR TITLE
[C++] fix misordered class elements in soma_vfs.cc

### DIFF
--- a/apis/python/src/tiledbsoma/soma_vfs.cc
+++ b/apis/python/src/tiledbsoma/soma_vfs.cc
@@ -37,8 +37,8 @@ class SOMAFileHandle {
     std::ios::openmode openmode_ = std::ios::in;  // hardwired to read-only
 
     // Ensure proper order of destruction
-    SOMAFilebuf buf_;
     tiledb::VFS vfs_;
+    SOMAFilebuf buf_;
     std::shared_ptr<SOMAContext> ctx_;
 
    public:


### PR DESCRIPTION
Fixes C++ compile warning about incorrect element order in soma_vfs.cc

Fixes SOMA-190
