### PR TITLE
[python] remove unnecessary file from MANIFEST.in

### DIFF
--- a/apis/python/MANIFEST.in
+++ b/apis/python/MANIFEST.in
@@ -1,4 +1,4 @@
-include RELEASE-VERSION version.py py.typed
+include RELEASE-VERSION version.py
 include src/tiledbsoma/*.cc
 include src/tiledbsoma/*.h
 graft dist_links


### PR DESCRIPTION
**Issue and/or context:**

The Python MANIFEST.in file had an obsolete reference to `py.typed`.  It is no longer necessary to specify these (see setuptools docs), and it pointed to the wrong file location - so I removed it.

Fixes SOMA-219
