### PR TITLE
[python] add lock around SOMAGroup reification

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- \[[#4147](https://github.com/single-cell-data/TileDB-SOMA/pull/4147)\] [python] Fix a race condition in SOMA collection caching which would result in redundant object opens.
+
 ### Security
 
 ## [Release 1.18.0]

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -696,7 +696,7 @@ class ExperimentAxisQuery(query.ExperimentAxisQuery):
         original_index_metadata = json.loads(axis_df.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, "null"))
         if not (original_index_metadata is None or isinstance(original_index_metadata, str)):
             raise ValueError(
-                f"{axis_df.uri}: invalid {SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}"
+                f"{axis_df.uri}: invalid {SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}",
             )
 
         df: pd.DataFrame = arrow_table.to_pandas()

--- a/apis/python/src/tiledbsoma/io/outgest.py
+++ b/apis/python/src/tiledbsoma/io/outgest.py
@@ -199,7 +199,7 @@ def _read_dataframe(
     original_index_metadata = json.loads(df.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, "null"))
     if not (original_index_metadata is None or isinstance(original_index_metadata, str)):
         raise ValueError(
-            f"{df.uri}: invalid {SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}"
+            f"{df.uri}: invalid {SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON} metadata: {original_index_metadata}",
         )
 
     pdf: pd.DataFrame = df.read().concat().to_pandas()

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -916,7 +916,7 @@ def test_experiment_query_historical(version, obs_params, var_params):
         assert adata.n_vars == var_count
         assert adata.X.shape == (obs_count, var_count)
         assert adata.obs.index.name == expected_index_name(
-            obs.to_pandas(), exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None), "obs_id"
+            obs.to_pandas(), exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None), "obs_id",
         )
         assert adata.var.index.name == expected_index_name(
             var.to_pandas(),

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -916,7 +916,9 @@ def test_experiment_query_historical(version, obs_params, var_params):
         assert adata.n_vars == var_count
         assert adata.X.shape == (obs_count, var_count)
         assert adata.obs.index.name == expected_index_name(
-            obs.to_pandas(), exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None), "obs_id",
+            obs.to_pandas(),
+            exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
+            "obs_id",
         )
         assert adata.var.index.name == expected_index_name(
             var.to_pandas(),


### PR DESCRIPTION
The SOMAGroup / Collection caches reified objects in getitem. This code lacked any concurrency protection, so objects requested concurrently would repeatedly load and overwrite the cache slot in the parent group.

This had a couple of problematic effects if a race to populate the cache occurs:
* the TileDB group is read multiple times, create multiple SOMA objects, etc. Essentially a performance problem
* unlike serial invocations, it would return different SOMA objects for the same underlying array, causing object identity tests to fail (we don't normally promise that the identities are `eq`, but a side effect of the cache is that they are anyway)

Changes:
* add a simple mutex around the cache update
* pre-commit/ruff also reformatted a couple of misc files for free
* this PR (randomly) tripped over a test bug which was partially fixed in #4135. The fix for other array types was added in this PR