### PR TITLE
[python] import time check of expected TileDB version

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] at package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeWarning if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
+- \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] At package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeError exception if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
 
 ### Deprecated
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] at package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeWarning if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
+
 ### Deprecated
 
 ### Removed
@@ -25,7 +27,7 @@ The primary changes are modifications and deprecations to the `tiledbsoma.io` in
 ### Changed
 
 - \[[#3983](https://github.com/single-cell-data/TileDB-SOMA/pull/3983)\] [python] Multiple writes of pre-sorted data may now be written to a single fragment using TileDB global order writes. Enable this performance optimization by setting the platform_config parameter `sort_coords` to `False` in the call to write. Will raise an error if data is not written in global sort order.
-- \[[#4086](https://github.com/single-cell-data/TileDB-SOMA/pull/4086)\] [python] Add new parameter `allow_duplicate_obs_ids` to the `tiledbsoma.io` functions `register_anndatas` and `register_h5ads`.  When `False` (default), a error will be raised if there are any duplicate `obs` IDs in the provided SOMA Experiment or AnnData objects. Set the parameter to `True` for legacy behavior. ID handling on the `var` axis is unchanged.
+- \[[#4086](https://github.com/single-cell-data/TileDB-SOMA/pull/4086)\] [python] Add new parameter `allow_duplicate_obs_ids` to the `tiledbsoma.io` functions `register_anndatas` and `register_h5ads`. When `False` (default), a error will be raised if there are any duplicate `obs` IDs in the provided SOMA Experiment or AnnData objects. Set the parameter to `True` for legacy behavior. ID handling on the `var` axis is unchanged.
 - \[[#4108](https://github.com/single-cell-data/TileDB-SOMA/pull/4108)\] [python] improve performance of `tiledbsoma.io.from_anndata` and `from_h5ad` when appending groups of AnnData known to have no duplicate obs axis IDs.
 
 - \[[#4106](https://github.com/single-cell-data/TileDB-SOMA/pull/4106)\] [python][BREAKING] The `SOMAObject.reopen` method now modifies the orginal `SOMAObject` in place (flushes data to disk and reopens with the requested timestamp and mode) and returns a reference to itself instead of flushing data to disk and opening a new object.

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -168,6 +168,7 @@ from ._exception import (
 from ._experiment import Experiment
 from ._factory import open
 from ._general_utilities import (
+    _verify_expected_tiledb_version,
     get_implementation,
     get_implementation_version,
     get_libtiledbsoma_core_version,
@@ -195,6 +196,7 @@ from .stats import (
     tiledbsoma_stats_json,
 )
 
+_verify_expected_tiledb_version()
 __version__ = get_implementation_version()
 
 __all__ = [
@@ -213,6 +215,7 @@ __all__ = [
     "GeometryDataFrame",
     "get_implementation_version",
     "get_implementation",
+    "get_libtiledbsoma_core_version",
     "get_SOMA_version",
     "get_storage_engine",
     "IdentityTransform",

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -80,9 +80,9 @@ def _verify_expected_tiledb_version() -> None:
     expected = expected_tiledb_version()
     found = tiledb_version()
     if found != expected:
-        warnings.warn(
+        raise RuntimeError(
             f"TileDB version mismatch - expected version {expected}, but found {found}. This should not occur, and"
             " is likely the result of a corrupted package installation. Recommend uninstalling/reinstalling the"
-            " tiledbsoma package.",
-            category=RuntimeWarning,
+            " tiledbsoma package. Alternatively, if you are using a Python virtual environment (e.g., conda)"
+            " remove and reinstall the Python virtual environment."
         )

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -82,7 +82,7 @@ def _verify_expected_tiledb_version() -> None:
     if found != expected:
         warnings.warn(
             f"TileDB version mismatch - expected version {expected}, but found {found}. This should not occur, and"
-            "is likely the result of a corrupted package installation. Recommend uninstalling/reinstalling the"
-            "tiledbsoma package.",
+            " is likely the result of a corrupted package installation. Recommend uninstalling/reinstalling the"
+            " tiledbsoma package.",
             category=RuntimeWarning,
         )

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 
 """General utility functions."""
+
 import importlib.metadata
 import platform
 import sys
 import warnings
 from re import fullmatch
 
+from .pytiledbsoma import expected_tiledb_version, tiledb_version
 from .pytiledbsoma import version as libtiledbsoma_core_version_str
 
 
@@ -39,16 +41,6 @@ def get_implementation_version() -> str:
         return "unknown"
 
 
-def assert_version_before(major: int, minor: int) -> None:
-    version_string = get_implementation_version()
-    if version_string == "unknown":
-        warnings.warn("`assert_version_before` could not retrieve the current " "implementation version")
-        return
-
-    version = version_string.split(".")
-    assert (int(version[0]), int(version[1])) < (major, minor)
-
-
 def get_storage_engine() -> str:
     """Returns underlying storage engine name, e.g., "tiledb".
 
@@ -69,11 +61,6 @@ def get_libtiledbsoma_core_version() -> str:
     return m.group(1)
 
 
-# Set this env var to "err" to print an error to stderr when TileDB-Py's and libtiledbsoma's core
-# versions mismatch (by default, an AssertionError is raised).
-TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL_VAR = "TILEDB_CORE_MISMATCHED_VERSIONS_ERROR_LEVEL"
-
-
 def show_package_versions() -> None:
     """Nominal use is for bug reports, so issue filers and issue fixers can be on
     the same page.
@@ -87,3 +74,13 @@ def show_package_versions() -> None:
     print("python version                     ", ".".join(str(v) for v in sys.version_info))
     print("OS version                         ", u.system, u.release)
     # fmt: on
+
+
+def _verify_expected_tiledb_version() -> None:
+    expected = expected_tiledb_version()
+    found = tiledb_version()
+    if found != expected:
+        warnings.warn(
+            f"TileDB version mismatch - expected version {expected}, but found {found}",
+            category=RuntimeWarning,
+        )

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -81,6 +81,8 @@ def _verify_expected_tiledb_version() -> None:
     found = tiledb_version()
     if found != expected:
         warnings.warn(
-            f"TileDB version mismatch - expected version {expected}, but found {found}",
+            f"TileDB version mismatch - expected version {expected}, but found {found}. This should not occur, and"
+            "is likely the result of a corrupted package installation. Recommend uninstalling/reinstalling the"
+            "tiledbsoma package.",
             category=RuntimeWarning,
         )

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -80,8 +80,11 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     m.doc() = "SOMA acceleration library";
 
     m.def("version", []() { return tiledbsoma::version::as_string(); });
-    m.def("embedded_version_triple", []() {
+    m.def("tiledb_version", []() {
         return tiledbsoma::version::embedded_version_triple();
+    });
+    m.def("expected_tiledb_version", []() {
+        return tiledbsoma::version::expected_version();
     });
 
     m.def(

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -80,7 +80,7 @@ def test_replace_config_after_construction():
 
     # verify defaults expected by subsequent tests
     assert context.timestamp_ms is None
-    if tiledbsoma.pytiledbsoma.embedded_version_triple() < (2, 27, 0):
+    if tiledbsoma.pytiledbsoma.tiledb_version() < (2, 27, 0):
         assert context.native_context.config()["vfs.s3.region"] == "us-east-1"
     else:
         assert context.native_context.config()["vfs.s3.region"] == ""

--- a/apis/python/tests/test_general_utilities.py
+++ b/apis/python/tests/test_general_utilities.py
@@ -26,7 +26,7 @@ def test_verify_expected_tiledb_version() -> None:
     with mock.patch("tiledbsoma._general_utilities.expected_tiledb_version") as mock_expected_tiledb_version:
         mock_expected_tiledb_version.return_value = (1, 2, 3)
 
-        with pytest.warns(RuntimeWarning, match="TileDB version mismatch"):
+        with pytest.raises(RuntimeError):
             _verify_expected_tiledb_version()
 
         mock_expected_tiledb_version.assert_called_once()

--- a/apis/python/tests/test_general_utilities.py
+++ b/apis/python/tests/test_general_utilities.py
@@ -1,4 +1,9 @@
+from unittest import mock
+
+import pytest
+
 import tiledbsoma
+import tiledbsoma.pytiledbsoma as clib
 
 
 def test_general_utilities():
@@ -9,3 +14,19 @@ def test_general_utilities():
 def test_versions_api():
     assert tiledbsoma.get_SOMA_version() == "0.2.0-dev"
     assert tiledbsoma.get_implementation_version() == tiledbsoma.__version__
+
+
+def test_expected_version_api():
+    assert clib.tiledb_version() == clib.expected_tiledb_version()
+
+
+def test_verify_expected_tiledb_version() -> None:
+    from tiledbsoma._general_utilities import _verify_expected_tiledb_version
+
+    with mock.patch("tiledbsoma._general_utilities.expected_tiledb_version") as mock_expected_tiledb_version:
+        mock_expected_tiledb_version.return_value = (1, 2, 3)
+
+        with pytest.warns(RuntimeWarning, match="TileDB version mismatch"):
+            _verify_expected_tiledb_version()
+
+        mock_expected_tiledb_version.assert_called_once()

--- a/libtiledbsoma/src/utils/version.cc
+++ b/libtiledbsoma/src/utils/version.cc
@@ -28,4 +28,14 @@ std::tuple<int, int, int> embedded_version_triple() {
     return std::make_tuple(major, minor, patch);
 }
 
+/**
+ * @brief Link-time version of TileDB. Used for error checking at runtime.
+ *
+ * @return std::tuple<int, int, int>
+ */
+std::tuple<int, int, int> expected_version() {
+    return std::make_tuple(
+        TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH);
+}
+
 };  // namespace tiledbsoma::version

--- a/libtiledbsoma/src/utils/version.h
+++ b/libtiledbsoma/src/utils/version.h
@@ -22,6 +22,7 @@ namespace tiledbsoma::version {
 
 std::string as_string();
 std::tuple<int, int, int> embedded_version_triple();
+std::tuple<int, int, int> expected_version();
 
 };  // namespace tiledbsoma::version
 


### PR DESCRIPTION
There have been several examples where users end up with corrupted conda environments, manifesting as strange and difficult to diagnose errors. Root cause in at least one is a mismatch between the build-time and run-time TileDB version. This is an attempt to provide some detection and warning of this condition.

Changes:
1. Add C++ API to report the TileDB version that the Python pybind11 module was built against ("expected" TileDB version)
2. Add package import-time check to validate that our build-time and run-time TileDB versions match. A `RuntimeError` (exception) is raised upon mismatch.
3. Tests

Fixes SOMA-267