### PR TITLE
Update pre-commit hooks (autoupdate)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^doc/source/
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v20.1.6
     hooks:
     - id: clang-format
       types_or: [c++, c]
@@ -13,12 +13,12 @@ repos:
     - id: black
       args: ["--config=apis/python/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.12.0
     hooks:
     - id: ruff
       args: ["--config=apis/python/pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
     - id: mypy
       additional_dependencies:

--- a/apis/python/src/tiledbsoma/_collection.py
+++ b/apis/python/src/tiledbsoma/_collection.py
@@ -44,7 +44,7 @@ _Coll = TypeVar("_Coll", bound="CollectionBase[AnySOMAObject]")
 _NDArr = TypeVar("_NDArr", bound=NDArray)
 
 
-class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
+class CollectionBase(
     SOMAGroup[CollectionElementType],
     somacore.collection.BaseCollection[CollectionElementType],
 ):
@@ -440,9 +440,7 @@ class CollectionBase(  # type: ignore[misc]  # __eq__ false positive
 AnyTileDBCollection = CollectionBase[Any]
 
 
-class Collection(  # type: ignore[misc]  # __eq__ false positive
-    CollectionBase[CollectionElementType], somacore.Collection[CollectionElementType]
-):
+class Collection(CollectionBase[CollectionElementType], somacore.Collection[CollectionElementType]):
     """:class:`Collection` is a persistent container of named SOMA objects, stored as
     a mapping of string keys and SOMA object values. Values may be any
     persistent ``tiledbsoma`` object, including :class:`DataFrame`,

--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -20,7 +20,7 @@ from ._scene import Scene
 from ._soma_object import AnySOMAObject
 
 
-class Experiment(  # type: ignore[misc]  # `SOMAObject.__eq__`, `SOMAGroup.set` false positives
+class Experiment(
     CollectionBase[AnySOMAObject],
     experiment.Experiment[
         DataFrame,
@@ -77,7 +77,7 @@ class Experiment(  # type: ignore[misc]  # `SOMAObject.__eq__`, `SOMAGroup.set` 
         "obs_spatial_presence": ("SOMADataFrame",),
     }
 
-    def axis_query(  # type: ignore
+    def axis_query(
         self,
         measurement_name: str,
         *,

--- a/apis/python/src/tiledbsoma/_measurement.py
+++ b/apis/python/src/tiledbsoma/_measurement.py
@@ -16,7 +16,7 @@ from ._soma_object import AnySOMAObject
 from ._sparse_nd_array import SparseNDArray
 
 
-class Measurement(  # type: ignore[misc]  # __eq__ false positive
+class Measurement(
     CollectionBase[AnySOMAObject],
     measurement.Measurement[
         DataFrame,

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -80,7 +80,7 @@ class _MultiscaleImageMetadata:
         return cls(datatype=type, **kwargs)
 
 
-class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
+class MultiscaleImage(
     SOMAGroup[DenseNDArray],
     somacore.MultiscaleImage[DenseNDArray, AnySOMAObject],
 ):

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -43,7 +43,7 @@ _spatial_element = Union[GeometryDataFrame, MultiscaleImage, PointCloudDataFrame
 _SE = TypeVar("_SE", bound=_spatial_element)
 
 
-class Scene(  # type: ignore[misc]   # __eq__ false positive
+class Scene(
     CollectionBase[AnySOMAObject],
     somacore.Scene[MultiscaleImage, PointCloudDataFrame, GeometryDataFrame, AnySOMAObject],
 ):

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -99,12 +99,13 @@ SEXP soma_array_reader(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        tdbs::LOG_INFO(fmt::format(
-            "[soma_array_reader] Dimension {} type {} domain {} extent {}",
-            dim.name(),
-            tiledb::impl::to_str(dim.type()),
-            dim.domain_to_str(),
-            dim.tile_extent_to_str()));
+        tdbs::LOG_INFO(
+            fmt::format(
+                "[soma_array_reader] Dimension {} type {} domain {} extent {}",
+                dim.name(),
+                tiledb::impl::to_str(dim.type()),
+                dim.domain_to_str(),
+                dim.tile_extent_to_str()));
         name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
@@ -140,10 +141,11 @@ SEXP soma_array_reader(
             "or using iterated partial reads.",
             uri);
     }
-    tdbs::LOG_INFO(fmt::format(
-        "[soma_array_reader] Read complete with {} rows and {} cols",
-        sr_data->get()->num_rows(),
-        sr_data->get()->names().size()));
+    tdbs::LOG_INFO(
+        fmt::format(
+            "[soma_array_reader] Read complete with {} rows and {} cols",
+            sr_data->get()->num_rows(),
+            sr_data->get()->names().size()));
 
     const std::vector<std::string> names = sr_data->get()->names();
     auto ncol = names.size();
@@ -175,8 +177,9 @@ SEXP soma_array_reader(
         // pp.first.get(), sizeof(ArrowArray));
         ArrowArrayMove(pp.first.get(), arr->children[i]);
         ArrowSchemaMove(pp.second.get(), sch->children[i]);
-        tdbs::LOG_INFO(fmt::format(
-            "[soma_array_reader] Incoming name {} length {}", std::string(pp.second->name), pp.first->length));
+        tdbs::LOG_INFO(
+            fmt::format(
+                "[soma_array_reader] Incoming name {} length {}", std::string(pp.second->name), pp.first->length));
 
         if (pp.first->length > arr->length) {
             tdbs::LOG_DEBUG(fmt::format("[soma_array_reader] Setting array length to {}", pp.first->length));
@@ -375,11 +378,12 @@ SEXP c_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
     exitIfError(ArrowSchemaAllocateChildren(sch, lib_retval->n_children), "Bad schema children alloc");
 
     for (size_t i = 0; i < static_cast<size_t>(lib_retval->n_children); i++) {
-        tdbs::LOG_INFO(fmt::format(
-            "[c_schema] Accessing name '{}' format '{}' at position {}",
-            std::string(lib_retval->children[i]->name),
-            std::string(lib_retval->children[i]->format),
-            i));
+        tdbs::LOG_INFO(
+            fmt::format(
+                "[c_schema] Accessing name '{}' format '{}' at position {}",
+                std::string(lib_retval->children[i]->name),
+                std::string(lib_retval->children[i]->format),
+                i));
 
         ArrowSchemaMove(lib_retval->children[i], sch->children[i]);
     }

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -121,12 +121,13 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
     tiledb::Domain domain = schema->domain();
     std::vector<tiledb::Dimension> dims = domain.dimensions();
     for (auto& dim : dims) {
-        tdbs::LOG_DEBUG(fmt::format(
-            "[mq_setup] Dimension {} type {} domain {} extent {}",
-            dim.name(),
-            tiledb::impl::to_str(dim.type()),
-            dim.domain_to_str(),
-            dim.tile_extent_to_str()));
+        tdbs::LOG_DEBUG(
+            fmt::format(
+                "[mq_setup] Dimension {} type {} domain {} extent {}",
+                dim.name(),
+                tiledb::impl::to_str(dim.type()),
+                dim.domain_to_str(),
+                dim.tile_extent_to_str()));
         name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
@@ -272,11 +273,12 @@ void mq_set_dim_points(Rcpp::XPtr<tdbs::ManagedQuery> mq, std::string dim, Rcpp:
 
     std::vector<int64_t> vec = Rcpp::fromInteger64(points);
     mq->select_points<int64_t>(dim, vec);
-    tdbs::LOG_DEBUG(fmt::format(
-        "[mq_set_dim_points] Set on dim '{}' for {} points, first two are {} "
-        "and {}",
-        dim,
-        points.length(),
-        vec[0],
-        vec[1]));
+    tdbs::LOG_DEBUG(
+        fmt::format(
+            "[mq_set_dim_points] Set on dim '{}' for {} points, first two are {} "
+            "and {}",
+            dim,
+            points.length(),
+            vec[0],
+            vec[1]));
 }

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -108,13 +108,14 @@ void apply_dim_ranges(
                 uint64_t l = static_cast<uint64_t>(Rcpp::fromInteger64(lo[i]));
                 uint64_t h = static_cast<uint64_t>(Rcpp::fromInteger64(hi[i]));
                 vp[i] = std::make_pair(std::max(l, pr.first), std::min(h, pr.second));
-                tdbs::LOG_DEBUG(fmt::format(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
-                    "{}",
-                    i,
-                    nm,
-                    l,
-                    h));
+                tdbs::LOG_DEBUG(
+                    fmt::format(
+                        "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                        "{}",
+                        i,
+                        nm,
+                        l,
+                        h));
                 suitable = l < pr.second && h > pr.first;  // lower must be less than max, higher
                                                            // more than min
             }
@@ -128,13 +129,14 @@ void apply_dim_ranges(
             const std::pair<int64_t, int64_t> pr = dm->domain<int64_t>();
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                tdbs::LOG_DEBUG(fmt::format(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
-                    "{}",
-                    i,
-                    nm,
-                    lo[i],
-                    hi[i]));
+                tdbs::LOG_DEBUG(
+                    fmt::format(
+                        "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                        "{}",
+                        i,
+                        nm,
+                        lo[i],
+                        hi[i]));
                 suitable = lo[i] < pr.second && hi[i] > pr.first;  // lower must be less than max,
                                                                    // higher more than min
             }
@@ -150,13 +152,14 @@ void apply_dim_ranges(
                 float l = static_cast<float>(lo[i]);
                 float h = static_cast<float>(hi[i]);
                 vp[i] = std::make_pair(std::max(l, pr.first), std::min(h, pr.second));
-                tdbs::LOG_DEBUG(fmt::format(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
-                    "{}",
-                    i,
-                    nm,
-                    l,
-                    h));
+                tdbs::LOG_DEBUG(
+                    fmt::format(
+                        "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                        "{}",
+                        i,
+                        nm,
+                        l,
+                        h));
                 suitable = l < pr.second && h > pr.first;  // lower must be less than max, higher
                                                            // more than min
             }
@@ -170,13 +173,14 @@ void apply_dim_ranges(
             const std::pair<double, double> pr = dm->domain<double>();
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                tdbs::LOG_DEBUG(fmt::format(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
-                    "{}",
-                    i,
-                    nm,
-                    lo[i],
-                    hi[i]));
+                tdbs::LOG_DEBUG(
+                    fmt::format(
+                        "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                        "{}",
+                        i,
+                        nm,
+                        lo[i],
+                        hi[i]));
                 suitable = lo[i] < pr.second && hi[i] > pr.first;  // lower must be less than max,
                                                                    // higher more than min
             }
@@ -190,13 +194,14 @@ void apply_dim_ranges(
             const std::pair<int32_t, int32_t> pr = dm->domain<int32_t>();
             for (int i = 0; i < mm.nrow(); i++) {
                 vp[i] = std::make_pair(std::max(lo[i], pr.first), std::min(hi[i], pr.second));
-                tdbs::LOG_DEBUG(fmt::format(
-                    "[apply_dim_ranges] Applying dim point {} on {} with {} - "
-                    "{}",
-                    i,
-                    nm[i],
-                    lo[i],
-                    hi[i]));
+                tdbs::LOG_DEBUG(
+                    fmt::format(
+                        "[apply_dim_ranges] Applying dim point {} on {} with {} - "
+                        "{}",
+                        i,
+                        nm[i],
+                        lo[i],
+                        hi[i]));
                 suitable = lo[i] < pr.second && hi[i] > pr.first;  // lower must be less than max,
                                                                    // higher more than min
             }
@@ -426,21 +431,23 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
             // offsets, data
             std::vector<std::string> lohi = tiledbsoma::ArrowAdapter::get_array_string_column(
                 arrow_array->children[i], arrow_schema->children[i]);
-            tdbs::LOG_INFO(fmt::format(
-                "[domainish] name {} format {} length {} lo {} hi {}",
-                std::string(arrow_schema->children[i]->name),
-                std::string(arrow_schema->children[i]->format),
-                arrow_array->children[i]->length,
-                lohi[0],
-                lohi[1]));
+            tdbs::LOG_INFO(
+                fmt::format(
+                    "[domainish] name {} format {} length {} lo {} hi {}",
+                    std::string(arrow_schema->children[i]->name),
+                    std::string(arrow_schema->children[i]->format),
+                    arrow_array->children[i]->length,
+                    lohi[0],
+                    lohi[1]));
         } else {
             // Arrow semantics: non-variable-length: buffers 0,1 are validity &
             // data
-            tdbs::LOG_INFO(fmt::format(
-                "[domainish] name {} format {} length {}",
-                std::string(arrow_schema->children[i]->name),
-                std::string(arrow_schema->children[i]->format),
-                arrow_array->children[i]->length));
+            tdbs::LOG_INFO(
+                fmt::format(
+                    "[domainish] name {} format {} length {}",
+                    std::string(arrow_schema->children[i]->name),
+                    std::string(arrow_schema->children[i]->format),
+                    arrow_array->children[i]->length));
         }
 
         ArrowArrayMove(arrow_array->children[i], arr->children[i]);

--- a/apis/r/src/rutilities.h
+++ b/apis/r/src/rutilities.h
@@ -37,8 +37,9 @@ inline std::map<std::string, std::string> config_vector_to_map(Rcpp::Nullable<Rc
         size_t n = confvec.length();
         for (size_t i = 0; i < n; i++) {
             platform_config.emplace(std::make_pair(std::string(namesvec[i]), std::string(confvec[i])));
-            tdbs::LOG_TRACE(fmt::format(
-                "[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i])));
+            tdbs::LOG_TRACE(
+                fmt::format(
+                    "[config_vector_to_map] adding '{}' = '{}'", std::string(namesvec[i]), std::string(confvec[i])));
         }
     }
 

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -73,8 +73,9 @@ void test_arrow(const std::string& uri) {
         tdbs::LOG_WARN(fmt::format("Read of '{}' incomplete", uri));
         exit(-1);
     }
-    tdbs::LOG_INFO(fmt::format(
-        "Read complete with {} obs and {} cols", obs_data->get()->num_rows(), obs_data->get()->names().size()));
+    tdbs::LOG_INFO(
+        fmt::format(
+            "Read complete with {} obs and {} cols", obs_data->get()->num_rows(), obs_data->get()->names().size()));
     std::vector<std::string> names = obs_data->get()->names();
     for (auto nm : names) {
         auto buf = obs_data->get()->at(nm);

--- a/libtiledbsoma/src/reindexer/reindexer.cc
+++ b/libtiledbsoma/src/reindexer/reindexer.cc
@@ -74,8 +74,9 @@ void IntIndexer::lookup(const int64_t* keys, int64_t* results, size_t size) {
         }
         return;
     }
-    LOG_DEBUG(fmt::format(
-        "Lookup with thread concurrency {} on data size {}", context_->thread_pool()->concurrency_level(), size));
+    LOG_DEBUG(
+        fmt::format(
+            "Lookup with thread concurrency {} on data size {}", context_->thread_pool()->concurrency_level(), size));
 
     std::vector<tiledbsoma::ThreadPool::Task> tasks;
 

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -135,10 +135,11 @@ void ColumnBuffer::attach(Query& query, std::optional<Subarray> subarray) {
     // compatibility issue with pyarrow versions below 17. Thus we log and
     // continue.
     if (!validity_.empty() && is_dim) {
-        LOG_DEBUG(fmt::format(
-            "[ColumnBuffer::attach] Validity buffer passed for dimension '{}' "
-            "is being ignored",
-            name_));
+        LOG_DEBUG(
+            fmt::format(
+                "[ColumnBuffer::attach] Validity buffer passed for dimension '{}' "
+                "is being ignored",
+                name_));
     }
 
     return use_subarray ? attach_subarray(*subarray) : attach_buffer(query);

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -319,8 +319,9 @@ void ManagedQuery::_fill_in_subarrays_if_dense_without_new_shape(bool is_read) {
 
     array_shape = schema.domain().dimension(0).domain<int64_t>();
     subarray_->add_range(0, array_shape.first, array_shape.second);
-    LOG_TRACE(fmt::format(
-        "[ManagedQuery] Add full range to dense subarray dim0 = ({}, {})", array_shape.first, array_shape.second));
+    LOG_TRACE(
+        fmt::format(
+            "[ManagedQuery] Add full range to dense subarray dim0 = ({}, {})", array_shape.first, array_shape.second));
 
     // Set the subarray for range slicing
     query_->set_subarray(*subarray_);
@@ -350,8 +351,11 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(const CurrentDomai
             throw TileDBSOMAError(fmt::format("found dense array with unexpected dim name {}", dim_name));
         }
         if (dim.type() != TILEDB_INT64) {
-            throw TileDBSOMAError(fmt::format(
-                "expected dense arrays to have int64 dims; got {} for {}", tiledb::impl::to_str(dim.type()), dim_name));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "expected dense arrays to have int64 dims; got {} for {}",
+                    tiledb::impl::to_str(dim.type()),
+                    dim_name));
         }
 
         std::array<int64_t, 2> lo_hi_arr = ndrect.range<int64_t>(dim_name);
@@ -360,21 +364,23 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(const CurrentDomai
         int64_t lo = cd_lo;
         int64_t hi = cd_hi;
 
-        LOG_TRACE(fmt::format(
-            "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
-            "name {} current domain ({}, {})",
-            dim_name,
-            cd_lo,
-            cd_hi));
+        LOG_TRACE(
+            fmt::format(
+                "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
+                "name {} current domain ({}, {})",
+                dim_name,
+                cd_lo,
+                cd_hi));
 
         if (is_read) {
             auto [dom_lo, dom_hi] = schema.domain().dimension(0).domain<int64_t>();
-            LOG_TRACE(fmt::format(
-                "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape "
-                "dim name {} non-empty domain ({}, {})",
-                dim_name,
-                dom_lo,
-                dom_hi));
+            LOG_TRACE(
+                fmt::format(
+                    "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape "
+                    "dim name {} non-empty domain ({}, {})",
+                    dim_name,
+                    dom_lo,
+                    dom_hi));
             if (dom_lo > cd_lo) {
                 lo = dom_lo;
             }
@@ -383,12 +389,13 @@ void ManagedQuery::_fill_in_subarrays_if_dense_with_new_shape(const CurrentDomai
             }
         }
 
-        LOG_TRACE(fmt::format(
-            "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
-            "name {} select ({}, {})",
-            dim_name,
-            lo,
-            hi));
+        LOG_TRACE(
+            fmt::format(
+                "[ManagedQuery] _fill_in_subarrays_if_dense_with_new_shape dim "
+                "name {} select ({}, {})",
+                dim_name,
+                lo,
+                hi));
 
         std::pair<int64_t, int64_t> lo_hi_pair(lo, hi);
         select_ranges(dim_name, std::vector({lo_hi_pair}));
@@ -447,10 +454,11 @@ std::shared_ptr<ArrayBuffers> ManagedQuery::results() {
 
 void ManagedQuery::check_column_name(const std::string& name) {
     if (!buffers_->contains(name)) {
-        throw TileDBSOMAError(fmt::format(
-            "[ManagedQuery] Column '{}' is not available in the query "
-            "results.",
-            name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[ManagedQuery] Column '{}' is not available in the query "
+                "results.",
+                name));
     }
 }
 
@@ -557,10 +565,11 @@ bool ManagedQuery::_cast_column(ArrowSchema* schema, ArrowArray* array, ArraySch
         case TILEDB_FLOAT64:
             return _cast_column_aux<double>(schema, array, se);
         default:
-            throw TileDBSOMAError(fmt::format(
-                "Saw invalid TileDB user type when attempting to cast table: "
-                "{}",
-                tiledb::impl::type_to_str(user_type)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "Saw invalid TileDB user type when attempting to cast table: "
+                    "{}",
+                    tiledb::impl::type_to_str(user_type)));
     }
 }
 
@@ -603,10 +612,11 @@ void ManagedQuery::_promote_indexes_to_values(ArrowSchema* schema, ArrowArray* a
         case TILEDB_FLOAT64:
             return _cast_dictionary_values<double>(schema, array);
         default:
-            throw TileDBSOMAError(fmt::format(
-                "Saw invalid TileDB value type when attempting to promote "
-                "indexes to values: {}",
-                tiledb::impl::type_to_str(value_type)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "Saw invalid TileDB value type when attempting to promote "
+                    "indexes to values: {}",
+                    tiledb::impl::type_to_str(value_type)));
     }
 }
 
@@ -733,10 +743,11 @@ bool ManagedQuery::_cast_column_aux<std::string>(ArrowSchema* schema, ArrowArray
     //   from Python/R.)
 
     if (array->n_buffers != 3) {
-        throw TileDBSOMAError(fmt::format(
-            "[ManagedQuery] internal error: Arrow-table string column should "
-            "have 3 buffers; got {}",
-            array->n_buffers));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[ManagedQuery] internal error: Arrow-table string column should "
+                "have 3 buffers; got {}",
+                array->n_buffers));
     }
 
     const void* data = array->buffers[2];
@@ -884,8 +895,9 @@ bool ManagedQuery::_extend_and_write_enumeration(
             return _extend_and_evolve_schema_and_write<double>(
                 value_schema, value_array, index_schema, index_array, enmr, se);
         default:
-            throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB dict datatype: {} ", tiledb::impl::type_to_str(value_type)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "ArrowAdapter: Unsupported TileDB dict datatype: {} ", tiledb::impl::type_to_str(value_type)));
     }
 }
 
@@ -974,10 +986,11 @@ bool ManagedQuery::_extend_enumeration(
     auto value_type_in_data = ArrowAdapter::to_tiledb_format(value_schema->format);
 
     if (value_type_in_schema != value_type_in_data) {
-        throw TileDBSOMAError(fmt::format(
-            "extend_enumeration: data type '{}' != schema type '{}'",
-            tiledb::impl::type_to_str(value_type_in_data),
-            tiledb::impl::type_to_str(value_type_in_schema)));
+        throw TileDBSOMAError(
+            fmt::format(
+                "extend_enumeration: data type '{}' != schema type '{}'",
+                tiledb::impl::type_to_str(value_type_in_data),
+                tiledb::impl::type_to_str(value_type_in_schema)));
     }
 
     switch (value_type_in_schema) {
@@ -1018,9 +1031,10 @@ bool ManagedQuery::_extend_enumeration(
             return _extend_and_evolve_schema_without_details<double, double>(
                 value_schema, value_array, column_name, deduplicate, enmr, se);
         default:
-            throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB enumeration datatype: {} ",
-                tiledb::impl::type_to_str(value_type_in_schema)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "ArrowAdapter: Unsupported TileDB enumeration datatype: {} ",
+                    tiledb::impl::type_to_str(value_type_in_schema)));
     }
 }
 
@@ -1070,16 +1084,18 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     uint64_t num_elems = value_array->length;
 
     if (value_array->n_buffers != 3) {
-        throw std::invalid_argument(fmt::format(
-            "[ManagedQuery] _extend_and_evolve_schema_with_details string: "
-            "expected values n_buffers == 3; got {}",
-            value_array->n_buffers));
+        throw std::invalid_argument(
+            fmt::format(
+                "[ManagedQuery] _extend_and_evolve_schema_with_details string: "
+                "expected values n_buffers == 3; got {}",
+                value_array->n_buffers));
     }
 
     if (value_array->null_count != 0) {
         throw std::invalid_argument(
-            fmt::format("[ManagedQuery] _extend_and_evolve_schema_with_details string: "
-                        "null values are not supported"));
+            fmt::format(
+                "[ManagedQuery] _extend_and_evolve_schema_with_details string: "
+                "null values are not supported"));
     }
 
     // Set up input values as a char buffer, and offsets within it.  This is
@@ -1126,10 +1142,11 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     // values in the array schema. See also sc-65078.
     if (enum_values_in_write.size() != unique_values_in_write.size()) {
         // std::range_error maps to Python ValueError
-        throw std::range_error(fmt::format(
-            "[extend_enumeration] new values provided for column '{}' must "
-            "be unique within themselves, irrespective of the deduplicate flag",
-            column_name));
+        throw std::range_error(
+            fmt::format(
+                "[extend_enumeration] new values provided for column '{}' must "
+                "be unique within themselves, irrespective of the deduplicate flag",
+                column_name));
     }
 
     // Separate out the values already in the array schema from the
@@ -1180,11 +1197,12 @@ ManagedQuery::_extend_and_evolve_schema_with_details<std::string>(
     //      we still need to pass core only the d,e values. (It will
     //      throw otherwise).
     if (!deduplicate && enum_values_to_add.size() != enum_values_in_write.size()) {
-        throw TileDBSOMAError(fmt::format(
-            "[extend_enumeration] one or more values provided are already "
-            "present in the enumeration for column '{}', and deduplicate was "
-            "not specified",
-            column_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[extend_enumeration] one or more values provided are already "
+                "present in the enumeration for column '{}', and deduplicate was "
+                "not specified",
+                column_name));
     }
 
     // Extend the enumeration in the schema, if there are any values to be
@@ -1250,16 +1268,18 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
         // Higher-level code should be catching this with an error message which
         // is intended to be user-facing. Here is a low-level check before we
         // dereference buffers[1] and buffers[2].
-        throw std::invalid_argument(fmt::format(
-            "[ManagedQuery] _extend_and_evolve_schema_with_details non-string: "
-            "internal coding error: expected n_buffers == 2; got {}",
-            value_array->n_buffers));
+        throw std::invalid_argument(
+            fmt::format(
+                "[ManagedQuery] _extend_and_evolve_schema_with_details non-string: "
+                "internal coding error: expected n_buffers == 2; got {}",
+                value_array->n_buffers));
     }
 
     if (value_array->null_count != 0) {
         throw std::invalid_argument(
-            fmt::format("[ManagedQuery] _extend_and_evolve_schema_with_details non-string: "
-                        "null values are not supported"));
+            fmt::format(
+                "[ManagedQuery] _extend_and_evolve_schema_with_details non-string: "
+                "null values are not supported"));
     }
     std::optional<std::vector<uint8_t>> validities = std::nullopt;
     if (index_array != nullptr) {
@@ -1292,10 +1312,11 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     // values in the array schema. See also sc-65078.
     if (enum_values_in_write.size() != unique_values_in_write.size()) {
         // std::range_error maps to Python ValueError
-        throw std::range_error(fmt::format(
-            "[extend_enumeration] new values provided for column '{}' must "
-            "be unique within themselves, irrespective of the deduplicate flag",
-            column_name));
+        throw std::range_error(
+            fmt::format(
+                "[extend_enumeration] new values provided for column '{}' must "
+                "be unique within themselves, irrespective of the deduplicate flag",
+                column_name));
     }
 
     // The enumeration values are tracked here in as a vector of string-views,
@@ -1380,11 +1401,12 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
     //      we still need to pass core only the d,e values. (It will
     //      throw otherwise).
     if (!deduplicate && enum_values_to_add.size() != enum_values_in_write.size()) {
-        throw TileDBSOMAError(fmt::format(
-            "[extend_enumeration] one or more values provided are already "
-            "present in the enumeration for column '{}', and deduplicate was "
-            "not specified",
-            column_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[extend_enumeration] one or more values provided are already "
+                "present in the enumeration for column '{}', and deduplicate was "
+                "not specified",
+                column_name));
     }
 
     // Extend the enumeration in the schema, if there are any values to be
@@ -1421,10 +1443,11 @@ ManagedQuery::_extend_and_evolve_schema_with_details(
 
 std::vector<uint8_t> ManagedQuery::_bool_data_bits_to_bytes(ArrowSchema* schema, ArrowArray* array) {
     if (strcmp(schema->format, "b") != 0) {
-        throw TileDBSOMAError(fmt::format(
-            "_cast_bit_to_uint8 expected column format to be 'b' but saw "
-            "{}",
-            schema->format));
+        throw TileDBSOMAError(
+            fmt::format(
+                "_cast_bit_to_uint8 expected column format to be 'b' but saw "
+                "{}",
+                schema->format));
     }
 
     const uint8_t* data = reinterpret_cast<const uint8_t*>(array->buffers[1]);

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -128,11 +128,12 @@ SOMAArray::SOMAArray(
         default: {  // Only allow read/write when constructing from TileDB.
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(arr_->query_type(), &query_type_str);
-            throw std::invalid_argument(fmt::format(
-                "Internal error: SOMAArray constructor does not accept a "
-                "TileDB array opened in mode '{}'. The array must be opened in "
-                "either read or write mode.",
-                query_type_str));
+            throw std::invalid_argument(
+                fmt::format(
+                    "Internal error: SOMAArray constructor does not accept a "
+                    "TileDB array opened in mode '{}'. The array must be opened in "
+                    "either read or write mode.",
+                    query_type_str));
         }
     }
     fill_metadata_cache(soma_mode_, timestamp_);
@@ -173,11 +174,12 @@ void SOMAArray::fill_columns() {
 
     if (type().value_or("") == "SOMAGeometryDataFrame") {
         if (!has_metadata(TILEDB_SOMA_SCHEMA_KEY)) {
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAArray][fill_columns] Missing required metadata key '{}' "
-                "from SOMAGeometryDataFrame '{}'",
-                TILEDB_SOMA_SCHEMA_KEY,
-                uri()));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAArray][fill_columns] Missing required metadata key '{}' "
+                    "from SOMAGeometryDataFrame '{}'",
+                    TILEDB_SOMA_SCHEMA_KEY,
+                    uri()));
         }
     }
 
@@ -338,10 +340,11 @@ Enumeration SOMAArray::get_existing_enumeration_for_column(std::string column_na
     auto attribute = schema_->attribute(column_name);
     auto enumeration_name = AttributeExperimental::get_enumeration_name(*tctx, attribute);
     if (!enumeration_name.has_value()) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::get_existing_enumeration_for_column] column_name '{}' "
-            "is non-enumerated",
-            column_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAArray::get_existing_enumeration_for_column] column_name '{}' "
+                "is non-enumerated",
+                column_name));
     }
     return ArrayExperimental::get_enumeration(*tctx, *arr_, enumeration_name.value());
 }
@@ -367,10 +370,11 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAArray::get_enumeration_values_for_colum
 
     // Throw if this column is not of dictionary type
     if (column_schema->dictionary == nullptr) {
-        throw TileDBSOMAError(fmt::format(
-            "[get_enumeration_values_for_column] column named '{}' is not of "
-            "dictionary type",
-            column_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[get_enumeration_values_for_column] column named '{}' is not of "
+                "dictionary type",
+                column_name));
     }
 
     // Release the pointers within the ArrowSchema*:
@@ -438,8 +442,9 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAArray::get_enumeration_values_for_colum
             break;
 
         default:
-            throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB dict datatype: {} ", tiledb::impl::type_to_str(value_dtype)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "ArrowAdapter: Unsupported TileDB dict datatype: {} ", tiledb::impl::type_to_str(value_dtype)));
     }
 
     return std::pair(output_arrow_array, output_arrow_schema);
@@ -464,10 +469,11 @@ void SOMAArray::extend_enumeration_values(
         auto attribute = schema_->attribute(column_name);
         auto enumeration_name = AttributeExperimental::get_enumeration_name(*tctx, attribute);
         if (!enumeration_name.has_value()) {
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAArray::extend_enumeration_values] column_name '{}' is "
-                "non-enumerated",
-                column_name));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAArray::extend_enumeration_values] column_name '{}' is "
+                    "non-enumerated",
+                    column_name));
         }
         Enumeration core_enum = get_existing_enumeration_for_column(column_name);
 
@@ -753,11 +759,12 @@ void SOMAArray::_set_shape_helper(
 
     size_t array_ndim = static_cast<size_t>(ndim());
     if (newshape.size() != array_ndim) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray::resize]: newshape has dimension count {}; array has "
-            "{} ",
-            newshape.size(),
-            array_ndim));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAArray::resize]: newshape has dimension count {}; array has "
+                "{} ",
+                newshape.size(),
+                array_ndim));
     }
 
     size_t idx = 0;
@@ -803,18 +810,20 @@ void SOMAArray::_set_soma_joinid_shape_helper(
         for (const auto& column : columns_ | std::views::filter([](const auto& col) { return col->isIndexColumn(); })) {
             if (column->name() == SOMA_JOINID) {
                 if (column->domain_type().value() != TILEDB_INT64) {
-                    throw TileDBSOMAError(fmt::format(
-                        "{}: expected soma_joinid to be of type {}; got {}",
-                        function_name_for_messages,
-                        tiledb::impl::type_to_str(TILEDB_INT64),
-                        tiledb::impl::type_to_str(column->domain_type().value())));
+                    throw TileDBSOMAError(
+                        fmt::format(
+                            "{}: expected soma_joinid to be of type {}; got {}",
+                            function_name_for_messages,
+                            tiledb::impl::type_to_str(TILEDB_INT64),
+                            tiledb::impl::type_to_str(column->domain_type().value())));
                 }
 
                 if (column->type() != soma_column_datatype_t::SOMA_COLUMN_DIMENSION) {
-                    throw TileDBSOMAError(fmt::format(
-                        "{}: expected soma_joinid type to be of type "
-                        "SOMA_COLUMN_DIMENSION",
-                        function_name_for_messages));
+                    throw TileDBSOMAError(
+                        fmt::format(
+                            "{}: expected soma_joinid type to be of type "
+                            "SOMA_COLUMN_DIMENSION",
+                            function_name_for_messages));
                 }
 
                 column->set_current_domain_slot(ndrect, std::vector<int64_t>({0, newshape - 1}));
@@ -943,12 +952,13 @@ void SOMAArray::_set_domain_helper(
     }
 
     if (newdomain.second->n_children != static_cast<int64_t>(ndim())) {
-        throw TileDBSOMAError(fmt::format(
-            "{}: requested domain has ndim={} but the dataframe has "
-            "ndim={}",
-            function_name_for_messages,
-            newdomain.second->n_children,
-            ndim()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "{}: requested domain has ndim={} but the dataframe has "
+                "ndim={}",
+                function_name_for_messages,
+                newdomain.second->n_children,
+                ndim()));
     }
 
     if (newdomain.second->n_children != newdomain.first->n_children) {
@@ -1039,11 +1049,12 @@ std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape_via_tiledb_current_do
 
     auto column = get_column(SOMA_JOINID);
     if (column->domain_type().value() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
-            "expected {} dim to be {}; got {}",
-            SOMA_JOINID,
-            tiledb::impl::type_to_str(TILEDB_INT64),
-            tiledb::impl::type_to_str(column->domain_type().value())));
+        throw TileDBSOMAError(
+            fmt::format(
+                "expected {} dim to be {}; got {}",
+                SOMA_JOINID,
+                tiledb::impl::type_to_str(TILEDB_INT64),
+                tiledb::impl::type_to_str(column->domain_type().value())));
     }
 
     auto max = column->core_current_domain_slot<int64_t>(*ctx_, *arr_).second + 1;
@@ -1058,11 +1069,12 @@ std::optional<int64_t> SOMAArray::_maybe_soma_joinid_shape_via_tiledb_domain() {
 
     auto column = get_column(SOMA_JOINID);
     if (column->domain_type().value() != TILEDB_INT64) {
-        throw TileDBSOMAError(fmt::format(
-            "expected {} dim to be {}; got {}",
-            SOMA_JOINID,
-            tiledb::impl::type_to_str(TILEDB_INT64),
-            tiledb::impl::type_to_str(column->domain_type().value())));
+        throw TileDBSOMAError(
+            fmt::format(
+                "expected {} dim to be {}; got {}",
+                SOMA_JOINID,
+                tiledb::impl::type_to_str(TILEDB_INT64),
+                tiledb::impl::type_to_str(column->domain_type().value())));
     }
 
     auto max = column->core_domain_slot<int64_t>().second + 1;
@@ -1112,11 +1124,12 @@ std::shared_ptr<SOMAColumn> SOMAArray::get_column(std::string_view name) const {
 
 std::shared_ptr<SOMAColumn> SOMAArray::get_column(std::size_t index) const {
     if (index >= columns_.size()) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAArray] internal coding error: Column index outside of range. "
-            "Requested {}, but {} exist.",
-            index,
-            columns_.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAArray] internal coding error: Column index outside of range. "
+                "Requested {}, but {} exist.",
+                index,
+                columns_.size()));
     }
 
     return columns_[index];

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -30,10 +30,11 @@ std::shared_ptr<SOMAColumn> SOMAAttribute::deserialize(
                                                    .template get<std::vector<std::string>>();
 
     if (attribute_names.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAAttribute][deserialize] Invalid number of attributes. "
-            "Epected 1, got {}",
-            attribute_names.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAAttribute][deserialize] Invalid number of attributes. "
+                "Epected 1, got {}",
+                attribute_names.size()));
     }
 
     if (!array.schema().has_attribute(attribute_names[0])) {
@@ -45,8 +46,9 @@ std::shared_ptr<SOMAColumn> SOMAAttribute::deserialize(
     auto enumeration_name = AttributeExperimental::get_enumeration_name(ctx, attribute);
 
     std::optional<Enumeration> enumeration = enumeration_name.has_value() ?
-                                                 std::make_optional(ArrayExperimental::get_enumeration(
-                                                     ctx, array, enumeration_name.value())) :
+                                                 std::make_optional(
+                                                     ArrayExperimental::get_enumeration(
+                                                         ctx, array, enumeration_name.value())) :
                                                  std::nullopt;
 
     return std::make_shared<SOMAAttribute>(attribute, enumeration);
@@ -60,75 +62,85 @@ std::shared_ptr<SOMAAttribute> SOMAAttribute::create(
 }
 
 void SOMAAttribute::_set_dim_points(ManagedQuery&, const std::any&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_set_dim_points] Column with name {} is not an index "
-        "column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_set_dim_points] Column with name {} is not an index "
+            "column",
+            name()));
 }
 
 void SOMAAttribute::_set_dim_ranges(ManagedQuery&, const std::any&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_set_dim_ranges] Column with name {} is not an index "
-        "column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_set_dim_ranges] Column with name {} is not an index "
+            "column",
+            name()));
 }
 
 void SOMAAttribute::_set_current_domain_slot(NDRectangle&, std::span<const std::any>) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
-        "an index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+            "an index column",
+            name()));
 }
 
 std::pair<bool, std::string> SOMAAttribute::_can_set_current_domain_slot(
     std::optional<NDRectangle>&, std::span<const std::any>) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
-        "an index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_set_current_domain_slot] Column with name {} is not "
+            "an index column",
+            name()));
 };
 
 std::any SOMAAttribute::_core_domain_slot() const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_core_domain_slot] Column with name {} is not an "
-        "index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_core_domain_slot] Column with name {} is not an "
+            "index column",
+            name()));
 }
 
 std::any SOMAAttribute::_non_empty_domain_slot(Array&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
-        "index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
+            "index column",
+            name()));
 }
 
 std::any SOMAAttribute::_non_empty_domain_slot_opt(const SOMAContext&, Array&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
-        "index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_non_empty_domain_slot] Column with name {} is not an "
+            "index column",
+            name()));
 }
 
 std::any SOMAAttribute::_core_current_domain_slot(const SOMAContext&, Array&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
-        "an index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+            "an index column",
+            name()));
 }
 
 std::any SOMAAttribute::_core_current_domain_slot(NDRectangle&) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
-        "an index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][_core_current_domain_slot] Column with name {} is not "
+            "an index column",
+            name()));
 }
 
 std::pair<ArrowArray*, ArrowSchema*> SOMAAttribute::arrow_domain_slot(
     const SOMAContext&, Array&, enum Domainish) const {
-    throw TileDBSOMAError(fmt::format(
-        "[SOMAAttribute][arrow_domain_slot] Column with name {} is not an "
-        "index column",
-        name()));
+    throw TileDBSOMAError(
+        fmt::format(
+            "[SOMAAttribute][arrow_domain_slot] Column with name {} is not an "
+            "index column",
+            name()));
 }
 
 ArrowSchema* SOMAAttribute::arrow_schema_slot(const SOMAContext& ctx, Array& array) const {

--- a/libtiledbsoma/src/soma/soma_column.cc
+++ b/libtiledbsoma/src/soma/soma_column.cc
@@ -34,10 +34,11 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
                                                        nlohmann::json::object();
 
         if (!soma_schema_extension.contains(TILEDB_SOMA_SCHEMA_COL_KEY)) {
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAArray][fill_columns] Missing '{}' key from '{}'",
-                TILEDB_SOMA_SCHEMA_COL_KEY,
-                TILEDB_SOMA_SCHEMA_KEY));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAArray][fill_columns] Missing '{}' key from '{}'",
+                    TILEDB_SOMA_SCHEMA_COL_KEY,
+                    TILEDB_SOMA_SCHEMA_KEY));
         }
 
         soma_schema_columns = soma_schema_extension.value(TILEDB_SOMA_SCHEMA_COL_KEY, nlohmann::json::array());
@@ -92,9 +93,10 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
             }
 
             auto enumeration_name = AttributeExperimental::get_enumeration_name(ctx, attribute);
-            auto enumeration = enumeration_name.has_value() ? std::make_optional(ArrayExperimental::get_enumeration(
-                                                                  ctx, array, enumeration_name.value())) :
-                                                              std::nullopt;
+            auto enumeration = enumeration_name.has_value() ?
+                                   std::make_optional(
+                                       ArrayExperimental::get_enumeration(ctx, array, enumeration_name.value())) :
+                                   std::nullopt;
 
             columns.push_back(std::make_shared<SOMAAttribute>(attribute, enumeration));
         }
@@ -108,9 +110,10 @@ std::vector<std::shared_ptr<SOMAColumn>> SOMAColumn::deserialize(
         for (size_t i = 0; i < array.schema().attribute_num(); ++i) {
             auto attribute = array.schema().attribute(i);
             auto enumeration_name = AttributeExperimental::get_enumeration_name(ctx, attribute);
-            auto enumeration = enumeration_name.has_value() ? std::make_optional(ArrayExperimental::get_enumeration(
-                                                                  ctx, array, enumeration_name.value())) :
-                                                              std::nullopt;
+            auto enumeration = enumeration_name.has_value() ?
+                                   std::make_optional(
+                                       ArrayExperimental::get_enumeration(ctx, array, enumeration_name.value())) :
+                                   std::nullopt;
 
             columns.push_back(std::make_shared<SOMAAttribute>(attribute, enumeration));
         }
@@ -150,11 +153,12 @@ std::pair<std::string, std::string> SOMAColumn::core_current_domain_slot<std::st
         if (current_domain.first == "" && (current_domain.second == "\x7f" || current_domain.second == "\xff")) {
             return std::pair<std::string, std::string>("", "");
         } else {
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAColumn][core_current_domain_slot] unexpected current "
-                "domain returnd ({}, {})",
-                current_domain.first,
-                current_domain.second));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAColumn][core_current_domain_slot] unexpected current "
+                    "domain returnd ({}, {})",
+                    current_domain.first,
+                    current_domain.second));
         }
     } catch (const std::exception& e) {
         throw TileDBSOMAError(e.what());
@@ -170,11 +174,12 @@ std::pair<std::string, std::string> SOMAColumn::core_current_domain_slot<std::st
         if (current_domain.first == "" && (current_domain.second == "\x7f" || current_domain.second == "\xff")) {
             return std::pair<std::string, std::string>("", "");
         } else {
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAColumn][core_current_domain_slot] unexpected current "
-                "domain returnd ({}, {})",
-                current_domain.first,
-                current_domain.second));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAColumn][core_current_domain_slot] unexpected current "
+                    "domain returnd ({}, {})",
+                    current_domain.first,
+                    current_domain.second));
         }
     } catch (const std::exception& e) {
         throw TileDBSOMAError(e.what());

--- a/libtiledbsoma/src/soma/soma_context.cc
+++ b/libtiledbsoma/src/soma/soma_context.cc
@@ -30,12 +30,13 @@ std::shared_ptr<ThreadPool>& SOMAContext::thread_pool() {
             try {
                 concurrency = std::stoull(value_str);
             } catch (const std::exception& e) {
-                throw TileDBSOMAError(fmt::format(
-                    "[SOMAContext] Error parsing {}: '{}' ({}) - must be a "
-                    "postive integer.",
-                    CONFIG_KEY_COMPUTE_CONCURRENCY_LEVEL,
-                    value_str,
-                    e.what()));
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "[SOMAContext] Error parsing {}: '{}' ({}) - must be a "
+                        "postive integer.",
+                        CONFIG_KEY_COMPUTE_CONCURRENCY_LEVEL,
+                        value_str,
+                        e.what()));
             }
         }
 

--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -116,12 +116,13 @@ SOMACoordinateSpace::SOMACoordinateSpace(
 SOMACoordinateSpace SOMACoordinateSpace::from_metadata(
     tiledb_datatype_t value_type, uint32_t value_num, const void* value) {
     if (value_type != TILEDB_STRING_UTF8 && value_type != TILEDB_STRING_ASCII) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMACoordinateSpace]: Unexpected datatype for coordinate space "
-            "metadata. Expected {} or {}; got {}",
-            tiledb::impl::type_to_str(TILEDB_STRING_UTF8),
-            tiledb::impl::type_to_str(TILEDB_STRING_ASCII),
-            tiledb::impl::type_to_str(value_type)));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMACoordinateSpace]: Unexpected datatype for coordinate space "
+                "metadata. Expected {} or {}; got {}",
+                tiledb::impl::type_to_str(TILEDB_STRING_UTF8),
+                tiledb::impl::type_to_str(TILEDB_STRING_ASCII),
+                tiledb::impl::type_to_str(value_type)));
     }
     if (value == nullptr) {
         throw TileDBSOMAError(

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -131,14 +131,15 @@ void SOMADataFrame::update_dataframe_schema(
             // SOMA converts string and binary to large string and large binary
             auto enmr_name = attr_name + "_" + ((enmr_type == "u") ? "U" : (enmr_type == "z" ? "Z" : enmr_type));
 
-            LOG_DEBUG(fmt::format(
-                "[SOMADataFrame::update_dataframe_schema] add col name {} "
-                "index_type "
-                "{} value_type {} ordered {}",
-                attr_name,
-                attr_type,
-                enmr_type,
-                ordered));
+            LOG_DEBUG(
+                fmt::format(
+                    "[SOMADataFrame::update_dataframe_schema] add col name {} "
+                    "index_type "
+                    "{} value_type {} ordered {}",
+                    attr_name,
+                    attr_type,
+                    enmr_type,
+                    ordered));
 
             // First we need to check if the array has (ever had) an enumeration
             // of this type in its history.
@@ -164,14 +165,15 @@ void SOMADataFrame::update_dataframe_schema(
                 // We cannot continue without intervention, but let's at least
                 // be as clear as possible why we can't continue.
                 if (ordered != existing_ordered || enmr_type != existing_type) {
-                    throw TileDBSOMAError(fmt::format(
-                        "[SOMADataFrame::update_dataframe_schema] requested "
-                        "enumeration [type='{}', ordered={}] incompatible with "
-                        "existing [type='{}', ordered={}]",
-                        enmr_type,
-                        ordered,
-                        existing_type,
-                        existing_ordered));
+                    throw TileDBSOMAError(
+                        fmt::format(
+                            "[SOMADataFrame::update_dataframe_schema] requested "
+                            "enumeration [type='{}', ordered={}] incompatible with "
+                            "existing [type='{}', ordered={}]",
+                            enmr_type,
+                            ordered,
+                            existing_type,
+                            existing_ordered));
                 }
 
                 array_already_has_it = true;
@@ -185,8 +187,9 @@ void SOMADataFrame::update_dataframe_schema(
                 if (msg.find("already exists in this ArraySchema") != std::string::npos) {
                     array_already_has_it = true;
                 } else if (
-                    msg.find("Unable to check if unknown enumeration is "
-                             "loaded. No enumeration named") != std::string::npos) {
+                    msg.find(
+                        "Unable to check if unknown enumeration is "
+                        "loaded. No enumeration named") != std::string::npos) {
                     array_already_has_it = false;
                 } else {
                     throw(e);
@@ -194,21 +197,24 @@ void SOMADataFrame::update_dataframe_schema(
             }
 
             if (!array_already_has_it) {
-                se.add_enumeration(Enumeration::create_empty(
-                    tctx,
-                    enmr_name,
-                    ArrowAdapter::to_tiledb_format(enmr_type),
-                    enmr_type == "u" || enmr_type == "z" || enmr_type == "U" || enmr_type == "Z" ? TILEDB_VAR_NUM : 1,
-                    ordered));
+                se.add_enumeration(
+                    Enumeration::create_empty(
+                        tctx,
+                        enmr_name,
+                        ArrowAdapter::to_tiledb_format(enmr_type),
+                        enmr_type == "u" || enmr_type == "z" || enmr_type == "U" || enmr_type == "Z" ? TILEDB_VAR_NUM :
+                                                                                                       1,
+                        ordered));
                 AttributeExperimental::set_enumeration_name(tctx, attr, enmr_name);
             }
 
         } else {
-            LOG_DEBUG(fmt::format(
-                "[SOMADataFrame::update_dataframe_schema] add col name {} type "
-                "{}",
-                attr_name,
-                attr_type));
+            LOG_DEBUG(
+                fmt::format(
+                    "[SOMADataFrame::update_dataframe_schema] add col name {} type "
+                    "{}",
+                    attr_name,
+                    attr_type));
         }
 
         se.add_attribute(attr);

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -32,10 +32,11 @@ std::shared_ptr<SOMAColumn> SOMADimension::deserialize(
                                                    .template get<std::vector<std::string>>();
 
     if (dimension_names.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMADimension][deserialize] Invalid number of dimensions: "
-            "expected 1, got {}",
-            dimension_names.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMADimension][deserialize] Invalid number of dimensions: "
+                "expected 1, got {}",
+                dimension_names.size()));
     }
 
     auto dimension = array.schema().domain().dimension(dimension_names[0]);
@@ -187,10 +188,11 @@ void SOMADimension::_set_dim_ranges(ManagedQuery& query, const std::any& ranges)
 
 void SOMADimension::_set_current_domain_slot(NDRectangle& rectangle, std::span<const std::any> domain) const {
     if (domain.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMADimension][_set_current_domain_slot] Invalid domain size. "
-            "Expected 1, got {}",
-            domain.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMADimension][_set_current_domain_slot] Invalid domain size. "
+                "Expected 1, got {}",
+                domain.size()));
     }
 
     switch (dimension.type()) {
@@ -282,31 +284,34 @@ void SOMADimension::_set_current_domain_slot(NDRectangle& rectangle, std::span<c
             if (dom[0] == "" && dom[1] == "") {
                 rectangle.set_range(dimension.name(), "", "\x7f");
             } else {
-                throw TileDBSOMAError(fmt::format(
-                    "[SOMADimension][_set_current_domain_slot] domain (\"{}\", "
-                    "\"{}\") cannot be set for "
-                    "string index columns: please use "
-                    "(\"\", \"\")",
-                    dom[0],
-                    dom[1]));
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "[SOMADimension][_set_current_domain_slot] domain (\"{}\", "
+                        "\"{}\") cannot be set for "
+                        "string index columns: please use "
+                        "(\"\", \"\")",
+                        dom[0],
+                        dom[1]));
             }
 
         } break;
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][_set_current_domain_slot] Unknown datatype {}",
-                tiledb::impl::type_to_str(dimension.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][_set_current_domain_slot] Unknown datatype {}",
+                    tiledb::impl::type_to_str(dimension.type())));
     }
 }
 
 std::pair<bool, std::string> SOMADimension::_can_set_current_domain_slot(
     std::optional<NDRectangle>& rectangle, std::span<const std::any> new_domain) const {
     if (new_domain.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMADimension][_can_set_current_domain_slot] Expected domain "
-            "size for '{}' is 1, found {}",
-            name(),
-            new_domain.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMADimension][_can_set_current_domain_slot] Expected domain "
+                "size for '{}' is 1, found {}",
+                name(),
+                new_domain.size()));
     }
 
     auto comparator = [&]<typename T>(const std::array<T, 2>& new_dom) -> std::pair<bool, std::string> {
@@ -430,10 +435,11 @@ std::pair<bool, std::string> SOMADimension::_can_set_current_domain_slot(
             return std::pair(true, "");
         }
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][_can_set_current_domain_slot] Unknown dataype "
-                "{}",
-                tiledb::impl::type_to_str(dimension.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][_can_set_current_domain_slot] Unknown dataype "
+                    "{}",
+                    tiledb::impl::type_to_str(dimension.type())));
     }
 }
 
@@ -482,8 +488,10 @@ std::any SOMADimension::_core_domain_slot() const {
         case TILEDB_FLOAT64:
             return std::make_any<std::pair<double_t, double_t>>(dimension.domain<double_t>());
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][_core_domain_slot] Unknown dimension type {}", impl::type_to_str(dimension.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][_core_domain_slot] Unknown dimension type {}",
+                    impl::type_to_str(dimension.type())));
     }
 }
 
@@ -535,10 +543,11 @@ std::any SOMADimension::_non_empty_domain_slot(Array& array) const {
         case TILEDB_STRING_UTF8:
             return std::make_any<std::pair<std::string, std::string>>(array.non_empty_domain_var(dimension.name()));
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][_non_empty_domain_slot] Unknown dimension "
-                "type {}",
-                impl::type_to_str(dimension.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][_non_empty_domain_slot] Unknown dimension "
+                    "type {}",
+                    impl::type_to_str(dimension.type())));
     }
 }
 
@@ -688,11 +697,12 @@ std::any SOMADimension::_non_empty_domain_slot_opt(const SOMAContext& ctx, Array
                 return std::make_any<std::optional<std::pair<double_t, double_t>>>(data);
             }
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][_non_empty_domain_slot] Unknown "
-                "dimension "
-                "type {}",
-                impl::type_to_str(dimension.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][_non_empty_domain_slot] Unknown "
+                    "dimension "
+                    "type {}",
+                    impl::type_to_str(dimension.type())));
     }
 }
 
@@ -840,12 +850,13 @@ std::pair<ArrowArray*, ArrowSchema*> SOMADimension::arrow_domain_slot(
             arrow_array = ArrowAdapter::make_arrow_array_child_string(domain_slot<std::string>(ctx, array, kind));
             break;
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMADimension][arrow_domain_slot] dim {} has unhandled "
-                "type "
-                "{}",
-                name(),
-                tiledb::impl::type_to_str(domain_type().value())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][arrow_domain_slot] dim {} has unhandled "
+                    "type "
+                    "{}",
+                    name(),
+                    tiledb::impl::type_to_str(domain_type().value())));
     }
 
     return std::make_pair(arrow_array, arrow_schema_slot(ctx, array));

--- a/libtiledbsoma/src/soma/soma_geometry_column.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_column.cc
@@ -38,16 +38,18 @@ std::shared_ptr<SOMAColumn> SOMAGeometryColumn::deserialize(
                                                    .template get<std::vector<std::string>>();
 
     if (dimension_names.size() % 2 != 0) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryColumn][deserialize] Invalid number of dimensions: "
-            "expected number divisible by 2, got {}",
-            dimension_names.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryColumn][deserialize] Invalid number of dimensions: "
+                "expected number divisible by 2, got {}",
+                dimension_names.size()));
     }
     if (attribute_names.size() != 1) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryColumn][deserialize] Invalid number of attributes: "
-            "expected 1, got {}",
-            attribute_names.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryColumn][deserialize] Invalid number of attributes: "
+                "expected 1, got {}",
+                attribute_names.size()));
     }
 
     std::vector<Dimension> dimensions;
@@ -58,10 +60,11 @@ std::shared_ptr<SOMAColumn> SOMAGeometryColumn::deserialize(
     auto attribute = array.schema().attribute(attribute_names[0]);
 
     if (!metadata.contains(SOMA_COORDINATE_SPACE_KEY)) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryColumn][deserialize] Missing required '{}' "
-            "metadata key.",
-            SOMA_COORDINATE_SPACE_KEY));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryColumn][deserialize] Missing required '{}' "
+                "metadata key.",
+                SOMA_COORDINATE_SPACE_KEY));
     }
 
     auto coordinate_space = std::apply(SOMACoordinateSpace::from_metadata, metadata.at(SOMA_COORDINATE_SPACE_KEY));
@@ -80,36 +83,39 @@ std::shared_ptr<SOMAGeometryColumn> SOMAGeometryColumn::create(
     PlatformConfig platform_config) {
     std::vector<Dimension> dims;
     if (type_metadata.compare("WKB") != 0) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryColumn] "
-            "Unkwown type metadata for `{}`: "
-            "Expected 'WKB', got '{}'",
-            SOMA_GEOMETRY_COLUMN_NAME,
-            type_metadata));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryColumn] "
+                "Unkwown type metadata for `{}`: "
+                "Expected 'WKB', got '{}'",
+                SOMA_GEOMETRY_COLUMN_NAME,
+                type_metadata));
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
-            ctx,
-            spatial_schema->children[j],
-            spatial_array->children[j],
-            soma_type,
-            type_metadata,
-            SOMA_GEOMETRY_DIMENSION_PREFIX,
-            "__min",
-            platform_config));
+        dims.push_back(
+            ArrowAdapter::tiledb_dimension_from_arrow_schema(
+                ctx,
+                spatial_schema->children[j],
+                spatial_array->children[j],
+                soma_type,
+                type_metadata,
+                SOMA_GEOMETRY_DIMENSION_PREFIX,
+                "__min",
+                platform_config));
     }
 
     for (int64_t j = 0; j < spatial_schema->n_children; ++j) {
-        dims.push_back(ArrowAdapter::tiledb_dimension_from_arrow_schema(
-            ctx,
-            spatial_schema->children[j],
-            spatial_array->children[j],
-            soma_type,
-            type_metadata,
-            SOMA_GEOMETRY_DIMENSION_PREFIX,
-            "__max",
-            platform_config));
+        dims.push_back(
+            ArrowAdapter::tiledb_dimension_from_arrow_schema(
+                ctx,
+                spatial_schema->children[j],
+                spatial_array->children[j],
+                soma_type,
+                type_metadata,
+                SOMA_GEOMETRY_DIMENSION_PREFIX,
+                "__max",
+                platform_config));
     }
 
     auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(ctx, schema, type_metadata, platform_config);
@@ -162,11 +168,12 @@ void SOMAGeometryColumn::_set_dim_ranges(ManagedQuery& query, const std::any& ra
 void SOMAGeometryColumn::_set_current_domain_slot(
     NDRectangle& rectangle, std::span<const std::any> new_current_domain) const {
     if (TDB_DIM_PER_SPATIAL_AXIS * new_current_domain.size() != dimensions.size()) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryColumn] Dimension - Current Domain mismatch. "
-            "Expected current domain of size {}, found {}",
-            dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS,
-            new_current_domain.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryColumn] Dimension - Current Domain mismatch. "
+                "Expected current domain of size {}, found {}",
+                dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS,
+                new_current_domain.size()));
     }
 
     for (size_t i = 0; i < new_current_domain.size(); ++i) {
@@ -183,11 +190,12 @@ void SOMAGeometryColumn::_set_current_domain_slot(
 std::pair<bool, std::string> SOMAGeometryColumn::_can_set_current_domain_slot(
     std::optional<NDRectangle>& rectangle, std::span<const std::any> new_current_domain) const {
     if (new_current_domain.size() != dimensions.size() / TDB_DIM_PER_SPATIAL_AXIS) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMADimension][_can_set_current_domain_slot] Expected current "
-            "domain "
-            "size is 2, found {}",
-            new_current_domain.size()));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMADimension][_can_set_current_domain_slot] Expected current "
+                "domain "
+                "size is 2, found {}",
+                new_current_domain.size()));
     }
 
     for (size_t i = 0; i < new_current_domain.size(); ++i) {
@@ -446,12 +454,13 @@ std::pair<ArrowArray*, ArrowSchema*> SOMAGeometryColumn::arrow_domain_slot(
             return std::make_pair(parent_array, parent_schema);
         } break;
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAGeometryColumn][arrow_domain_slot] dim {} has unhandled "
-                "extended type "
-                "{}",
-                name(),
-                tiledb::impl::type_to_str(domain_type().value())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAGeometryColumn][arrow_domain_slot] dim {} has unhandled "
+                    "extended type "
+                    "{}",
+                    name(),
+                    tiledb::impl::type_to_str(domain_type().value())));
     }
 }
 

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -91,10 +91,11 @@ void SOMAGeometryDataFrame::initialize() {
     auto coordinate_space_meta = get_metadata(SOMA_COORDINATE_SPACE_KEY);
 
     if (!coordinate_space_meta.has_value()) {
-        throw TileDBSOMAError(fmt::format(
-            "[SOMAGeometryDataFrame][initialize] Missing required '{}' "
-            "metadata key.",
-            SOMA_COORDINATE_SPACE_KEY));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[SOMAGeometryDataFrame][initialize] Missing required '{}' "
+                "metadata key.",
+                SOMA_COORDINATE_SPACE_KEY));
     }
 
     coord_space_ = std::apply(SOMACoordinateSpace::from_metadata, coordinate_space_meta.value());

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -112,11 +112,12 @@ SOMAGroup::SOMAGroup(
         default: {  // Only allow read/write when constructing from TileDB.
             const char* query_type_str = nullptr;
             tiledb_query_type_to_str(group_->query_type(), &query_type_str);
-            throw TileDBSOMAError(fmt::format(
-                "Internal error: SOMAGroup constructor does not accept a "
-                "TileDB group opened in mode '{}'. The group must be opened in "
-                "either read or write mode.",
-                query_type_str));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "Internal error: SOMAGroup constructor does not accept a "
+                    "TileDB group opened in mode '{}'. The group must be opened in "
+                    "either read or write mode.",
+                    query_type_str));
         }
     }
     fill_caches();

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -49,35 +49,39 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
     }
 
     if (schema->children != nullptr) {
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] release_schema name {} n_children {} begin "
-            "recurse ",
-            name_for_log,
-            schema->n_children));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] release_schema name {} n_children {} begin "
+                "recurse ",
+                name_for_log,
+                schema->n_children));
 
         for (auto i = 0; i < schema->n_children; i++) {
             if (schema->children[i] != nullptr) {
                 if (schema->children[i]->release != nullptr) {
-                    LOG_TRACE(fmt::format(
-                        "[ArrowAdapter] release_schema name {} schema->child "
-                        "{} "
-                        "release",
-                        name_for_log,
-                        i));
+                    LOG_TRACE(
+                        fmt::format(
+                            "[ArrowAdapter] release_schema name {} schema->child "
+                            "{} "
+                            "release",
+                            name_for_log,
+                            i));
                     schema->children[i]->release(schema->children[i]);
                 }
-                LOG_TRACE(fmt::format(
-                    "[ArrowAdapter] release_schema name {} schema->child {} "
-                    "free",
-                    name_for_log,
-                    i));
+                LOG_TRACE(
+                    fmt::format(
+                        "[ArrowAdapter] release_schema name {} schema->child {} "
+                        "free",
+                        name_for_log,
+                        i));
                 free(schema->children[i]);
                 schema->children[i] = nullptr;
             }
         }
 
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] release_schema name {} n_children {} end recurse ", name_for_log, schema->n_children));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] release_schema name {} n_children {} end recurse ", name_for_log, schema->n_children));
 
         free(schema->children);
         schema->children = nullptr;
@@ -100,10 +104,11 @@ void ArrowAdapter::release_schema(struct ArrowSchema* schema) {
 void ArrowAdapter::release_array(struct ArrowArray* array) {
     auto arrow_buffer = static_cast<ArrowBuffer*>(array->private_data);
     if (arrow_buffer != nullptr) {
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] release_array {} use_count={}",
-            arrow_buffer->buffer_->name(),
-            arrow_buffer->buffer_.use_count()));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] release_array {} use_count={}",
+                arrow_buffer->buffer_->name(),
+                arrow_buffer->buffer_.use_count()));
 
         // Delete the ArrowBuffer, which was allocated with new.
         // If the ArrowBuffer.buffer_ shared_ptr is the last reference to the
@@ -337,12 +342,13 @@ managed_unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
         child->dictionary = nullptr;
         child->release = &ArrowAdapter::release_schema;
         child->private_data = nullptr;
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] arrow_schema_from_tiledb_array dim {} format {} "
-            "name {}",
-            i,
-            child->format,
-            child->name));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] arrow_schema_from_tiledb_array dim {} format {} "
+                "name {}",
+                i,
+                child->format,
+                child->name));
     }
 
     for (uint32_t i = 0; i < nattr; ++i) {
@@ -363,12 +369,13 @@ managed_unique_ptr<ArrowSchema> ArrowAdapter::arrow_schema_from_tiledb_array(
         child->release = &ArrowAdapter::release_schema;
         child->private_data = nullptr;
 
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] arrow_schema_from_tiledb_array attr {} format {} "
-            "name {}",
-            i,
-            child->format,
-            child->name));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] arrow_schema_from_tiledb_array attr {} format {} "
+                "name {}",
+                i,
+                child->format,
+                child->name));
 
         auto enmr_name = AttributeExperimental::get_enumeration_name(*ctx, attr);
         if (enmr_name.has_value()) {
@@ -418,11 +425,12 @@ ArrowSchema* ArrowAdapter::arrow_schema_from_tiledb_dimension(const Dimension& d
     arrow_schema->dictionary = nullptr;
     arrow_schema->release = &ArrowAdapter::release_schema;
     arrow_schema->private_data = nullptr;
-    LOG_TRACE(fmt::format(
-        "[ArrowAdapter] arrow_schema_from_tiledb_dimension format {} "
-        "name {}",
-        arrow_schema->format,
-        arrow_schema->name));
+    LOG_TRACE(
+        fmt::format(
+            "[ArrowAdapter] arrow_schema_from_tiledb_dimension format {} "
+            "name {}",
+            arrow_schema->format,
+            arrow_schema->name));
 
     return arrow_schema;
 }
@@ -462,11 +470,12 @@ ArrowSchema* ArrowAdapter::arrow_schema_from_tiledb_attribute(
         ArrowSchemaSetMetadata(arrow_schema, reinterpret_cast<char*>(metadata_buffer->data));
     }
 
-    LOG_TRACE(fmt::format(
-        "[ArrowAdapter] arrow_schema_from_tiledb_array format {} "
-        "name {}",
-        arrow_schema->format,
-        arrow_schema->name));
+    LOG_TRACE(
+        fmt::format(
+            "[ArrowAdapter] arrow_schema_from_tiledb_array format {} "
+            "name {}",
+            arrow_schema->format,
+            arrow_schema->name));
 
     if (enmr_name.has_value()) {
         auto dict = (ArrowSchema*)malloc(sizeof(ArrowSchema));
@@ -805,23 +814,25 @@ std::tuple<ArraySchema, nlohmann::json> ArrowAdapter::tiledb_schema_from_arrow_s
         for (int64_t i = 0; i < index_column_schema->n_children; ++i) {
             if (strcmp(child->name, index_column_schema->children[i]->name) == 0) {
                 if (strcmp(child->name, SOMA_GEOMETRY_COLUMN_NAME.c_str()) == 0) {
-                    columns.push_back(SOMAGeometryColumn::create(
-                        ctx,
-                        child,
-                        index_column_schema->children[i],
-                        index_column_array->children[i],
-                        coordinate_space.value(),
-                        soma_type,
-                        type_metadata,
-                        platform_config));
+                    columns.push_back(
+                        SOMAGeometryColumn::create(
+                            ctx,
+                            child,
+                            index_column_schema->children[i],
+                            index_column_array->children[i],
+                            coordinate_space.value(),
+                            soma_type,
+                            type_metadata,
+                            platform_config));
                 } else {
-                    columns.push_back(SOMADimension::create(
-                        ctx,
-                        index_column_schema->children[i],
-                        index_column_array->children[i],
-                        soma_type,
-                        type_metadata,
-                        platform_config));
+                    columns.push_back(
+                        SOMADimension::create(
+                            ctx,
+                            index_column_schema->children[i],
+                            index_column_array->children[i],
+                            soma_type,
+                            type_metadata,
+                            platform_config));
                 }
                 isattr = false;
                 LOG_DEBUG(fmt::format("[ArrowAdapter] adding dimension {}", child->name));
@@ -960,11 +971,12 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema(
     FilterList filter_list = ArrowAdapter::_create_dim_filter_list(col_name, platform_config, soma_type, ctx);
 
     if (array->length != 5) {
-        throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
-            "'{}'",
-            array->length,
-            col_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "ArrowAdapter: unexpected length {} != 5 for name "
+                "'{}'",
+                array->length,
+                col_name));
     }
 
     const void* buff = array->buffers[1];
@@ -985,14 +997,16 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
     PlatformConfig platform_config) {
     if (strcmp(schema->format, "+l") != 0) {
         throw TileDBSOMAError(
-            fmt::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should be of type list."));
+            fmt::format(
+                "[tiledb_dimension_from_arrow_schema_ext] Schema "
+                "should be of type list."));
     }
 
     if (schema->n_children != 1) {
         throw TileDBSOMAError(
-            fmt::format("[tiledb_dimension_from_arrow_schema_ext] Schema "
-                        "should have exactly 1 child"));
+            fmt::format(
+                "[tiledb_dimension_from_arrow_schema_ext] Schema "
+                "should have exactly 1 child"));
     }
 
     auto type = ArrowAdapter::to_tiledb_format(schema->children[0]->format, type_metadata);
@@ -1006,11 +1020,12 @@ Dimension ArrowAdapter::tiledb_dimension_from_arrow_schema_ext(
     FilterList filter_list = ArrowAdapter::_create_dim_filter_list(col_name, platform_config, soma_type, ctx);
 
     if (array->length != 5) {
-        throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter: unexpected length {} != 5 for name "
-            "'{}'",
-            array->length,
-            col_name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "ArrowAdapter: unexpected length {} != 5 for name "
+                "'{}'",
+                array->length,
+                col_name));
     }
 
     const void* buff = array->children[0]->buffers[1];
@@ -1053,11 +1068,12 @@ std::pair<Attribute, std::optional<Enumeration>> ArrowAdapter::tiledb_attribute_
             ArrowAdapter::arrow_is_var_length_type(enmr_format) ? TILEDB_VAR_NUM : 1,
             arrow_schema->flags & ARROW_FLAG_DICTIONARY_ORDERED);
         AttributeExperimental::set_enumeration_name(*ctx, attr, enmr_label);
-        LOG_DEBUG(fmt::format(
-            "[ArrowAdapter] dictionary for '{}' as '{}' '{}'",
-            std::string(arrow_schema->name),
-            tiledb::impl::type_to_str(enmr_type),
-            std::string(enmr_format)));
+        LOG_DEBUG(
+            fmt::format(
+                "[ArrowAdapter] dictionary for '{}' as '{}' '{}'",
+                std::string(arrow_schema->name),
+                tiledb::impl::type_to_str(enmr_type),
+                std::string(enmr_format)));
     }
 
     return {attr, enmr};
@@ -1109,20 +1125,22 @@ std::pair<managed_unique_ptr<ArrowArray>, managed_unique_ptr<ArrowSchema>> Arrow
     exitIfError(ArrowArrayAllocateChildren(arr, 0), "Bad array children alloc");
     array->length = column->size();
 
-    LOG_TRACE(fmt::format(
-        "[ArrowAdapter] column type {} name {} nbuf {} {} nullable {}",
-        to_arrow_format(column->type()).data(),
-        column->name().data(),
-        n_buffers,
-        array->n_buffers,
-        column->is_nullable()));
+    LOG_TRACE(
+        fmt::format(
+            "[ArrowAdapter] column type {} name {} nbuf {} {} nullable {}",
+            to_arrow_format(column->type()).data(),
+            column->name().data(),
+            n_buffers,
+            array->n_buffers,
+            column->is_nullable()));
 
     if (array->n_buffers != n_buffers) {
-        throw TileDBSOMAError(fmt::format(
-            "[ArrowAdapter] expected array n_buffers {} for column {}; got {}",
-            n_buffers,
-            column->name(),
-            array->n_buffers));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[ArrowAdapter] expected array n_buffers {} for column {}; got {}",
+                n_buffers,
+                column->name(),
+                array->n_buffers));
     }
 
     // After allocating and initializing via nanoarrow we
@@ -1360,11 +1378,12 @@ managed_unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
     auto num_types = tiledb_datatypes.size();
 
     if (num_names != num_types) {
-        throw TileDBSOMAError(fmt::format(
-            "ArrowAdapter::make_arrow_schema: internal coding error: num_types "
-            "{} != num_names {}",
-            num_names,
-            num_types));
+        throw TileDBSOMAError(
+            fmt::format(
+                "ArrowAdapter::make_arrow_schema: internal coding error: num_types "
+                "{} != num_names {}",
+                num_names,
+                num_types));
     }
 
     auto arrow_schema = make_managed_unique<ArrowSchema>();
@@ -1382,8 +1401,12 @@ managed_unique_ptr<ArrowSchema> ArrowAdapter::make_arrow_schema(
 
     for (int i = 0; i < (int)num_names; i++) {
         auto dim_schema = make_arrow_schema_child(names[i], tiledb_datatypes[i]);
-        LOG_TRACE(fmt::format(
-            "[ArrowAdapter] make_arrow_schema child {} format {} name {}", i, dim_schema->format, dim_schema->name));
+        LOG_TRACE(
+            fmt::format(
+                "[ArrowAdapter] make_arrow_schema child {} format {} name {}",
+                i,
+                dim_schema->format,
+                dim_schema->name));
         arrow_schema->children[i] = dim_schema;
     }
 
@@ -1504,47 +1527,52 @@ ArrowArray* ArrowAdapter::_get_and_check_column(
     const ArrowTable& arrow_table, int64_t column_index, int64_t expected_n_buffers) {
     ArrowArray* arrow_array = arrow_table.first.get();
     if (column_index < 0 || column_index >= arrow_array->n_children) {
-        throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: column index {} out of "
-            "bounds {}..{}",
-            column_index,
-            0,
-            arrow_array->n_children - 1));
+        throw std::runtime_error(
+            fmt::format(
+                "ArrowAdapter::_get_and_check_column: column index {} out of "
+                "bounds {}..{}",
+                column_index,
+                0,
+                arrow_array->n_children - 1));
     }
 
     ArrowArray* child = arrow_array->children[column_index];
 
     if (child->n_children != 0) {
-        throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: column index {} is "
-            "non-terminal",
-            column_index));
+        throw std::runtime_error(
+            fmt::format(
+                "ArrowAdapter::_get_and_check_column: column index {} is "
+                "non-terminal",
+                column_index));
     }
 
     if (expected_n_buffers == 2) {
         if (child->n_buffers != 2) {
-            throw std::runtime_error(fmt::format(
-                "ArrowAdapter::_get_and_check_column: column index {} "
-                "has buffer count {}; expected 2 for non-string data",
-                column_index,
-                child->n_buffers));
+            throw std::runtime_error(
+                fmt::format(
+                    "ArrowAdapter::_get_and_check_column: column index {} "
+                    "has buffer count {}; expected 2 for non-string data",
+                    column_index,
+                    child->n_buffers));
         }
 
     } else if (expected_n_buffers == 3) {
         if (child->n_buffers != 3) {
-            throw std::runtime_error(fmt::format(
-                "ArrowAdapter::_get_and_check_column: column index {} is "
-                "has buffer count {}; expected 3 for string data",
-                column_index,
-                child->n_buffers));
+            throw std::runtime_error(
+                fmt::format(
+                    "ArrowAdapter::_get_and_check_column: column index {} is "
+                    "has buffer count {}; expected 3 for string data",
+                    column_index,
+                    child->n_buffers));
         }
 
     } else {
-        throw std::runtime_error(fmt::format(
-            "ArrowAdapter::_get_and_check_column: internal coding error: "
-            "expected_n_buffers {} is "
-            "neither 2 nor 3.",
-            expected_n_buffers));
+        throw std::runtime_error(
+            fmt::format(
+                "ArrowAdapter::_get_and_check_column: internal coding error: "
+                "expected_n_buffers {} is "
+                "neither 2 nor 3.",
+                expected_n_buffers));
     }
 
     return child;
@@ -1715,8 +1743,10 @@ size_t ArrowAdapter::_set_dictionary_buffers(Enumeration& enumeration, const Con
         case TILEDB_FLOAT64:
             return data_size / sizeof(double_t);
         default:
-            throw TileDBSOMAError(fmt::format(
-                "ArrowAdapter: Unsupported TileDB dict datatype: {} ", tiledb::impl::type_to_str(enumeration.type())));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "ArrowAdapter: Unsupported TileDB dict datatype: {} ",
+                    tiledb::impl::type_to_str(enumeration.type())));
     }
 }
 

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -1105,25 +1105,25 @@ class ArrowAdapter {
             }
             case TILEDB_UINT8:
                 return std::make_any<std::array<uint8_t, S>>(
-                    std::to_array((uint8_t(&)[S])(*((uint8_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((uint8_t (&)[S])(*((uint8_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_UINT16:
                 return std::make_any<std::array<uint16_t, S>>(
-                    std::to_array((uint16_t(&)[S])(*((uint16_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((uint16_t (&)[S])(*((uint16_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_UINT32:
                 return std::make_any<std::array<uint32_t, S>>(
-                    std::to_array((uint32_t(&)[S])(*((uint32_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((uint32_t (&)[S])(*((uint32_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_UINT64:
                 return std::make_any<std::array<uint64_t, S>>(
-                    std::to_array((uint64_t(&)[S])(*((uint64_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((uint64_t (&)[S])(*((uint64_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_INT8:
                 return std::make_any<std::array<int8_t, S>>(
-                    std::to_array((int8_t(&)[S])(*((int8_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((int8_t (&)[S])(*((int8_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_INT16:
                 return std::make_any<std::array<int16_t, S>>(
-                    std::to_array((int16_t(&)[S])(*((int16_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((int16_t (&)[S])(*((int16_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_INT32:
                 return std::make_any<std::array<int32_t, S>>(
-                    std::to_array((int32_t(&)[S])(*((int32_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((int32_t (&)[S])(*((int32_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_DATETIME_YEAR:
             case TILEDB_DATETIME_MONTH:
             case TILEDB_DATETIME_WEEK:
@@ -1139,7 +1139,7 @@ class ArrowAdapter {
             case TILEDB_DATETIME_AS:
             case TILEDB_INT64:
                 return std::make_any<std::array<int64_t, S>>(
-                    std::to_array((int64_t(&)[S])(*((int64_t*)array->buffers[1] + arrow_offset + offset))));
+                    std::to_array((int64_t (&)[S])(*((int64_t*)array->buffers[1] + arrow_offset + offset))));
             case TILEDB_FLOAT32:
                 return std::make_any<std::array<float_t, S>>(
                     std::to_array((float_t(&)[S])(*((float_t*)array->buffers[1] + arrow_offset + offset))));

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -70,10 +70,11 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
     auto column_it = std::find_if(columns.begin(), columns.end(), [&](auto col) { return col->name() == name; });
 
     if (column_it == columns.end()) {
-        throw TileDBSOMAError(fmt::format(
-            "[ArrowAdapter][tiledb_schema_from_arrow_schema] Index column "
-            "'{}' missing",
-            name));
+        throw TileDBSOMAError(
+            fmt::format(
+                "[ArrowAdapter][tiledb_schema_from_arrow_schema] Index column "
+                "'{}' missing",
+                name));
     }
 
     return *column_it;
@@ -99,11 +100,12 @@ Enumeration get_enumeration(
         try {
             return ArrayExperimental::get_enumeration(*ctx, *arr, old_way);
         } catch (const std::exception& e) {
-            throw TileDBSOMAError(fmt::format(
-                "[get_enumeration] Could not find enumeration with name '{} or "
-                "'{}'",
-                new_way,
-                old_way));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[get_enumeration] Could not find enumeration with name '{} or "
+                    "'{}'",
+                    new_way,
+                    old_way));
         }
     }
 }
@@ -119,20 +121,22 @@ std::string soma_type_from_tiledb_type(tiledb::Object::Type tiledb_type) {
         case Object::Type::Group:
             return "SOMAGroup";
         case Object::Type::Invalid:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAObject::open] Saw TileDB type Invalid ({}), which is "
-                "neither Array ({}) nor Group ({})",
-                static_cast<int>(tiledb_type),
-                static_cast<int>(Object::Type::Array),
-                static_cast<int>(Object::Type::Group)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAObject::open] Saw TileDB type Invalid ({}), which is "
+                    "neither Array ({}) nor Group ({})",
+                    static_cast<int>(tiledb_type),
+                    static_cast<int>(Object::Type::Array),
+                    static_cast<int>(Object::Type::Group)));
         default:
-            throw TileDBSOMAError(fmt::format(
-                "[SOMAObject::open] Saw unrecognized TileDB type ({}), which "
-                "is neither Array ({}) nor Group ({}) nor Invalid ({})",
-                static_cast<int>(tiledb_type),
-                static_cast<int>(Object::Type::Array),
-                static_cast<int>(Object::Type::Group),
-                static_cast<int>(Object::Type::Invalid)));
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMAObject::open] Saw unrecognized TileDB type ({}), which "
+                    "is neither Array ({}) nor Group ({}) nor Invalid ({})",
+                    static_cast<int>(tiledb_type),
+                    static_cast<int>(Object::Type::Array),
+                    static_cast<int>(Object::Type::Group),
+                    static_cast<int>(Object::Type::Invalid)));
     }
 }
 

--- a/libtiledbsoma/test/common.cc
+++ b/libtiledbsoma/test/common.cc
@@ -93,11 +93,12 @@ std::pair<managed_unique_ptr<ArrowSchema>, ArrowTable> create_arrow_schema_and_i
 // Create index-column info only, no schema involving the attrs
 ArrowTable create_column_index_info(const std::vector<DimInfo>& dim_infos) {
     for (auto info : dim_infos) {
-        LOG_DEBUG(fmt::format(
-            "create_column_index_info name={} type={} dim_max={}",
-            info.name,
-            tiledb::impl::to_str(info.tiledb_datatype),
-            info.dim_max));
+        LOG_DEBUG(
+            fmt::format(
+                "create_column_index_info name={} type={} dim_max={}",
+                info.name,
+                tiledb::impl::to_str(info.tiledb_datatype),
+                info.dim_max));
     }
 
     auto index_cols_info_schema = create_index_cols_info_schema(dim_infos);

--- a/libtiledbsoma/test/unit_geometry_envelope.cc
+++ b/libtiledbsoma/test/unit_geometry_envelope.cc
@@ -39,12 +39,15 @@ TEST_CASE("Geometry: Envelope") {
     LineString linestring(std::vector<BasePoint>({BasePoint(2, 2), BasePoint(3, 4)}));
     Polygon polygon(std::vector<BasePoint>({BasePoint(0, 0), BasePoint(1, 0), BasePoint(0, 1)}));
     MultiPoint multi_point(std::vector<Point>({Point(0, 0), Point(1, 1)}));
-    MultiLineString multi_linestring(std::vector<LineString>(
-        {LineString(std::vector<BasePoint>({BasePoint(2, 2), BasePoint(3, 4)})),
-         LineString(std::vector<BasePoint>({BasePoint(0, -2), BasePoint(3, 0)}))}));
-    MultiPolygon multi_polygon(std::vector<Polygon>(
-        {Polygon(std::vector<BasePoint>({BasePoint(0, 1), BasePoint(1, 1), BasePoint(-10, 10)})),
-         Polygon(std::vector<BasePoint>({BasePoint(-2, -2), BasePoint(-2, 2), BasePoint(2, 2), BasePoint(2, -2)}))}));
+    MultiLineString multi_linestring(
+        std::vector<LineString>(
+            {LineString(std::vector<BasePoint>({BasePoint(2, 2), BasePoint(3, 4)})),
+             LineString(std::vector<BasePoint>({BasePoint(0, -2), BasePoint(3, 0)}))}));
+    MultiPolygon multi_polygon(
+        std::vector<Polygon>(
+            {Polygon(std::vector<BasePoint>({BasePoint(0, 1), BasePoint(1, 1), BasePoint(-10, 10)})),
+             Polygon(
+                 std::vector<BasePoint>({BasePoint(-2, -2), BasePoint(-2, 2), BasePoint(2, 2), BasePoint(2, -2)}))}));
     GeometryCollection collection({point, linestring, polygon, multi_point, multi_linestring, multi_polygon});
 
     Envelope point_envelope = envelope(point);

--- a/libtiledbsoma/test/unit_geometry_roundtrip.cc
+++ b/libtiledbsoma/test/unit_geometry_roundtrip.cc
@@ -118,9 +118,10 @@ TEST_CASE("Geometry: Multipoint roundtrip") {
 }
 
 TEST_CASE("Geometry: MultiLineString roundtrip") {
-    MultiLineString multi_linestring(std::vector<LineString>(
-        {LineString(std::vector<BasePoint>({BasePoint(5.2, 1.3), BasePoint(1.0, 3.0), BasePoint(1.0, 1.4)})),
-         LineString(std::vector<BasePoint>({BasePoint(0, 100), BasePoint(3.15, 1.67)}))}));
+    MultiLineString multi_linestring(
+        std::vector<LineString>(
+            {LineString(std::vector<BasePoint>({BasePoint(5.2, 1.3), BasePoint(1.0, 3.0), BasePoint(1.0, 1.4)})),
+             LineString(std::vector<BasePoint>({BasePoint(0, 100), BasePoint(3.15, 1.67)}))}));
 
     BinaryBuffer buffer = to_wkb(GenericGeometry(multi_linestring));
     CHECK(buffer.size() == 107);
@@ -143,12 +144,13 @@ TEST_CASE("Geometry: MultiLineString roundtrip") {
 }
 
 TEST_CASE("Geometry: MultiPolygon roundtrip") {
-    MultiPolygon multi_polygon(std::vector<Polygon>(
-        {Polygon(
-             std::vector<BasePoint>({BasePoint(5.2, 1.3), BasePoint(1.0, 3.0), BasePoint(1.0, 1.4)}),
-             std::vector<std::vector<BasePoint>>(
-                 {std::vector<BasePoint>({BasePoint(5.234, 1.3), BasePoint(13.0, 3.0)})})),
-         Polygon(std::vector<BasePoint>({BasePoint(5.2, 6.3), BasePoint(1.3664, 3.0), BasePoint(1, 10)}))}));
+    MultiPolygon multi_polygon(
+        std::vector<Polygon>(
+            {Polygon(
+                 std::vector<BasePoint>({BasePoint(5.2, 1.3), BasePoint(1.0, 3.0), BasePoint(1.0, 1.4)}),
+                 std::vector<std::vector<BasePoint>>(
+                     {std::vector<BasePoint>({BasePoint(5.234, 1.3), BasePoint(13.0, 3.0)})})),
+             Polygon(std::vector<BasePoint>({BasePoint(5.2, 6.3), BasePoint(1.3664, 3.0), BasePoint(1, 10)}))}));
 
     BinaryBuffer buffer = to_wkb(GenericGeometry(multi_polygon));
     CHECK(buffer.size() == 167);

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -197,13 +197,14 @@ TEST_CASE("SOMAColumn: SOMADimension") {
     std::vector<std::shared_ptr<SOMAColumn>> columns;
 
     for (int64_t i = 0; i < index_columns.second->n_children; ++i) {
-        columns.push_back(SOMADimension::create(
-            ctx->tiledb_ctx(),
-            index_columns.second->children[i],
-            index_columns.first->children[i],
-            "SOMAGeometryDataFrame",
-            "",
-            platform_config));
+        columns.push_back(
+            SOMADimension::create(
+                ctx->tiledb_ctx(),
+                index_columns.second->children[i],
+                index_columns.first->children[i],
+                "SOMAGeometryDataFrame",
+                "",
+                platform_config));
 
         REQUIRE(columns.back()->tiledb_dimensions().value()[0].type() == dim_infos[i].tiledb_datatype);
     }

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -45,8 +45,9 @@ TEST_CASE("SOMADenseNDArray: basic", "[SOMADenseNDArray]") {
         REQUIRE(dnda->shape() == std::vector<int64_t>{dim_max + 1});
         dnda->close();
     } else {
-        REQUIRE_THROWS(SOMADenseNDArray::create(
-            uri, dim_arrow_format, index_columns, ctx, PlatformConfig(), TimestampRange(0, 2)));
+        REQUIRE_THROWS(
+            SOMADenseNDArray::create(
+                uri, dim_arrow_format, index_columns, ctx, PlatformConfig(), TimestampRange(0, 2)));
     }
 
     REQUIRE(SOMADenseNDArray::exists(uri, ctx));

--- a/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_geometry_dataframe.cc
@@ -131,8 +131,9 @@ TEST_CASE("SOMAGeometryDataFrame: Roundtrip", "[SOMAGeometryDataFrame]") {
     ArrowArrayStartAppending(data_array->children[1]);
     ArrowArrayStartAppending(data_array->children[2]);
 
-    geometry::GenericGeometry polygon = geometry::Polygon(std::vector<geometry::BasePoint>(
-        {geometry::BasePoint(0, 0), geometry::BasePoint(1, 0), geometry::BasePoint(0, 1)}));
+    geometry::GenericGeometry polygon = geometry::Polygon(
+        std::vector<geometry::BasePoint>(
+            {geometry::BasePoint(0, 0), geometry::BasePoint(1, 0), geometry::BasePoint(0, 1)}));
     NANOARROW_THROW_NOT_OK(ArrowBufferAppendUInt32(ArrowArrayBuffer(data_array->children[0], 1), 0));
     data_array->children[0]->length = 1;
     NANOARROW_THROW_NOT_OK(ArrowArrayAppendDouble(data_array->children[0]->children[0], 0));


### PR DESCRIPTION
Changes:
1. Run `pre-commit autoupdate`
2. Run pre-commit which auto-reformatted a bunch of stuff
3. Fix a handful of (now) redundant Python `# type: ignore` declarations

No (actual) code changes.