### PR TITLE
Update r-valgrind.yaml to install all suggested packages

### DIFF
--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -26,7 +26,7 @@ jobs:
         run: apt update -qq && apt upgrade --yes && apt install --yes --no-install-recommends valgrind cmake git
 
       - name: Package Dependencies
-        run: cd apis/r && R -q -e 'remotes::install_deps(".", dependencies=TRUE, upgrade=FALSE)'
+        run: cd apis/r && R -q -e 'remotes::install_deps(".", dependencies=TRUE)'
 
       - name: Build Package
         run: cd apis/r && R CMD build --no-build-vignettes --no-manual .


### PR DESCRIPTION
Using `, upgrade=FALSE` in `install_deps()` prevents some BioConductor packages from being installed.

**Issue and/or context:**

The [r-valgrind action](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-valgrind.yaml) has been failing every night [for three+ months now](https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/r-valgrind.yaml?page=4).  GitHub still sends me an email each time.

The error is actually plain: Three suggested packages (needed for the test) are missing.  I took a brief look, given that this runs in a container I designed and still look after, about the 'why'.  Turns out that at some point we chose to (had to ?) select an option to not upgrade packages when we call the helper `remotes::install_deps()`.  I never use that option elsewhere either, `install_deps()` reliably does its job of parsing `DESCRIPTION` and installing everything as needed, and as ordered either with or without suggested packages.

**Changes:**

Remove the extra option and letting `install_deps()` do its work does the trick. One can test that by invoking the`rocker/r2u` container in the source directory and calling `Rscript -e 'remotes::install_deps(".", dependencies=TRUE)'`.

**Notes for Reviewer:**

The valgrind job still fail afterwards, but when it does it most likely does so where intended, in the actual valgrind-ing.
