### PR TITLE
[ci] Fix extra '-' in R-CMD CI yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout TileDB-SOMA
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Print current commit
         run: git log -1 --oneline


### PR DESCRIPTION
Fix an extra `-` I added to the R-CMD github action.