### PR TITLE
[python] `python-dockers`: bump 1.16.x builds (to pick up ARM wheels)

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -28,18 +28,18 @@ jobs:
           - name: Ubuntu 1.15.7
             file: ubuntu
             args: v=1.15.7
-          - name: Ubuntu 1.16.0
+          - name: Ubuntu 1.16.2
             file: ubuntu
-            args: v=1.16.0
+            args: v=1.16.2
           - name: Debian 1.15.7 gcc12
             file: bookworm
             args: gcc=12 v=1.15.7
           - name: Debian 1.15.7 gcc13
             file: bookworm
             args: gcc=13 v=1.15.7
-          - name: Debian 1.16.0 gcc13
+          - name: Debian 1.16.2 gcc13
             file: bookworm
-            args: gcc=13 v=1.16.0
+            args: gcc=13 v=1.16.2
           - name: Langchain
             file: langchain
           - name: Python 3.12 + uv


### PR DESCRIPTION
**Issue and/or context:**
- #3909 

**Changes:**
- Test Docker builds ([python-dockers.yml](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-dockers.yml)) against 1.16.2 (wheels) instead of 1.16.0 (source build, on ARM Linux)

1.16.x ARM images [are fast now](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/15189344256?pr=4079) (1-2mins, instead of 20-30 from source):

<details><summary>Timings screenshot</summary>

![Screenshot 2025-05-22 at 10 11 38 PM](https://github.com/user-attachments/assets/faccf350-d653-4a16-9da7-24990737786c)
</details> 
