### PR TITLE
[r] Improve memory usage in `pad_matrix.matrix()` [WIP]

### DIFF
--- a/apis/r/R/pad_matrix.R
+++ b/apis/r/R/pad_matrix.R
@@ -89,24 +89,45 @@ pad_matrix.matrix <- function(x, rowidx, colidx, shape, sparse = FALSE, ...) {
   }
   type <- typeof(x)
   type <- match.arg(arg = type, choices = c("integer", "double", "logical"))
-  mat <- if (isTRUE(sparse)) {
-    Matrix::sparseMatrix(
-      i = integer(),
-      j = integer(),
-      x = switch(EXPR = type,
-        logical = logical(),
-        numeric()
-      ),
+  # mat <- if (isTRUE(sparse)) {
+  #   Matrix::sparseMatrix(
+  #     i = integer(),
+  #     j = integer(),
+  #     x = switch(EXPR = type,
+  #       logical = logical(),
+  #       numeric()
+  #     ),
+  #     dims = shape,
+  #     repr = "T"
+  #   )
+  # } else {
+  #   matrix(
+  #     data = vector(mode = type, length = prod(shape)),
+  #     nrow = shape[1L],
+  #     ncol = shape[2L]
+  #   )
+  # }
+  if (isTRUE(sparse)) {
+    on.exit(gc(), add = TRUE, after = FALSE)
+    return(Matrix::sparseMatrix(
+      i = replicate(n = ncol(x = x), expr = rowidx),
+      j = as.vector(vapply(
+        X = colidx,
+        FUN = rep_len,
+        FUN.VALUE = integer(length = nrow(x = x)),
+        length.out = nrow(x = x),
+        USE.NAMES = FALSE
+      )),
+      x = as.vector(x),
       dims = shape,
       repr = "T"
-    )
-  } else {
-    matrix(
-      data = vector(mode = type, length = prod(shape)),
-      nrow = shape[1L],
-      ncol = shape[2L]
-    )
+    ))
   }
+  mat <- matrix(
+    data = vector(mode = type, length = prod(shape)),
+    nrow = shape[1L],
+    ncol = shape[2L]
+  )
   mat[rowidx, colidx] <- x
   return(mat)
 }

--- a/apis/r/R/utils-seurat.R
+++ b/apis/r/R/utils-seurat.R
@@ -361,5 +361,7 @@
       immediate. = TRUE
     )
   }
+  spdl::debug("gc assay")
+  gc()
   return(ms)
 }

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -313,6 +313,8 @@ write_soma.DimReduc <- function(
     )
   }
 
+  spdl::debug("gc reduction")
+  gc()
   return(invisible(soma_parent))
 }
 
@@ -398,6 +400,8 @@ write_soma.Graph <- function(
     tiledbsoma_ctx = tiledbsoma_ctx
   )
 
+  spdl::debug("gc graph")
+  gc()
   return(invisible(soma_parent))
 }
 
@@ -693,6 +697,8 @@ write_soma.Seurat <- function(
     )
   }
 
+  spdl::debug("gc seurat")
+  gc()
   return(experiment$uri)
 }
 
@@ -821,5 +827,7 @@ write_soma.SeuratCommand <- function(
     relative = relative
   )
 
+  spdl::debug("gc command")
+  gc()
   return(invisible(soma_parent))
 }

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -103,6 +103,8 @@ write_soma.character <- function(
     relative = relative
   )
   sdf$set_metadata(uns_hint("1d"))
+  spdl::debug("gc character")
+  gc()
   return(sdf)
 }
 
@@ -291,6 +293,8 @@ write_soma.data.frame <- function(
     )
   }
   # Return
+  spdl::debug("gc data frame")
+  gc()
   return(sdf)
 }
 
@@ -430,6 +434,8 @@ write_soma.matrix <- function(
     )
   }
   # Return
+  spdl::debug("gc matrix")
+  gc()
   return(array)
 }
 
@@ -598,6 +604,8 @@ write_soma.TsparseMatrix <- function(
     )
   }
   # Return
+  spdl::debug("gc tsparse")
+  gc()
   return(array)
 }
 


### PR DESCRIPTION
Improve memory using in `pad_matrix.matrix()` when padding a dense S3 matrix to a larger size and casting to a TsparseMatrix. Previously, `pad_matrix.matrix()` would

 - re-index the matrix access indexes `mat[access_row, access_col]` to the expanded shape
 - create an empty TsparseMatrix with the expanded shape
 - fill the empty TsparseMatrix using the the re-indexed matrix access indexes

This led to OOMs for large dense matrices, and would occasionally trigger a conversion from TsparseMatrix to CsparseMatrix, which would then necessitate another conversion back to TsparseMatrix

The updated `pad_matrix.matrix()` instead:

 - re-indexes the matrix access indexes to the expanded shape
 - converts the matrix access indexes to COO indexes
 - creates a TsparseMatrix with the expanded shape using the COO indexes and the matrix data itself

This is more memory efficient than filling using matrix access indexes and eliminates the occasional conversion from TsparseMatrix to CsparseMatrix

Fixes [SOMA-273](https://linear.app/tiledb/issue/SOMA-273)