### PR TITLE
[python] Fixes for the factory `open` method

### DIFF
--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -21,7 +21,7 @@ class DoesNotExistError(SOMAError):
     """
 
 
-def is_does_not_exist_error(e: RuntimeError | SOMAError) -> bool:
+def is_does_not_exist_error(e: Exception) -> bool:
     """Given a RuntimeError or SOMAError, return true if it indicates the object
     does not exist.
 

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -120,16 +120,18 @@ def open(
     Lifecycle:
         Maturing.
     """
-    context = _validate_soma_tiledb_context(context)
     if soma_type is None:
+        context = _validate_soma_tiledb_context(context)
         handle = _tdb_handles.open_handle_wrapper(uri=uri, mode=mode, context=context, timestamp=tiledb_timestamp)
         return reify_handle(handle)
+
     if isinstance(soma_type, str):
         soma_type_name = soma_type
     elif issubclass(soma_type, somacore.SOMAObject):
         soma_type_name = soma_type.soma_type
     else:
         raise TypeError(f"Cannot convert soma_type {soma_type!r} to expected SOMA type.")
+
     obj = _type_name_to_cls(soma_type_name).open(uri=uri, mode=mode, context=context, tiledb_timestamp=tiledb_timestamp)
     if soma_type and obj.soma_type.lower() != soma_type_name.lower():
         obj.close()

--- a/apis/python/src/tiledbsoma/_factory.py
+++ b/apis/python/src/tiledbsoma/_factory.py
@@ -121,26 +121,20 @@ def open(
         Maturing.
     """
     context = _validate_soma_tiledb_context(context)
-    handle = _tdb_handles.open_handle_wrapper(uri, mode, context, tiledb_timestamp)
-    try:
-        obj: SOMAObject[_Wrapper] = reify_handle(handle)  # type: ignore[valid-type]
-    except Exception:
-        handle.close()
-        raise
-    try:
-        if soma_type:
-            if isinstance(soma_type, str):
-                soma_type_name = soma_type
-            elif issubclass(soma_type, somacore.SOMAObject):
-                soma_type_name = soma_type.soma_type
-            else:
-                raise TypeError(f"Cannot convert soma_type {soma_type!r} to expected SOMA type.")
-            if obj.soma_type.lower() != soma_type_name.lower():
-                raise TypeError(f"Type of URI {uri!r} was {obj.soma_type}; expected {soma_type_name}.")
-        return obj
-    except Exception:
+    if soma_type is None:
+        handle = _tdb_handles.open_handle_wrapper(uri=uri, mode=mode, context=context, timestamp=tiledb_timestamp)
+        return reify_handle(handle)
+    if isinstance(soma_type, str):
+        soma_type_name = soma_type
+    elif issubclass(soma_type, somacore.SOMAObject):
+        soma_type_name = soma_type.soma_type
+    else:
+        raise TypeError(f"Cannot convert soma_type {soma_type!r} to expected SOMA type.")
+    obj = _type_name_to_cls(soma_type_name).open(uri=uri, mode=mode, context=context, tiledb_timestamp=tiledb_timestamp)
+    if soma_type and obj.soma_type.lower() != soma_type_name.lower():
         obj.close()
-        raise
+        raise TypeError(f"Type of URI {uri!r} was {obj.soma_type}; expected {soma_type_name}.")
+    return obj
 
 
 @typeguard_ignore

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -160,7 +160,7 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
             raise SOMAError(f"cannot delete previously-mutated key {key!r}")
         try:
             self._handle.deleter.remove(key)
-        except RuntimeError as tdbe:
+        except Exception as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise KeyError(tdbe) from tdbe
             raise

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -107,10 +107,10 @@ def open_handle_wrapper(
                 timestamp=(0, timestamp_ms),
                 clib_type=clib_type,
             )
-        except (SOMAError, RuntimeError) as tdbe:
+        except Exception as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise DoesNotExistError(tdbe) from tdbe
-            raise SOMAError(tdbe) from tdbe
+            raise
         try:
             return _type_to_class[handle.type.lower()].open_from_handle(handle, uri=uri, mode=mode, context=context)
         except KeyError:

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -165,16 +165,11 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
         timestamp = context._open_timestamp_ms(clib_handle.timestamp)
         try:
             wrapper = cls(uri, mode, context, timestamp, clib_handle)
-            if mode == "w":  # TODO: Fix before merging
-                with cls._opener(uri, "r", context, timestamp) as auxiliary_reader:
-                    wrapper._do_initial_reads(auxiliary_reader)
-            else:
-                wrapper._do_initial_reads(clib_handle)
         except RuntimeError as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise DoesNotExistError(tdbe) from tdbe
             raise
-
+        wrapper._do_initial_reads(clib_handle)
         obj_type = wrapper.metadata.get(SOMA_OBJECT_TYPE_METADATA_KEY)
         if obj_type is None:
             raise SOMAError(

--- a/apis/python/src/tiledbsoma/_tdb_handles.py
+++ b/apis/python/src/tiledbsoma/_tdb_handles.py
@@ -84,22 +84,6 @@ def open_handle_wrapper(
     """Determine whether the URI is an array or group, and open it."""
     timestamp_ms = context._open_timestamp_ms(timestamp)
 
-    try:
-        if clib_type is None:
-            clib_type = clib.get_soma_type_metadata_value(uri, context.native_context, (0, timestamp_ms))
-        elif clib_type.lower() == "somaarray":
-            clib_type = clib.get_soma_type_metadata_value_from_array(uri, context.native_context, (0, timestamp_ms))
-        elif clib_type.lower() == "somagroup":
-            clib_type = clib.get_soma_type_metadata_value_from_group(uri, context.native_context, (0, timestamp_ms))
-    except SOMAError as soma_err:
-        # Note: SOMAError is only raised above if the reference isn't a TileDB object or
-        # it doesn't have SOMA datatype metadata.
-        raise DoesNotExistError(soma_err) from soma_err
-    except RuntimeError as tdbe:
-        if is_does_not_exist_error(tdbe):
-            raise DoesNotExistError(tdbe) from tdbe
-        raise SOMAError(tdbe) from tdbe
-
     _type_to_class = {
         "somadataframe": DataFrameWrapper,
         "somapointclouddataframe": PointCloudDataFrameWrapper,
@@ -112,6 +96,25 @@ def open_handle_wrapper(
         "somascene": SceneWrapper,
         "somamultiscaleimage": MultiscaleImageWrapper,
     }
+
+    if clib_type is None or clib_type.lower() in ["somaarray", "somagroup"]:
+        try:
+            open_mode = _open_mode_to_clib_mode(mode)
+            handle = clib.SOMAObject.open(
+                uri=uri,
+                mode=open_mode,
+                context=context.native_context,
+                timestamp=(0, timestamp_ms),
+                clib_type=clib_type,
+            )
+        except (SOMAError, RuntimeError) as tdbe:
+            if is_does_not_exist_error(tdbe):
+                raise DoesNotExistError(tdbe) from tdbe
+            raise SOMAError(tdbe) from tdbe
+        try:
+            return _type_to_class[handle.type.lower()].open_from_handle(handle, uri=uri, mode=mode, context=context)
+        except KeyError:
+            raise SOMAError(f"{uri!r} has unknown storage type {clib_type!r}") from None
 
     try:
         return _type_to_class[clib_type.lower()].open(uri=uri, mode=mode, context=context, timestamp=timestamp_ms)
@@ -149,16 +152,28 @@ class Wrapper(Generic[_RawHdl_co], metaclass=abc.ABCMeta):
 
         try:
             tdb_handle = cls._opener(uri, mode, context, timestamp_ms)
-            wrapper = cls(uri, mode, context, timestamp_ms, tdb_handle)
-            if mode == "w":
-                with cls._opener(uri, "r", context, timestamp_ms) as auxiliary_reader:
-                    wrapper._do_initial_reads(auxiliary_reader)
-            else:
-                wrapper._do_initial_reads(tdb_handle)
         except (RuntimeError, SOMAError) as tdbe:
             if is_does_not_exist_error(tdbe):
                 raise DoesNotExistError(tdbe) from tdbe
             raise SOMAError(tdbe) from tdbe
+        return cls.open_from_handle(tdb_handle, uri=uri, mode=mode, context=context)
+
+    @classmethod
+    def open_from_handle(
+        cls, clib_handle: clib.SOMAObject, *, uri: str, mode: options.OpenMode, context: SOMATileDBContext
+    ) -> Self:
+        timestamp = context._open_timestamp_ms(clib_handle.timestamp)
+        try:
+            wrapper = cls(uri, mode, context, timestamp, clib_handle)
+            if mode == "w":  # TODO: Fix before merging
+                with cls._opener(uri, "r", context, timestamp) as auxiliary_reader:
+                    wrapper._do_initial_reads(auxiliary_reader)
+            else:
+                wrapper._do_initial_reads(clib_handle)
+        except RuntimeError as tdbe:
+            if is_does_not_exist_error(tdbe):
+                raise DoesNotExistError(tdbe) from tdbe
+            raise
 
         obj_type = wrapper.metadata.get(SOMA_OBJECT_TYPE_METADATA_KEY)
         if obj_type is None:

--- a/apis/python/tests/test_clib.py
+++ b/apis/python/tests/test_clib.py
@@ -79,7 +79,7 @@ def test_get_soma_type_metadata_value_from_array_error(tmp_path_factory):
         coll.close()
 
     ctx = tiledbsoma.SOMATileDBContext()
-    with pytest.raises(RuntimeError, match=".* Array does not exist."):
+    with pytest.raises(Exception, match=".* Array does not exist."):
         somaclib.get_soma_type_metadata_value_from_array(uri, ctx.native_context, None)
 
 
@@ -89,5 +89,5 @@ def test_get_soma_type_metadata_value_from_group_error(tmp_path_factory):
         df.close()
 
     ctx = tiledbsoma.SOMATileDBContext()
-    with pytest.raises(RuntimeError, match=".* Group does not exist."):
+    with pytest.raises(Exception, match=".* Group does not exist."):
         somaclib.get_soma_type_metadata_value_from_group(uri, ctx.native_context, None)


### PR DESCRIPTION
**Issue and/or context:**
* Closes SOMA-350
* Closes SOMA-351

**Changes:**
* Add back method that creates a TileDB-SOMA Wrapper from an open handle.
* Fix error handling for creating `DoesNotExistError` to check generic errors (if TileDB-Py is installed before TileDB-SOMA they will be TileDB errors).