### PR TITLE
[python] enable Ruff lint rules BLE, C4 and YTT

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -26,6 +26,8 @@ line-length = 120
 [tool.ruff.lint]
 select = [  # see https://docs.astral.sh/ruff/rules/
     "B",    # flake8-bugbear
+    "BLE",  # flake8-blind-exception
+    "C4",   # flake8-comprehensions
     "COM",  # flake8-commas
     "D",    # pydocstyle (Google convention, see setting below)
     "E",    # pycodestyle
@@ -35,6 +37,7 @@ select = [  # see https://docs.astral.sh/ruff/rules/
     "ISC",  # flake8-implicit-str-concat
     "S",    # flake8-bandit
     "W",    # pycodestyle warnings
+    "YTT",  # flake8-2020
 ]
 ignore = [
     "E501",  # line too long
@@ -46,7 +49,8 @@ extend-select = []
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore these rules everywhere except for the `src/` directory.
-"!apis/python/src/**.py" = ["D", "B", "S"]
+# Over time, we should enforce them more broadly.
+"!apis/python/src/**.py" = ["BLE", "C4", "D", "B", "S"]
 
 # Ignore in notebooks
 "apis/python/**/*.ipynb" = ["COM"]

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -562,7 +562,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 f"{function_name_for_messages}: requested domain has length {len(dim_names)} but the dataframe's schema has index-column count {len(newdomain)}",
             )
 
-        if any([slot is not None and len(slot) != 2 for slot in newdomain]):
+        if any(slot is not None and len(slot) != 2 for slot in newdomain):
             raise ValueError(
                 f"{function_name_for_messages}: requested domain must have low,high pairs, or `None`, in each slot",
             )
@@ -835,7 +835,7 @@ def _canonicalize_schema(
 
     # Check for column names containing null bytes
     for field in schema:
-        if any([char == "\x00" for char in field.name]):
+        if any(char == "\x00" for char in field.name):
             raise ValueError(f"Illegal character in field name `{field.name}`. Null byte found.")
 
     if SOMA_JOINID in schema.names:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -420,7 +420,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         coords, data_region, inv_transform = process_spatial_df_region(
             region,
             region_transform,
-            dict(),  # Move index value_filters into this dict to optimize queries
+            {},  # Move index value_filters into this dict to optimize queries
             self.index_column_names,
             self._coord_space.axis_names,
             self._handle.schema,

--- a/apis/python/src/tiledbsoma/_managed_query.py
+++ b/apis/python/src/tiledbsoma/_managed_query.py
@@ -201,7 +201,7 @@ class ManagedQuery:
 
         column = self._array._handle._handle.get_column(dim.name)
 
-        if all([is_slice_of(x, np.float64) for x in coord]):
+        if all(is_slice_of(x, np.float64) for x in coord):
             range_min = []
             range_max = []
             for sub_coord, dom_min, dom_max in zip(coord, ordered_dom_min, ordered_dom_max):
@@ -217,7 +217,7 @@ class ManagedQuery:
                     range_max.append(lo_hi[1])
 
             column.set_dim_ranges_double_array(self._handle, [(range_min, range_max)])
-        elif all([isinstance(x, np.number) for x in coord]):
+        elif all(isinstance(x, np.number) for x in coord):
             column.set_dim_points_double_array(self._handle, [coord])
         else:
             raise ValueError(f"Unsupported spatial coordinate type. Expected slice or float, found {type(coord)}")

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -403,7 +403,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         coords, data_region, inv_transform = process_spatial_df_region(
             region,
             region_transform,
-            dict(),  # Move index value_filters into this dict to optimize queries
+            {},  # Move index value_filters into this dict to optimize queries
             self._tiledb_dim_names(),
             self._coord_space.axis_names,
             self._handle.schema,

--- a/apis/python/src/tiledbsoma/_read_iters.py
+++ b/apis/python/src/tiledbsoma/_read_iters.py
@@ -182,7 +182,7 @@ class BlockwiseReadIterBase(somacore.ReadIter[_RT], metaclass=abc.ABCMeta):
         assert context is not None
         self.minor_axes_indexer = {
             d: IntIndexer(self.joinids[d].to_numpy(), context=context)
-            for d in (self.axes_to_reindex - set((self.major_axis,)))
+            for d in (self.axes_to_reindex - {self.major_axis})
         }
 
         # Ask subclass to create the type-specific reader/iterator

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -821,7 +821,8 @@ class MetadataWrapper(MutableMapping[str, Any]):
                         set_metadata(key, np.array([val]))
                 if mod is _DictMod.DELETED:
                     self.owner._handle.delete_metadata(key)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
+                # This should be done with Exception Groups
                 errors.append(e)
 
         # Temporary hack: When we flush writes, note that the cache

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -338,7 +338,7 @@ def build_clib_platform_config(
 
 
 def _build_column_config(col: Mapping[str, _ColumnConfig] | None) -> str:
-    column_config: dict[str, dict[str, _JSONFilterList | int]] = dict()
+    column_config: dict[str, dict[str, _JSONFilterList | int]] = {}
 
     if col is None:
         return ""
@@ -415,7 +415,7 @@ def _build_filter_list(filters: tuple[_DictFilterSpec, ...] | None, return_json:
         if len(info) == 1:
             filter = _convert_filter[cast("str", info["_type"])]
         else:
-            filter = dict()
+            filter = {}
             for option_name, option_value in info.items():
                 filter_name = _convert_filter[cast("str", info["_type"])]
                 if option_name == "_type":

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -626,7 +626,7 @@ class AnnDataAxisMetadata:
     @classmethod
     def reduce(cls, ams: list[Self]) -> AnnDataAxisMetadata:
         assert all(isinstance(a, cls) for a in ams)
-        assert all([a.field_name == ams[0].field_name for a in ams])
+        assert all(a.field_name == ams[0].field_name for a in ams)
         if not all(a.field_index.dtype == ams[0].field_index.dtype for a in ams):
             raise SOMAError("All AnnData must have a common dtype for their index.")
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -562,7 +562,7 @@ def _from_anndata(
         for key, val in getattr(anndata, ad_key).items():
             if not isinstance(val, get_args(Matrix)):
                 raise TypeError(
-                    f"{ad_key} value at {key} is not of type {list(cl.__name__ for cl in get_args(Matrix))}: {type(val)}",
+                    f"{ad_key} value at {key} is not of type {[cl.__name__ for cl in get_args(Matrix)]}: {type(val)}",
                 )
 
     # For single ingest (no append):
@@ -607,11 +607,11 @@ def _from_anndata(
     s = _util.get_start_stamp()
     logging.log_io(None, f"START  WRITING {experiment_uri}")
 
-    ingest_ctx: IngestCtx = dict(
-        context=context,
-        ingestion_params=ingestion_params,
-        additional_metadata=additional_metadata,
-    )
+    ingest_ctx: IngestCtx = {
+        "context": context,
+        "ingestion_params": ingestion_params,
+        "additional_metadata": additional_metadata,
+    }
     ingest_platform_ctx: IngestPlatformCtx = dict(**ingest_ctx, platform_config=platform_config)
 
     # Must be done first, to create the parent directory.
@@ -1805,8 +1805,8 @@ def _update_dataframe(
         arrow_table = conversions.df_to_arrow_table(new_data)
         arrow_schema = arrow_table.schema.remove_metadata()
 
-        add_attrs = dict()
-        add_enmrs = dict()
+        add_attrs = {}
+        add_enmrs = {}
         for add_key in add_keys:
             # Don't directly use the new dataframe's dtypes. Go through the
             # to-Arrow-schema logic, and back, as this recapitulates the original
@@ -2774,12 +2774,12 @@ def _ingest_uns_node(
         coll.metadata[key] = value
         return
 
-    ingest_platform_ctx: IngestPlatformCtx = dict(
-        platform_config=platform_config,
-        context=context,
-        ingestion_params=ingestion_params,
-        additional_metadata=additional_metadata,
-    )
+    ingest_platform_ctx: IngestPlatformCtx = {
+        "platform_config": platform_config,
+        "context": context,
+        "ingestion_params": ingestion_params,
+        "additional_metadata": additional_metadata,
+    }
     if isinstance(value, Mapping):
         # Mappings are represented as sub-dictionaries.
         _ingest_uns_dict(

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -460,7 +460,6 @@ def _treewalk(
     # to be shown *all* the component arrays which have issues, not just
     # the first such.
     with tiledbsoma.open(uri, context=kwargs["context"]) as item:
-
         # Non-terminal
         if isinstance(item, tiledbsoma.Experiment):
             retval = {}
@@ -689,7 +688,6 @@ def _leaf_visitor_upgrade(
                 print("  Already upgraded", file=output_handle)
 
     elif isinstance(item, tiledbsoma.SparseNDArray):
-
         old_bounds = item.non_empty_domain()
         # Make a tuple of hi+1
         counts_from_old_bounds = tuple(e[1] + 1 for e in old_bounds)
@@ -775,7 +773,6 @@ def _leaf_visitor_resize(
 ) -> dict[str, Any]:
     retval = {"status": True}
     if isinstance(item, tiledbsoma.DataFrame):
-
         if node_name == "obs":
             new_soma_joinid_shape = nobs
             if new_soma_joinid_shape is None:
@@ -820,7 +817,6 @@ def _leaf_visitor_resize(
                 writer.tiledbsoma_resize_soma_joinid_shape(new_soma_joinid_shape)
 
     elif isinstance(item, tiledbsoma.SparseNDArray):
-
         _print_leaf_node_banner(
             uri=item.uri,
             type_name="SparseNDArray",
@@ -856,7 +852,6 @@ def _leaf_visitor_resize(
                 writer.resize(new_shape)
 
     elif isinstance(item, tiledbsoma.DenseNDArray):
-
         _print_leaf_node_banner(
             uri=item.uri,
             type_name="DenseNDArray",

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -68,8 +68,7 @@ def _convert_axis_names(
     if data_axis_names is None:
         data_axis_names = coord_axis_names
     spatial_data_axes = tuple(dim_map[axis_name] for axis_name in data_axis_names)
-    soma_dim_map = {key: val for key, val in dim_map.items()}
-    return spatial_data_axes, soma_dim_map
+    return spatial_data_axes, dim_map
 
 
 def _get_transform_from_collection(key: str, metadata: Mapping[str, Any]) -> somacore.CoordinateTransform | None:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -451,7 +451,7 @@ def test_empty_read(tmp_path):
         assert sum(len(t) for t in a.read(coords).tables()) == 0
 
 
-@pytest.mark.xfail(sys.version_info.minor > 7, reason="bug ARROW-17933")
+@pytest.mark.xfail(sys.version_info > (3, 7), reason="bug ARROW-17933")
 def test_empty_read_sparse_coo(tmp_path):
     """
     this test is factored from test_empty_read() because it is subject
@@ -1761,7 +1761,6 @@ def test_pass_configs(tmp_path):
         "r",
         context=soma.SOMATileDBContext({"sm.mem.total_budget": "0", "sm.io_concurrency_level": "0"}),
     ) as sdf:
-
         # This errors out as 0 is not a valid value to set the total memory
         # budget or number of threads
         with pytest.raises(soma.SOMAError):


### PR DESCRIPTION
Additional linter rules added to our baseline config:  BLE, C4 and YTT.

Also fixes the errors raised by these new rules.

Part of SOMA-323
