### PR TITLE
[ci] Run `backport.yml` only on backport-labeled PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,6 +15,15 @@ jobs:
     name: Backport
     steps:
       - name: Backport
+        if: >
+          github.event.pull_request.merged
+          && (
+            github.event.action == 'closed'
+            || (
+              github.event.action == 'labeled'
+              && contains(github.event.label.name, 'backport')
+            )
+          )
         uses: tibdex/backport@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backport v2 runs on any labeled PR and throws an error if the PR is open; this updates the action to run only on merged PRs with a backport label

Condition taken from the [example `backport.yml`](https://github.com/tibdex/backport/blob/7005ef85c4562bc23b0e9b4a9940d5922f439750/.github/workflows/backport.yml)

Fixes [SOMA-330](https://linear.app/tiledb/issue/SOMA-330/run-backportyml-only-on-backport-labeled-prs)