### PR TITLE
[r] Update docs to resolve remaining CRAN checks

### DIFF
--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -1,7 +1,7 @@
 #' SOMA Array Base Class
 #'
-#' Virtual base class to add SOMA-specific functionality to the
-#' \code{\link{TileDBArray}} class (lifecycle: maturing).
+#' Virtual base class to add array-specific functionality to the
+#' \code{\link{SOMAObject}} class (lifecycle: maturing).
 #'
 #' @keywords internal
 #'

--- a/apis/r/R/SOMAExperiment.R
+++ b/apis/r/R/SOMAExperiment.R
@@ -44,7 +44,7 @@ SOMAExperiment <- R6::R6Class(
     },
 
     #' @description Update the \code{obs} data frame to add or remove columns.
-    #' See \code{\link[tiledbomsa:SOMADataFrame]{SOMADataFrame$update()}} for
+    #' See \code{\link[tiledbsoma:SOMADataFrame]{SOMADataFrame$update()}} for
     #' more details.
     #'
     update_obs = function(values, row_index_name = NULL) {
@@ -52,7 +52,7 @@ SOMAExperiment <- R6::R6Class(
     },
 
     #' @description Update the \code{var} data frame to add or remove columns.
-    #' See \code{\link[tiledbomsa:SOMADataFrame]{SOMADataFrame$update()}} for
+    #' See \code{\link[tiledbsoma:SOMADataFrame]{SOMADataFrame$update()}} for
     #' more details.
     #'
     #' @param measurement_name The name of the \code{\link{SOMAMeasurement}}

--- a/apis/r/R/SOMAOpen.R
+++ b/apis/r/R/SOMAOpen.R
@@ -36,10 +36,11 @@ SOMAOpen <- function(
   tiledb_timestamp = NULL
 ) {
   ctx <- soma_context()
+  type <- get_tiledb_object_type(uri, ctxxp = ctx)
   metadata <- get_all_metadata(
     uri,
     is_array = switch(
-      get_tiledb_object_type(uri, ctxxp = ctx),
+      EXPR = type,
       ARRAY = TRUE,
       GROUP = FALSE,
       stop("Unknown TileDB object type: ", dQuote(type), call. = FALSE)
@@ -94,6 +95,10 @@ SOMAOpen <- function(
       tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
-    stop(sprintf("No support for type '%s'", obj), call. = FALSE)
+    stop(
+      "No support for type ",
+      dQuote(metadata$soma_object_type),
+      call. = FALSE
+    )
   ))
 }

--- a/apis/r/R/ephemeral.R
+++ b/apis/r/R/ephemeral.R
@@ -58,7 +58,6 @@ EphemeralCollectionBase <- R6::R6Class(
       return(gen$new())
     },
 
-    # Override TileDBGroup private methods
     #' @description Dummy method for ephemeral objects for compatibility with
     #' SOMA collections.
     #'
@@ -92,7 +91,6 @@ EphemeralCollectionBase <- R6::R6Class(
     #'
     exists = \() FALSE,
 
-    # Override TileDBGroup methods
     #' @description Special method for printing object representation to
     #' console.
     #'
@@ -157,7 +155,7 @@ EphemeralCollectionBase <- R6::R6Class(
 
     #' @description Add object to an ephemeral collection.
     #'
-    #' @param object A TileDB object (eg. \code{\link{TileDBGroup}}) to add
+    #' @param object A SOMA object (eg. \code{\link{SOMACollection}}) to add
     #' to the collection.
     #' @param name A name to add \code{object} as.
     #' @param relative Ignored for ephemeral objects.
@@ -368,12 +366,9 @@ EphemeralCollectionBase <- R6::R6Class(
     .check_open_for_write = \() invisible(NULL),
     .check_open_for_read_or_write = \() invisible(NULL),
 
-    # Override TileDBGroup private fields
+    # Override SOMACollectionBase private fields
     .member_cache = NULL,
     .update_member_cache = \() invisible(self),
-
-    # Override SOMACollectionBase private fields
-    soma_type_cache = NULL,
 
     # Ephemeral fields
     .data = NULL,

--- a/apis/r/R/write_bioc.R
+++ b/apis/r/R/write_bioc.R
@@ -5,6 +5,7 @@
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)
+#' # Write a Bioconductor S4 DataFrame object to a SOMA
 #' uri <- withr::local_tempfile(pattern = "s4-data-frame")
 #' data("pbmc_small", package = "SeuratObject")
 #' obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]]
@@ -12,9 +13,7 @@
 #'
 #' (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' sdf$close()
-#' }
 #'
 write_soma.DataFrame <- function(
   x,
@@ -57,6 +56,7 @@ write_soma.DataFrame <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)
+#' # Write a Bioconductor SelfHits object to a SOMA
 #' uri <- withr::local_tempfile(pattern = "hits")
 #' (hits <- S4Vectors::SelfHits(
 #'   c(2, 3, 3, 3, 3, 3, 4, 4, 4),
@@ -67,9 +67,7 @@ write_soma.DataFrame <- function(
 #'
 #' (arr <- write_soma(hits, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
 write_soma.Hits <- function(
   x,
@@ -131,6 +129,7 @@ write_soma.Hits <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("SingleCellExperiment", quietly = TRUE)
+#' \donttest{
 #' uri <- withr::local_tempfile(pattern = "single-cell-experiment")
 #'
 #' mat <- abs(Matrix::rsparsematrix(
@@ -157,7 +156,6 @@ write_soma.Hits <- function(
 #' ms$X$names()
 #' ms$obsm$names()
 #'
-#' \dontshow{
 #' exp$close()
 #' }
 #'
@@ -351,6 +349,7 @@ write_soma.SingleCellExperiment <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("SummarizedExperiment", quietly = TRUE)
+#' \donttest{
 #' uri <- withr::local_tempfile(pattern = "summarized-experiment")
 #'
 #' mat <- abs(Matrix::rsparsematrix(
@@ -369,7 +368,6 @@ write_soma.SingleCellExperiment <- function(
 #' ms$var
 #' ms$X$names()
 #'
-#' \dontshow{
 #' exp$close()
 #' }
 #'

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -102,9 +102,7 @@ write_soma.Assay <- .write_seurat_assay
 #' (assay5 <- methods::as(pbmc_small[["RNA"]], "Assay5"))
 #' (ms5 <- write_soma(assay5, "RNA5", soma_parent = col))
 #'
-#' \dontshow{
 #' ms5$close()
-#' }
 #'
 write_soma.Assay5 <- .write_seurat_assay
 
@@ -420,6 +418,7 @@ write_soma.Graph <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)
+#' \donttest{
 #' uri <- withr::local_tempfile(pattern = "pbmc-small")
 #'
 #' data("pbmc_small", package = "SeuratObject")
@@ -437,7 +436,6 @@ write_soma.Graph <- function(
 #' ms$varm$names()
 #' ms$obsp$names()
 #'
-#' \dontshow{
 #' exp$close()
 #' }
 #'
@@ -713,9 +711,7 @@ write_soma.Seurat <- function(
 #' (logs <- col$get("seurat_commands"))
 #' logs$get("NormalizeData.RNA")
 #'
-#' \dontshow{
 #' col$close()
-#' }
 #'
 write_soma.SeuratCommand <- function(
   x,

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -72,12 +72,11 @@ NULL
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' # Write a character vector to a SOMA
 #' uri <- withr::local_tempfile(pattern = "character")
 #' (sdf <- write_soma(letters, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' sdf$close()
-#' }
 #'
 write_soma.character <- function(
   x,
@@ -141,15 +140,14 @@ write_soma.character <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)
+#' # Write a data.frame to a SOMA
 #' uri <- withr::local_tempfile(pattern = "data-frame")
 #' data("pbmc_small", package = "SeuratObject")
 #' head(obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]])
 #'
 #' (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' sdf$close()
-#' }
 #'
 write_soma.data.frame <- function(
   x,
@@ -318,13 +316,12 @@ write_soma.data.frame <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' # Write a matrix to a SOMA
 #' uri <- withr::local_tempfile(pattern = "matrix")
 #' mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 #' (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
 write_soma.matrix <- function(
   x,
@@ -440,13 +437,12 @@ write_soma.matrix <- function(
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' # Write a dense S4 Matrix to a SOMA
 #' uri <- withr::local_tempfile(pattern = "s4-matrix")
 #' mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 #' (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
 write_soma.Matrix <- write_soma.matrix
 
@@ -472,29 +468,26 @@ write_soma.Matrix <- write_soma.matrix
 #' @export
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' # Write a TsparseMatrix to a SOMA
 #' uri <- withr::local_tempfile(pattern = "tsparse-matrix")
 #' mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "T")
 #' (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
+#' # Write a CsparseMatrix to a SOMA
 #' uri <- withr::local_tempfile(pattern = "csparse-matrix")
 #' mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "C")
 #' (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
+#' # Write an RsparseMatrix to a SOMA
 #' uri <- withr::local_tempfile(pattern = "rsparse-matrix")
 #' mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "R")
 #' (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 #'
-#' \dontshow{
 #' arr$close()
-#' }
 #'
 write_soma.TsparseMatrix <- function(
   x,

--- a/apis/r/man/EphemeralCollectionBase.Rd
+++ b/apis/r/man/EphemeralCollectionBase.Rd
@@ -232,7 +232,7 @@ Add object to an ephemeral collection.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{object}}{A TileDB object (eg. \code{\link{TileDBGroup}}) to add
+\item{\code{object}}{A SOMA object (eg. \code{\link{SOMACollection}}) to add
 to the collection.}
 
 \item{\code{name}}{A name to add \code{object} as.}

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -9,8 +9,8 @@ SOMA Array Base Class
 SOMA Array Base Class
 }
 \details{
-Virtual base class to add SOMA-specific functionality to the
-\code{\link{TileDBArray}} class (lifecycle: maturing).
+Virtual base class to add array-specific functionality to the
+\code{\link{SOMAObject}} class (lifecycle: maturing).
 }
 \seealso{
 Derived classes: \code{\link{SOMADataFrame}},

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -132,7 +132,7 @@ A \code{\link{SOMAExperimentAxisQuery}} object.
 \if{latex}{\out{\hypertarget{method-SOMAExperiment-update_obs}{}}}
 \subsection{Method \code{update_obs()}}{
 Update the \code{obs} data frame to add or remove columns.
-See \code{\link[tiledbomsa:SOMADataFrame]{SOMADataFrame$update()}} for
+See \code{\link[tiledbsoma:SOMADataFrame]{SOMADataFrame$update()}} for
 more details.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMAExperiment$update_obs(values, row_index_name = NULL)}\if{html}{\out{</div>}}
@@ -158,7 +158,7 @@ to the value specified by \code{row_index_name}.}
 \if{latex}{\out{\hypertarget{method-SOMAExperiment-update_var}{}}}
 \subsection{Method \code{update_var()}}{
 Update the \code{var} data frame to add or remove columns.
-See \code{\link[tiledbomsa:SOMADataFrame]{SOMADataFrame$update()}} for
+See \code{\link[tiledbsoma:SOMADataFrame]{SOMADataFrame$update()}} for
 more details.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMAExperiment$update_var(values, measurement_name, row_index_name = NULL)}\if{html}{\out{</div>}}

--- a/apis/r/man/write_soma.Rd
+++ b/apis/r/man/write_soma.Rd
@@ -38,6 +38,7 @@ function and methods can be written for it to provide a high-level
 
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a Bioconductor S4 DataFrame object to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-data-frame")
 data("pbmc_small", package = "SeuratObject")
 obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]]
@@ -45,11 +46,10 @@ head(obs <- as(obs, "DataFrame"))
 
 (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a Bioconductor SelfHits object to a SOMA
 uri <- withr::local_tempfile(pattern = "hits")
 (hits <- S4Vectors::SelfHits(
   c(2, 3, 3, 3, 3, 3, 4, 4, 4),
@@ -60,70 +60,61 @@ uri <- withr::local_tempfile(pattern = "hits")
 
 (arr <- write_soma(hits, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a character vector to a SOMA
 uri <- withr::local_tempfile(pattern = "character")
 (sdf <- write_soma(letters, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a data.frame to a SOMA
 uri <- withr::local_tempfile(pattern = "data-frame")
 data("pbmc_small", package = "SeuratObject")
 head(obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]])
 
 (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "matrix")
 mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a dense S4 Matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-matrix")
 mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a TsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "tsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "T")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 
+# Write a CsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "csparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "C")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 
+# Write an RsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "rsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "R")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 }

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -140,6 +140,7 @@ as \link[tiledbsoma:SOMADataFrame]{data frames} to the
 
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\donttest{
 uri <- withr::local_tempfile(pattern = "pbmc-small")
 
 data("pbmc_small", package = "SeuratObject")
@@ -157,7 +158,6 @@ ms$obsm$names()
 ms$varm$names()
 ms$obsp$names()
 
-\dontshow{
 exp$close()
 }
 \dontshow{\}) # examplesIf}

--- a/apis/r/man/write_soma.SingleCellExperiment.Rd
+++ b/apis/r/man/write_soma.SingleCellExperiment.Rd
@@ -96,6 +96,7 @@ the \code{\link[tiledbsoma:SOMAMeasurement]{measurement}} level.
 
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SingleCellExperiment", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\donttest{
 uri <- withr::local_tempfile(pattern = "single-cell-experiment")
 
 mat <- abs(Matrix::rsparsematrix(
@@ -122,7 +123,6 @@ ms$var
 ms$X$names()
 ms$obsm$names()
 
-\dontshow{
 exp$close()
 }
 \dontshow{\}) # examplesIf}

--- a/apis/r/man/write_soma.SummarizedExperiment.Rd
+++ b/apis/r/man/write_soma.SummarizedExperiment.Rd
@@ -71,6 +71,7 @@ the \code{\link[tiledbsoma:SOMAMeasurement]{measurement}} level.
 
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SummarizedExperiment", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\donttest{
 uri <- withr::local_tempfile(pattern = "summarized-experiment")
 
 mat <- abs(Matrix::rsparsematrix(
@@ -89,7 +90,6 @@ exp$obs
 ms$var
 ms$X$names()
 
-\dontshow{
 exp$close()
 }
 \dontshow{\}) # examplesIf}

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -228,6 +228,7 @@ The array type is determined by \code{type}, or
 
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a Bioconductor S4 DataFrame object to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-data-frame")
 data("pbmc_small", package = "SeuratObject")
 obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]]
@@ -235,11 +236,10 @@ head(obs <- as(obs, "DataFrame"))
 
 (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a Bioconductor SelfHits object to a SOMA
 uri <- withr::local_tempfile(pattern = "hits")
 (hits <- S4Vectors::SelfHits(
   c(2, 3, 3, 3, 3, 3, 4, 4, 4),
@@ -250,71 +250,62 @@ uri <- withr::local_tempfile(pattern = "hits")
 
 (arr <- write_soma(hits, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a character vector to a SOMA
 uri <- withr::local_tempfile(pattern = "character")
 (sdf <- write_soma(letters, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a data.frame to a SOMA
 uri <- withr::local_tempfile(pattern = "data-frame")
 data("pbmc_small", package = "SeuratObject")
 head(obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]])
 
 (sdf <- write_soma(obs, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 sdf$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "matrix")
 mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a dense S4 Matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-matrix")
 mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 (arr <- write_soma(mat, uri, soma_parent = NULL, sparse = FALSE, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Write a TsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "tsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "T")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 
+# Write a CsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "csparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "C")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 
+# Write an RsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "rsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "R")
 (arr <- write_soma(mat, uri, soma_parent = NULL, relative = FALSE))
 
-\dontshow{
 arr$close()
-}
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/apis/r/man/write_soma_seurat_sub.Rd
+++ b/apis/r/man/write_soma_seurat_sub.Rd
@@ -223,9 +223,7 @@ col <- SOMACollectionCreate(uri)
 (assay5 <- methods::as(pbmc_small[["RNA"]], "Assay5"))
 (ms5 <- write_soma(assay5, "RNA5", soma_parent = col))
 
-\dontshow{
 ms5$close()
-}
 \dontshow{\}) # examplesIf}
 \dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 (tsne <- pbmc_small[["tsne"]])
@@ -243,9 +241,7 @@ write_soma(cmd, "NormalizeData.RNA", soma_parent = col)
 (logs <- col$get("seurat_commands"))
 logs$get("NormalizeData.RNA")
 
-\dontshow{
 col$close()
-}
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}


### PR DESCRIPTION
The complicated rebase for the SOMAObject ABC PR yielded bad docs (my bad); this resolves the docs and marks some long-running examples as `donttest` to allow CRAN to skip them with their daily checks

Fixes [SOMA-278](https://linear.app/tiledb/issue/SOMA-278/r-update-docs)