### PR TITLE
[python] deprecate tiledbsoma.io.append_ functions

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Deprecated
 
+- \[[#4081](https://github.com/single-cell-data/TileDB-SOMA/pull/4081)\] [python] the `tiledbsoma.io` functions `append_obs`, `append_var` and `append_X` are deprecated and will be removed in a future release. It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+
 ### Removed
 
 ### Fixed

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Deprecated
 
 - \[[#4081](https://github.com/single-cell-data/TileDB-SOMA/pull/4081)\] [python] the `tiledbsoma.io` functions `append_obs`, `append_var` and `append_X` are deprecated and will be removed in a future release. It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+- \[[#4082](https://github.com/single-cell-data/TileDB-SOMA/pull/4082)\] [python] `tiledbsoma.io.create_from_matrix` is deprecated and will be removed in a future release. To add a new matrix as a layer within an existing SOMA Experiment (e.g., to X, obsm, varm), please use the more specific functions tiledbsoma.io.add_X_layer or tiledbsoma.io.add_matrix_to_collection. If you need to create a standalone SOMA NDArray outside of a pre-defined Experiment structure, please use the direct SOMA API constructors, such as tiledbsoma.SparseNDArray.create.
+- \[[#4083](https://github.com/single-cell-data/TileDB-SOMA/pull/4083)\] [python] "resume" mode in tiledbsoma.io ingestion methods is deprecated and will be removed i a future release. This includes from_anndata, from_h5ad and related ingest functions. The recommended and safest approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart the ingestion process from the original input files or a known-good backup.
 
 ### Removed
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -351,7 +351,7 @@ setuptools.setup(
         "scipy",
         # Note: the somacore version is also in .pre-commit-config.yaml
         "somacore==1.0.28",
-        "typing-extensions",  # Note "-" even though `import typing_extensions`
+        "typing-extensions>=4.5.0",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={
         "dev": open("requirements_dev.txt").read(),

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
 from somacore.query.types import IndexLike
+from typing_extensions import deprecated
 
 from tiledbsoma import pytiledbsoma as clib
 
@@ -28,6 +29,7 @@ IndexerDataType = Union[
 ]
 
 
+@deprecated("This function is deprecated and will be removed in a future release.")
 def tiledbsoma_build_index(data: IndexerDataType, *, context: SOMATileDBContext | None = None) -> IndexLike:
     """Initialize re-indexer for provided indices (deprecated).
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any
 
 import pyarrow as pa
+from typing_extensions import deprecated
 
 from . import _tdb_handles
 
@@ -63,6 +64,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.schema_config_options()
 
+    @deprecated("This method is deprecated and will be removed in a future release.")
     def config_options_from_schema(self) -> clib.PlatformConfig:
         """Returns metadata about the array that is not encompassed within the
         Arrow Schema, in the form of a PlatformConfig (deprecated).

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -40,6 +40,7 @@ import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
 from more_itertools import batched
+from typing_extensions import deprecated
 
 # As of anndata 0.11 we get a warning importing anndata.experimental.
 # But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
@@ -784,6 +785,12 @@ def from_anndata(
     return experiment.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_obs(
     exp: Experiment,
     new_obs: pd.DataFrame,
@@ -795,6 +802,12 @@ def append_obs(
 ) -> str:
     """Writes new rows to an existing ``obs`` dataframe (this is distinct from ``update_obs``
     which mutates the entirety of the ``obs`` dataframe, e.g. to add/remove columns).
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -812,7 +825,7 @@ def append_obs(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
 
@@ -839,6 +852,12 @@ def append_obs(
     return exp.obs.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_var(
     exp: Experiment,
     new_var: pd.DataFrame,
@@ -851,6 +870,12 @@ def append_var(
 ) -> str:
     """Writes new rows to an existing ``var`` dataframe (this is distinct from ``update_var``
     which mutates the entirety of the ``var`` dataframe, e.g. to add/remove columns).
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -868,7 +893,7 @@ def append_var(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
     if measurement_name not in exp.ms:
@@ -898,6 +923,12 @@ def append_var(
     return sdf.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_X(
     exp: Experiment,
     new_X: Matrix | h5py.Dataset,
@@ -914,6 +945,12 @@ def append_X(
     """Appends new data to an existing ``X`` matrix. Nominally to be used in conjunction
     with ``update_obs`` and ``update_var``, as an itemized alternative to doing
     ``from_anndata`` with a registration mapping supplied.
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -938,7 +975,7 @@ def append_X(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
     if measurement_name not in exp.ms:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -788,8 +788,7 @@ def from_anndata(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_obs(
     exp: Experiment,
@@ -855,8 +854,7 @@ def append_obs(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_var(
     exp: Experiment,
@@ -926,8 +924,7 @@ def append_var(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_X(
     exp: Experiment,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -348,12 +348,20 @@ def from_h5ad(
         ingest_mode: The ingestion type to perform:
 
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
-            - ``resume``: Adds data to an existing SOMA, skipping writing data
+            - ``resume``: (deprecated) Adds data to an existing SOMA, skipping writing data
               that was previously written. Useful for continuing after a partial
               or interrupted ingestion operation.
             - ``schema_only``: Creates groups and the array schema, without
               writing any data to the array. Useful to prepare for appending
               multiple H5AD files to a single SOMA.
+
+          The 'resume' ingest_mode is deprecated and will be removed in a future version. The
+          current implementation has a known issue that can can cause multi-dataset appends to
+          not resume correctly.
+
+          The recommended and safest approach for recovering from a failed ingestion is to delete
+          the partially written SOMA Experiment and restart the ingestion process from the original
+          input files or a known-good backup.
 
         X_kind: Which type of matrix is used to store dense X data from the
           H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
@@ -409,6 +417,7 @@ def from_h5ad(
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(f'expected ingest_mode to be one of {INGEST_MODES}; got "{ingest_mode}"')
+    _check_for_deprecated_modes(ingest_mode)
 
     if isinstance(input_path, ad.AnnData):
         raise TypeError("input path is an AnnData object -- did you want from_anndata?")
@@ -423,7 +432,7 @@ def from_h5ad(
     with read_h5ad(input_path, mode="r", ctx=context) as anndata:
         logging.log_io(None, _util.format_elapsed(s, f"FINISH READING {input_path}"))
 
-        uri = from_anndata(
+        uri = _from_anndata(
             experiment_uri,
             anndata,
             measurement_name,
@@ -491,7 +500,46 @@ def from_anndata(
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(f'expected ingest_mode to be one of {INGEST_MODES}; got "{ingest_mode}"')
+    _check_for_deprecated_modes(ingest_mode)
 
+    return _from_anndata(
+        experiment_uri,
+        anndata,
+        measurement_name,
+        context=context,
+        platform_config=platform_config,
+        obs_id_name=obs_id_name,
+        var_id_name=var_id_name,
+        X_layer_name=X_layer_name,
+        raw_X_layer_name=raw_X_layer_name,
+        ingest_mode=ingest_mode,
+        use_relative_uri=use_relative_uri,
+        X_kind=X_kind,
+        registration_mapping=registration_mapping,
+        uns_keys=uns_keys,
+        additional_metadata=additional_metadata,
+    )
+
+
+def _from_anndata(
+    experiment_uri: str,
+    anndata: ad.AnnData,
+    measurement_name: str,
+    *,
+    context: SOMATileDBContext | None = None,
+    platform_config: PlatformConfig | None = None,
+    obs_id_name: str = "obs_id",
+    var_id_name: str = "var_id",
+    X_layer_name: str = "data",
+    raw_X_layer_name: str = "data",
+    ingest_mode: IngestMode = "write",
+    use_relative_uri: bool | None = None,
+    X_kind: type[SparseNDArray] | type[DenseNDArray] = SparseNDArray,
+    registration_mapping: ExperimentAmbientLabelMapping | None = None,
+    uns_keys: Sequence[str] | None = None,
+    additional_metadata: AdditionalMetadata = None,
+) -> str:
+    """Private helper function."""
     # Map the user-level ingest mode to a set of implementation-level boolean flags
     ingestion_params = IngestionParams(ingest_mode, registration_mapping)
 
@@ -1453,6 +1501,11 @@ def _write_dataframe_impl(
     return soma_df
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+To add a new matrix as a layer within an existing SOMA Experiment (e.g., to X, obsm, varm), please use the more specific functions tiledbsoma.io.add_X_layer or tiledbsoma.io.add_matrix_to_collection. If you need to create a standalone SOMA NDArray outside of a pre-defined Experiment structure, please use the direct SOMA API constructors, such as tiledbsoma.SparseNDArray.create."""
+)
 def create_from_matrix(
     cls: type[_NDArr],
     uri: str,
@@ -1463,9 +1516,14 @@ def create_from_matrix(
 ) -> _NDArr:
     """Create and populate the ``soma_matrix`` from the contents of ``matrix``.
 
+    This function is deprecated and will be removed in a future version of this package.
+
+    To add a new matrix as a layer within an existing SOMA :class:`Experiment` (e.g., to X, obsm, varm), please use the more specific functions ``tiledbsoma.io.add_X_layer`` or ``tiledbsoma.io.add_matrix_to_collection``. If you need to create a standalone SOMA NDArray outside of a pre-defined :class:`Experiment` structure, please use the direct SOMA API constructors, such as ``tiledbsoma.SparseNDArray.create``.
+
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
+    _check_for_deprecated_modes(ingest_mode)
     return _create_from_matrix(
         cls,
         uri,
@@ -1858,12 +1916,11 @@ def add_X_layer(
     `Scanpy <https://scanpy.readthedocs.io/>`_'s ``scanpy.pp.normalize_total``,
     ``scanpy.pp.log1p``, etc.
 
-    Use ``ingest_mode="resume"`` to not error out if the schema already exists.
-
     Lifecycle:
         Maturing.
     """
     exp.verify_open_for_writing()
+    _check_for_deprecated_modes(ingest_mode)
     add_matrix_to_collection(
         exp,
         measurement_name,
@@ -1890,12 +1947,11 @@ def add_matrix_to_collection(
     """This is useful for adding X/obsp/varm/etc data, for example from
     Scanpy's ``scanpy.pp.normalize_total``, ``scanpy.pp.log1p``, etc.
 
-    Use ``ingest_mode="resume"`` to not error out if the schema already exists.
-
     Lifecycle:
         Maturing.
     """
     ingestion_params = IngestionParams(ingest_mode, None)
+    _check_for_deprecated_modes(ingest_mode)
 
     # For local disk and S3, creation and storage URIs are identical.  For
     # cloud, creation URIs look like tiledb://namespace/s3://bucket/path/to/obj
@@ -2989,3 +3045,18 @@ def _concurrency_level(context: SOMATileDBContext) -> int:
             int(context.tiledb_config.get("soma.compute_concurrency_level", concurrency_level)),
         )
     return concurrency_level
+
+
+@deprecated(
+    """The 'resume' ingest_mode is deprecated and will be removed in a future version. The current implementation has a known issue that can can cause multi-dataset appends to not resume correctly.
+
+The recommended and safest approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart the ingestion process from the original input files or a known-good backup.""",
+    stacklevel=3,
+)
+def _resume_mode_is_deprecated() -> None:
+    pass
+
+
+def _check_for_deprecated_modes(ingest_mode: str) -> None:
+    if ingest_mode == "resume":
+        _resume_mode_is_deprecated()

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import gc
 import json
 import random
@@ -104,13 +105,15 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind, tmp_path):
     all2d = (slice(None), slice(None))  # keystroke-saver
 
     for ingest_mode in ingest_modes:
-        uri = tiledbsoma.io.from_anndata(
-            output_path,
-            orig,
-            "RNA",
-            ingest_mode=ingest_mode,
-            X_kind=X_kind,
-        )
+
+        with pytest.deprecated_call() if ingest_mode == "resume" else contextlib.nullcontext():
+            uri = tiledbsoma.io.from_anndata(
+                output_path,
+                orig,
+                "RNA",
+                ingest_mode=ingest_mode,
+                X_kind=X_kind,
+            )
         if ingest_mode != "schema_only":
             have_ingested = True
 
@@ -273,7 +276,8 @@ def test_resume_mode(resume_mode_h5ad_file, tmp_path):
 
     output_path2 = (tmp_path / "test_resume_mode_2_").as_posix()
     tiledbsoma.io.from_h5ad(output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write")
-    tiledbsoma.io.from_h5ad(output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="resume")
+    with pytest.deprecated_call():
+        tiledbsoma.io.from_h5ad(output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="resume")
 
     exp1 = _factory.open(output_path1)
     exp2 = _factory.open(output_path2)
@@ -517,18 +521,19 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small, tmp_path):
             with coll:
                 matrix_uri = f"{coll_uri}/{matrix_name}"
 
-                with tiledbsoma.io.ingest.create_from_matrix(
-                    tiledbsoma.SparseNDArray,
-                    matrix_uri,
-                    matrix_data,
-                    context=context,
-                ) as sparse_nd_array:
-                    tiledbsoma.io.ingest._maybe_set(
-                        coll,
-                        matrix_name,
-                        sparse_nd_array,
-                        use_relative_uri=use_relative_uri,
-                    )
+                with pytest.deprecated_call():
+                    with tiledbsoma.io.ingest.create_from_matrix(
+                        tiledbsoma.SparseNDArray,
+                        matrix_uri,
+                        matrix_data,
+                        context=context,
+                    ) as sparse_nd_array:
+                        tiledbsoma.io.ingest._maybe_set(
+                            coll,
+                            matrix_name,
+                            sparse_nd_array,
+                            use_relative_uri=use_relative_uri,
+                        )
 
     output_path = tmp_path.as_posix()
     original = conftest_pbmc_small.copy()

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -50,12 +50,13 @@ def test_io_create_from_matrix_dense_nd_array(tmp_path, tdb_create_options, src_
     * _tiledb_platform_config.write_X_chunked: True or False
     * src_array bigger or smaller than _tiledb_platform_config.goal_chunk_nnz
     """
-    somaio.create_from_matrix(
-        soma.DenseNDArray,
-        tmp_path.as_posix(),
-        src_matrix,
-        platform_config={"tiledb": {"create": tdb_create_options}},
-    ).close()
+    with pytest.deprecated_call():
+        somaio.create_from_matrix(
+            soma.DenseNDArray,
+            tmp_path.as_posix(),
+            src_matrix,
+            platform_config={"tiledb": {"create": tdb_create_options}},
+        ).close()
     with _factory.open(tmp_path.as_posix()) as snda:
         assert snda.ndim == src_matrix.ndim
 
@@ -99,12 +100,13 @@ def test_io_create_from_matrix_sparse_nd_array(tmp_path, tdb_create_options, src
     * _tiledb_platform_config.write_X_chunked: True or False
     * src_array bigger or smaller than _tiledb_platform_config.goal_chunk_nnz
     """
-    somaio.create_from_matrix(
-        soma.SparseNDArray,
-        tmp_path.as_posix(),
-        src_matrix,
-        platform_config={"tiledb": {"create": tdb_create_options}},
-    ).close()
+    with pytest.deprecated_call():
+        somaio.create_from_matrix(
+            soma.SparseNDArray,
+            tmp_path.as_posix(),
+            src_matrix,
+            platform_config={"tiledb": {"create": tdb_create_options}},
+        ).close()
 
     with _factory.open(tmp_path.as_posix()) as snda:
         assert snda.ndim == src_matrix.ndim

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -816,28 +816,31 @@ def test_append_items_with_experiment(obs_field_name, var_field_name, tmp_path):
     rd.prepare_experiment(soma1)
 
     with tiledbsoma.Experiment.open(soma1, "w") as exp1:
-        tiledbsoma.io.append_obs(
-            exp1,
-            adata2.obs,
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_obs(
+                exp1,
+                adata2.obs,
+                registration_mapping=rd,
+            )
 
-        tiledbsoma.io.append_var(
-            exp1,
-            adata2.var,
-            measurement_name="measname",
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_var(
+                exp1,
+                adata2.var,
+                measurement_name="measname",
+                registration_mapping=rd,
+            )
 
-        tiledbsoma.io.append_X(
-            exp1,
-            adata2.X,
-            measurement_name="measname",
-            X_layer_name="data",
-            obs_ids=list(adata2.obs.index),
-            var_ids=list(adata2.var.index),
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_X(
+                exp1,
+                adata2.X,
+                measurement_name="measname",
+                X_layer_name="data",
+                obs_ids=list(adata2.obs.index),
+                var_ids=list(adata2.var.index),
+                registration_mapping=rd,
+            )
 
     assert_adata_equal(original, adata2)
 


### PR DESCRIPTION
**Issue and/or context:**

tiledbsoma.io.append_{obs,var,X} are deprecated

Fixes SOMA-147

**Changes:**

* Added dependency pin for typing-extensions - minimum set to the version where the deprecated decorator was added
* Marked append functions as deprecated
* Marked several other (previously) deprecated functions with the deprecation decorator
* Added tests to verify warning is generated for append functions
