### PR TITLE
[r] Add tibble as suggested package

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -70,6 +70,7 @@ Suggests:
     SingleCellExperiment (>= 1.20.0),
     SummarizedExperiment (>= 1.28.0),
     testthat (>= 3.0.0),
+    tibble,
     withr
 Config/testthat/edition: 2
 OS_type: unix


### PR DESCRIPTION
R CI started failing on 2025-05-27; appears to be a lack of tibble

Fixes [SOMA-209](https://linear.app/tiledb/issue/SOMA-209/fix-r-ci-failures)