### PR TITLE
[python] add dup obs id check to tiledbsoma.io register functions

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -193,6 +193,7 @@ def register_h5ads(
     append_obsm_varm: bool = False,
     context: SOMATileDBContext | None = None,
     use_multiprocessing: bool = False,
+    allow_duplicate_obs_ids: bool = False,
 ) -> ExperimentAmbientLabelMapping:
     """Extends registration data from the baseline, already-written SOMA
     experiment to include multiple H5AD input files. See ``from_h5ad`` and
@@ -248,6 +249,7 @@ def register_h5ads(
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
         context=context,
+        allow_duplicate_obs_ids=allow_duplicate_obs_ids,
     )
 
 
@@ -260,6 +262,7 @@ def register_anndatas(
     var_field_name: str,
     append_obsm_varm: bool = False,
     context: SOMATileDBContext | None = None,
+    allow_duplicate_obs_ids: bool = False,
 ) -> ExperimentAmbientLabelMapping:
     """Extends registration data from the baseline, already-written SOMA
     experiment to include multiple H5AD input files. See ``from_h5ad`` and
@@ -286,6 +289,7 @@ def register_anndatas(
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
         context=context,
+        allow_duplicate_obs_ids=allow_duplicate_obs_ids,
     )
 
 
@@ -2795,7 +2799,7 @@ def _ingest_uns_node(
         )
         return
 
-    msg = f"Skipped {coll.uri}[{key!r}]" f" (uns object): unrecognized type {type(value)}"
+    msg = f"Skipped {coll.uri}[{key!r}] (uns object): unrecognized type {type(value)}"
     logging.log_io(msg, msg)
 
 
@@ -2813,7 +2817,7 @@ def _ingest_uns_array(
     """
     if value.dtype.names is not None:
         # This is a structured array, which we do not support.
-        logging.log_io_same(f"Skipped {coll.uri}[{key!r}]" " (uns): unsupported structured array")
+        logging.log_io_same(f"Skipped {coll.uri}[{key!r}] (uns): unsupported structured array")
 
     if value.dtype.char in ("U", "O"):
         # In the wild it's quite common to see arrays of strings in uns data.
@@ -2858,9 +2862,7 @@ def _ingest_uns_string_array(
     elif len(value.shape) == 2:
         helper = _ingest_uns_2d_string_array
     else:
-        msg = (
-            f"Skipped {coll.uri}[{key!r}]" f" (uns object): string array is neither one-dimensional nor two-dimensional"
-        )
+        msg = f"Skipped {coll.uri}[{key!r}] (uns object): string array is neither one-dimensional nor two-dimensional"
         logging.log_io(msg, msg)
         return
 
@@ -2989,7 +2991,7 @@ def _ingest_uns_ndarray(
     try:
         pa_dtype = pa.from_numpy_dtype(value.dtype)
     except pa.ArrowNotImplementedError:
-        msg = f"Skipped {arr_uri} (uns ndarray):" f" unsupported dtype {value.dtype!r} ({value.dtype})"
+        msg = f"Skipped {arr_uri} (uns ndarray): unsupported dtype {value.dtype!r} ({value.dtype})"
         logging.log_io(msg, msg)
         return
     try:

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1178,12 +1178,13 @@ def test_outgest_X_layers(tmp_path):
         assert sorted(list(bdata.layers.keys())) == ["data2", "data3"]
 
 
-# fmt: off
-@pytest.mark.parametrize("dtype", ["float64", "string"])          # new column dtype
-@pytest.mark.parametrize("nans", ["all", "none", "some"])         # how many `nan`s in new column?
-@pytest.mark.parametrize("new_obs_ids", ["all", "none", "half"])  # how many new obs IDs?
-# fmt: on
-def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids, tmp_path):
+@pytest.mark.parametrize("dtype", ["float64", "string"])  # new column dtype
+@pytest.mark.parametrize("nans", ["all", "none", "some"])  # how many `nan`s in new column?
+@pytest.mark.parametrize(
+    "new_obs_ids,allow_duplicate_obs_ids",
+    [("all", False), ("all", True), ("none", True), ("half", True)],
+)  # how many new obs IDs?
+def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids, allow_duplicate_obs_ids, tmp_path):
     """Test append-ingesting an AnnData object, including a new `obs` column with various properties:
 
     - {all,some,none} of its values are `nan`
@@ -1231,6 +1232,7 @@ def test_nan_append(conftest_pbmc_small, dtype, nans, new_obs_ids, tmp_path):
         measurement_name="RNA",
         obs_field_name="obs_id",
         var_field_name="var_id",
+        allow_duplicate_obs_ids=allow_duplicate_obs_ids,
     )
 
     rd.prepare_experiment(experiment_uri=SOMA_URI)

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -273,6 +273,7 @@ def test_axis_mappings(obs_field_name, var_field_name, tmp_path):
         joinid_map=pd.Series({"a": 10, "b": 20, "c": 30}, name="soma_joinid").to_frame(),
         field_name=obs_field_name,
         enum_values={},
+        allow_duplicate_ids=True,
     )
 
     assert_array_equal(dictionary.id_mapping_from_values(["a", "b", "c"]).data, (10, 20, 30))
@@ -423,6 +424,7 @@ def test_multiples_without_experiment(
             obs_field_name=obs_field_name,
             var_field_name=var_field_name,
             use_multiprocessing=use_multiprocessing,
+            allow_duplicate_obs_ids=True,
         )
         rd.prepare_experiment(experiment_uri)
 
@@ -435,6 +437,7 @@ def test_multiples_without_experiment(
             obs_field_name=obs_field_name,
             var_field_name=var_field_name,
             use_multiprocessing=use_multiprocessing,
+            allow_duplicate_obs_ids=True,
         )
 
     assert_array_equal(rd.obs_axis.id_mapping_from_values(["AGAG", "GGAG"]).data, (2, 8))
@@ -520,7 +523,6 @@ def test_multiples_without_experiment(
         h5ad_file_names[permutation[2]],
         h5ad_file_names[permutation[3]],
     ]:
-
         if tiledbsoma.Experiment.exists(experiment_uri):
             rd.prepare_experiment(experiment_uri)
 
@@ -932,6 +934,7 @@ def test_append_with_disjoint_measurements(tmp_path, obs_field_name, var_field_n
         measurement_name="two",
         obs_field_name=obs_field_name,
         var_field_name=var_field_name,
+        allow_duplicate_obs_ids=use_same_cells,
     )
 
     rd.prepare_experiment(soma_uri)
@@ -1381,6 +1384,7 @@ def test_multimodal_names(tmp_path, conftest_pbmc3k_adata):
         measurement_name="protein",
         obs_field_name=adata_protein.obs.index.name,
         var_field_name=adata_protein.var.index.name,
+        allow_duplicate_obs_ids=True,
     )
 
     assert rd.get_obs_shape() == 2638
@@ -1738,3 +1742,35 @@ def test_field_name(tmp_path):
     with tiledbsoma.Experiment.open(soma_uri) as exp:
         assert exp.obs.count == sum(adata.n_obs for adata in anndatas)
         assert exp.ms[ms_name].var.count == pd.concat(adata.var[var_field_name] for adata in anndatas).nunique()
+
+
+def test_allow_duplicate_obs_ids_catches_dups(tmp_path):
+    obs_field_name = "obs_id"
+    var_field_name = "var_id"
+    ms_name = "RNA"
+
+    adata1 = create_anndata_canned(1, obs_field_name, var_field_name)
+
+    # catch dup between AnnData?
+    tiledbsoma.io.from_anndata(
+        (tmp_path / "soma1").as_posix(), adata1, measurement_name=ms_name, ingest_mode="schema_only"
+    )
+    with pytest.raises(tiledbsoma.SOMAError):
+        tiledbsoma.io.register_anndatas(
+            (tmp_path / "soma1").as_posix(),
+            [adata1, adata1.copy()],
+            measurement_name=ms_name,
+            obs_field_name=obs_field_name,
+            var_field_name=var_field_name,
+        )
+
+    # catch dup between existing SOMA and AnnData
+    tiledbsoma.io.from_anndata((tmp_path / "soma2").as_posix(), adata1, measurement_name=ms_name)
+    with pytest.raises(tiledbsoma.SOMAError):
+        tiledbsoma.io.register_anndatas(
+            (tmp_path / "soma2").as_posix(),
+            [adata1],
+            measurement_name=ms_name,
+            obs_field_name=obs_field_name,
+            var_field_name=var_field_name,
+        )


### PR DESCRIPTION
**Issue and/or context:**

Add check for duplicate obs axis IDs in `tiledbsoma.io.register_anndatas` and `tiledbsoma.io.register_h5ads`. Controlled by a parameter (`allow_duplicate_obs_ids`, default: True). Will raise an error if there are any IDs in the intersection of provided AnnData and existing SOMA. 

Fixes SOMA-131

**Changes:**
* Add ID check logic to the registration code
* Add test cases and modify existing tests to account for the new behavior
