### PR TITLE
[python] Ruff lint rules

### DIFF
--- a/apis/python/notebooks/tutorial_soma_reading.ipynb
+++ b/apis/python/notebooks/tutorial_soma_reading.ipynb
@@ -1686,7 +1686,7 @@
    ],
    "source": [
     "Y = X.read([slice(0, 5)]).coos().concat()\n",
-    "Y "
+    "Y"
    ]
   },
   {

--- a/apis/python/notebooks/tutorial_spatial.ipynb
+++ b/apis/python/notebooks/tutorial_spatial.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "def sh(*cmd):\n",
     "    err(f\"Running: {shlex.join(cmd)}\")\n",
-    "    check_call(cmd)    "
+    "    check_call(cmd)"
    ]
   },
   {

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -42,10 +42,6 @@ extend-select = []
 [tool.ruff.lint.per-file-ignores]
 # Ignore these rules everywhere except for the `src/` directory.
 "!apis/python/src/**.py" = ["D", "B"]
-# Ignore line too long (E501) in tests
-"apis/python/tests/**/*.py" = ["E501"]
-# Ignore line too long in notebooks
-"apis/python/**/*.ipynb" = ["E501"]
 
 # Temporarily disable checks in the io and io.spatial modules.
 "apis/python/src/tiledbsoma/io/**/*.py" = [

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -24,19 +24,28 @@ target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
-extend-select = ["I001"]  # unsorted-imports
-
-# Enable all `pydocstyle` rules, limiting to those that adhere to the
-# Google convention via `convention = "google"`, below.
-select = ["D"]
+select = [  # see https://docs.astral.sh/ruff/rules/
+    "B",    # bugbear
+    "D",    # pydocstyle (Google convention, see setting below)
+    "E",    # pycodestyle
+    "F",    # Pyflakes
+    "I",    # isort
+    "W",    # pycodestyle warnings
+]
 ignore = [
+    "E501",  # line too long
     "D417",  # disable documentation for every function parameter
     "D205",  # disable blank line requirement between summary and description
 ]
+extend-select = []
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore `D` rules everywhere except for the `src/` directory.
-"!apis/python/src/**.py" = ["D"]
+# Ignore these rules everywhere except for the `src/` directory.
+"!apis/python/src/**.py" = ["D", "B"]
+# Ignore line too long (E501) in tests
+"apis/python/tests/**/*.py" = ["E501"]
+# Ignore line too long in notebooks
+"apis/python/**/*.ipynb" = ["E501"]
 
 # Temporarily disable checks in the io and io.spatial modules.
 "apis/python/src/tiledbsoma/io/**/*.py" = [

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -100,7 +100,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
         """
         context = _validate_soma_tiledb_context(context)
         try:
-            wrapper = cast(_tdb_handles.SOMAGroupWrapper[Any], cls._wrapper_type)
+            wrapper = cast("_tdb_handles.SOMAGroupWrapper[Any]", cls._wrapper_type)
             timestamp_ms = context._open_timestamp_ms(tiledb_timestamp)
             clib.SOMAGroup.create(
                 uri=uri,
@@ -379,7 +379,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
 
     def members(self) -> dict[str, tuple[str, str]]:
         """Get a mapping of {member_name: (uri, soma_object_type)}."""
-        handle = cast(_tdb_handles.SOMAGroupWrapper[Any], self._handle)
+        handle = cast("_tdb_handles.SOMAGroupWrapper[Any]", self._handle)
         return handle.members()
 
     def __repr__(self) -> str:
@@ -511,7 +511,7 @@ def _real_class(cls: type[Any]) -> type:
     err = TypeError(f"{cls} cannot be turned into a real type")
     try:
         # All types of generic alias have this.
-        origin = getattr(cls, "__origin__")
+        origin = cls.__origin__
         # Other special forms, like Union, also have an __origin__ that is not
         # an actual type.  Verify that the origin is a real, instantiable type.
         issubclass(object, origin)  # Ordering intentional here.

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -122,7 +122,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         Lifecycle:
             Maturing.
         """
-        return cast(tuple[int, ...], tuple(self._handle.shape))
+        return cast("tuple[int, ...]", tuple(self._handle.shape))
 
     @property
     def maxshape(self) -> tuple[int, ...]:
@@ -133,7 +133,7 @@ class NDArray(SOMAArray, somacore.NDArray):
         Lifecycle:
             Maturing.
         """
-        return cast(tuple[int, ...], tuple(self._handle.maxshape))
+        return cast("tuple[int, ...]", tuple(self._handle.maxshape))
 
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -448,7 +448,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         """
         self._verify_open_for_reading()
         # if is it in read open mode, then it is a DataFrameWrapper
-        return cast(DataFrameWrapper, self._handle).count
+        return cast("DataFrameWrapper", self._handle).count
 
     @property
     def _maybe_soma_joinid_shape(self) -> int | None:
@@ -505,7 +505,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         if check_only:
             return cast(
-                StatusAndReason,
+                "StatusAndReason",
                 self._handle._handle.can_resize_soma_joinid_shape(
                     newshape,
                     function_name_for_messages=function_name_for_messages,
@@ -532,7 +532,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         if check_only:
             return cast(
-                StatusAndReason,
+                "StatusAndReason",
                 self._handle._handle.can_upgrade_soma_joinid_shape(
                     newshape,
                     function_name_for_messages=function_name_for_messages,
@@ -616,7 +616,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
         if check_only:
             return cast(
-                StatusAndReason,
+                "StatusAndReason",
                 self._handle._handle.can_upgrade_domain(
                     pyarrow_domain_table,
                     function_name_for_messages,
@@ -671,7 +671,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         )
         if check_only:
             return cast(
-                StatusAndReason,
+                "StatusAndReason",
                 self._handle._handle.can_change_domain(
                     pyarrow_domain_table,
                     function_name_for_messages,
@@ -977,7 +977,7 @@ def _fill_out_slot_soma_domain(
         if is_max_domain:
             # Core max domain is immutable. If unspecified, it should be as big
             # as possible since it can never be resized.
-            iinfo: NPIInfo = np.iinfo(cast(NPInteger, dtype))
+            iinfo: NPIInfo = np.iinfo(cast("NPInteger", dtype))
             slot_domain = iinfo.min, iinfo.max - 1
             # Here the slot_domain isn't specified by the user; we're setting it.
             # The SOMA spec disallows negative soma_joinid.
@@ -995,7 +995,7 @@ def _fill_out_slot_soma_domain(
             slot_domain = 0, 0
     elif np.issubdtype(dtype, NPFloating):
         if is_max_domain:
-            finfo: NPFInfo = np.finfo(cast(NPFloating, dtype))
+            finfo: NPFInfo = np.finfo(cast("NPFloating", dtype))
             slot_domain = finfo.min, finfo.max
             saturated_range = True
         else:
@@ -1016,25 +1016,25 @@ def _fill_out_slot_soma_domain(
     #   to allow for expansion.
     elif dtype == "datetime64[s]":
         if is_max_domain:
-            iinfo = np.iinfo(cast(NPInteger, np.int64))
+            iinfo = np.iinfo(cast("NPInteger", np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "s"), np.datetime64(iinfo.max - 1000000, "s")
         else:
             slot_domain = np.datetime64(0, "s"), np.datetime64(0, "s")
     elif dtype == "datetime64[ms]":
         if is_max_domain:
-            iinfo = np.iinfo(cast(NPInteger, np.int64))
+            iinfo = np.iinfo(cast("NPInteger", np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "ms"), np.datetime64(iinfo.max - 1000000, "ms")
         else:
             slot_domain = np.datetime64(0, "ms"), np.datetime64(0, "ms")
     elif dtype == "datetime64[us]":
         if is_max_domain:
-            iinfo = np.iinfo(cast(NPInteger, np.int64))
+            iinfo = np.iinfo(cast("NPInteger", np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "us"), np.datetime64(iinfo.max - 1000000, "us")
         else:
             slot_domain = np.datetime64(0, "us"), np.datetime64(0, "us")
     elif dtype == "datetime64[ns]":
         if is_max_domain:
-            iinfo = np.iinfo(cast(NPInteger, np.int64))
+            iinfo = np.iinfo(cast("NPInteger", np.int64))
             slot_domain = np.datetime64(iinfo.min + 1, "ns"), np.datetime64(iinfo.max - 1000000, "ns")
         else:
             slot_domain = np.datetime64(0, "ns"), np.datetime64(0, "ns")
@@ -1108,7 +1108,7 @@ def _revise_domain_for_extent(
     domain: tuple[Any, Any], extent: Any, saturated_range: bool | tuple[bool, ...]
 ) -> tuple[Any, Any]:
     if isinstance(domain[0], (np.datetime64, pa.TimestampScalar)):
-        domain = cast(tuple[Any, Any], (_util.to_unix_ts(domain[0]), _util.to_unix_ts(domain[1])))
+        domain = cast("tuple[Any, Any]", (_util.to_unix_ts(domain[0]), _util.to_unix_ts(domain[1])))
 
     if isinstance(saturated_range, tuple):
         # Handle SOMA_GEOMETRY domain with is tuple[list[float], list[float]]

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -224,6 +224,7 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
                 "removed in future versions. Please use 'row-order' (the default "
                 "if no option is provided) or 'col-order' instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             result_order = somacore.ResultOrder.ROW_MAJOR
 

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -9,7 +9,6 @@ Collection.
 from __future__ import annotations
 
 from typing import (
-    Callable,
     TypeVar,
     cast,
     no_type_check,
@@ -34,7 +33,6 @@ from . import (
     _tdb_handles,
 )
 from ._constants import (
-    SOMA_ENCODING_VERSION_METADATA_KEY,
     SOMA_OBJECT_TYPE_METADATA_KEY,
 )
 from ._exception import SOMAError
@@ -150,7 +148,7 @@ def reify_handle(hdl: _Wrapper) -> SOMAObject[_Wrapper]:
     if not isinstance(hdl, cls._wrapper_type):
         raise SOMAError(f"cannot open {hdl.uri!r}: a {type(hdl._handle)}" f" cannot be converted to a {typename}")
     return cast(
-        _soma_object.SOMAObject[_Wrapper],
+        "_soma_object.SOMAObject[_Wrapper]",
         cls(hdl, _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code"),
     )
 

--- a/apis/python/src/tiledbsoma/_fastercsx.py
+++ b/apis/python/src/tiledbsoma/_fastercsx.py
@@ -117,7 +117,7 @@ class CompressedMatrix:
         tbl = pa.concat_tables(tables) if isinstance(tables, collections.abc.Sequence) else tables
 
         def chunks(a: pa.Array | pa.ChunkedArray) -> list[pa.Array]:
-            return list(a) if isinstance(a, pa.Array) else cast(list[pa.Array], a.chunks)
+            return list(a) if isinstance(a, pa.Array) else cast("list[pa.Array]", a.chunks)
 
         if len(tbl) > 0:
             i = tuple(a.to_numpy() for a in chunks(tbl["soma_dim_0"]))

--- a/apis/python/src/tiledbsoma/_general_utilities.py
+++ b/apis/python/src/tiledbsoma/_general_utilities.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 
 """General utility functions."""
+
 import importlib.metadata
 import platform
 import sys
@@ -42,7 +43,7 @@ def get_implementation_version() -> str:
 def assert_version_before(major: int, minor: int) -> None:
     version_string = get_implementation_version()
     if version_string == "unknown":
-        warnings.warn("`assert_version_before` could not retrieve the current " "implementation version")
+        warnings.warn("`assert_version_before` could not retrieve the current implementation version", stacklevel=2)
         return
 
     version = version_string.split(".")

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -110,7 +110,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         Lifecycle:
             Experimental.
         """
-        warnings.warn(SPATIAL_DISCLAIMER)
+        warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 
         # Get coordinate space axis data.
         if isinstance(coordinate_space, CoordinateSpace):
@@ -290,7 +290,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         """Returns the number of rows in the geometry dataframe."""
         self._verify_open_for_reading()
         # if is it in read open mode, then it is a GeometryDataFrameWrapper
-        return cast(GeometryDataFrameWrapper, self._handle).count
+        return cast("GeometryDataFrameWrapper", self._handle).count
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -164,7 +164,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             Experimental.
         """
         # Warn about the experimental nature of the spatial classes.
-        warnings.warn(SPATIAL_DISCLAIMER)
+        warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 
         context = _validate_soma_tiledb_context(context)
 
@@ -244,12 +244,10 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
                 spatial_encoding_version = str(spatial_encoding_version, "utf-8")
             if spatial_encoding_version not in {"0.1.0", "0.2.0"}:
                 raise ValueError(
-                    f"Unsupported MultiscaleImage with spatial encoding version " f"{spatial_encoding_version}"
+                    f"Unsupported MultiscaleImage with spatial encoding version {spatial_encoding_version}"
                 )
         except KeyError as ke:
-            raise SOMAError(
-                "Missing spatial encoding version. May be deprecated experimental " "MultiscaleImage."
-            ) from ke
+            raise SOMAError("Missing spatial encoding version. May be deprecated experimental MultiscaleImage.") from ke
 
         # Get the coordinate space.
         try:
@@ -267,7 +265,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             metadata_json = str(metadata_json, "utf-8")
         if not isinstance(metadata_json, str):
             raise SOMAError(
-                f"Stored '{SOMA_MULTISCALE_IMAGE_SCHEMA}' metadata is unexpected " f"type {type(metadata_json)!r}."
+                f"Stored '{SOMA_MULTISCALE_IMAGE_SCHEMA}' metadata is unexpected type {type(metadata_json)!r}."
             )
         image_meta = _MultiscaleImageMetadata.from_json(metadata_json)
         self._data_axis_permutation = image_meta.data_axis_permutation
@@ -312,9 +310,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         shape = tuple(shape)
         ndim = len(self._data_axis_permutation)
         if len(shape) != ndim:
-            raise ValueError(
-                f"New level must have {ndim} dimensions, but shape {shape} has " f"{len(shape)} dimensions."
-            )
+            raise ValueError(f"New level must have {ndim} dimensions, but shape {shape} has {len(shape)} dimensions.")
 
         if self._has_channel_axis and len(self._levels) > 0:
             channel_index = self._data_axis_permutation.index(len(self._coord_space))
@@ -322,7 +318,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             actual_nchannels = shape[channel_index]
             if actual_nchannels != expected_nchannels:
                 raise ValueError(
-                    f"New level must have {expected_nchannels}, but provided shape has " f"{actual_nchannels} channels."
+                    f"New level must have {expected_nchannels}, but provided shape has {actual_nchannels} channels."
                 )
 
         # Add the level properties to level list.
@@ -384,7 +380,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         Lifecycle: experimental
         """
         raise NotImplementedError(
-            "Support for setting external DenseNDArray objects to a MultiscaleImage " "is not yet implemented."
+            "Support for setting external DenseNDArray objects to a MultiscaleImage is not yet implemented."
         )
 
     # Data operations
@@ -438,7 +434,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             Experimental.
         """
         if data_axis_order is not None:
-            raise NotImplementedError("Support for altering the data axis order on read is not yet " "implemented.")
+            raise NotImplementedError("Support for altering the data axis order on read is not yet implemented.")
 
         # Get reference level. Check image is 2D.
         if len(self._coord_space) > 2:
@@ -446,7 +442,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
         # Check channel coords input is valid.
         if channel_coords is not None and not self._has_channel_axis:
-            raise ValueError("Invalid channel coordinate provided. This image has no channel " "dimension.")
+            raise ValueError("Invalid channel coordinate provided. This image has no channel dimension.")
 
         # Get the transformation for the group and the data coordinate space.
         # We may want to revisit copying the units for the data coordinate space.
@@ -458,7 +454,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         # - Create or check the coordinate space for the input data region.
         if region_transform is None:
             if region_coord_space is not None:
-                raise ValueError("Cannot specify the output coordinate space when region transform " "is ``None``.")
+                raise ValueError("Cannot specify the output coordinate space when region transform is ``None``.")
             region_transform = group_to_level
             region_coord_space = data_coord_space
         else:
@@ -471,7 +467,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             if region_coord_space is None:
                 region_coord_space = CoordinateSpace.from_axis_names(region_transform.input_axes)
             elif len(region_coord_space) != len(data_coord_space):
-                raise ValueError("The number of output coordinates must match the number of " "input coordinates.")
+                raise ValueError("The number of output coordinates must match the number of input coordinates.")
             if region_transform.output_axes != self._coord_space.axis_names:
                 raise ValueError(
                     f"The output axes of '{region_transform.output_axes}' of the "

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Sequence, cast
+from typing import Sequence, cast
 
 import pyarrow as pa
 import somacore
@@ -117,7 +117,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         Lifecycle:
             Experimental.
         """
-        warnings.warn(SPATIAL_DISCLAIMER)
+        warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 
         axis_dtype: pa.DataType | None = None
 
@@ -281,7 +281,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         """Returns the number of rows in the dataframe."""
         self._verify_open_for_reading()
         # if is it in read open mode, then it is a PointCloudDataFrameWrapper
-        return cast(PointCloudDataFrameWrapper, self._handle).count
+        return cast("PointCloudDataFrameWrapper", self._handle).count
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -403,7 +403,7 @@ class QueryConditionTree(ast.NodeVisitor):
                 if isinstance(val, str):
                     raise SOMAError(f"Cannot cast `{val}` to {dtype}.")
                 if np.issubdtype(dtype, np.datetime64):
-                    cast = getattr(np, "int64")
+                    cast = np.int64
                 # silence DeprecationWarning: `np.bool`
                 elif dtype == "bool":
                     cast = bool
@@ -411,7 +411,7 @@ class QueryConditionTree(ast.NodeVisitor):
                     cast = getattr(np, dtype)
                 val = cast(val)
             except ValueError:
-                raise SOMAError(f"Cannot cast `{val}` to {dtype}.")
+                raise SOMAError(f"Cannot cast `{val}` to {dtype}.") from None
 
         return val
 
@@ -444,7 +444,9 @@ class QueryConditionTree(ast.NodeVisitor):
         try:
             op = self.visit(node.op)
         except KeyError:
-            raise SOMAError(f"Unsupported binary operator: {ast.dump(node.op)}. Only & is currently supported.")
+            raise SOMAError(
+                f"Unsupported binary operator: {ast.dump(node.op)}. Only & is currently supported."
+            ) from None
 
         result = self.visit(node.left)
         rhs = node.right[1:] if isinstance(node.right, list) else [node.right]
@@ -453,7 +455,7 @@ class QueryConditionTree(ast.NodeVisitor):
             if not isinstance(result, clib.PyQueryCondition):
                 raise Exception(
                     f"Unable to parse expression component {ast.dump(node)} -- did you mean to quote it as a string?"
-                )
+                ) from None
             result = result.combine(visited, op)
 
         return result
@@ -462,7 +464,7 @@ class QueryConditionTree(ast.NodeVisitor):
         try:
             op = self.visit(node.op)
         except KeyError:
-            raise SOMAError(f"Unsupported Boolean operator: {ast.dump(node.op)}.")
+            raise SOMAError(f"Unsupported Boolean operator: {ast.dump(node.op)}.") from None
 
         result = self.visit(node.values[0])
         for value in node.values[1:]:

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -402,7 +402,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
 
         Make shape of this iterator step.
         """
-        shape = cast(tuple[int, int], tuple(self.shape))
+        shape = cast("tuple[int, int]", tuple(self.shape))
         assert len(shape) == 2
         _sp_shape: list[int] = list(shape)
 
@@ -411,7 +411,7 @@ class BlockwiseScipyReadIter(BlockwiseReadIterBase[BlockwiseScipyReadIterResult]
         if self.minor_axis not in self.reindex_disable_on_axis:
             _sp_shape[self.minor_axis] = len(minor_coords)
 
-        return cast(tuple[int, int], tuple(_sp_shape))
+        return cast("tuple[int, int]", tuple(_sp_shape))
 
     def _coo_reader(self, _pool: ThreadPoolExecutor | None = None) -> Iterator[tuple[sparse.coo_matrix, IndicesType]]:
         """Private.
@@ -604,7 +604,7 @@ def _coords_strider(coords: options.SparseNDCoord, length: int, stride: int) -> 
     else:
         assert isinstance(coords, np.ndarray) and coords.dtype == np.int64
         for i in range(0, len(coords), stride):
-            yield cast(npt.NDArray[np.int64], coords[i : i + stride])
+            yield cast("npt.NDArray[np.int64]", coords[i : i + stride])
 
 
 _ElemT = TypeVar("_ElemT")

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -100,7 +100,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         Lifecycle:
             Experimental.
         """
-        warnings.warn(SPATIAL_DISCLAIMER)
+        warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 
         context = _validate_soma_tiledb_context(context)
 
@@ -605,7 +605,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         try:
             transform_json = coll.metadata[f"soma_scene_registry_{key}"]
         except KeyError:
-            raise KeyError(f"No coordinate space registry for '{key}' in collection " f"'{subcollection}'")
+            raise KeyError(f"No coordinate space registry for '{key}' in collection " f"'{subcollection}'") from None
         base_transform = transform_from_json(transform_json)
         try:
             image: MultiscaleImage = coll[key]  # type: ignore[assignment]
@@ -683,7 +683,7 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
         try:
             transform_json = coll.metadata[f"soma_scene_registry_{key}"]
         except KeyError:
-            raise KeyError(f"No coordinate space registry for '{key}' in collection " f"'{subcollection}'")
+            raise KeyError(f"No coordinate space registry for '{key}' in collection " f"'{subcollection}'") from None
         base_transform = transform_from_json(transform_json)
         if level is None:
             return base_transform

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -103,7 +103,7 @@ class SOMAArray(SOMAObject[_tdb_handles.SOMAArrayWrapper[Any]]):
         Lifecycle:
             Deprecated.
         """
-        warnings.warn("Deprecated. Use schema_config_options instead.", DeprecationWarning)
+        warnings.warn("Deprecated. Use schema_config_options instead.", DeprecationWarning, stacklevel=2)
         return self._handle.config_options_from_schema()
 
     def non_empty_domain(self) -> tuple[tuple[Any, Any], ...]:

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -80,7 +80,7 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
 
             # Since we just opened this object, we own it and should close it.
             self._close_stack.enter_context(entry.soma)
-        return cast(CollectionElementType, entry.soma)
+        return cast("CollectionElementType", entry.soma)
 
     def __setitem__(self, key: str, value: CollectionElementType) -> None:
         """Default collection __setattr__."""

--- a/apis/python/src/tiledbsoma/_soma_object.py
+++ b/apis/python/src/tiledbsoma/_soma_object.py
@@ -13,11 +13,6 @@ from somacore import options
 from typing_extensions import Self
 
 from . import _constants, _tdb_handles
-from ._constants import (
-    SOMA_ENCODING_VERSION_METADATA_KEY,
-    SOMA_OBJECT_TYPE_METADATA_KEY,
-    SUPPORTED_SOMA_ENCODING_VERSIONS,
-)
 from ._exception import SOMAError
 from ._types import OpenTimestamp
 from ._util import check_type, ms_to_datetime

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -220,7 +220,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             Maturing.
         """
         self._verify_open_for_reading()
-        return cast(SparseNDArrayWrapper, self._handle).nnz
+        return cast("SparseNDArrayWrapper", self._handle).nnz
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_spatial_util.py
+++ b/apis/python/src/tiledbsoma/_spatial_util.py
@@ -38,14 +38,14 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
     except KeyError:
         raise KeyError(
             "'transform_type' not found when attempting to convert " "JSON to CoordinateTransform child class"
-        )
+        ) from None
 
     try:
         kwargs = raw.pop("transform")
     except KeyError:
         raise KeyError(
             "'transform' kwargs options not found when attempting to " "convert JSON to CoordinateTransform child class"
-        )
+        ) from None
 
     coord_transform_init: dict[str, type[somacore.CoordinateTransform]] = {
         "AffineTransform": somacore.AffineTransform,
@@ -57,7 +57,7 @@ def transform_from_json(data: str) -> somacore.CoordinateTransform:
     try:
         return coord_transform_init[transform_type](**kwargs)
     except KeyError:
-        raise KeyError(f"Unrecognized transform type key '{transform_type}'")
+        raise KeyError(f"Unrecognized transform type key '{transform_type}'") from None
 
 
 def transform_to_json(transform: somacore.CoordinateTransform) -> str:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -126,7 +126,7 @@ def open_handle_wrapper(
             timestamp=soma_object.timestamp,
         )
     except KeyError:
-        raise SOMAError(f"{uri!r} has unknown storage type {soma_object.type!r}")
+        raise SOMAError(f"{uri!r} has unknown storage type {soma_object.type!r}") from None
 
 
 @attrs.define(eq=False, hash=False, slots=False)
@@ -320,7 +320,7 @@ class SOMAGroupWrapper(Wrapper[_SOMAObjectType]):
         return self.metadata
 
     def members(self) -> dict[str, tuple[str, str]]:
-        return cast(dict[str, tuple[str, str]], self._handle.members())
+        return cast("dict[str, tuple[str, str]]", self._handle.members())
 
 
 class CollectionWrapper(SOMAGroupWrapper[clib.SOMACollection]):
@@ -435,12 +435,12 @@ class SOMAArrayWrapper(Wrapper[_SOMAObjectType]):
     @property
     def shape(self) -> tuple[int, ...]:
         """Not implemented for DataFrame."""
-        return cast(tuple[int, ...], tuple(self._handle.shape))
+        return cast("tuple[int, ...]", tuple(self._handle.shape))
 
     @property
     def maxshape(self) -> tuple[int, ...]:
         """Not implemented for DataFrame."""
-        return cast(tuple[int, ...], tuple(self._handle.maxshape))
+        return cast("tuple[int, ...]", tuple(self._handle.maxshape))
 
     @property
     def maybe_soma_joinid_shape(self) -> int | None:
@@ -530,7 +530,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
         self._handle.write(values)
 
     def get_enumeration_values(self, column_names: Sequence[str]) -> dict[str, pa.Array]:
-        return cast(dict[str, pa.Array], self._handle.get_enumeration_values(column_names))
+        return cast("dict[str, pa.Array]", self._handle.get_enumeration_values(column_names))
 
     def extend_enumeration_values(self, values: dict[str, pa.Array], deduplicate: bool) -> None:
         self._handle.extend_enumeration_values(values, deduplicate)
@@ -538,17 +538,17 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     @property
     def maybe_soma_joinid_shape(self) -> int | None:
         """Wrapper-class internals."""
-        return cast(Union[int, None], self._handle.maybe_soma_joinid_shape)
+        return cast("Union[int, None]", self._handle.maybe_soma_joinid_shape)
 
     @property
     def maybe_soma_joinid_maxshape(self) -> int | None:
         """Wrapper-class internals."""
-        return cast(Union[int, None], self._handle.maybe_soma_joinid_maxshape)
+        return cast("Union[int, None]", self._handle.maybe_soma_joinid_maxshape)
 
     @property
     def tiledbsoma_has_upgraded_domain(self) -> bool:
         """Wrapper-class internals."""
-        return cast(bool, self._handle.tiledbsoma_has_upgraded_domain)
+        return cast("bool", self._handle.tiledbsoma_has_upgraded_domain)
 
     def resize_soma_joinid_shape(self, newshape: int, function_name_for_messages: str) -> None:
         """Wrapper-class internals."""
@@ -557,7 +557,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def can_resize_soma_joinid_shape(self, newshape: int, function_name_for_messages: str) -> StatusAndReason:
         """Wrapper-class internals."""
         return cast(
-            StatusAndReason,
+            "StatusAndReason",
             self._handle.can_resize_soma_joinid_shape(newshape, function_name_for_messages),
         )
 
@@ -568,7 +568,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def can_upgrade_soma_joinid_shape(self, newshape: int, function_name_for_messages: str) -> StatusAndReason:
         """Wrapper-class internals."""
         return cast(
-            StatusAndReason,
+            "StatusAndReason",
             self._handle.can_upgrade_soma_joinid_shape(newshape, function_name_for_messages),
         )
 
@@ -579,7 +579,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def can_upgrade_domain(self, newdomain: Domain, function_name_for_messages: str) -> StatusAndReason:
         """Wrapper-class internals."""
         return cast(
-            StatusAndReason,
+            "StatusAndReason",
             self._handle.can_upgrade_domain(newdomain, function_name_for_messages),
         )
 
@@ -590,7 +590,7 @@ class DataFrameWrapper(SOMAArrayWrapper[clib.SOMADataFrame]):
     def can_change_domain(self, newdomain: Domain, function_name_for_messages: str) -> StatusAndReason:
         """Wrapper-class internals."""
         return cast(
-            StatusAndReason,
+            "StatusAndReason",
             self._handle.can_change_domain(newdomain, function_name_for_messages),
         )
 
@@ -629,7 +629,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
         """Wrapper-class internals."""
-        return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
+        return cast("bool", self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals."""
@@ -637,7 +637,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals."""
-        return cast(StatusAndReason, self._handle.tiledbsoma_can_resize(newshape))
+        return cast("StatusAndReason", self._handle.tiledbsoma_can_resize(newshape))
 
     def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals."""
@@ -645,7 +645,7 @@ class DenseNDArrayWrapper(SOMAArrayWrapper[clib.SOMADenseNDArray]):
 
     def tiledbsoma_can_upgrade_shape(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals."""
-        return cast(StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape))
+        return cast("StatusAndReason", self._handle.tiledbsoma_can_upgrade_shape(newshape))
 
 
 class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
@@ -660,7 +660,7 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
     @property
     def tiledbsoma_has_upgraded_shape(self) -> bool:
         """Wrapper-class internals."""
-        return cast(bool, self._handle.tiledbsoma_has_upgraded_shape)
+        return cast("bool", self._handle.tiledbsoma_has_upgraded_shape)
 
     def resize(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals."""
@@ -668,7 +668,7 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
 
     def tiledbsoma_can_resize(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals."""
-        return cast(StatusAndReason, self._handle.can_resize(newshape))
+        return cast("StatusAndReason", self._handle.can_resize(newshape))
 
     def tiledbsoma_upgrade_shape(self, newshape: Sequence[int | None]) -> None:
         """Wrapper-class internals."""
@@ -676,7 +676,7 @@ class SparseNDArrayWrapper(SOMAArrayWrapper[clib.SOMASparseNDArray]):
 
     def tiledbsoma_can_upgrade_shape(self, newshape: Sequence[int | None]) -> StatusAndReason:
         """Wrapper-class internals."""
-        return cast(StatusAndReason, self._handle.tiledbsoma_can_upgrade_shape(newshape))
+        return cast("StatusAndReason", self._handle.tiledbsoma_can_upgrade_shape(newshape))
 
 
 class _DictMod(enum.Enum):
@@ -758,14 +758,14 @@ class MetadataWrapper(MutableMapping[str, Any]):
         return self.cache[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
-        self.owner.writer  # Ensures we're open in write mode.
+        self.owner.writer  # noqa: B018 Ensures we're open in write mode.
         state = self._current_state(key)
         _check_metadata_type(key, value)
         self.cache[key] = value
         self._mods[key] = state.next_state("set")
 
     def __delitem__(self, key: str) -> None:
-        self.owner.writer  # Ensures we're open in write mode.
+        self.owner.writer  # noqa: B018 Ensures we're open in write mode.
         state = self._current_state(key)
         del self.cache[key]
         self._mods[key] = state.next_state("del")

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -262,7 +262,9 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
             return self._handle
         if self.mode == "w":
             warnings.warn(
-                f"Deleting in write mode is deprecated. {self} should be reopened with mode='d'.", DeprecationWarning
+                f"Deleting in write mode is deprecated. {self} should be reopened with mode='d'.",
+                DeprecationWarning,
+                stacklevel=3,
             )
             return self._handle
         raise SOMAError(f"Cannot delete from {self}; current mode='{self.mode}'. Reopen in mode='d'.")

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -348,7 +348,7 @@ def _build_column_config(col: Mapping[str, _ColumnConfig] | None) -> str:
         if col[k].filters is not None:
             dikt["filters"] = _build_filter_list(col[k].filters, False)
         if col[k].tile is not None:
-            dikt["tile"] = cast(int, col[k].tile)
+            dikt["tile"] = cast("int", col[k].tile)
         if len(dikt) != 0:
             column_config[k] = dikt
     return json.dumps(column_config)
@@ -413,15 +413,15 @@ def _build_filter_list(filters: tuple[_DictFilterSpec, ...] | None, return_json:
 
     for info in filters:
         if len(info) == 1:
-            filter = _convert_filter[cast(str, info["_type"])]
+            filter = _convert_filter[cast("str", info["_type"])]
         else:
             filter = dict()
             for option_name, option_value in info.items():
-                filter_name = _convert_filter[cast(str, info["_type"])]
+                filter_name = _convert_filter[cast("str", info["_type"])]
                 if option_name == "_type":
                     filter["name"] = filter_name
                 else:
-                    filter[_convert_option[filter_name][option_name]] = cast(Union[float, int], option_value)
+                    filter[_convert_option[filter_name][option_name]] = cast("Union[float, int]", option_value)
         filter_list.append(filter)
     return json.dumps(filter_list) if return_json else filter_list
 
@@ -480,7 +480,7 @@ def _set_coord(
             _set_geometry_coord(
                 mq,
                 dim,
-                cast(tuple[Mapping[str, float], Mapping[str, float]], dom),
+                cast("tuple[Mapping[str, float], Mapping[str, float]]", dom),
                 coord,
                 axis_names,
             )

--- a/apis/python/src/tiledbsoma/experiment_query.py
+++ b/apis/python/src/tiledbsoma/experiment_query.py
@@ -45,7 +45,7 @@ def X_as_series(tbl: pa.Table) -> PDSeries:
     dim_0 = tbl["soma_dim_0"].to_numpy()
     dim_1 = tbl["soma_dim_1"].to_numpy()
     return pd.Series(
-        cast(NPNDArray, data),
+        cast("NPNDArray", data),
         pd.MultiIndex.from_arrays((dim_0, dim_1), names=("soma_dim_0", "soma_dim_1")),
         dtype=pd.SparseDtype(data.dtype, fill_value=0),
         name="soma_data",

--- a/apis/python/src/tiledbsoma/io/_caching_reader.py
+++ b/apis/python/src/tiledbsoma/io/_caching_reader.py
@@ -110,7 +110,7 @@ class CachingReader:
             self._cache.move_to_end(block_idx)
             self._cache_stats[block_idx].hit += 1
 
-        for i in range(max(0, len(self._cache) - self._max_cache_blocks)):
+        for _i in range(max(0, len(self._cache) - self._max_cache_blocks)):
             self._cache.popitem(last=False)
 
     def _reset_cache(self) -> None:
@@ -139,7 +139,7 @@ class CachingReader:
         assert arr.offset == 0
         b = arr.buffers()[1].to_pybytes()  # NB: copy
         self._pos += len(b)
-        return cast(bytes, b)
+        return cast("bytes", b)
 
     def readinto(self, buf: WritableBuffer) -> int | None:
         """Read bytes into a pre-allocated, writable bytes-like object b,

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -228,7 +228,8 @@ class ExperimentAmbientLabelMapping:
             else:
                 warnings.warn(
                     "Experiment does not support resizing. Please consider upgrading the dataset "
-                    "using 'tiledbsoma.io.upgrade_experiment_shapes'."
+                    "using 'tiledbsoma.io.upgrade_experiment_shapes'.",
+                    stacklevel=2,
                 )
 
         with Experiment.open(experiment_uri, context=context, mode="w") as E:
@@ -261,7 +262,7 @@ class ExperimentAmbientLabelMapping:
 
         def categorical_columns(df: pd.DataFrame) -> dict[Any, pd.CategoricalDtype]:
             return cast(
-                dict[str, pd.CategoricalDtype],
+                "dict[str, pd.CategoricalDtype]",
                 {k: v.dtype for k, v in df.items() if v.dtype == "category"},
             )
 
@@ -353,7 +354,7 @@ class ExperimentAmbientLabelMapping:
 
         def _get_joinid_map(df: DataFrame, field_name: str) -> pd.DataFrame:
             return cast(
-                pd.DataFrame,
+                "pd.DataFrame",
                 df.read(column_names=["soma_joinid", field_name]).concat().to_pandas().set_index(field_name),
             )
 
@@ -594,7 +595,8 @@ class ExperimentAmbientLabelMapping:
             warnings.warn(
                 "The append-mode ingest of 'uns' is typically an error due to uns key collisions "
                 "across multiple AnnData. Drop 'uns' from AnnData to remove this warning, or if you "
-                "intend for 'uns' to merge, ensure each AnnData uses unique keys."
+                "intend for 'uns' to merge, ensure each AnnData uses unique keys.",
+                stacklevel=3,
             )
 
 

--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -79,9 +79,9 @@ def get_dataframe_values(df: pd.DataFrame, field_name: str) -> pd.Series:  # typ
     ``obs`` or ``var`` dataframe.
     """
     if field_name in df:
-        values = cast(pd.Series, df[field_name].astype(str))  # type: ignore[type-arg]
+        values = cast("pd.Series", df[field_name].astype(str))  # type: ignore[type-arg]
     elif df.index.name in (field_name, "index", None):
-        values = cast(pd.Series, df.index.to_series().astype(str))  # type: ignore[type-arg]
+        values = cast("pd.Series", df.index.to_series().astype(str))  # type: ignore[type-arg]
     else:
         raise ValueError(f"Could not find field name {field_name} in dataframe.")
 

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -119,4 +119,4 @@ def get_arrow_str_format(pa_type: pa.DataType) -> str:
     try:
         return _pa_type_to_str_fmt[pa_type]
     except KeyError:
-        raise SOMAError(f"Could not convert {pa_type} to Arrow string format")
+        raise SOMAError(f"Could not convert {pa_type} to Arrow string format") from None

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -14,9 +14,7 @@ import pandas._typing as pdt
 import pandas.api.types
 import pyarrow as pa
 import scipy.sparse as sp
-from pandas.core.dtypes.dtypes import (
-    ExtensionDtype,  # do not delete. referenced by "_DT" type alias
-)
+from pandas.api.extensions import ExtensionDtype  # noqa - required to resolve pdt.Dtype below
 
 from .._fastercsx import CompressedMatrix
 from .._funcs import typeguard_ignore
@@ -180,7 +178,7 @@ def obs_or_var_to_tiledb_supported_array_type(obs_or_var: pd.DataFrame) -> pd.Da
 def _to_tiledb_supported_dtype(dtype: _DT) -> _DT:
     """A handful of types are cast into the TileDB type system."""
     # TileDB has no float16 -- cast up to float32
-    return cast(_DT, np.dtype("float32")) if dtype == np.dtype("float16") else dtype
+    return cast("_DT", np.dtype("float32")) if dtype == np.dtype("float16") else dtype
 
 
 def to_tiledb_supported_array_type(name: str, x: _MT) -> _MT:

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -355,7 +355,7 @@ def to_anndata(
             raise ValueError(f"X_layer_name '{X_layer_name}' not found in measurement: {measurement.X.keys()}")
         anndata_X_future = _extract_X_key(
             measurement=measurement,
-            X_layer_name=cast(str, X_layer_name),
+            X_layer_name=cast("str", X_layer_name),
             nobs=nobs,
             nvar=nvar,
             dask=dask,
@@ -436,7 +436,7 @@ def to_anndata(
     uns_future: Future[dict[str, FutureUnsDictNode]] | None = None
     if "uns" in measurement:
         s = _util.get_start_stamp()
-        uns_coll = cast(Collection[Any], measurement["uns"])
+        uns_coll = cast("Collection[Any]", measurement["uns"])
         logging.log_io(None, f"Start  writing uns for {uns_coll.uri}")
         uns_future = tp.submit(_extract_uns, uns_coll, uns_keys=uns_keys)
         logging.log_io(

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -19,6 +19,7 @@ import tiledbsoma
 from .._soma_object import SOMAObject
 
 Printable = Union[io.TextIOWrapper, io.StringIO]
+printableStdout = cast("Printable", sys.stdout)
 
 _SOMAObjectType = TypeVar("_SOMAObjectType", bound=SOMAObject)  # type: ignore[type-arg]
 
@@ -123,7 +124,7 @@ def show_experiment_shapes(
     uri: str,
     *,
     context: tiledbsoma.SOMATileDBContext | None = None,
-    output_handle: Printable = cast(Printable, sys.stdout),
+    output_handle: Printable = printableStdout,
 ) -> bool:
     """Outputs the current shapes of the elements in the ``Experiment``.
 
@@ -200,7 +201,7 @@ def upgrade_experiment_shapes(
     verbose: bool = False,
     check_only: bool = False,
     context: tiledbsoma.SOMATileDBContext | None = None,
-    output_handle: Printable = cast(Printable, sys.stdout),
+    output_handle: Printable = printableStdout,
 ) -> bool:
     """Upgrade the elements inside a SOMA ``Experiment`` to use the ``shape`` feature
     introduced in TileDB-SOMA 1.15.
@@ -292,7 +293,7 @@ def resize_experiment(
     verbose: bool = False,
     check_only: bool = False,
     context: tiledbsoma.SOMATileDBContext | None = None,
-    output_handle: Printable = cast(Printable, sys.stdout),
+    output_handle: Printable = printableStdout,
 ) -> bool:
     """Resize the elements in the SOMA ``Experiment`` to fit the requested number
     of observations and variables.
@@ -999,7 +1000,7 @@ def _get_new_ndarray_shape(
     try:
         return coll_dict[coll_name]
     except KeyError:
-        raise tiledbsoma.SOMAError(f"experiment resize: internal error: unhandled collection {coll_name}")
+        raise tiledbsoma.SOMAError(f"experiment resize: internal error: unhandled collection {coll_name}") from None
 
 
 def _leaf_visitor_get_shapes(
@@ -1064,7 +1065,7 @@ def _check_statuses(dikt: dict[str, Any]) -> bool:
         ok = dikt["status"]
         assert isinstance(ok, bool)
         return ok
-    for key, value in dikt.items():
+    for _key, value in dikt.items():
         assert isinstance(value, dict)
         if not _check_statuses(value):
             return False

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -14,19 +14,19 @@ from anndata import AnnData
 try:
     import spatialdata as sd
 except ImportError as err:
-    warnings.warn("Experimental spatial outgestor requires the spatialdata package.")
+    warnings.warn("Experimental spatial outgestor requires the spatialdata package.", stacklevel=1)
     raise err
 
 try:
     import dask.dataframe as dd
 except ImportError as err:
-    warnings.warn("Experimental spatial outgestor requires the dask package.")
+    warnings.warn("Experimental spatial outgestor requires the dask package.", stacklevel=1)
     raise err
 
 try:
     import geopandas as gpd
 except ImportError as err:
-    warnings.warn("Experimental spatial outgestor requires the geopandas package.")
+    warnings.warn("Experimental spatial outgestor requires the geopandas package.", stacklevel=1)
     raise err
 
 
@@ -106,7 +106,7 @@ def _transform_to_spatialdata(
         return sd.transformations.Affine(transform.augmented_matrix, input_axes, output_axes)
 
     raise NotImplementedError(
-        f"Support for converting transform of type {type(transform).__name__} is not " f"yet implemented."
+        f"Support for converting transform of type {type(transform).__name__} is not yet implemented."
     )
 
 
@@ -177,13 +177,13 @@ def to_spatialdata_shapes(
         radius = points.metadata["soma_geometry"]
     except KeyError as ke:
         raise KeyError(
-            "Missing metadata 'soma_geometry' needed for reading the point cloud " "dataframe as a shape."
+            "Missing metadata 'soma_geometry' needed for reading the point cloud dataframe as a shape."
         ) from ke
     try:
         soma_geometry_type = points.metadata["soma_geometry_type"]
         if soma_geometry_type != "radius":
             raise NotImplementedError(
-                f"Support for a point cloud with shape '{soma_geometry_type}' is " f"not yet implemented."
+                f"Support for a point cloud with shape '{soma_geometry_type}' is not yet implemented."
             )
     except KeyError as ke:
         raise KeyError("Missing metadata 'soma_geometry_type'.") from ke
@@ -208,7 +208,7 @@ def to_spatialdata_shapes(
         geometry = gpd.points_from_xy(data.pop(orig_axis_names[0]), data.pop(orig_axis_names[1]))
     else:
         raise NotImplementedError(
-            f"Support for export {ndim}D point cloud dataframes to SpatialData shapes " f"is not yet implemented."
+            f"Support for export {ndim}D point cloud dataframes to SpatialData shapes is not yet implemented."
         )
     df = gpd.GeoDataFrame(data, geometry=geometry)
     df.attrs["transform"] = transforms
@@ -240,8 +240,7 @@ def to_spatialdata_image(
     """
     if not image.has_channel_axis:
         raise NotImplementedError(
-            "Support for exporting a MultiscaleImage to without a channel axis to "
-            "SpatialData is not yet implemented."
+            "Support for exporting a MultiscaleImage to without a channel axis to SpatialData is not yet implemented."
         )
 
     # Convert from SOMA axis names to SpatialData axis names.
@@ -253,9 +252,7 @@ def to_spatialdata_image(
     # Get the URI of the requested level.
     if level is None:
         if image.level_count != 1:
-            raise ValueError(
-                "The level must be specified for a multiscale image with more than one " "resolution level."
-            )
+            raise ValueError("The level must be specified for a multiscale image with more than one resolution level.")
         level = 0
     level_uri = image.level_uri(level)
 
@@ -313,8 +310,7 @@ def to_spatialdata_multiscale_image(
     # Check for channel axis.
     if not image.has_channel_axis:
         raise NotImplementedError(
-            "Support for exporting a MultiscaleImage to without a channel axis to "
-            "SpatialData is not yet implemented."
+            "Support for exporting a MultiscaleImage to without a channel axis to SpatialData is not yet implemented."
         )
 
     # Convert from SOMA axis names to SpatialData axis names.
@@ -436,7 +432,8 @@ def _spatial_to_spatialdata(
 
                 else:
                     warnings.warn(
-                        f"Skipping obsl[{key}] in Scene {scene_name}; unexpected " f"datatype {type(df).__name__}."
+                        f"Skipping obsl[{key}] in Scene {scene_name}; unexpected datatype {type(df).__name__}.",
+                        stacklevel=3,
                     )
 
         # Export varl data to SpatialData.
@@ -475,7 +472,8 @@ def _spatial_to_spatialdata(
                     else:
                         warnings.warn(
                             f"Skipping varl[{measurement_name}][{key}] in Scene "
-                            f"{scene_name}; unexpected datatype {type(df).__name__}."
+                            f"{scene_name}; unexpected datatype {type(df).__name__}.",
+                            stacklevel=3,
                         )
 
         # Export img data to SpatialData.
@@ -485,7 +483,8 @@ def _spatial_to_spatialdata(
                 transform = _get_transform_from_collection(key, scene.img.metadata)
                 if not isinstance(image, MultiscaleImage):
                     warnings.warn(  # type: ignore[unreachable]
-                        f"Skipping img[{image}] in Scene {scene_name}; unexpected " f"datatype {type(image).__name__}."
+                        f"Skipping img[{image}] in Scene {scene_name}; unexpected datatype {type(image).__name__}.",
+                        stacklevel=3,
                     )
                 if image.level_count == 1:
                     sdata.images[output_key] = to_spatialdata_image(
@@ -543,7 +542,7 @@ def _spatial_to_spatialdata(
                     )
                 except pd.errors.MergeError as err:
                     raise NotImplementedError(
-                        "Unable to export to SpatialData; exported assets have " "overlapping observations."
+                        "Unable to export to SpatialData; exported assets have overlapping observations."
                     ) from err
                 adata.obs["region_key"] = pd.Categorical(adata.obs["region_key"])
                 regions = list(region_joinids.keys())

--- a/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
@@ -17,12 +17,12 @@ try:
     import spatialdata as sd
     from spatialdata.models.models import DataTree
 except ImportError as err:
-    warnings.warn("Experimental spatial exporter requires the spatialdata package.")
+    warnings.warn("Experimental spatial exporter requires the spatialdata package.", stacklevel=1)
     raise err
 try:
     import xarray as xr
 except ImportError as err:
-    warnings.warn("Experimental spatial exporter requires the xarray package.")
+    warnings.warn("Experimental spatial exporter requires the xarray package.", stacklevel=1)
     raise err
 
 from ... import DenseNDArray

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 try:
     from PIL import Image
 except ImportError as err:
-    warnings.warn("Experimental spatial ingestor requires the `pillow` package.")
+    warnings.warn("Experimental spatial ingestor requires the `pillow` package.", stacklevel=1)
     raise err
 
 
@@ -182,8 +182,8 @@ class VisiumPaths:
         if version is None:
             try:
                 version = _read_visium_software_version(gene_expression)
-            except (KeyError, ValueError):
-                raise ValueError("Unable to determine Space Ranger version from gene expression file.")
+            except (KeyError, ValueError) as e:
+                raise ValueError("Unable to determine Space Ranger version from gene expression file.") from e
 
         # Find the tissue positions file path if it wasn't supplied.
         if tissue_positions is None:
@@ -652,8 +652,8 @@ def _write_arrow_to_dataframe(
             platform_config=platform_config,
             context=context,
         )
-    except (AlreadyExistsError, NotCreateableError):
-        raise SOMAError(f"{df_uri} already exists")
+    except (AlreadyExistsError, NotCreateableError) as e:
+        raise SOMAError(f"{df_uri} already exists") from e
 
     if not ingestion_params.write_schema_no_data:
         tiledb_create_options = TileDBCreateOptions.from_platform_config(platform_config)
@@ -701,9 +701,9 @@ def _write_X_layer(
             platform_config=platform_config,
             context=context,
         )
-    except (AlreadyExistsError, NotCreateableError):
+    except (AlreadyExistsError, NotCreateableError) as e:
         if ingestion_params.error_if_already_exists:
-            raise SOMAError(f"{uri} already exists")
+            raise SOMAError(f"{uri} already exists") from e
         soma_ndarray = cls.open(uri, "w", platform_config=platform_config, context=context)
 
     logging.log_io(
@@ -775,9 +775,9 @@ def _write_scene_presence_dataframe(
             platform_config=platform_config,
             context=context,
         )
-    except (AlreadyExistsError, NotCreateableError):
+    except (AlreadyExistsError, NotCreateableError) as e:
         if ingestion_params.error_if_already_exists:
-            raise SOMAError(f"{df_uri} already exists")
+            raise SOMAError(f"{df_uri} already exists") from e
         soma_df = DataFrame.open(df_uri, "w", context=context)
 
     if ingestion_params.write_schema_no_data:
@@ -900,10 +900,10 @@ def _create_or_open_scene(
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             scene = Scene.create(uri, context=context)
-    except (AlreadyExistsError, NotCreateableError):
+    except (AlreadyExistsError, NotCreateableError) as e:
         # It already exists. Are we resuming?
         if ingestion_params.error_if_already_exists:
-            raise SOMAError(f"{uri} already exists")
+            raise SOMAError(f"{uri} already exists") from e
         scene = Scene.open(uri, "w", context=context)
 
     add_metadata(scene, additional_metadata)

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping, Sequence
 try:
     import spatialdata as sd
 except ImportError as err:
-    warnings.warn("Experimental spatial outgestor requires the spatialdata package.")
+    warnings.warn("Experimental spatial outgestor requires the spatialdata package.", stacklevel=1)
     raise err
 
 
@@ -45,7 +45,7 @@ def to_spatialdata(
             pass to table conversions. See :method:`to_anndata` for possible keyword
             arguments.
     """
-    warnings.warn(SPATIAL_DISCLAIMER)
+    warnings.warn(SPATIAL_DISCLAIMER, stacklevel=2)
 
     # Read non-spatial data into Anndata tables.
     if measurement_names is not None:

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -312,7 +312,7 @@ class SOMATileDBContext(ContextBase):
                     raise ValueError(
                         "Either tiledb_config or tiledb_ctx may be provided" " to replace(), but not both."
                     )
-                new_config = cast(ReplaceConfig, self._internal_tiledb_config())
+                new_config = cast("ReplaceConfig", self._internal_tiledb_config())
                 new_config.update(tiledb_config)
                 new_tiledb_config: ConfigDict | None = {k: v for k, v in new_config.items() if v is not None}
             else:

--- a/apis/python/src/tiledbsoma/stats.py
+++ b/apis/python/src/tiledbsoma/stats.py
@@ -15,10 +15,10 @@ ParsedStats = list[dict[Literal["counters", "timers"], dict[str, Union[float, in
 def tiledbsoma_stats_json() -> str:
     """Returns tiledbsoma stats as a JSON string."""
     # cast is needed for pybind11 things
-    return cast(str, tiledbsoma_stats_string())
+    return cast("str", tiledbsoma_stats_string())
 
 
 def tiledbsoma_stats_as_py() -> ParsedStats:
     """Returns tiledbsoma stats as a Python dict."""
     # cast is needed for pybind11 things
-    return cast(ParsedStats, json.loads(tiledbsoma_stats_string()))
+    return cast("ParsedStats", json.loads(tiledbsoma_stats_string()))

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -217,7 +217,7 @@ def filter(value_filter: str) -> AxisQuery:
     return AxisQuery(value_filter=value_filter)
 
 
-def create_basic_object(soma_type, uri, **kwargs) -> SOMAObject:
+def create_basic_object(soma_type, uri, **kwargs) -> tiledbsoma.SOMAObject:
     """Create a basic SOMA object of the requested type."""
 
     if soma_type == "SOMAExperiment":

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -19,7 +19,6 @@ from typing_extensions import TypeAlias
 
 import tiledbsoma as soma
 
-from tests.ht._ht_test_config import HT_TEST_CONFIG
 from tests.ht._ledger import Ledger, PyDictLedgerEntry
 
 SOMAArray: TypeAlias = Union[soma.DataFrame, soma.SparseNDArray, soma.DenseNDArray]

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import pathlib
 import textwrap

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -23,7 +23,6 @@ import tiledbsoma as soma
 
 from tests._util import raises_no_typeguard
 
-from . import NDARRAY_ARROW_TYPES_SUPPORTED
 from ._util import ROOT_DATA_DIR
 
 

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -7,8 +7,6 @@ import pytest
 import tiledbsoma as soma
 from tiledbsoma import _factory
 
-from tests._util import raises_no_typeguard
-
 
 # ----------------------------------------------------------------
 def create_and_populate_obs(uri: str) -> soma.DataFrame:

--- a/apis/python/tests/test_factory.py
+++ b/apis/python/tests/test_factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from time import sleep
-from typing import Optional, Type
+from typing import Type
 
 import numpy as np
 import pyarrow as pa

--- a/apis/python/tests/test_multiscale_image.py
+++ b/apis/python/tests/test_multiscale_image.py
@@ -490,7 +490,7 @@ def test_multiscale_2d_read_region_with_channel(
             image[f"level{i}"].write((slice(None), slice(None)), pa.Tensor.from_numpy(data))
 
     with soma.MultiscaleImage.open(image_uri, mode="r") as image:
-        for i, shape in enumerate(shapes):
+        for i, _shape in enumerate(shapes):
             actual_data = image.read_spatial_region(i, region=region).data
             if expected_coords is None:
                 expected_data = image[f"level{i}"].read()

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -10,8 +10,6 @@ import typeguard
 
 import tiledbsoma as soma
 
-from . import NDARRAY_ARROW_TYPES_SUPPORTED
-
 
 def test_point_cloud_bad_create(tmp_path):
     baseuri = urljoin(f"{tmp_path.as_uri()}/", "bad_create")

--- a/apis/python/tests/test_reopen.py
+++ b/apis/python/tests/test_reopen.py
@@ -68,7 +68,7 @@ def test_experiment_reopen(tmp_path, soma_type):
 
     ts1 = datetime.datetime(2023, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
     ts2 = datetime.datetime(2024, 1, 1, 1, 0, tzinfo=datetime.timezone.utc)
-    for mode in ["r", "w"]:
+    for _mode in ["r", "w"]:
         with tiledbsoma.open(uri, "r", tiledb_timestamp=ts1) as x1:
             x2 = x1.reopen("r", tiledb_timestamp=ts2)
             assert x2 is x1

--- a/apis/python/tests/test_soma_array.py
+++ b/apis/python/tests/test_soma_array.py
@@ -2,12 +2,9 @@
 
 import os
 
-import numpy as np
-import pandas as pd
 import pyarrow as pa
 import pytest
 
-import tiledbsoma as soma
 import tiledbsoma.pytiledbsoma as clib
 
 VERBOSE = False

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -23,4 +23,4 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
         """
 
     def test_r_character(self, experiment):
-        self.r_assert("stopifnot(all(vapply(md, \(x) is.character(x$name), logical(1L))))")
+        self.r_assert(r"stopifnot(all(vapply(md, \(x) is.character(x$name), logical(1L))))")

--- a/libtiledbsoma/src/reindexer/test_indexer_data_types_perf.py
+++ b/libtiledbsoma/src/reindexer/test_indexer_data_types_perf.py
@@ -73,7 +73,7 @@ def main():
         ]
     )
     lookups = []
-    for x in range(10):
+    for _x in range(10):
         lookups.append(list(np.random.randint(0, 1000, 100000000, dtype=np.int64)))
     lookups = pa.chunked_array(lookups)
     indexer_test_build("pa.chunked_array", keys, lookups)

--- a/profiler/src/profiler/data.py
+++ b/profiler/src/profiler/data.py
@@ -179,7 +179,7 @@ class S3ProfileDB(ProfileDB):
             for command_file_key in self.read_object_keys("", "/command.txt"):
                 # Extract runs prefix
                 runs_prefix = command_file_key.replace("/command.txt", "")
-                for data_file_key in self.read_object_keys(runs_prefix, ".json"):
+                for _data_file_key in self.read_object_keys(runs_prefix, ".json"):
                     # Read command.
                     command = self.read_s3_text(command_file_key)
                     # Get the number of runs.

--- a/profiler/src/profiler/report.py
+++ b/profiler/src/profiler/report.py
@@ -21,7 +21,7 @@ def collect_tiledb_stats(data: ProfileData) -> dict[str, Union[int, float]]:
 
     lines = tiledb_stats.split("\n")
 
-    for idx, line in enumerate(lines):
+    for _idx, line in enumerate(lines):
         perf_match = re.match(r"\s+\"(.+)\": (\d+\.\d+)\s*,", line)
         if perf_match:
             value = float(perf_match.groups()[1])
@@ -41,7 +41,7 @@ def extract_tiledb_data(data: ProfileData, metric: str) -> Union[int, float, Non
     """
     tiledb_stats = getattr(data, str("tiledb_stats"))
     lines = tiledb_stats.split("\n")
-    for idx, line in enumerate(lines):
+    for _idx, line in enumerate(lines):
         perf_match = re.match(rf"\s+\"{metric}\": (\d+\.\d+)\s*,", line)
         if perf_match:
             value = float(perf_match.groups()[0])


### PR DESCRIPTION
Recent changes inadvertently disabled Ruff lint rules except for pydocstyle. Changes in this PR:

* enable high-value lint rules (list below)
* fix lint found by these rules (includes one "real" bug found by bugbear in some exception handling code).  Most of the changes were auto-fixed by Ruff, and the remainder are semantically equivalent changes.

Enabled rules now are the default Ruff rules, plus a couple that we used to use stand-alone (e.g., isort):
```
select = [  # see https://docs.astral.sh/ruff/rules/
    "B",    # bugbear
    "D",    # pydocstyle (Google convention, see setting below)
    "E",    # pycodestyle
    "F",    # Pyflakes
    "I",    # isort
    "W",    # pycodestyle warnings
]
```

Several of these rules are disabled for tests and notebooks, as we have looser standards in those code paths.

Future work will add additional Ruff rules, gradually tightening our lint enforcement.

This is a partial fix for SOMA-295