### PR TITLE
[r] [ci] Use pak-release instead of pak-devel for R dependencies

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -85,8 +85,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: 'apis/r/'
-          cache-version: 2
-          pak-version: "devel"
+          cache-version: 3
 
       # - name: CMake
       #   uses: lukka/get-cmake@latest

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: 'apis/r/'
-          pak-version: "devel"
+          cache-version: 3
 
       - name: Build Package
         run: cd apis/r && R CMD build --no-build-vignettes --no-manual .


### PR DESCRIPTION
Use release version of pak for R dependency resolution. As of today (2025-06-02), the current versions of pak and pkgbuild are:

 - [pak](https://cran.r-project.org/package=pak): 0.9.0 released 2025-05-27
 - [pkgbuild](https://cran.r-project.org/package=pkgbuild) 1.4.8 released 2025-05-26

cf r-lib/pak#778, r-lib/pkgbuild#208

Fixes [SOMA-74](https://linear.app/tiledb/issue/SOMA-74/roll-back-pakpkgbuild-devel-to-release)