### PR TITLE
[python] Fix / Update `python-uv` docker CI build

### DIFF
--- a/.github/workflows/python-dockers.yml
+++ b/.github/workflows/python-dockers.yml
@@ -78,5 +78,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/workflows/daily-python-dockers-issue-template.md
-          assignees: ryan-williams, johnkerl
+          assignees: ryan-williams, jp-dark
           update_existing: true

--- a/docker/python-uv.dockerfile
+++ b/docker/python-uv.dockerfile
@@ -22,10 +22,7 @@ RUN pip install --upgrade pip \
   && uv init example
 
 WORKDIR example
-# Required on ARM, until ARM Linux wheels are published:
-# - https://github.com/single-cell-data/TileDB-SOMA/issues/3890
-# - https://github.com/single-cell-data/TileDB-SOMA/issues/3909
-RUN echo "cmake<4" > constraints.txt
-RUN uv pip install --system --build-constraints constraints.txt tiledbsoma
+# Explicit scanpy>=1.11 pin is required, otherwise `uv` gets confused and fails trying to install Scanpy 1.9 → Numba 0.53 → llvmlite 0.36 → Python 3.8
+RUN uv pip install --system tiledbsoma 'scanpy>=1.11'
 
 ENTRYPOINT [ "python", "-c", "import tiledbsoma; tiledbsoma.show_package_versions()" ]


### PR DESCRIPTION
**Issue and/or context:** #4110

**Changes:**
- Fix python-uv build by pinning `scanpy>=1.11`.
- Update `python-dockers` assignees list (add @jp-dark, remove @johnkerl).
- Remove unnecessary `--build-constraints` flag (now that ARM Linux wheels are published)

Not clear why `uv pip install` started failing without the explicit `scanpy>=1.11` pin; [the failure message](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/15531736433/job/43721977528#step:3:647) says:

```
`llvmlite` (v0.36.0) was included because `tiledbsoma` (v1.17.0) depends on `scanpy` (v1.9.8) which depends on `numba` (v0.53.1) which depends on `llvmlite`
…
Cannot install on Python version 3.12.11; only versions >=3.6,<3.10 are supported.
```
