### PR TITLE
Fix CI so all C++ tests run

### DIFF
--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build libTileDB-SOMA
       run: TILEDBSOMA_COVERAGE="--coverage" ./scripts/bld --no-tiledb-deprecated=true --werror=true
     - name: Run libTileDB-SOMA unittests
-      run: ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
+      run: ctest --test-dir build/libtiledbsoma/test -C Release --verbose --rerun-failed --output-on-failure
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -41,4 +41,4 @@ jobs:
           cmake --build build -j 2
           ls external/lib/
       - name: Run C++ unittests
-        run:  ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build/libtiledbsoma -C ASAN --verbose --rerun-failed --output-on-failure
+        run:  ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build/libtiledbsoma/test -C ASAN --verbose --rerun-failed --output-on-failure


### PR DESCRIPTION
The CI was only running `unit_soma`. Fix the `ctest` call so all C++ tests are included.
