### PR TITLE
[ci] Update checkout to fetch tags with depth=1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,7 +49,11 @@ jobs:
           - {os: ubuntu-latest, r: 'oldrel-1'}
 
     steps:
+      - name: Checkout TileDB-SOMA
       - uses: actions/checkout@v4
+
+      - name: Print current commit
+        run: git log -1 --oneline
 
       - name: Show matrix OS
         run: echo "matrix.config.os:" ${{ matrix.config.os }}

--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -21,10 +21,16 @@ jobs:
     steps:
     - name: Checkout TileDB-SOMA
       uses: actions/checkout@v4
+
+    - name: Print current commit
+      run: git log -1 --oneline
+
     - name: Build libTileDB-SOMA
       run: TILEDBSOMA_COVERAGE="--coverage" ./scripts/bld --no-tiledb-deprecated=true --werror=true
+
     - name: Run libTileDB-SOMA unittests
       run: ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
+
+      - name: Print current commit
+        run: git log -1 --oneline
+
       - name: Install pre-built libtiledb
         run: |
           mkdir -p external
@@ -28,6 +32,7 @@ jobs:
           wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.28.1/tiledb-linux-x86_64-2.28.1-d648231.tar.gz
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/
+
       - name: Build and install libtiledbsoma
         run: |
           cmake -S libtiledbsoma -B build \
@@ -40,5 +45,6 @@ jobs:
             -D FORCE_BUILD_TILEDB=OFF
           cmake --build build -j 2
           ls external/lib/
+
       - name: Run C++ unittests
         run:  ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build/libtiledbsoma -C ASAN --verbose --rerun-failed --output-on-failure

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
 
+      - name: Print current commit
+        run: git log -1 --oneline
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -78,7 +81,10 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # ensure we get all tags to inform package version determination
+          fetch-tags: true # ensure we get all tags to inform package version determination
+
+      - name: Print current commit
+        run: git log -1 --oneline
 
       - name: Set Up Test Data
         run: make data

--- a/.github/workflows/python-dependency-variation.yml
+++ b/.github/workflows/python-dependency-variation.yml
@@ -53,7 +53,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Check out TileDB-SOMA
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Current commit
+        run: git log -1 --one-line
 
       - name: Show matrix OS
         run: echo "matrix.os:" ${{ matrix.os }}
@@ -72,23 +78,15 @@ jobs:
         with:
           xcode-version: '15.4'
 
+      - name: Show XCode version
+        run: clang --version
+
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           cache: pip
           cache-dependency-path: ./apis/python/setup.py
-
-      - name: Show XCode version
-        run: clang --version
-
-      - name: Check out TileDB-SOMA
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # ensure we get all tags to inform package version determination
-
-      - name: Log pip dependencies
-        run: pip list
 
       - name: Install tiledbsoma
         run: pip -v install -e apis/python[all] -C "--build-option=--no-tiledb-deprecated"
@@ -109,6 +107,9 @@ jobs:
             pyarrow==${{matrix.pyarrow}} \
             scanpy==${{matrix.scanpy}} \
             scipy==${{matrix.scipy}}
+
+      - name: Log pip dependencies
+        run: pip list
 
       - name: Show package versions
         run: python scripts/show-versions.py

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # ensure we get all tags to inform package version determination
+          fetch-tags: true
+
+      - name: Print current commit
+        run: git log -1 --oneline
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Update GitHub actions to fetch tags with depth=1 instead of cloning entire repo.