### PR TITLE
Add delete mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore==1.0.28"
+        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@04f02d3"  # DO NOT MERGE
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
         - "pandas-stubs>=2"
-        - "somacore @ git+https://github.com/single-cell-data/SOMA.git@04f02d3"  # DO NOT MERGE
+        - "somacore==1.0.29"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]
       pass_filenames: false

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+* \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
+* \[[#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125)\] Add `verify_open_for_reading` and `verify_open_for_deleting` to SOMA objects.
+
 ### Changed
 
 ### Deprecated
+
+* \[[#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125)\] Deprecate removing elements from a collection in write mode. In the future, all new removals will need to be done in delete mode.
 
 ### Removed
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 * \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
-* \[[#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125)\] Add `verify_open_for_reading` and `verify_open_for_deleting` to SOMA objects.
 
 ### Changed
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -350,7 +350,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is also in .pre-commit-config.yaml
-        "somacore @ git+https://github.com/single-cell-data/SOMA.git@04f02d3",  # DO NOT MERGE
+        "somacore==1.0.29",
         "typing-extensions>=4.5.0",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -350,7 +350,7 @@ setuptools.setup(
         "scanpy>=1.9.2",
         "scipy",
         # Note: the somacore version is also in .pre-commit-config.yaml
-        "somacore==1.0.28",
+        "somacore @ git+https://github.com/single-cell-data/SOMA.git@04f02d3",  # DO NOT MERGE
         "typing-extensions>=4.5.0",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -446,7 +446,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Lifecycle:
             Maturing.
         """
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         # if is it in read open mode, then it is a DataFrameWrapper
         return cast(DataFrameWrapper, self._handle).count
 
@@ -750,7 +750,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -446,7 +446,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Lifecycle:
             Maturing.
         """
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a DataFrameWrapper
         return cast(DataFrameWrapper, self._handle).count
 
@@ -750,7 +750,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -201,7 +201,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             Maturing.
         """
         del partitions  # Currently unused.
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         result_order = somacore.ResultOrder(result_order)
 
         # The dense_indices_to_shape includes, as one of its roles, how to handle default

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -201,7 +201,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             Maturing.
         """
         del partitions  # Currently unused.
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         result_order = somacore.ResultOrder(result_order)
 
         # The dense_indices_to_shape includes, as one of its roles, how to handle default

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -85,7 +85,10 @@ def open(
         uri:
             The URI to open.
         mode:
-            The mode to open in: ``r`` to read (default), ``w`` to write.
+            The mode to open the object in.
+            - ``r``: Open to read.
+            - ``w``: Open to write.
+            - ``d``: Open to delete.
         soma_type:
             If set, the SOMA class you are expecting to get back.
             This can be provided as a SOMA type name.

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -288,7 +288,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the geometry dataframe."""
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a GeometryDataFrameWrapper
         return cast(GeometryDataFrameWrapper, self._handle).count
 
@@ -327,7 +327,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -288,7 +288,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the geometry dataframe."""
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         # if is it in read open mode, then it is a GeometryDataFrameWrapper
         return cast(GeometryDataFrameWrapper, self._handle).count
 
@@ -327,7 +327,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -279,7 +279,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the dataframe."""
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         # if is it in read open mode, then it is a PointCloudDataFrameWrapper
         return cast(PointCloudDataFrameWrapper, self._handle).count
 
@@ -318,7 +318,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -279,7 +279,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
     @property
     def count(self) -> int:
         """Returns the number of rows in the dataframe."""
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         # if is it in read open mode, then it is a PointCloudDataFrameWrapper
         return cast(PointCloudDataFrameWrapper, self._handle).count
 
@@ -318,7 +318,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         """
         del batch_size  # Currently unused.
         _util.check_unpartitioned(partitions)
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
 
         # TODO: batch_size
         return TableReadIter(

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -154,7 +154,7 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
         if key in self._mutated_keys:
             raise SOMAError(f"cannot delete previously-mutated key {key!r}")
         try:
-            self._handle.deleter.remove(key, True)
+            self._handle.deleter.remove(key)
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise KeyError(tdbe) from tdbe

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -154,7 +154,7 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
         if key in self._mutated_keys:
             raise SOMAError(f"cannot delete previously-mutated key {key!r}")
         try:
-            self._handle.writer.remove(key)
+            self._handle.deleter.remove(key, True)
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise KeyError(tdbe) from tdbe
@@ -230,8 +230,9 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
         Args:
             mode:
                 The mode to open the object in.
-                - ``r``: Open for reading only (cannot write).
-                - ``w``: Open for writing only (cannot read).
+                - ``r``: Open for reading only (cannot write or delete).
+                - ``w``: Open for writing only (cannot read or delete).
+                - ``d``: Open for deleting only (cannot read or write).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at, either an int representing milliseconds since the Unix
                 epoch or a datetime.datetime object. When not provided (the default), the current time is used.

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -251,8 +251,8 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         """
         return self._handle.mode
 
-    def verify_open_for_deleting(self) -> None:
-        """Raises an error if the object is not open for reading."""
+    def _verify_open_for_deleting(self) -> None:
+        """Raises an error if the object is not open for deleting."""
         if self.closed:
             raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for deleting (closed).")
         if self.mode != "d":
@@ -265,7 +265,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         if self.mode != "w":
             raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for writing. Mode is '{self.mode}'.")
 
-    def verify_open_for_reading(self) -> None:
+    def _verify_open_for_reading(self) -> None:
         """Raises an error if the object is not open for reading."""
         if self.closed:
             raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for reading (closed)")

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -74,8 +74,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 The URI to open.
             mode:
                 The mode to open the object in.
-                - ``r``: Open for reading only (cannot write).
-                - ``w``: Open for writing only (cannot read).
+                - ``r``: Open for reading only (cannot write or delete).
+                - ``w``: Open for writing only (cannot read or delete).
+                - ``d``: Open for deleting only (cannot read or write).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at,
                 either an int representing milliseconds since the Unix epoch
@@ -155,8 +156,9 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         Args:
             mode:
                 The mode to open the object in.
-                - ``r``: Open for reading only (cannot write).
-                - ``w``: Open for writing only (cannot read).
+                - ``r``: Open for reading only (cannot write or delete).
+                - ``w``: Open for writing only (cannot read or delete).
+                - ``d``: Open for deleting only (cannot read or write).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at, either an int representing milliseconds since the Unix
                 epoch or a datetime.datetime object. When not provided (the default), the current time is used.
@@ -236,7 +238,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
 
     @property
     def mode(self) -> options.OpenMode:
-        """The mode this object was opened in, either ``r`` or ``w``.
+        """The mode this object was opened in, either ``r``, ``w``, or ``d``.
 
         Examples:
             >>> with tiledbsoma.open("an_object") as soma_object:
@@ -249,19 +251,26 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
         """
         return self._handle.mode
 
+    def verify_open_for_deleting(self) -> None:
+        """Raises an error if the object is not open for reading."""
+        if self.closed:
+            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for deleting (closed).")
+        if self.mode != "d":
+            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for deleting. Mode is '{self.mode}'.")
+
     def verify_open_for_writing(self) -> None:
         """Raises an error if the object is not open for writing."""
         if self.closed:
             raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for writing (closed)")
         if self.mode != "w":
-            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for writing")
+            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for writing. Mode is '{self.mode}'.")
 
-    def _verify_open_for_reading(self) -> None:
+    def verify_open_for_reading(self) -> None:
         """Raises an error if the object is not open for reading."""
         if self.closed:
             raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for reading (closed)")
         if self.mode != "r":
-            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for reading")
+            raise SOMAError(f"{self.__class__.__name__} ({self.uri}) must be open for reading. Mode is '{self.mode}'.")
 
     @property
     def tiledb_timestamp(self) -> datetime.datetime:

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -219,7 +219,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         Lifecycle:
             Maturing.
         """
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         return cast(SparseNDArrayWrapper, self._handle).nnz
 
     def read(
@@ -266,7 +266,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             * Negative indexing is unsupported.
         """
         del batch_size  # Currently unused.
-        self.verify_open_for_reading()
+        self._verify_open_for_reading()
         _util.check_unpartitioned(partitions)
 
         return SparseNDArrayRead(

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -219,7 +219,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
         Lifecycle:
             Maturing.
         """
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         return cast(SparseNDArrayWrapper, self._handle).nnz
 
     def read(
@@ -266,7 +266,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             * Negative indexing is unsupported.
         """
         del batch_size  # Currently unused.
-        self._verify_open_for_reading()
+        self.verify_open_for_reading()
         _util.check_unpartitioned(partitions)
 
         return SparseNDArrayRead(

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -63,6 +63,18 @@ _RawHdl_co = TypeVar("_RawHdl_co", bound=RawHandle, covariant=True)
 _SOMAObjectType = TypeVar("_SOMAObjectType", bound=clib.SOMAObject)
 
 
+def _open_mode_to_clib_mode(mode: options.OpenMode) -> clib.OpenMode:
+    """Convert options.OpenMode to clib.OpenMode."""
+    if mode == "r":
+        return clib.OpenMode.soma_read
+    elif mode == "w":
+        return clib.OpenMode.soma_write
+    elif mode == "d":
+        return clib.OpenMode.soma_delete
+    else:
+        raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
+
+
 def open_handle_wrapper(
     uri: str,
     mode: options.OpenMode,
@@ -71,15 +83,7 @@ def open_handle_wrapper(
     clib_type: str | None = None,
 ) -> "Wrapper[RawHandle]":
     """Determine whether the URI is an array or group, and open it."""
-    if mode == "r":
-        open_mode = clib.OpenMode.soma_read
-    elif mode == "w":
-        open_mode = clib.OpenMode.soma_write
-    elif mode == "d":
-        open_mode = clib.OpenMode.soma_delete
-    else:
-        raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
-
+    open_mode = _open_mode_to_clib_mode(mode)
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
     _type_to_open = {
@@ -322,15 +326,7 @@ class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAGroup:
-        if mode == "r":
-            open_mode = clib.OpenMode.soma_read
-        elif mode == "w":
-            open_mode = clib.OpenMode.soma_write
-        elif mode == "d":
-            open_mode = clib.OpenMode.soma_delete
-        else:
-            raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
-
+        open_mode = _open_mode_to_clib_mode(mode)
         return cls._WRAPPED_TYPE.open(
             uri,
             mode=open_mode,
@@ -398,15 +394,7 @@ class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAArray:
-        if mode == "r":
-            open_mode = clib.OpenMode.soma_read
-        elif mode == "w":
-            open_mode = clib.OpenMode.soma_write
-        elif mode == "d":
-            open_mode = clib.OpenMode.soma_delete
-        else:
-            raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
-
+        open_mode = _open_mode_to_clib_mode(mode)
         return cls._WRAPPED_TYPE.open(
             uri,
             mode=open_mode,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -70,7 +70,14 @@ def open_handle_wrapper(
     clib_type: str | None = None,
 ) -> "Wrapper[RawHandle]":
     """Determine whether the URI is an array or group, and open it."""
-    open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+    if mode == "r":
+        open_mode = clib.OpenMode.soma_read
+    elif mode == "w":
+        open_mode = clib.OpenMode.soma_write
+    elif mode == "d":
+        open_mode = clib.OpenMode.soma_delete
+    else:
+        raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
 
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
@@ -300,7 +307,15 @@ class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAGroup:
-        open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+        if mode == "r":
+            open_mode = clib.OpenMode.soma_read
+        elif mode == "w":
+            open_mode = clib.OpenMode.soma_write
+        elif mode == "d":
+            open_mode = clib.OpenMode.soma_delete
+        else:
+            raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
+
         return cls._WRAPPED_TYPE.open(
             uri,
             mode=open_mode,
@@ -368,7 +383,14 @@ class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
         context: SOMATileDBContext,
         timestamp: int,
     ) -> clib.SOMAArray:
-        open_mode = clib.OpenMode.read if mode == "r" else clib.OpenMode.write
+        if mode == "r":
+            open_mode = clib.OpenMode.soma_read
+        elif mode == "w":
+            open_mode = clib.OpenMode.soma_write
+        elif mode == "d":
+            open_mode = clib.OpenMode.soma_delete
+        else:
+            raise ValueError(f"Unexpected mode '{mode}'. Valid modes are 'r', 'w', or 'd'.")
 
         return cls._WRAPPED_TYPE.open(
             uri,

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -250,13 +250,13 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         raise SOMAError(f"Cannot write to {self}; current mode='{self.mode}'. Reopen in mode='w'.")
 
     @property
-    def deleter(self, allow_deprecated_writer: bool = False) -> _RawHdl_co:
+    def deleter(self) -> _RawHdl_co:
         """Accessor to assert that you are working in delete mode."""
         if self.closed:
             raise SOMAError(f"{self} is closed")
         if self.mode == "d":
             return self._handle
-        if allow_deprecated_writer and self.mode == "w":
+        if self.mode == "w":
             warnings.warn(
                 f"Deleting in write mode is deprecated. {self} should be reopened with mode='d'.", DeprecationWarning
             )

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -62,8 +62,9 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     });
 
     py::enum_<OpenMode>(m, "OpenMode")
-        .value("read", OpenMode::read)
-        .value("write", OpenMode::write);
+        .value("soma_read", OpenMode::soma_read)
+        .value("soma_write", OpenMode::soma_write)
+        .value("soma_delete", OpenMode::soma_delete);
 
     py::enum_<ResultOrder>(m, "ResultOrder")
         .value("automatic", ResultOrder::automatic)

--- a/apis/python/src/tiledbsoma/soma_array.cc
+++ b/apis/python/src/tiledbsoma/soma_array.cc
@@ -48,7 +48,7 @@ void load_soma_array(py::module& m) {
                    std::map<std::string, std::string> platform_config,
                    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
                     return SOMAArray::open(
-                        OpenMode::read,
+                        OpenMode::soma_read,
                         uri,
                         std::make_shared<SOMAContext>(platform_config),
                         timestamp);
@@ -73,7 +73,18 @@ void load_soma_array(py::module& m) {
         .def_property_readonly(
             "mode",
             [](SOMAArray& array) {
-                return array.mode() == OpenMode::read ? "r" : "w";
+                OpenMode soma_mode = array.mode();
+                switch (soma_mode) {
+                    case OpenMode::soma_read:
+                        return "r";
+                    case OpenMode::soma_write:
+                        return "w";
+                    case OpenMode::soma_delete:
+                        return "d";
+                    default:
+                        throw TileDBSOMAError(
+                            "Internal error: unrecognized mode.");
+                }
             })
         .def_property_readonly(
             "schema",

--- a/apis/python/src/tiledbsoma/soma_group.cc
+++ b/apis/python/src/tiledbsoma/soma_group.cc
@@ -48,7 +48,18 @@ void load_soma_group(py::module& m) {
         .def_property_readonly(
             "mode",
             [](SOMAGroup& group) {
-                return group.mode() == OpenMode::read ? "r" : "w";
+                OpenMode soma_mode = group.mode();
+                switch (soma_mode) {
+                    case OpenMode::soma_read:
+                        return "r";
+                    case OpenMode::soma_write:
+                        return "w";
+                    case OpenMode::soma_delete:
+                        return "d";
+                    default:
+                        throw TileDBSOMAError(
+                            "Internal error: unrecognized mode.");
+                }
             })
         .def("close", &SOMAGroup::close)
         .def_property_readonly(

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -115,13 +115,13 @@ class SOMAArrayStateMachine(RuleBasedStateMachine):
         self._close()
 
     @precondition(lambda self: self.closed)
-    @rule(mode=st.sampled_from(["r", "w"]))
+    @rule(mode=st.sampled_from(["r", "w", "d"]))
     def open(self, mode: OpenMode) -> None:
         # TODO: time travel
         self._open(mode=mode)
 
     @precondition(lambda self: self.is_initialized)
-    @rule(mode=st.sampled_from(["r", "w"]))
+    @rule(mode=st.sampled_from(["r", "w", "d"]))
     def reopen(self, mode: OpenMode) -> None:
         self.A.reopen(
             mode,

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -190,6 +190,22 @@ def test_delete_add(soma_object, tmp_path: pathlib.Path):
             update["porkchop sandwiches"] = soma_object
 
 
+def test_delete_add_write_mode(soma_object, tmp_path: pathlib.Path):
+    tmp_uri = tmp_path.as_uri()
+    with soma.Collection.create(tmp_uri) as create:
+        create["porkchop sandwiches"] = soma_object
+
+    with soma.open(tmp_uri, "w", soma_type=soma.Collection) as update:
+        with warnings.catch_warnings(record=True) as warn_list:
+            del update["porkchop sandwiches"]
+            assert len(warn_list) == 1
+            assert issubclass(warn_list[0].category, DeprecationWraning)
+        # TEMPORARY: This should no longer raise once TileDB supports replacing
+        # an existing group member.
+        with pytest.raises(soma.SOMAError):
+            update["porkchop sandwiches"] = soma_object
+
+
 @pytest.mark.parametrize("relative", [False, True])
 def test_collection_repr(tmp_path: pathlib.Path, relative: bool) -> None:
     a_path = tmp_path / "A"

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -182,7 +182,7 @@ def test_delete_add(soma_object, tmp_path: pathlib.Path):
     with soma.Collection.create(tmp_uri) as create:
         create["porkchop sandwiches"] = soma_object
 
-    with soma.open(tmp_uri, "w", soma_type=soma.Collection) as update:
+    with soma.open(tmp_uri, "d", soma_type=soma.Collection) as update:
         del update["porkchop sandwiches"]
         # TEMPORARY: This should no longer raise once TileDB supports replacing
         # an existing group member.

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -196,10 +196,8 @@ def test_delete_add_write_mode(soma_object, tmp_path: pathlib.Path):
         create["porkchop sandwiches"] = soma_object
 
     with soma.open(tmp_uri, "w", soma_type=soma.Collection) as update:
-        with warnings.catch_warnings(record=True) as warn_list:
+        with pytest.warns(DeprecationWarning):
             del update["porkchop sandwiches"]
-            assert len(warn_list) == 1
-            assert issubclass(warn_list[0].category, DeprecationWraning)
         # TEMPORARY: This should no longer raise once TileDB supports replacing
         # an existing group member.
         with pytest.raises(soma.SOMAError):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -125,7 +125,7 @@ def test_dataframe(tmp_path, arrow_schema):
 
     # Open and read with bindings
     with contextlib.closing(
-        soma.pytiledbsoma.SOMADataFrame.open(uri, soma.pytiledbsoma.OpenMode.read, soma.pytiledbsoma.SOMAContext())
+        soma.pytiledbsoma.SOMADataFrame.open(uri, soma.pytiledbsoma.OpenMode.soma_read, soma.pytiledbsoma.SOMAContext())
     ) as sdf:
         mq = soma.pytiledbsoma.ManagedQuery(sdf, sdf.context())
         table = mq.next()

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -116,7 +116,7 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: tuple[int, ...]):
     with contextlib.closing(
         soma.pytiledbsoma.SOMADenseNDArray.open(
             uri,
-            soma.pytiledbsoma.OpenMode.read,
+            soma.pytiledbsoma.OpenMode.soma_read,
             soma.pytiledbsoma.SOMAContext(),
         )
     ) as a:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -69,7 +69,7 @@ def test_sparse_nd_array_create_ok(tmp_path, shape: tuple[int, ...], element_typ
     with contextlib.closing(
         soma.pytiledbsoma.SOMASparseNDArray.open(
             tmp_path.as_posix(),
-            soma.pytiledbsoma.OpenMode.read,
+            soma.pytiledbsoma.OpenMode.soma_read,
             soma.pytiledbsoma.SOMAContext(),
         )
     ) as b:

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.18.99
+Version: 1.18.99.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = "aut", email = "aaron@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,9 +2,13 @@
 
 ## Added
 
+* Add delete mode specified by `mode='d'`. ([#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125))
+
 ## Changed
 
 ## Deprecated
+
+* Deprecate removing elements from a collection in write mode. In the future, all new removals will need to be done in delete mode. ([#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125))
 
 ## Removed
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-* Add delete mode specified by `mode='d'`. ([#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125))
+* Add delete mode specified by `mode="DELETE"`. ([#4125](https://github.com/single-cell-data/tiledb-soma/pull/4125))
 
 ## Changed
 

--- a/apis/r/R/SOMAArrayBase.R
+++ b/apis/r/R/SOMAArrayBase.R
@@ -25,7 +25,7 @@ SOMAArrayBase <- R6::R6Class(
     #'
     #' @return Return s\code{self}.
     #'
-    open = function(mode = c("READ", "WRITE")) {
+    open = function(mode = c("READ", "WRITE", "DELETE")) {
       envs <- unique(vapply(
         X = unique(sys.parents()),
         FUN = function(n) environmentName(environment(sys.function(n))),

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -86,7 +86,7 @@ SOMACollectionBase <- R6::R6Class(
     #'
     #' @return Returns \code{self}.
     #'
-    open = function(mode = c("READ", "WRITE")) {
+    open = function(mode = c("READ", "WRITE", "DELETE")) {
       envs <- unique(vapply(
         X = unique(sys.parents()),
         FUN = function(n) environmentName(environment(sys.function(n))),
@@ -216,7 +216,7 @@ SOMACollectionBase <- R6::R6Class(
       if (!is.character(name) || length(name) != 1L || !nzchar(name)) {
         stop("'name' must be a single, non-empty string", call. = FALSE)
       }
-      private$.check_open_for_read_or_write()
+      private$.check_open()
       private$.update_member_cache()
 
       if (is.null(member <- self$members[[name]])) {
@@ -254,10 +254,18 @@ SOMACollectionBase <- R6::R6Class(
     #' @return Invisibly returns \code{self}
     #'
     remove = function(name) {
+      if (self$mode == "WRITE") {
+        warnings.warn(
+          "Removing a member in 'write' mode is deprecated. Collection should be open in 'delete' mode."
+        )
+      } else if (self$mode != "DELETE") {
+        stop("SOMA object is not opened in 'delete' mode; cannot remove member.")
+      }
+
       if (!is.character(name) || length(name) != 1L || !nzchar(name)) {
         stop("'name' must be a single, non-empty string", call. = FALSE)
       }
-      private$.check_open_for_read_or_write()
+      private$.check_open()
 
       c_group_remove_member(private$.tiledb_group, name)
 
@@ -275,7 +283,7 @@ SOMACollectionBase <- R6::R6Class(
     #' @return The number of members in this collection.
     #'
     length = function() {
-      private$.check_open_for_read_or_write()
+      private$.check_open()
       private$.update_member_cache()
       return(length(self$members))
     },
@@ -285,7 +293,7 @@ SOMACollectionBase <- R6::R6Class(
     #' @return A character vector of member names.
     #'
     names = function() {
-      private$.check_open_for_read_or_write()
+      private$.check_open()
       private$.update_member_cache()
       return(names(self$members) %||% character(length = 0L))
     },
@@ -687,7 +695,7 @@ SOMACollectionBase <- R6::R6Class(
     # @param name the name of the field to retrieve or set.
     # @param expected_class the expected class of the value to set.
     get_or_set_soma_field = function(value, name, expected_class) {
-      private$.check_open_for_read_or_write()
+      private$.check_open()
 
       if (missing(value)) {
         return(self$get(name))

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -255,11 +255,13 @@ SOMACollectionBase <- R6::R6Class(
     #'
     remove = function(name) {
       if (self$mode == "WRITE") {
-        warnings.warn(
-          "Removing a member in 'write' mode is deprecated. Collection should be open in 'delete' mode."
-        )
+        .Deprecated(msg = sprintf(
+          "Removing a member in %s mode is deprecated. Collection should be opened in %s mode.",
+          sQuote("WRITE"),
+          sQuote("DELETE")
+        ))
       } else if (self$mode != "DELETE") {
-        stop("SOMA object is not opened in 'delete' mode; cannot remove member.")
+        stop("SOMA object is not opened in 'delete' mode; cannot remove member.", call. = FALSE)
       }
 
       if (!is.character(name) || length(name) != 1L || !nzchar(name)) {

--- a/apis/r/R/SOMAObject.R
+++ b/apis/r/R/SOMAObject.R
@@ -418,7 +418,7 @@ SOMAObject <- R6::R6Class(
     # @description Check that the object is open
     #
     .check_open_for_read_or_write = function() {
-      if (!switch(self$mode() %||% "", READ = TRUE, WRITE = TRUE, FALSE)) {
+      if (!switch(self$mode() %||% "", READ = , WRITE = TRUE, FALSE)) {
         stop("Item must be open for read or write: ", self$uri, call. = FALSE)
       }
       return(invisible(NULL))

--- a/apis/r/R/ephemeral.R
+++ b/apis/r/R/ephemeral.R
@@ -366,7 +366,9 @@ EphemeralCollectionBase <- R6::R6Class(
     # Override SOMAObject private methods
     .check_open_for_read = \() invisible(NULL),
     .check_open_for_write = \() invisible(NULL),
+    .check_open_for_delete = \() invisible(NULL),
     .check_open_for_read_or_write = \() invisible(NULL),
+    .check_open = \() invisible(NULL),
 
     # Override TileDBGroup private fields
     .member_cache = NULL,

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -1,4 +1,4 @@
-#include <Rcpp/Lighter>             // for R interface to C++
+#include <Rcpp/Lighter>  // for R interface to C++
 
 #include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
@@ -223,11 +223,12 @@ void writeArrayFromArrow(
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(tsvec);
 
     std::unique_ptr<tdbs::SOMAArray> arrup = tdbs::SOMAArray::open(
-        OpenMode::write, uri, somactx, tsrng);
+        OpenMode::soma_write, uri, somactx, tsrng);
 
     auto mq = tdbs::ManagedQuery(*arrup, somactx->tiledb_ctx(), "unnamed");
-    mq.set_layout(arraytype == "SOMADenseNDArray" ? 
-                  ResultOrder::colmajor : ResultOrder::automatic);
+    mq.set_layout(
+        arraytype == "SOMADenseNDArray" ? ResultOrder::colmajor :
+                                          ResultOrder::automatic);
     mq.set_array_data(schema.get(), array.get());
     mq.submit_write();
     mq.close();

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -28,7 +28,8 @@ void c_group_create(
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamp);
     if (timestamp.isNotNull()) {
         Rcpp::DatetimeVector v(timestamp);
-        tdbs::LOG_DEBUG(fmt::format("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]));
+        tdbs::LOG_DEBUG(
+            fmt::format("[c_group_create] uri {} ts ({},{})", uri, v[0], v[1]));
     } else {
         tdbs::LOG_DEBUG(fmt::format("[c_group_create] uri {}", uri));
     }
@@ -50,7 +51,9 @@ Rcpp::XPtr<somagrp_wrap_t> c_group_open(
     // optional timestamp range
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(timestamp);
 
-    OpenMode mode = type == "READ" ? OpenMode::read : OpenMode::write;
+    // Note: both OpenMode.soma_write and OpenMode.soma_delete should be opened
+    // in TILEDB_WRITE mode.
+    OpenMode mode = type == "READ" ? OpenMode::soma_read : OpenMode::soma_write;
 
     auto sgrpptr = tdbs::SOMAGroup::open(mode, uri, sctx, "unnamed", tsrng);
 

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -42,7 +42,8 @@ int32_t get_metadata_num(
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::read, uri, sctx);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::soma_read, uri, sctx);
     int32_t nb = soup->metadata_num();
     return nb;
 }
@@ -65,7 +66,8 @@ Rcpp::List get_all_metadata(
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
 
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::read, uri, sctx);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::soma_read, uri, sctx);
     auto mvmap = soup->get_metadata();
 
     std::vector<std::string> namvec;
@@ -115,7 +117,8 @@ std::string get_metadata(
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
 
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::read, uri, sctx);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::soma_read, uri, sctx);
     auto mv = soup->get_metadata(key);
     if (!mv.has_value()) {
         Rcpp::stop("No value for '%s'", key.c_str());
@@ -150,7 +153,8 @@ bool has_metadata(
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::read, uri, sctx);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::soma_read, uri, sctx);
     return soup->has_metadata(key);
 }
 
@@ -172,7 +176,8 @@ void delete_metadata(
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
-    auto soup = getObjectUniquePointer(is_array, OpenMode::write, uri, sctx);
+    auto soup = getObjectUniquePointer(
+        is_array, OpenMode::soma_write, uri, sctx);
     soup->delete_metadata(key);
     soup->close();
 }
@@ -202,12 +207,13 @@ void set_metadata(
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
     // SOMA Object unique pointer (aka soup)
     auto soup = getObjectUniquePointer(
-        is_array, OpenMode::write, uri, sctx, tsvec);
+        is_array, OpenMode::soma_write, uri, sctx, tsvec);
 
     if (type == "character") {
         const tiledb_datatype_t value_type = TILEDB_STRING_UTF8;
         std::string value = Rcpp::as<std::string>(valuesxp);
-        tdbs::LOG_DEBUG(fmt::format("[set_metadata] key {} value {} is_array {} type {}",
+        tdbs::LOG_DEBUG(fmt::format(
+            "[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,
             is_array,
@@ -218,7 +224,8 @@ void set_metadata(
         const tiledb_datatype_t value_type = TILEDB_INT64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
-        tdbs::LOG_DEBUG(fmt::format("[set_metadata] key {} value {} is_array {} type {}",
+        tdbs::LOG_DEBUG(fmt::format(
+            "[set_metadata] key {} value {} is_array {} type {}",
             key,
             value,
             is_array,

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -109,11 +109,11 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
 
     auto tdb_result_order = get_tdb_result_order(result_order);
 
-    auto arr = tdbs::SOMAArray(OpenMode::read, uri, somactx, tsrng);
+    auto arr = tdbs::SOMAArray(OpenMode::soma_read, uri, somactx, tsrng);
 
     auto mq = new tdbs::ManagedQuery(arr, somactx->tiledb_ctx(), name);
     mq->set_layout(tdb_result_order);
-    if(!column_names.empty()){
+    if (!column_names.empty()) {
         mq->select_columns(column_names);
     }
 
@@ -123,7 +123,8 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        tdbs::LOG_DEBUG(fmt::format("[mq_setup] Dimension {} type {} domain {} extent {}",
+        tdbs::LOG_DEBUG(fmt::format(
+            "[mq_setup] Dimension {} type {} domain {} extent {}",
             dim.name(),
             tiledb::impl::to_str(dim.type()),
             dim.domain_to_str(),
@@ -222,7 +223,7 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
         mq_data->get()->num_rows(),
         mq_data->get()->names().size()));
 
-    if(!mq_data){
+    if (!mq_data) {
         tdbs::LOG_TRACE("[mq_next] complete - mq_data read no data");
         return create_empty_arrow_table();
     }
@@ -249,7 +250,8 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
     arr->length = 0;  // initial value
 
     for (size_t i = 0; i < ncol; i++) {
-        tdbs::LOG_TRACE(fmt::format("[mq_next] Accessing {} at {}", names[i], i));
+        tdbs::LOG_TRACE(
+            fmt::format("[mq_next] Accessing {} at {}", names[i], i));
 
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = mq_data->get()->at(names[i]);
@@ -268,7 +270,8 @@ SEXP mq_next(Rcpp::XPtr<tdbs::ManagedQuery> mq) {
         }
     }
 
-    tdbs::LOG_DEBUG(fmt::format("[mq_next] Exporting chunk with {} rows", arr->length));
+    tdbs::LOG_DEBUG(
+        fmt::format("[mq_next] Exporting chunk with {} rows", arr->length));
     // Nanoarrow special: stick schema into xptr tag to return single SEXP
     array_xptr_set_schema(arrayxp, schemaxp);  // embed schema in array
     return arrayxp;

--- a/apis/r/src/soma.cpp
+++ b/apis/r/src/soma.cpp
@@ -1,4 +1,4 @@
-#include <Rcpp/Lighter>             // for R interface to C++
+#include <Rcpp/Lighter>  // for R interface to C++
 
 #include <nanoarrow/r.h>  // for C/C++ interface to Arrow (via header exported from the R package)
 #include <RcppInt64>                // for fromInteger64
@@ -20,7 +20,7 @@ std::string get_soma_object_type(
     // shared pointer to TileDB Context from SOMAContext
     std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
 
-    auto soup = tdbs::SOMAObject::open(uri, OpenMode::read, sctx);
+    auto soup = tdbs::SOMAObject::open(uri, OpenMode::soma_read, sctx);
     auto tpstr = soup->type();
     if (!tpstr.has_value()) {
         Rcpp::stop("No object type value for URI '%s'", uri);

--- a/apis/r/tests/testthat/test-05-contexts.R
+++ b/apis/r/tests/testthat/test-05-contexts.R
@@ -55,7 +55,7 @@ test_that("context-create", {
   group$close()
 
   # Remove
-  group$open(mode = "WRITE", internal_use_only = "allowed_use")
+  group$open(mode = "DELETE", internal_use_only = "allowed_use")
   group$remove("a1")
   expect_equal(group$length(), 1)
   group$remove("g1")

--- a/apis/r/tests/testthat/test-11-reopen.R
+++ b/apis/r/tests/testthat/test-11-reopen.R
@@ -54,6 +54,15 @@ test_that("`reopen()` works on arrays", {
     )
     expect_true(arr$is_open(), info = is_open)
 
+    # Test reopen("DELETE")
+    expect_invisible(arr$reopen("DELETE"), label=lab)
+    expect_identical(
+      arr$mode(),
+      "DELETE",
+      info = sprintr("%s$reopen('DELETE') reopens as 'DELETE'", cls)
+    )
+    expect_true(arr$is_open(), info = is_open)
+
     # Test reopening in the same mode
     orig <- arr$mode()
     expect_invisible(arr$reopen(orig), label = lab)

--- a/apis/r/tests/testthat/test-11-reopen.R
+++ b/apis/r/tests/testthat/test-11-reopen.R
@@ -55,11 +55,11 @@ test_that("`reopen()` works on arrays", {
     expect_true(arr$is_open(), info = is_open)
 
     # Test reopen("DELETE")
-    expect_invisible(arr$reopen("DELETE"), label=lab)
+    expect_invisible(arr$reopen("DELETE"), label = lab)
     expect_identical(
       arr$mode(),
       "DELETE",
-      info = sprintr("%s$reopen('DELETE') reopens as 'DELETE'", cls)
+      info = sprintf("%s$reopen('DELETE') reopens as 'DELETE'", cls)
     )
     expect_true(arr$is_open(), info = is_open)
 

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -30,12 +30,12 @@ void test_sdf(const std::string& uri) {
     // config["sm.mem.total_budget"] = "1118388608";
 
     // Read all values from the obs array
-    auto obs = SOMAArray::open(OpenMode::read, uri + "/obs", ctx);
+    auto obs = SOMAArray::open(OpenMode::soma_read, uri + "/obs", ctx);
     auto obs_mq = ManagedQuery(*obs, ctx->tiledb_ctx(), "obs");
     auto obs_data = obs_mq.read_next();
 
     // Read all values from the var array
-    auto var = SOMAArray::open(OpenMode::read, uri + "/ms/RNA/var", ctx);
+    auto var = SOMAArray::open(OpenMode::soma_read, uri + "/ms/RNA/var", ctx);
     auto var_mq = ManagedQuery(*var, ctx->tiledb_ctx(), "var");
     auto var_data = var_mq.read_next();
 
@@ -46,7 +46,7 @@ void test_sdf(const std::string& uri) {
 
     // Read all values from the X/data array
     auto x_data = SOMAArray::open(
-        OpenMode::read,
+        OpenMode::soma_read,
         uri + "/ms/RNA/X/data",
         std::make_shared<SOMAContext>(config));
     auto x_mq = ManagedQuery(*x_data, ctx->tiledb_ctx(), "X/data");
@@ -68,7 +68,7 @@ namespace tdbs = tiledbsoma;
 void test_arrow(const std::string& uri) {
     auto ctx = std::make_shared<SOMAContext>();
     const std::vector<std::string>& colnames{"n_counts", "n_genes", "louvain"};
-    auto obs = tdbs::SOMAArray::open(OpenMode::read, uri, ctx);
+    auto obs = tdbs::SOMAArray::open(OpenMode::soma_read, uri, ctx);
     auto obs_mq = ManagedQuery(*obs, ctx->tiledb_ctx(), "");
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto obs_data = obs_mq.read_next();

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -14,8 +14,10 @@
 #ifndef SOMA_ENUMS
 #define SOMA_ENUMS
 
+#include <string>
+
 /** Defines whether the SOMAObject should be opened in read or write mode */
-enum class OpenMode { read = 0, write };
+enum class OpenMode { read = 0, write, del };
 
 /** Defines whether the result should be opened in row-major or column-major
  * order */
@@ -37,5 +39,18 @@ enum class Domainish {
     kind_core_current_domain = 1,
     kind_non_empty_domain = 2
 };
+
+inline std::string open_mode_to_string(OpenMode mode) {
+    switch (mode) {
+        case OpenMode::read:
+            return "read";
+        case OpenMode::write:
+            return "write";
+        case OpenMode::del:
+            return "delete";
+        default:
+            return "invalid";
+    }
+}
 
 #endif  // SOMA_ENUMS

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -17,7 +17,7 @@
 #include <string>
 
 /** Defines whether the SOMAObject should be opened in read or write mode */
-enum class OpenMode { read = 0, write, del };
+enum class OpenMode { soma_read, soma_write, soma_delete };
 
 /** Defines whether the result should be opened in row-major or column-major
  * order */
@@ -42,11 +42,11 @@ enum class Domainish {
 
 inline std::string open_mode_to_string(OpenMode mode) {
     switch (mode) {
-        case OpenMode::read:
+        case OpenMode::soma_read:
             return "read";
-        case OpenMode::write:
+        case OpenMode::soma_write:
             return "write";
-        case OpenMode::del:
+        case OpenMode::soma_delete:
             return "delete";
         default:
             return "invalid";

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -150,9 +150,9 @@ SOMAArray::SOMAArray(
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(arr_->query_type(), &query_type_str);
             throw std::invalid_argument(fmt::format(
-                "SOMAArray constructor does not accept a TileDB array opened "
-                "in mode '{}'. The array must be opened in either read or "
-                "write mode.",
+                "Internal error: SOMAArray constructor does not accept a "
+                "TileDB array opened in mode '{}'. The array must be opened in "
+                "either read or write mode.",
                 query_type_str));
         }
     }

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -141,10 +141,10 @@ SOMAArray::SOMAArray(
     , schema_(std::make_shared<ArraySchema>(arr->schema())) {
     switch (arr_->query_type()) {
         case TILEDB_READ:
-            soma_mode_ = OpenMode::read;
+            soma_mode_ = OpenMode::soma_read;
             break;
         case TILEDB_WRITE:
-            soma_mode_ = OpenMode::write;
+            soma_mode_ = OpenMode::soma_write;
             break;
         default: {  // Remaining querty types are only supported on TileDB
             const char* query_type_str = nullptr;
@@ -162,7 +162,7 @@ SOMAArray::SOMAArray(
 
 void SOMAArray::fill_metadata_cache(
     OpenMode mode, std::optional<TimestampRange> timestamp) {
-    if (mode == OpenMode::read) {
+    if (mode == OpenMode::soma_read) {
         meta_cache_arr_ = arr_;
     } else {  // Need to create a metadata cache array for all non-read modes.
         if (timestamp) {
@@ -337,13 +337,13 @@ void SOMAArray::validate(
     OpenMode mode, std::optional<TimestampRange> timestamp) {
     tiledb_query_type_t tiledb_mode{};
     switch (mode) {
-        case OpenMode::read: {
+        case OpenMode::soma_read: {
             tiledb_mode = TILEDB_READ;
         } break;
-        case OpenMode::write: {
+        case OpenMode::soma_write: {
             tiledb_mode = TILEDB_WRITE;
         } break;
-        case OpenMode::del: {
+        case OpenMode::soma_delete: {
             tiledb_mode = TILEDB_DELETE;
         } break;
         default:
@@ -1193,7 +1193,7 @@ bool SOMAArray::_exists(
     std::string_view soma_type,
     std::shared_ptr<SOMAContext> ctx) {
     try {
-        auto obj = SOMAArray::open(OpenMode::read, uri, ctx, std::nullopt);
+        auto obj = SOMAArray::open(OpenMode::soma_read, uri, ctx, std::nullopt);
         return soma_type == obj->type();
     } catch (TileDBSOMAError& e) {
         return false;

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -107,12 +107,11 @@ SOMAArray::SOMAArray(
     std::string_view uri,
     std::map<std::string, std::string> platform_config,
     std::optional<TimestampRange> timestamp)
-    : uri_(util::rstrip_uri(uri))
-    , timestamp_(timestamp) {
-    ctx_ = std::make_shared<SOMAContext>(platform_config);
-    validate(mode, timestamp);
-    fill_metadata_cache(timestamp);
-    fill_columns();
+    : SOMAArray(
+          mode,
+          uri,
+          std::make_shared<SOMAContext>(platform_config),
+          timestamp) {
 }
 
 SOMAArray::SOMAArray(
@@ -122,9 +121,10 @@ SOMAArray::SOMAArray(
     std::optional<TimestampRange> timestamp)
     : uri_(util::rstrip_uri(uri))
     , ctx_(ctx)
-    , timestamp_(timestamp) {
-    validate(mode, timestamp);
-    fill_metadata_cache(timestamp);
+    , timestamp_(timestamp)
+    , soma_mode_(mode) {
+    validate(soma_mode_, timestamp_);
+    fill_metadata_cache(soma_mode_, timestamp_);
     fill_columns();
 }
 
@@ -139,12 +139,32 @@ SOMAArray::SOMAArray(
     // Initialize private attributes next to control the order of destruction
     , timestamp_(timestamp)
     , schema_(std::make_shared<ArraySchema>(arr->schema())) {
-    fill_metadata_cache(timestamp);
+    switch (arr_->query_type()) {
+        case TILEDB_READ:
+            soma_mode_ = OpenMode::read;
+            break;
+        case TILEDB_WRITE:
+            soma_mode_ = OpenMode::write;
+            break;
+        default: {  // Remaining querty types are only supported on TileDB
+            const char* query_type_str = nullptr;
+            tiledb_query_type_to_str(arr_->query_type(), &query_type_str);
+            throw std::invalid_argument(fmt::format(
+                "SOMAArray constructor does not accept a TileDB array opened "
+                "in mode '{}'. The array must be opened in either read or "
+                "write mode.",
+                query_type_str));
+        }
+    }
+    fill_metadata_cache(soma_mode_, timestamp_);
     fill_columns();
 }
 
-void SOMAArray::fill_metadata_cache(std::optional<TimestampRange> timestamp) {
-    if (arr_->query_type() == TILEDB_WRITE) {
+void SOMAArray::fill_metadata_cache(
+    OpenMode mode, std::optional<TimestampRange> timestamp) {
+    if (mode == OpenMode::read) {
+        meta_cache_arr_ = arr_;
+    } else {  // Need to create a metadata cache array for all non-read modes.
         if (timestamp) {
             meta_cache_arr_ = std::make_shared<Array>(
                 *ctx_->tiledb_ctx(),
@@ -156,10 +176,7 @@ void SOMAArray::fill_metadata_cache(std::optional<TimestampRange> timestamp) {
             meta_cache_arr_ = std::make_shared<Array>(
                 *ctx_->tiledb_ctx(), uri_, TILEDB_READ);
         }
-    } else {
-        meta_cache_arr_ = arr_;
     }
-
     metadata_.clear();
 
     for (uint64_t idx = 0; idx < meta_cache_arr_->metadata_num(); ++idx) {
@@ -202,9 +219,9 @@ std::shared_ptr<SOMAContext> SOMAArray::ctx() {
 
 void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     timestamp_ = timestamp;
-
-    validate(mode, timestamp);
-    fill_metadata_cache(timestamp_);
+    soma_mode_ = mode;
+    validate(soma_mode_, timestamp);
+    fill_metadata_cache(soma_mode_, timestamp_);
     fill_columns();
 }
 
@@ -212,7 +229,6 @@ void SOMAArray::close() {
     if (arr_->query_type() == TILEDB_WRITE) {
         meta_cache_arr_->close();
     }
-
     arr_->close();
     metadata_.clear();
 }
@@ -319,8 +335,20 @@ uint64_t SOMAArray::metadata_num() const {
 
 void SOMAArray::validate(
     OpenMode mode, std::optional<TimestampRange> timestamp) {
-    // Validate parameters
-    auto tdb_mode = mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE;
+    tiledb_query_type_t tiledb_mode{};
+    switch (mode) {
+        case OpenMode::read: {
+            tiledb_mode = TILEDB_READ;
+        } break;
+        case OpenMode::write: {
+            tiledb_mode = TILEDB_WRITE;
+        } break;
+        case OpenMode::del: {
+            tiledb_mode = TILEDB_DELETE;
+        } break;
+        default:
+            throw TileDBSOMAError("Internal error: Unrecognized OpenMode.");
+    }
 
     try {
         LOG_DEBUG(fmt::format("[SOMAArray] opening array '{}'", uri_));
@@ -328,11 +356,12 @@ void SOMAArray::validate(
             arr_ = std::make_shared<Array>(
                 *ctx_->tiledb_ctx(),
                 uri_,
-                tdb_mode,
+                tiledb_mode,
                 TemporalPolicy(
                     TimestampStartEnd, timestamp->first, timestamp->second));
         } else {
-            arr_ = std::make_shared<Array>(*ctx_->tiledb_ctx(), uri_, tdb_mode);
+            arr_ = std::make_shared<Array>(
+                *ctx_->tiledb_ctx(), uri_, tiledb_mode);
         }
         LOG_TRACE(fmt::format("[SOMAArray] loading enumerations"));
         ArrayExperimental::load_all_enumerations(

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -146,7 +146,7 @@ SOMAArray::SOMAArray(
         case TILEDB_WRITE:
             soma_mode_ = OpenMode::soma_write;
             break;
-        default: {  // Remaining querty types are only supported on TileDB
+        default: {  // Only allow read/write when constructing from TileDB.
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(arr_->query_type(), &query_type_str);
             throw std::invalid_argument(fmt::format(

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -161,25 +161,6 @@ class SOMAArray : public SOMAObject {
         std::optional<TimestampRange> timestamp = std::nullopt);
 
     /**
-     * @brief Copy constructor for a new SOMAArray object
-     */
-    SOMAArray(const SOMAArray& other)
-        // Ensure protected attributes initalized first in a consistent ordering
-        : uri_(other.uri_)
-        , ctx_(other.ctx_)
-        , arr_(other.arr_)
-        // Initialize private attributes next to control the order of
-        // destruction
-        , metadata_(other.metadata_)
-        , timestamp_(other.timestamp_)
-        , soma_mode_(other.soma_mode_)
-        , schema_(other.schema_)
-        , meta_cache_arr_(other.meta_cache_arr_) {
-        fill_metadata_cache(soma_mode_, timestamp_);
-        fill_columns();
-    }
-
-    /**
      * @brief Construct a new SOMAArray from a TileDB array
      *
      * @param ctx SOMAContext
@@ -191,6 +172,7 @@ class SOMAArray : public SOMAObject {
         std::shared_ptr<Array> arr,
         std::optional<TimestampRange> timestamp);
 
+    SOMAArray(const SOMAArray& other) = default;
     SOMAArray(SOMAArray&&) = default;
 
     SOMAArray() = delete;

--- a/libtiledbsoma/src/soma/soma_collection.cc
+++ b/libtiledbsoma/src/soma/soma_collection.cc
@@ -69,7 +69,7 @@ void SOMACollection::close() {
 std::unique_ptr<SOMAObject> SOMACollection::get(const std::string& key) {
     auto tiledb_obj = SOMAGroup::get(key);
     auto soma_obj = SOMAObject::open(
-        tiledb_obj.uri(), OpenMode::read, this->ctx(), this->timestamp());
+        tiledb_obj.uri(), OpenMode::soma_read, this->ctx(), this->timestamp());
     return soma_obj;
 }
 
@@ -89,7 +89,7 @@ std::shared_ptr<SOMACollection> SOMACollection::add_new_collection(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMACollection> member = SOMACollection::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
@@ -115,7 +115,7 @@ std::shared_ptr<SOMAExperiment> SOMACollection::add_new_experiment(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAExperiment> member = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
@@ -141,7 +141,7 @@ std::shared_ptr<SOMAMeasurement> SOMACollection::add_new_measurement(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMAMeasurement> member = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAGroup");
     children_[std::string(key)] = member;
     return member;
@@ -167,7 +167,7 @@ std::shared_ptr<SOMADataFrame> SOMACollection::add_new_dataframe(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADataFrame> member = SOMADataFrame::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;
@@ -193,7 +193,7 @@ std::shared_ptr<SOMADenseNDArray> SOMACollection::add_new_dense_ndarray(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMADenseNDArray> member = SOMADenseNDArray::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;
@@ -219,7 +219,7 @@ std::shared_ptr<SOMASparseNDArray> SOMACollection::add_new_sparse_ndarray(
     // unique_ptr because we place the SOMA object into the `children_` cache
     // in addition to returning the SOMA object to the user.
     std::shared_ptr<SOMASparseNDArray> member = SOMASparseNDArray::open(
-        uri, OpenMode::read, ctx, timestamp);
+        uri, OpenMode::soma_read, ctx, timestamp);
     this->set(std::string(uri), uri_type, std::string(key), "SOMAArray");
     children_[std::string(key)] = member;
     return member;

--- a/libtiledbsoma/src/soma/soma_experiment.cc
+++ b/libtiledbsoma/src/soma/soma_experiment.cc
@@ -46,7 +46,11 @@ void SOMAExperiment::create(
 
         auto name = std::string(std::filesystem::path(uri).filename());
         auto group = SOMAGroup::open(
-            OpenMode::write, experiment_uri.string(), ctx, name, timestamp);
+            OpenMode::soma_write,
+            experiment_uri.string(),
+            ctx,
+            name,
+            timestamp);
         group->set(
             (experiment_uri / "obs").string(),
             URIType::absolute,
@@ -87,7 +91,7 @@ std::shared_ptr<SOMADataFrame> SOMAExperiment::obs() {
     if (obs_ == nullptr) {
         obs_ = SOMADataFrame::open(
             (std::filesystem::path(uri()) / "obs").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -98,7 +102,7 @@ std::shared_ptr<SOMACollection> SOMAExperiment::ms() {
     if (ms_ == nullptr) {
         ms_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "ms").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -129,7 +129,7 @@ SOMAGroup::SOMAGroup(
                 "TileDB-SOMA.",
                 query_type_str));
         }
-        default: {  // Remaining querty types are only supported on TileDB
+        default: {  // Remaining query types are only supported on TileDB
                     // arrays.
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(group_->query_type(), &query_type_str);

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -100,7 +100,7 @@ SOMAGroup::SOMAGroup(
     group_ = std::make_shared<Group>(
         *ctx_->tiledb_ctx(),
         std::string(uri),
-        mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE,
+        mode == OpenMode::soma_read ? TILEDB_READ : TILEDB_WRITE,
         _set_timestamp(ctx, timestamp));
     fill_caches();
 }
@@ -115,10 +115,10 @@ SOMAGroup::SOMAGroup(
     , timestamp_(timestamp) {
     switch (group_->query_type()) {
         case TILEDB_READ:
-            soma_mode_ = OpenMode::read;
+            soma_mode_ = OpenMode::soma_read;
             break;
         case TILEDB_WRITE:
-            soma_mode_ = OpenMode::write;
+            soma_mode_ = OpenMode::soma_write;
             break;
         case TILEDB_MODIFY_EXCLUSIVE:  // Not supported in SOMA
         {
@@ -176,7 +176,7 @@ void SOMAGroup::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     group_->set_config(_set_timestamp(ctx_, timestamp));
     // Note: both OpenMode.write and OpenMode.del should be opened in
     // TILEDB_WRITE mode.
-    group_->open(mode == OpenMode::read ? TILEDB_READ : TILEDB_WRITE);
+    group_->open(mode == OpenMode::soma_read ? TILEDB_READ : TILEDB_WRITE);
     fill_caches();
 }
 

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -120,21 +120,13 @@ SOMAGroup::SOMAGroup(
         case TILEDB_WRITE:
             soma_mode_ = OpenMode::soma_write;
             break;
-        case TILEDB_MODIFY_EXCLUSIVE:  // Not supported in SOMA
-        {
-            const char* query_type_str = nullptr;
-            tiledb_query_type_to_str(group_->query_type(), &query_type_str);
-            throw std::invalid_argument(fmt::format(
-                "Cannot open a TileDB group with query type '{}' in "
-                "TileDB-SOMA.",
-                query_type_str));
-        }
-        default: {  // Remaining query types are only supported on TileDB
-                    // arrays.
+        default: {  // Only allow read/write when constructing from TileDB.
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(group_->query_type(), &query_type_str);
             throw TileDBSOMAError(fmt::format(
-                "Internal error: unexpected TileDB group query type '{}'",
+                "Internal error: SOMAGroup constructor does not accept a "
+                "TileDB group opened in mode '{}'. The group must be opened in "
+                "either read or write mode.",
                 query_type_str));
         }
     }

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -95,7 +95,7 @@ class SOMAGroup : public SOMAObject {
      * @param ctx SOMA context
      * @param group TileDB group to open as a SOMAGroup. Must be opened in read
      * or write mode.
-     * @param timestamp 
+     * @param timestamp
      */
     SOMAGroup(
         std::shared_ptr<SOMAContext> ctx,

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -87,6 +87,16 @@ class SOMAGroup : public SOMAObject {
         std::string_view name,
         std::optional<TimestampRange> timestamp = std::nullopt);
 
+    /**
+     * @brief Construct a new SOMAGroup object from a TileDB Group.
+     *
+     * This can only be used to create a SOMAGroup opened in read or write mode.
+     *
+     * @param ctx SOMA context
+     * @param group TileDB group to open as a SOMAGroup. Must be opened in read
+     * or write mode.
+     * @param timestamp 
+     */
     SOMAGroup(
         std::shared_ptr<SOMAContext> ctx,
         std::shared_ptr<Group> group,
@@ -125,9 +135,8 @@ class SOMAGroup : public SOMAObject {
      *
      * @return OpenMode
      */
-    OpenMode mode() const {
-        return group_->query_type() == TILEDB_READ ? OpenMode::read :
-                                                     OpenMode::write;
+    inline OpenMode mode() const {
+        return soma_mode_;
     }
 
     /**
@@ -335,6 +344,9 @@ class SOMAGroup : public SOMAObject {
 
     // Read timestamp range (start, end)
     std::optional<TimestampRange> timestamp_;
+
+    // Current mode of the group.
+    OpenMode soma_mode_;
 
     // Member-to-URI cache
     std::map<std::string, SOMAGroupEntry> members_map_;

--- a/libtiledbsoma/src/soma/soma_measurement.cc
+++ b/libtiledbsoma/src/soma/soma_measurement.cc
@@ -54,7 +54,7 @@ void SOMAMeasurement::create(
 
         auto name = std::string(std::filesystem::path(uri).filename());
         auto group = SOMAGroup::open(
-            OpenMode::write, uri, ctx, name, timestamp);
+            OpenMode::soma_write, uri, ctx, name, timestamp);
         group->set(
             (measurement_uri / "var").string(),
             URIType::absolute,
@@ -115,7 +115,7 @@ std::shared_ptr<SOMADataFrame> SOMAMeasurement::var() {
     if (var_ == nullptr) {
         var_ = SOMADataFrame::open(
             (std::filesystem::path(uri()) / "var").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -126,7 +126,7 @@ std::shared_ptr<SOMACollection> SOMAMeasurement::X() {
     if (X_ == nullptr) {
         X_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "X").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -137,7 +137,7 @@ std::shared_ptr<SOMACollection> SOMAMeasurement::obsm() {
     if (obsm_ == nullptr) {
         obsm_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "obsm").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -148,7 +148,7 @@ std::shared_ptr<SOMACollection> SOMAMeasurement::obsp() {
     if (obsp_ == nullptr) {
         obsp_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "obsp").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -159,7 +159,7 @@ std::shared_ptr<SOMACollection> SOMAMeasurement::varm() {
     if (varm_ == nullptr) {
         varm_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "varm").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -170,7 +170,7 @@ std::shared_ptr<SOMACollection> SOMAMeasurement::varp() {
     if (varp_ == nullptr) {
         varp_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "varp").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -87,7 +87,7 @@ std::shared_ptr<SOMACollection> SOMAScene::img() {
     if (img_ == nullptr) {
         img_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "img").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -98,7 +98,7 @@ std::shared_ptr<SOMACollection> SOMAScene::obsl() {
     if (obsl_ == nullptr) {
         obsl_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "obsl").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }
@@ -109,7 +109,7 @@ std::shared_ptr<SOMACollection> SOMAScene::varl() {
     if (varl_ == nullptr) {
         varl_ = SOMACollection::open(
             (std::filesystem::path(uri()) / "varl").string(),
-            OpenMode::read,
+            OpenMode::soma_read,
             ctx(),
             timestamp());
     }

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(unit_soma
     $<TARGET_OBJECTS:TILEDBSOMA_NANOARROW_OBJECT>
     common.cc
     common.h
+    test_soma_object_basics.cc
     unit_geometry_roundtrip.cc
     unit_arrow_adapter.cc
     unit_column_buffer.cc
@@ -36,6 +37,7 @@ add_executable(unit_soma
     unit_soma_multiscale_image.cc
     unit_soma_coordinates.cc
     test_indexer.cc
+    test_soma_object_basics.cc
 # TODO: uncomment when thread_pool is enabled
 #    unit_thread_pool.cc
 )

--- a/libtiledbsoma/test/test_soma_object_basics.cc
+++ b/libtiledbsoma/test/test_soma_object_basics.cc
@@ -1,0 +1,93 @@
+/**
+ * @file   unit_soma_dense_ndarray.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages unit tests for the SOMADenseNDArray class
+ */
+
+#include "common.h"
+
+void create_soma_object(
+    std::string_view soma_type,
+    std::string_view uri,
+    std::shared_ptr<SOMAContext> context) {
+    if (soma_type == "SOMACollection") {
+        return SOMACollection::create(uri, context);
+    }
+    if (soma_type == "SOMADataFrame") {
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                {helper::DimInfo(
+                    {.name = "soma_joinid",
+                     .tiledb_datatype = TILEDB_INT64,
+                     .dim_max = 100,
+                     .string_lo = "N/A",
+                     .string_hi = "N/A"})},
+                {helper::AttrInfo(
+                    {.name = "attr1",
+                     .tiledb_datatype = TILEDB_STRING_ASCII})});
+        return SOMADataFrame::create(uri, schema, index_columns, context);
+    }
+    if (soma_type == "SOMASparseNDArray") {
+        auto index_columns = helper::create_column_index_info({helper::DimInfo(
+            {.name = "soma_dim_0",
+             .tiledb_datatype = TILEDB_INT64,
+             .dim_max = 1000,
+             .string_lo = "N/A",
+             .string_hi = "N/A"})});
+        return SOMASparseNDArray::create(uri, "g", index_columns, context);
+    }
+    if (soma_type == "SOMADenseNDArray") {
+        auto index_columns = helper::create_column_index_info({helper::DimInfo(
+            {.name = "soma_dim_0",
+             .tiledb_datatype = TILEDB_INT64,
+             .dim_max = 1000,
+             .string_lo = "N/A",
+             .string_hi = "N/A"})});
+        return SOMADenseNDArray::create(uri, "g", index_columns, context);
+    }
+
+    INFO("No support for testing type " + std::string(soma_type));
+    REQUIRE(false);
+}
+
+TEST_CASE(
+    "SOMAObject: basics",
+    "[SOMAObject][SOMACollection][SOMADataFrame][SOMASparseNDArray]["
+    "SOMADenseNDArray]") {
+    auto soma_type = GENERATE(
+        "SOMACollection",
+        "SOMADataFrame",
+        "SOMASparseNDArray",
+        "SOMADenseNDArray");
+    INFO("SOMA type: " + std::string(soma_type));
+
+    std::string uri = "mem://test-soma-object-basics";
+    auto context = std::make_shared<SOMAContext>();
+
+    create_soma_object(soma_type, uri, context);
+
+    // Close and test opening in different modes.
+    OpenMode mode = GENERATE(OpenMode::read, OpenMode::write, OpenMode::del);
+    INFO("Setting open mode to " + open_mode_to_string(mode));
+
+    auto soma_obj = SOMAObject::open(uri, mode, context, std::nullopt);
+
+    auto actual_type = soma_obj->type();
+    REQUIRE(actual_type.has_value());
+    REQUIRE(actual_type.value() == soma_type);
+
+    REQUIRE(soma_obj->is_open());
+    UNSCOPED_INFO(
+        "Actual open mode is " + open_mode_to_string(soma_obj->mode()));
+    REQUIRE(soma_obj->mode() == mode);
+
+    soma_obj->close();
+    REQUIRE(!soma_obj->is_open());
+}

--- a/libtiledbsoma/test/test_soma_object_basics.cc
+++ b/libtiledbsoma/test/test_soma_object_basics.cc
@@ -136,7 +136,8 @@ TEST_CASE(
     create_soma_object(soma_type, uri, context);
 
     // Close and test opening in different modes.
-    OpenMode mode = GENERATE(OpenMode::read, OpenMode::write, OpenMode::del);
+    OpenMode mode = GENERATE(
+        OpenMode::soma_read, OpenMode::soma_write, OpenMode::soma_delete);
     INFO("Setting open mode to " + open_mode_to_string(mode));
 
     auto soma_obj = SOMAObject::open(uri, mode, context, std::nullopt);

--- a/libtiledbsoma/test/test_soma_object_basics.cc
+++ b/libtiledbsoma/test/test_soma_object_basics.cc
@@ -20,6 +20,9 @@ void create_soma_object(
     if (soma_type == "SOMACollection") {
         return SOMACollection::create(uri, context);
     }
+    if (soma_type == "SOMAScene") {
+        return SOMAScene::create(uri, context, std::nullopt);
+    }
     if (soma_type == "SOMADataFrame") {
         auto [schema, index_columns] =
             helper::create_arrow_schema_and_index_columns(
@@ -51,6 +54,65 @@ void create_soma_object(
              .string_lo = "N/A",
              .string_hi = "N/A"})});
         return SOMADenseNDArray::create(uri, "g", index_columns, context);
+    }
+    if (soma_type == "SOMAMultiscaleImage") {
+        SOMACoordinateSpace coord_space{};
+        return SOMAMultiscaleImage::create(
+            uri, context, coord_space, std::nullopt);
+    }
+    if (soma_type == "SOMAPointCloudDataFrame") {
+        std::vector<helper::DimInfo> dim_infos({
+            helper::DimInfo(
+                {.name = "soma_joinid",
+                 .tiledb_datatype = TILEDB_INT64,
+                 .dim_max = 1000,
+                 .string_lo = "N/A",
+                 .string_hi = "N/A"}),
+            helper::DimInfo(
+                {.name = "x",
+                 .tiledb_datatype = TILEDB_UINT32,
+                 .dim_max = 100,
+                 .string_lo = "N/A",
+                 .string_hi = "N/A"}),
+            helper::DimInfo(
+                {.name = "y",
+                 .tiledb_datatype = TILEDB_UINT32,
+                 .dim_max = 100,
+                 .string_lo = "N/A",
+                 .string_hi = "N/A"}),
+        });
+        std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
+            {.name = "radius", .tiledb_datatype = TILEDB_FLOAT64})});
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos);
+        SOMACoordinateSpace coord_space{};
+        return SOMAPointCloudDataFrame::create(
+            uri, schema, index_columns, coord_space, context);
+    }
+    if (soma_type == "SOMAGeometryDataFrame") {
+        std::vector<helper::DimInfo> dim_infos(
+            {helper::DimInfo(
+                 {.name = "soma_joinid",
+                  .tiledb_datatype = TILEDB_INT64,
+                  .dim_max = 1000,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A"}),
+             helper::DimInfo(
+                 {.name = "soma_geometry",
+                  .tiledb_datatype = TILEDB_GEOM_WKB,
+                  .dim_max = 100,
+                  .string_lo = "N/A",
+                  .string_hi = "N/A"})});
+
+        std::vector<helper::AttrInfo> attr_infos({helper::AttrInfo(
+            {.name = "quality", .tiledb_datatype = TILEDB_FLOAT64})});
+        SOMACoordinateSpace coord_space{};
+        auto [schema, index_columns] =
+            helper::create_arrow_schema_and_index_columns(
+                dim_infos, attr_infos, coord_space);
+        SOMAGeometryDataFrame::create(
+            uri, schema, index_columns, coord_space, context);
     }
 
     INFO("No support for testing type " + std::string(soma_type));

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -21,7 +21,8 @@ TEST_CASE("SOMACollection: basic") {
     std::string uri = "mem://unit-test-collection-basic";
 
     SOMACollection::create(uri, ctx, ts);
-    auto soma_collection = SOMACollection::open(uri, OpenMode::read, ctx, ts);
+    auto soma_collection = SOMACollection::open(
+        uri, OpenMode::soma_read, ctx, ts);
     REQUIRE(soma_collection->uri() == uri);
     REQUIRE(soma_collection->ctx() == ctx);
     REQUIRE(soma_collection->type() == "SOMACollection");
@@ -53,7 +54,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
         {"sparse_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
-        base_uri, OpenMode::write, ctx, ts);
+        base_uri, OpenMode::soma_write, ctx, ts);
     REQUIRE(soma_collection->timestamp() == ts);
 
     auto soma_sparse = soma_collection->add_new_sparse_ndarray(
@@ -75,7 +76,7 @@ TEST_CASE("SOMACollection: add SOMASparseNDArray") {
     soma_sparse->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
@@ -102,7 +103,7 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         {"dense_ndarray", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
-        base_uri, OpenMode::write, ctx, ts);
+        base_uri, OpenMode::soma_write, ctx, ts);
     REQUIRE(soma_collection->timestamp() == ts);
 
     if (helper::have_dense_current_domain_support()) {
@@ -124,7 +125,8 @@ TEST_CASE("SOMACollection: add SOMADenseNDArray") {
         REQUIRE(soma_dense->timestamp() == ts);
         soma_collection->close();
 
-        soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+        soma_collection = SOMACollection::open(
+            base_uri, OpenMode::soma_read, ctx);
         REQUIRE(soma_collection->members_map() == expected_map);
         soma_collection->close();
     }
@@ -158,7 +160,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
         {"dataframe", SOMAGroupEntry(sub_uri, "SOMAArray")}};
 
     auto soma_collection = SOMACollection::open(
-        base_uri, OpenMode::write, ctx, ts);
+        base_uri, OpenMode::soma_write, ctx, ts);
     REQUIRE(soma_collection->timestamp() == ts);
 
     auto soma_dataframe = soma_collection->add_new_dataframe(
@@ -174,7 +176,7 @@ TEST_CASE("SOMACollection: add SOMADataFrame") {
     REQUIRE(soma_dataframe->timestamp() == ts);
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
     REQUIRE(soma_dataframe->count() == 0);
     soma_collection->close();
@@ -192,7 +194,8 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"subcollection", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
-    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
+    auto soma_collection = SOMACollection::open(
+        base_uri, OpenMode::soma_write, ctx);
     auto soma_subcollection = soma_collection->add_new_collection(
         "subcollection", sub_uri, URIType::absolute, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
@@ -201,7 +204,7 @@ TEST_CASE("SOMACollection: add SOMACollection") {
     REQUIRE(soma_subcollection->type() == "SOMACollection");
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
@@ -231,7 +234,8 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"experiment", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
-    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
+    auto soma_collection = SOMACollection::open(
+        base_uri, OpenMode::soma_write, ctx);
     auto soma_experiment = soma_collection->add_new_experiment(
         "experiment", sub_uri, URIType::absolute, ctx, schema, index_columns);
 
@@ -242,7 +246,7 @@ TEST_CASE("SOMACollection: add SOMAExperiment") {
     soma_experiment->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
@@ -272,7 +276,8 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     std::map<std::string, SOMAGroupEntry> expected_map{
         {"measurement", SOMAGroupEntry(sub_uri, "SOMAGroup")}};
 
-    auto soma_collection = SOMACollection::open(base_uri, OpenMode::write, ctx);
+    auto soma_collection = SOMACollection::open(
+        base_uri, OpenMode::soma_write, ctx);
     auto soma_measurement = soma_collection->add_new_measurement(
         "measurement", sub_uri, URIType::absolute, ctx, schema, index_columns);
 
@@ -283,7 +288,7 @@ TEST_CASE("SOMACollection: add SOMAMeasurement") {
     soma_measurement->close();
     soma_collection->close();
 
-    soma_collection = SOMACollection::open(base_uri, OpenMode::read, ctx);
+    soma_collection = SOMACollection::open(base_uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_collection->members_map() == expected_map);
     soma_collection->close();
 }
@@ -294,14 +299,14 @@ TEST_CASE("SOMACollection: metadata") {
     std::string uri = "mem://unit-test-collection";
     SOMACollection::create(uri, ctx, TimestampRange(0, 2));
     auto soma_collection = SOMACollection::open(
-        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+        uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
     soma_collection->set_metadata("md", TILEDB_INT32, 1, &val);
     soma_collection->close();
 
     // Read metadata
-    soma_collection->open(OpenMode::read, TimestampRange(0, 2));
+    soma_collection->open(OpenMode::soma_read, TimestampRange(0, 2));
     REQUIRE(soma_collection->metadata_num() == 3);
     REQUIRE(soma_collection->has_metadata("soma_object_type"));
     REQUIRE(soma_collection->has_metadata("soma_encoding_version"));
@@ -313,7 +318,7 @@ TEST_CASE("SOMACollection: metadata") {
     soma_collection->close();
 
     // md should not be available at (2, 2)
-    soma_collection->open(OpenMode::read, TimestampRange(2, 2));
+    soma_collection->open(OpenMode::soma_read, TimestampRange(2, 2));
     REQUIRE(soma_collection->metadata_num() == 2);
     REQUIRE(soma_collection->has_metadata("soma_object_type"));
     REQUIRE(soma_collection->has_metadata("soma_encoding_version"));
@@ -321,7 +326,7 @@ TEST_CASE("SOMACollection: metadata") {
     soma_collection->close();
 
     // Metadata should also be retrievable in write mode
-    soma_collection->open(OpenMode::write, TimestampRange(0, 2));
+    soma_collection->open(OpenMode::soma_write, TimestampRange(0, 2));
     REQUIRE(soma_collection->metadata_num() == 3);
     REQUIRE(soma_collection->has_metadata("soma_object_type"));
     REQUIRE(soma_collection->has_metadata("soma_encoding_version"));
@@ -337,7 +342,7 @@ TEST_CASE("SOMACollection: metadata") {
     soma_collection->close();
 
     // Confirm delete in read mode
-    soma_collection->open(OpenMode::read, TimestampRange(0, 2));
+    soma_collection->open(OpenMode::soma_read, TimestampRange(0, 2));
     REQUIRE(!soma_collection->has_metadata("md"));
     REQUIRE(soma_collection->metadata_num() == 2);
 }
@@ -371,7 +376,7 @@ TEST_CASE("SOMAExperiment: metadata") {
         TimestampRange(0, 2));
 
     auto soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+        uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
     soma_experiment->set_metadata("md", TILEDB_INT32, 1, &val);
@@ -379,7 +384,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 
     // Read metadata
     soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(0, 2));
     REQUIRE(soma_experiment->metadata_num() == 4);
     REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
@@ -393,7 +398,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 
     // md should not be available at (2, 2)
     soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(2, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(2, 2));
     REQUIRE(soma_experiment->metadata_num() == 3);
     REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
@@ -403,7 +408,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 
     // Metadata should also be retrievable in write mode
     soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::write, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
     REQUIRE(soma_experiment->metadata_num() == 4);
     REQUIRE(soma_experiment->has_metadata("dataset_type"));
     REQUIRE(soma_experiment->has_metadata("soma_object_type"));
@@ -421,7 +426,7 @@ TEST_CASE("SOMAExperiment: metadata") {
 
     // Confirm delete in read mode
     soma_experiment = SOMAExperiment::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(0, 2));
     REQUIRE(!soma_experiment->has_metadata("md"));
     REQUIRE(soma_experiment->metadata_num() == 3);
 }
@@ -454,7 +459,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
         TimestampRange(0, 2));
 
     auto soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
+        uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
     soma_measurement->set_metadata("md", TILEDB_INT32, 1, &val);
@@ -462,7 +467,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
 
     // Read metadata
     soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(0, 2));
     REQUIRE(soma_measurement->metadata_num() == 3);
     REQUIRE(soma_measurement->has_metadata("soma_object_type"));
     REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
@@ -475,7 +480,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
 
     // md should not be available at (2, 2)
     soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(2, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(2, 2));
     REQUIRE(soma_measurement->metadata_num() == 2);
     REQUIRE(soma_measurement->has_metadata("soma_object_type"));
     REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
@@ -484,7 +489,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
 
     // Metadata should also be retrievable in write mode
     soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::write, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
     REQUIRE(soma_measurement->metadata_num() == 3);
     REQUIRE(soma_measurement->has_metadata("soma_object_type"));
     REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
@@ -501,7 +506,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
 
     // Confirm delete in read mode
     soma_measurement = SOMAMeasurement::open(
-        uri, OpenMode::read, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_read, ctx, TimestampRange(0, 2));
     REQUIRE(!soma_measurement->has_metadata("md"));
     REQUIRE(soma_measurement->metadata_num() == 2);
 }

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -132,7 +132,7 @@ struct VariouslyIndexedDataFrameFixture {
     }
 
     void write_sjid_u32_str_data_from(int64_t sjid_base) {
-        auto sdf = SOMADataFrame::open(uri_, OpenMode::write, ctx_);
+        auto sdf = SOMADataFrame::open(uri_, OpenMode::soma_write, ctx_);
 
         auto i64_data = std::vector<int64_t>({sjid_base + 1, sjid_base + 2});
 
@@ -272,7 +272,7 @@ TEST_CASE_METHOD(
         create(dim_infos, attr_infos);
 
         // Check current domain
-        auto sdf = open(OpenMode::read);
+        auto sdf = open(OpenMode::soma_read);
 
         // External column initialization
         auto raw_array = tiledb::Array(*ctx_->tiledb_ctx(), uri_, TILEDB_READ);
@@ -385,17 +385,18 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        sdf = open(OpenMode::write);
+        sdf = open(OpenMode::soma_write);
         write_sjid_u32_str_data_from(0);
 
         sdf->close();
 
-        sdf = open(OpenMode::read);
+        sdf = open(OpenMode::soma_read);
         REQUIRE(sdf->nnz() == 2);
 
         sdf->close();
 
-        ManagedQuery external_query(*open(OpenMode::read), ctx_->tiledb_ctx());
+        ManagedQuery external_query(
+            *open(OpenMode::soma_read), ctx_->tiledb_ctx());
 
         columns[1]->select_columns(external_query);
         columns[1]->set_dim_point<uint32_t>(external_query, 1234);
@@ -444,7 +445,7 @@ TEST_CASE_METHOD(
         create(dim_infos, attr_infos);
 
         // Check current domain
-        auto sdf = open(OpenMode::read);
+        auto sdf = open(OpenMode::soma_read);
 
         // External column initialization
         auto raw_array = tiledb::Array(*ctx_->tiledb_ctx(), uri_, TILEDB_READ);
@@ -557,17 +558,18 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        sdf = open(OpenMode::write);
+        sdf = open(OpenMode::soma_write);
         write_sjid_u32_str_data_from(0);
 
         sdf->close();
 
-        sdf = open(OpenMode::read);
+        sdf = open(OpenMode::soma_read);
         REQUIRE(sdf->nnz() == 2);
 
         sdf->close();
 
-        ManagedQuery external_query(*open(OpenMode::read), ctx_->tiledb_ctx());
+        ManagedQuery external_query(
+            *open(OpenMode::soma_read), ctx_->tiledb_ctx());
 
         columns[1]->select_columns(external_query);
         columns[1]->set_dim_point<uint32_t>(external_query, 1234);

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -49,7 +49,7 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
             PlatformConfig(),
             TimestampRange(0, 2));
 
-        auto dnda = SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+        auto dnda = SOMADenseNDArray::open(uri, OpenMode::soma_read, ctx);
         REQUIRE(dnda->shape() == std::vector<int64_t>{dim_max + 1});
         dnda->close();
     } else {
@@ -92,7 +92,7 @@ TEST_CASE("SOMADenseNDArray: platform_config", "[SOMADenseNDArray]") {
         SOMADenseNDArray::create(
             uri, arrow_format, index_columns, ctx, platform_config);
 
-        auto dnda = SOMADenseNDArray::open(uri, OpenMode::read, ctx);
+        auto dnda = SOMADenseNDArray::open(uri, OpenMode::soma_read, ctx);
         auto dim_filter = dnda->tiledb_schema()
                               ->domain()
                               .dimension(dim_name)
@@ -137,14 +137,14 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     // TO DO: do more data writes and readbacks here in C++ tests.
     // https://github.com/single-cell-data/TileDB-SOMA/issues/3721
     auto dnda = SOMADenseNDArray::open(
-        uri, OpenMode::write, ctx, TimestampRange(0, 2));
+        uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
 
     int32_t val = 100;
     dnda->set_metadata("md", TILEDB_INT32, 1, &val);
     dnda->close();
 
     // Read metadata
-    dnda->open(OpenMode::read, TimestampRange(0, 2));
+    dnda->open(OpenMode::soma_read, TimestampRange(0, 2));
     REQUIRE(dnda->metadata_num() == 3);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
@@ -156,7 +156,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     dnda->close();
 
     // md should not be available at (0, 1)
-    dnda->open(OpenMode::read, TimestampRange(0, 1));
+    dnda->open(OpenMode::soma_read, TimestampRange(0, 1));
     REQUIRE(dnda->metadata_num() == 2);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
@@ -164,7 +164,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     dnda->close();
 
     // Metadata should also be retrievable in write mode
-    dnda->open(OpenMode::write);
+    dnda->open(OpenMode::soma_write);
     REQUIRE(dnda->metadata_num() == 3);
     REQUIRE(dnda->has_metadata("soma_object_type"));
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
@@ -179,7 +179,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     dnda->close();
 
     // Confirm delete in read mode
-    dnda->open(OpenMode::read);
+    dnda->open(OpenMode::soma_read);
     REQUIRE(!dnda->has_metadata("md"));
     REQUIRE(dnda->metadata_num() == 2);
 }

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -67,7 +67,7 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
     REQUIRE(!SOMADataFrame::exists(uri, ctx));
 
     auto soma_geometry = SOMAGeometryDataFrame::open(
-        uri, OpenMode::read, ctx, std::nullopt);
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     REQUIRE(soma_geometry->uri() == uri);
     REQUIRE(soma_geometry->ctx() == ctx);
     REQUIRE(soma_geometry->type() == "SOMAGeometryDataFrame");
@@ -79,7 +79,7 @@ TEST_CASE("SOMAGeometryDataFrame: basic", "[SOMAGeometryDataFrame]") {
     REQUIRE(soma_geometry->nnz() == 0);
     soma_geometry->close();
 
-    auto soma_object = SOMAObject::open(uri, OpenMode::read, ctx);
+    auto soma_object = SOMAObject::open(uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_object->uri() == uri);
     REQUIRE(soma_object->type() == "SOMAGeometryDataFrame");
     soma_object->close();
@@ -195,7 +195,7 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
 
     // Write to point cloud.
     auto soma_geometry = SOMAGeometryDataFrame::open(
-        uri, OpenMode::write, ctx, std::nullopt);
+        uri, OpenMode::soma_write, ctx, std::nullopt);
     auto mq = ManagedQuery(*soma_geometry, ctx->tiledb_ctx());
     std::tie(data_array, data_schema) = TransformerPipeline(
                                             std::move(data_array),
@@ -210,7 +210,7 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
 
     // Read back the data.
     soma_geometry = SOMAGeometryDataFrame::open(
-        uri, OpenMode::read, ctx, std::nullopt);
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     mq = ManagedQuery(*soma_geometry, ctx->tiledb_ctx());
     while (auto batch = mq.read_next()) {
         auto arrbuf = batch.value();
@@ -247,7 +247,7 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     }
     soma_geometry->close();
 
-    auto soma_object = SOMAObject::open(uri, OpenMode::read, ctx);
+    auto soma_object = SOMAObject::open(uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_object->uri() == uri);
     REQUIRE(soma_object->type() == "SOMAGeometryDataFrame");
     soma_object->close();

--- a/libtiledbsoma/test/unit_soma_multiscale_image.cc
+++ b/libtiledbsoma/test/unit_soma_multiscale_image.cc
@@ -19,7 +19,7 @@ TEST_CASE("SOMAMultiscaleImage: basic", "[multiscale_image][spatial]") {
     SOMACoordinateSpace coord_space{};
     SOMAMultiscaleImage::create(uri, ctx, coord_space, std::nullopt);
     auto soma_image = SOMAMultiscaleImage::open(
-        uri, OpenMode::read, ctx, std::nullopt);
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     REQUIRE(soma_image->uri() == uri);
     REQUIRE(soma_image->ctx() == ctx);
     REQUIRE(soma_image->type() == "SOMAMultiscaleImage");

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -69,7 +69,7 @@ TEST_CASE(
     REQUIRE(!SOMADataFrame::exists(uri, ctx));
 
     auto soma_point_cloud = SOMAPointCloudDataFrame::open(
-        uri, OpenMode::read, ctx, std::nullopt);
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     REQUIRE(soma_point_cloud->uri() == uri);
     REQUIRE(soma_point_cloud->ctx() == ctx);
     REQUIRE(soma_point_cloud->type() == "SOMAPointCloudDataFrame");
@@ -90,7 +90,8 @@ TEST_CASE(
     std::vector<double> a0(10, 1.0);
 
     // Write to point cloud.
-    soma_point_cloud = SOMAPointCloudDataFrame::open(uri, OpenMode::write, ctx);
+    soma_point_cloud = SOMAPointCloudDataFrame::open(
+        uri, OpenMode::soma_write, ctx);
     auto mq = ManagedQuery(*soma_point_cloud, ctx->tiledb_ctx());
     mq.setup_write_column(
         dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
@@ -105,7 +106,7 @@ TEST_CASE(
 
     // Read back the data.
     soma_point_cloud = SOMAPointCloudDataFrame::open(
-        uri, OpenMode::read, ctx, std::nullopt);
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     mq = ManagedQuery(*soma_point_cloud, ctx->tiledb_ctx());
     while (auto batch = mq.read_next()) {
         auto arrbuf = batch.value();
@@ -124,7 +125,7 @@ TEST_CASE(
     CHECK(point_cloud_coord_space == coord_space);
     soma_point_cloud->close();
 
-    auto soma_object = SOMAObject::open(uri, OpenMode::read, ctx);
+    auto soma_object = SOMAObject::open(uri, OpenMode::soma_read, ctx);
     REQUIRE(soma_object->uri() == uri);
     REQUIRE(soma_object->type() == "SOMAPointCloudDataFrame");
     soma_object->close();

--- a/libtiledbsoma/test/unit_soma_scene.cc
+++ b/libtiledbsoma/test/unit_soma_scene.cc
@@ -18,7 +18,8 @@ TEST_CASE("SOMAScene: basic", "[scene][spatial]") {
     std::string uri{"mem://unit-test-scene-basic"};
 
     SOMAScene::create(uri, ctx, std::nullopt);
-    auto soma_scene = SOMAScene::open(uri, OpenMode::read, ctx, std::nullopt);
+    auto soma_scene = SOMAScene::open(
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     CHECK(soma_scene->uri() == uri);
     CHECK(soma_scene->ctx() == ctx);
     CHECK(soma_scene->type() == "SOMAScene");
@@ -36,7 +37,8 @@ TEST_CASE("SOMAScene: with coordinates", "[scene][spatial]") {
 
     SOMAScene::create(uri, ctx, coord_space, std::nullopt);
 
-    auto soma_scene = SOMAScene::open(uri, OpenMode::read, ctx, std::nullopt);
+    auto soma_scene = SOMAScene::open(
+        uri, OpenMode::soma_read, ctx, std::nullopt);
     CHECK(soma_scene->uri() == uri);
     CHECK(soma_scene->ctx() == ctx);
     CHECK(soma_scene->type() == "SOMAScene");


### PR DESCRIPTION
**Issue and/or context:**
* Closes SOMA-168
* Closes SOMA-170
* Closes SOMA-180

**Changes:**

C++ Changes:
* Make `SOMAArray` copy constructor the default copy constructor.
* Add `soma_mode_` as a private variable to `SOMAArray` and `SOMAGroup`.
* Add new `OpenMode::soma_delete` option to `OpenMode` enum (the `soma_` prefix was added since `delete` is a special keyword.
* Add `soma_` prefix to existing `OpenMode` values for consistency.
* 

Python Changes:
* Update to a new version of somacore (adds 'd' mode to `somacore.options.OpenMode`)
* Add `verify_open_for_deleting` to SOMA objects
* Rename `_verify_open_for_reading` to `verify_open_for_reading`
* Add `d` as a valid mode for opening/reopening SOMA objects
* Deprecate deleting elements from a `Collection` in write mode
* Add support for deleting elements from a `Collection` in delete mode    

R Changes:
* Deprecate deleting elements from a `Collection` in write mode
* Add support for deleting elements from a `Collection` in delete mode

Before Merging:
* [x] Update changelogs
* [x] Release and update somacore version
