### PR TITLE
[ci] Various modifications to the existing GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,15 +4,11 @@
 on:
   pull_request:
     paths:
-      - '**'
+      - 'libtiledbsoma/**'
+      - 'apis/**'
       - '!**.md'
-      - '!.github/**'
       - '.github/workflows/R-CMD-check.yaml'
-      - '!.pre-commit-config.yaml'
-      - '!apis/python/**'
-      - '!docker/**'
-      - '!docs/**'
-      - '!LICENSE'
+      - '.github/actions/setup-r/**'
   push:
     branches:
       - main

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,9 +48,6 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
 
-      - name: Print current commit
-        run: git log -1 --oneline
-
       - name: Show matrix OS
         run: echo "matrix.config.os:" ${{ matrix.config.os }}
 

--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -2,13 +2,9 @@ name: libTileDB-SOMA CodeCov
 
 on:
   pull_request:
-    paths-ignore:
-      - "apis/python/**"
-      - "apis/r/**"
-      - "docker/**"
-      - ".pre-commit-config.yaml"
-      - ".github/workflows/**"
-      - "!.github/workflows/libtiledb-ci.yml"
+    paths:
+      - "libtiledbsoma/**"
+      - ".github/workflows/libtiledb-ci.yml"
   push:
     branches:
       - main

--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Run libTileDB-SOMA unittests
       run: ctest --test-dir build/libtiledbsoma -C Release --verbose --rerun-failed --output-on-failure
+      env:
+        TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   codecov:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout TileDB-SOMA
       uses: actions/checkout@v4

--- a/.github/workflows/libtiledb-ci.yml
+++ b/.github/workflows/libtiledb-ci.yml
@@ -18,9 +18,6 @@ jobs:
     - name: Checkout TileDB-SOMA
       uses: actions/checkout@v4
 
-    - name: Print current commit
-      run: git log -1 --oneline
-
     - name: Build libTileDB-SOMA
       run: TILEDBSOMA_COVERAGE="--coverage" ./scripts/bld --no-tiledb-deprecated=true --werror=true
 

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -2,13 +2,9 @@ name: libtiledbsoma ASAN
 
 on:
   pull_request:
-    paths-ignore:
-      - "apis/python/**"
-      - "apis/r/**"
-      - "docker/**"
-      - ".pre-commit-config.yaml"
-      - ".github/workflows/**"
-      - "!.github/workflows/libtiledbsoma-asan-ci.yml"
+    paths:
+      - "libtiledbsoma/**"
+      - ".github/workflows/libtiledbsoma-asan-ci.yml"
   push:
     branches:
       - main

--- a/.github/workflows/libtiledbsoma-asan-ci.yml
+++ b/.github/workflows/libtiledbsoma-asan-ci.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
 
-      - name: Print current commit
-        run: git log -1 --oneline
-
       - name: Install pre-built libtiledb
         run: |
           mkdir -p external

--- a/.github/workflows/python-ci-full.yml
+++ b/.github/workflows/python-ci-full.yml
@@ -1,8 +1,7 @@
 name: TileDB-SOMA Python CI (Full)
 
 # This workflow calls ./python-ci-single.yml on the full {os} x {python version}
-# matrix. Since that's CI-resource-intensive, it runs only for main branch and
-# releases.
+# matrix.
 on:
   push:
     branches:
@@ -10,9 +9,6 @@ on:
       - 'release-*'
   release:
     types: [published]
-  # You can also invoke this workflow manually from
-  #   https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml
-  # to test a working branch on the full matrix.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-ci-minimal.yml
+++ b/.github/workflows/python-ci-minimal.yml
@@ -1,24 +1,16 @@
 name: TileDB-SOMA Python CI (Minimal)
 
 # This workflow calls ./python-ci-single.yml on a limited subset of the
-# {os} x {python version} matrix. It runs for all branches, in contrast to
-# ./python-ci-full.yml, which exhausts the matrix but only for main & releases,
-# since that's CI-resource-intensive.
-#
-# To test the full matrix on a working branch, invoke ./python-ci-full.yml from
-#   https://github.com/single-cell-data/TileDB-SOMA/actions/workflows/python-ci-full.yml
+# {os} x {python version} matrix.
 on:
   pull_request:
     branches:
       - main
       - "release-*"
     paths:
-      - "**"
+      - "libtiledbsoma/**"
+      - "apis/python/**"
       - "!**.md"
-      - "!apis/r/**"
-      - "!docker/**"
-      - "!docs/**"
-      - "!.github/**"
       - ".github/workflows/python-ci-minimal.yml"
       - ".github/workflows/python-ci-single.yml"
   workflow_dispatch:

--- a/.github/workflows/python-ci-packaging.yml
+++ b/.github/workflows/python-ci-packaging.yml
@@ -4,35 +4,6 @@
 name: TileDB-SOMA Python CI (Packaging)
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - '.github/workflows/python-ci-packaging.yml'
-      - 'apis/python/MANIFEST.in'
-      - 'apis/python/pyproject.toml'
-      - 'apis/python/setup.py'
-      - 'apis/python/version.py'
-      - 'apis/python/src/tiledbsoma/__init__.py'
-      - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
-      - 'libtiledbsoma/cmake/inputs/tiledbsoma.pc.in'
-      - 'libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake'
-      - 'libtiledbsoma/cmake/Modules/TileDBCommon.cmake'
-      - 'libtiledbsoma/cmake/Superbuild.cmake'
-      - 'libtiledbsoma/CMakeLists.txt'
-  pull_request:
-    paths:
-      - '.github/workflows/python-ci-packaging.yml'
-      - 'apis/python/MANIFEST.in'
-      - 'apis/python/pyproject.toml'
-      - 'apis/python/setup.py'
-      - 'apis/python/version.py'
-      - 'apis/python/src/tiledbsoma/__init__.py'
-      - 'libtiledbsoma/cmake/inputs/Config.cmake.in'
-      - 'libtiledbsoma/cmake/inputs/tiledbsoma.pc.in'
-      - 'libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake'
-      - 'libtiledbsoma/cmake/Modules/TileDBCommon.cmake'
-      - 'libtiledbsoma/cmake/Superbuild.cmake'
-      - 'libtiledbsoma/CMakeLists.txt'
   workflow_dispatch:
 
 jobs:
@@ -299,9 +270,8 @@ jobs:
           cmake --build build-libtiledbsoma -j 2
           cmake --build build-libtiledbsoma --target install-libtiledbsoma
           ls external/lib/
-      # Delete all cmake executables from the runner. This will ensure that
-      # tiledbsoma-py has to use the cli flags to find the external
-      # libtiledbsoma.so and not build it from source by shelling out to cmake
+      # Delete all cmake executables from the runner. This will ensure that tiledbsoma-py has to use
+      # the cli flags to find the external libtiledbsoma.so and not build it from source.
       - name: Delete cmake
         run: |
           echo before
@@ -344,25 +314,15 @@ jobs:
       - name: Runtime test
         run: ./venv-soma/bin/python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
 
-  # Build a wheel from a source tarball (confirms all required files are
-  # distributed in the sdist). This is in preparation for the official building of
-  # the PyPI wheels in python-packaging.yml.
+  # Build a wheel from a source tarball (confirms all required files are distributed in the sdist).
+  # This is in preparation for the official building of the PyPI wheels in python-packaging.yml.
   # https://github.com/single-cell-data/TileDB-SOMA/pull/2506
-  #
   #
   #  Differences to python-packaging.yml:
   #
-  #  * Uses transparent python commands instead of the opaque action
-  #    `pypa/cibuildwheel`, and therefore easier to debug
-  #  * Only builds two wheels total (python 3.11 on Ubuntu and macOS), so it is
-  #    much faster. It's not creating the wheels for distribution, but instead just
-  #    providing a quick check that all the required files are distributed in the
-  #    source tarball
-  #  * Runs whenever an installation-related file is modified instead of only
-  #    after a release
+  #  * Easier debugging: uses transparent python commands instead of the opaque action `pypa/cibuildwheel`.
+  #  * Faster: only builds two wheels total (python 3.11 on Ubuntu and macOS).
   #
-  # In summary, the goal is to identify any potential problems with building
-  # the PyPI wheels when a PR is submitted, and not at release time.
   sdist:
     runs-on: ${{ matrix.os }}
     name: "Wheel from sdist (${{ matrix.os }})"

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
 
-      - name: Print current commit
-        run: git log -1 --oneline
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -82,9 +79,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: true # ensure we get all tags to inform package version determination
-
-      - name: Print current commit
-        run: git log -1 --oneline
 
       - name: Set up test data
         run: make data

--- a/.github/workflows/python-ci-single.yml
+++ b/.github/workflows/python-ci-single.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Print current commit
         run: git log -1 --oneline
 
-      - name: Set Up Test Data
+      - name: Set up test data
         run: make data
 
       - name: Set up Python ${{ inputs.python_version }}
@@ -95,15 +95,6 @@ jobs:
           python-version: ${{ inputs.python_version }}
           cache: pip
           cache-dependency-path: ./apis/python/setup.py
-
-      # Experiment for macOS CI false negatives ...
-      #    - name: Cache native libraries
-      #      uses: actions/cache@v4
-      #      with:
-      #        path: |
-      #          build
-      #          dist
-      #        key: libtiledbsoma-build-dist-${{ inputs.os }}-${{ inputs.python_version }}-${{ hashFiles('libtiledbsoma', 'scripts/bld') }}
 
       - name: Install tiledbsoma
         run: pip -v install -e apis/python[all] -C "--build-option=--no-tiledb-deprecated"
@@ -119,11 +110,6 @@ jobs:
 
       - name: Log pip dependencies
         run: pip list
-
-      - name: Run libtiledbsoma unit tests
-        run: ctest --output-on-failure --test-dir build/libtiledbsoma -C Release --verbose
-        env:
-          TILEDB_SOMA_INIT_BUFFER_BYTES: 33554432 # accommodate tiny runners
 
       - name: Run pytests for Python
         shell: bash

--- a/.github/workflows/python-dependency-variation.yml
+++ b/.github/workflows/python-dependency-variation.yml
@@ -5,14 +5,6 @@ on:
     branches:
       - main
       - 'release-*'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'apis/r/**'
-      - 'docker/**'
-      - 'docs/**'
-      - '.github/**'
-      - '!.github/workflows/python-dependency-variation.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-dependency-variation.yml
+++ b/.github/workflows/python-dependency-variation.yml
@@ -50,9 +50,6 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Current commit
-        run: git log -1 --oneline
-
       - name: Show matrix OS
         run: echo "matrix.os:" ${{ matrix.os }}
 

--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -6,21 +6,16 @@ on:
       - main
       - 'release-*'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'apis/r/**'
-      - 'docker/**'
-      - 'docs/**'
-      - '.github/**'
-      - '!.github/workflows/python-remote-storage.yml'
+    paths:
+      - "libtiledbsoma/**"
+      - "apis/python/**"
+      - "!**.md"
+      - '.github/workflows/python-remote-storage.yml'
   workflow_dispatch:
 
 env:
-  # Don't name this "TILEDB_REST_TOKEN" since that will map into a core
-  # env/config override, as if config key "rest.token" had been set.  One of the
-  # purposes of this CI is to run tests where all config is passed via context
-  # arguments and none via environment variables, in order to flush out
-  # callsites within the code which aren't passing context as they should.
+  # Don't name this "TILEDB_REST_TOKEN" since that will map into a core env/config override. This
+  # test should verify all config options are being properly passed with just config/context.
   TILEDB_REST_UNITTEST_TOKEN: ${{ secrets.TILEDB_REST_UNITTEST_TOKEN}}
 
 jobs:
@@ -29,15 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # This could be run on MacOS too, but, we have enough OS redundancy,
-          # and MacOS-runner availability is a more tightly constrained resource
-          # in GitHub Actions as of 2025-02-06.
           - name: linux
             os: ubuntu-24.04
-            # TO DO: also on 3.12. But 3.9 is higher-pri, until we drop support
-            # for it. (Note our main CI run tests across a broader set of Python
-            # versions.)
-            python_version: 3.9
+            python_version: 3.9 # Should match TileDB-Cloud version
             cc: gcc-13
             cxx: g++-13
 

--- a/.github/workflows/r-python-interop-testing.yml
+++ b/.github/workflows/r-python-interop-testing.yml
@@ -3,15 +3,11 @@ name: TileDB-SOMA R-Python interop testing
 on:
   pull_request:
     paths:
-      - '**'
-      - '!.github/**'
+      - 'libtiledbsoma/**'
+      - 'apis/**'
+      - '!**.md'
       - '.github/workflows/r-python-interop-testing.yml'
-      - '!docker/**'
-    # TODO: leave this enabled for pre-merge signal for now. At some point we may want to go back to
-    # only having this signal post-merge.
-    #  - "apis/python/**"
-    #  - "apis/r/**"
-    #  - "apis/system/**"
+      - '.github/actions/setup-r/**'
   push:
     branches:
       - main
@@ -33,36 +29,12 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Print current commit
-        run: git log -1 --oneline
-
       - name: Set Up Test Data
         run: make data
 
-      - name: Set Up Test Data
-        run: make data
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
+      - uses: ./.github/actions/setup-r
         with:
-          use-public-rspm: true
-          extra-repositories: https://tiledb-inc.r-universe.dev
-
-      - name: P3M Bioconductor
-        run: |
-          cat(
-            'options(BioC_mirror = "https://packagemanager.posit.co/bioconductor/latest")\n',
-            'options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/latest/config.yaml")\n',
-            sep = '',
-            file = '~/.Rprofile',
-            append = TRUE
-          )
-        shell: Rscript {0}
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          working-directory: 'apis/r/'
-          cache-version: 3
+          os: ${{ matrix.os }}
 
       - name: Build Package
         run: cd apis/r && R CMD build --no-build-vignettes --no-manual .

--- a/.github/workflows/r-valgrind.yaml
+++ b/.github/workflows/r-valgrind.yaml
@@ -3,9 +3,9 @@ name: r-valgrind
 on:
   # allows for 'as needed' manual trigger
   workflow_dispatch:
-  # use a regular nighly build as well (time is UTC)
-  schedule:
-    - cron: "23 4 * * *"
+  # # use a regular nighly build as well (time is UTC)
+  # schedule:
+  #   - cron: "23 4 * * *"
 
 env:
   _R_CHECK_TESTS_NLINES_: 0

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,10 +12,6 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!LICENSE'
-  push:
-    branches:
-      - main
-      - 'release-*'
   workflow_dispatch:
 
 name: test-coverage.yaml


### PR DESCRIPTION
**Issue and/or context:**
* Closes SOMA-413
* Towards SOMA-410
* Towards SOMA-412

**Changes:**
* Clean-up path specification for PR jobs
* Use R action for R/Python interop CI
* Remove redundant git log commands
* Remove libtiledbsoma tests from Python runner
* Switch libtiledbsoma coverage to use Ubuntu instead of MacOS
* Only run coverage on PRs
* Reduce some chron jobs to only manual (will rework which tests to run when in follow-up PR)
