### PR TITLE
[r] Add examples for utility classes

### DIFF
--- a/apis/r/R/CoordsStrider.R
+++ b/apis/r/R/CoordsStrider.R
@@ -1,7 +1,7 @@
 #' The Coordinate Strider
 #'
 #' @description The \code{CoordsStrider} allows creating coordinate slices
-#' in an interated manner. Alternatively, it can chunk an existing vector of
+#' in an iterated manner. Alternatively, it can chunk an existing vector of
 #' coordinates
 #'
 #' @note The \code{CoordsStrider} operates using
@@ -16,7 +16,7 @@
 #' @export
 #'
 #' @examples
-#' strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L)
+#' (strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
 #' while (strider$has_next()) {
 #'   str(strider$next_element())
 #' }
@@ -137,6 +137,7 @@ CoordsStrider <- R6::R6Class(
     #' @field coords If set, the coordinates to iterate over
     #'
     coords = function() private$.coords,
+
     #' @field start If set, the starting point of the iterated coordinates;
     #' otherwise the minimum value of \code{self$coords}
     #'
@@ -147,6 +148,7 @@ CoordsStrider <- R6::R6Class(
         min(self$coords)
       }
     },
+
     #' @field end If set, the end point of the iterated coordinates;
     #' otherwise the maximum value of \code{self$coords}
     #'
@@ -157,6 +159,7 @@ CoordsStrider <- R6::R6Class(
         max(self$coords)
       }
     },
+
     #' @field stride The stride, or how many coordinates to generate per
     #' iteration; note: this field is settable, which will reset the iterator
     #'
@@ -197,8 +200,14 @@ CoordsStrider <- R6::R6Class(
   )
 )
 
+#' @rdname CoordsStrider
+#'
 #' @method as.list CoordsStrider
 #' @export
+#'
+#' @examples
+#' (strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
+#' as.list(strider)
 #'
 as.list.CoordsStrider <- function(x, ...) {
   res <- vector(mode = "list", length = ceiling(x$length() / x$stride))
@@ -213,15 +222,30 @@ as.list.CoordsStrider <- function(x, ...) {
   return(Filter(Negate(is.null), res))
 }
 
+#' @rdname CoordsStrider
+#'
 #' @method length CoordsStrider
 #' @export
 #'
+#' @examples
+#' length(strider)
+#'
 length.CoordsStrider <- function(x) x$length()
 
+#' @rdname CoordsStrider
+#'
 #' @exportS3Method iterators::nextElem
+#'
+#' @examplesIf requireNamespace("itertools", quietly = TRUE)
+#' (strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
+#' while (itertools::hasNext(strider)) {
+#'   str(iterators::nextElem(strider))
+#' }
 #'
 nextElem.CoordsStrider <- function(obj, ...) obj$next_element()
 
+#' @rdname CoordsStrider
+#'
 #' @exportS3Method itertools::hasNext
 #'
 hasNext.CoordsStrider <- function(obj, ...) obj$has_next()

--- a/apis/r/R/IntIndexer.R
+++ b/apis/r/R/IntIndexer.R
@@ -1,7 +1,17 @@
 #' The SOMA Re-Indexer
 #'
 #' @description A re-indexer for unique integer indices
+#'
 #' @export
+#'
+#' @examples
+#' (keys <- c(-10000, -100000, 200000, 5, 1, 7))
+#' (lookups <- unlist(replicate(n = 4L, c(-1L, 1:5), simplify = FALSE)))
+#'
+#' indexer <- IntIndexer$new(keys)
+#' indexer$get_indexer(lookups)
+#' indexer$get_indexer(lookups, nomatch_na = TRUE)
+#'
 IntIndexer <- R6::R6Class(
   classname = "IntIndexer",
   public = list(
@@ -19,6 +29,7 @@ IntIndexer <- R6::R6Class(
       reindex_map(private$.reindexer, bit64::as.integer64(data))
       return(invisible(NULL))
     },
+
     #' @description Get the underlying indices for the target data
     #'
     #' @param target Data to re-index

--- a/apis/r/man/CoordsStrider.Rd
+++ b/apis/r/man/CoordsStrider.Rd
@@ -2,10 +2,23 @@
 % Please edit documentation in R/CoordsStrider.R
 \name{CoordsStrider}
 \alias{CoordsStrider}
+\alias{as.list.CoordsStrider}
+\alias{length.CoordsStrider}
+\alias{nextElem.CoordsStrider}
+\alias{hasNext.CoordsStrider}
 \title{The Coordinate Strider}
+\usage{
+\method{as.list}{CoordsStrider}(x, ...)
+
+\method{length}{CoordsStrider}(x)
+
+\method{nextElem}{CoordsStrider}(obj, ...)
+
+\method{hasNext}{CoordsStrider}(obj, ...)
+}
 \description{
 The \code{CoordsStrider} allows creating coordinate slices
-in an interated manner. Alternatively, it can chunk an existing vector of
+in an iterated manner. Alternatively, it can chunk an existing vector of
 coordinates
 }
 \note{
@@ -17,11 +30,22 @@ such as \code{strider$start} or \code{strider$stride} will return an
 as necessary
 }
 \examples{
-strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L)
+(strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
 while (strider$has_next()) {
   str(strider$next_element())
 }
 
+(strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
+as.list(strider)
+
+length(strider)
+
+\dontshow{if (requireNamespace("itertools", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+(strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
+while (itertools::hasNext(strider)) {
+  str(iterators::nextElem(strider))
+}
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}
 \section{Active bindings}{

--- a/apis/r/man/IntIndexer.Rd
+++ b/apis/r/man/IntIndexer.Rd
@@ -6,6 +6,15 @@
 \description{
 A re-indexer for unique integer indices
 }
+\examples{
+(keys <- c(-10000, -100000, 200000, 5, 1, 7))
+(lookups <- unlist(replicate(n = 4L, c(-1L, 1:5), simplify = FALSE)))
+
+indexer <- IntIndexer$new(keys)
+indexer$get_indexer(lookups)
+indexer$get_indexer(lookups, nomatch_na = TRUE)
+
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{


### PR DESCRIPTION
Add examples for the following objects

 - `CoordsStrider`
 - `IntIndexer`

Fixes [SOMA-213](https://linear.app/tiledb/issue/SOMA-213/add-examples-for-utility-classes)

Partially replaces #4075