### PR TITLE
[c++/python/r] Remove extra ManagedQuery constructors

### DIFF
--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -31,7 +31,15 @@ void load_managed_query(py::module& m) {
     py::class_<ManagedQuery>(m, "ManagedQuery")
         .def(
             py::init([](SOMAArray array, std::shared_ptr<SOMAContext> ctx, std::string_view name) {
-                return ManagedQuery(array, ctx->tiledb_ctx(), name);
+                return array.create_managed_query(ctx, name);
+            }),
+            py::arg("array"),
+            py::arg("ctx"),
+            py::arg("name") = "unnamed")
+
+        .def(
+            py::init([](SOMAArray array, std::shared_ptr<SOMAContext> ctx, std::string_view name) {
+                return array.create_managed_query(name);
             }),
             py::arg("array"),
             py::arg("ctx"),

--- a/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_dense_ndarray.cc
@@ -28,7 +28,7 @@ using namespace py::literals;
 using namespace tiledbsoma;
 
 void write(SOMAArray& array, py::array data) {
-    ManagedQuery mq(array, array.ctx()->tiledb_ctx());
+    auto mq = array.create_managed_query();
 
     py::buffer_info data_info = data.request();
     mq.setup_write_column("soma_data", data.size(), (const void*)data_info.ptr, (uint64_t*)nullptr);

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -202,7 +202,7 @@ void writeArrayFromArrow(
 
     std::unique_ptr<tdbs::SOMAArray> arrup = tdbs::SOMAArray::open(OpenMode::soma_write, uri, somactx, tsrng);
 
-    auto mq = tdbs::ManagedQuery(*arrup, somactx->tiledb_ctx(), "unnamed");
+    auto mq = arrup->create_managed_query("unnamed");
     mq.set_layout(arraytype == "SOMADenseNDArray" ? ResultOrder::colmajor : ResultOrder::automatic);
     mq.set_array_data(schema.get(), array.get());
     mq.submit_write();

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -88,7 +88,7 @@ SEXP soma_array_reader(
     // Read selected columns from the uri (return is unique_ptr<SOMAArray>)
     auto sr = tdbs::SOMAArray::open(OpenMode::soma_read, uri, somactx, tsrng);
 
-    auto mq = tdbs::ManagedQuery(*sr, somactx->tiledb_ctx(), "unnamed");
+    auto mq = sr->create_managed_query("unnamed");
     mq.set_layout(tdb_result_order);
     if (!column_names.empty()) {
         mq.select_columns(column_names);
@@ -214,7 +214,7 @@ void set_log_level(const std::string& level) {
 // [[Rcpp::export]]
 Rcpp::CharacterVector get_column_types(const std::string& uri, const std::vector<std::string>& colnames) {
     auto sr = tdbs::SOMAArray::open(OpenMode::soma_read, uri);
-    auto mq = tdbs::ManagedQuery(*sr, sr->ctx()->tiledb_ctx());
+    auto mq = sr->create_managed_query();
     auto sr_data = mq.read_next();
     size_t n = colnames.size();
     Rcpp::CharacterVector vs(n);

--- a/apis/r/src/riterator.cpp
+++ b/apis/r/src/riterator.cpp
@@ -110,7 +110,7 @@ Rcpp::XPtr<tdbs::ManagedQuery> mq_setup(
 
     auto arr = tdbs::SOMAArray(OpenMode::soma_read, uri, somactx, tsrng);
 
-    auto mq = new tdbs::ManagedQuery(arr, somactx->tiledb_ctx(), name);
+    auto mq = new tdbs::ManagedQuery(arr.tiledb_array(), somactx->tiledb_ctx(), name);
     mq->set_layout(tdb_result_order);
     if (!column_names.empty()) {
         mq->select_columns(column_names);

--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -31,12 +31,12 @@ void test_sdf(const std::string& uri) {
 
     // Read all values from the obs array
     auto obs = SOMAArray::open(OpenMode::soma_read, uri + "/obs", ctx);
-    auto obs_mq = ManagedQuery(*obs, ctx->tiledb_ctx(), "obs");
+    auto obs_mq = obs->create_managed_query("obs");
     auto obs_data = obs_mq.read_next();
 
     // Read all values from the var array
     auto var = SOMAArray::open(OpenMode::soma_read, uri + "/ms/RNA/var", ctx);
-    auto var_mq = ManagedQuery(*var, ctx->tiledb_ctx(), "var");
+    auto var_mq = var->create_managed_query("var");
     auto var_data = var_mq.read_next();
 
     // Check if obs and var reads are complete
@@ -46,7 +46,7 @@ void test_sdf(const std::string& uri) {
 
     // Read all values from the X/data array
     auto x_data = SOMAArray::open(OpenMode::soma_read, uri + "/ms/RNA/X/data", std::make_shared<SOMAContext>(config));
-    auto x_mq = ManagedQuery(*x_data, ctx->tiledb_ctx(), "X/data");
+    auto x_mq = x_data->create_managed_query("X/data");
 
     int batches = 0;
     int total_num_rows = 0;
@@ -66,7 +66,7 @@ void test_arrow(const std::string& uri) {
     auto ctx = std::make_shared<SOMAContext>();
     const std::vector<std::string>& colnames{"n_counts", "n_genes", "louvain"};
     auto obs = tdbs::SOMAArray::open(OpenMode::soma_read, uri, ctx);
-    auto obs_mq = ManagedQuery(*obs, ctx->tiledb_ctx(), "");
+    auto obs_mq = obs->create_managed_query("");
     // Getting next batch:  std::optional<std::shared_ptr<ArrayBuffers>>
     auto obs_data = obs_mq.read_next();
     if (!obs_mq.results_complete()) {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -18,7 +18,6 @@
 
 #include <unordered_set>
 
-#include "soma_array.h"
 #include "utils/common.h"
 #include "utils/logger.h"
 #include "utils/util.h"
@@ -36,14 +35,6 @@ ManagedQuery::ManagedQuery(std::shared_ptr<Array> array, std::shared_ptr<Context
     , array_(array)
     , name_(name)
     , schema_(std::make_shared<ArraySchema>(array->schema())) {
-    reset();
-}
-
-ManagedQuery::ManagedQuery(SOMAArray array, std::shared_ptr<Context> ctx, std::string_view name)
-    : ctx_(ctx)
-    , array_(array.arr_)
-    , name_(name)
-    , schema_(std::make_shared<ArraySchema>(array.arr_->schema())) {
     reset();
 }
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -66,8 +66,6 @@ class ManagedQuery {
      */
     ManagedQuery(std::shared_ptr<Array> array, std::shared_ptr<Context> ctx, std::string_view name = "unnamed");
 
-    ManagedQuery(SOMAArray array, std::shared_ptr<Context> ctx, std::string_view name = "unnamed");
-
     /** No default constructor. */
     ManagedQuery() = delete;
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -68,40 +68,11 @@ class ManagedQuery {
 
     ManagedQuery(SOMAArray array, std::shared_ptr<Context> ctx, std::string_view name = "unnamed");
 
+    /** No default constructor. */
     ManagedQuery() = delete;
 
-    ManagedQuery(const ManagedQuery& other)
-        : ctx_(other.ctx_)
-        , array_(other.array_)
-        , name_(other.name_)
-        , schema_(other.schema_)
-        , query_(std::make_unique<Query>(*other.ctx_, *other.array_))
-        , subarray_(std::make_unique<Subarray>(*other.ctx_, *other.array_))
-        , subarray_range_set_(other.subarray_range_set_)
-        , subarray_range_empty_(other.subarray_range_empty_)
-        , columns_(other.columns_)
-        , results_complete_(other.results_complete_)
-        , total_num_cells_(other.total_num_cells_)
-        , buffers_(other.buffers_)
-        , query_submitted_(other.query_submitted_) {
-    }
-
-    ManagedQuery& operator=(const ManagedQuery& other) {
-        ctx_ = other.ctx_;
-        array_ = other.array_;
-        name_ = other.name_;
-        schema_ = other.schema_;
-        query_ = std::make_unique<Query>(*other.ctx_, *other.array_);
-        subarray_ = std::make_unique<Subarray>(*other.ctx_, *other.array_);
-        subarray_range_set_ = other.subarray_range_set_;
-        subarray_range_empty_ = other.subarray_range_empty_;
-        columns_ = other.columns_;
-        results_complete_ = other.results_complete_;
-        total_num_cells_ = other.total_num_cells_;
-        buffers_ = other.buffers_;
-        query_submitted_ = other.query_submitted_;
-        return *this;
-    }
+    /** No copy constructor: use move constructor instead. */
+    ManagedQuery(const ManagedQuery&) = delete;
 
     ManagedQuery(ManagedQuery&& other)
         : ctx_(std::move(other.ctx_))

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -190,10 +190,6 @@ const std::string SOMAArray::uri() const {
     return uri_;
 };
 
-std::shared_ptr<SOMAContext> SOMAArray::ctx() {
-    return ctx_;
-};
-
 void SOMAArray::open(OpenMode mode, std::optional<TimestampRange> timestamp) {
     timestamp_ = timestamp;
     soma_mode_ = mode;

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -73,8 +73,6 @@ using StatusAndReason = std::pair<bool, std::string>;
 
 class SOMAArray : public SOMAObject {
    public:
-    friend class ManagedQuery;
-
     //===================================================================
     //= public static
     //===================================================================
@@ -187,7 +185,9 @@ class SOMAArray : public SOMAObject {
      *
      * @return SOMAContext
      */
-    std::shared_ptr<SOMAContext> ctx();
+    inline std::shared_ptr<SOMAContext> ctx() {
+        return ctx_;
+    }
 
     /**
      * Open the SOMAArray object.
@@ -196,6 +196,33 @@ class SOMAArray : public SOMAObject {
      * @param timestamp Timestamp
      */
     void open(OpenMode mode, std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * Creates a new ManagedQuery for this array.
+     *
+     * @param name Name of the array.
+     */
+    inline ManagedQuery create_managed_query(std::string_view name = "unnamed") const {
+        return ManagedQuery(arr_, ctx_->tiledb_ctx(), name);
+    }
+
+    /**
+     * Returns a shared pointer of the internal TileDB array.
+     */
+    inline std::shared_ptr<Array> tiledb_array() {
+        return arr_;
+    }
+
+    /**
+     * Creates a new ManagedQuery for this array.
+     *
+     * @param ctx SOMA context to use for the query.
+     * @param name Name of the array.
+     */
+    inline ManagedQuery create_managed_query(
+        std::shared_ptr<SOMAContext> query_ctx, std::string_view name = "unnamed") const {
+        return ManagedQuery(arr_, query_ctx->tiledb_ctx(), name);
+    }
 
     /**
      * Close the SOMAArray object.

--- a/libtiledbsoma/test/unit_soma_column.cc
+++ b/libtiledbsoma/test/unit_soma_column.cc
@@ -135,7 +135,7 @@ struct VariouslyIndexedDataFrameFixture {
         }
         char_offsets.push_back(offset);
 
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         mq.setup_write_column(i64_name, i64_data.size(), i64_data.data(), (uint64_t*)nullptr);
         mq.setup_write_column(str_name, strings.size(), char_data.data(), char_offsets.data());
         mq.setup_write_column(u32_name, u32_data.size(), u32_data.data(), (uint64_t*)nullptr);
@@ -337,7 +337,7 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        ManagedQuery external_query(*open(OpenMode::soma_read), ctx_->tiledb_ctx());
+        auto external_query = open(OpenMode::soma_read)->create_managed_query();
 
         columns[1]->select_columns(external_query);
         columns[1]->set_dim_point<uint32_t>(external_query, 1234);
@@ -484,7 +484,7 @@ TEST_CASE_METHOD(
 
         sdf->close();
 
-        ManagedQuery external_query(*open(OpenMode::soma_read), ctx_->tiledb_ctx());
+        auto external_query = open(OpenMode::soma_read)->create_managed_query();
 
         columns[1]->select_columns(external_query);
         columns[1]->set_dim_point<uint32_t>(external_query, 1234);

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -131,7 +131,7 @@ struct VariouslyIndexedDataFrameFixture {
         }
         char_offsets.push_back(offset);
 
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         mq.setup_write_column(i64_name, i64_data.size(), i64_data.data(), (uint64_t*)nullptr);
         mq.setup_write_column(str_name, strings.size(), char_data.data(), char_offsets.data());
         mq.setup_write_column(u32_name, u32_data.size(), u32_data.data(), (uint64_t*)nullptr);
@@ -172,7 +172,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: basic", "[SOM
     // A write in read mode should fail
     {
         sdf = open(OpenMode::soma_read);
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_infos[0].name, a0.size(), a0.data(), (uint64_t*)nullptr);
         REQUIRE_THROWS(mq.submit_write());
@@ -181,7 +181,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: basic", "[SOM
 
     {
         sdf = open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_infos[0].name, a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -190,7 +190,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: basic", "[SOM
 
     {
         sdf = open(OpenMode::soma_read);
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         while (auto batch = mq.read_next()) {
             auto arrbuf = batch.value();
             auto d0span = arrbuf->at(dim_infos[0].name)->data<int64_t>();
@@ -363,7 +363,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: bounds-checki
 
     {
         auto sdf = open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
 
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_infos[0].name, a0.size(), a0.data(), (uint64_t*)nullptr);
@@ -378,7 +378,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: bounds-checki
 
     {
         auto sdf = open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*sdf, ctx_->tiledb_ctx());
+        auto mq = sdf->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_infos[0].name, a0.size(), a0.data(), (uint64_t*)nullptr);
         // Writing after resize should succeed

--- a/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_point_cloud_dataframe.cc
@@ -71,7 +71,7 @@ TEST_CASE("SOMAPointCloudDataFrame: basic", "[point_cloud_dataframe][spatial]") 
     // Write to point cloud.
     {
         auto soma_point_cloud = SOMAPointCloudDataFrame::open(uri, OpenMode::soma_write, ctx);
-        auto mq = ManagedQuery(*soma_point_cloud, ctx->tiledb_ctx());
+        auto mq = soma_point_cloud->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(dim_infos[1].name, d1.size(), d1.data(), (uint64_t*)nullptr);
         mq.setup_write_column(dim_infos[2].name, d2.size(), d2.data(), (uint64_t*)nullptr);
@@ -83,7 +83,7 @@ TEST_CASE("SOMAPointCloudDataFrame: basic", "[point_cloud_dataframe][spatial]") 
     // Read back the data.
     {
         auto soma_point_cloud = SOMAPointCloudDataFrame::open(uri, OpenMode::soma_read, ctx, std::nullopt);
-        auto mq = ManagedQuery(*soma_point_cloud, ctx->tiledb_ctx());
+        auto mq = soma_point_cloud->create_managed_query();
         while (auto batch = mq.read_next()) {
             auto arrbuf = batch.value();
             auto d0span = arrbuf->at(dim_infos[0].name)->data<int64_t>();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -72,7 +72,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     // A write in read mode should fail
     {
         snda->open(OpenMode::soma_read);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
         REQUIRE_THROWS(mq.submit_write());
@@ -81,7 +81,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
 
     {
         snda->open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -90,7 +90,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
 
     {
         snda->open(OpenMode::soma_read);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         while (auto batch = mq.read_next()) {
             auto arrbuf = batch.value();
             auto d0span = arrbuf->at(dim_name)->data<int64_t>();
@@ -111,7 +111,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     // the (mutable) current domain.
     {
         snda->open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
         REQUIRE_THROWS(mq.submit_write());
@@ -130,7 +130,7 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     // Try out-of-bounds write after resize.
     {
         snda->open(OpenMode::soma_write);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
         mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
         // Implicitly checking for no throw
@@ -381,7 +381,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
     {
         auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -395,7 +395,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
     {
         auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -410,7 +410,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
     {
         auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -424,7 +424,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
     a0 = {3, 3, 3};
     {
         auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq = snda->create_managed_query();
         mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq.submit_write();
@@ -439,7 +439,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
     {
         auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-        auto mq1 = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq1 = snda->create_managed_query();
         mq1.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq1.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq1.submit_write();
@@ -448,7 +448,7 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
 
         d0 = {12, 13, 14};
         a0 = {5, 5, 5};
-        auto mq2 = ManagedQuery(*snda, ctx->tiledb_ctx());
+        auto mq2 = snda->create_managed_query();
         mq2.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
         mq2.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
         mq2.submit_write();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -70,30 +70,36 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     std::vector<int32_t> a0(10, 1);
 
     // A write in read mode should fail
-    snda->open(OpenMode::soma_read);
-    auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
-    REQUIRE_THROWS(mq.submit_write());
-    snda->close();
-
-    snda->open(OpenMode::soma_write);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
-
-    snda->open(OpenMode::soma_read);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    while (auto batch = mq.read_next()) {
-        auto arrbuf = batch.value();
-        auto d0span = arrbuf->at(dim_name)->data<int64_t>();
-        auto a0span = arrbuf->at(attr_name)->data<int32_t>();
-        REQUIRE(d0 == std::vector<int64_t>(d0span.begin(), d0span.end()));
-        REQUIRE(a0 == std::vector<int32_t>(a0span.begin(), a0span.end()));
+    {
+        snda->open(OpenMode::soma_read);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
+        REQUIRE_THROWS(mq.submit_write());
+        snda->close();
     }
-    snda->close();
+
+    {
+        snda->open(OpenMode::soma_write);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column(attr_name, a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq.submit_write();
+        snda->close();
+    }
+
+    {
+        snda->open(OpenMode::soma_read);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        while (auto batch = mq.read_next()) {
+            auto arrbuf = batch.value();
+            auto d0span = arrbuf->at(dim_name)->data<int64_t>();
+            auto a0span = arrbuf->at(attr_name)->data<int32_t>();
+            REQUIRE(d0 == std::vector<int64_t>(d0span.begin(), d0span.end()));
+            REQUIRE(a0 == std::vector<int32_t>(a0span.begin(), a0span.end()));
+        }
+        snda->close();
+    }
 
     std::vector<int64_t> d0b({dim_max, dim_max + 1});
     std::vector<int64_t> a0b({30, 40});
@@ -103,16 +109,18 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     //   outside the (immutable) doqain.
     // * With current domain support: this should throw since it's outside
     // the (mutable) current domain.
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
-    mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
-    REQUIRE_THROWS(mq.submit_write());
-    snda->close();
+    {
+        snda->open(OpenMode::soma_write);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
+        mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
+        REQUIRE_THROWS(mq.submit_write());
+        snda->close();
+    }
 
     auto new_shape = std::vector<int64_t>({shape * 2});
 
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+    snda->open(OpenMode::soma_write);
     // Should throw since this already has a shape (core current
     // domain).
     REQUIRE_THROWS(snda->upgrade_shape(new_shape, "testing"));
@@ -120,14 +128,15 @@ TEST_CASE("SOMASparseNDArray: basic", "[SOMASparseNDArray]") {
     snda->close();
 
     // Try out-of-bounds write after resize.
-    snda->open(OpenMode::soma_write);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
-    mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
-    // Implicitly checking for no throw
-    mq.submit_write();
-    snda->close();
-
+    {
+        snda->open(OpenMode::soma_write);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_name, d0b.size(), d0b.data(), (uint64_t*)nullptr);
+        mq.setup_write_column(attr_name, a0b.size(), a0b.data(), (uint64_t*)nullptr);
+        // Implicitly checking for no throw
+        mq.submit_write();
+        snda->close();
+    }
     snda->open(OpenMode::soma_read);
     REQUIRE(snda->shape() == new_shape);
     snda->close();
@@ -370,75 +379,83 @@ TEST_CASE("SOMASparseNDArray: nnz", "[SOMASparseNDArray]") {
     std::vector<int64_t> d0 = {1, 2, 3};
     std::vector<int32_t> a0 = {0, 0, 0};
 
-    auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
+    {
+        auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq.submit_write();
+        snda->close();
 
-    REQUIRE(snda->nnz() == 3);
-
+        REQUIRE(snda->nnz() == 3);
+    }
     // Write to non overlapping fragment
     d0 = {4, 5, 6};
     a0 = {1, 1, 1};
 
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
+    {
+        auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq.submit_write();
+        snda->close();
 
-    REQUIRE(snda->nnz() == 6);
+        REQUIRE(snda->nnz() == 6);
+    }
 
     // Write to partially overlapping fragment
     d0 = {6, 7, 8};
     a0 = {2, 2, 2};
 
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
+    {
+        auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq.submit_write();
+        snda->close();
 
-    REQUIRE(snda->nnz() == 8);
+        REQUIRE(snda->nnz() == 8);
+    }
 
     // Write to overlapping fragment
     d0 = {1, 4, 8};
     a0 = {3, 3, 3};
+    {
+        auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+        auto mq = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq.submit_write();
+        snda->close();
 
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
-
-    REQUIRE(snda->nnz() == 8);
+        REQUIRE(snda->nnz() == 8);
+    }
 
     // Write separate overlapping fragments
     d0 = {10, 11, 12};
     a0 = {4, 4, 4};
 
-    snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
+    {
+        auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
+        auto mq1 = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq1.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq1.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq1.submit_write();
 
-    mq.reset();
-    d0 = {12, 13, 14};
-    a0 = {5, 5, 5};
+        mq1.reset();
 
-    mq = ManagedQuery(*snda, ctx->tiledb_ctx());
-    mq.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
-    mq.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
-    mq.submit_write();
-    snda->close();
+        d0 = {12, 13, 14};
+        a0 = {5, 5, 5};
+        auto mq2 = ManagedQuery(*snda, ctx->tiledb_ctx());
+        mq2.setup_write_column(dim_infos[0].name, d0.size(), d0.data(), (uint64_t*)nullptr);
+        mq2.setup_write_column("soma_data", a0.size(), a0.data(), (uint64_t*)nullptr);
+        mq2.submit_write();
+        snda->close();
 
-    REQUIRE(snda->nnz() == 13);
+        REQUIRE(snda->nnz() == 13);
+    }
 }
 
 TEST_CASE("SOMASparseNDArray: resize with timestamp", "[SOMASparseNDArray]") {


### PR DESCRIPTION
**Changes:**
* Remove copy constructor for `ManagedQuery`.
* Remove constructor from `ManagedQuery` that uses private `SOMAArray` members.
* Add method to `SOMAArray` that creates and returns a `ManagedQuery`.
* Add method to `SOMAArray` that returns internal TileDB array.
* Use the above in Python and R.

**Notes for Reviewer:**
Pull off of branch adding deletes.