### PR TITLE
Update TileDB core to 2.28.1

### DIFF
--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir -p external
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-linux-x86_64-2.28.0-4764907.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/
       - name: Build and install libtiledbsoma

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-linux-x86_64-2.28.0-4764907.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz
           tar -C external -xzf tiledb-linux-x86_64-*.tar.gz
           ls external/lib/
           echo "LD_LIBRARY_PATH=$(pwd)/external/lib" >> $GITHUB_ENV
@@ -179,10 +179,10 @@ jobs:
           mkdir -p external
           # Please do not edit manually -- let scripts/update-tiledb-version.py update this
           if [ `uname -m` == "arm64" ]; then
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-arm64-2.28.0-4764907.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-arm64-2.28.1-d648231.tar.gz
             tar -C external -xzf tiledb-macos-arm64-*.tar.gz
           else
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-x86_64-2.28.0-4764907.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-x86_64-2.28.1-d648231.tar.gz
             tar -C external -xzf tiledb-macos-x86_64-*.tar.gz
           fi
           ls external/lib/
@@ -275,14 +275,14 @@ jobs:
           if [ `uname -s` == "Darwin" ]; then
             if [ `uname -m` == "arm64" ]; then
                 # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-arm64-2.28.0-4764907.tar.gz
+                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-arm64-2.28.1-d648231.tar.gz
             else
                 # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-x86_64-2.28.0-4764907.tar.gz
+                wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-x86_64-2.28.1-d648231.tar.gz
             fi
           else
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-linux-x86_64-2.28.0-4764907.tar.gz
+            wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz
           fi
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,5 @@
 exclude: ^doc/source/
 repos:
-  - repo: https://github.com/psf/black
-    rev: "25.1.0"
-    hooks:
-    - id: black
-      args: ["--config=apis/python/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- \[[#4126](https://github.com/single-cell-data/TileDB-SOMA/pull/4126)\] [python] At package import time, validate that the expected TileDB version is installed and used. Raises a RuntimeError exception if the condition is not met. This is an attempt to better warn users who have corrupted conda installations.
+- \[[#4137](https://github.com/single-cell-data/TileDB-SOMA/pull/4137)\] [python][BREAKING] Add user-specified obs/var index column to `ExperimentAxisQuery.to_anndata`. This change will also set the index columns based upon metadata hints, following the conventions of `tiledbsoma.io`. See the docstrings for more details. Prior to this change, the index dtype would be set to `string` in all cases - this change removes the forced cast, and leaves the column type as-is.
+- Update TileDB version to https://github.com/single-cell-data/TileDB-SOMA/pull/4177
+
 ### Deprecated
 
 ### Removed
@@ -17,6 +21,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 ### Security
+
+## [Release 1.17.0]
+
+Release 1.17.0 upgrades from TileDB 2.28.0 to TileDB 2.28.1.
+
+
+### Changed
+
+- \[[#4177](https://github.com/single-cell-data/TileDB-SOMA/pull/4177)\] Update [TileDB core to 2.28.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.28.1).
+
 
 ## [Release 1.17.0]
 

--- a/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/ambient_label_mappings.py
@@ -495,7 +495,7 @@ class ExperimentAmbientLabelMapping:
         # Step 3: create a joinid map for each axis
         #
         def _make_joinid_map(
-            joinids_index: pd.Index,  # type:ignore[type-arg]
+            joinids_index: pd.Index,
             prev_joinid_map: pd.DataFrame,
         ) -> pd.DataFrame:
             maps = []
@@ -648,7 +648,7 @@ class AnnDataAxisMetadata:
         if len(ams) == 1:
             return ams[0]
 
-        def _reduce_field_index(indices: list[pd.Index]) -> pd.Index:  # type: ignore[type-arg]
+        def _reduce_field_index(indices: list[pd.Index]) -> pd.Index:
             """Reducer for joinid indices."""
             if len(indices) == 0:
                 return pd.Index([])
@@ -710,10 +710,10 @@ class AnnDataAxisMetadata:
         return {k: _merge_categoricals(k, v) for k, v in inverted_enum_values.items()}
 
 
-def _get_dataframe_joinid_index(df: pd.DataFrame, field_name: str) -> pd.Index:  # type: ignore[type-arg]
+def _get_dataframe_joinid_index(df: pd.DataFrame, field_name: str) -> pd.Index:
     """Given an AnnData obs/var, extract the index for the user-selected join column."""
     if field_name in df:
         return cast("pd.Index[Any]", pd.Index(df[field_name]))
     if df.index.name in (field_name, "index", None):
-        return df.index
+        return cast("pd.Index[Any]", df.index)
     raise ValueError(f"Could not find field name {field_name} in dataframe.")

--- a/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
+++ b/apis/python/src/tiledbsoma/io/_registration/id_mappings.py
@@ -74,14 +74,14 @@ class ExperimentIDMapping:
         return cls(obs_axis=obs_axis, var_axes=var_axes)
 
 
-def get_dataframe_values(df: pd.DataFrame, field_name: str) -> pd.Series:  # type: ignore[type-arg]
+def get_dataframe_values(df: pd.DataFrame, field_name: str) -> pd.Series:
     """Extracts the label values (e.g. cell barcode, gene symbol) from an AnnData/H5AD
     ``obs`` or ``var`` dataframe.
     """
     if field_name in df:
-        values = cast(pd.Series, df[field_name].astype(str))  # type: ignore[type-arg]
+        values = cast(pd.Series, df[field_name].astype(str))
     elif df.index.name in (field_name, "index", None):
-        values = cast(pd.Series, df.index.to_series().astype(str))  # type: ignore[type-arg]
+        values = cast(pd.Series, df.index.to_series().astype(str))
     else:
         raise ValueError(f"Could not find field name {field_name} in dataframe.")
 

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -5,12 +5,27 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Union
 
+import _pytest
 import numpy as np
 import pandas as pd
 import pytest
 from _pytest._code import ExceptionInfo
 from _pytest.logging import LogCaptureFixture
-from _pytest.python_api import E, RaisesContext
+from packaging.version import Version
+from typing_extensions import TypeVar
+
+if Version(_pytest.__version__) < Version("8.4.0"):
+    from _pytest.python_api import RaisesContext
+
+    E = TypeVar("E", bound=BaseException, default=BaseException)
+    MaybeRaisesReturn = Union[RaisesContext[E], ExceptionInfo[E], nullcontext]
+else:
+    from _pytest.raises import RaisesExc
+
+    E = TypeVar("E", bound=BaseException, default=BaseException)
+    MaybeRaisesReturn = Union[RaisesExc[E], ExceptionInfo[E], nullcontext]
+
+
 from anndata import AnnData
 from numpy import array_equal
 from pandas._testing import assert_frame_equal, assert_series_equal

--- a/apis/python/tests/ht/_ht_util.py
+++ b/apis/python/tests/ht/_ht_util.py
@@ -719,7 +719,8 @@ def arrays_equal(
             pa.compute.equal(
                 combine_chunks(read).dictionary_decode(),
                 combine_chunks(expected).dictionary_decode(),
-            )
+            ),
+            min_count=0,
         )
         if not is_eq:
             note("arrays_equal: dictionary arrays not equal")

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 1.17.0
+Version: 1.17.1
 Authors@R: c(
     person(given = "Aaron", family = "Wolen",
            role = "aut", email = "aaron@tiledb.com",
@@ -70,6 +70,7 @@ Suggests:
     SingleCellExperiment (>= 1.20.0),
     SummarizedExperiment (>= 1.28.0),
     testthat (>= 3.0.0),
+    tibble,
     withr
 Config/testthat/edition: 2
 OS_type: unix

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,6 +12,12 @@
 
 ## Security
 
+# tiledbsoma 1.17.1
+
+## Changed
+
+- Update [TileDB core to 2.28.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.28.1). ([#4077](https://github.com/single-cell-data/TileDB-SOMA/pull/4177))
+
 # tiledbsoma 1.17.0
 
 ## Removed

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,14 +14,14 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
     arch <- system('uname -m', intern = TRUE)
     if (arch == "x86_64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-x86_64-2.28.0-4764907.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-x86_64-2.28.1-d648231.tar.gz"
     } else if (arch == "arm64") {
-      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-arm64-2.28.0-4764907.tar.gz"
+      url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-arm64-2.28.1-d648231.tar.gz"
     } else {
       stop("Unsupported Mac architecture. Please have TileDB Core installed locally.")
     }
 } else if (isLinux) {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-linux-x86_64-2.28.0-4764907.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz"
 } else {
     message("Unsupported platform for downloading artifacts. Please have TileDB Core installed locally.")
     q(save = "no", status = 1)

--- a/apis/system/tests/test_sparsendarray_write_r_read_python.py
+++ b/apis/system/tests/test_sparsendarray_write_r_read_python.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pyarrow as pa
 import pytest
+from packaging.version import Version
 
 import tiledbsoma as soma
 
@@ -50,8 +52,14 @@ class TestSparseNDArrayWriteRReadPython(TestReadPythonWriteR):
         """
         with soma.open(self.uri) as sdf:
             arr = sdf.read().coos().concat().to_scipy().todense()
-            assert np.array_equal(arr[0], np.matrix([0, 1, 0, 0, 0]))
-            assert np.array_equal(arr[1], np.matrix([0, 0, 2, 0, 0]))
-            assert np.array_equal(arr[2], np.matrix([0, 0, 0, 0, 0]))
-            assert np.array_equal(arr[3], np.matrix([0, 0, 0, 0, 0]))
-            assert np.array_equal(arr[4], np.matrix([0, 0, 0, 0, 0]))
+
+            # As of Arrow 21, `to_scipy` returns sparray. Previously spmatrix.
+            ctor = (
+                np.array if Version(pa.__version__) >= Version("21.0.0") else np.matrix
+            )
+
+            assert np.array_equal(arr[0], ctor([0, 1, 0, 0, 0]))
+            assert np.array_equal(arr[1], ctor([0, 0, 2, 0, 0]))
+            assert np.array_equal(arr[2], ctor([0, 0, 0, 0, 0]))
+            assert np.array_equal(arr[3], ctor([0, 0, 0, 0, 0]))
+            assert np.array_equal(arr[4], ctor([0, 0, 0, 0, 0]))

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -38,8 +38,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-windows-x86_64-2.28.0-4764907.zip")
-          SET(DOWNLOAD_SHA1 "3629193fc9b8e8aecff4156a2a2183f1c4c1a0ee")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-windows-x86_64-2.28.1-d648231.zip")
+          SET(DOWNLOAD_SHA1 "ca6ccd339b6e3ce0ad1ff8c195a00412e3392178")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -56,22 +56,22 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-x86_64-2.28.0-4764907.tar.gz")
-            SET(DOWNLOAD_SHA1 "4e053376b707765eb223afd9261505315f217be0")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-x86_64-2.28.1-d648231.tar.gz")
+            SET(DOWNLOAD_SHA1 "6191aca6e76a95a57288e9733f299c7b47e0d55e")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-arm64-2.28.0-4764907.tar.gz")
-            SET(DOWNLOAD_SHA1 "de6f1c79351191702ebc08e15a7257ade8b40b92")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-arm64-2.28.1-d648231.tar.gz")
+            SET(DOWNLOAD_SHA1 "ce14964eb027e1bab3704668208f5289c9fbca1d")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-x86_64-2.28.0-4764907.tar.gz")
-            SET(DOWNLOAD_SHA1 "4e053376b707765eb223afd9261505315f217be0")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-x86_64-2.28.1-d648231.tar.gz")
+            SET(DOWNLOAD_SHA1 "6191aca6e76a95a57288e9733f299c7b47e0d55e")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-macos-arm64-2.28.0-4764907.tar.gz")
-            SET(DOWNLOAD_SHA1 "de6f1c79351191702ebc08e15a7257ade8b40b92")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-macos-arm64-2.28.1-d648231.tar.gz")
+            SET(DOWNLOAD_SHA1 "ce14964eb027e1bab3704668208f5289c9fbca1d")
           endif()
 
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-linux-x86_64-2.28.0-4764907.tar.gz")
-          SET(DOWNLOAD_SHA1 "cd65b2978920ecd5017b061e15f172048c081dd2")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz")
+          SET(DOWNLOAD_SHA1 "f7c2c76bae0373cfc259b2a854b464abb873bbee")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -93,8 +93,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.28.0.zip"
-          URL_HASH SHA1=ec633e4440ff7d16f2668e37f24e80e3b7d168cd
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.28.1.zip"
+          URL_HASH SHA1=9118c60f166ebe62ac39ab7fc72c39403b5af086
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
**Changes:**
* Update TileDB core version from 2.28.0 to 2.28.1
* Update changelogs and TileDB-R version
* Backport a series of small test/linter fixes
