### PR TITLE
Update C++ exists methods to use SOMAArray _exists method

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -1159,6 +1159,18 @@ std::vector<int64_t> SOMAArray::_shape_via_tiledb_domain() {
     return result;
 }
 
+bool SOMAArray::_exists(
+    std::string_view uri,
+    std::string_view soma_type,
+    std::shared_ptr<SOMAContext> ctx) {
+    try {
+        auto obj = SOMAArray::open(OpenMode::read, uri, ctx, std::nullopt);
+        return soma_type == obj->type();
+    } catch (TileDBSOMAError& e) {
+        return false;
+    }
+}
+
 std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape() {
     return _get_current_domain().is_empty() ?
                _maybe_soma_joinid_shape_via_tiledb_domain() :

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -875,6 +875,11 @@ class SOMAArray : public SOMAObject {
     std::shared_ptr<SOMAColumn> get_column(std::size_t index) const;
 
    protected:
+    static bool _exists(
+        std::string_view uri,
+        std::string_view soma_type,
+        std::shared_ptr<SOMAContext> ctx);
+
     // See top-of-file notes regarding methods for SOMADataFrame being
     // defined in this file.
     //

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -76,16 +76,6 @@ std::unique_ptr<SOMADataFrame> SOMADataFrame::open(
     return array;
 }
 
-bool SOMADataFrame::exists(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    try {
-        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
-        return "SOMADataFrame" == obj->type();
-    } catch (TileDBSOMAError& e) {
-        return false;
-    }
-}
-
 void SOMADataFrame::update_dataframe_schema(
     std::vector<std::string> drop_attrs,
     std::map<std::string, std::string> add_attrs,

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -98,7 +98,10 @@ class SOMADataFrame : public SOMAArray {
      * @param uri URI to create the SOMADataFrame
      * @param ctx SOMAContext
      */
-    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+    static inline bool exists(
+        std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+        return SOMAArray::_exists(uri, "SOMADataFrame", ctx);
+    }
 
     /**
      * This is for schema evolution.

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -97,16 +97,6 @@ std::unique_ptr<SOMADenseNDArray> SOMADenseNDArray::open(
     return array;
 }
 
-bool SOMADenseNDArray::exists(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    try {
-        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
-        return "SOMADenseNDArray" == obj->type();
-    } catch (TileDBSOMAError& e) {
-        return false;
-    }
-}
-
 std::string_view SOMADenseNDArray::soma_data_type() {
     return ArrowAdapter::to_arrow_format(
         tiledb_schema()->attribute("soma_data").type());

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.h
@@ -70,7 +70,10 @@ class SOMADenseNDArray : public SOMAArray {
      * @param uri URI to create the SOMADenseNDArray
      * @param ctx SOMAContext
      */
-    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+    static inline bool exists(
+        std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+        return SOMAArray::_exists(uri, "SOMADenseNDArray", ctx);
+    }
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -76,16 +76,6 @@ std::unique_ptr<SOMAGeometryDataFrame> SOMAGeometryDataFrame::open(
     return std::make_unique<SOMAGeometryDataFrame>(mode, uri, ctx, timestamp);
 }
 
-bool SOMAGeometryDataFrame::exists(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    try {
-        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
-        return "SOMAGeometryDataFrame" == obj->type();
-    } catch (TileDBSOMAError& e) {
-        return false;
-    }
-}
-
 //===================================================================
 //= public non-static
 //===================================================================

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.h
@@ -81,7 +81,10 @@ class SOMAGeometryDataFrame : virtual public SOMAArray {
      * @param uri URI to create the SOMAGeometryDataFrame
      * @param ctx SOMAContext
      */
-    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+    static inline bool exists(
+        std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+        return SOMAArray::_exists(uri, "SOMAGeometryDataFrame", ctx);
+    }
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -79,16 +79,6 @@ std::unique_ptr<SOMAPointCloudDataFrame> SOMAPointCloudDataFrame::open(
     return array;
 }
 
-bool SOMAPointCloudDataFrame::exists(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    try {
-        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
-        return "SOMAPointCloudDataFrame" == obj->type();
-    } catch (TileDBSOMAError& e) {
-        return false;
-    }
-}
-
 //===================================================================
 //= public non-static
 //===================================================================

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.h
@@ -80,7 +80,10 @@ class SOMAPointCloudDataFrame : public SOMAArray {
      * @param uri URI to create the SOMAPointCloudDataFrame
      * @param ctx SOMAContext
      */
-    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+    static inline bool exists(
+        std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+        return SOMAArray::_exists(uri, "SOMAPointCloudDataFrame", ctx);
+    }
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -98,16 +98,6 @@ std::unique_ptr<SOMASparseNDArray> SOMASparseNDArray::open(
     return array;
 }
 
-bool SOMASparseNDArray::exists(
-    std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
-    try {
-        auto obj = SOMAObject::open(uri, OpenMode::read, ctx);
-        return "SOMASparseNDArray" == obj->type();
-    } catch (TileDBSOMAError& e) {
-        return false;
-    }
-}
-
 std::string_view SOMASparseNDArray::soma_data_type() {
     return ArrowAdapter::to_arrow_format(
         tiledb_schema()->attribute("soma_data").type());

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.h
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.h
@@ -70,7 +70,10 @@ class SOMASparseNDArray : public SOMAArray {
      *
      * @param ctx SOMAContext
      */
-    static bool exists(std::string_view uri, std::shared_ptr<SOMAContext> ctx);
+    static inline bool exists(
+        std::string_view uri, std::shared_ptr<SOMAContext> ctx) {
+        return SOMAArray::_exists(uri, "SOMASparseNDArray", ctx);
+    }
 
     //===================================================================
     //= public non-static

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -61,6 +61,11 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
             PlatformConfig(),
             TimestampRange(0, 2)));
     }
+
+    REQUIRE(SOMADenseNDArray::exists(uri, ctx));
+
+    index_columns.first->release(index_columns.first.get());
+    index_columns.second->release(index_columns.second.get());
 }
 
 TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {


### PR DESCRIPTION
**Issue and/or context:**

Towards SOMA-168

**Changes:**

Deduplicate `exists` checks for `SOMAArray` and use the faster `SOMAArray::open` methods instead of `SOMAObject::open`` factory method.

**Notes for Reviewer:**

Internal refactor - no changelog changes.