### PR TITLE
[c++] Clean-up SOMAArray construction

### DIFF
--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -1112,8 +1112,6 @@ class SOMAArray : public SOMAObject {
     std::optional<int64_t> _maybe_soma_joinid_shape_via_tiledb_current_domain();
     std::optional<int64_t> _maybe_soma_joinid_shape_via_tiledb_domain();
 
-    void fill_columns();
-
     /**
      * Convenience function for creating an ArraySchemaEvolution object
      * referencing this array's context pointer, along with its open-at

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -40,7 +40,10 @@ class SOMAColumn {
     //===================================================================
 
     static std::vector<std::shared_ptr<SOMAColumn>> deserialize(
-        const Context& ctx, const Array& array, const std::map<std::string, tiledbsoma::MetadataValue>& metadata);
+        const Context& ctx,
+        const Array& array,
+        std::map<std::string, tiledbsoma::MetadataValue>& metadata,
+        std::string_view uri);
 
     //===================================================================
     //= public non-static


### PR DESCRIPTION
**Changes:**
Directly construct the components of a `SOMAArray` with helper functions rather than using methods with side-effects.