### PR TITLE
[python] skip obs axis read-back when appending known unique observations to Experiment

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - \[[#4086](https://github.com/single-cell-data/TileDB-SOMA/pull/4086)\] [python] Add new parameter `allow_duplicate_obs_ids` to the `tiledbsoma.io` functions `register_anndatas` and `register_h5ads`.  When `False` (default), a error will be raised if there are any duplicate `obs` IDs in the provided SOMA Experiment or AnnData objects. Set the parameter to `True` for legacy behavior. ID handling on the `var` axis is unchanged.
+- \[[#4108](https://github.com/single-cell-data/TileDB-SOMA/pull/4108)\] [python] improve performance of `tiledbsoma.io.from_anndata` and `from_h5ad` when appending groups of AnnData known to have no duplicate obs axis IDs.
 
 ### Deprecated
 


### PR DESCRIPTION
**Issue and/or context:**

Ingest (`from_anndata`/`from_h5ad`) will filter duplicate obs and var IDs as part of appending new data. In the case where the obs axis is a priori known to contain only unique IDs, this filter step can be bypassed, for a performance win. This builds upon the previous change to `register_{anndatas,h5ads}` which introduced the `allow_duplicate_obs_ids` parameter.

Fixes SOMA-259
