### PR TITLE
[r] Add examples for objects using example datasets

### DIFF
--- a/apis/r/R/SOMAOpen.R
+++ b/apis/r/R/SOMAOpen.R
@@ -1,14 +1,32 @@
-#' @title Open a SOMA Object
-#' @description Utility function to open the corresponding SOMA Object given a URI, (lifecycle: maturing)
-#' @param mode One of `"READ"` or `"WRITE"`
-#' @param uri URI for the TileDB object
-#' @param platform_config Optional platform configuration
-#' @param tiledbsoma_ctx Optional SOMATileDBContext
-#' @param tiledb_timestamp Optional Datetime (POSIXct) with TileDB timestamp. For SOMACollections,
-#'        all accessed members inherit the collection opening timestamp, and in READ mode the
-#'        collection timestamp defaults to the time of opening.
+#' Open a SOMA Object
+#'
+#' Utility function to open the corresponding SOMA Object given a URI
+#' (lifecycle: maturing)
+#'
+#' @inheritParams SOMACollectionOpen
+#' @param mode One of \dQuote{\code{READ}} or \dQuote{\code{WRITE}}
+#'
+#' @return A SOMA object
 #'
 #' @export
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "soma-open")
+#' dir.create(dir, recursive = TRUE)
+#'
+#' uri <- extract_dataset("soma-exp-pbmc-small", dir)
+#' (exp <- SOMAOpen(uri))
+#'
+#' \dontshow{
+#' exp$close()
+#' }
+#'
+#' uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs", dir)
+#' (obs <- SOMAOpen(uri))
+#'
+#' \dontshow{
+#' obs$close()
+#' }
 #'
 SOMAOpen <- function(
   uri,

--- a/apis/r/R/datasets.R
+++ b/apis/r/R/datasets.R
@@ -1,30 +1,32 @@
 #' SOMA Example Datasets
 #'
-#' @description
-#' Access example SOMA objects bundled with the tiledbsoma package.
+#' Access example SOMA objects bundled with the tiledbsoma package\cr
+#' \cr
+#' Use \code{list_datasets()} to list the available datasets and
+#' \code{load_dataset()} to load a dataset into memory using the appropriate
+#' SOMA class. The \code{extract_dataset()} function returns the path to the
+#' extracted dataset without loading it into memory.
 #'
-#' Use `list_datasets()` to list the available datasets and `load_dataset()` to
-#' load a dataset into memory using the appropriate SOMA class. The
-#'  `extract_dataset()` method returns the path to the extracted dataset without
-#'  loading it into memory.
-#'
-#' @details
-#' The SOMA objects are stored as `tar.gz` files in the package's `extdata`
-#' directory. Calling `load_dataset()` extracts the `tar.gz` file to the
-#' specified `dir`, inspects its metadata to determine the appropriate SOMA
-#' class to instantiate, and returns the SOMA object.
-#'
-#' @examples
-#' soma_pbmc_small <- load_dataset("soma-exp-pbmc-small")
+#' The SOMA objects are stored as \code{tar.gz} files in the package's
+#' \code{extdata} directory. Calling \code{load_dataset()} extracts the
+#' \code{tar.gz} file to the specified \code{dir}, inspects its metadata to
+#' determine the appropriate SOMA class to instantiate, and returns the
+#' SOMA object.
 #'
 #' @name example-datasets
+#' @rdname example-datasets
+#'
 NULL
 
 #' @rdname example-datasets
-#' @return
-#'  - `list_datasets()` returns a character vector of the available datasets.
+#'
+#' @return \code{list_datasets()}: returns a character vector of the
+#' available datasets
 #'
 #' @export
+#'
+#' @examples
+#' list_datasets()
 #'
 list_datasets <- function() {
   data_dir <- example_data_dir()
@@ -33,12 +35,21 @@ list_datasets <- function() {
 }
 
 #' @rdname example-datasets
-#' @param name The name of the dataset.
-#' @param dir The directory where the dataset will be extracted to (default:
-#' `tempdir()`).
-#' @return
-#'  - `extract_dataset()` returns the path to the extracted dataset.
+#'
+#' @param name The name of the dataset
+#' @param dir The directory where the dataset will be extracted to
+#' (default: \code{\link[base]{tempdir}()})
+#'
+#' @return \code{extract_dataset()}: returns the path to the extracted dataset
+#'
 #' @export
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "pbmc-small")
+#' dir.create(dir, recursive = TRUE)
+#' dest <- extract_dataset("soma-exp-pbmc-small", dir)
+#' list.files(dest)
+#'
 extract_dataset <- function(name, dir = tempdir()) {
   data_dir <- example_data_dir()
   tarfiles <- list_datasets()
@@ -60,10 +71,23 @@ extract_dataset <- function(name, dir = tempdir()) {
 }
 
 #' @rdname example-datasets
-#' @param tiledbsoma_ctx Optional TileDB \sQuote{Context} object, defaults to \code{NULL}
-#' @return
-#'  - `load_dataset()` returns a SOMA object.
+#'
+#' @param tiledbsoma_ctx Optional TileDB \dQuote{Context} object,
+#' defaults to \code{NULL}
+#'
+#' @return \code{load_dataset()}: returns a SOMA object.
+#'
 #' @export
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "pbmc_small")
+#' dir.create(dir, recursive = TRUE)
+#' (exp <- load_dataset("soma-exp-pbmc-small", dir))
+#'
+#' \dontshow{
+#' exp$close()
+#' }
+#'
 load_dataset <- function(name, dir = tempdir(), tiledbsoma_ctx = NULL) {
   dataset_uri <- extract_dataset(name, dir)
 

--- a/apis/r/R/ephemeral.R
+++ b/apis/r/R/ephemeral.R
@@ -1,11 +1,17 @@
 #' Ephemeral Collection Base
 #'
-#' @description Base class for ephemeral collections; ephemeral collections are
-#' equivalent to \link[tiledbsoma:SOMACollection]{SOMA collections} but are
-#' stored in-memory instead of on-disks
+#' @description Virtual base class for ephemeral collections; ephemeral
+#' collections are equivalent to
+#' \link[tiledbsoma:SOMACollection]{SOMA collections} but are stored in-memory
+#' instead of on-disk
 #'
 #' @keywords internal
+#'
 #' @export
+#'
+#' @seealso Derived classes: \code{\link{EphemeralCollection}},
+#' \code{\link{EphemeralMeasurement}},
+#' \code{\link{EphemeralExperiment}}
 #'
 EphemeralCollectionBase <- R6::R6Class(
   classname = "EphemeralCollectionBase",
@@ -53,18 +59,19 @@ EphemeralCollectionBase <- R6::R6Class(
     },
 
     # Override TileDBGroup private methods
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param mode Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     open = function(mode) {
       private$.ephemeral_error("opened")
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @return Invisibly returns \code{NULL}
@@ -79,7 +86,7 @@ EphemeralCollectionBase <- R6::R6Class(
       return(invisible(NULL))
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @return Returns \code{FALSE} as ephemeral collections do not
@@ -101,7 +108,7 @@ EphemeralCollectionBase <- R6::R6Class(
       return(invisible(self))
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param param Ignored for ephemeral objects
@@ -189,18 +196,19 @@ EphemeralCollectionBase <- R6::R6Class(
       return(invisible(self))
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param metadata Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     set_metadata = function(metadata) {
       private$.ephemeral_error("edited")
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param key Ignored for ephemeral objects
@@ -218,45 +226,49 @@ EphemeralCollectionBase <- R6::R6Class(
     },
 
     # Override SOMACollectionBase methods
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param object,key Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     add_new_collection = function(object, key) {
       private$.ephemeral_error()
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param key,schema,index_column_names Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     add_new_dataframe = function(key, schema, index_column_names) {
       private$.ephemeral_error()
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param key,type,shape Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     add_new_dense_ndarray = function(key, type, shape) {
       private$.ephemeral_error()
     },
 
-    #' @description Dummy method for ephemeral cobjects for compatibility with
+    #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections
     #'
     #' @param key,type,shape Ignored for ephemeral objects
     #'
-    #' @return Throws an error as this method is not supported by ephemeral objects
+    #' @return Throws an error as this method is not supported by ephemeral
+    #' objects
     #'
     add_new_sparse_ndarray = function(key, type, shape) {
       private$.ephemeral_error()
@@ -394,6 +406,22 @@ EphemeralCollectionBase <- R6::R6Class(
 #'
 #' @export
 #'
+#' @examples
+#' (col <- EphemeralCollection$new())
+#' col$soma_type
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "obs")
+#' dir.create(dir, recursive = TRUE)
+#'
+#' (obs <- load_dataset("soma-dataframe-pbmc3k-processed-obs", dir))
+#' col$set(obs, "obs")
+#' col$names()
+#'
+#' \dontshow{
+#' obs$close()
+#' }
+#'
 EphemeralCollection <- R6::R6Class(
   classname = "EphemeralCollection",
   inherit = EphemeralCollectionBase,
@@ -418,6 +446,13 @@ EphemeralCollection <- R6::R6Class(
 #' @keywords internal
 #'
 #' @export
+#'
+#' @examples
+#' (ms <- EphemeralMeasurement$new())
+#' ms$soma_type
+#'
+#' ms$set(EphemeralCollection$new(), "X")
+#' ms$X
 #'
 EphemeralMeasurement <- R6::R6Class(
   classname = "EphemeralMeasurement",
@@ -513,6 +548,22 @@ EphemeralMeasurement <- R6::R6Class(
 #' @keywords internal
 #'
 #' @export
+#'
+#' @examples
+#' (exp <- EphemeralExperiment$new())
+#' exp$soma_type
+#'
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' dir <- withr::local_tempfile(pattern = "obs")
+#' dir.create(dir, recursive = TRUE)
+#'
+#' (obs <- load_dataset("soma-dataframe-pbmc3k-processed-obs", dir))
+#' exp$set(obs, "obs")
+#' exp$obs
+#'
+#' \dontshow{
+#' obs$close()
+#' }
 #'
 EphemeralExperiment <- R6::R6Class(
   classname = "EphemeralExperiment",

--- a/apis/r/man/EphemeralCollection.Rd
+++ b/apis/r/man/EphemeralCollection.Rd
@@ -9,6 +9,23 @@ collections are equivalent to
 \link[tiledbsoma:SOMACollection]{SOMA collections} but are stored in-memory
 instead of on-disk
 }
+\examples{
+(col <- EphemeralCollection$new())
+col$soma_type
+
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "obs")
+dir.create(dir, recursive = TRUE)
+
+(obs <- load_dataset("soma-dataframe-pbmc3k-processed-obs", dir))
+col$set(obs, "obs")
+col$names()
+
+\dontshow{
+obs$close()
+}
+\dontshow{\}) # examplesIf}
+}
 \keyword{internal}
 \section{Super classes}{
 \code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralCollection}

--- a/apis/r/man/EphemeralCollectionBase.Rd
+++ b/apis/r/man/EphemeralCollectionBase.Rd
@@ -4,9 +4,15 @@
 \alias{EphemeralCollectionBase}
 \title{Ephemeral Collection Base}
 \description{
-Base class for ephemeral collections; ephemeral collections are
-equivalent to \link[tiledbsoma:SOMACollection]{SOMA collections} but are
-stored in-memory instead of on-disks
+Virtual base class for ephemeral collections; ephemeral
+collections are equivalent to
+\link[tiledbsoma:SOMACollection]{SOMA collections} but are stored in-memory
+instead of on-disk
+}
+\seealso{
+Derived classes: \code{\link{EphemeralCollection}},
+\code{\link{EphemeralMeasurement}},
+\code{\link{EphemeralExperiment}}
 }
 \keyword{internal}
 \section{Super classes}{
@@ -101,7 +107,7 @@ Returns a new ephemeral collection of class \code{class(self)}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-open"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-open}{}}}
 \subsection{Method \code{open()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$open(mode)}\if{html}{\out{</div>}}
@@ -115,14 +121,15 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-close"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-close}{}}}
 \subsection{Method \code{close()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$close()}\if{html}{\out{</div>}}
@@ -136,7 +143,7 @@ Invisibly returns \code{NULL}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-exists"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-exists}{}}}
 \subsection{Method \code{exists()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$exists()}\if{html}{\out{</div>}}
@@ -165,7 +172,7 @@ returns itself
 \if{html}{\out{<a id="method-EphemeralCollectionBase-get_tiledb_config"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-get_tiledb_config}{}}}
 \subsection{Method \code{get_tiledb_config()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$get_tiledb_config(param = NULL)}\if{html}{\out{</div>}}
@@ -280,7 +287,7 @@ Remove objects from an ephemeral collection
 \if{html}{\out{<a id="method-EphemeralCollectionBase-set_metadata"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-set_metadata}{}}}
 \subsection{Method \code{set_metadata()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$set_metadata(metadata)}\if{html}{\out{</div>}}
@@ -294,14 +301,15 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-get_metadata"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-get_metadata}{}}}
 \subsection{Method \code{get_metadata()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$get_metadata(key = NULL)}\if{html}{\out{</div>}}
@@ -322,7 +330,7 @@ An empty list
 \if{html}{\out{<a id="method-EphemeralCollectionBase-add_new_collection"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-add_new_collection}{}}}
 \subsection{Method \code{add_new_collection()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$add_new_collection(object, key)}\if{html}{\out{</div>}}
@@ -336,14 +344,15 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-add_new_dataframe"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-add_new_dataframe}{}}}
 \subsection{Method \code{add_new_dataframe()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$add_new_dataframe(key, schema, index_column_names)}\if{html}{\out{</div>}}
@@ -357,14 +366,15 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-add_new_dense_ndarray"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-add_new_dense_ndarray}{}}}
 \subsection{Method \code{add_new_dense_ndarray()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$add_new_dense_ndarray(key, type, shape)}\if{html}{\out{</div>}}
@@ -378,14 +388,15 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EphemeralCollectionBase-add_new_sparse_ndarray"></a>}}
 \if{latex}{\out{\hypertarget{method-EphemeralCollectionBase-add_new_sparse_ndarray}{}}}
 \subsection{Method \code{add_new_sparse_ndarray()}}{
-Dummy method for ephemeral cobjects for compatibility with
+Dummy method for ephemeral objects for compatibility with
 SOMA collections
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EphemeralCollectionBase$add_new_sparse_ndarray(key, type, shape)}\if{html}{\out{</div>}}
@@ -399,7 +410,8 @@ SOMA collections
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Throws an error as this method is not supported by ephemeral objects
+Throws an error as this method is not supported by ephemeral
+objects
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/EphemeralExperiment.Rd
+++ b/apis/r/man/EphemeralExperiment.Rd
@@ -9,6 +9,23 @@ experiments are equivalent to
 \link[tiledbsoma:SOMAExperiment]{SOMA experiments} but are stored in-memory
 instead of on-disk
 }
+\examples{
+(exp <- EphemeralExperiment$new())
+exp$soma_type
+
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "obs")
+dir.create(dir, recursive = TRUE)
+
+(obs <- load_dataset("soma-dataframe-pbmc3k-processed-obs", dir))
+exp$set(obs, "obs")
+exp$obs
+
+\dontshow{
+obs$close()
+}
+\dontshow{\}) # examplesIf}
+}
 \keyword{internal}
 \section{Super classes}{
 \code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralExperiment}

--- a/apis/r/man/EphemeralMeasurement.Rd
+++ b/apis/r/man/EphemeralMeasurement.Rd
@@ -9,6 +9,14 @@ measurements are equivalent to
 \link[tiledbsoma:SOMAMeasurement]{SOMA measurements} but are stored in-memory
 instead of on-disk
 }
+\examples{
+(ms <- EphemeralMeasurement$new())
+ms$soma_type
+
+ms$set(EphemeralCollection$new(), "X")
+ms$X
+
+}
 \keyword{internal}
 \section{Super classes}{
 \code{\link[tiledbsoma:TileDBObject]{tiledbsoma::TileDBObject}} -> \code{\link[tiledbsoma:TileDBGroup]{tiledbsoma::TileDBGroup}} -> \code{\link[tiledbsoma:SOMACollectionBase]{tiledbsoma::SOMACollectionBase}} -> \code{\link[tiledbsoma:EphemeralCollectionBase]{tiledbsoma::EphemeralCollectionBase}} -> \code{EphemeralMeasurement}

--- a/apis/r/man/SOMAOpen.Rd
+++ b/apis/r/man/SOMAOpen.Rd
@@ -15,16 +15,40 @@ SOMAOpen(
 \arguments{
 \item{uri}{URI for the TileDB object}
 
-\item{mode}{One of \code{"READ"} or \code{"WRITE"}}
+\item{mode}{One of \dQuote{\code{READ}} or \dQuote{\code{WRITE}}}
 
 \item{platform_config}{Optional platform configuration}
 
 \item{tiledbsoma_ctx}{Optional SOMATileDBContext}
 
-\item{tiledb_timestamp}{Optional Datetime (POSIXct) with TileDB timestamp. For SOMACollections,
-all accessed members inherit the collection opening timestamp, and in READ mode the
-collection timestamp defaults to the time of opening.}
+\item{tiledb_timestamp}{Optional Datetime (POSIXct) for TileDB timestamp.
+In READ mode, defaults to the current time. If non-NULL, then all members
+accessed through the collection object inherit the timestamp.}
+}
+\value{
+A SOMA object
 }
 \description{
-Utility function to open the corresponding SOMA Object given a URI, (lifecycle: maturing)
+Utility function to open the corresponding SOMA Object given a URI
+(lifecycle: maturing)
+}
+\examples{
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "soma-open")
+dir.create(dir, recursive = TRUE)
+
+uri <- extract_dataset("soma-exp-pbmc-small", dir)
+(exp <- SOMAOpen(uri))
+
+\dontshow{
+exp$close()
+}
+
+uri <- extract_dataset("soma-dataframe-pbmc3k-processed-obs", dir)
+(obs <- SOMAOpen(uri))
+
+\dontshow{
+obs$close()
+}
+\dontshow{\}) # examplesIf}
 }

--- a/apis/r/man/example-datasets.Rd
+++ b/apis/r/man/example-datasets.Rd
@@ -14,41 +14,53 @@ extract_dataset(name, dir = tempdir())
 load_dataset(name, dir = tempdir(), tiledbsoma_ctx = NULL)
 }
 \arguments{
-\item{name}{The name of the dataset.}
+\item{name}{The name of the dataset}
 
-\item{dir}{The directory where the dataset will be extracted to (default:
-\code{tempdir()}).}
+\item{dir}{The directory where the dataset will be extracted to
+(default: \code{\link[base]{tempdir}()})}
 
-\item{tiledbsoma_ctx}{Optional TileDB \sQuote{Context} object, defaults to \code{NULL}}
+\item{tiledbsoma_ctx}{Optional TileDB \dQuote{Context} object,
+defaults to \code{NULL}}
 }
 \value{
-\itemize{
-\item \code{list_datasets()} returns a character vector of the available datasets.
-}
+\code{list_datasets()}: returns a character vector of the
+available datasets
 
-\itemize{
-\item \code{extract_dataset()} returns the path to the extracted dataset.
-}
+\code{extract_dataset()}: returns the path to the extracted dataset
 
-\itemize{
-\item \code{load_dataset()} returns a SOMA object.
-}
+\code{load_dataset()}: returns a SOMA object.
 }
 \description{
-Access example SOMA objects bundled with the tiledbsoma package.
-
-Use \code{list_datasets()} to list the available datasets and \code{load_dataset()} to
-load a dataset into memory using the appropriate SOMA class. The
-\code{extract_dataset()} method returns the path to the extracted dataset without
-loading it into memory.
+Access example SOMA objects bundled with the tiledbsoma package\cr
+\cr
+Use \code{list_datasets()} to list the available datasets and
+\code{load_dataset()} to load a dataset into memory using the appropriate
+SOMA class. The \code{extract_dataset()} function returns the path to the
+extracted dataset without loading it into memory.
 }
 \details{
-The SOMA objects are stored as \code{tar.gz} files in the package's \code{extdata}
-directory. Calling \code{load_dataset()} extracts the \code{tar.gz} file to the
-specified \code{dir}, inspects its metadata to determine the appropriate SOMA
-class to instantiate, and returns the SOMA object.
+The SOMA objects are stored as \code{tar.gz} files in the package's
+\code{extdata} directory. Calling \code{load_dataset()} extracts the
+\code{tar.gz} file to the specified \code{dir}, inspects its metadata to
+determine the appropriate SOMA class to instantiate, and returns the
+SOMA object.
 }
 \examples{
-soma_pbmc_small <- load_dataset("soma-exp-pbmc-small")
+list_datasets()
 
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "pbmc-small")
+dir.create(dir, recursive = TRUE)
+dest <- extract_dataset("soma-exp-pbmc-small", dir)
+list.files(dest)
+\dontshow{\}) # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+dir <- withr::local_tempfile(pattern = "pbmc_small")
+dir.create(dir, recursive = TRUE)
+(exp <- load_dataset("soma-exp-pbmc-small", dir))
+
+\dontshow{
+exp$close()
+}
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
Add examples for the following objects:

 - `list_datasets()`
 - `extract_dataset()`
 - `load_dataset()`
 - `EphemeralCollection`
 - `EphemeralMeasurement`
 - `EphemeralExperiment`
 - `SOMAOpen()`

Add links from the following ABCs to real classes:

 - `EphemeralCollectionBase`

Note for reviewers: the `#' @examplesIf` construct allows conditional examples; this is used as
 - CRAN requires all docs that write to disk to write to a temporary directory
 - CRAN requires that all temporary directories be cleaned up
 - withr handles the temporary directory management, but I don't want to take a hard dependency on it
 - `#' @examplesIf` allows the examples to run if and only if the conditions are met (eg. withr is installed)

Fixes [SOMA-216](https://linear.app/tiledb/issue/SOMA-216/add-examples-using-example-datasets)

Partially replaces #4075