### PR TITLE
[r] Add examples for read iterators

### DIFF
--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -1,6 +1,7 @@
 #' SOMA Blockwise Read Iterator Base Class
 #'
-#' @description Class that allows for blockwise read iteration of SOMA reads
+#' @description Virtual base class that allows for blockwise read iteration of
+#' SOMA reads.
 #'
 #' @keywords internal
 #'
@@ -13,7 +14,7 @@ BlockwiseReadIterBase <- R6::R6Class(
   classname = "BlockwiseReadIterBase",
   inherit = ReadIter,
   public = list(
-    #' @description Create
+    #' @description Create.
     #'
     #' @template param-blockwise-iter
     #' @template param-coords-iter
@@ -98,9 +99,9 @@ BlockwiseReadIterBase <- R6::R6Class(
         names(private$.reindexers)[i] <- dnames[ax]
       }
     },
-    #' @description Check if the iterated read is complete or not
+    #' @description Check if the iterated read is complete or not.
     #'
-    #' @return \code{TRUE} if read is complete, otherwise \code{FALSE}
+    #' @return \code{TRUE} if read is complete, otherwise \code{FALSE}.
     #'
     read_complete = function() {
       !self$coords_axis$has_next() ||
@@ -108,9 +109,9 @@ BlockwiseReadIterBase <- R6::R6Class(
     },
     #' @description Read the next chunk of the iterated read. If read
     #' is complete, throws an \code{iterationCompleteWarning} warning and
-    #' returns \code{NULL}
+    #' returns \code{NULL}.
     #'
-    #' @return \code{NULL} or the next blockwise chunk of the iterated read
+    #' @return \code{NULL} or the next blockwise chunk of the iterated read.
     #'
     read_next = function() {
       if (is.null(private$soma_reader_pointer)) {
@@ -127,13 +128,13 @@ BlockwiseReadIterBase <- R6::R6Class(
     }
   ),
   active = list(
-    #' @field array The underlying SOMA array
+    #' @field array The underlying SOMA array.
     #'
     array = function() private$.array,
-    #' @field axis The axis to iterate over in a blockwise fashion
+    #' @field axis The axis to iterate over in a blockwise fashion.
     #'
     axis = function() private$.axis,
-    #' @field axes_to_reindex The axes to re-index
+    #' @field axes_to_reindex The axes to re-index.
     #'
     axes_to_reindex = function() {
       ax <- seq(bit64::as.integer64(0L), self$array$ndim() - 1L)
@@ -146,20 +147,21 @@ BlockwiseReadIterBase <- R6::R6Class(
       }
       return(ax)
     },
-    #' @field coords A list of \code{\link{CoordsStrider}} objects
+    #' @field coords A list of \code{\link{CoordsStrider}} objects.
     #'
     coords = function() private$.coords,
-    #' @field coords_axis The \code{\link{CoordsStrider}} for \code{axis}
+    #' @field coords_axis The \code{\link{CoordsStrider}} for \code{axis}.
     #'
     coords_axis = function() {
       dname <- self$array$dimnames()[self$axis + 1L]
       return(self$coords[[dname]])
     },
-    #' @field reindex_disable_on_axis Additional axes that will not be re-indexed
+    #' @field reindex_disable_on_axis Additional axes that will not be
+    #' re-indexed.
     #'
     reindex_disable_on_axis = function() private$.reindex_disable_on_axis,
     #' @field reindexable Shorthand to see if this iterator is poised to be
-    #' re-indexed or not
+    #' re-indexed or not.
     #'
     reindexable = function() {
       length(self$axes_to_reindex) ||
@@ -249,7 +251,7 @@ BlockwiseReadIterBase <- R6::R6Class(
 #' SOMA Blockwise Read Iterator for Arrow Tables
 #'
 #' @description Class that allows for blockwise read iteration of SOMA reads
-#' as Arrow \code{\link[arrow]{Table}s}
+#' as Arrow \code{\link[arrow]{Table}s}.
 #'
 #' @keywords internal
 #'
@@ -277,9 +279,9 @@ BlockwiseTableReadIter <- R6::R6Class(
   classname = "BlockwiseTableReadIter",
   inherit = BlockwiseReadIterBase,
   public = list(
-    #' @description Concatenate the remainder of the blockwise iterator
+    #' @description Concatenate the remainder of the blockwise iterator.
     #'
-    #' @return An Arrow Table with the remainder of the iterator
+    #' @return An Arrow Table with the remainder of the iterator.
     #'
     concat = function() {
       if (self$reindexable) {
@@ -299,7 +301,7 @@ BlockwiseTableReadIter <- R6::R6Class(
 #' SOMA Blockwise Read Iterator for Sparse Matrices
 #'
 #' @description Class that allows for blockwise read iteration of SOMA reads
-#' as sparse matrices
+#' as sparse matrices.
 #'
 #' @keywords internal
 #'
@@ -327,7 +329,7 @@ BlockwiseSparseReadIter <- R6::R6Class(
   classname = "BlockwiseSparseReadIter",
   inherit = BlockwiseReadIterBase,
   public = list(
-    #' @description Create
+    #' @description Create.
     #'
     #' @template param-blockwise-iter
     #' @template param-coords-iter
@@ -362,10 +364,10 @@ BlockwiseSparseReadIter <- R6::R6Class(
       private$.repr <- match.arg(repr, choices = reprs)
       private$.shape <- sapply(coords, length)
     },
-    #' @description Concatenate the remainder of the blockwise iterator
+    #' @description Concatenate the remainder of the blockwise iterator.
     #'
     #' @return A sparse matrix (determined by \code{self$repr}) with
-    #' the remainder of the iterator
+    #' the remainder of the iterator.
     #'
     concat = function() {
       if (self$reindexable) {
@@ -375,7 +377,7 @@ BlockwiseSparseReadIter <- R6::R6Class(
     }
   ),
   active = list(
-    #' @field repr Representation of the sparse matrix to return
+    #' @field repr Representation of the sparse matrix to return.
     #'
     repr = function() private$.repr
   ),

--- a/apis/r/R/BlockwiseIter.R
+++ b/apis/r/R/BlockwiseIter.R
@@ -6,6 +6,9 @@
 #'
 #' @export
 #'
+#' @seealso Derived classes: \code{\link{BlockwiseTableReadIter}},
+#' \code{\link{BlockwiseSparseReadIter}}
+#'
 BlockwiseReadIterBase <- R6::R6Class(
   classname = "BlockwiseReadIterBase",
   inherit = ReadIter,
@@ -25,9 +28,9 @@ BlockwiseReadIterBase <- R6::R6Class(
       reindex_disable_on_axis = NA
     ) {
       super$initialize(sr)
-      stopifnot(
-        "'array' must be a 'SOMASparseNDArray'" = inherits(array, "SOMASparseNDArray")
-      )
+      if (!inherits(array, "SOMASparseNDArray")) {
+        stop("'array' must be a 'SOMASparseNDArray'", call. = FALSE)
+      }
       private$.array <- array
       # Check axis
       ndim <- self$array$ndim() - 1L
@@ -252,6 +255,24 @@ BlockwiseReadIterBase <- R6::R6Class(
 #'
 #' @export
 #'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "blockwise-table")
+#' dir.create(dir, recursive = TRUE)
+#' (exp <- load_dataset("soma-exp-pbmc-small", dir))
+#' qry <- exp$axis_query("RNA")
+#' xqry <- qry$X("data")
+#'
+#' iter <- xqry$blockwise(0L, size = 20L, reindex_disable_on_axis = TRUE)$tables()
+#' stopifnot(inherits(iter, "BlockwiseTableReadIter"))
+#'
+#' while (!iter$read_complete()) {
+#'   block <- iter$read_next()
+#' }
+#'
+#' \dontshow{
+#' exp$close()
+#' }
+#'
 BlockwiseTableReadIter <- R6::R6Class(
   classname = "BlockwiseTableReadIter",
   inherit = BlockwiseReadIterBase,
@@ -283,6 +304,24 @@ BlockwiseTableReadIter <- R6::R6Class(
 #' @keywords internal
 #'
 #' @export
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "blockwise-matrix")
+#' dir.create(dir, recursive = TRUE)
+#' (exp <- load_dataset("soma-exp-pbmc-small", dir))
+#' qry <- exp$axis_query("RNA")
+#' xqry <- qry$X("data")
+#'
+#' iter <- xqry$blockwise(0L, size = 20L, reindex_disable_on_axis = TRUE)$sparse_matrix()
+#' stopifnot(inherits(iter, "BlockwiseSparseReadIter"))
+#'
+#' while (!iter$read_complete()) {
+#'   block <- iter$read_next()
+#' }
+#'
+#' \dontshow{
+#' exp$close()
+#' }
 #'
 BlockwiseSparseReadIter <- R6::R6Class(
   classname = "BlockwiseSparseReadIter",

--- a/apis/r/R/ReadIter.R
+++ b/apis/r/R/ReadIter.R
@@ -1,21 +1,32 @@
 #' SOMA Read Iterator Base class
 #'
-#' Class that allows for read iteration of SOMA reads.
+#' Virtual class that allows for read iteration of SOMA reads
+#'
 #' @keywords internal
+#'
 #' @export
-
+#'
+#' @seealso \code{\link{BlockwiseReadIterBase}},
+#' \code{\link{SparseReadIter}},
+#' \code{\link{TableReadIter}}
+#'
 ReadIter <- R6::R6Class(
   classname = "ReadIter",
   public = list(
 
     #' @description Create (lifecycle: maturing)
+    #'
     #' @param sr soma read pointer
+    #'
     initialize = function(sr) {
       private$soma_reader_pointer <- sr
     },
 
-    #' @description Check if iterated read is complete or not. (lifecycle: maturing)
+    #' @description @description Check if iterated read is complete or not
+    #' (lifecycle: maturing)
+    #'
     #' @return logical
+    #'
     read_complete = function() {
       if (is.null(private$soma_reader_pointer)) {
         TRUE
@@ -24,9 +35,12 @@ ReadIter <- R6::R6Class(
       }
     },
 
-    #' @description Read the next chunk of an iterated read. (lifecycle: maturing).
-    #' If read is complete, retunrs `NULL` and raises warning.
-    #' @return \code{NULL} or one of arrow::\link[arrow]{Table}, \link{matrixZeroBasedView}
+    #' @description Read the next chunk of an iterated read. If read is
+    #' complete, returns \code{NULL} and raises warning (lifecycle: maturing)
+    #'
+    #' @return \code{NULL} or one of \link[arrow:Table]{arrow::Table},
+    #' \link{matrixZeroBasedView}
+    #'
     read_next = function() {
       if (is.null(private$soma_reader_pointer)) {
         return(NULL)
@@ -40,6 +54,7 @@ ReadIter <- R6::R6Class(
 
     #' @description  Concatenate remainder of iterator
     # to be refined in derived classes
+    #
     concat = function() {
       .NotYetImplemented()
     }
@@ -47,12 +62,15 @@ ReadIter <- R6::R6Class(
   private = list(
 
     # Internal 'external pointer' object used for iterated reads
+    #
     soma_reader_pointer = NULL,
 
     # to be refined in derived classes
+    #
     soma_reader_transform = function(x) .NotYetImplemented(),
 
     # Internal `read_next()` to avoid `self$read_complete()` checks
+    #
     .read_next = function() {
       if (is.null(private$soma_reader_pointer)) {
         return(NULL)
@@ -62,6 +80,7 @@ ReadIter <- R6::R6Class(
     },
 
     # Throw a warning for read completion
+    #
     .readComplete = function() {
       warning(warningCondition(
         "Iteration complete, returning NULL",

--- a/apis/r/R/ReadIter.R
+++ b/apis/r/R/ReadIter.R
@@ -1,6 +1,6 @@
 #' SOMA Read Iterator Base class
 #'
-#' Virtual class that allows for read iteration of SOMA reads
+#' Virtual class that allows for read iteration of SOMA reads.
 #'
 #' @keywords internal
 #'
@@ -14,16 +14,16 @@ ReadIter <- R6::R6Class(
   classname = "ReadIter",
   public = list(
 
-    #' @description Create (lifecycle: maturing)
+    #' @description Create (lifecycle: maturing).
     #'
-    #' @param sr soma read pointer
+    #' @param sr soma read pointer.
     #'
     initialize = function(sr) {
       private$soma_reader_pointer <- sr
     },
 
     #' @description @description Check if iterated read is complete or not
-    #' (lifecycle: maturing)
+    #' (lifecycle: maturing).
     #'
     #' @return logical
     #'
@@ -36,10 +36,10 @@ ReadIter <- R6::R6Class(
     },
 
     #' @description Read the next chunk of an iterated read. If read is
-    #' complete, returns \code{NULL} and raises warning (lifecycle: maturing)
+    #' complete, returns \code{NULL} and raises warning (lifecycle: maturing).
     #'
     #' @return \code{NULL} or one of \link[arrow:Table]{arrow::Table},
-    #' \link{matrixZeroBasedView}
+    #' \link{matrixZeroBasedView}.
     #'
     read_next = function() {
       if (is.null(private$soma_reader_pointer)) {
@@ -52,7 +52,7 @@ ReadIter <- R6::R6Class(
       return(private$.read_next())
     },
 
-    #' @description  Concatenate remainder of iterator
+    #' @description  Concatenate remainder of iterator.
     # to be refined in derived classes
     #
     concat = function() {

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -1,7 +1,7 @@
 #' SOMA Read Iterator Over Sparse Matrices
 #'
 #' @description \code{SparseReadIter} is a class that allows for iteration over
-#' a reads on \link{SOMASparseNDArray}
+#' a reads on \link{SOMASparseNDArray}.
 #'
 #' @export
 #'
@@ -28,11 +28,11 @@ SparseReadIter <- R6::R6Class(
   inherit = ReadIter,
   public = list(
 
-    #' @description Create (lifecycle: maturing)
+    #' @description Create (lifecycle: maturing).
     #'
-    #' @param sr Soma reader pointer
-    #' @param shape Shape of the full matrix
-    #' @param zero_based Logical, if TRUE will make iterator for
+    #' @param sr Soma reader pointer.
+    #' @param shape Shape of the full matrix.
+    #' @param zero_based Logical, if \code{TRUE} will make iterator for
     #' Matrix::\link[Matrix]{dgTMatrix-class}
     #' otherwise \link{matrixZeroBasedView}.
     #'
@@ -53,7 +53,7 @@ SparseReadIter <- R6::R6Class(
 
     #' @description  Concatenate remainder of iterator.
     #'
-    #' @return \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}
+    #' @return \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
     #'
     concat = function() soma_array_to_sparse_matrix_concat(
       self,

--- a/apis/r/R/SparseReadIter.R
+++ b/apis/r/R/SparseReadIter.R
@@ -1,21 +1,41 @@
-#' SparseReadIter
+#' SOMA Read Iterator Over Sparse Matrices
 #'
-#' @description
-#' \code{SparseReadIter} is a class that allows for iteration over
-#'  a reads on \link{SOMASparseNDArray}.
-#' Iteration chunks are retrieved as 0-based Views \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
+#' @description \code{SparseReadIter} is a class that allows for iteration over
+#' a reads on \link{SOMASparseNDArray}
+#'
 #' @export
-
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "matrix-iter")
+#' dir.create(dir, recursive = TRUE)
+#' (exp <- load_dataset("soma-exp-pbmc-small", dir))
+#' qry <- exp$axis_query("RNA")
+#' xqry <- qry$X("data")
+#'
+#' iter <- xqry$sparse_matrix()
+#' stopifnot(inherits(iter, "SparseReadIter"))
+#'
+#' while (!iter$read_complete()) {
+#'   block <- iter$read_next()
+#' }
+#'
+#' \dontshow{
+#' exp$close()
+#' }
+#'
 SparseReadIter <- R6::R6Class(
   classname = "SparseReadIter",
   inherit = ReadIter,
   public = list(
 
     #' @description Create (lifecycle: maturing)
+    #'
     #' @param sr Soma reader pointer
     #' @param shape Shape of the full matrix
-    #' @param zero_based Logical, if TRUE will make iterator for Matrix::\link[Matrix]{dgTMatrix-class}
+    #' @param zero_based Logical, if TRUE will make iterator for
+    #' Matrix::\link[Matrix]{dgTMatrix-class}
     #' otherwise \link{matrixZeroBasedView}.
+    #'
     initialize = function(sr, shape, zero_based = FALSE) {
       # TODO implement zero_based argument, currently doesn't do anything
       stopifnot(
@@ -32,15 +52,21 @@ SparseReadIter <- R6::R6Class(
     },
 
     #' @description  Concatenate remainder of iterator.
+    #'
     #' @return \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}
-    concat = function() soma_array_to_sparse_matrix_concat(self, private$zero_based)
+    #'
+    concat = function() soma_array_to_sparse_matrix_concat(
+      self,
+      private$zero_based
+    )
   ),
   private = list(
     repr = NULL,
     shape = NULL,
     zero_based = NULL,
 
-    ## refined from base class
+    # refined from base class
+    #
     soma_reader_transform = function(x) {
       return(arrow_table_to_sparse(
         soma_array_to_arrow_table(x),

--- a/apis/r/R/TableReadIter.R
+++ b/apis/r/R/TableReadIter.R
@@ -1,21 +1,42 @@
-#' SOMA Read Iterator over Arrow Table
+#' SOMA Read Iterator Over Arrow Tables
 #'
-#' @description
-#' `TableReadIter` is a class that allows for iteration over
-#'  a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
-#' Iteration chunks are retrieved as arrow::\link[arrow]{Table}
+#' @description \code{TableReadIter} is a class that allows for iteration over
+#' a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
+#' Iteration chunks are retrieved as an Arrow \link[arrow]{Table}
+#'
 #' @export
-
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "table-iter")
+#' dir.create(dir, recursive = TRUE)
+#' (exp <- load_dataset("soma-exp-pbmc-small", dir))
+#' qry <- exp$axis_query("RNA")
+#' xqry <- qry$X("data")
+#'
+#' iter <- xqry$tables()
+#' stopifnot(inherits(iter, "TableReadIter"))
+#'
+#' while (!iter$read_complete()) {
+#'   block <- iter$read_next()
+#' }
+#'
+#' \dontshow{
+#' exp$close()
+#' }
+#'
 TableReadIter <- R6::R6Class(
   classname = "TableReadIter",
   inherit = ReadIter,
   public = list(
-    #' @description  Concatenate remainder of iterator.
-    #' @return arrow::\link[arrow]{Table}
+    #' @description  Concatenate remainder of iterator
+    #'
+    #' @return An Arrow \code{\link[arrow:Table]{Table}}
+    #'
     concat = function() soma_array_to_arrow_table_concat(self)
   ),
   private = list(
-    ## refined from base class
+    # refined from base class
+    #
     soma_reader_transform = function(x) {
       at <- soma_array_to_arrow_table(x)
       at

--- a/apis/r/R/TableReadIter.R
+++ b/apis/r/R/TableReadIter.R
@@ -2,7 +2,7 @@
 #'
 #' @description \code{TableReadIter} is a class that allows for iteration over
 #' a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
-#' Iteration chunks are retrieved as an Arrow \link[arrow]{Table}
+#' Iteration chunks are retrieved as an Arrow \link[arrow]{Table}.
 #'
 #' @export
 #'
@@ -28,9 +28,9 @@ TableReadIter <- R6::R6Class(
   classname = "TableReadIter",
   inherit = ReadIter,
   public = list(
-    #' @description  Concatenate remainder of iterator
+    #' @description  Concatenate remainder of iterator.
     #'
-    #' @return An Arrow \code{\link[arrow:Table]{Table}}
+    #' @return An Arrow \code{\link[arrow:Table]{Table}}.
     #'
     concat = function() soma_array_to_arrow_table_concat(self)
   ),

--- a/apis/r/man/BlockwiseReadIterBase.Rd
+++ b/apis/r/man/BlockwiseReadIterBase.Rd
@@ -4,7 +4,8 @@
 \alias{BlockwiseReadIterBase}
 \title{SOMA Blockwise Read Iterator Base Class}
 \description{
-Class that allows for blockwise read iteration of SOMA reads
+Virtual base class that allows for blockwise read iteration of
+SOMA reads.
 }
 \seealso{
 Derived classes: \code{\link{BlockwiseTableReadIter}},
@@ -17,20 +18,21 @@ Derived classes: \code{\link{BlockwiseTableReadIter}},
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{array}}{The underlying SOMA array}
+\item{\code{array}}{The underlying SOMA array.}
 
-\item{\code{axis}}{The axis to iterate over in a blockwise fashion}
+\item{\code{axis}}{The axis to iterate over in a blockwise fashion.}
 
-\item{\code{axes_to_reindex}}{The axes to re-index}
+\item{\code{axes_to_reindex}}{The axes to re-index.}
 
-\item{\code{coords}}{A list of \code{\link{CoordsStrider}} objects}
+\item{\code{coords}}{A list of \code{\link{CoordsStrider}} objects.}
 
-\item{\code{coords_axis}}{The \code{\link{CoordsStrider}} for \code{axis}}
+\item{\code{coords_axis}}{The \code{\link{CoordsStrider}} for \code{axis}.}
 
-\item{\code{reindex_disable_on_axis}}{Additional axes that will not be re-indexed}
+\item{\code{reindex_disable_on_axis}}{Additional axes that will not be
+re-indexed.}
 
 \item{\code{reindexable}}{Shorthand to see if this iterator is poised to be
-re-indexed or not}
+re-indexed or not.}
 }
 \if{html}{\out{</div>}}
 }
@@ -54,7 +56,7 @@ re-indexed or not}
 \if{html}{\out{<a id="method-BlockwiseReadIterBase-new"></a>}}
 \if{latex}{\out{\hypertarget{method-BlockwiseReadIterBase-new}{}}}
 \subsection{Method \code{new()}}{
-Create
+Create.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseReadIterBase$new(
   sr,
@@ -97,13 +99,13 @@ disable re-indexing
 \if{html}{\out{<a id="method-BlockwiseReadIterBase-read_complete"></a>}}
 \if{latex}{\out{\hypertarget{method-BlockwiseReadIterBase-read_complete}{}}}
 \subsection{Method \code{read_complete()}}{
-Check if the iterated read is complete or not
+Check if the iterated read is complete or not.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseReadIterBase$read_complete()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-\code{TRUE} if read is complete, otherwise \code{FALSE}
+\code{TRUE} if read is complete, otherwise \code{FALSE}.
 }
 }
 \if{html}{\out{<hr>}}
@@ -112,13 +114,13 @@ Check if the iterated read is complete or not
 \subsection{Method \code{read_next()}}{
 Read the next chunk of the iterated read. If read
 is complete, throws an \code{iterationCompleteWarning} warning and
-returns \code{NULL}
+returns \code{NULL}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseReadIterBase$read_next()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-\code{NULL} or the next blockwise chunk of the iterated read
+\code{NULL} or the next blockwise chunk of the iterated read.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/BlockwiseReadIterBase.Rd
+++ b/apis/r/man/BlockwiseReadIterBase.Rd
@@ -6,6 +6,10 @@
 \description{
 Class that allows for blockwise read iteration of SOMA reads
 }
+\seealso{
+Derived classes: \code{\link{BlockwiseTableReadIter}},
+\code{\link{BlockwiseSparseReadIter}}
+}
 \keyword{internal}
 \section{Super class}{
 \code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{BlockwiseReadIterBase}

--- a/apis/r/man/BlockwiseSparseReadIter.Rd
+++ b/apis/r/man/BlockwiseSparseReadIter.Rd
@@ -7,6 +7,26 @@
 Class that allows for blockwise read iteration of SOMA reads
 as sparse matrices
 }
+\examples{
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "blockwise-matrix")
+dir.create(dir, recursive = TRUE)
+(exp <- load_dataset("soma-exp-pbmc-small", dir))
+qry <- exp$axis_query("RNA")
+xqry <- qry$X("data")
+
+iter <- xqry$blockwise(0L, size = 20L, reindex_disable_on_axis = TRUE)$sparse_matrix()
+stopifnot(inherits(iter, "BlockwiseSparseReadIter"))
+
+while (!iter$read_complete()) {
+  block <- iter$read_next()
+}
+
+\dontshow{
+exp$close()
+}
+\dontshow{\}) # examplesIf}
+}
 \keyword{internal}
 \section{Super classes}{
 \code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseSparseReadIter}

--- a/apis/r/man/BlockwiseSparseReadIter.Rd
+++ b/apis/r/man/BlockwiseSparseReadIter.Rd
@@ -5,7 +5,7 @@
 \title{SOMA Blockwise Read Iterator for Sparse Matrices}
 \description{
 Class that allows for blockwise read iteration of SOMA reads
-as sparse matrices
+as sparse matrices.
 }
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -34,7 +34,7 @@ exp$close()
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{repr}}{Representation of the sparse matrix to return}
+\item{\code{repr}}{Representation of the sparse matrix to return.}
 }
 \if{html}{\out{</div>}}
 }
@@ -58,7 +58,7 @@ exp$close()
 \if{html}{\out{<a id="method-BlockwiseSparseReadIter-new"></a>}}
 \if{latex}{\out{\hypertarget{method-BlockwiseSparseReadIter-new}{}}}
 \subsection{Method \code{new()}}{
-Create
+Create.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseSparseReadIter$new(
   sr,
@@ -115,14 +115,14 @@ disable re-indexing
 \if{html}{\out{<a id="method-BlockwiseSparseReadIter-concat"></a>}}
 \if{latex}{\out{\hypertarget{method-BlockwiseSparseReadIter-concat}{}}}
 \subsection{Method \code{concat()}}{
-Concatenate the remainder of the blockwise iterator
+Concatenate the remainder of the blockwise iterator.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseSparseReadIter$concat()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
 A sparse matrix (determined by \code{self$repr}) with
-the remainder of the iterator
+the remainder of the iterator.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/BlockwiseTableReadIter.Rd
+++ b/apis/r/man/BlockwiseTableReadIter.Rd
@@ -7,6 +7,26 @@
 Class that allows for blockwise read iteration of SOMA reads
 as Arrow \code{\link[arrow]{Table}s}
 }
+\examples{
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "blockwise-table")
+dir.create(dir, recursive = TRUE)
+(exp <- load_dataset("soma-exp-pbmc-small", dir))
+qry <- exp$axis_query("RNA")
+xqry <- qry$X("data")
+
+iter <- xqry$blockwise(0L, size = 20L, reindex_disable_on_axis = TRUE)$tables()
+stopifnot(inherits(iter, "BlockwiseTableReadIter"))
+
+while (!iter$read_complete()) {
+  block <- iter$read_next()
+}
+
+\dontshow{
+exp$close()
+}
+\dontshow{\}) # examplesIf}
+}
 \keyword{internal}
 \section{Super classes}{
 \code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{\link[tiledbsoma:BlockwiseReadIterBase]{tiledbsoma::BlockwiseReadIterBase}} -> \code{BlockwiseTableReadIter}

--- a/apis/r/man/BlockwiseTableReadIter.Rd
+++ b/apis/r/man/BlockwiseTableReadIter.Rd
@@ -5,7 +5,7 @@
 \title{SOMA Blockwise Read Iterator for Arrow Tables}
 \description{
 Class that allows for blockwise read iteration of SOMA reads
-as Arrow \code{\link[arrow]{Table}s}
+as Arrow \code{\link[arrow]{Table}s}.
 }
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -51,13 +51,13 @@ exp$close()
 \if{html}{\out{<a id="method-BlockwiseTableReadIter-concat"></a>}}
 \if{latex}{\out{\hypertarget{method-BlockwiseTableReadIter-concat}{}}}
 \subsection{Method \code{concat()}}{
-Concatenate the remainder of the blockwise iterator
+Concatenate the remainder of the blockwise iterator.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BlockwiseTableReadIter$concat()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-An Arrow Table with the remainder of the iterator
+An Arrow Table with the remainder of the iterator.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/ReadIter.Rd
+++ b/apis/r/man/ReadIter.Rd
@@ -9,7 +9,7 @@ SOMA Read Iterator Base class
 SOMA Read Iterator Base class
 }
 \details{
-Virtual class that allows for read iteration of SOMA reads
+Virtual class that allows for read iteration of SOMA reads.
 }
 \seealso{
 \code{\link{BlockwiseReadIterBase}},
@@ -31,7 +31,7 @@ Virtual class that allows for read iteration of SOMA reads
 \if{html}{\out{<a id="method-ReadIter-new"></a>}}
 \if{latex}{\out{\hypertarget{method-ReadIter-new}{}}}
 \subsection{Method \code{new()}}{
-Create (lifecycle: maturing)
+Create (lifecycle: maturing).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$new(sr)}\if{html}{\out{</div>}}
 }
@@ -39,7 +39,7 @@ Create (lifecycle: maturing)
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{sr}}{soma read pointer}
+\item{\code{sr}}{soma read pointer.}
 }
 \if{html}{\out{</div>}}
 }
@@ -49,7 +49,7 @@ Create (lifecycle: maturing)
 \if{latex}{\out{\hypertarget{method-ReadIter-read_complete}{}}}
 \subsection{Method \code{read_complete()}}{
 @description Check if iterated read is complete or not
-(lifecycle: maturing)
+(lifecycle: maturing).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$read_complete()}\if{html}{\out{</div>}}
 }
@@ -63,21 +63,21 @@ logical
 \if{latex}{\out{\hypertarget{method-ReadIter-read_next}{}}}
 \subsection{Method \code{read_next()}}{
 Read the next chunk of an iterated read. If read is
-complete, returns \code{NULL} and raises warning (lifecycle: maturing)
+complete, returns \code{NULL} and raises warning (lifecycle: maturing).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$read_next()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
 \code{NULL} or one of \link[arrow:Table]{arrow::Table},
-\link{matrixZeroBasedView}
+\link{matrixZeroBasedView}.
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ReadIter-concat"></a>}}
 \if{latex}{\out{\hypertarget{method-ReadIter-concat}{}}}
 \subsection{Method \code{concat()}}{
-Concatenate remainder of iterator
+Concatenate remainder of iterator.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$concat()}\if{html}{\out{</div>}}
 }

--- a/apis/r/man/ReadIter.Rd
+++ b/apis/r/man/ReadIter.Rd
@@ -9,7 +9,12 @@ SOMA Read Iterator Base class
 SOMA Read Iterator Base class
 }
 \details{
-Class that allows for read iteration of SOMA reads.
+Virtual class that allows for read iteration of SOMA reads
+}
+\seealso{
+\code{\link{BlockwiseReadIterBase}},
+\code{\link{SparseReadIter}},
+\code{\link{TableReadIter}}
 }
 \keyword{internal}
 \section{Methods}{
@@ -43,7 +48,8 @@ Create (lifecycle: maturing)
 \if{html}{\out{<a id="method-ReadIter-read_complete"></a>}}
 \if{latex}{\out{\hypertarget{method-ReadIter-read_complete}{}}}
 \subsection{Method \code{read_complete()}}{
-Check if iterated read is complete or not. (lifecycle: maturing)
+@description Check if iterated read is complete or not
+(lifecycle: maturing)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$read_complete()}\if{html}{\out{</div>}}
 }
@@ -56,14 +62,15 @@ logical
 \if{html}{\out{<a id="method-ReadIter-read_next"></a>}}
 \if{latex}{\out{\hypertarget{method-ReadIter-read_next}{}}}
 \subsection{Method \code{read_next()}}{
-Read the next chunk of an iterated read. (lifecycle: maturing).
-If read is complete, retunrs \code{NULL} and raises warning.
+Read the next chunk of an iterated read. If read is
+complete, returns \code{NULL} and raises warning (lifecycle: maturing)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ReadIter$read_next()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-\code{NULL} or one of arrow::\link[arrow]{Table}, \link{matrixZeroBasedView}
+\code{NULL} or one of \link[arrow:Table]{arrow::Table},
+\link{matrixZeroBasedView}
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/SparseReadIter.Rd
+++ b/apis/r/man/SparseReadIter.Rd
@@ -2,11 +2,30 @@
 % Please edit documentation in R/SparseReadIter.R
 \name{SparseReadIter}
 \alias{SparseReadIter}
-\title{SparseReadIter}
+\title{SOMA Read Iterator Over Sparse Matrices}
 \description{
 \code{SparseReadIter} is a class that allows for iteration over
-a reads on \link{SOMASparseNDArray}.
-Iteration chunks are retrieved as 0-based Views \link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
+a reads on \link{SOMASparseNDArray}
+}
+\examples{
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "matrix-iter")
+dir.create(dir, recursive = TRUE)
+(exp <- load_dataset("soma-exp-pbmc-small", dir))
+qry <- exp$axis_query("RNA")
+xqry <- qry$X("data")
+
+iter <- xqry$sparse_matrix()
+stopifnot(inherits(iter, "SparseReadIter"))
+
+while (!iter$read_complete()) {
+  block <- iter$read_next()
+}
+
+\dontshow{
+exp$close()
+}
+\dontshow{\}) # examplesIf}
 }
 \section{Super class}{
 \code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{SparseReadIter}
@@ -43,7 +62,8 @@ Create (lifecycle: maturing)
 
 \item{\code{shape}}{Shape of the full matrix}
 
-\item{\code{zero_based}}{Logical, if TRUE will make iterator for Matrix::\link[Matrix]{dgTMatrix-class}
+\item{\code{zero_based}}{Logical, if TRUE will make iterator for
+Matrix::\link[Matrix]{dgTMatrix-class}
 otherwise \link{matrixZeroBasedView}.}
 }
 \if{html}{\out{</div>}}

--- a/apis/r/man/SparseReadIter.Rd
+++ b/apis/r/man/SparseReadIter.Rd
@@ -5,7 +5,7 @@
 \title{SOMA Read Iterator Over Sparse Matrices}
 \description{
 \code{SparseReadIter} is a class that allows for iteration over
-a reads on \link{SOMASparseNDArray}
+a reads on \link{SOMASparseNDArray}.
 }
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -50,7 +50,7 @@ exp$close()
 \if{html}{\out{<a id="method-SparseReadIter-new"></a>}}
 \if{latex}{\out{\hypertarget{method-SparseReadIter-new}{}}}
 \subsection{Method \code{new()}}{
-Create (lifecycle: maturing)
+Create (lifecycle: maturing).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SparseReadIter$new(sr, shape, zero_based = FALSE)}\if{html}{\out{</div>}}
 }
@@ -58,11 +58,11 @@ Create (lifecycle: maturing)
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{sr}}{Soma reader pointer}
+\item{\code{sr}}{Soma reader pointer.}
 
-\item{\code{shape}}{Shape of the full matrix}
+\item{\code{shape}}{Shape of the full matrix.}
 
-\item{\code{zero_based}}{Logical, if TRUE will make iterator for
+\item{\code{zero_based}}{Logical, if \code{TRUE} will make iterator for
 Matrix::\link[Matrix]{dgTMatrix-class}
 otherwise \link{matrixZeroBasedView}.}
 }
@@ -79,7 +79,7 @@ Concatenate remainder of iterator.
 }
 
 \subsection{Returns}{
-\link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}
+\link{matrixZeroBasedView} of Matrix::\link[Matrix]{sparseMatrix}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/TableReadIter.Rd
+++ b/apis/r/man/TableReadIter.Rd
@@ -6,7 +6,7 @@
 \description{
 \code{TableReadIter} is a class that allows for iteration over
 a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
-Iteration chunks are retrieved as an Arrow \link[arrow]{Table}
+Iteration chunks are retrieved as an Arrow \link[arrow]{Table}.
 }
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -51,13 +51,13 @@ exp$close()
 \if{html}{\out{<a id="method-TableReadIter-concat"></a>}}
 \if{latex}{\out{\hypertarget{method-TableReadIter-concat}{}}}
 \subsection{Method \code{concat()}}{
-Concatenate remainder of iterator
+Concatenate remainder of iterator.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableReadIter$concat()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-An Arrow \code{\link[arrow:Table]{Table}}
+An Arrow \code{\link[arrow:Table]{Table}}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/TableReadIter.Rd
+++ b/apis/r/man/TableReadIter.Rd
@@ -2,11 +2,31 @@
 % Please edit documentation in R/TableReadIter.R
 \name{TableReadIter}
 \alias{TableReadIter}
-\title{SOMA Read Iterator over Arrow Table}
+\title{SOMA Read Iterator Over Arrow Tables}
 \description{
 \code{TableReadIter} is a class that allows for iteration over
 a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
-Iteration chunks are retrieved as arrow::\link[arrow]{Table}
+Iteration chunks are retrieved as an Arrow \link[arrow]{Table}
+}
+\examples{
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "table-iter")
+dir.create(dir, recursive = TRUE)
+(exp <- load_dataset("soma-exp-pbmc-small", dir))
+qry <- exp$axis_query("RNA")
+xqry <- qry$X("data")
+
+iter <- xqry$tables()
+stopifnot(inherits(iter, "TableReadIter"))
+
+while (!iter$read_complete()) {
+  block <- iter$read_next()
+}
+
+\dontshow{
+exp$close()
+}
+\dontshow{\}) # examplesIf}
 }
 \section{Super class}{
 \code{\link[tiledbsoma:ReadIter]{tiledbsoma::ReadIter}} -> \code{TableReadIter}
@@ -31,13 +51,13 @@ Iteration chunks are retrieved as arrow::\link[arrow]{Table}
 \if{html}{\out{<a id="method-TableReadIter-concat"></a>}}
 \if{latex}{\out{\hypertarget{method-TableReadIter-concat}{}}}
 \subsection{Method \code{concat()}}{
-Concatenate remainder of iterator.
+Concatenate remainder of iterator
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableReadIter$concat()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-arrow::\link[arrow]{Table}
+An Arrow \code{\link[arrow:Table]{Table}}
 }
 }
 \if{html}{\out{<hr>}}


### PR DESCRIPTION
Add examples for the following objects:

 - `BlockwiseSparseReadIter`
 - `BlockwiseTableReadIter`
 - `SparseReadIter`
 - `TableReadIter`

Add links from the following ABCs to real classes:

 - `ReadIter` ABC
 - `BlockwiseReadIterBase` ABC

Note for reviewers: the `#' @examplesIf` construct allows conditional examples; this is used as
 - CRAN requires all docs that write to disk to write to a temporary directory
 - CRAN requires that all temporary directories be cleaned up
 - withr handles the temporary directory management, but I don't want to take a hard dependency on it
 - `#' @examplesIf` allows the examples to run if and only if the conditions are met (eg. withr is installed)

Fixes [SOMA-210](https://linear.app/tiledb/issue/SOMA-210/add-examples-for-read-iterators)

Partially replaces #4075 