### PR TITLE
[python] fix unit test bugs related to hypothesis usage

### DIFF
--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -97,7 +97,7 @@ jobs:
           CXX: ${{ matrix.cxx }}
 
       - name: Install dependencies
-        run: pip install --prefer-binary pytest typeguard tiledb.cloud
+        run: pip install --prefer-binary pytest typeguard tiledb<=0.34.0 tiledb.cloud
 
       - name: Show package versions
         run: python scripts/show-versions.py

--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -97,7 +97,7 @@ jobs:
           CXX: ${{ matrix.cxx }}
 
       - name: Install dependencies
-        run: pip install --prefer-binary pytest typeguard tiledb<=0.34.0 tiledb.cloud
+        run: pip install --prefer-binary pytest typeguard 'tiledb<=0.34.0' tiledb.cloud
 
       - name: Show package versions
         run: python scripts/show-versions.py

--- a/apis/python/tests/ht/_array_state_machine.py
+++ b/apis/python/tests/ht/_array_state_machine.py
@@ -95,6 +95,7 @@ class SOMAArrayStateMachine(RuleBasedStateMachine):
     ##
 
     @precondition(lambda self: self.is_initialized)
+    @invariant()
     def check_exists(self) -> None:
         assert self._array_exists(self.uri, self.context, None)
 

--- a/apis/python/tests/ht/test_ht_caching_reader.py
+++ b/apis/python/tests/ht/test_ht_caching_reader.py
@@ -36,15 +36,15 @@ class CachingReaderStateMachine(RuleBasedStateMachine):
 
         super().teardown()
 
-    @invariant()
     @precondition(lambda self: self.raw is not None and self._closed)
+    @invariant()
     def check_closed_state(self) -> None:
         """Invariants that should be true when we have a file handle (in any state)"""
         assert self.raw is not None and self.cached is not None
         assert self.raw.closed == self.cached.closed
 
-    @invariant()
     @precondition(lambda self: self.raw is not None and not self._closed)
+    @invariant()
     def check_open_state(self) -> None:
         """Invariants that should be true if we have an open handle"""
         assert self.raw is not None and not self._closed

--- a/apis/python/tests/ht/test_ht_densendarray.py
+++ b/apis/python/tests/ht/test_ht_densendarray.py
@@ -188,7 +188,8 @@ class SOMADenseNDArrayStateMachine(SOMANDArrayStateMachine):
     # XXX temporarily override this so we can disable any reshapes (sc-61676).
     # If we allow reshapes, read/write tests fail due to the bug.
     # TODO: remove this code (let base class do its thing) when this bug is fixed.
-    @precondition(HT_TEST_CONFIG["sc-61676_workaround"])
+    @precondition(lambda self: HT_TEST_CONFIG["sc-61676_workaround"])
+    @rule(data=st.data())
     def expand_shape(self, data: st.DataObject) -> None:
         return
 

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -259,7 +259,7 @@ def test_change_counts(
 
 
 @pytest.mark.parametrize("separate_ingest", [False, True])
-def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_ingest):
+def test_update_non_null_to_null(soma_tiledb_context, tmp_path, conftest_pbmc3k_adata, separate_ingest):
     uri = tmp_path.as_uri()
 
     # Two ways to test:
@@ -280,6 +280,7 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
             conftest_pbmc3k_adata,
             measurement_name="RNA",
             uns_keys=[],
+            context=soma_tiledb_context,
         )
 
         conftest_pbmc3k_adata.obs["batch_id"] = "testing"
@@ -295,6 +296,7 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
             conftest_pbmc3k_adata,
             measurement_name="RNA",
             uns_keys=[],
+            context=soma_tiledb_context,
         )
 
     conftest_pbmc3k_adata.obs["batch_id"] = pd.NA
@@ -303,11 +305,11 @@ def test_update_non_null_to_null(tmp_path, conftest_pbmc3k_adata, separate_inges
     verify_updates(uri, conftest_pbmc3k_adata.obs, conftest_pbmc3k_adata.var)
 
 
-def test_enmr_add_drop_readd(tmp_path, conftest_pbmc3k_adata):
+def test_enmr_add_drop_readd(soma_tiledb_context, tmp_path, conftest_pbmc3k_adata):
     uri = tmp_path.as_posix()
 
     # Add
-    tiledbsoma.io.from_anndata(uri, conftest_pbmc3k_adata, measurement_name="RNA")
+    tiledbsoma.io.from_anndata(uri, conftest_pbmc3k_adata, measurement_name="RNA", context=soma_tiledb_context)
 
     with tiledbsoma.Experiment.open(uri, "r") as exp:
         schema = exp.obs.schema


### PR DESCRIPTION
Correct typos in unit tests incorrectly using Hypothesis `precondition` decorator.

Fixes  SOMA-368
Fixes  #4174 

Note to reviewers: testing this PR also exposed an OOM condition in unit tests (on MacOS runners), due to use of the default SOMA context (which allows for more memory than is available in small runners). Fixed by specifying the small mem context used elsewhere in unit tests.

Note 2 to reviewer: PR also contains a temporary pin for `tiledb` to work-around the core version breakage caused by new symbols being added in a patch release.