### PR TITLE
[python] unit tests:  Arrow 20 API changes

### DIFF
--- a/apis/python/tests/ht/_ht_util.py
+++ b/apis/python/tests/ht/_ht_util.py
@@ -666,6 +666,7 @@ def arrays_equal(read: pa.ChunkedArray, expected: pa.ChunkedArray, *, equal_nan:
                 combine_chunks(read).dictionary_decode(),
                 combine_chunks(expected).dictionary_decode(),
             ),
+            min_count=0,
         )
         if not is_eq:
             note("arrays_equal: dictionary arrays not equal")

--- a/apis/system/tests/test_sparsendarray_write_r_read_python.py
+++ b/apis/system/tests/test_sparsendarray_write_r_read_python.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pyarrow as pa
 import pytest
+from packaging.version import Version
 
 import tiledbsoma as soma
 
@@ -50,8 +52,13 @@ class TestSparseNDArrayWriteRReadPython(TestReadPythonWriteR):
         """
         with soma.open(self.uri) as sdf:
             arr = sdf.read().coos().concat().to_scipy().todense()
-            assert np.array_equal(arr[0], np.matrix([0, 1, 0, 0, 0]))
-            assert np.array_equal(arr[1], np.matrix([0, 0, 2, 0, 0]))
-            assert np.array_equal(arr[2], np.matrix([0, 0, 0, 0, 0]))
-            assert np.array_equal(arr[3], np.matrix([0, 0, 0, 0, 0]))
-            assert np.array_equal(arr[4], np.matrix([0, 0, 0, 0, 0]))
+
+            # As of Arrow 20, `to_scipy` returns sparray. Previously spmatrix.
+
+            ctor = np.array if Version(pa) < Version("20.0.0") else np.matrix
+
+            assert np.array_equal(arr[0], ctor([0, 1, 0, 0, 0]))
+            assert np.array_equal(arr[1], ctor([0, 0, 2, 0, 0]))
+            assert np.array_equal(arr[2], ctor([0, 0, 0, 0, 0]))
+            assert np.array_equal(arr[3], ctor([0, 0, 0, 0, 0]))
+            assert np.array_equal(arr[4], ctor([0, 0, 0, 0, 0]))

--- a/apis/system/tests/test_sparsendarray_write_r_read_python.py
+++ b/apis/system/tests/test_sparsendarray_write_r_read_python.py
@@ -53,9 +53,8 @@ class TestSparseNDArrayWriteRReadPython(TestReadPythonWriteR):
         with soma.open(self.uri) as sdf:
             arr = sdf.read().coos().concat().to_scipy().todense()
 
-            # As of Arrow 20, `to_scipy` returns sparray. Previously spmatrix.
-
-            ctor = np.array if Version(pa) < Version("20.0.0") else np.matrix
+            # As of Arrow 21, `to_scipy` returns sparray. Previously spmatrix.
+            ctor = np.array if Version(pa.__version__) < Version("21.0.0") else np.matrix
 
             assert np.array_equal(arr[0], ctor([0, 1, 0, 0, 0]))
             assert np.array_equal(arr[1], ctor([0, 0, 2, 0, 0]))

--- a/apis/system/tests/test_sparsendarray_write_r_read_python.py
+++ b/apis/system/tests/test_sparsendarray_write_r_read_python.py
@@ -54,7 +54,7 @@ class TestSparseNDArrayWriteRReadPython(TestReadPythonWriteR):
             arr = sdf.read().coos().concat().to_scipy().todense()
 
             # As of Arrow 21, `to_scipy` returns sparray. Previously spmatrix.
-            ctor = np.array if Version(pa.__version__) < Version("21.0.0") else np.matrix
+            ctor = np.array if Version(pa.__version__) >= Version("21.0.0") else np.matrix
 
             assert np.array_equal(arr[0], ctor([0, 1, 0, 0, 0]))
             assert np.array_equal(arr[1], ctor([0, 0, 2, 0, 0]))


### PR DESCRIPTION
Fixes SOMA-363
Fixes SOMA-364

Arrow 20 chnages:
* fixed a casting bug for BooleanScalar types, which exposed a bug in the unit test logic for comparing empty arrays.
* update to sparray (scipy.sparse) changes

