### PR TITLE
[r/docs] Update missing docs

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.18.99.1
+Version: 1.18.99.2
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = "aut", email = "aaron@tiledb.com",

--- a/apis/r/man/SOMAArrayBase.Rd
+++ b/apis/r/man/SOMAArrayBase.Rd
@@ -66,7 +66,7 @@ Open the SOMA object for read or write.\cr
 called directly; use factory functions
 (eg. \code{\link{SOMASparseNDArrayOpen}()}) instead.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMAArrayBase$open(mode = c("READ", "WRITE"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMAArrayBase$open(mode = c("READ", "WRITE", "DELETE"))}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -83,7 +83,7 @@ Open the SOMA collection for read or write.\cr
 called#' directly; use factory functions
 (eg. \code{\link{SOMACollectionOpen}()}) instead.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$open(mode = c("READ", "WRITE"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$open(mode = c("READ", "WRITE", "DELETE"))}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/apis/r/man/SOMAObject.Rd
+++ b/apis/r/man/SOMAObject.Rd
@@ -122,6 +122,7 @@ The mode of the object, one of:
 \item \dQuote{\code{CLOSED}}
 \item \dQuote{\code{READ}}
 \item \dQuote{\code{WRITE}}
+\item \dQuote{\code{DELETE}}
 }
 }
 }
@@ -141,6 +142,7 @@ Close and reopen the TileDB object in a new mode
 \itemize{
 \item \dQuote{\code{READ}}
 \item \dQuote{\code{WRITE}}
+\item \dQuote{\code{DELETE}}
 }}
 
 \item{\code{tiledb_timestamp}}{Optional Datetime (POSIXct) with TileDB timestamp}


### PR DESCRIPTION
It looks like some delete-mode docs for R weren't generated; this PR generates them

Fixes [SOMA-329](https://linear.app/tiledb/issue/SOMA-329/r-update-missing-docs)