### PR TITLE
document timestamp value of zero

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -234,7 +234,8 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
                 - ``w``: Open for writing only (cannot read).
             tiledb_timestamp:
                 The TileDB timestamp to open this object at, either an int representing milliseconds since the Unix
-                epoch or a datetime.datetime object. When not provided (the default), the current time is used.
+                epoch or a datetime.datetime object. When not provided (the default), the current time is used. A
+                value of zero results in current time.
 
         Raises:
             ValueError:

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -81,6 +81,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 either an int representing milliseconds since the Unix epoch
                 or a datetime.datetime object.
                 When not provided (the default), the current time is used.
+                A value of zero results in default, i.e., the current time.
 
         Returns:
             The opened SOMA object.
@@ -292,6 +293,7 @@ class SOMAObject(somacore.SOMAObject, Generic[_WrapperType_co]):
                 The TileDB timestamp to open this object at,
                 measured in milliseconds since the Unix epoch.
                 When unset (the default), the current time is used.
+                A value of zero results in default, i.e., current time.
 
         Raises:
             TypeError:

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -137,7 +137,8 @@ class SOMATileDBContext(ContextBase):
                 that of the time you called ``open``.
 
                 If a value is passed, that timestamp is used as the timestamp
-                to record all operations.
+                to record all operations. A timestamp value of zero (0) is
+                equivalent to current time.
 
                 Set to 0xFFFFFFFFFFFFFFFF (UINT64_MAX) to get the absolute
                 latest revision (i.e., including changes that occur "after"
@@ -339,9 +340,9 @@ class SOMATileDBContext(ContextBase):
     def _open_timestamp_ms(self, in_timestamp: OpenTimestamp | None) -> int:
         """Returns the real timestamp that should be used to open an object.
 
-        Timestamp values of zero or None are treated as "use default". This is
-        consistent with other TileDB API (e.g., TileDB-Py). The datetime.datetime
-        epoch is treated as zero/default.
+        Timestamp values of zero or None are treated as "use default", which results
+        in "current time". This is consistent with other TileDB API (e.g., TileDB-Py).
+        The datetime.datetime epoch is treated as zero/default.
         """
         if isinstance(in_timestamp, datetime.datetime):
             # if a datetime, convert to int/ms

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -86,6 +86,8 @@ def test_replace_config_after_construction():
         assert context.native_context.config()["vfs.s3.region"] == ""
 
     now = int(time.time() * 1000)
+    open_ts = context._open_timestamp_ms(0)
+    assert -100 < now - open_ts < 100
     open_ts = context._open_timestamp_ms(None)
     assert -100 < now - open_ts < 100
     assert 999 == context._open_timestamp_ms(999)


### PR DESCRIPTION
Docstrings did not specifically cover the behavior of a `timestamp` value of zero.

Fixes SOMA-195

Changes:
* add docstrings
* added explicit test for this behavior

