### PR TITLE
Fix undocumented reopen behavior in Python

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - \[[#4071](https://github.com/single-cell-data/TileDB-SOMA/pull/4071)\] [python] A `tiledb_timestamp` with value of zero is now equivalent to an unspecified timestamp (or `None`), and will be a synonym for "current time". Prior to this fix, a zero-valued timestamp would generate errors or unpredictable results.
 - \[[#4103](https://github.com/single-cell-data/TileDB-SOMA/pull/4103)\] [python] Do not attempt to resize empty measurements in tiledbsoma.io.prepare_experiment. This fixes a bug where calling `prepare_experiment` would fail if the Experiment contained any empty Measurements.
 
+- \[[#4106](https://github.com/single-cell-data/TileDB-SOMA/pull/4106)\] [python] The `SOMAObject.reopen` method no longer modifies the original `SOMAObject`. It only creates a new instance of a `SOMAObject` in the requested mode and at the requested timestamp. Attempting to `reopen` an object with unwritten metadata now raises a `SOMAError`.
+
 ### Security
 
 ## [Release 1.17.0]

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4086](https://github.com/single-cell-data/TileDB-SOMA/pull/4086)\] [python] Add new parameter `allow_duplicate_obs_ids` to the `tiledbsoma.io` functions `register_anndatas` and `register_h5ads`.  When `False` (default), a error will be raised if there are any duplicate `obs` IDs in the provided SOMA Experiment or AnnData objects. Set the parameter to `True` for legacy behavior. ID handling on the `var` axis is unchanged.
 
+- \[[#4106](https://github.com/single-cell-data/TileDB-SOMA/pull/4106)\] [python][BREAKING] The `SOMAObject.reopen` method now modifies the orginal `SOMAObject` in place (flushes data to disk and reopens with the requested timestamp and mode) and returns a reference to itself instead of flushing data to disk and opening a new object.
+
 ### Deprecated
 
 - \[[#4081](https://github.com/single-cell-data/TileDB-SOMA/pull/4081)\] [python] the `tiledbsoma.io` functions `append_obs`, `append_var` and `append_X` are deprecated and will be removed in a future release. It is recommended to use tiledbsoma.io.from_anndata (with a registration map from tiledbsoma.io.register_anndatas or tiledbsoma.io.register_h5ads) for appending new, complete AnnData objects to an Experiment.
@@ -24,8 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4071](https://github.com/single-cell-data/TileDB-SOMA/pull/4071)\] [python] A `tiledb_timestamp` with value of zero is now equivalent to an unspecified timestamp (or `None`), and will be a synonym for "current time". Prior to this fix, a zero-valued timestamp would generate errors or unpredictable results.
 - \[[#4103](https://github.com/single-cell-data/TileDB-SOMA/pull/4103)\] [python] Do not attempt to resize empty measurements in tiledbsoma.io.prepare_experiment. This fixes a bug where calling `prepare_experiment` would fail if the Experiment contained any empty Measurements.
-
-- \[[#4106](https://github.com/single-cell-data/TileDB-SOMA/pull/4106)\] [python] The `SOMAObject.reopen` method no longer modifies the original `SOMAObject`. It only creates a new instance of a `SOMAObject` in the requested mode and at the requested timestamp. Attempting to `reopen` an object with unwritten metadata now raises a `SOMAError`.
 
 ### Security
 

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -24,6 +24,7 @@ from . import (
     _dataframe,
     _dense_nd_array,
     _experiment,
+    _geometry_dataframe,
     _measurement,
     _multiscale_image,
     _point_cloud_dataframe,
@@ -168,6 +169,7 @@ def _type_name_to_cls(type_name: str) -> type[AnySOMAObject]:
             _sparse_nd_array.SparseNDArray,
             _scene.Scene,
             _point_cloud_dataframe.PointCloudDataFrame,
+            _geometry_dataframe.GeometryDataFrame,
         )
     }
     try:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -270,12 +270,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 
-    def __init__(
-        self,
-        handle: GeometryDataFrameWrapper,
-        **kwargs: Any,
-    ):
-        super().__init__(handle, **kwargs)
+    def _parse_special_metadata(self) -> None:
 
         # Get and validate coordinate space.
         try:

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -237,14 +237,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
         return multiscale
 
-    def __init__(
-        self,
-        handle: _tdb_handles.SOMAGroupWrapper[Any],
-        **kwargs: Any,
-    ):
-        # Do generic SOMA collection initialization.
-        super().__init__(handle, **kwargs)
-
+    def _parse_special_metadata(self) -> None:
         try:
             spatial_encoding_version = self.metadata[SOMA_SPATIAL_VERSION_METADATA_KEY]
             if isinstance(spatial_encoding_version, bytes):

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -257,13 +257,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 
-    def __init__(
-        self,
-        handle: PointCloudDataFrameWrapper,
-        **kwargs: Any,
-    ):
-        super().__init__(handle, **kwargs)
-
+    def _parse_special_metadata(self) -> None:
         # Get and validate coordinate space.
         try:
             coord_space = self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY]

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -130,12 +130,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         except SOMAError as e:
             raise map_exception_for_create(e, uri) from None
 
-    def __init__(
-        self,
-        handle: _tdb_handles.SOMAGroupWrapper[Any],
-        **kwargs: Any,
-    ):
-        super().__init__(handle, **kwargs)
+    def _parse_special_metadata(self) -> None:
         coord_space = self.metadata.get(SOMA_COORDINATE_SPACE_METADATA_KEY)
         if coord_space is None:
             self._coord_space: CoordinateSpace | None = None

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -212,10 +212,6 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         """Opens and returns a TileDB object specific to this type."""
         raise NotImplementedError()
 
-    def has_modified_metadata(self) -> bool:
-        """Write metadata changes to disk, if there were any."""
-        return not self.metadata.is_synced
-
     # Covariant types should normally not be in parameters, but this is for
     # internal use only so it's OK.
     def _do_initial_reads(self, reader: _RawHdl_co) -> None:  # type: ignore[misc]

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -818,10 +818,6 @@ class MetadataWrapper(MutableMapping[str, Any]):
             return f"<{prefix}>"
         return f"<{prefix} {self.cache}>"
 
-    @property
-    def is_synced(self) -> bool:
-        return not self._mods
-
 
 def _check_metadata_type(key: str, obj: Metadatum) -> None:
     """Pre-checks that a metadata entry can be stored in an array.

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -66,57 +66,6 @@ void load_soma_array(py::module& m) {
                py::object exc_value,
                py::object traceback) { array.close(); })
 
-        .def(
-            "reopen",
-            [](SOMAArray& array,
-               OpenMode mode,
-               std::optional<TimestampRange> timestamp) -> py::object {
-                auto new_array = array.reopen(mode, timestamp);
-
-                std::optional<std::string> soma_obj_type;
-                try {
-                    soma_obj_type = new_array->type();
-                } catch (const std::exception& e) {
-                    TPY_ERROR_LOC(e.what());
-                }
-
-                if (!soma_obj_type) {
-                    throw TileDBSOMAError(
-                        "Unreachable code: The missing soma_object_type case "
-                        "is already handled. This indicates an "
-                        "unexpected failure to catch exceptions by "
-                        "SOMAArray::reopen");
-                }
-
-                std::transform(
-                    soma_obj_type->begin(),
-                    soma_obj_type->end(),
-                    soma_obj_type->begin(),
-                    [](unsigned char c) { return std::tolower(c); });
-
-                if (soma_obj_type == "somadataframe")
-                    return py::cast(SOMADataFrame(*new_array));
-                else if (soma_obj_type == "somapointclouddataframe")
-                    return py::cast(SOMAPointCloudDataFrame(*new_array));
-                else if (soma_obj_type == "somageometrydataframe")
-                    return py::cast(SOMAGeometryDataFrame(*new_array));
-                else if (soma_obj_type == "somasparsendarray")
-                    return py::cast(SOMASparseNDArray(*new_array));
-                else if (soma_obj_type == "somadensendarray")
-                    return py::cast(SOMADenseNDArray(*new_array));
-
-                throw TileDBSOMAError(
-                    "Unreachable code: All possible SOMA object types are "
-                    "already handled. This indicates a logic error or an "
-                    "unexpected failure to catch exceptions by "
-                    "SOMAArray::reopen");
-
-                return py::none();  // Unreached, but appeases a compiler
-                                    // warning
-            },
-            "mode"_a,
-            "timestamp"_a = py::none())
-
         .def("close", &SOMAArray::close)
         .def_property_readonly(
             "closed",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -50,7 +50,6 @@ void load_soma_group(py::module& m) {
             [](SOMAGroup& group) {
                 return group.mode() == OpenMode::read ? "r" : "w";
             })
-        .def("reopen", &SOMAGroup::reopen)
         .def("close", &SOMAGroup::close)
         .def_property_readonly(
             "closed",

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -120,18 +120,16 @@ class SOMAArrayStateMachine(RuleBasedStateMachine):
         # TODO: time travel
         self._open(mode=mode)
 
-    @precondition(lambda self: not self.closed)
-    @precondition(lambda self: not self.A._handle.has_modified_metadata)
+    @precondition(lambda self: self.is_initialized)
     @rule(mode=st.sampled_from(["r", "w"]))
     def reopen(self, mode: OpenMode) -> None:
-        assert not self.A._handle.has_modified_metadata
-        assert self.mode is not None
-        self.A = self.A.reopen(
+        self.A.reopen(
             mode,
             tiledb_timestamp=None,  # no time-travel for now
         )
-        self.mode = mode
         assert self.A.mode == mode and not self.A.closed
+        self.closed = False
+        self.mode = mode
 
     ##
     ## --- metadata

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -120,17 +120,11 @@ class SOMAArrayStateMachine(RuleBasedStateMachine):
         # TODO: time travel
         self._open(mode=mode)
 
-    @precondition(
-        lambda self: not HT_TEST_CONFIG["sc-61123_workaround"]
-    )  # TODO: this entire rule disabled until sc-61123 fixed.
     @precondition(lambda self: not self.closed)
-    @precondition(
-        lambda self: not HT_TEST_CONFIG["sc-61118_workaround"] or self.mode != "w"
-    )  # TODO - fails due to loss of metadata on reopen from w->r. See sc-61118. Remove when fixed.
+    @precondition(lambda self: not self.A._handle.has_modified_metadata)
     @rule(mode=st.sampled_from(["r", "w"]))
     def reopen(self, mode: OpenMode) -> None:
-        assert not self.A.closed
-        assert not self.closed
+        assert not self.A._handle.has_modified_metadata
         assert self.mode is not None
         self.A = self.A.reopen(
             mode,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -518,44 +518,6 @@ def test_context_timestamp(tmp_path: pathlib.Path):
         assert sub_1["sub_sub"].tiledb_timestamp_ms == 234
 
 
-def test_collection_reopen(tmp_path):
-    # Ensure that reopen uses the correct mode
-    soma.Collection.create(tmp_path.as_uri(), tiledb_timestamp=1)
-
-    with soma.Collection.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as col1:
-        with raises_no_typeguard(ValueError):
-            col1.reopen("invalid")
-
-        with col1.reopen("w", tiledb_timestamp=2) as col2:
-            with col2.reopen("r", tiledb_timestamp=3) as col3:
-                assert col1.mode == "r"
-                assert col2.mode == "w"
-                assert col3.mode == "r"
-                assert col1.tiledb_timestamp_ms == 1
-                assert col2.tiledb_timestamp_ms == 2
-                assert col3.tiledb_timestamp_ms == 3
-
-    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    with soma.Collection.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as col1:
-        with col1.reopen("r", tiledb_timestamp=ts2) as col2:
-            assert col1.mode == "r"
-            assert col2.mode == "r"
-            assert col1.tiledb_timestamp == ts1
-            assert col2.tiledb_timestamp == ts2
-
-    with soma.Collection.open(tmp_path.as_posix(), "w") as col1:
-        with col1.reopen("w", tiledb_timestamp=None) as col2:
-            with col2.reopen("w") as col3:
-                assert col1.mode == "w"
-                assert col2.mode == "w"
-                assert col3.mode == "w"
-                now = datetime.datetime.now(datetime.timezone.utc)
-                assert col1.tiledb_timestamp <= now
-                assert col2.tiledb_timestamp <= now
-                assert col2.tiledb_timestamp <= now
-
-
 @pytest.mark.parametrize(
     ("key", "sanitized_key"),
     (

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -180,43 +180,6 @@ def test_dataframe(tmp_path, arrow_schema):
         soma.MultiscaleImage.open(tmp_path.as_posix())
 
 
-def test_dataframe_reopen(tmp_path, arrow_schema):
-    soma.DataFrame.create(tmp_path.as_posix(), schema=arrow_schema(), tiledb_timestamp=1)
-
-    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as sdf1:
-        with raises_no_typeguard(ValueError):
-            sdf1.reopen("invalid")
-
-        with sdf1.reopen("w", tiledb_timestamp=2) as sdf2:
-            with sdf2.reopen("r", tiledb_timestamp=3) as sdf3:
-                assert sdf1.mode == "r"
-                assert sdf2.mode == "w"
-                assert sdf3.mode == "r"
-                assert sdf1.tiledb_timestamp_ms == 1
-                assert sdf2.tiledb_timestamp_ms == 2
-                assert sdf3.tiledb_timestamp_ms == 3
-
-    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    with soma.DataFrame.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as sdf1:
-        with sdf1.reopen("r", tiledb_timestamp=ts2) as sdf2:
-            assert sdf1.mode == "r"
-            assert sdf2.mode == "r"
-            assert sdf1.tiledb_timestamp == ts1
-            assert sdf2.tiledb_timestamp == ts2
-
-    with soma.DataFrame.open(tmp_path.as_posix(), "w") as sdf1:
-        with sdf1.reopen("w", tiledb_timestamp=None) as sdf2:
-            with sdf1.reopen("w") as sdf3:
-                assert sdf1.mode == "w"
-                assert sdf2.mode == "w"
-                assert sdf3.mode == "w"
-                now = datetime.datetime.now(datetime.timezone.utc)
-                assert sdf1.tiledb_timestamp <= now
-                assert sdf2.tiledb_timestamp <= now
-                assert sdf3.tiledb_timestamp <= now
-
-
 def test_dataframe_with_float_dim(tmp_path, arrow_schema):
     sdf = soma.DataFrame.create(tmp_path.as_posix(), schema=arrow_schema(), index_column_names=("myfloat",))
     assert sdf.index_column_names == ("myfloat",)

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 import json
 import pathlib
 
@@ -74,51 +73,6 @@ def test_dense_nd_array_create_ok(tmp_path, shape: tuple[int, ...], element_type
 
     with pytest.raises(soma.SOMAError):
         soma.MultiscaleImage.open(tmp_path.as_posix())
-
-
-def test_dense_nd_array_reopen(tmp_path):
-    soma.DenseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,), tiledb_timestamp=1)
-
-    # Ensure that reopen uses the correct mode
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
-        with raises_no_typeguard(ValueError):
-            A1.reopen("invalid")
-
-        with A1.reopen("w", tiledb_timestamp=2) as A2:
-            with A2.reopen("r", tiledb_timestamp=3) as A3:
-                assert A1.mode == "r"
-                assert A2.mode == "w"
-                assert A3.mode == "r"
-                assert A1.tiledb_timestamp_ms == 1
-                assert A2.tiledb_timestamp_ms == 2
-                assert A3.tiledb_timestamp_ms == 3
-
-    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as A1:
-        with A1.reopen("r", tiledb_timestamp=ts2) as A2:
-            assert A1.mode == "r"
-            assert A2.mode == "r"
-            assert A1.tiledb_timestamp == ts1
-            assert A2.tiledb_timestamp == ts2
-
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "w", tiledb_timestamp=1) as A1:
-        with A1.reopen("w", tiledb_timestamp=2) as A2:
-            assert A1.mode == "w"
-            assert A2.mode == "w"
-            assert A1.tiledb_timestamp.timestamp() == 0.001
-            assert A2.tiledb_timestamp.timestamp() == 0.002
-
-    with soma.DenseNDArray.open(tmp_path.as_posix(), "w") as A1:
-        with A1.reopen("w", tiledb_timestamp=None) as A2:
-            with A2.reopen("w") as A3:
-                assert A1.mode == "w"
-                assert A2.mode == "w"
-                assert A3.mode == "w"
-                now = datetime.datetime.now(datetime.timezone.utc)
-                assert A1.tiledb_timestamp <= now
-                assert A2.tiledb_timestamp <= now
-                assert A3.tiledb_timestamp <= now
 
 
 @pytest.mark.parametrize("shape", [(10,)])

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -1,4 +1,3 @@
-import datetime
 from urllib.parse import urljoin
 
 import numpy as np
@@ -249,41 +248,3 @@ def test_experiment_ms_type_constraint(tmp_path):
             schema=pa.schema([("A", pa.int32())]),
             index_column_names=["A"],
         )
-
-
-def test_experiment_reopen(tmp_path):
-    # Ensure that reopen uses the correct mode
-    soma.Experiment.create(tmp_path.as_uri(), tiledb_timestamp=1)
-
-    with soma.Experiment.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as exp1:
-        with raises_no_typeguard(ValueError):
-            exp1.reopen("invalid")
-
-        with exp1.reopen("w", tiledb_timestamp=2) as exp2:
-            with exp2.reopen("r", tiledb_timestamp=3) as exp3:
-                assert exp1.mode == "r"
-                assert exp2.mode == "w"
-                assert exp3.mode == "r"
-                assert exp1.tiledb_timestamp_ms == 1
-                assert exp2.tiledb_timestamp_ms == 2
-                assert exp3.tiledb_timestamp_ms == 3
-
-    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    with soma.Experiment.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as exp1:
-        with exp1.reopen("r", tiledb_timestamp=ts2) as exp2:
-            assert exp1.mode == "r"
-            assert exp2.mode == "r"
-            assert exp1.tiledb_timestamp == ts1
-            assert exp2.tiledb_timestamp == ts2
-
-    with soma.Experiment.open(tmp_path.as_posix(), "w") as exp1:
-        with exp1.reopen("w", tiledb_timestamp=None) as exp2:
-            with exp2.reopen("w") as exp3:
-                assert exp1.mode == "w"
-                assert exp2.mode == "w"
-                assert exp3.mode == "w"
-                now = datetime.datetime.now(datetime.timezone.utc)
-                assert exp1.tiledb_timestamp <= now
-                assert exp2.tiledb_timestamp <= now
-                assert exp2.tiledb_timestamp <= now

--- a/apis/python/tests/test_reopen.py
+++ b/apis/python/tests/test_reopen.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 
 import tiledbsoma
-import tiledb
 
 from ._util import create_basic_object, raises_no_typeguard
 

--- a/apis/python/tests/test_reopen.py
+++ b/apis/python/tests/test_reopen.py
@@ -1,0 +1,85 @@
+import datetime
+
+import pytest
+
+import tiledbsoma
+import tiledb
+
+from ._util import create_basic_object, raises_no_typeguard
+
+
+@pytest.mark.parametrize(
+    "soma_type",
+    [
+        "SOMAExperiment",
+        "SOMAMeasurement",
+        "SOMACollection",
+        "SOMAScene",
+        "SOMADataFrame",
+        "SOMASparseNDArray",
+        "SOMADenseNDArray",
+        "SOMAScene",
+        "SOMAPointCloudDataFrame",
+        "SOMAGeometryDataFrame",
+        "SOMAMultiscaleImage",
+    ],
+)
+def test_experiment_reopen(tmp_path, soma_type):
+    # Create object and an error is thrown for reopen with invalid mode.
+    uri = f"{tmp_path}/{soma_type}"
+    with create_basic_object(soma_type, uri, tiledb_timestamp=1) as x1:
+        with raises_no_typeguard(ValueError):
+            x1.reopen("invalid")
+
+    # Check reopen without specifying timestamp.
+    with tiledbsoma.open(uri, "r") as x1:
+        assert x1.mode == "r"
+        x2 = x1.reopen("w")
+        assert x2 is x1
+        assert x1.mode == "w"
+    assert x1.closed
+
+    with tiledbsoma.open(uri, "w") as x1:
+        assert x1.mode == "w"
+        x2 = x1.reopen("r")
+        assert x2 is x1
+        assert x1.mode == "r"
+    assert x1.closed
+
+    for mode in ["r", "w"]:
+        with tiledbsoma.open(uri, mode) as x1:
+            assert x1.mode == mode
+            x2 = x1.reopen(mode)
+            assert x2 is x1
+            assert x1.mode == mode
+    assert x1.closed
+
+    # Check modifying the timestamp.
+    with tiledbsoma.open(uri, "r") as x1:
+        x2 = x1.reopen("w", tiledb_timestamp=2)
+        assert x2 is x1
+        assert x1.mode == "w"
+        assert x1.tiledb_timestamp_ms == 2
+        x2 = x1.reopen("r", tiledb_timestamp=3)
+        assert x2 is x1
+        assert x1.mode == "r"
+        assert x1.tiledb_timestamp_ms == 3
+    assert x1.closed
+
+    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
+    for mode in ["r", "w"]:
+        with tiledbsoma.open(uri, "r", tiledb_timestamp=ts1) as x1:
+            x2 = x1.reopen("r", tiledb_timestamp=ts2)
+            assert x2 is x1
+            assert x1.mode == "r"
+            assert x1.tiledb_timestamp == ts2
+        assert x1.closed
+
+        with tiledbsoma.open(uri, "w", tiledb_timestamp=1) as x1:
+            x2 = x1.reopen("w", tiledb_timestamp=None)
+            assert x1 is x1
+            assert x1.mode == "w"
+            now = datetime.datetime.now(datetime.timezone.utc)
+            assert x1.tiledb_timestamp <= now
+        assert x1.closed

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import gc
 import itertools
 import json
@@ -106,43 +105,6 @@ def test_sparse_nd_array_create_ok(tmp_path, shape: tuple[int, ...], element_typ
 
     with pytest.raises(soma.SOMAError):
         soma.MultiscaleImage.open(tmp_path.as_posix())
-
-
-def test_sparse_nd_array_reopen(tmp_path):
-    soma.SparseNDArray.create(tmp_path.as_posix(), type=pa.float64(), shape=(1,), tiledb_timestamp=1)
-
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=1) as A1:
-        with raises_no_typeguard(ValueError):
-            A1.reopen("invalid")
-
-        with A1.reopen("w", tiledb_timestamp=2) as A2:
-            with A2.reopen("r", tiledb_timestamp=3) as A3:
-                assert A1.mode == "r"
-                assert A2.mode == "w"
-                assert A3.mode == "r"
-                assert A1.tiledb_timestamp_ms == 1
-                assert A2.tiledb_timestamp_ms == 2
-                assert A3.tiledb_timestamp_ms == 3
-
-    ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "r", tiledb_timestamp=ts1) as A1:
-        with A1.reopen("r", tiledb_timestamp=ts2) as A2:
-            assert A1.mode == "r"
-            assert A2.mode == "r"
-            assert A1.tiledb_timestamp == ts1
-            assert A2.tiledb_timestamp == ts2
-
-    with soma.SparseNDArray.open(tmp_path.as_posix(), "w") as A1:
-        with A1.reopen("w", tiledb_timestamp=None) as A2:
-            with A2.reopen("w") as A3:
-                assert A1.mode == "w"
-                assert A2.mode == "w"
-                assert A3.mode == "w"
-                now = datetime.datetime.now(datetime.timezone.utc)
-                assert A1.tiledb_timestamp <= now
-                assert A2.tiledb_timestamp <= now
-                assert A3.tiledb_timestamp <= now
 
 
 @pytest.mark.parametrize("shape", [(10,)])
@@ -1899,35 +1861,6 @@ def test_sparse_nd_array_null(tmp_path):
         # any null values present in non-nullable attributes get casted to
         # fill values. In the case for float64, the fill value is 0
         np.testing.assert_array_equal(pdf["soma_data"], table["soma_data"].fill_null(0))
-
-
-def test_reopen_metadata_sc61118(tmp_path):
-    uri = tmp_path.as_posix()
-    with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A1:
-        A1.metadata["foo"] = "bar"
-        with pytest.raises(soma.SOMAError):
-            A1.reopen(mode="r")
-        expected_metadata = dict(A1.metadata)
-        A1.close()
-        with A1.reopen(mode="r") as A2:
-            assert dict(A2.metadata) == expected_metadata
-
-
-def test_reopen_shape_sc61123(tmp_path):
-    uri = tmp_path.as_posix()
-    with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A:
-        assert A.shape == (10,)
-        assert isinstance(A, soma.SparseNDArray)
-        A = A.reopen(mode="r")
-        assert A.shape == (10,)
-        assert isinstance(A, soma.SparseNDArray)
-
-
-def test_match_read_schemas_61222(tmp_path):
-    uri = tmp_path.as_posix()
-    soma.SparseNDArray.create(uri, type=pa.int32(), shape=(None, None))
-    with soma.SparseNDArray.open(uri) as A:
-        assert A.schema == A.read().tables().concat().schema
 
 
 @pytest.mark.parametrize("ts", (None, 1))

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1905,8 +1905,12 @@ def test_reopen_metadata_sc61118(tmp_path):
     uri = tmp_path.as_posix()
     with soma.SparseNDArray.create(uri, type=pa.int64(), shape=(10,)) as A1:
         A1.metadata["foo"] = "bar"
+        with pytest.raises(soma.SOMAError):
+            A1.reopen(mode="r")
+        expected_metadata = dict(A1.metadata)
+        A1.close()
         with A1.reopen(mode="r") as A2:
-            assert dict(A1.metadata) == dict(A2.metadata)
+            assert dict(A2.metadata) == expected_metadata
 
 
 def test_reopen_shape_sc61123(tmp_path):

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -208,17 +208,6 @@ void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     fill_columns();
 }
 
-std::unique_ptr<SOMAArray> SOMAArray::reopen(
-    OpenMode mode, std::optional<TimestampRange> timestamp) {
-    if (arr_->query_type() == TILEDB_READ) {
-        arr_->reopen();
-    } else {
-        arr_->close();
-        arr_->open(TILEDB_WRITE);
-    }
-    return std::make_unique<SOMAArray>(mode, uri_, ctx_, timestamp);
-}
-
 void SOMAArray::close() {
     if (arr_->query_type() == TILEDB_WRITE) {
         meta_cache_arr_->close();

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -213,16 +213,6 @@ class SOMAArray : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * Return a new SOMAArray with the given mode at the current Unix timestamp.
-     *
-     * @param mode if the OpenMode is not given, If the SOMAObject was opened in
-     * READ mode, reopen it in WRITE mode and vice versa
-     * @param timestamp Timestamp
-     */
-    std::unique_ptr<SOMAArray> reopen(
-        OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
-
-    /**
      * Close the SOMAArray object.
      */
     void close();

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -150,11 +150,6 @@ void SOMAGroup::open(
     fill_caches();
 }
 
-std::unique_ptr<SOMAGroup> SOMAGroup::reopen(
-    OpenMode mode, std::optional<TimestampRange> timestamp) {
-    return std::make_unique<SOMAGroup>(mode, uri_, ctx_, name_, timestamp);
-}
-
 void SOMAGroup::close() {
     if (group_->query_type() == TILEDB_WRITE)
         cache_group_->close();

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -107,16 +107,6 @@ class SOMAGroup : public SOMAObject {
         OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * Return a new SOMAGroup with the given mode at the current Unix timestamp.
-     *
-     * @param mode if the OpenMode is not given, If the SOMAObject was opened in
-     * READ mode, reopen it in WRITE mode and vice versa
-     * @param timestamp Timestamp
-     */
-    std::unique_ptr<SOMAGroup> reopen(
-        OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
-
-    /**
      * Close the SOMAGroup object.
      */
     void close();


### PR DESCRIPTION
**Issue and/or context:**
Towards SOMA-168

**Changes:**
The Python `SOMAObject.reopen` method is documented as creating a new `SOMAObject` with the requested mode and timestamp from an existing `SOMAObject`. The existing behavior was to close and reopen the original `SOMAObject` in its original mode in order to write metadata to the object before reopening, and would then create and return a new `SOMAObject` with the requested mode and timestamp.

This breaking change will close the internal handle, open a new internal handle in the requested mode and timestamp, and return the original (i.e. `self`) from the method in the requested mode and timestamp.
