### PR TITLE
[python] enable Ruff lint rules SLOT, SIM and TID

### DIFF
--- a/apis/python/devtools/ingestor
+++ b/apis/python/devtools/ingestor
@@ -273,10 +273,8 @@ def ingest_one(
     # This is for local-disk use only -- for S3-backed tiledb://... URIs we should
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.
     parent = os.path.dirname(output_path.rstrip("/"))
-    if parent != "":
-        if tiledbsoma._util.is_local_path(parent):
-            if not os.path.exists(parent):
-                os.mkdir(parent)
+    if parent != "" and tiledbsoma._util.is_local_path(parent) and not os.path.exists(parent):
+        os.mkdir(parent)
 
     exp_name = os.path.splitext(os.path.basename(output_path))[0]
 

--- a/apis/python/devtools/outgestor
+++ b/apis/python/devtools/outgestor
@@ -88,9 +88,8 @@ def main():
 
     # This is for local-disk use only -- for S3-backed tiledb://... URIs we should
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.
-    if tiledbsoma._util.is_local_path(outdir):
-        if not os.path.exists(outdir):
-            os.mkdir(outdir)
+    if tiledbsoma._util.is_local_path(outdir) and not os.path.exists(outdir):
+        os.mkdir(outdir)
 
     if args.debug:
         tiledbsoma.logging.debug()

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -60,7 +60,6 @@ ignore = [
     "S101",     # Use of `assert` detected
     "COM812",   # Ignore recommended by Ruff
     "SIM105",   # contextlib.suppress
-
 ]
 extend-select = []
 

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -47,6 +47,9 @@ select = [  # see https://docs.astral.sh/ruff/rules/
     "Q",    # flake8-quotes
     "RET",  # flake8-return
     "RSE",  # flake8-raise
+    "SLOT", # flake8-slots
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
     "W",    # pycodestyle warnings
     "YTT",  # flake8-2020
 ]
@@ -56,6 +59,8 @@ ignore = [
     "D205",     # disable blank line requirement between summary and description
     "S101",     # Use of `assert` detected
     "COM812",   # Ignore recommended by Ruff
+    "SIM105",   # contextlib.suppress
+
 ]
 extend-select = []
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -277,7 +277,7 @@ if os.name == "posix" and sys.platform != "darwin":
 setuptools.setup(
     name="tiledbsoma",
     description="Python API for efficient storage and retrieval of single-cell data using TileDB",
-    long_description=open("README.md", encoding="utf-8").read(),
+    long_description=open("README.md", encoding="utf-8").read(),  # noqa: SIM115
     long_description_content_type="text/markdown",
     author="TileDB, Inc.",
     author_email="help@tiledb.io",
@@ -352,9 +352,9 @@ setuptools.setup(
         "typing-extensions>=4.5.0",  # Note "-" even though `import typing_extensions`
     ],
     extras_require={
-        "dev": open("requirements_dev.txt").read(),
-        "spatial-io": open("requirements_spatial.txt").read(),
-        "all": open("requirements_dev.txt").read() + open("requirements_spatial.txt").read(),
+        "dev": open("requirements_dev.txt").read(),  # noqa: SIM115
+        "spatial-io": open("requirements_spatial.txt").read(),  # noqa: SIM115
+        "all": open("requirements_dev.txt").read() + open("requirements_spatial.txt").read(),  # noqa: SIM115
     },
     python_requires=">=3.9",
     cmdclass={"build_ext": build_ext, "bdist_wheel": bdist_wheel},

--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -39,17 +39,14 @@ def is_does_not_exist_error(e: RuntimeError | SOMAError) -> bool:
     stre = str(e)
     # Local-disk/S3 does-not-exist exceptions say 'Group does not exist'; TileDB Cloud
     # does-not-exist exceptions are worded less clearly.
-    if (
+    return bool(
         "does not exist" in stre
         or "Unrecognized array" in stre
         or "HTTP code 401" in stre
         or "HTTP code 404" in stre
         or "[SOMAObject::open] " in stre
         or "has TileDB type Invalid" in stre
-    ):
-        return True
-
-    return False
+    )
 
 
 class AlreadyExistsError(SOMAError):

--- a/apis/python/src/tiledbsoma/_funcs.py
+++ b/apis/python/src/tiledbsoma/_funcs.py
@@ -67,16 +67,15 @@ def forwards_kwargs_to(dst: Callable[..., Any], *, exclude: Collection[str] = ()
                     if dst_param.kind == inspect.Parameter.VAR_KEYWORD:
                         # This is dst's **kwargs parameter. Pass it directly.
                         merged.append(dst_param)
-                    elif _can_be_kwarg(dst_param):
+                    elif _can_be_kwarg(dst_param) and dst_param.name not in claimed_names:
                         # In this case:
                         #     def internal(a, b): ...
                         #     @forwards_kwargs_to(internal)
                         #     def public(b, **kwargs): ...
                         # `b` cannot be forwarded to `internal`, so we skip it.
-                        if dst_param.name not in claimed_names:
-                            # ...however, `a` can.
-                            merged.append(dst_param.replace(kind=inspect.Parameter.KEYWORD_ONLY))
-                            claimed_names.add(dst_param.name)
+                        # ...however, `a` can.
+                        merged.append(dst_param.replace(kind=inspect.Parameter.KEYWORD_ONLY))
+                        claimed_names.add(dst_param.name)
                     # else: this param is positional-only.
             else:
                 # This is one of our other params; add it to the signature.

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -540,12 +540,11 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         Lifecycle:
             Experimental.
         """
-        if self._coord_space is not None:
-            if value.axis_names != self._coord_space.axis_names:
-                raise ValueError(
-                    f"Cannot change axis names of a geometry dataframe. Existing "
-                    f"axis names are {self._coord_space.axis_names}. New coordinate "
-                    f"space has axis names {value.axis_names}.",
-                )
+        if self._coord_space is not None and value.axis_names != self._coord_space.axis_names:
+            raise ValueError(
+                f"Cannot change axis names of a geometry dataframe. Existing "
+                f"axis names are {self._coord_space.axis_names}. New coordinate "
+                f"space has axis names {value.axis_names}.",
+            )
         self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(value)
         self._coord_space = value

--- a/apis/python/src/tiledbsoma/_managed_query.py
+++ b/apis/python/src/tiledbsoma/_managed_query.py
@@ -42,9 +42,8 @@ class ManagedQuery:
             object.__setattr__(self, "_handle", clib.ManagedQuery(array_handle))
 
     def _set_coord_by_py_seq_or_np_array(self, dim: pa.Field, coord: object) -> None:
-        if isinstance(coord, np.ndarray):
-            if coord.ndim != 1:
-                raise ValueError(f"only 1D numpy arrays may be used to index; got {coord.ndim}")
+        if isinstance(coord, np.ndarray) and coord.ndim != 1:
+            raise ValueError(f"only 1D numpy arrays may be used to index; got {coord.ndim}")
 
         column = self._array._handle._handle.get_column(dim.name)
 
@@ -99,20 +98,19 @@ class ManagedQuery:
 
         column = array_handle.get_column(dim.name)
 
-        if dim.metadata is not None:
-            if dim.metadata[b"dtype"].decode("utf-8") == "WKB":
-                if axis_names is None:
-                    raise ValueError("Axis names are required to set geometry column coordinates")
-                if not isinstance(dom[0], Mapping) or not isinstance(dom[1], Mapping):
-                    raise ValueError("Domain should be expressed per axis for geometry columns")
+        if dim.metadata is not None and dim.metadata[b"dtype"].decode("utf-8") == "WKB":
+            if axis_names is None:
+                raise ValueError("Axis names are required to set geometry column coordinates")
+            if not isinstance(dom[0], Mapping) or not isinstance(dom[1], Mapping):
+                raise ValueError("Domain should be expressed per axis for geometry columns")
 
-                self.set_geometry_coord(
-                    dim,
-                    cast("tuple[Mapping[str, float], Mapping[str, float]]", dom),
-                    coord,
-                    axis_names,
-                )
-                return
+            self.set_geometry_coord(
+                dim,
+                cast("tuple[Mapping[str, float], Mapping[str, float]]", dom),
+                coord,
+                axis_names,
+            )
+            return
 
         if isinstance(coord, (str, bytes)):
             column.set_dim_points_string_or_bytes(self._handle, [coord])

--- a/apis/python/src/tiledbsoma/_multiscale_image.py
+++ b/apis/python/src/tiledbsoma/_multiscale_image.py
@@ -544,13 +544,12 @@ class MultiscaleImage(
         Lifecycle:
             Experimental.
         """
-        if self._coord_space is not None:
-            if value.axis_names != self._coord_space.axis_names:
-                raise ValueError(
-                    f"Cannot change axis names of a multiscale image. Existing axis "
-                    f"names are {self._coord_space.axis_names}. New coordinate space "
-                    f"has axis names {value.axis_names}.",
-                )
+        if self._coord_space is not None and value.axis_names != self._coord_space.axis_names:
+            raise ValueError(
+                f"Cannot change axis names of a multiscale image. Existing axis "
+                f"names are {self._coord_space.axis_names}. New coordinate space "
+                f"has axis names {value.axis_names}.",
+            )
         self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(value)
         self._coord_space = value
 

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -479,13 +479,12 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         Lifecycle:
             Experimental.
         """
-        if self._coord_space is not None:
-            if value.axis_names != self._coord_space.axis_names:
-                raise ValueError(
-                    f"Cannot change axis names of a point cloud dataframe. Existing "
-                    f"axis names are {self._coord_space.axis_names}. New coordinate "
-                    f"space has axis names {value.axis_names}.",
-                )
+        if self._coord_space is not None and value.axis_names != self._coord_space.axis_names:
+            raise ValueError(
+                f"Cannot change axis names of a point cloud dataframe. Existing "
+                f"axis names are {self._coord_space.axis_names}. New coordinate "
+                f"space has axis names {value.axis_names}.",
+            )
         self.metadata[SOMA_COORDINATE_SPACE_METADATA_KEY] = coordinate_space_to_json(value)
         self._coord_space = value
 

--- a/apis/python/src/tiledbsoma/_query.py
+++ b/apis/python/src/tiledbsoma/_query.py
@@ -833,10 +833,7 @@ def _read_inner_ndarray(
     # Prior to the shape / current_domain change in release 1.15.0, there
     # was no way to determine the "max" number of features, aka shape, of
     # the sparse obsm/varm array. Guess based upon the array contents.
-    if matrix.tiledbsoma_has_upgraded_shape:
-        n_col = matrix.shape[1]
-    else:
-        n_col = pa.compute.max(table["soma_dim_1"]).as_py() + 1
+    n_col = matrix.shape[1] if matrix.tiledbsoma_has_upgraded_shape else pa.compute.max(table["soma_dim_1"]).as_py() + 1
 
     z: npt.NDArray[np.float32] = np.zeros(n_row * n_col, dtype=dtype)
     np.put(z, idx * n_col + table["soma_dim_1"], table["soma_data"])

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -257,10 +257,7 @@ class QueryConditionTree(ast.NodeVisitor):
             if pa.types.is_dictionary(dt):
                 dt = dt.value_type
 
-            if pa_types_is_string_or_bytes(dt):
-                dtype = "string"
-            else:
-                dtype = np.dtype(dt.to_pandas_dtype()).name
+            dtype = "string" if pa_types_is_string_or_bytes(dt) else np.dtype(dt.to_pandas_dtype()).name
 
             # sdf.read(column_names=["foo"], value_filter='bar == 999') should
             # result in bar being added to the column names. See also
@@ -292,10 +289,7 @@ class QueryConditionTree(ast.NodeVisitor):
         if pa.types.is_dictionary(dt):
             dt = dt.value_type
 
-        if pa_types_is_string_or_bytes(dt):
-            dtype = "string"
-        else:
-            dtype = np.dtype(dt.to_pandas_dtype()).name
+        dtype = "string" if pa_types_is_string_or_bytes(dt) else np.dtype(dt.to_pandas_dtype()).name
         val = self.cast_val_to_dtype(val, dtype)
 
         pyqc = clib.PyQueryCondition()

--- a/apis/python/src/tiledbsoma/_scene.py
+++ b/apis/python/src/tiledbsoma/_scene.py
@@ -140,10 +140,7 @@ class Scene(
     def _open_subcollection(self, subcollection: str | Sequence[str]) -> CollectionBase[AnySOMAObject]:
         if len(subcollection) == 0:
             raise ValueError("Invalid subcollection: value cannot be empty.")
-        if isinstance(subcollection, str):
-            subcollection = (subcollection,)
-        else:
-            subcollection = tuple(subcollection)
+        subcollection = (subcollection,) if isinstance(subcollection, str) else tuple(subcollection)
         coll: CollectionBase[AnySOMAObject] = self
         # Keep track of collection hierarchy for informative error reporting
         parent_name: list[str] = []

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -63,9 +63,7 @@ def format_elapsed(start_stamp: float, message: str) -> str:
 def is_local_path(path: str) -> bool:
     if path.startswith("file://"):
         return True
-    if "://" in path:
-        return False
-    return True
+    return "://" not in path
 
 
 def make_relative_path(uri: str, relative_to: str) -> str:
@@ -211,10 +209,7 @@ def dense_index_to_shape(coord: options.DenseCoord, array_length: int) -> int:
     if is_slice_of(coord, int):
         # We verify that ``step`` is None elsewhere, so we can always assume
         # that we're asked for a continuous slice.
-        if coord.stop is None:
-            stop = array_length
-        else:
-            stop = min(coord.stop + 1, array_length)
+        stop = array_length if coord.stop is None else min(coord.stop + 1, array_length)
         return stop - (coord.start or 0)
 
     raise TypeError(f"coordinate {coord} must be integer or integer slice")
@@ -495,7 +490,7 @@ def _df_set_index(
         # - `default_index_name` was provided (e.g. `{obs,var}_id_name` args to `to_anndata`)
         #
         # ⇒ Verify a column with that name exists, and set it as index (keeping its name).
-        if default_index_name not in df.keys():
+        if default_index_name not in df:
             raise ValueError(f"Requested ID column name {default_index_name} not found in input: {df.keys()}")
         df.set_index(default_index_name, inplace=True)
 

--- a/apis/python/src/tiledbsoma/io/__init__.py
+++ b/apis/python/src/tiledbsoma/io/__init__.py
@@ -38,11 +38,10 @@ from .shaping import (
 # https://github.com/single-cell-data/TileDB-SOMA/issues/3920
 scipy_version = Version(scipy.__version__)
 anndata_version = Version(ad.__version__)
-if anndata_version >= Version("0.10.7") and anndata_version < Version("0.11.2"):
-    if scipy_version >= Version("1.15.0"):
-        raise RuntimeError(
-            f"anndata '{ad.__version__}' is incompatible with '{scipy.__version__}', and more generally, anndata 0.10.7-0.11.1 are incompatible with scipy 0.15. Please upgrade your anndata to >= 0.11.2, or downgrade your scipy to < 0.15.",
-        )
+if anndata_version >= Version("0.10.7") and anndata_version < Version("0.11.2") and scipy_version >= Version("1.15.0"):
+    raise RuntimeError(
+        f"anndata '{ad.__version__}' is incompatible with '{scipy.__version__}', and more generally, anndata 0.10.7-0.11.1 are incompatible with scipy 0.15. Please upgrade your anndata to >= 0.11.2, or downgrade your scipy to < 0.15.",
+    )
 
 __all__ = (
     "add_matrix_to_collection",

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -14,10 +14,11 @@ import anndata as ad
 import pyarrow as pa
 from anndata._core import file_backing
 
-from .. import pytiledbsoma as clib
-from .._exception import SOMAError
-from .._types import Path
-from ..options import SOMATileDBContext
+from tiledbsoma import pytiledbsoma as clib
+from tiledbsoma._exception import SOMAError
+from tiledbsoma._types import Path
+from tiledbsoma.options import SOMATileDBContext
+
 from ._caching_reader import CachingReader
 
 _pa_type_to_str_fmt = {

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -16,10 +16,10 @@ import pyarrow as pa
 import scipy.sparse as sp
 from pandas.api.extensions import ExtensionDtype  # noqa - required to resolve pdt.Dtype below
 
-from .._fastercsx import CompressedMatrix
-from .._funcs import typeguard_ignore
-from .._types import NPNDArray, PDSeries
-from ..options._soma_tiledb_context import SOMATileDBContext
+from tiledbsoma._fastercsx import CompressedMatrix
+from tiledbsoma._funcs import typeguard_ignore
+from tiledbsoma._types import NPNDArray, PDSeries
+from tiledbsoma.options._soma_tiledb_context import SOMATileDBContext
 
 _DT = TypeVar("_DT", bound=pdt.Dtype)
 _MT = TypeVar("_MT", NPNDArray, sp.spmatrix, PDSeries)
@@ -190,10 +190,13 @@ def to_tiledb_supported_array_type(name: str, x: _MT) -> _MT:
     # If the column is categorical-of-string of high cardinality, we declare
     # this is likely a mistake, and it will definitely lead to performance
     # issues in subsequent processing.
-    if isinstance(x, pd.Series) and isinstance(x.dtype, pd.CategoricalDtype):
+    if (
+        isinstance(x, pd.Series)
+        and isinstance(x.dtype, pd.CategoricalDtype)
+        and len(x.cat.categories) > COLUMN_DECAT_THRESHOLD
+    ):
         # Heuristic number
-        if len(x.cat.categories) > COLUMN_DECAT_THRESHOLD:
-            return x.astype(x.cat.categories.dtype)
+        return x.astype(x.cat.categories.dtype)
 
     return x
 

--- a/apis/python/src/tiledbsoma/io/shaping.py
+++ b/apis/python/src/tiledbsoma/io/shaping.py
@@ -15,8 +15,7 @@ import sys
 from typing import Any, Callable, TypeVar, Union, cast
 
 import tiledbsoma
-
-from .._soma_object import SOMAObject
+from tiledbsoma._soma_object import SOMAObject
 
 Printable = Union[io.TextIOWrapper, io.StringIO]
 printableStdout = cast("Printable", sys.stdout)
@@ -368,8 +367,8 @@ def resize_experiment(
     # on one measurement while the experiment's other measurements aren't being
     # updated -- then we need to find those other measurements' var-shapes.
     with tiledbsoma.Experiment.open(uri, context=context) as exp:
-        for ms_key in exp.ms.keys():
-            if ms_key not in nvars.keys():
+        for ms_key in exp.ms:
+            if ms_key not in nvars:
                 nvars[ms_key] = exp.ms[ms_key].var._maybe_soma_joinid_shape or 1
 
     retval = _treewalk(
@@ -647,10 +646,7 @@ def _leaf_visitor_upgrade(
     retval = {"status": True}
 
     if isinstance(item, tiledbsoma.DataFrame):
-        if item.index_column_names == ("soma_joinid",):
-            count = item.non_empty_domain()[0][1] + 1
-        else:
-            count = item.count
+        count = item.non_empty_domain()[0][1] + 1 if item.index_column_names == ("soma_joinid",) else item.count
 
         _print_leaf_node_banner(
             uri=item.uri,

--- a/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_spatialdata_util.py
@@ -30,9 +30,10 @@ except ImportError as err:
     raise err
 
 
-from ... import Collection, MultiscaleImage, PointCloudDataFrame, Scene
-from ..._constants import SOMA_JOINID
-from ..._spatial_util import transform_from_json
+from tiledbsoma import Collection, MultiscaleImage, PointCloudDataFrame, Scene
+from tiledbsoma._constants import SOMA_JOINID
+from tiledbsoma._spatial_util import transform_from_json
+
 from ._xarray_backend import dense_nd_array_to_data_array, images_to_datatree
 
 if TYPE_CHECKING:
@@ -437,10 +438,7 @@ def _spatial_to_spatialdata(
 
         # Export varl data to SpatialData.
         if "varl" in scene:
-            if measurement_names is None:
-                measurements = tuple(scene.varl.keys())
-            else:
-                measurements = measurement_names
+            measurements = tuple(scene.varl.keys()) if measurement_names is None else measurement_names
             for measurement_name in measurements:
                 if measurement_name not in scene.varl:
                     continue

--- a/apis/python/src/tiledbsoma/io/spatial/_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_util.py
@@ -14,7 +14,7 @@ import pyarrow as pa
 import pyarrow.compute as pacomp
 from typing_extensions import Self
 
-from ..._exception import SOMAError
+from tiledbsoma._exception import SOMAError
 
 
 def _expand_compressed_index_pointers(indptr: npt.NDArray, nval: int) -> npt.NDArray:

--- a/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_xarray_backend.py
@@ -25,8 +25,9 @@ except ImportError as err:
     warnings.warn("Experimental spatial exporter requires the xarray package.", stacklevel=1)
     raise err
 
-from ... import DenseNDArray
-from ...options._soma_tiledb_context import SOMATileDBContext
+from tiledbsoma import DenseNDArray
+from tiledbsoma.options._soma_tiledb_context import SOMATileDBContext
+
 from ._util import _str_to_int
 
 

--- a/apis/python/src/tiledbsoma/io/spatial/outgest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/outgest.py
@@ -14,9 +14,10 @@ except ImportError as err:
     raise err
 
 
-from ... import Experiment
-from ..._constants import SPATIAL_DISCLAIMER
-from .. import to_anndata
+from tiledbsoma import Experiment
+from tiledbsoma._constants import SPATIAL_DISCLAIMER
+from tiledbsoma.io import to_anndata
+
 from ._spatialdata_util import _spatial_to_spatialdata
 
 
@@ -51,10 +52,7 @@ def to_spatialdata(
     if measurement_names is not None:
         measurement_names = tuple(measurement_names)
     if "ms" in experiment:
-        if measurement_names is None:
-            ms_keys = tuple(experiment.ms.keys())
-        else:
-            ms_keys = measurement_names
+        ms_keys = tuple(experiment.ms.keys()) if measurement_names is None else measurement_names
         if table_kwargs is None:
             table_kwargs = {}
         tables = {
@@ -83,10 +81,7 @@ def to_spatialdata(
     if "spatial" not in experiment:
         return sd.SpatialData(tables=tables)
 
-    if scene_names is None:
-        scene_names = tuple(experiment.spatial.keys())
-    else:
-        scene_names = tuple(scene_names)
+    scene_names = tuple(experiment.spatial.keys()) if scene_names is None else tuple(scene_names)
 
     return _spatial_to_spatialdata(
         experiment.spatial,

--- a/apis/python/src/tiledbsoma/io/update_uns.py
+++ b/apis/python/src/tiledbsoma/io/update_uns.py
@@ -198,9 +198,8 @@ def _update_uns_dict(
                 ) as df:
                     _maybe_set(coll, k, df, use_relative_uri=use_relative_uri)
         elif isinstance(v, dict):
-            if exists:
-                if not isinstance(cur, Collection):
-                    raise ValueError(f"{coll.uri}/{k}: expected Collection, found {type(cur).__name__}")
+            if exists and not isinstance(cur, Collection):
+                raise ValueError(f"{coll.uri}/{k}: expected Collection, found {type(cur).__name__}")
             _update_uns_dict(
                 coll[k],
                 v,

--- a/apis/python/src/tiledbsoma/logging.py
+++ b/apis/python/src/tiledbsoma/logging.py
@@ -70,6 +70,5 @@ def log_io(info_message: str | None, debug_message: str) -> None:
     if logger.level == logging.INFO:
         if info_message is not None:
             logger.info(info_message)
-    elif logger.level <= logging.DEBUG:
-        if debug_message is not None:
-            logger.debug(debug_message)
+    elif logger.level <= logging.DEBUG and debug_message is not None:
+        logger.debug(debug_message)

--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -14,9 +14,9 @@ from typing import Any, Literal, Mapping, Optional, Union, cast
 from somacore import ContextBase
 from typing_extensions import Self
 
-from .. import pytiledbsoma as clib
-from .._types import OpenTimestamp
-from .._util import ms_to_datetime, to_timestamp_ms
+from tiledbsoma import pytiledbsoma as clib
+from tiledbsoma._types import OpenTimestamp
+from tiledbsoma._util import ms_to_datetime, to_timestamp_ms
 
 try:
     from tiledb import Ctx as TileDBCtx

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -75,7 +75,7 @@ def assert_uns_equal(uns0, uns1):
 
 def assert_array_dicts_equal(d0, d1):
     assert d0.keys() == d1.keys()
-    for k in d0.keys():
+    for k in d0:
         assert_array_equal(d0[k], d1[k])
 
 
@@ -163,9 +163,8 @@ def raises_no_typeguard(exc: type[Exception], *args: Any, **kwargs: Any):
     Otherwise, most errors end up manifesting as ``TypeCheckError``s, during tests (thanks to
     ``typeguard``'s import hook).
     """
-    with suppress_type_checks():
-        with pytest.raises(exc, *args, **kwargs):
-            yield
+    with suppress_type_checks(), pytest.raises(exc, *args, **kwargs):
+        yield
 
 
 # Alias for several types that can be used to specify expected exceptions in `maybe_raises`

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -162,7 +162,7 @@ class SOMAArrayStateMachine(RuleBasedStateMachine):
             ),
         )
         assert set(array_metadata.keys()) == set(expected_metadata.keys())
-        for k in array_metadata.keys():
+        for k in array_metadata:
             if isinstance(array_metadata[k], float) and math.isnan(array_metadata[k]):
                 assert math.isnan(expected_metadata[k])
                 continue

--- a/apis/python/tests/ht/_ht_util.py
+++ b/apis/python/tests/ht/_ht_util.py
@@ -114,10 +114,7 @@ def arrow_floating_datatypes(draw: st.DrawFn) -> pa.DataType:
 # pyarrow and pandas timestamp interop lacks support for anything other than `ns`
 # units prior to pandas 2. For info, see https://github.com/apache/arrow/issues/33321
 # The simple solution is to just to restrict types to 'ns' for pandas<2.
-if Version(pd.__version__) >= Version("2.0.0"):
-    TIMESTAMP_UNITS = ("s", "ms", "us", "ns")
-else:
-    TIMESTAMP_UNITS = ("ns",)
+TIMESTAMP_UNITS = ("s", "ms", "us", "ns") if Version(pd.__version__) >= Version("2.0.0") else ("ns",)
 
 
 @st.composite

--- a/apis/python/tests/ht/test_ht_caching_reader.py
+++ b/apis/python/tests/ht/test_ht_caching_reader.py
@@ -11,7 +11,7 @@ from hypothesis.stateful import (
 
 from tiledbsoma.io._caching_reader import CachingReader
 
-from .._util import TESTDATA
+from tests._util import TESTDATA
 
 
 class CachingReaderStateMachine(RuleBasedStateMachine):
@@ -56,8 +56,8 @@ class CachingReaderStateMachine(RuleBasedStateMachine):
     @rule()
     def open(self) -> None:
         self._closed = False
-        self.raw = open(self._fname, "rb")
-        self.cached = CachingReader(open(self._fname, "rb"))
+        self.raw = open(self._fname, "rb")  # noqa: SIM115
+        self.cached = CachingReader(open(self._fname, "rb"))  # noqa: SIM115
 
     @precondition(lambda self: not self._closed)
     @rule()

--- a/apis/python/tests/ht/test_ht_densendarray.py
+++ b/apis/python/tests/ht/test_ht_densendarray.py
@@ -46,10 +46,7 @@ def dense_array_shape(
     # to keep the array under some number of elements max, use the nth root as max per-dim size
     MAX_ELEM = 2**20  # 1M
     shape_limit = int(MAX_ELEM ** (1 / ndim))
-    if max_shape is None:
-        max_values = [shape_limit] * ndim
-    else:
-        max_values = [min(shape_limit, s) for s in max_shape]
+    max_values = [shape_limit] * ndim if max_shape is None else [min(shape_limit, s) for s in max_shape]
 
     elements = [
         draw(

--- a/apis/python/tests/ht/test_ht_fastercsx.py
+++ b/apis/python/tests/ht/test_ht_fastercsx.py
@@ -209,7 +209,7 @@ def test_fastercsx_clib_compress_coo(
         np.allclose(
             csr.data,
             scipy_csr.data,
-            equal_nan=True if value_dtype.kind == "f" else False,
+            equal_nan=value_dtype.kind == "f",
             atol=1e-06,
             rtol=1e-04,
         )
@@ -217,7 +217,7 @@ def test_fastercsx_clib_compress_coo(
         else np.array_equal(
             csr.data,
             scipy_csr.data,
-            equal_nan=True if value_dtype.kind == "f" else False,
+            equal_nan=value_dtype.kind == "f",
         )
     )
 
@@ -345,12 +345,12 @@ def test_fastercsx_from_ijd(
         np.allclose(
             cm.data,
             scipy_cm.data,
-            equal_nan=True if value_dtype.kind == "f" else False,
+            equal_nan=value_dtype.kind == "f",
             atol=1e-06,
             rtol=1e-04,
         )
         if not unique
-        else np.array_equal(cm.data, scipy_cm.data, equal_nan=True if value_dtype.kind == "f" else False)
+        else np.array_equal(cm.data, scipy_cm.data, equal_nan=value_dtype.kind == "f")
     )
 
 
@@ -401,7 +401,7 @@ def test_fastercsx_to_scipy(
         np.allclose(
             cm_slc.data,
             scipy_slc.data,
-            equal_nan=True if value_dtype.kind == "f" else False,
+            equal_nan=value_dtype.kind == "f",
             atol=1e-06,
             rtol=1e-04,
         )
@@ -409,6 +409,6 @@ def test_fastercsx_to_scipy(
         else np.array_equal(
             cm_slc.data,
             scipy_slc.data,
-            equal_nan=True if value_dtype.kind == "f" else False,
+            equal_nan=value_dtype.kind == "f",
         )
     )

--- a/apis/python/tests/ht/test_ht_io_anndata.py
+++ b/apis/python/tests/ht/test_ht_io_anndata.py
@@ -460,7 +460,7 @@ def assert_frame_equal_strict(f1: pd.DataFrame, f2: pd.DataFrame) -> None:
 
 def assert_map_of_matrix_equal(m1: Mapping[str, np.ndarray], m2: dict[str, np.ndarray]) -> None:
     assert m1.keys() == m2.keys()
-    for k in m1.keys():
+    for k in m1:
         assert_matrix_equal(m1[k], m2[k])
 
 
@@ -507,14 +507,13 @@ def assert_uns_equal(src_adata: ad.AnnData, read_adata: ad.Anndata) -> None:
             continue
 
         # bools incorrectly read back as uint8
-        if HT_TEST_CONFIG["sc-63447_workaround"]:
-            if (
-                chng["old_type"] in (np.bool_, list)
-                and chng["new_type"] == np.uint8
-                and ndarray_equal(np.asarray(chng["old_value"]).astype(np.uint8), chng["new_value"])
-            ):
-                del diff["type_changes"][key]
-                continue
+        if HT_TEST_CONFIG["sc-63447_workaround"] and (
+            chng["old_type"] in (np.bool_, list)
+            and chng["new_type"] == np.uint8
+            and ndarray_equal(np.asarray(chng["old_value"]).astype(np.uint8), chng["new_value"])
+        ):
+            del diff["type_changes"][key]
+            continue
 
     if diff.get("type_changes", None) == {}:
         del diff["type_changes"]

--- a/apis/python/tests/ht/test_ht_sparsendarray.py
+++ b/apis/python/tests/ht/test_ht_sparsendarray.py
@@ -59,10 +59,7 @@ def sparse_array_shape(
     # that force the max of any one dimension to be a bit smaller. Set our per-dim
     # limit to the min of the nth root of int64.max or the tiledb limit.
     shape_limit = min(int((2**63 - 1) ** (1 / ndim)), (2**63 - 2050))
-    if max_shape is None:
-        max_values = [shape_limit] * ndim
-    else:
-        max_values = [min(shape_limit, s) for s in max_shape]
+    max_values = [shape_limit] * ndim if max_shape is None else [min(shape_limit, s) for s in max_shape]
 
     if allow_none:
         elements = [
@@ -247,7 +244,7 @@ class SOMASparseNDArrayStateMachine(SOMANDArrayStateMachine):
         assert tables_equal(
             found,
             expected,
-            equal_nan=True if pa.types.is_floating(self.type) else False,
+            equal_nan=bool(pa.types.is_floating(self.type)),
         ), f"{found}\n is not equal to {expected}"
 
     @precondition(lambda self: not self.closed and self.mode == "r")

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -289,16 +289,16 @@ def test_resume_mode(resume_mode_h5ad_file, tmp_path):
         meas2 = exp2.ms["RNA"]
 
         if "obsm" in meas1:
-            for key in meas1.obsm.keys():
+            for key in meas1.obsm:
                 assert _get_fragment_count(meas1.obsm[key].uri) == _get_fragment_count(meas2.obsm[key].uri)
         if "varm" in meas1:
-            for key in meas1.varm.keys():
+            for key in meas1.varm:
                 assert _get_fragment_count(meas1.obsm[key].uri) == _get_fragment_count(meas2.obsm[key].uri)
         if "obsp" in meas1:
-            for key in meas1.obsp.keys():
+            for key in meas1.obsp:
                 assert _get_fragment_count(meas1.obsp[key].uri) == _get_fragment_count(meas2.obsp[key].uri)
         if "varp" in meas1:
-            for key in meas1.varp.keys():
+            for key in meas1.varp:
                 assert _get_fragment_count(meas1.varm[key].uri) == _get_fragment_count(meas2.varm[key].uri)
 
 
@@ -439,9 +439,8 @@ def test_add_matrix_to_collection(conftest_pbmc_small, tmp_path):
     with _factory.open(output_path) as exp_r:
         assert sorted(list(exp_r.ms["RNA"].X.keys())) == ["data", "data2"]
 
-    with _factory.open(output_path, "w") as exp:
-        with pytest.raises(KeyError):
-            tiledbsoma.io.add_X_layer(exp, "nonesuch", "data3", conftest_pbmc_small.X)
+    with _factory.open(output_path, "w") as exp, pytest.raises(KeyError):
+        tiledbsoma.io.add_X_layer(exp, "nonesuch", "data3", conftest_pbmc_small.X)
 
     with _factory.open(output_path) as exp_r:
         assert sorted(list(exp_r.ms["RNA"].obsm.keys())) == sorted(list(conftest_pbmc_small.obsm.keys()))
@@ -520,19 +519,21 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small, tmp_path):
             with coll:
                 matrix_uri = f"{coll_uri}/{matrix_name}"
 
-                with pytest.deprecated_call():
-                    with tiledbsoma.io.ingest.create_from_matrix(
+                with (
+                    pytest.deprecated_call(),
+                    tiledbsoma.io.ingest.create_from_matrix(
                         tiledbsoma.SparseNDArray,
                         matrix_uri,
                         matrix_data,
                         context=context,
-                    ) as sparse_nd_array:
-                        tiledbsoma.io.ingest._maybe_set(
-                            coll,
-                            matrix_name,
-                            sparse_nd_array,
-                            use_relative_uri=use_relative_uri,
-                        )
+                    ) as sparse_nd_array,
+                ):
+                    tiledbsoma.io.ingest._maybe_set(
+                        coll,
+                        matrix_name,
+                        sparse_nd_array,
+                        use_relative_uri=use_relative_uri,
+                    )
 
     output_path = tmp_path.as_posix()
     original = conftest_pbmc_small.copy()
@@ -553,9 +554,8 @@ def test_add_matrix_to_collection_1_2_7(conftest_pbmc_small, tmp_path):
     with _factory.open(output_path) as exp_r:
         assert sorted(list(exp_r.ms["RNA"].X.keys())) == ["data", "data2"]
 
-    with _factory.open(output_path, "w") as exp:
-        with pytest.raises(KeyError):
-            add_X_layer(exp, "nonesuch", "data3", conftest_pbmc_small.X)
+    with _factory.open(output_path, "w") as exp, pytest.raises(KeyError):
+        add_X_layer(exp, "nonesuch", "data3", conftest_pbmc_small.X)
 
     with _factory.open(output_path) as exp_r:
         assert sorted(list(exp_r.ms["RNA"].obsm.keys())) == sorted(list(conftest_pbmc_small.obsm.keys()))
@@ -606,13 +606,13 @@ def test_export_anndata(conftest_pbmc_small, tmp_path):
     assert readback.var.shape == conftest_pbmc_small.var.shape
     assert readback.X.shape == conftest_pbmc_small.X.shape
 
-    for key in conftest_pbmc_small.obsm.keys():
+    for key in conftest_pbmc_small.obsm:
         assert readback.obsm[key].shape == conftest_pbmc_small.obsm[key].shape
-    for key in conftest_pbmc_small.varm.keys():
+    for key in conftest_pbmc_small.varm:
         assert readback.varm[key].shape == conftest_pbmc_small.varm[key].shape
-    for key in conftest_pbmc_small.obsp.keys():
+    for key in conftest_pbmc_small.obsp:
         assert readback.obsp[key].shape == conftest_pbmc_small.obsp[key].shape
-    for key in conftest_pbmc_small.varp.keys():
+    for key in conftest_pbmc_small.varp:
         assert readback.varp[key].shape == conftest_pbmc_small.varp[key].shape
 
     with _factory.open(output_path) as exp:
@@ -866,8 +866,8 @@ def test_id_names(tmp_path, obs_id_name, var_id_name, indexify_obs, indexify_var
     assert_adata_equal(original, adata)
 
     with tiledbsoma.Experiment.open(uri) as exp:
-        assert obs_id_name in exp.obs.keys()
-        assert var_id_name in exp.ms["RNA"].var.keys()
+        assert obs_id_name in exp.obs.keys()  # noqa: SIM118
+        assert var_id_name in exp.ms["RNA"].var.keys()  # noqa: SIM118
 
         if indexify_obs:
             expected_obs_keys = ["soma_joinid", obs_id_name] + adata.obs_keys()

--- a/apis/python/tests/test_basic_spatialdata_io.py
+++ b/apis/python/tests/test_basic_spatialdata_io.py
@@ -30,118 +30,120 @@ def experiment_with_single_scene(tmp_path_factory, sample_2d_data) -> soma.Exper
     with soma.Experiment.create(uri) as exp:
         assert exp.uri == uri
         # Create spatial folder.
-        with exp.add_new_collection("spatial") as spatial:
+        with (
+            exp.add_new_collection("spatial") as spatial,
+            spatial.add_new_collection("scene1", soma.Scene, coordinate_space=("x_scene1", "y_scene1")) as scene1,
+        ):
             # Create scene 1.
-            with spatial.add_new_collection("scene1", soma.Scene, coordinate_space=("x_scene1", "y_scene1")) as scene1:
-                scene1.add_new_collection("obsl")
-                scene1.add_new_collection("varl")
-                scene1.varl.add_new_collection("RNA")
-                scene1.add_new_collection("img")
+            scene1.add_new_collection("obsl")
+            scene1.add_new_collection("varl")
+            scene1.varl.add_new_collection("RNA")
+            scene1.add_new_collection("img")
 
-                # Add point cloud with shape to scene 1 obsl.
-                points1 = scene1.add_new_point_cloud_dataframe(
-                    "points1",
-                    "obsl",
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 2.0),
-                    schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
-                    domain=[[0, 1], [0, 1], [0, 3]],
-                )
-                points1.write(
-                    pa.Table.from_pydict(
-                        {
-                            "soma_joinid": np.arange(4),
-                            "x": np.array([0, 0, 0.5, 0.5]),
-                            "y": np.array([0, 0.5, 0, 0.5]),
-                        },
-                    ),
-                )
-                points1.metadata["soma_geometry"] = 1.0
-                points1.metadata["soma_geometry_type"] = "radius"
+            # Add point cloud with shape to scene 1 obsl.
+            points1 = scene1.add_new_point_cloud_dataframe(
+                "points1",
+                "obsl",
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 2.0),
+                schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
+                domain=[[0, 1], [0, 1], [0, 3]],
+            )
+            points1.write(
+                pa.Table.from_pydict(
+                    {
+                        "soma_joinid": np.arange(4),
+                        "x": np.array([0, 0, 0.5, 0.5]),
+                        "y": np.array([0, 0.5, 0, 0.5]),
+                    },
+                ),
+            )
+            points1.metadata["soma_geometry"] = 1.0
+            points1.metadata["soma_geometry_type"] = "radius"
 
-                # Add point cloud wihtout shape to scene 1 obsl
-                points3 = scene1.add_new_point_cloud_dataframe(
-                    "points3",
-                    "obsl",
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 4.0),
-                    schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
-                    domain=[[-1, 0], [-1, 0], [0, 3]],
-                )
-                points3.write(
-                    pa.Table.from_pydict(
-                        {
-                            "soma_joinid": np.arange(4),
-                            "x": np.array([0, 0, -0.5, -0.5]),
-                            "y": np.array([0, -0.5, 0, -0.5]),
-                        },
-                    ),
-                )
+            # Add point cloud wihtout shape to scene 1 obsl
+            points3 = scene1.add_new_point_cloud_dataframe(
+                "points3",
+                "obsl",
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 4.0),
+                schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
+                domain=[[-1, 0], [-1, 0], [0, 3]],
+            )
+            points3.write(
+                pa.Table.from_pydict(
+                    {
+                        "soma_joinid": np.arange(4),
+                        "x": np.array([0, 0, -0.5, -0.5]),
+                        "y": np.array([0, -0.5, 0, -0.5]),
+                    },
+                ),
+            )
 
-                # Add point cloud without shape to scene 1 varl.
-                points2 = scene1.add_new_point_cloud_dataframe(
-                    "points2",
-                    ["varl", "RNA"],
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), -1.0),
-                    schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
-                    domain=[[-1, 0], [-1, 0], [0, 3]],
-                )
-                points2.write(
-                    pa.Table.from_pydict(
-                        {
-                            "soma_joinid": np.arange(4),
-                            "x": np.array([0, 0, -0.5, -0.5]),
-                            "y": np.array([0, -0.5, 0, -0.5]),
-                        },
-                    ),
-                )
+            # Add point cloud without shape to scene 1 varl.
+            points2 = scene1.add_new_point_cloud_dataframe(
+                "points2",
+                ["varl", "RNA"],
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), -1.0),
+                schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
+                domain=[[-1, 0], [-1, 0], [0, 3]],
+            )
+            points2.write(
+                pa.Table.from_pydict(
+                    {
+                        "soma_joinid": np.arange(4),
+                        "x": np.array([0, 0, -0.5, -0.5]),
+                        "y": np.array([0, -0.5, 0, -0.5]),
+                    },
+                ),
+            )
 
-                # Add point cloud with shape to scene 1 varl.
-                points4 = scene1.add_new_point_cloud_dataframe(
-                    "points4",
-                    ["varl", "RNA"],
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.25),
-                    schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
-                    domain=[[0, 1], [0, 1], [0, 3]],
-                )
-                points4.write(
-                    pa.Table.from_pydict(
-                        {
-                            "soma_joinid": np.arange(4),
-                            "x": np.array([0, 0, 0.5, 0.5]),
-                            "y": np.array([0, 0.5, 0, 0.5]),
-                        },
-                    ),
-                )
-                points4.metadata["soma_geometry"] = 2.0
-                points4.metadata["soma_geometry_type"] = "radius"
+            # Add point cloud with shape to scene 1 varl.
+            points4 = scene1.add_new_point_cloud_dataframe(
+                "points4",
+                ["varl", "RNA"],
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.25),
+                schema=pa.schema([("x", pa.float64()), ("y", pa.float64())]),
+                domain=[[0, 1], [0, 1], [0, 3]],
+            )
+            points4.write(
+                pa.Table.from_pydict(
+                    {
+                        "soma_joinid": np.arange(4),
+                        "x": np.array([0, 0, 0.5, 0.5]),
+                        "y": np.array([0, 0.5, 0, 0.5]),
+                    },
+                ),
+            )
+            points4.metadata["soma_geometry"] = 2.0
+            points4.metadata["soma_geometry_type"] = "radius"
 
-                # Add multiscale image with a single image.
-                with scene1.add_new_multiscale_image(
-                    "image1",
-                    "img",
-                    type=pa.uint8(),
-                    level_shape=(3, 64, 64),
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.5),
-                ) as image1:
-                    coords = (slice(None), slice(None), slice(None))
-                    l0 = image1["level0"]
-                    l0.write(coords, pa.Tensor.from_numpy(sample_2d_data[0]))
+            # Add multiscale image with a single image.
+            with scene1.add_new_multiscale_image(
+                "image1",
+                "img",
+                type=pa.uint8(),
+                level_shape=(3, 64, 64),
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.5),
+            ) as image1:
+                coords = (slice(None), slice(None), slice(None))
+                l0 = image1["level0"]
+                l0.write(coords, pa.Tensor.from_numpy(sample_2d_data[0]))
 
-                # Add multiscale image with multiple resolutions.
-                with scene1.add_new_multiscale_image(
-                    "image2",
-                    "img",
-                    type=pa.uint8(),
-                    level_key="fullres",
-                    level_shape=(3, 32, 32),
-                    transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.5),
-                ) as image2:
-                    coords = (slice(None), slice(None), slice(None))
-                    fullres = image2["fullres"]
-                    fullres.write(coords, pa.Tensor.from_numpy(sample_2d_data[1]))
-                    hires = image2.add_new_level("hires", shape=(3, 16, 16))
-                    hires.write(coords, pa.Tensor.from_numpy(sample_2d_data[2]))
-                    lowres = image2.add_new_level("lowres", shape=(3, 8, 8))
-                    lowres.write(coords, pa.Tensor.from_numpy(sample_2d_data[3]))
+            # Add multiscale image with multiple resolutions.
+            with scene1.add_new_multiscale_image(
+                "image2",
+                "img",
+                type=pa.uint8(),
+                level_key="fullres",
+                level_shape=(3, 32, 32),
+                transform=soma.UniformScaleTransform(("x_scene1", "y_scene1"), ("x", "y"), 0.5),
+            ) as image2:
+                coords = (slice(None), slice(None), slice(None))
+                fullres = image2["fullres"]
+                fullres.write(coords, pa.Tensor.from_numpy(sample_2d_data[1]))
+                hires = image2.add_new_level("hires", shape=(3, 16, 16))
+                hires.write(coords, pa.Tensor.from_numpy(sample_2d_data[2]))
+                lowres = image2.add_new_level("lowres", shape=(3, 8, 8))
+                lowres.write(coords, pa.Tensor.from_numpy(sample_2d_data[3]))
 
     return soma.Experiment.open(uri, mode="r")
 
@@ -168,13 +170,13 @@ def test_outgest_no_spatial(tmp_path, conftest_pbmc_small):
     assert rna.var.shape == conftest_pbmc_small.var.shape
     assert rna.X.shape == conftest_pbmc_small.X.shape
 
-    for key in conftest_pbmc_small.obsm.keys():
+    for key in conftest_pbmc_small.obsm:
         assert rna.obsm[key].shape == conftest_pbmc_small.obsm[key].shape
-    for key in conftest_pbmc_small.varm.keys():
+    for key in conftest_pbmc_small.varm:
         assert rna.varm[key].shape == conftest_pbmc_small.varm[key].shape
-    for key in conftest_pbmc_small.obsp.keys():
+    for key in conftest_pbmc_small.obsp:
         assert rna.obsp[key].shape == conftest_pbmc_small.obsp[key].shape
-    for key in conftest_pbmc_small.varp.keys():
+    for key in conftest_pbmc_small.varp:
         assert rna.varp[key].shape == conftest_pbmc_small.varp[key].shape
 
     # Check the values of the anndata table.

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -480,11 +480,10 @@ def test_collection_entries_from_methods(tmp_path):
 def test_collection_entries_from_setter(tmp_path, entry_type):
     uri = f"{tmp_path}/collection_with_{entry_type.lower()}"
 
-    with soma.Collection.create(uri) as coll:
-        with create_basic_object(entry_type, f"{uri}_entry") as entry:
-            coll["entry"] = entry
-            entry2 = coll["entry"]
-            assert entry2 is entry
+    with soma.Collection.create(uri) as coll, create_basic_object(entry_type, f"{uri}_entry") as entry:
+        coll["entry"] = entry
+        entry2 = coll["entry"]
+        assert entry2 is entry
 
     with soma.Collection.open(uri) as coll:
         entry = coll["entry"]

--- a/apis/python/tests/test_context.py
+++ b/apis/python/tests/test_context.py
@@ -90,7 +90,7 @@ def test_replace_config_after_construction():
     assert -100 < now - open_ts < 100
     open_ts = context._open_timestamp_ms(None)
     assert -100 < now - open_ts < 100
-    assert 999 == context._open_timestamp_ms(999)
+    assert context._open_timestamp_ms(999) == 999
 
     context_ts_1 = context.replace(timestamp=1)
 

--- a/apis/python/tests/test_dataframe_index_columns.py
+++ b/apis/python/tests/test_dataframe_index_columns.py
@@ -2029,9 +2029,8 @@ def test_types_write_errors(
         domain=domain,
     )
 
-    with pytest.raises(error):
-        with soma.DataFrame.open(uri, "w") as sdf:
-            sdf.write(arrow_table)
+    with pytest.raises(error), soma.DataFrame.open(uri, "w") as sdf:
+        sdf.write(arrow_table)
 
 
 @pytest.mark.parametrize(
@@ -2129,6 +2128,5 @@ def test_types_read_errors(
     with soma.DataFrame.open(uri, "w") as sdf:
         sdf.write(arrow_table)
 
-    with pytest.raises(soma.SOMAError):
-        with soma.DataFrame.open(uri, "r") as sdf:
-            sdf.read(coords=coords).concat()
+    with pytest.raises(soma.SOMAError), soma.DataFrame.open(uri, "r") as sdf:
+        sdf.read(coords=coords).concat()

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -98,9 +98,8 @@ def test_dense_nd_array_read_write_tensor(tmp_path, shape: tuple[int, ...]):
     a.close()
 
     # Array write should fail if array opened in read mode
-    with soma.DenseNDArray.open(uri) as a:
-        with pytest.raises(soma.SOMAError):
-            a.write(coords, pa.Tensor.from_numpy(data))
+    with soma.DenseNDArray.open(uri) as a, pytest.raises(soma.SOMAError):
+        a.write(coords, pa.Tensor.from_numpy(data))
 
     del a
 
@@ -355,9 +354,8 @@ def test_dense_nd_array_indexing_errors(tmp_path, io):
         write_coords = tuple(slice(0, dim_len) for dim_len in shape)
         a.write(coords=write_coords, values=pa.Tensor.from_numpy(npa))
 
-    with soma.DenseNDArray.open(tmp_path.as_posix()) as a:
-        with raises_no_typeguard(io["throws"]):
-            a.read(coords=read_coords).to_numpy()
+    with soma.DenseNDArray.open(tmp_path.as_posix()) as a, raises_no_typeguard(io["throws"]):
+        a.read(coords=read_coords).to_numpy()
 
 
 def test_tile_extents(tmp_path):

--- a/apis/python/tests/test_experiment_basic.py
+++ b/apis/python/tests/test_experiment_basic.py
@@ -123,7 +123,7 @@ def test_experiment_basic(tmp_path):
     assert isinstance(experiment.ms["RNA"].X, soma.Collection)
 
     assert experiment.ms["RNA"].var == experiment["ms"]["RNA"]["var"]
-    assert experiment.ms["RNA"].X == experiment["ms"]["RNA"]["X"]
+    assert experiment["ms"]["RNA"]["X"] == experiment.ms["RNA"].X
 
     assert len(experiment.ms["RNA"].X) == 1
     assert "data" in experiment.ms["RNA"].X

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -472,24 +472,20 @@ def test_error_corners(soma_experiment: Experiment):
         soma_experiment.axis_query("no-such-measurement")
 
     # Unknown X layer name
-    with pytest.raises(KeyError):
-        with soma_experiment.axis_query("RNA") as query:
-            next(query.X("no-such-layer"))
+    with pytest.raises(KeyError), soma_experiment.axis_query("RNA") as query:
+        next(query.X("no-such-layer"))
 
     # Unknown X layer name
-    with pytest.raises(ValueError):
-        with soma_experiment.axis_query("RNA") as query:
-            query.to_anndata("no-such-layer")
+    with pytest.raises(ValueError), soma_experiment.axis_query("RNA") as query:
+        query.to_anndata("no-such-layer")
 
     # Unknown obsp layer name
-    with pytest.raises(ValueError):
-        with soma_experiment.axis_query("RNA") as query:
-            next(query.obsp("no-such-layer"))
+    with pytest.raises(ValueError), soma_experiment.axis_query("RNA") as query:
+        next(query.obsp("no-such-layer"))
 
     # Unknown varp layer name
-    with pytest.raises(ValueError):
-        with soma_experiment.axis_query("RNA") as query:
-            next(query.varp("no-such-layer"))
+    with pytest.raises(ValueError), soma_experiment.axis_query("RNA") as query:
+        next(query.varp("no-such-layer"))
 
     # Illegal layer name type
     for lyr_name in [True, 3, 99.3]:

--- a/apis/python/tests/test_indexer.py
+++ b/apis/python/tests/test_indexer.py
@@ -93,10 +93,7 @@ def test_duplicate_key_indexer_error(keys: np.array | list[int], lookups: np.arr
     ],
 )
 def test_indexer(contextual: bool, keys: np.array, lookups: np.array):
-    if contextual:
-        context = _validate_soma_tiledb_context(SOMATileDBContext())
-    else:
-        context = None
+    context = _validate_soma_tiledb_context(SOMATileDBContext()) if contextual else None
     all_results = []
     num_threads = 10
 

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -442,9 +442,8 @@ def test_point_cloud_read_spatial_region_2d_bad(tmp_path, name, region, exc_type
         rb = pa.Table.from_pydict(pydict)
         ptc.write(rb)
 
-    with soma.PointCloudDataFrame.open(uri, "r") as ptc:
-        with pytest.raises(exc_type):
-            ptc.read_spatial_region(region=region)
+    with soma.PointCloudDataFrame.open(uri, "r") as ptc, pytest.raises(exc_type):
+        ptc.read_spatial_region(region=region)
 
 
 @pytest.mark.skip("3D regions not supported yet")
@@ -472,9 +471,8 @@ def test_point_cloud_read_spatial_region_3d_bad(tmp_path, name, region, exc_type
         rb = pa.Table.from_pydict(pydict)
         ptc.write(rb)
 
-    with soma.PointCloudDataFrame.open(uri, "r") as ptc:
-        with pytest.raises(exc_type):
-            ptc.read_spatial_region(region=region)
+    with soma.PointCloudDataFrame.open(uri, "r") as ptc, pytest.raises(exc_type):
+        ptc.read_spatial_region(region=region)
 
 
 def point_cloud_read_spatial_region_transform_setup(uri, transform, input_axes, kwargs):

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -276,9 +276,8 @@ def test_eval_error_conditions(malformed_condition):
 def test_query_condition_syntax_handling(expression_and_message):
     uri = os.path.join(SOMA_URI, "obs")
     expression, message = expression_and_message
-    with DataFrame.open(uri) as obs:
-        with pytest.raises(SOMAError, match=message):
-            obs.read(value_filter=expression).concat()
+    with DataFrame.open(uri) as obs, pytest.raises(SOMAError, match=message):
+        obs.read(value_filter=expression).concat()
 
 
 if __name__ == "__main__":

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1622,7 +1622,7 @@ def test_prepare_experiment(tmp_path) -> None:
     with tiledbsoma.open(soma_uri) as E:
         # check shapes
         assert E.obs.domain[0] == (0, rd.get_obs_shape() - 1)
-        for k in E.ms.keys():
+        for k in E.ms:
             assert E.ms[k].var.domain[0] == (0, rd.get_var_shapes()[k] - 1)
         assert E.ms["RNA"].X["data"].shape == (
             rd.get_obs_shape(),

--- a/apis/python/tests/test_reopen.py
+++ b/apis/python/tests/test_reopen.py
@@ -27,9 +27,8 @@ from ._util import create_basic_object, raises_no_typeguard
 def test_experiment_reopen(tmp_path, soma_type):
     # Create object and an error is thrown for reopen with invalid mode.
     uri = f"{tmp_path}/{soma_type}"
-    with create_basic_object(soma_type, uri, tiledb_timestamp=1) as x1:
-        with raises_no_typeguard(ValueError):
-            x1.reopen("invalid")
+    with create_basic_object(soma_type, uri, tiledb_timestamp=1) as x1, raises_no_typeguard(ValueError):
+        x1.reopen("invalid")
 
     # Check reopen without specifying timestamp.
     with tiledbsoma.open(uri, "r") as x1:

--- a/apis/python/tests/test_shape.py
+++ b/apis/python/tests/test_shape.py
@@ -99,12 +99,11 @@ def test_sparse_nd_array_basics(
             snda.read(coords).tables().concat()
 
     # Test writes out of bounds
-    with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
-        with pytest.raises(tiledbsoma.SOMAError):
-            dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
-            dikt["soma_data"] = [30]
-            table = pa.Table.from_pydict(dikt, schema=snda.schema)
-            snda.write(table)
+    with tiledbsoma.SparseNDArray.open(uri, "w") as snda, pytest.raises(tiledbsoma.SOMAError):
+        dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
+        dikt["soma_data"] = [30]
+        table = pa.Table.from_pydict(dikt, schema=snda.schema)
+        snda.write(table)
 
     with tiledbsoma.SparseNDArray.open(uri) as snda:
         assert snda.shape == arg_shape
@@ -131,12 +130,11 @@ def test_sparse_nd_array_basics(
         assert snda.shape == arg_shape
 
     # Test writes out of bounds
-    with tiledbsoma.SparseNDArray.open(uri, "w") as snda:
-        with pytest.raises(tiledbsoma.SOMAError):
-            dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
-            dikt["soma_data"] = [30]
-            table = pa.Table.from_pydict(dikt)
-            snda.write(table)
+    with tiledbsoma.SparseNDArray.open(uri, "w") as snda, pytest.raises(tiledbsoma.SOMAError):
+        dikt = {name: [shape + 20] for name, shape in zip(dim_names, arg_shape)}
+        dikt["soma_data"] = [30]
+        table = pa.Table.from_pydict(dikt)
+        snda.write(table)
 
     # Test resize
     new_shape = tuple([arg_shape[i] + 50 for i in range(ndim)])
@@ -426,10 +424,7 @@ def test_domain_mods(tmp_path):
 def test_canned_experiments(tmp_path, has_shapes):
     uri = tmp_path.as_posix()
 
-    if not has_shapes:
-        tgz = TESTDATA / "pbmc-exp-without-shapes.tgz"
-    else:
-        tgz = TESTDATA / "pbmc-exp-with-shapes.tgz"
+    tgz = TESTDATA / "pbmc-exp-without-shapes.tgz" if not has_shapes else TESTDATA / "pbmc-exp-with-shapes.tgz"
 
     with tarfile.open(tgz) as handle:
         if hasattr(tarfile, "data_filter"):
@@ -679,10 +674,7 @@ def test_canned_experiments(tmp_path, has_shapes):
     dict_output["ms"]["raw"]["var"]["uri"] = "test"
     dict_output["ms"]["raw"]["X"]["data"]["uri"] = "test"
 
-    if has_shapes:
-        var_max_domain_hi = 9223372036854773968
-    else:
-        var_max_domain_hi = 9223372036854773758
+    var_max_domain_hi = 9223372036854773968 if has_shapes else 9223372036854773758
 
     expect = {
         "obs": {
@@ -835,9 +827,7 @@ def test_get_experiment_shapes_corner_cases(tmp_path, level):
         expect = {}
     elif level == 2:
         expect = {"ms": {}}
-    elif level == 3:
-        expect = {"ms": {"RNA": {}}}
-    elif level == 4:
+    elif level == 3 or level == 4:
         expect = {"ms": {"RNA": {}}}
     assert actual == expect
 

--- a/apis/python/tests/test_update_uns.py
+++ b/apis/python/tests/test_update_uns.py
@@ -184,9 +184,8 @@ def test_update_uns(
     caplog.set_level(logging.INFO)
     soma_uri, adata = make_uns_adata(tmp_path)
 
-    with Experiment.open(soma_uri, "w") as exp:
-        with maybe_raises(err):
-            _update_uns(exp, uns_updates, measurement_name="RNA", strict=strict)
+    with Experiment.open(soma_uri, "w") as exp, maybe_raises(err):
+        _update_uns(exp, uns_updates, measurement_name="RNA", strict=strict)
 
     verify_logs(caplog, logs)
 

--- a/apis/system/tests/test_character_write_r_read_python.py
+++ b/apis/system/tests/test_character_write_r_read_python.py
@@ -20,5 +20,5 @@ class TestCharacterMetadataWriteRReadPython(TestReadPythonWriteR):
 
     def test_py_character(self, R_character):
         with tiledbsoma.open(self.uri) as exp:
-            for key in exp.metadata.keys():
+            for key in exp.metadata:
                 assert isinstance(exp.metadata.get(key), str)

--- a/apis/system/tests/test_dataframe_write_python_read_r.py
+++ b/apis/system/tests/test_dataframe_write_python_read_r.py
@@ -47,7 +47,7 @@ class TestDataframeWritePythonReadR(TestWritePythonReadR):
         self.r_assert(f"stopifnot(length(df) == {len(dataframe)})")
 
     def test_dataframe_columns_match(self, dataframe):
-        for key in dataframe.keys():
+        for key in dataframe:
             col = dataframe[key].tolist()
             R_list = embed_python_list_into_R_code(col)
             self.r_assert(f"""stopifnot(all.equal(as.list(df)$"{key}", c({R_list})))""")

--- a/libtiledbsoma/src/reindexer/example.py
+++ b/libtiledbsoma/src/reindexer/example.py
@@ -8,12 +8,14 @@ import tiledbsoma as soma
 def main():
     census_s3 = dict(census_version="latest")
     t1 = perf_counter()
-    with cellxgene_census.open_soma(**census_s3) as census:
-        with census["census_data"]["homo_sapiens"].axis_query(
+    with (
+        cellxgene_census.open_soma(**census_s3) as census,
+        census["census_data"]["homo_sapiens"].axis_query(
             measurement_name="RNA",
             obs_query=soma.AxisQuery(value_filter="tissue_general == 'eye'"),
-        ) as query:
-            query.to_anndata(X_name="raw")
+        ) as query,
+    ):
+        query.to_anndata(X_name="raw")
     t2 = perf_counter()
     print(f"End to end time {t2 - t1}")
 

--- a/libtiledbsoma/src/reindexer/test_indexer_data_types_perf.py
+++ b/libtiledbsoma/src/reindexer/test_indexer_data_types_perf.py
@@ -34,10 +34,7 @@ def run(data_type, keys, lookups, pandas):
     build_time = perf_counter()
     lookup(indexer, lookups)
     lookup_time = perf_counter()
-    if pandas:
-        name = "pandas"
-    else:
-        name = "reindexer"
+    name = "pandas" if pandas else "reindexer"
     print(f"{data_type}: Setup time: {name}: {build_time - start_time}: Lookup time: {lookup_time - build_time}")
 
 

--- a/profiler/src/profiler/report.py
+++ b/profiler/src/profiler/report.py
@@ -58,7 +58,7 @@ def extract_tiledb_data(data: ProfileData, metric: str) -> Union[int, float, Non
 def extract_context_data(data: ProfileData, metric: str) -> Union[int, float, None]:
     """Read the context data from a profile stored data and return the expected metric"""
     context = data.context
-    if metric in context.keys():
+    if metric in context:
         return context[metric]
     raise Exception(f"context does not have the following metric {metric}")
 


### PR DESCRIPTION
Enabled Ruff lint rules:
* SLOT: flake8-slots
* SIM: flake8-simplify
* TDY: flake8-tidy-imports

And fixed lint exposed by these rules.

Part of SOMA-323
