### PR TITLE
[ci] Update `pypa/cibuildwheel` version

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -8,6 +8,9 @@ on:
   # Specify the branch or other ref as required, allowing testing
   # of PRs/branches.
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/python-packaging.yml'
   # Trigger publication to PyPi via new release event.
   release:
     types: [published]

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           xcode-version: '15.4'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.1.1
         with:
           package-dir: tiledbsoma.tar.gz
           only: cp${{ matrix.python-version }}-${{ matrix.cibw_build }}


### PR DESCRIPTION
`python-packaging.yml` uses `pypa/cibuildwheel@v2.23.2`, latest is [v3.1.1](https://github.com/pypa/cibuildwheel/releases/tag/v3.1.1)

Fixes [SOMA-375](https://linear.app/tiledb/issue/SOMA-375/python-packagingyml)
Resolves [SOMA-242](https://linear.app/tiledb/issue/SOMA-242/update-soma-gh-action-workflow-versions)

Note for reviewers: I've adjusted the workflow triggers to include PRs that modify `python-packaging.yml`; I can remove this if necessary