### PR TITLE
[python] Add obs_id_name/var_id_name params to ExperimentAxisQuery.to_anndata

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] At package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeError exception if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
+- \[[#4137](https://github.com/single-cell-data/TileDB-SOMA/pull/4137)\] [python] Add user-specified obs/var index column to `ExperimentAxisQuery.to_anndata`. This change will also set the index columns based upon metadata hints, following the conventions of `tiledbsoma.io`. See the docstrings for more details.
 
 ### Deprecated
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] At package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeError exception if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
-- \[[#4137](https://github.com/single-cell-data/TileDB-SOMA/pull/4137)\] [python] Add user-specified obs/var index column to `ExperimentAxisQuery.to_anndata`. This change will also set the index columns based upon metadata hints, following the conventions of `tiledbsoma.io`. See the docstrings for more details.
+- \[[#4137](https://github.com/single-cell-data/TileDB-SOMA/pull/4137)\] [python][BREAKING] Add user-specified obs/var index column to `ExperimentAxisQuery.to_anndata`. This change will also set the index columns based upon metadata hints, following the conventions of `tiledbsoma.io`. See the docstrings for more details. Prior to this change, the index dtype would be set to `string` in all cases - this change removes the forced cast, and leaves the column type as-is.
 
 ### Deprecated
 

--- a/apis/python/src/tiledbsoma/_constants.py
+++ b/apis/python/src/tiledbsoma/_constants.py
@@ -23,3 +23,5 @@ SPATIAL_DISCLAIMER = (
     "Support for spatial types is experimental. Changes to both the API and data "
     "storage may not be backwards compatible."
 )
+
+SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON = "soma_dataframe_original_index_name"

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import somacore
 from somacore import options
@@ -484,3 +485,30 @@ def sanitize_key(key: str) -> str:
         raise ValueError(f"{key} is not a supported name")
 
     return sanitized_name
+
+
+def _df_set_index(
+    df: pd.DataFrame,
+    default_index_name: str | None = None,
+    fallback_index_name: str | None = None,
+) -> None:
+    if default_index_name is not None:
+        # One or both of the following was true:
+        # - Original DataFrame had an index name (other than "index") ⇒ that name was written as `OriginalIndexMetadata`
+        # - `default_index_name` was provided (e.g. `{obs,var}_id_name` args to `to_anndata`)
+        #
+        # ⇒ Verify a column with that name exists, and set it as index (keeping its name).
+        if default_index_name not in df.keys():
+            raise ValueError(f"Requested ID column name {default_index_name} not found in input: {df.keys()}")
+        df.set_index(default_index_name, inplace=True)
+
+    else:
+        # The assumption here is that the original index was unnamed, and was given a "fallback name" (e.g. "obs_id",
+        # "var_id") during ingest that matches the `fallback_index_name` arg here. In this case, we restore that column
+        # as index, and remove the name.
+        #
+        # NOTE: several edge cases result in the outgested DF not matching the original DF; see
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
+        if fallback_index_name is not None and fallback_index_name in df:
+            df.set_index(fallback_index_name, inplace=True)
+            df.index.name = None

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -50,4 +50,3 @@ _UNS_OUTGEST_COLUMN_NAME_1D = "values"
 _UNS_OUTGEST_COLUMN_PREFIX_2D = "values_"
 
 _TILEDBSOMA_TYPE = "soma_tiledbsoma_type"
-_DATAFRAME_ORIGINAL_INDEX_NAME_JSON = "soma_dataframe_original_index_name"

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -68,7 +68,7 @@ from .. import (
 )
 from .._collection import AnyTileDBCollection, CollectionBase
 from .._common_nd_array import NDArray
-from .._constants import SOMA_JOINID
+from .._constants import SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, SOMA_JOINID
 from .._exception import (
     AlreadyExistsError,
     DoesNotExistError,
@@ -94,7 +94,6 @@ from ..options._tiledb_create_write_options import (
 )
 from . import conversions
 from ._common import (
-    _DATAFRAME_ORIGINAL_INDEX_NAME_JSON,
     _TILEDBSOMA_TYPE,
     _UNS_OUTGEST_COLUMN_NAME_1D,
     _UNS_OUTGEST_HINT_1D,
@@ -1490,7 +1489,7 @@ def _write_dataframe_impl(
             )
             # Save the original index name for outgest. We use JSON for elegant indication of index name
             # being None (in Python anyway).
-            soma_df.metadata[_DATAFRAME_ORIGINAL_INDEX_NAME_JSON] = json.dumps(original_index_metadata)
+            soma_df.metadata[SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON] = json.dumps(original_index_metadata)
         except (AlreadyExistsError, NotCreateableError) as e:
             if ingestion_params.error_if_already_exists:
                 raise SOMAError(f"{df_uri} already exists") from e

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -37,14 +37,13 @@ from .. import (
     _util,
     logging,
 )
-from .._constants import SOMA_JOINID
+from .._constants import SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, SOMA_JOINID
 from .._dask.load import SOMADaskConfig, load_daskarray
 from .._exception import SOMAError
 from .._types import NPNDArray, Path
-from .._util import MISSING, Sentinel, _resolve_futures
+from .._util import MISSING, Sentinel, _df_set_index, _resolve_futures
 from . import conversions
 from ._common import (
-    _DATAFRAME_ORIGINAL_INDEX_NAME_JSON,
     _UNS_OUTGEST_COLUMN_NAME_1D,
     _UNS_OUTGEST_COLUMN_PREFIX_2D,
     _UNS_OUTGEST_HINT_1D,
@@ -197,34 +196,18 @@ def _read_dataframe(
     `test_dataframe_io_roundtrips.py` / https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
     """
     # Read and validate the "original index metadata" stored alongside this SOMA DataFrame.
-    original_index_metadata = json.loads(df.metadata.get(_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, "null"))
+    original_index_metadata = json.loads(df.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, "null"))
     if not (original_index_metadata is None or isinstance(original_index_metadata, str)):
-        raise ValueError(f"{df.uri}: invalid {_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}")
+        raise ValueError(
+            f"{df.uri}: invalid {SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}"
+        )
 
     pdf: pd.DataFrame = df.read().concat().to_pandas()
     # SOMA DataFrames always have a `soma_joinid` added, as part of the ingest process, which we remove on outgest.
     pdf.drop(columns=SOMA_JOINID, inplace=True)
 
     default_index_name = default_index_name or original_index_metadata
-    if default_index_name is not None:
-        # One or both of the following was true:
-        # - Original DataFrame had an index name (other than "index") ⇒ that name was written as `OriginalIndexMetadata`
-        # - `default_index_name` was provided (e.g. `{obs,var}_id_name` args to `to_anndata`)
-        #
-        # ⇒ Verify a column with that name exists, and set it as index (keeping its name).
-        if default_index_name not in pdf.keys():
-            raise ValueError(f"Requested ID column name {default_index_name} not found in input: {pdf.keys()}")
-        pdf.set_index(default_index_name, inplace=True)
-    else:
-        # The assumption here is that the original index was unnamed, and was given a "fallback name" (e.g. "obs_id",
-        # "var_id") during ingest that matches the `fallback_index_name` arg here. In this case, we restore that column
-        # as index, and remove the name.
-        #
-        # NOTE: several edge cases result in the outgested DF not matching the original DF; see
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/2829.
-        if fallback_index_name is not None and fallback_index_name in pdf:
-            pdf.set_index(fallback_index_name, inplace=True)
-            pdf.index.name = None
+    _df_set_index(pdf, default_index_name, fallback_index_name)
 
     return pdf
 

--- a/apis/python/tests/test_dataframe_io_roundtrips.py
+++ b/apis/python/tests/test_dataframe_io_roundtrips.py
@@ -17,7 +17,7 @@ from pandas._testing import assert_frame_equal
 from scipy.sparse import csr_matrix
 
 from tiledbsoma import SOMA_JOINID, DataFrame, Experiment
-from tiledbsoma.io._common import _DATAFRAME_ORIGINAL_INDEX_NAME_JSON
+from tiledbsoma._constants import SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON
 from tiledbsoma.io._registration import AxisIDMapping
 from tiledbsoma.io.ingest import IngestionParams, _write_dataframe, from_anndata
 from tiledbsoma.io.outgest import _read_dataframe, to_anndata
@@ -118,7 +118,7 @@ def verify_metadata(sdf: DataFrame, persisted_column_names: list[str], persisted
         assert string_col_type == pa.large_string()
 
     # Verify "original index metadata"
-    actual_index_metadata = json.loads(sdf.metadata[_DATAFRAME_ORIGINAL_INDEX_NAME_JSON])
+    actual_index_metadata = json.loads(sdf.metadata[SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON])
     assert actual_index_metadata == persisted_metadata
 
 

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from concurrent import futures
@@ -20,6 +21,7 @@ from tiledbsoma import (
     pytiledbsoma,
 )
 from tiledbsoma._collection import CollectionBase
+from tiledbsoma._constants import SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON
 from tiledbsoma.experiment_query import X_as_series
 
 from tests._util import raises_no_typeguard
@@ -889,6 +891,13 @@ def test_experiment_query_historical(version, obs_params, var_params):
     obs_condition, obs_count = obs_params
     var_condition, var_count = var_params
 
+    def expected_index_name(df, hint, fallback) -> str:
+        if hint:
+            return json.loads(hint)
+        if fallback in df.columns:
+            return fallback
+        return ""
+
     with soma.open(uri) as exp:
         query = exp.axis_query(
             measurement_name="RNA",
@@ -901,3 +910,24 @@ def test_experiment_query_historical(version, obs_params, var_params):
 
         var = query.var().concat()
         assert len(var) == var_count
+
+        adata = query.to_anndata("data")
+        assert adata.n_obs == obs_count
+        assert adata.n_vars == var_count
+        assert adata.X.shape == (obs_count, var_count)
+        assert adata.obs.index.name == expected_index_name(
+            obs.to_pandas(), exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None), "obs_id"
+        )
+        assert adata.var.index.name == expected_index_name(
+            var.to_pandas(),
+            exp.ms["RNA"].var.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
+            "var_id",
+        )
+
+        adata = query.to_anndata("data", obs_id_name="soma_joinid", var_id_name="soma_joinid")
+        assert adata.obs.index.name == "soma_joinid"
+        assert adata.var.index.name == "soma_joinid"
+
+        adata = query.to_anndata("data", obs_id_name="obs_id", var_id_name="var_id")
+        assert adata.obs.index.name == "obs_id"
+        assert adata.var.index.name == "var_id"


### PR DESCRIPTION
Add functionality to `ExperimentAxisQuery.to_anndata` which will set the axis dataframe index:
* on user request
* or using the ingestion-time metadata

Fixes SOMA-89

Acknowledgement: this is largely based upon #3779 
