### PR TITLE
[r] Add examples for mapping types

### DIFF
--- a/apis/r/R/ConfigList.R
+++ b/apis/r/R/ConfigList.R
@@ -9,6 +9,12 @@
 #'
 #' @noMd
 #'
+#' @examples
+#' (cfg <- ConfigList$new())
+#' cfg$set("op1", "a", 1L)
+#' cfg
+#' cfg$get("op1")
+#'
 ConfigList <- R6::R6Class(
   classname = "ConfigList",
   inherit = MappingBase,
@@ -39,6 +45,7 @@ ConfigList <- R6::R6Class(
       }
       return(parammap$get(key = key, default = default))
     },
+
     #' @param param Outer key or \dQuote{parameter} to set
     #' @param key Inner key to set
     #' @param value Value to add for \code{key}, or \code{NULL} to remove
@@ -49,6 +56,7 @@ ConfigList <- R6::R6Class(
     #'
     #' @return \[chainable\] Invisibly returns \code{self} with \code{value}
     #' added for \code{key} in \code{param}
+    #'
     set = function(param, key, value) {
       stopifnot(
         "'param' must be a single character" = is_scalar_character(param)
@@ -63,6 +71,7 @@ ConfigList <- R6::R6Class(
       super$set(key = param, value = parammap)
       return(invisible(self))
     },
+
     #' @template param-dots-ignored
     #'
     #' @return Nothing; \code{setv()} is disabled for \code{ConfigList} objects

--- a/apis/r/R/MappingBase.R
+++ b/apis/r/R/MappingBase.R
@@ -5,15 +5,22 @@
 #' getting (\code{self$get()}) and setting (\code{self$set()}) items in the map
 #'
 #' @keywords internal
+#'
 #' @export
-
+#'
+#' @seealso Derived classes: \code{\link{ConfigList}},
+#' \code{\link{PlatformConfig}},
+#' \code{\link{ScalarMap}},
+#' \code{\link{TileDBCreateOptions}}
+#'
 MappingBase <- R6::R6Class(
   classname = "MappingBase",
   lock_class = TRUE,
   public = list(
     #' @param ... Ignored
     #'
-    #' @return This is a \strong{virtual} class and cannot be directly instantiated
+    #' @return This is a \strong{virtual} class and cannot be
+    #' directly instantiated
     #'
     initialize = function(...) {
       calls <- vapply_char(
@@ -29,21 +36,25 @@ MappingBase <- R6::R6Class(
       }
       private$.data <- list()
     },
+
     #' @return The keys of the map
     #'
     keys = function() {
       return(names(private$.data))
     },
+
     #' @return A `list` containing the map values
     #'
     values = function() {
       return(unname(self$items()))
     },
+
     #' @return Return the items of the map as a list
     #'
     items = function() {
       return(private$.data)
     },
+
     #' @param key Key to fetch
     #' @templateVar key key
     #' @templateVar default NULL
@@ -65,6 +76,7 @@ MappingBase <- R6::R6Class(
       }
       return(value)
     },
+
     #' @param key Key to set
     #' @templateVar key key
     #' @template param-value
@@ -83,6 +95,7 @@ MappingBase <- R6::R6Class(
       }
       return(invisible(self))
     },
+
     #' @param ... Named arguments to add to \code{self}
     #'
     #' @return \[chainable\] Invisibly returns \code{self} with the values
@@ -96,6 +109,7 @@ MappingBase <- R6::R6Class(
       }
       return(invisible(self))
     },
+
     #' @param key Key to remove
     #'
     #' @return \[chainable\] Invisibly returns \code{self} with \code{key}
@@ -105,6 +119,7 @@ MappingBase <- R6::R6Class(
       self$set(key = key, value = NULL)
       return(invisible(self))
     },
+
     #' @param map A mapping type to update the current map with
     #'
     #' @return \[chainable\] Invisibly returns \code{self} with the value
@@ -117,16 +132,19 @@ MappingBase <- R6::R6Class(
       self$setv(map$items())
       return(invisible(self))
     },
+
     #' @return The number of items in the map
     #'
     length = function() {
       return(length(private$.data))
     },
+
     #' @return The map as a list
     #'
     to_list = function() {
       return(self$items())
     },
+
     #' @return \[chainable\] Prints information about the map to \code{stdout}
     #' and invisibly returns \code{self}
     #'

--- a/apis/r/R/PlatformConfig.R
+++ b/apis/r/R/PlatformConfig.R
@@ -10,6 +10,14 @@
 #'
 #' @noMd
 #'
+#' @examples
+#' (cfg <- PlatformConfig$new())
+#' cfg$set("plat1", "op1", "a", 1L)
+#' cfg
+#'
+#' cfg$get("plat1")
+#' cfg$get("plat1")$get("op1")
+#'
 PlatformConfig <- R6::R6Class(
   classname = "PlatformConfig",
   inherit = MappingBase,
@@ -47,6 +55,7 @@ PlatformConfig <- R6::R6Class(
       platform <- match.arg(arg = platform, choices = self$platforms())
       return(super$get(key = platform)$keys())
     },
+
     #' @param platform The name of the \dQuote{platform} (outer key) to fetch
     #' @param param The name of the \dQuote{paramters} of \code{platform}
     #' to fetch; if \code{NULL}, returns the
@@ -89,6 +98,7 @@ PlatformConfig <- R6::R6Class(
       }
       return(pmap$get(param = param, key = key, default = default))
     },
+
     #' @param platform The name of the \dQuote{platform} (outer key) to fetch
     #'
     #' @return The \code{\link{ConfigList}} for \code{platform}
@@ -102,6 +112,7 @@ PlatformConfig <- R6::R6Class(
       platform <- match.arg(arg = platform, choices = self$platforms())
       return(super$get(platform))
     },
+
     #' @param platform The name of the \dQuote{platform} (outer key) to set
     #' @param param Name of the \dQuote{parameter} (middle key) in
     #' \code{platform} to set
@@ -125,6 +136,7 @@ PlatformConfig <- R6::R6Class(
       super$set(key = platform, value = pmap)
       return(invisible(self))
     },
+
     #' @template param-dots-ignored
     #'
     #' @return Nothing; \code{setv()} is disabled for

--- a/apis/r/R/SOMAContextBase.R
+++ b/apis/r/R/SOMAContextBase.R
@@ -1,12 +1,15 @@
 #' Base SOMA Context
 #'
-#' R6 mapping class for SOMA context options. This class should be used
+#' Virtual R6 mapping class for SOMA context options. This class should be used
 #' as the basis for platform-specific contexts as it checks SOMA-specific
 #' context options
 #'
 #' @keywords internal
+#'
 #' @export
-
+#'
+#' @seealso Derived classes: \code{\link{SOMATileDBContext}}
+#'
 SOMAContextBase <- R6::R6Class(
   classname = "SOMAContextBase",
   inherit = ScalarMap,
@@ -43,6 +46,7 @@ SOMAContextBase <- R6::R6Class(
         self$setv(config)
       }
     },
+
     #' @param key Key to set
     #' @templateVar key key
     #' @template param-value

--- a/apis/r/R/SOMATileDBContext.R
+++ b/apis/r/R/SOMATileDBContext.R
@@ -3,7 +3,13 @@
 #' Context map for TileDB-backed SOMA objects
 #'
 #' @export
-
+#'
+#' @examplesIf requireNamespace("tiledb", quietly = TRUE)
+#' (ctx <- SOMATileDBContext$new())
+#' ctx$get("sm.mem.reader.sparse_global_order.ratio_array_data")
+#'
+#' ctx$to_tiledb_context()
+#'
 SOMATileDBContext <- R6::R6Class(
   classname = "SOMATileDBContext",
   inherit = SOMAContextBase,
@@ -39,21 +45,25 @@ SOMATileDBContext <- R6::R6Class(
       }
       private$.tiledb_ctx <- tiledb::tiledb_ctx(config = cfg, cached = cached)
     },
+
     #' @return The keys of the map
     #'
     keys = function() {
       return(c(super$keys(), private$.tiledb_ctx_names()))
     },
+
     #' @return Return the items of the map as a list
     #'
     items = function() {
       return(c(super$items(), as.list(tiledb::config(object = private$.tiledb_ctx))))
     },
+
     #' @return The number of items in the map
     #'
     length = function() {
       return(super$length() + length(private$.tiledb_ctx_names()))
     },
+
     #' @param key Key to fetch
     #' @templateVar key key
     #' @templateVar default NULL
@@ -73,6 +83,7 @@ SOMATileDBContext <- R6::R6Class(
       }
       return(super$get(key = key, default = default))
     },
+
     #' @param key Key to set
     #' @templateVar key key
     #' @template param-value
@@ -94,6 +105,7 @@ SOMATileDBContext <- R6::R6Class(
       }
       return(invisible(self))
     },
+
     #' @return A \code{\link[tiledb:tiledb_ctx]{tiledb_ctx}} object, dynamically
     #' constructed. Most useful for the constructor of this class.
     #'
@@ -106,8 +118,10 @@ SOMATileDBContext <- R6::R6Class(
       tiledb_ctx <- tiledb::tiledb_ctx(cfg)
       return(tiledb_ctx)
     },
+
     #' @return A \code{\link[tiledb:tiledb_ctx]{tiledb_ctx}} object, which is
     #' a stored (and long-lived) result from \code{to_tiledb_context}.
+    #'
     context = function() {
       return(private$.tiledb_ctx)
     }

--- a/apis/r/R/ScalarMap.R
+++ b/apis/r/R/ScalarMap.R
@@ -5,8 +5,17 @@
 #' (eg. \dQuote{\code{logical}}).
 #'
 #' @keywords internal
+#'
 #' @export
-
+#'
+#' @examples
+#' (map <- ScalarMap$new())
+#' map$set("a", 1L)
+#' map
+#'
+#' map$get("a")
+#' map$get("b", default = NULL)
+#'
 ScalarMap <- R6::R6Class(
   classname = "ScalarMap",
   inherit = MappingBase,
@@ -26,6 +35,7 @@ ScalarMap <- R6::R6Class(
     initialize = function(type = "any") {
       private$.type <- match.arg(arg = type, choices = .SCALAR_TYPES())
     },
+
     #' @param key Key to set
     #' @templateVar key key
     #' @template param-value

--- a/apis/r/R/TileDBCreateOptions.R
+++ b/apis/r/R/TileDBCreateOptions.R
@@ -53,6 +53,13 @@
 #'
 #' @noMd
 #'
+#' @examples
+#' (cfg <- PlatformConfig$new())
+#' (tdco <- TileDBCreateOptions$new(cfg))
+#' tdco$cell_tile_orders()
+#' tdco$to_list()
+#' tdco$to_list(build_filters = FALSE)
+#'
 TileDBCreateOptions <- R6::R6Class(
   classname = "TileDBCreateOptions",
   inherit = MappingBase,
@@ -82,8 +89,8 @@ TileDBCreateOptions <- R6::R6Class(
     },
 
     #' @description Returns the cell and tile orders that should be used.
-    #' If neither \code{cell_order} nor \code{tile_order} is present, only in this
-    #' case will we use the default values provided.
+    #' If neither \code{cell_order} nor \code{tile_order} is present, only in
+    #' this case will we use the default values provided.
     #
     #' @return A two-length character vector with names of
     #' \dQuote{\code{cell_order}} and \dQuote{\code{tile_order}}

--- a/apis/r/man/ConfigList.Rd
+++ b/apis/r/man/ConfigList.Rd
@@ -9,6 +9,13 @@ Essentially, serves as a nested map where the inner map is a
 \code{\link{ScalarMap}}:
 \code{\{<param>: \link[tiledbsoma:ScalarMap]{\{<key>: <value>\}}\}}
 }
+\examples{
+(cfg <- ConfigList$new())
+cfg$set("op1", "a", 1L)
+cfg
+cfg$get("op1")
+
+}
 \section{Super class}{
 \code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ConfigList}
 }

--- a/apis/r/man/MappingBase.Rd
+++ b/apis/r/man/MappingBase.Rd
@@ -50,6 +50,12 @@ Virtual base mapping type for R6 objects; defines internal data structure
 (\code{private$.data}) as a named list along with behavior methods for
 getting (\code{self$get()}) and setting (\code{self$set()}) items in the map
 }
+\seealso{
+Derived classes: \code{\link{ConfigList}},
+\code{\link{PlatformConfig}},
+\code{\link{ScalarMap}},
+\code{\link{TileDBCreateOptions}}
+}
 \keyword{internal}
 \section{Methods}{
 \subsection{Public methods}{
@@ -85,7 +91,8 @@ getting (\code{self$get()}) and setting (\code{self$set()}) items in the map
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-This is a \strong{virtual} class and cannot be directly instantiated
+This is a \strong{virtual} class and cannot be
+directly instantiated
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/PlatformConfig.Rd
+++ b/apis/r/man/PlatformConfig.Rd
@@ -10,6 +10,15 @@ map is a \code{\link{ScalarMap}} contained within a \code{\link{ConfigList}}
 (middle map):
 \code{\{platform: \{param: \{key: value\}\}\}}
 }
+\examples{
+(cfg <- PlatformConfig$new())
+cfg$set("plat1", "op1", "a", 1L)
+cfg
+
+cfg$get("plat1")
+cfg$get("plat1")$get("op1")
+
+}
 \section{Super class}{
 \code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{PlatformConfig}
 }

--- a/apis/r/man/SOMAContextBase.Rd
+++ b/apis/r/man/SOMAContextBase.Rd
@@ -4,9 +4,12 @@
 \alias{SOMAContextBase}
 \title{Base SOMA Context}
 \description{
-R6 mapping class for SOMA context options. This class should be used
+Virtual R6 mapping class for SOMA context options. This class should be used
 as the basis for platform-specific contexts as it checks SOMA-specific
 context options
+}
+\seealso{
+Derived classes: \code{\link{SOMATileDBContext}}
 }
 \keyword{internal}
 \section{Super classes}{

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -6,6 +6,14 @@
 \description{
 Context map for TileDB-backed SOMA objects
 }
+\examples{
+\dontshow{if (requireNamespace("tiledb", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+(ctx <- SOMATileDBContext$new())
+ctx$get("sm.mem.reader.sparse_global_order.ratio_array_data")
+
+ctx$to_tiledb_context()
+\dontshow{\}) # examplesIf}
+}
 \section{Super classes}{
 \code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{\link[tiledbsoma:ScalarMap]{tiledbsoma::ScalarMap}} -> \code{\link[tiledbsoma:SOMAContextBase]{tiledbsoma::SOMAContextBase}} -> \code{SOMATileDBContext}
 }

--- a/apis/r/man/ScalarMap.Rd
+++ b/apis/r/man/ScalarMap.Rd
@@ -8,6 +8,15 @@ An R6 mapping type that is limited to scalar atomic vector types only; can
 optionally be limited further to a specific atomic vector type
 (eg. \dQuote{\code{logical}}).
 }
+\examples{
+(map <- ScalarMap$new())
+map$set("a", 1L)
+map
+
+map$get("a")
+map$get("b", default = NULL)
+
+}
 \keyword{internal}
 \section{Super class}{
 \code{\link[tiledbsoma:MappingBase]{tiledbsoma::MappingBase}} -> \code{ScalarMap}

--- a/apis/r/man/TileDBCreateOptions.Rd
+++ b/apis/r/man/TileDBCreateOptions.Rd
@@ -11,6 +11,12 @@ Provides strongly-typed access and default values for
 Intended for internal use only.
 }
 \examples{
+(cfg <- PlatformConfig$new())
+(tdco <- TileDBCreateOptions$new(cfg))
+tdco$cell_tile_orders()
+tdco$to_list()
+tdco$to_list(build_filters = FALSE)
+
 
 ## ------------------------------------------------
 ## Method `TileDBCreateOptions$dim_tile`
@@ -122,8 +128,8 @@ object}
 \if{latex}{\out{\hypertarget{method-TileDBCreateOptions-cell_tile_orders}{}}}
 \subsection{Method \code{cell_tile_orders()}}{
 Returns the cell and tile orders that should be used.
-If neither \code{cell_order} nor \code{tile_order} is present, only in this
-case will we use the default values provided.
+If neither \code{cell_order} nor \code{tile_order} is present, only in
+this case will we use the default values provided.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TileDBCreateOptions$cell_tile_orders()}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Add examples for the following objects

 - `ConfigList`
 - `PlatformConfig`
 - `ScalarMap`
 - `SOMATileDBContext`
 - `TileDBCreateOptions`

Add links from the following ABCs to real classes:

 - `MappingBase` ABC
 - `SOMAContextBase` ABC

Fixes [SOMA-211](https://linear.app/tiledb/issue/SOMA-211/add-examples-for-mapping-types)

Partially replaces #4075