### PR TITLE
[HOTFIX] Upgrading the xcode-pinned-version in CI

### DIFF
--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Select XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '16.0'
       - name: Install pre-built libtiledb
         if: ${{ matrix.TILEDB_EXISTS == 'yes' }}
         run: |

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -76,7 +76,7 @@ jobs:
         if: startsWith(inputs.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "16.0"
 
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4

--- a/.github/workflows/python-dependency-variation.yml
+++ b/.github/workflows/python-dependency-variation.yml
@@ -76,7 +76,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '16.0'
 
       - name: Show XCode version
         run: clang --version

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.0'
+          xcode-version: ${{ matrix.os == 'macos-latest' && '16.0' || '15.4' }}
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         with:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '16.0'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         with:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -66,7 +66,7 @@ jobs:
             # vcpkg source build requires this on ARM, for some reason; cf. https://github.com/NixOS/nixpkgs/issues/335868
             CIBW_ENVIRONMENT_LINUX: VCPKG_FORCE_SYSTEM_BINARIES=1
           - cibw_build: macosx_x86_64
-            os: macos-latest
+            os: macos-15-large
             cibw_archs_macos: x86_64
             wheel-name: macos-x86_64
           - cibw_build: macosx_arm64
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: ${{ matrix.os == 'macos-latest' && '16.0' || '15.4' }}
+          xcode-version: '16.1'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         with:
@@ -151,7 +151,7 @@ jobs:
             os: ubuntu-24.04-arm
             arch: aarch64
           - wheel-name: macos-x86_64
-            os: macos-13
+            os: macos-15-large
             arch: x86_64
           - wheel-name: macos-arm64
             os: macos-14

--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -61,7 +61,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '16.0'
 
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5

--- a/apis/python/tests/test_soma_experiment_versions.py
+++ b/apis/python/tests/test_soma_experiment_versions.py
@@ -1,7 +1,7 @@
+import gc
 import os
 
 import pytest
-import gc
 
 import tiledbsoma
 
@@ -54,10 +54,9 @@ def test_to_anndata(soma_tiledb_context, version, name_and_expected_shape):
                 assert adata.obsp[key].shape == (expected_nobs, expected_nobs)
 
             assert adata.varm["PCs"].shape == (expected_nvar, 50)
-        
+
         del adata
         gc.collect()
-
 
 
 @pytest.mark.parametrize(

--- a/apis/python/tests/test_soma_experiment_versions.py
+++ b/apis/python/tests/test_soma_experiment_versions.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import gc
 
 import tiledbsoma
 
@@ -53,6 +54,10 @@ def test_to_anndata(soma_tiledb_context, version, name_and_expected_shape):
                 assert adata.obsp[key].shape == (expected_nobs, expected_nobs)
 
             assert adata.varm["PCs"].shape == (expected_nvar, 50)
+        
+        del adata
+        gc.collect()
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue and/or context:**
The macos-latest label will migrate to macOS 15 beginning August 4, 2025. For more information see https://github.com/actions/runner-images/issues/12520

**Changes:**
- Change the pinned version where `xcode` was called in CI, from 15.4 to 16.0
 
**Notes for Reviewer:**

This is a HOTFIX to unblock PRs
