### PR TITLE
Adding sparray official support from_anndata

### DIFF
--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from typing import Mapping, Union
-import os
 
 import h5py
 import numpy as np
@@ -51,6 +50,3 @@ _UNS_OUTGEST_COLUMN_NAME_1D = "values"
 _UNS_OUTGEST_COLUMN_PREFIX_2D = "values_"
 
 _TILEDBSOMA_TYPE = "soma_tiledbsoma_type"
-
-
-

--- a/apis/python/src/tiledbsoma/io/_common.py
+++ b/apis/python/src/tiledbsoma/io/_common.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from typing import Mapping, Union
+import os
 
 import h5py
 import numpy as np
@@ -23,7 +24,7 @@ except (AttributeError, ModuleNotFoundError):
 
 from tiledbsoma._types import Metadatum, NPNDArray
 
-SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSCDataset, CSRDataset]
+SparseMatrix = Union[sp.csr_matrix, sp.csc_matrix, CSCDataset, CSRDataset, sp.csr_array, sp.csc_array]
 DenseMatrix = Union[NPNDArray, h5py.Dataset]
 Matrix = Union[DenseMatrix, SparseMatrix]
 
@@ -50,3 +51,6 @@ _UNS_OUTGEST_COLUMN_NAME_1D = "values"
 _UNS_OUTGEST_COLUMN_PREFIX_2D = "values_"
 
 _TILEDBSOMA_TYPE = "soma_tiledbsoma_type"
+
+
+

--- a/apis/python/src/tiledbsoma/io/conversions.py
+++ b/apis/python/src/tiledbsoma/io/conversions.py
@@ -22,7 +22,7 @@ from tiledbsoma._types import NPNDArray, PDSeries
 from tiledbsoma.options._soma_tiledb_context import SOMATileDBContext
 
 _DT = TypeVar("_DT", bound=pdt.Dtype)
-_MT = TypeVar("_MT", NPNDArray, sp.spmatrix, PDSeries)
+_MT = TypeVar("_MT", NPNDArray, sp.spmatrix, sp.sparray, PDSeries)
 _str_to_type = {"boolean": bool, "string": str, "bytes": bytes}
 
 COLUMN_DECAT_THRESHOLD = 32767
@@ -183,7 +183,7 @@ def to_tiledb_supported_array_type(name: str, x: _MT) -> _MT:  # noqa: ARG001
     """Converts datatypes unrepresentable by TileDB into datatypes it can represent,
     e.g., float16 -> float32.
     """
-    if isinstance(x, (np.ndarray, sp.spmatrix)) or not isinstance(x.dtype, pd.CategoricalDtype):
+    if isinstance(x, (np.ndarray, sp.spmatrix, sp.sparray)) or not isinstance(x.dtype, pd.CategoricalDtype):
         target_dtype = _to_tiledb_supported_dtype(x.dtype)
         return x if target_dtype == x.dtype else x.astype(target_dtype)
 

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -83,7 +83,7 @@ def assert_array_equal(a0, a1):
     assert type(a0) is type(a1)
     if isinstance(a0, np.ndarray):
         assert array_equal(a0, a1)
-    elif isinstance(a0, spmatrix):
+    elif isinstance(a0, (spmatrix, sp.sparray)):
         assert type(a0) is type(a1)
         assert a0.shape == a1.shape
         assert (a0 != a1).nnz == 0

--- a/apis/python/tests/_util.py
+++ b/apis/python/tests/_util.py
@@ -32,7 +32,7 @@ else:
 from anndata import AnnData
 from numpy import array_equal
 from pandas._testing import assert_frame_equal, assert_series_equal
-from scipy.sparse import spmatrix
+from scipy.sparse import sparray, spmatrix
 from somacore import (
     AffineTransform,
     AxisQuery,
@@ -83,7 +83,7 @@ def assert_array_equal(a0, a1):
     assert type(a0) is type(a1)
     if isinstance(a0, np.ndarray):
         assert array_equal(a0, a1)
-    elif isinstance(a0, (spmatrix, sp.sparray)):
+    elif isinstance(a0, (spmatrix, sparray)):
         assert type(a0) is type(a1)
         assert a0.shape == a1.shape
         assert (a0 != a1).nnz == 0

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -592,7 +592,7 @@ def test_experiment_query_to_anndata_obsp_varp(soma_experiment):
         assert set(ad.obsp.keys()) == {"foo"}
         obsp = ad.obsp["foo"]
         assert isinstance(obsp, (sparse.spmatrix, sparse.sparray))
-        assert hasattr(obsp, 'format') and obsp.format == 'csr'
+        assert hasattr(obsp, "format") and obsp.format == "csr"
         assert obsp.shape == (query.n_obs, query.n_obs)
 
         assert (query.obsp("foo").coos().concat().to_scipy() != obsp).nnz == 0
@@ -601,7 +601,7 @@ def test_experiment_query_to_anndata_obsp_varp(soma_experiment):
         assert set(ad.varp.keys()) == {"bar"}
         varp = ad.varp["bar"]
         assert isinstance(varp, (sparse.spmatrix, sparse.sparray))
-        assert hasattr(varp, 'format') and varp.format == 'csr'
+        assert hasattr(varp, "format") and varp.format == "csr"
         assert varp.shape == (query.n_vars, query.n_vars)
         assert (query.varp("bar").coos().concat().to_scipy() != varp).nnz == 0
         assert np.array_equal(query.varp("bar").coos().concat().to_scipy().todense(), varp.todense())

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -591,8 +591,8 @@ def test_experiment_query_to_anndata_obsp_varp(soma_experiment):
         ad = query.to_anndata("raw", obsp_layers=["foo"], varp_layers=["bar"])
         assert set(ad.obsp.keys()) == {"foo"}
         obsp = ad.obsp["foo"]
-        assert isinstance(obsp, sparse.spmatrix)
-        assert sparse.isspmatrix_csr(obsp)
+        assert isinstance(obsp, (sparse.spmatrix, sparse.sparray))
+        assert hasattr(obsp, 'format') and obsp.format == 'csr'
         assert obsp.shape == (query.n_obs, query.n_obs)
 
         assert (query.obsp("foo").coos().concat().to_scipy() != obsp).nnz == 0
@@ -600,8 +600,8 @@ def test_experiment_query_to_anndata_obsp_varp(soma_experiment):
 
         assert set(ad.varp.keys()) == {"bar"}
         varp = ad.varp["bar"]
-        assert isinstance(varp, sparse.spmatrix)
-        assert sparse.isspmatrix_csr(varp)
+        assert isinstance(varp, (sparse.spmatrix, sparse.sparray))
+        assert hasattr(varp, 'format') and varp.format == 'csr'
         assert varp.shape == (query.n_vars, query.n_vars)
         assert (query.varp("bar").coos().concat().to_scipy() != varp).nnz == 0
         assert np.array_equal(query.varp("bar").coos().concat().to_scipy().todense(), varp.todense())

--- a/apis/python/tests/test_fastercsx.py
+++ b/apis/python/tests/test_fastercsx.py
@@ -45,7 +45,7 @@ def context(concurrency: int | None) -> soma.SOMATileDBContext:
     return soma.SOMATileDBContext(tiledb_config={"soma.compute_concurrency_level": f"{concurrency}"})
 
 
-def assert_eq(sp: sparse.spmatrix, cm: fastercsx.CompressedMatrix) -> bool:
+def assert_eq(sp: sparse.spmatrix | sparse.sparray, cm: fastercsx.CompressedMatrix) -> bool:
     sp_csx = sp.tocsr() if cm.format == "csr" else sp.tocsc()
 
     assert cm.data.shape == sp_csx.data.shape


### PR DESCRIPTION
**Issue and/or context:**

`AnnData` equally supports `scipy.sparse.sparray` (eg., csr_array) and `scipy.sparse.spmatrix` (eg. csr_matrix) since the 0.11 release.

`tiledbsoma.io.from_anndata` seems to work just fine when given an `AnnData` containing an X of type `csr_array`, but the type signatures do not contain these types.

Request: add `csr_array` and `csc_array` support "officially" to tiledbsoma.io.from_anndata

**Changes:**
`apis/python/src/tiledbsoma/io/conversions.py` - Type hints and isinstance checks
`apis/python/src/tiledbsoma/io/_common.py` - SparseMatrix union type
`apis/python/tests/test_experiment_query.py` - Compatible assertions
`apis/python/tests/_util.py` - Utility compatibility
`apis/python/tests/test_fastercsx.py` - Type annotations

**Notes for Reviewer:**

This PR is a part of a wider epic for slowly but steadily migrating from `spmatrix` to `sparrays` with SOMA-365