### PR TITLE
[python] Add python implementation for delete cells

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
+- \[[](<>)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`. <!-- TODO: Add PR name before merging -->
 
 ### Changed
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
-- \[[#4205](https://github.com/single-cell-data/TileDB-SOMA/pull/4205)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`. <!-- TODO: Add PR name before merging -->
+- \[[#4205](https://github.com/single-cell-data/TileDB-SOMA/pull/4205)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`.
 
 ### Changed
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
-- \[[](<>)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`. <!-- TODO: Add PR name before merging -->
+- \[[#4205](https://github.com/single-cell-data/TileDB-SOMA/pull/4205)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`. <!-- TODO: Add PR name before merging -->
 
 ### Changed
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -324,6 +324,7 @@ setuptools.setup(
                 "src/tiledbsoma/soma_sparse_ndarray.cc",
                 "src/tiledbsoma/soma_group.cc",
                 "src/tiledbsoma/soma_collection.cc",
+                "src/tiledbsoma/coordinate_selection.cc",
                 "src/tiledbsoma/managed_query.cc",
                 "src/tiledbsoma/transformer.cc",
                 "src/tiledbsoma/pytiledbsoma.cc",

--- a/apis/python/src/tiledbsoma/__init__.py
+++ b/apis/python/src/tiledbsoma/__init__.py
@@ -183,7 +183,7 @@ from ._point_cloud_dataframe import PointCloudDataFrame
 from ._query import ExperimentAxisQuery
 from ._scene import Scene
 from ._sparse_nd_array import SparseNDArray, SparseNDArrayRead
-from .options import SOMATileDBContext, TileDBCreateOptions, TileDBWriteOptions
+from .options import SOMATileDBContext, TileDBCreateOptions, TileDBDeleteOptions, TileDBWriteOptions
 from .pytiledbsoma import (
     tiledbsoma_stats_disable,
     tiledbsoma_stats_dump,
@@ -227,6 +227,7 @@ __all__ = [
     "SparseNDArray",
     "SparseNDArrayRead",
     "TileDBCreateOptions",
+    "TileDBDeleteOptions",
     "TileDBWriteOptions",
     "UniformScaleTransform",
     "get_SOMA_version",

--- a/apis/python/src/tiledbsoma/_coordinate_selection.py
+++ b/apis/python/src/tiledbsoma/_coordinate_selection.py
@@ -1,0 +1,108 @@
+# Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+#
+# Licensed under the MIT License.
+
+"""Column selections using index query condition or subarray. Internal use only."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+import attrs
+import numpy as np
+import pyarrow as pa
+from somacore import options
+from typing_extensions import Self
+
+from . import pytiledbsoma as clib
+from ._types import is_nonstringy_sequence
+from ._util import pa_types_is_string_or_bytes, to_unix_ts
+
+if TYPE_CHECKING:
+    from ._soma_array import SOMAArray
+
+
+@attrs.define(frozen=True)
+class CoordinateValueFilters:
+    _array: SOMAArray
+    _handle: clib.CoordinateValueFilters = attrs.field(init=False)
+
+    @classmethod
+    def create(
+        cls, array: SOMAArray, coords: options.SparseDFCoords | options.SparseNDCoords | options.DenseNDCoords
+    ) -> Self:
+        if not is_nonstringy_sequence(coords):
+            raise TypeError(f"The coords type {type(coords)} must be a regular sequence, not str or bytes")
+
+        if len(coords) > len(array._handle._handle.dimension_names):
+            raise ValueError(
+                f"The coords ({len(coords)} elements) must be shorter than the number of index columns ({len(array._handle._handle.dimension_names)})",
+            )
+
+        value_filter = cls(array)
+        for column_index, coord in enumerate(coords):
+            value_filter.add_coordinate_selection(column_index, coord)
+        return value_filter
+
+    def __attrs_post_init__(self) -> None:
+        object.__setattr__(self, "_handle", clib.CoordinateValueFilters(self._array._handle._handle))
+
+    def add_coordinate_selection(
+        self, column_index: int, coord: options.SparseDFCoord | options.SparseNDCoord | options.DenseCoord
+    ) -> None:
+        array_handle = self._array._handle._handle
+        dim = array_handle.schema.field(column_index)
+        if dim.metadata is not None and dim.metadata[b"dtype"].decode("utf-8") == "WKB":
+            raise NotImplementedError("Support for adding a selection to a geometry column is not yet implemented.")
+
+        if isinstance(coord, (pa.Array, pa.ChunkedArray)):
+            # self._handle.add_arrow_points(column_index, coord)
+            # return
+            raise NotImplementedError  # TODO
+
+        if isinstance(coord, slice):
+            if coord.step is not None and coord.step != 1:
+                raise ValueError(
+                    f"Invalid coordinate selection on column number '{column_index}'. Slice steps are not supported."
+                )
+
+            if pa_types_is_string_or_bytes(dim.type):
+                self._handle.add_slice_string(column_index, coord.start, coord.stop)
+                return
+
+            if pa.types.is_timestamp(dim.type):
+                if (coord.start is None or isinstance(coord.start, (np.datetime64, pa.TimestampScalar, int))) and (
+                    coord.stop is None or isinstance(coord.stop, (np.datetime64, pa.TimestampScalar, int))
+                ):
+                    # Convert datetime stamp to int64.
+                    start = None if coord.start is None else to_unix_ts(coord.start)
+                    stop = None if coord.stop is None else to_unix_ts(coord.stop)
+                    self._handle.add_slice_int64(column_index, start, stop)
+                    return
+                raise TypeError("Unexpected type on column.")  # TODO Better error message before merging
+
+            add_slice_function = getattr(self._handle, f"add_slice_{dim.type}")
+            add_slice_function(column_index, coord.start, coord.stop)
+            return
+
+        if pa_types_is_string_or_bytes(dim.type):
+            if isinstance(coord, np.ndarray) and coord.ndim != 1:
+                raise ValueError(
+                    f"Cannot set points on column index={column_index}. Can only use 1D numpy arrays, but got an array with {coord.ndim}."
+                )
+            self._handle.add_points_string(column_index, coord)
+            return
+
+        if pa.types.is_timestamp(dim.type):
+            raise NotImplementedError  # TODO
+
+        if isinstance(coord, (Sequence, np.ndarray)):
+            if isinstance(coord, np.ndarray) and coord.ndim != 1:
+                raise ValueError(
+                    f"Cannot set points on column index={column_index}. Can only use 1D numpy arrays, but got an array with {coord.ndim}."
+                )
+            add_points_function = getattr(self._handle, f"add_points_{dim.type}")
+            add_points_function(column_index, coord)
+            return
+
+        raise TypeError  # TODO: Add error message

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -690,14 +690,22 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
     def delete_cells(
         self,
-        coords: options.SparseDFCoords,
+        coords: options.SparseDFCoords = (),
         *,
         value_filter: str | None = None,
         platform_config: options.PlatformConfig | None = None,
     ) -> None:
         """Deletes cells at the specified coordinates.
 
-        Note: Deleting cells with an enumeration value does not effect the possible enumerations.
+        Either ``coords`` or ``value_filter`` must be provided. When both ``coords`` and ``value_filter`` are provided,
+        the cells that match both constraints will be removed.
+
+        For example, to delete values from the ``obs`` dataframe with ``soma_joinid<=1000`` where ``n_genes > 1000``
+        and ``n_counts < 2000``:
+            >>> with tiledbsoma.DataFrame(obs_uri, mode="d") as obs_df:
+            ...     obs_df.delete_cells((slice(None, 1000),), value_filter="n_genes > 1000 and n_counts < 2000")
+
+        Note: Deleting cells does not change the size of the current domain or possible enumeration values.
 
         Args:
             coords:
@@ -708,7 +716,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 An optional [value filter] to apply to the results.
                 Defaults to no filter.
         """
-        if isinstance(platform_config, (TileDBCreateOptions, TileDBWriteOptions)):
+        if platform_config is not None and not isinstance(platform_config, TileDBDeleteOptions):
             raise TypeError(
                 f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
             )

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -690,7 +690,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
 
     def delete_cells(
         self,
-        coords: options.SparseNDCoords,
+        coords: options.SparseDFCoords,
         *,
         value_filter: str | None = None,
         platform_config: options.PlatformConfig | None = None,
@@ -713,12 +713,12 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
             )
         coord_filter = CoordinateValueFilters.create(self, coords)
-        if value_filter is None:
-            self._handle._handle.delete_cells(coord_filter._handle, None)
-            return
-        qc = QueryCondition(value_filter)
-        qc.init_query_condition(self.schema, [])
-        self._handle._handle.delete_cells(coord_filter._handle, qc.c_obj)
+        qc_handle = None
+        if value_filter is not None:
+            qc = QueryCondition(value_filter)
+            qc.init_query_condition(self.schema, [])
+            qc_handle = qc.c_obj
+        self._handle._handle.delete_cells(coord_filter._handle, qc_handle)
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -162,6 +162,21 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
             _dont_call_this_use_create_or_open_instead="tiledbsoma-internal-code",
         )
 
+    def delete_cells(
+        self, coords: options.DenseNDCoords, *, platform_config: options.PlatformConfig | None = None
+    ) -> None:
+        """Deletes cells at the specified coordinates. Not supported on dense arrays.
+
+        Not supported on DenseNDArray.
+
+        Args:
+            coords:
+                A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
+                `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>` values
+                defining the region to read.
+        """
+        raise NotImplementedError("Support for deleting cells is not implemented on dense arrays.")
+
     def read(
         self,
         coords: options.DenseNDCoords = (),

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -305,9 +305,19 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         value_filter: str | None = None,
         platform_config: options.PlatformConfig | None = None,
     ) -> None:
-        del coords
-        del value_filter
-        del platform_config
+        """Deletes cells at the specified coordinates.
+
+        Note: Deleting cells with an enumeration value does not effect the possible enumerations.
+
+        Args:
+            coords:
+                A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
+                `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>` values
+                defining the region to read.
+            value_filter:
+                An optional [value filter] to apply to the results.
+                Defaults to no filter.
+        """
         raise NotImplementedError("Support for deleting cells from a geometry dataframe is not yet implemented.")
 
     def read(

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -300,14 +300,12 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
 
     def delete_cells(
         self,
-        coords: options.SparseNDCoords,
+        coords: options.SparseDFCoords,
         *,
         value_filter: str | None = None,
         platform_config: options.PlatformConfig | None = None,
     ) -> None:
         """Deletes cells at the specified coordinates.
-
-        Note: Deleting cells with an enumeration value does not effect the possible enumerations.
 
         Args:
             coords:

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -298,6 +298,18 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         # if is it in read open mode, then it is a GeometryDataFrameWrapper
         return cast("GeometryDataFrameWrapper", self._handle).count
 
+    def delete_cells(
+        self,
+        coords: options.SparseNDCoords,
+        *,
+        value_filter: str | None = None,
+        platform_config: options.PlatformConfig | None = None,
+    ) -> None:
+        del coords
+        del value_filter
+        del platform_config
+        raise NotImplementedError("Support for deleting cells from a geometry dataframe is not yet implemented.")
+
     def read(
         self,
         coords: options.SparseDFCoords = (),

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -20,6 +20,7 @@ from ._constants import (
     SOMA_JOINID,
     SPATIAL_DISCLAIMER,
 )
+from ._coordinate_selection import CoordinateValueFilters
 from ._dataframe import (
     Domain,
     _canonicalize_schema,
@@ -28,6 +29,7 @@ from ._dataframe import (
     _revise_domain_for_extent,
 )
 from ._exception import SOMAError, map_exception_for_create
+from ._query_condition import QueryCondition
 from ._read_iters import TableReadIter
 from ._spatial_dataframe import SpatialDataFrame
 from ._spatial_util import (
@@ -37,12 +39,8 @@ from ._spatial_util import (
 )
 from ._tdb_handles import PointCloudDataFrameWrapper
 from ._types import OpenTimestamp
-from .options import SOMATileDBContext
+from .options import SOMATileDBContext, TileDBCreateOptions, TileDBDeleteOptions, TileDBWriteOptions
 from .options._soma_tiledb_context import _validate_soma_tiledb_context
-from .options._tiledb_create_write_options import (
-    TileDBCreateOptions,
-    TileDBWriteOptions,
-)
 
 _UNBATCHED = options.BatchSize()
 
@@ -283,6 +281,34 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
         self._verify_open_for_reading()
         # if is it in read open mode, then it is a PointCloudDataFrameWrapper
         return cast("PointCloudDataFrameWrapper", self._handle).count
+
+    def delete_cells(
+        self,
+        coords: options.SparseNDCoords,
+        *,
+        value_filter: str | None = None,
+        platform_config: options.PlatformConfig | None = None,
+    ) -> None:
+        """Deletes cells at the specified coordinates.
+
+        Note: Deleting cells with an enumeration value does not effect the possible enumerations.
+
+        Args:
+            coords:
+                A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
+                `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>` values
+                defining the region to read.
+            value_filter:
+                An optional [value filter] to apply to the results.
+                Defaults to no filter.
+        """
+        if isinstance(platform_config, (TileDBCreateOptions, TileDBWriteOptions)):
+            raise TypeError(
+                f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
+            )
+        coord_filter = CoordinateValueFilters.create(self, coords)
+        qc = None if value_filter is None else QueryCondition(value_filter)
+        self._handle._handle.delete_cells(coord_filter._handle, qc)
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -284,7 +284,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
 
     def delete_cells(
         self,
-        coords: options.SparseNDCoords,
+        coords: options.SparseDFCoords,
         *,
         value_filter: str | None = None,
         platform_config: options.PlatformConfig | None = None,
@@ -307,8 +307,12 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
                 f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
             )
         coord_filter = CoordinateValueFilters.create(self, coords)
-        qc = None if value_filter is None else QueryCondition(value_filter)
-        self._handle._handle.delete_cells(coord_filter._handle, qc)
+        qc_handle = None
+        if value_filter is not None:
+            qc = QueryCondition(value_filter)
+            qc.init_query_condition(self.schema, [])
+            qc_handle = qc.c_obj
+        self._handle._handle.delete_cells(coord_filter._handle, qc_handle)
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -211,13 +211,19 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
     def delete_cells(self, coords: options.SparseNDCoords, *, platform_config: PlatformConfig | None = None) -> None:
         """Deletes cells at the specified coordinates in a :class:`SparseNDArray`.
 
+        Note: Deleting cells does not change the shape of the :class:`SparseNDArray`.
+
+        Example deleting cells for ``soma_dim_1 >= 10000``:
+            >>> with tiledbsoma.SparseNDArray(count_matrix_uri, mode="d") as X:
+            ...     X.delete_cells(((slice(None, None), slice(10000, None)), value_filter="n_genes > 1000 and n_counts < 2000")
+
         Args:
             coords:
                 A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
                 `Arrow IntegerArray <https://arrow.apache.org/docs/python/generated/pyarrow.IntegerArray.html>` values
                 defining the region to read.
         """
-        if isinstance(platform_config, (TileDBCreateOptions, TileDBWriteOptions)):
+        if platform_config is not None and not isinstance(platform_config, TileDBDeleteOptions):
             raise TypeError(
                 f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
             )

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -222,7 +222,7 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
                 f"Invalid PlatformConfig with type {type(platform_config)}. Must have type {TileDBDeleteOptions.__name__}."
             )
         coord_filter = CoordinateValueFilters.create(self, coords)
-        self._handle._handle.delete_cells(coord_filter)
+        self._handle._handle.delete_cells(coord_filter._handle)
 
     def read(
         self,

--- a/apis/python/src/tiledbsoma/coordinate_selection.cc
+++ b/apis/python/src/tiledbsoma/coordinate_selection.cc
@@ -40,6 +40,78 @@ void add_slice(CoordinateValueFilters& value_filter, int64_t col_index, std::opt
 void load_coordinate_selection(py::module& m) {
     py::class_<CoordinateValueFilters>(m, "CoordinateValueFilters")
         .def(py::init([](SOMAArray array) { return array.create_coordinate_value_filter(); }), py::arg("array"))
+        .def(
+            "add_arrow_points",
+            [](CoordinateValueFilters& value_filter, int64_t col_index, py::object py_arrow_array) {
+                // Create a list of array chunks
+                py::list array_chunks;
+                if (py::hasattr(py_arrow_array, "chunks")) {
+                    array_chunks = py_arrow_array.attr("chunks").cast<py::list>();
+                } else {
+                    array_chunks.append(py_arrow_array);
+                }
+
+                for (const pybind11::handle array_handle : array_chunks) {
+                    ArrowSchema arrow_schema;
+                    ArrowArray arrow_array;
+                    uintptr_t arrow_schema_ptr = (uintptr_t)(&arrow_schema);
+                    uintptr_t arrow_array_ptr = (uintptr_t)(&arrow_array);
+
+                    // Call handle._export_to_c to get arrow array and schema
+                    //
+                    // If ever a NumPy array gets in here, there will be an
+                    // exception like "AttributeError: 'numpy.ndarray' object
+                    // has no attribute '_export_to_c'".
+                    array_handle.attr("_export_to_c")(arrow_array_ptr, arrow_schema_ptr);
+
+                    auto coords = array_handle.attr("tolist")();
+
+                    try {
+                        if (!strcmp(arrow_schema.format, "l")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<int64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "i")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<int32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "s")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<int16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "c")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<int8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "L")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<uint64_t>>());
+                        } else if (!strcmp(arrow_schema.format, "I")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<uint32_t>>());
+                        } else if (!strcmp(arrow_schema.format, "S")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<uint16_t>>());
+                        } else if (!strcmp(arrow_schema.format, "C")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<uint8_t>>());
+                        } else if (!strcmp(arrow_schema.format, "f")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<float_t>>());
+                        } else if (!strcmp(arrow_schema.format, "g")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<double_t>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "u") || !strcmp(arrow_schema.format, "U") ||
+                            !strcmp(arrow_schema.format, "z") || !strcmp(arrow_schema.format, "Z")) {
+                            add_points(value_filter, col_index, coords.cast<std::vector<std::string>>());
+                        } else if (
+                            !strcmp(arrow_schema.format, "tss:") || !strcmp(arrow_schema.format, "tsm:") ||
+                            !strcmp(arrow_schema.format, "tsu:") || !strcmp(arrow_schema.format, "tsn:")) {
+                            // convert the Arrow Array to int64
+                            auto pa = py::module::import("pyarrow");
+                            coords = array_handle.attr("cast")(pa.attr("int64")()).attr("tolist")();
+                            add_points(value_filter, col_index, coords.cast<std::vector<int64_t>>());
+                        } else {
+                            TPY_ERROR_LOC(
+                                "[pytiledbsoma] set_dim_points: type={} not "
+                                "supported" +
+                                std::string(arrow_schema.format));
+                        }
+                    } catch (const std::exception& e) {
+                        throw TileDBSOMAError(e.what());
+                    }
+
+                    // Release arrow schema
+                    arrow_schema.release(&arrow_schema);
+                }
+            })
         .def("add_slice_int8", add_slice<int8_t>)
         .def("add_slice_int16", add_slice<int16_t>)
         .def("add_slice_int32", add_slice<int32_t>)

--- a/apis/python/src/tiledbsoma/coordinate_selection.cc
+++ b/apis/python/src/tiledbsoma/coordinate_selection.cc
@@ -1,0 +1,63 @@
+/**
+ * @file   soma_column_filter.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines column filters for querying SOMA.
+ */
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include <tiledbsoma/tiledbsoma>
+
+#include "common.h"
+
+namespace libtiledbsomacpp {
+
+namespace py = pybind11;
+using namespace py::literals;
+using namespace tiledbsoma;
+
+template <typename T>
+void add_points(CoordinateValueFilters& value_filter, int64_t col_index, const std::vector<T>& values) {
+    value_filter.add_points<T>(col_index, PointSelection<T>(values));
+}
+
+template <typename T>
+void add_slice(CoordinateValueFilters& value_filter, int64_t col_index, std::optional<T> start, std::optional<T> stop) {
+    value_filter.add_slice<T>(col_index, SliceSelection<T>(start, stop));
+}
+
+void load_coordinate_selection(py::module& m) {
+    py::class_<CoordinateValueFilters>(m, "CoordinateValueFilters")
+        .def(py::init([](SOMAArray array) { return array.create_coordinate_value_filter(); }), py::arg("array"))
+        .def("add_slice_int8", add_slice<int8_t>)
+        .def("add_slice_int16", add_slice<int16_t>)
+        .def("add_slice_int32", add_slice<int32_t>)
+        .def("add_slice_int64", add_slice<int64_t>)
+        .def("add_slice_uint8", add_slice<uint8_t>)
+        .def("add_slice_uint16", add_slice<uint16_t>)
+        .def("add_slice_uint32", add_slice<uint32_t>)
+        .def("add_slice_uint64", add_slice<uint64_t>)
+        .def("add_slice_uint64", add_slice<std::string>)
+        .def("add_points_int8", add_points<int8_t>)
+        .def("add_points_int16", add_points<int16_t>)
+        .def("add_points_int32", add_points<int32_t>)
+        .def("add_points_int64", add_points<int64_t>)
+        .def("add_points_uint8", add_points<uint8_t>)
+        .def("add_points_uint16", add_points<uint16_t>)
+        .def("add_points_uint32", add_points<uint32_t>)
+        .def("add_points_uint64", add_points<uint64_t>)
+        .def("add_points_uint64", add_points<std::string>);
+}
+
+}  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/coordinate_selection.cc
+++ b/apis/python/src/tiledbsoma/coordinate_selection.cc
@@ -120,7 +120,9 @@ void load_coordinate_selection(py::module& m) {
         .def("add_slice_uint16", add_slice<uint16_t>)
         .def("add_slice_uint32", add_slice<uint32_t>)
         .def("add_slice_uint64", add_slice<uint64_t>)
-        .def("add_slice_uint64", add_slice<std::string>)
+        .def("add_slice_float", add_slice<float_t>)
+        .def("add_slice_double", add_slice<double_t>)
+        .def("add_slice_string", add_slice<std::string>)
         .def("add_points_int8", add_points<int8_t>)
         .def("add_points_int16", add_points<int16_t>)
         .def("add_points_int32", add_points<int32_t>)
@@ -129,7 +131,9 @@ void load_coordinate_selection(py::module& m) {
         .def("add_points_uint16", add_points<uint16_t>)
         .def("add_points_uint32", add_points<uint32_t>)
         .def("add_points_uint64", add_points<uint64_t>)
-        .def("add_points_uint64", add_points<std::string>);
+        .def("add_points_float", add_points<float_t>)
+        .def("add_points_double", add_points<double_t>)
+        .def("add_points_string", add_points<std::string>);
 }
 
 }  // namespace libtiledbsomacpp

--- a/apis/python/src/tiledbsoma/options/__init__.py
+++ b/apis/python/src/tiledbsoma/options/__init__.py
@@ -5,11 +5,12 @@
 """TileDB-SOMA configuration options."""
 
 from ._soma_tiledb_context import ConfigDict, SOMATileDBContext
-from ._tiledb_create_write_options import TileDBCreateOptions, TileDBWriteOptions
+from ._tiledb_create_write_options import TileDBCreateOptions, TileDBDeleteOptions, TileDBWriteOptions
 
 __all__ = [
     "ConfigDict",
     "SOMATileDBContext",
     "TileDBCreateOptions",
+    "TileDBDeleteOptions",
     "TileDBWriteOptions",
 ]

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -210,6 +210,19 @@ class TileDBWriteOptions:
 _T = TypeVar("_T")
 
 
+@attrs_.define(frozen=True, kw_only=True, slots=True)
+class TileDBDeleteOptions:
+    """Tuning options used when deleting cells in SOMA arrays."""
+
+    @classmethod
+    def from_platform_condif(
+        cls, platform_config: options.PlatformConfig | "TileDBDeleteOptions" | None = None
+    ) -> Self:
+        """Create the class from a value passed in ``platform_config``."""
+        del platform_config
+        return cls()
+
+
 def _dig_platform_config(input: object, typ: type[_T], full_path: tuple[str, ...]) -> dict[str, object] | _T:
     """Looks for an object of the given type in dictionaries.
 

--- a/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
+++ b/apis/python/src/tiledbsoma/options/_tiledb_create_write_options.py
@@ -215,7 +215,7 @@ class TileDBDeleteOptions:
     """Tuning options used when deleting cells in SOMA arrays."""
 
     @classmethod
-    def from_platform_condif(
+    def from_platform_config(
         cls, platform_config: options.PlatformConfig | "TileDBDeleteOptions" | None = None
     ) -> Self:
         """Create the class from a value passed in ``platform_config``."""

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -33,6 +33,7 @@ void load_soma_vfs(py::module&);
 void load_managed_query(py::module&);
 void load_soma_column(py::module&);
 void load_transformers(py::module&);
+void load_coordinate_selection(py::module&);
 
 PYBIND11_MODULE(pytiledbsoma, m) {
     py::register_exception<TileDBSOMAError>(m, "SOMAError");
@@ -193,6 +194,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
     load_soma_group(m);
     load_soma_collection(m);
     load_query_condition(m);
+    load_coordinate_selection(m);
     load_reindexer(m);
     load_soma_vfs(m);
     load_managed_query(m);

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -231,6 +231,17 @@ void load_soma_dataframe(py::module& m) {
             "function_name_for_messages"_a)
 
         .def(
+            "delete_cells",
+            [](SOMADataFrame& df,
+               const CoordinateValueFilters& coord_filter,
+               std::optional<PyQueryCondition> value_filter) {
+                if (value_filter.has_value()) {
+                    return df.delete_cells(coord_filter, *value_filter->ptr());
+                }
+                return df.delete_cells(coord_filter);
+            })
+
+        .def(
             "upgrade_soma_joinid_shape",
             [](SOMADataFrame& sdf, int64_t newshape, std::string function_name_for_messages) {
                 try {

--- a/apis/python/src/tiledbsoma/soma_point_cloud_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_point_cloud_dataframe.cc
@@ -119,6 +119,17 @@ void load_soma_point_cloud_dataframe(py::module& m) {
             "timestamp"_a = py::none(),
             py::call_guard<py::gil_scoped_release>())
 
+        .def(
+            "delete_cells",
+            [](SOMAPointCloudDataFrame& df,
+               const CoordinateValueFilters& coord_filter,
+               std::optional<PyQueryCondition> value_filter) {
+                if (value_filter.has_value()) {
+                    return df.delete_cells(coord_filter, *value_filter->ptr());
+                }
+                return df.delete_cells(coord_filter);
+            })
+
         .def_static("exists", &SOMAPointCloudDataFrame::exists)
         .def_property_readonly("index_column_names", &SOMAPointCloudDataFrame::index_column_names)
         .def_property_readonly("count", &SOMAPointCloudDataFrame::count, py::call_guard<py::gil_scoped_release>());

--- a/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
+++ b/apis/python/src/tiledbsoma/soma_sparse_ndarray.cc
@@ -85,6 +85,7 @@ void load_soma_sparse_ndarray(py::module& m) {
         .def_static("exists", &SOMASparseNDArray::exists)
 
         .def_property_readonly("shape", &SOMASparseNDArray::shape)
-        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape);
+        .def_property_readonly("maxshape", &SOMASparseNDArray::maxshape)
+        .def("delete_cells", py::overload_cast<const CoordinateValueFilters&>(&SOMASparseNDArray::delete_cells));
 }
 }  // namespace libtiledbsomacpp

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -194,7 +194,9 @@ def test_dataframe_with_float_dim(tmp_path, arrow_schema):
         pytest.param((slice(0, 7),), None, [], id="delete all with exact slice"),
         pytest.param((slice(-10, 10),), None, [], id="delete all with large slice"),
         pytest.param((np.arange(8).tolist(),), None, [], id="delete all with points"),
-        pytest.param(((2, 6, 3),), None, [0, 1, 4, 5, 7], id="delete with point selection"),
+        pytest.param(((2, 6, 3),), None, [0, 1, 4, 5, 7], id="delete with tuple"),
+        pytest.param((np.array((2, 6, 3), dtype=np.int64),), None, [0, 1, 4, 5, 7], id="delete with numpy array"),
+        pytest.param((pa.array((2, 6, 3), type=pa.int64()),), None, [0, 1, 4, 5, 7], id="delete with pyarrow"),
         pytest.param(((0, 7),), None, np.arange(1, 7).tolist(), id="delete end points"),
         pytest.param(tuple(), "string_data == 'two'", [0, 1, 3, 4, 5, 6, 7], id="value filter only"),
         pytest.param((slice(1, 3),), "string_data == 'two'", [0, 1, 3, 4, 5, 6, 7], id="slice and value filter"),
@@ -220,10 +222,6 @@ def test_dataframe_1d_delete_cells(tmp_path, delete_coords, value_filter, expect
             schema=schema,
         )
         soma_df.write(data)
-
-    with soma.DataFrame.open(str(tmp_path)) as soma_df:  # TODO: delete
-        df = soma_df.read(value_filter=value_filter).concat().to_pandas()  # TODO: delete
-        print(df)  # TODO: delete
 
     with soma.DataFrame.open(str(tmp_path), mode="d") as soma_df:
         soma_df.delete_cells(delete_coords, value_filter=value_filter)
@@ -274,6 +272,8 @@ def test_dataframe_delete_cells_exceptions(tmp_path):
             soma_df.delete_cells(((1, 20, 5, 3),))
         with pytest.raises(ValueError):
             soma_df.delete_cells(tuple())
+        with pytest.raises(ValueError):
+            soma_df.delete_cells((slice(3, 1),))
 
 
 def test_dataframe_with_enumeration(tmp_path):

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -343,12 +343,12 @@ def test_delete_cells_exceptions(tmp_path):
         soma_df.write(data)
     with soma.DataFrame.open(str(tmp_path), mode="w") as soma_df:
         assert soma_df.mode == "w"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             soma_df.delete_cells((slice(1, 4),))
 
     with soma.DataFrame.open(str(tmp_path), mode="r") as soma_df:
         assert soma_df.mode == "r"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             soma_df.delete_cells((slice(1, 4),))
 
     with soma.DataFrame.open(str(tmp_path), mode="d") as soma_df:

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -249,6 +249,24 @@ def test_delete_cells_joinid_with_string_column(tmp_path, delete_coords, value_f
         pytest.param(pa.uint32(), [[0, 7]], np.arange(8), id="uint32"),
         pytest.param(pa.uint64(), [[0, 7]], np.arange(8), id="uint64"),
         pytest.param(
+            pa.timestamp("s"),
+            [[np.datetime64("2020", "s"), np.datetime64("2020") + np.timedelta64(7, "s")]],
+            np.arange(np.datetime64("2020"), np.datetime64("2020") + np.timedelta64(8, "s"), np.timedelta64(1, "s")),
+            id="seconds",
+        ),
+        pytest.param(
+            pa.timestamp("ms"),
+            [[np.datetime64("2020", "ms"), np.datetime64("2020") + np.timedelta64(7, "ms")]],
+            np.arange(np.datetime64("2020"), np.datetime64("2020") + np.timedelta64(8, "ms"), np.timedelta64(1, "ms")),
+            id="milliseconds",
+        ),
+        pytest.param(
+            pa.timestamp("us"),
+            [[np.datetime64("2020", "us"), np.datetime64("2020") + np.timedelta64(7, "us")]],
+            np.arange(np.datetime64("2020"), np.datetime64("2020") + np.timedelta64(8, "us"), np.timedelta64(1, "us")),
+            id="microseconds",
+        ),
+        pytest.param(
             pa.large_string(),
             None,
             ["apple", "banana", "coconut", "durian", "eggplant", "fig", "guava", "honeydew"],

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -621,3 +621,13 @@ def test_use_same_slicing_semantics_61815(tmp_path):
 
     with soma.open(uri, mode="r") as A:
         assert np.array_equal(A.read(coords), subarray)
+
+
+def test_delete_cells_exception(tmp_path):
+    with soma.DenseNDArray.create(str(tmp_path), type=pa.float64(), shape=(100, 100)) as array:
+        array.close()
+
+    with soma.DenseNDArray.open(str(tmp_path), mode="d") as array:
+        assert array.mode == "d"
+        with pytest.raises(NotImplementedError):
+            array.delete_cells((slice(0, 10),))

--- a/apis/python/tests/test_geometry_dataframe.py
+++ b/apis/python/tests/test_geometry_dataframe.py
@@ -109,3 +109,14 @@ def test_geometry_basic_spatial_read(tmp_path):
         assert shapely.from_wkb(result["soma_geometry"].to_numpy()[0]) == shapely.Polygon(
             [(0, 0), (0, 1), (1, 0), (0, 0)],
         )
+
+
+def test_delete_cells_not_implemented(tmp_path):
+    uri = tmp_path.as_uri()
+    with soma.GeometryDataFrame.create(uri, schema=pa.schema([("quality", pa.float32())])) as geom:
+        geom.close()
+
+    with soma.GeometryDataFrame.open(uri, mode="d") as geom:
+        assert geom.mode == "d"
+        with pytest.raises(NotImplementedError):
+            geom.delete_cells((slice(None, None),))

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -770,6 +770,12 @@ def test_fragments_in_writes(tmp_path, dtype):
             (slice(None, None), slice(None, None), slice(0, 24)), None, [], id="delete all with slice on soma_joinid"
         ),
         pytest.param((slice(None, None), (0, -2, -1, 2)), None, [3, 8, 13, 18, 23], id="delete by points on y"),
+        pytest.param(
+            (slice(None, None), pa.chunked_array([[0, -2], [-1, 2]])),
+            None,
+            [3, 8, 13, 18, 23],
+            id="delete by points on y with chunked array",
+        ),
         pytest.param((slice(None, 1),), None, np.arange(20, 25), id="delete by slice on x"),
         pytest.param((slice(None, None),), "soma_joinid < 11", np.arange(11, 25), id="delete by value_filter only"),
     ],

--- a/apis/python/tests/test_point_cloud_dataframe.py
+++ b/apis/python/tests/test_point_cloud_dataframe.py
@@ -871,12 +871,12 @@ def test_delete_cells_exceptions(tmp_path):
         points.close()
     with soma.PointCloudDataFrame.open(str(tmp_path), mode="w") as points:
         assert points.mode == "w"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             points.delete_cells((slice(1, 4),))
 
     with soma.PointCloudDataFrame.open(str(tmp_path), mode="r") as points:
         assert points.mode == "r"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             points.delete_cells((slice(1, 4),))
 
     with soma.PointCloudDataFrame.open(str(tmp_path), mode="d") as points:

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -2054,12 +2054,12 @@ def test_delete_cells_exceptions(tmp_path):
 
     with soma.SparseNDArray.open(str(tmp_path), mode="w") as array:
         assert array.mode == "w"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             array.delete_cells((slice(1, 4),))
 
     with soma.SparseNDArray.open(str(tmp_path), mode="r") as array:
         assert array.mode == "r"
-        with pytest.raises(soma.SOMAError):
+        with pytest.raises((soma.SOMAError, RuntimeError)):
             array.delete_cells((slice(1, 4),))
 
     with soma.SparseNDArray.open(str(tmp_path), mode="d") as array:


### PR DESCRIPTION
**Issue and/or context:**
* Closes SOMA-175
* Closes SOMA-174

**Changes:**
* Add internal class `CoordinateValueFilter` for constructing delete cells query condition.
* Add `TileDBDeleteOptions` for platform config (currently no options).
* Add/implement `delete_cells` method for `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`.
* Add `delete_cells` method to `GeometryDataFrame`, but throw a `NotImpelmentedError` for now.
* Add `delete_cells` method to `DenseNDArray` that throws a `NotImplementedError` (not supported in core).
