### PR TITLE
[python] deprecate tiledbsoma.io.create_from_matrix

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Deprecated
 
+- \[[#4081](https://github.com/single-cell-data/TileDB-SOMA/pull/4081)\] [python] the `tiledbsoma.io` functions `append_obs`, `append_var` and `append_X` are deprecated and will be removed in a future release. It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+
 ### Removed
 
 ### Fixed

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -351,7 +351,7 @@ setuptools.setup(
         "scipy",
         # Note: the somacore version is also in .pre-commit-config.yaml
         "somacore==1.0.28",
-        "typing-extensions",  # Note "-" even though `import typing_extensions`
+        "typing-extensions>=4.5.0",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={
         "dev": open("requirements_dev.txt").read(),

--- a/apis/python/src/tiledbsoma/_indexer.py
+++ b/apis/python/src/tiledbsoma/_indexer.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
 from somacore.query.types import IndexLike
+from typing_extensions import deprecated
 
 from tiledbsoma import pytiledbsoma as clib
 
@@ -28,6 +29,7 @@ IndexerDataType = Union[
 ]
 
 
+@deprecated("This function is deprecated and will be removed in a future release.")
 def tiledbsoma_build_index(data: IndexerDataType, *, context: SOMATileDBContext | None = None) -> IndexLike:
     """Initialize re-indexer for provided indices (deprecated).
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any
 
 import pyarrow as pa
+from typing_extensions import deprecated
 
 from . import _tdb_handles
 
@@ -63,6 +64,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         """
         return self._handle.schema_config_options()
 
+    @deprecated("This method is deprecated and will be removed in a future release.")
     def config_options_from_schema(self) -> clib.PlatformConfig:
         """Returns metadata about the array that is not encompassed within the
         Arrow Schema, in the form of a PlatformConfig (deprecated).

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -40,6 +40,7 @@ import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
 from more_itertools import batched
+from typing_extensions import deprecated
 
 # As of anndata 0.11 we get a warning importing anndata.experimental.
 # But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
@@ -784,6 +785,12 @@ def from_anndata(
     return experiment.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_obs(
     exp: Experiment,
     new_obs: pd.DataFrame,
@@ -795,6 +802,12 @@ def append_obs(
 ) -> str:
     """Writes new rows to an existing ``obs`` dataframe (this is distinct from ``update_obs``
     which mutates the entirety of the ``obs`` dataframe, e.g. to add/remove columns).
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -812,7 +825,7 @@ def append_obs(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
 
@@ -839,6 +852,12 @@ def append_obs(
     return exp.obs.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_var(
     exp: Experiment,
     new_var: pd.DataFrame,
@@ -851,6 +870,12 @@ def append_var(
 ) -> str:
     """Writes new rows to an existing ``var`` dataframe (this is distinct from ``update_var``
     which mutates the entirety of the ``var`` dataframe, e.g. to add/remove columns).
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -868,7 +893,7 @@ def append_var(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
     if measurement_name not in exp.ms:
@@ -898,6 +923,12 @@ def append_var(
     return sdf.uri
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
+"""
+)
 def append_X(
     exp: Experiment,
     new_X: Matrix | h5py.Dataset,
@@ -914,6 +945,12 @@ def append_X(
     """Appends new data to an existing ``X`` matrix. Nominally to be used in conjunction
     with ``update_obs`` and ``update_var``, as an itemized alternative to doing
     ``from_anndata`` with a registration mapping supplied.
+
+    This function is deprecated and will be removed in a future version of this package.
+
+    It is recommended to use ``tiledbsoma.io.from_anndata`` (with a registration map from
+    ``tiledbsoma.io.register_anndatas`` or ``tiledbsoma.io.register_h5ads``) for appending new,
+    complete AnnData objects to an :class:`Experiment`.
 
     Example::
 
@@ -938,7 +975,7 @@ def append_X(
             )
 
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     exp.verify_open_for_writing()
     if measurement_name not in exp.ms:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -788,8 +788,7 @@ def from_anndata(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_obs(
     exp: Experiment,
@@ -855,8 +854,7 @@ def append_obs(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_var(
     exp: Experiment,
@@ -926,8 +924,7 @@ def append_var(
 @deprecated(
     """This function is deprecated and will be removed in a future version of this package.
 
-It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
-"""
+It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment."""
 )
 def append_X(
     exp: Experiment,

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1453,6 +1453,11 @@ def _write_dataframe_impl(
     return soma_df
 
 
+@deprecated(
+    """This function is deprecated and will be removed in a future version of this package.
+
+To add a new matrix as a layer within an existing SOMA Experiment (e.g., to X, obsm, varm), please use the more specific functions tiledbsoma.io.add_X_layer or tiledbsoma.io.add_matrix_to_collection. If you need to create a standalone SOMA NDArray outside of a pre-defined Experiment structure, please use the direct SOMA API constructors, such as tiledbsoma.SparseNDArray.create."""
+)
 def create_from_matrix(
     cls: type[_NDArr],
     uri: str,
@@ -1463,8 +1468,12 @@ def create_from_matrix(
 ) -> _NDArr:
     """Create and populate the ``soma_matrix`` from the contents of ``matrix``.
 
+    This function is deprecated and will be removed in a future version of this package.
+
+    To add a new matrix as a layer within an existing SOMA :class:`Experiment` (e.g., to X, obsm, varm), please use the more specific functions ``tiledbsoma.io.add_X_layer`` or ``tiledbsoma.io.add_matrix_to_collection``. If you need to create a standalone SOMA NDArray outside of a pre-defined :class:`Experiment` structure, please use the direct SOMA API constructors, such as ``tiledbsoma.SparseNDArray.create``.
+
     Lifecycle:
-        Maturing.
+        Deprecated.
     """
     return _create_from_matrix(
         cls,

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -517,18 +517,19 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small, tmp_path):
             with coll:
                 matrix_uri = f"{coll_uri}/{matrix_name}"
 
-                with tiledbsoma.io.ingest.create_from_matrix(
-                    tiledbsoma.SparseNDArray,
-                    matrix_uri,
-                    matrix_data,
-                    context=context,
-                ) as sparse_nd_array:
-                    tiledbsoma.io.ingest._maybe_set(
-                        coll,
-                        matrix_name,
-                        sparse_nd_array,
-                        use_relative_uri=use_relative_uri,
-                    )
+                with pytest.deprecated_call():
+                    with tiledbsoma.io.ingest.create_from_matrix(
+                        tiledbsoma.SparseNDArray,
+                        matrix_uri,
+                        matrix_data,
+                        context=context,
+                    ) as sparse_nd_array:
+                        tiledbsoma.io.ingest._maybe_set(
+                            coll,
+                            matrix_name,
+                            sparse_nd_array,
+                            use_relative_uri=use_relative_uri,
+                        )
 
     output_path = tmp_path.as_posix()
     original = conftest_pbmc_small.copy()

--- a/apis/python/tests/test_io.py
+++ b/apis/python/tests/test_io.py
@@ -50,12 +50,13 @@ def test_io_create_from_matrix_dense_nd_array(tmp_path, tdb_create_options, src_
     * _tiledb_platform_config.write_X_chunked: True or False
     * src_array bigger or smaller than _tiledb_platform_config.goal_chunk_nnz
     """
-    somaio.create_from_matrix(
-        soma.DenseNDArray,
-        tmp_path.as_posix(),
-        src_matrix,
-        platform_config={"tiledb": {"create": tdb_create_options}},
-    ).close()
+    with pytest.deprecated_call():
+        somaio.create_from_matrix(
+            soma.DenseNDArray,
+            tmp_path.as_posix(),
+            src_matrix,
+            platform_config={"tiledb": {"create": tdb_create_options}},
+        ).close()
     with _factory.open(tmp_path.as_posix()) as snda:
         assert snda.ndim == src_matrix.ndim
 
@@ -99,12 +100,13 @@ def test_io_create_from_matrix_sparse_nd_array(tmp_path, tdb_create_options, src
     * _tiledb_platform_config.write_X_chunked: True or False
     * src_array bigger or smaller than _tiledb_platform_config.goal_chunk_nnz
     """
-    somaio.create_from_matrix(
-        soma.SparseNDArray,
-        tmp_path.as_posix(),
-        src_matrix,
-        platform_config={"tiledb": {"create": tdb_create_options}},
-    ).close()
+    with pytest.deprecated_call():
+        somaio.create_from_matrix(
+            soma.SparseNDArray,
+            tmp_path.as_posix(),
+            src_matrix,
+            platform_config={"tiledb": {"create": tdb_create_options}},
+        ).close()
 
     with _factory.open(tmp_path.as_posix()) as snda:
         assert snda.ndim == src_matrix.ndim

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -816,28 +816,31 @@ def test_append_items_with_experiment(obs_field_name, var_field_name, tmp_path):
     rd.prepare_experiment(soma1)
 
     with tiledbsoma.Experiment.open(soma1, "w") as exp1:
-        tiledbsoma.io.append_obs(
-            exp1,
-            adata2.obs,
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_obs(
+                exp1,
+                adata2.obs,
+                registration_mapping=rd,
+            )
 
-        tiledbsoma.io.append_var(
-            exp1,
-            adata2.var,
-            measurement_name="measname",
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_var(
+                exp1,
+                adata2.var,
+                measurement_name="measname",
+                registration_mapping=rd,
+            )
 
-        tiledbsoma.io.append_X(
-            exp1,
-            adata2.X,
-            measurement_name="measname",
-            X_layer_name="data",
-            obs_ids=list(adata2.obs.index),
-            var_ids=list(adata2.var.index),
-            registration_mapping=rd,
-        )
+        with pytest.deprecated_call():
+            tiledbsoma.io.append_X(
+                exp1,
+                adata2.X,
+                measurement_name="measname",
+                X_layer_name="data",
+                obs_ids=list(adata2.obs.index),
+                var_ids=list(adata2.var.index),
+                registration_mapping=rd,
+            )
 
     assert_adata_equal(original, adata2)
 


### PR DESCRIPTION
**Issue and/or context:**

tiledbsoma.io.create_from_matrix is deprecated

Fixes SOMA-148

**Changes:**

* Marked function as deprecated
* Added test to confirm deprecation warning
