### PR TITLE
Attempt to make historical test garbage collection more aggressive

### DIFF
--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -914,30 +914,30 @@ def test_experiment_query_historical(soma_tiledb_context, version, obs_params, v
 
         obs = query.obs().concat()
         assert len(obs) == obs_count
+        obs_index_name = expected_index_name(
+            obs.to_pandas(),
+            exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
+            "obs_id",
+        )
+        del obs
+        gc.collect()
 
         var = query.var().concat()
         assert len(var) == var_count
+        var_index_name = expected_index_name(
+            var.to_pandas(),
+            exp.ms["RNA"].var.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
+            "var_id",
+        )
+        del var
+        gc.collect()
 
         adata = query.to_anndata("data")
         assert adata.n_obs == obs_count
         assert adata.n_vars == var_count
         assert adata.X.shape == (obs_count, var_count)
-        assert adata.obs.index.name == expected_index_name(
-            obs.to_pandas(),
-            exp.obs.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
-            "obs_id",
-        )
-        assert adata.var.index.name == expected_index_name(
-            var.to_pandas(),
-            exp.ms["RNA"].var.metadata.get(SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, None),
-            "var_id",
-        )
-        del adata, obs, var
-        gc.collect()
-
-        adata = query.to_anndata("data", obs_id_name="soma_joinid", var_id_name="soma_joinid")
-        assert adata.obs.index.name == "soma_joinid"
-        assert adata.var.index.name == "soma_joinid"
+        assert adata.obs.index.name == obs_index_name
+        assert adata.var.index.name == var_index_name
         del adata
         gc.collect()
 
@@ -945,8 +945,7 @@ def test_experiment_query_historical(soma_tiledb_context, version, obs_params, v
         assert adata.obs.index.name == "obs_id"
         assert adata.var.index.name == "var_id"
         del adata
-
-    gc.collect()
+        gc.collect()
 
 
 @pytest.mark.parametrize("version", ["1.7.3", "1.12.3", "1.14.5", "1.15.0", "1.15.7", "1.16.1"])


### PR DESCRIPTION
**Changes:**
* Remove redundant section of the test
* Delete obs/var sooner
