### PR TITLE
[python] Add support for `not` in query conditions

### DIFF
--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -487,7 +487,7 @@ class QueryConditionTree(ast.NodeVisitor):
     def visit_NameConstant(self, node: ast.Constant) -> ast.Constant:
         return node
 
-    def visit_UnaryOp(self, node: ast.UnaryOp, sign: int = 1) -> ast.Constant:
+    def visit_UnaryOp(self, node: ast.UnaryOp, sign: int = 1) -> Union[ast.Constant, clib.PyQueryCondition]:
         if isinstance(node.op, ast.Not):
             operand = self.visit(node.operand)
             if not isinstance(operand, clib.PyQueryCondition):

--- a/apis/python/src/tiledbsoma/_query_condition.py
+++ b/apis/python/src/tiledbsoma/_query_condition.py
@@ -494,6 +494,11 @@ class QueryConditionTree(ast.NodeVisitor):
         return node
 
     def visit_UnaryOp(self, node: ast.UnaryOp, sign: int = 1):
+        if isinstance(node.op, ast.Not):
+            operand = self.visit(node.operand)
+            if not isinstance(operand, clib.PyQueryCondition):
+                raise SOMAError(f"`not` can only be applied to a query condition, got {type(operand)}")
+            return operand.negate()
         if isinstance(node.op, ast.UAdd):
             sign *= 1
         elif isinstance(node.op, ast.USub):

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -137,6 +137,17 @@ class PyQueryCondition {
         return pyqc;
     }
 
+    PyQueryCondition negate() const {
+        try {
+            auto negated_qc = qc_->negate();
+            auto pyqc = PyQueryCondition(nullptr, ctx_.ptr().get());
+            pyqc.qc_ = std::make_shared<QueryCondition>(std::move(negated_qc));
+            return pyqc;
+        } catch (TileDBError& e) {
+            TPY_ERROR_LOC(e.what());
+        }
+    }
+
    private:
     PyQueryCondition(shared_ptr<QueryCondition> qc, tiledb_ctx_t* c_ctx)
         : qc_(qc) {

--- a/apis/python/src/tiledbsoma/query_condition.cc
+++ b/apis/python/src/tiledbsoma/query_condition.cc
@@ -88,6 +88,8 @@ void load_query_condition(py::module& m) {
 
         .def("combine", &PyQueryCondition::combine)
 
+        .def("negate", &PyQueryCondition::negate)
+
         .def_static(
             "create_string",
             static_cast<PyQueryCondition (*)(

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -63,6 +63,10 @@ def soma_query(uri, condition):
         "n_genes == +480",
         "n_genes >= -1",
         "n_genes > -(+(-1))",
+        # not ops
+        "not n_genes == 480",
+        "not n_genes > 500",
+        "not n_genes < 500",
         # boolean logic
         "percent_mito > 0.02 and n_genes > 700",  # and
         "percent_mito > 0.02 or n_genes > 700",  # or

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -208,6 +208,7 @@ def test_query_condition_reset():
         '"',
         "'",
         "attr(3) > 1attr(b) == 3",
+        "not > a",
     ],
 )
 def test_parsing_error_conditions(malformed_condition):
@@ -234,7 +235,6 @@ def test_parsing_error_conditions(malformed_condition):
         "attr() > 20",
         "n_genes < -val(-1)",
         "louvain in []",
-        "not > a",
     ],
 )
 def test_eval_error_conditions(malformed_condition):

--- a/apis/python/tests/test_query_condition.py
+++ b/apis/python/tests/test_query_condition.py
@@ -234,6 +234,7 @@ def test_parsing_error_conditions(malformed_condition):
         "attr() > 20",
         "n_genes < -val(-1)",
         "louvain in []",
+        "not > a",
     ],
 )
 def test_eval_error_conditions(malformed_condition):


### PR DESCRIPTION
Similarly to what is done in https://github.com/TileDB-Inc/TileDB-Py/pull/2211

Closes SOMA-377