### PR TITLE
[r] Add examples for exported `utils-*.R` objects

### DIFF
--- a/apis/r/R/utils-matrixZeroBasedView.R
+++ b/apis/r/R/utils-matrixZeroBasedView.R
@@ -2,7 +2,7 @@
 #'
 #' \code{matrixZeroBasedView} is a wrapper shim for a matrix or
 #' \code{\link[Matrix:sparseMatrix]{Matrix::sparseMatrix}} that allows
-#' elemental matrix access using zero-based indices
+#' elemental matrix access using zero-based indices.
 #'
 #' @export
 #'
@@ -16,9 +16,9 @@
 matrixZeroBasedView <- R6::R6Class(
   classname = "matrixZeroBasedView",
   public = list(
-    #' @description Initialize (lifecycle: maturing)
+    #' @description Initialize (lifecycle: maturing).
     #'
-    #' @param x A matrix
+    #' @param x A matrix.
     #'
     initialize = function(x) {
       if (!inherits(x, "matrix") && !inherits(x, "sparseMatrix") && !inherits(one_based_matrix, "Matrix")) {
@@ -30,12 +30,12 @@ matrixZeroBasedView <- R6::R6Class(
       private$one_based_matrix <- x
     },
 
-    #' @description Zero-based matrix element access
+    #' @description Zero-based matrix element access.
     #'
-    #' @param i Row index (zero-based)
-    #' @param j Column index (zero-based)
+    #' @param i Row index (zero-based).
+    #' @param j Column index (zero-based).
     #'
-    #' @return The specified matrix slice as another \link{matrixZeroBasedView}
+    #' @return The specified matrix slice as another \code{matrixZeroBasedView}.
     #'
     take = function(i = NULL, j = NULL) {
       x <- NULL
@@ -52,7 +52,7 @@ matrixZeroBasedView <- R6::R6Class(
       matrixZeroBasedView$new(x)
     },
 
-    #' @description dim
+    #' @description dim.
     #'
     #' @return The dimensions of the matrix.
     #'
@@ -60,9 +60,9 @@ matrixZeroBasedView <- R6::R6Class(
       dim(private$one_based_matrix)
     },
 
-    #' @description nrow
+    #' @description nrow.
     #'
-    #' @return Matrix row count
+    #' @return Matrix row count.
     #'
     #' @export
     #'
@@ -70,28 +70,28 @@ matrixZeroBasedView <- R6::R6Class(
       nrow(private$one_based_matrix)
     },
 
-    #' @description ncol
+    #' @description ncol.
     #'
-    #' @return Matrix column count
+    #' @return Matrix column count.
     #'
     ncol = function() {
       ncol(private$one_based_matrix)
     },
 
-    #' @description Get the one-based R matrix with its original class
+    #' @description Get the one-based \R matrix with its original class.
     #'
-    #' @return One-based matrix
+    #' @return One-based matrix.
     #'
     get_one_based_matrix = function() {
       private$one_based_matrix
     },
 
     #' @description Perform arithmetic sum between this
-    #' \link{matrixZeroBasedView} and another \link{matrixZeroBasedView}
+    #' \code{matrixZeroBasedView} and another \code{matrixZeroBasedView}.
     #'
-    #' @param x the \link{matrixZeroBasedView} to sum
+    #' @param x the \code{matrixZeroBasedView} to sum.
     #'
-    #' @return The result of the sum as a \link{matrixZeroBasedView}
+    #' @return The result of the sum as a \code{matrixZeroBasedView}.
     #'
     sum = function(x) {
       if (!inherits(x, "matrixZeroBasedView")) {
@@ -100,9 +100,9 @@ matrixZeroBasedView <- R6::R6Class(
       matrixZeroBasedView$new(private$one_based_matrix + x$get_one_based_matrix())
     },
 
-    #' @description print
+    #' @description print.
     #'
-    #' @return Invisibly returns \code{self}
+    #' @return Invisibly returns \code{self}.
     #'
     print = function() {
       dims <- self$dim()

--- a/apis/r/R/utils-matrixZeroBasedView.R
+++ b/apis/r/R/utils-matrixZeroBasedView.R
@@ -1,16 +1,25 @@
-#' matrixZeroBasedView is a wrapper shim for a matrix or Matrix::sparseMatrix providing
+#' Zero-based Wrapper for Sparse Matrices
 #'
-#' @description
-#' `matrixZeroBasedView` is a class that allows elemental
-#'  matrix access using zero-based indeces.
+#' \code{matrixZeroBasedView} is a wrapper shim for a matrix or
+#' \code{\link[Matrix:sparseMatrix]{Matrix::sparseMatrix}} that allows
+#' elemental matrix access using zero-based indices
+#'
 #' @export
-
+#'
+#' @examples
+#' (mat <- Matrix::rsparsematrix(3L, 3L, 0.3))
+#' (mat0 <- matrixZeroBasedView$new(mat))
+#'
+#' mat0$take(0, 0)
+#' mat0$take(0, 0:2)$get_one_based_matrix()
+#'
 matrixZeroBasedView <- R6::R6Class(
   classname = "matrixZeroBasedView",
   public = list(
-
     #' @description Initialize (lifecycle: maturing)
-    #' @param x \link{matrix} or Matrix::\link[Matrix]{sparseMatrix} or Matrix::\link[Matrix]{Matrix}
+    #'
+    #' @param x A matrix
+    #'
     initialize = function(x) {
       if (!inherits(x, "matrix") && !inherits(x, "sparseMatrix") && !inherits(one_based_matrix, "Matrix")) {
         stop("Matrix object must inherit class matrix or Matrix::sparseMatrix or Matrix::Matrix")
@@ -22,9 +31,12 @@ matrixZeroBasedView <- R6::R6Class(
     },
 
     #' @description Zero-based matrix element access
-    #' @param i Row index (zero-based).
-    #' @param j Column index (zero-based).
+    #'
+    #' @param i Row index (zero-based)
+    #' @param j Column index (zero-based)
+    #'
     #' @return The specified matrix slice as another \link{matrixZeroBasedView}
+    #'
     take = function(i = NULL, j = NULL) {
       x <- NULL
       if (is.null(i) && is.null(j)) {
@@ -41,34 +53,46 @@ matrixZeroBasedView <- R6::R6Class(
     },
 
     #' @description dim
+    #'
     #' @return The dimensions of the matrix.
+    #'
     dim = function() {
       dim(private$one_based_matrix)
     },
 
     #' @description nrow
-    #' @return Matrix row count.
+    #'
+    #' @return Matrix row count
+    #'
     #' @export
+    #'
     nrow = function() {
       nrow(private$one_based_matrix)
     },
 
     #' @description ncol
-    #' @return Matrix column count.
+    #'
+    #' @return Matrix column count
+    #'
     ncol = function() {
       ncol(private$one_based_matrix)
     },
 
     #' @description Get the one-based R matrix with its original class
+    #'
     #' @return One-based matrix
+    #'
     get_one_based_matrix = function() {
       private$one_based_matrix
     },
 
-    #' @description Perform arithmetic sum between this \link{matrixZeroBasedView}
-    #' and another \link{matrixZeroBasedView}.
-    #' @param x the \link{matrixZeroBasedView} to sum.
-    #' @return The result of the sum as a \link{matrixZeroBasedView}.
+    #' @description Perform arithmetic sum between this
+    #' \link{matrixZeroBasedView} and another \link{matrixZeroBasedView}
+    #'
+    #' @param x the \link{matrixZeroBasedView} to sum
+    #'
+    #' @return The result of the sum as a \link{matrixZeroBasedView}
+    #'
     sum = function(x) {
       if (!inherits(x, "matrixZeroBasedView")) {
         stop("Only arithmetic sum with another 'matrixZeroBasedView` is supported")
@@ -77,12 +101,15 @@ matrixZeroBasedView <- R6::R6Class(
     },
 
     #' @description print
+    #'
+    #' @return Invisibly returns \code{self}
+    #'
     print = function() {
       dims <- self$dim()
       cat("Non-mutable 0-based 'view' class for matrices.\n")
       cat("To get 1-based matrix use `x$get_one_based_matrix()\n")
       cat(paste0("Dimensions: ", dims[1], "x", dims[2], "\n"))
-      invisible(self)
+      return(invisible(self))
     }
   ),
   private = list(

--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -41,6 +41,9 @@ get_tiledb_version <- function(compact = FALSE) {
 #'
 #' @export
 #'
+#' @examples
+#' show_package_versions()
+#'
 show_package_versions <- function() {
   cat("tiledbsoma:    ", toString(utils::packageVersion("tiledbsoma")), "\n",
     "tiledb-r:      ", toString(utils::packageVersion("tiledb")), "\n",
@@ -56,4 +59,6 @@ show_package_versions <- function() {
 #'
 #' @export
 #'
-tiledbsoma_stats_show <- \() cat(tiledbsoma_stats_dump(), "\n")
+tiledbsoma_stats_show <- function() {
+  cat(tiledbsoma_stats_dump(), "\n")
+}

--- a/apis/r/R/utils-tiledb.R
+++ b/apis/r/R/utils-tiledb.R
@@ -36,8 +36,8 @@ get_tiledb_version <- function(compact = FALSE) {
 
 #' Display package versions
 #'
-#' Print version information for \pkg{tiledb} (R package), libtiledbsoma, and
-#' TileDB embedded, suitable for assisting with bug reports.
+#' Print version information for \CRANpkg{tiledb} (R package), libtiledbsoma,
+#' and TileDB embedded, suitable for assisting with bug reports.
 #'
 #' @export
 #'

--- a/apis/r/man/matrixZeroBasedView.Rd
+++ b/apis/r/man/matrixZeroBasedView.Rd
@@ -2,10 +2,24 @@
 % Please edit documentation in R/utils-matrixZeroBasedView.R
 \name{matrixZeroBasedView}
 \alias{matrixZeroBasedView}
-\title{matrixZeroBasedView is a wrapper shim for a matrix or Matrix::sparseMatrix providing}
+\title{Zero-based Wrapper for Sparse Matrices}
 \description{
-\code{matrixZeroBasedView} is a class that allows elemental
-matrix access using zero-based indeces.
+Zero-based Wrapper for Sparse Matrices
+
+Zero-based Wrapper for Sparse Matrices
+}
+\details{
+\code{matrixZeroBasedView} is a wrapper shim for a matrix or
+\code{\link[Matrix:sparseMatrix]{Matrix::sparseMatrix}} that allows
+elemental matrix access using zero-based indices
+}
+\examples{
+(mat <- Matrix::rsparsematrix(3L, 3L, 0.3))
+(mat0 <- matrixZeroBasedView$new(mat))
+
+mat0$take(0, 0)
+mat0$take(0, 0:2)$get_one_based_matrix()
+
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -33,7 +47,7 @@ Initialize (lifecycle: maturing)
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{x}}{\link{matrix} or Matrix::\link[Matrix]{sparseMatrix} or Matrix::\link[Matrix]{Matrix}}
+\item{\code{x}}{A matrix}
 }
 \if{html}{\out{</div>}}
 }
@@ -50,9 +64,9 @@ Zero-based matrix element access
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{i}}{Row index (zero-based).}
+\item{\code{i}}{Row index (zero-based)}
 
-\item{\code{j}}{Column index (zero-based).}
+\item{\code{j}}{Column index (zero-based)}
 }
 \if{html}{\out{</div>}}
 }
@@ -83,7 +97,7 @@ nrow
 }
 
 \subsection{Returns}{
-Matrix row count.
+Matrix row count
 }
 }
 \if{html}{\out{<hr>}}
@@ -96,7 +110,7 @@ ncol
 }
 
 \subsection{Returns}{
-Matrix column count.
+Matrix column count
 }
 }
 \if{html}{\out{<hr>}}
@@ -116,8 +130,8 @@ One-based matrix
 \if{html}{\out{<a id="method-matrixZeroBasedView-sum"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-sum}{}}}
 \subsection{Method \code{sum()}}{
-Perform arithmetic sum between this \link{matrixZeroBasedView}
-and another \link{matrixZeroBasedView}.
+Perform arithmetic sum between this
+\link{matrixZeroBasedView} and another \link{matrixZeroBasedView}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$sum(x)}\if{html}{\out{</div>}}
 }
@@ -125,12 +139,12 @@ and another \link{matrixZeroBasedView}.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{x}}{the \link{matrixZeroBasedView} to sum.}
+\item{\code{x}}{the \link{matrixZeroBasedView} to sum}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-The result of the sum as a \link{matrixZeroBasedView}.
+The result of the sum as a \link{matrixZeroBasedView}
 }
 }
 \if{html}{\out{<hr>}}
@@ -142,6 +156,9 @@ print
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$print()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+Invisibly returns \code{self}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-matrixZeroBasedView-clone"></a>}}

--- a/apis/r/man/matrixZeroBasedView.Rd
+++ b/apis/r/man/matrixZeroBasedView.Rd
@@ -11,7 +11,7 @@ Zero-based Wrapper for Sparse Matrices
 \details{
 \code{matrixZeroBasedView} is a wrapper shim for a matrix or
 \code{\link[Matrix:sparseMatrix]{Matrix::sparseMatrix}} that allows
-elemental matrix access using zero-based indices
+elemental matrix access using zero-based indices.
 }
 \examples{
 (mat <- Matrix::rsparsematrix(3L, 3L, 0.3))
@@ -39,7 +39,7 @@ mat0$take(0, 0:2)$get_one_based_matrix()
 \if{html}{\out{<a id="method-matrixZeroBasedView-new"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-new}{}}}
 \subsection{Method \code{new()}}{
-Initialize (lifecycle: maturing)
+Initialize (lifecycle: maturing).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$new(x)}\if{html}{\out{</div>}}
 }
@@ -47,7 +47,7 @@ Initialize (lifecycle: maturing)
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{x}}{A matrix}
+\item{\code{x}}{A matrix.}
 }
 \if{html}{\out{</div>}}
 }
@@ -56,7 +56,7 @@ Initialize (lifecycle: maturing)
 \if{html}{\out{<a id="method-matrixZeroBasedView-take"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-take}{}}}
 \subsection{Method \code{take()}}{
-Zero-based matrix element access
+Zero-based matrix element access.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$take(i = NULL, j = NULL)}\if{html}{\out{</div>}}
 }
@@ -64,21 +64,21 @@ Zero-based matrix element access
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{i}}{Row index (zero-based)}
+\item{\code{i}}{Row index (zero-based).}
 
-\item{\code{j}}{Column index (zero-based)}
+\item{\code{j}}{Column index (zero-based).}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-The specified matrix slice as another \link{matrixZeroBasedView}
+The specified matrix slice as another \code{matrixZeroBasedView}.
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-matrixZeroBasedView-dim"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-dim}{}}}
 \subsection{Method \code{dim()}}{
-dim
+dim.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$dim()}\if{html}{\out{</div>}}
 }
@@ -91,39 +91,39 @@ The dimensions of the matrix.
 \if{html}{\out{<a id="method-matrixZeroBasedView-nrow"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-nrow}{}}}
 \subsection{Method \code{nrow()}}{
-nrow
+nrow.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$nrow()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-Matrix row count
+Matrix row count.
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-matrixZeroBasedView-ncol"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-ncol}{}}}
 \subsection{Method \code{ncol()}}{
-ncol
+ncol.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$ncol()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-Matrix column count
+Matrix column count.
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-matrixZeroBasedView-get_one_based_matrix"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-get_one_based_matrix}{}}}
 \subsection{Method \code{get_one_based_matrix()}}{
-Get the one-based R matrix with its original class
+Get the one-based \R matrix with its original class.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$get_one_based_matrix()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-One-based matrix
+One-based matrix.
 }
 }
 \if{html}{\out{<hr>}}
@@ -131,7 +131,7 @@ One-based matrix
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-sum}{}}}
 \subsection{Method \code{sum()}}{
 Perform arithmetic sum between this
-\link{matrixZeroBasedView} and another \link{matrixZeroBasedView}
+\code{matrixZeroBasedView} and another \code{matrixZeroBasedView}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$sum(x)}\if{html}{\out{</div>}}
 }
@@ -139,25 +139,25 @@ Perform arithmetic sum between this
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{x}}{the \link{matrixZeroBasedView} to sum}
+\item{\code{x}}{the \code{matrixZeroBasedView} to sum.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-The result of the sum as a \link{matrixZeroBasedView}
+The result of the sum as a \code{matrixZeroBasedView}.
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-matrixZeroBasedView-print"></a>}}
 \if{latex}{\out{\hypertarget{method-matrixZeroBasedView-print}{}}}
 \subsection{Method \code{print()}}{
-print
+print.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{matrixZeroBasedView$print()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
-Invisibly returns \code{self}
+Invisibly returns \code{self}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/show_package_versions.Rd
+++ b/apis/r/man/show_package_versions.Rd
@@ -10,3 +10,7 @@ show_package_versions()
 Print version information for \pkg{tiledb} (R package), libtiledbsoma, and
 TileDB embedded, suitable for assisting with bug reports.
 }
+\examples{
+show_package_versions()
+
+}

--- a/apis/r/man/show_package_versions.Rd
+++ b/apis/r/man/show_package_versions.Rd
@@ -7,8 +7,8 @@
 show_package_versions()
 }
 \description{
-Print version information for \pkg{tiledb} (R package), libtiledbsoma, and
-TileDB embedded, suitable for assisting with bug reports.
+Print version information for \CRANpkg{tiledb} (R package), libtiledbsoma,
+and TileDB embedded, suitable for assisting with bug reports.
 }
 \examples{
 show_package_versions()


### PR DESCRIPTION
Add examples for the following objects

 - `matrixZeroBasedView`
 - `show_package_versions()`

Fixes [SOMA-214](https://linear.app/tiledb/issue/SOMA-214/add-examples-for-utils)

Partially replaces #4075