### PR TITLE
add support for pytest 8.4.0

### DIFF
--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -18,7 +18,6 @@ if Version(_pytest.__version__) < Version("8.4.0"):
     from _pytest.python_api import RaisesContext
 
     E = TypeVar("E", bound=BaseException, default=BaseException)
-
     MaybeRaisesReturn = Union[RaisesContext[E], ExceptionInfo[E], nullcontext]
 else:
     from _pytest.raises import RaisesExc


### PR DESCRIPTION
Our Python unit tests use some private pytest API which was changed in pytest 8.4.0.

Short term fix which introspects the pytest version to adapt to this change.

Affects only a handful of unit tests
