### PR TITLE
[python] Document supported workflows for registration functions

### DIFF
--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -283,9 +283,9 @@ def register_anndatas(
     context: SOMATileDBContext | None = None,
     allow_duplicate_obs_ids: bool = False,
 ) -> ExperimentAmbientLabelMapping:
-    """Extends registration data from the baseline, already-written SOMA
-    experiment to include multiple H5AD input files. See ``from_h5ad`` and
-    ``from_anndata`` on-line help.
+    """Register AnnData objects to extend an existing SOMA Experiment.
+
+    See :func:`register_h5ads()` for details.
     """
     if isinstance(adatas, ad.AnnData):
         adatas = [adatas]

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -181,15 +181,15 @@ def register_h5ads(
     """Register H5AD files to extend an existing SOMA ``Experiment``.
 
     This is the required first step before calling :func:`from_h5ad` or :func:`from_anndata` with ``append=True``. It
-    inspects all input H5ADs (and the target ``Experiment``, if ``experiment_uri`` is not ``None``) to produce a global
-    :class:`ExperimentAmbientLabelMapping` that describes how ``obs`` and ``var`` identifiers and schema elements map to
-    the target ``Experiment``.
+    inspects all input H5ADs (and the target ``Experiment``, if ``experiment_uri`` is supplied) to produce a global
+    :class:`ExperimentAmbientLabelMapping` that describes how ``obs``/``var`` identifiers map to the target ``Experiment``.
 
     Supported Workflows:
         This function and the subsequent append workflow are designed for two primary scenarios:
 
-        1. Concatenating multiple datasets where ``obs`` and ``var`` schemas are consistent across all inputs and the target ``Experiment``.
-        2. Adding a new ``Measurement`` for observations that *already exist* in the ``Experiment``.
+        1. Append new observations from inputs with ``obs``/``var`` schemas that are consistent with the target ``Experiment``
+        (i.e., same column names and dtypes).
+        2. Adding a new ``Measurement`` for observations that *already exist* in the target ``Experiment``.
 
     Schema Evolution:
         The append workflow does not automatically evolve the schema of the ``obs``/``var`` DataFrames in the target
@@ -197,10 +197,11 @@ def register_h5ads(
         thrown. If your append operation requires new columns, use :func:`update_obs()`/:func:`update_var()` *before*
         creating the registration map.
 
-    Duplicate obs IDs:
-        By default obs IDs (from ``obs_field_name``) across all inputs and the  existing ``Experiment`` must be globally
+    Duplicate ``obs`` IDs:
+        By default ``obs`` IDs (from ``obs_field_name``) across all inputs and the  existing ``Experiment`` must be globally
         unique. If any duplicates are found, a ``SOMAError`` is raised to prevent unintentionally overwriting existing
         data, which is non-deterministic in multi-writer scenarios. Set ``allow_duplicate_obs_ids=True`` only when
+        adding a *new ``Measurement``* for an existing set of observations (i.e., no new ``obs`` IDs).
 
     New ``var`` IDs:
         The append workflow automatically handles ``var`` IDs (from ``var_field_name``) that do not already exist in the target

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -192,9 +192,10 @@ def register_h5ads(
         2. Adding a new ``Measurement`` for observations that *already exist* in the ``Experiment``.
 
     Schema Evolution:
-        The append workflow does not automatically evolve the schema of the ``obs`` DataFrame. If inputs contain columns
-        in ``obs`` not present in the existing ``Experiment.obs`` they will not be added. If your append operation
-        requires adding new ``obs`` columns, use :func:`update_obs()` *before* creating the registration map.
+        The append workflow does not automatically evolve the schema of the ``obs``/``var`` DataFrames in the target
+        ``Experiment``. If inputs contain ``obs``/``var``columns not present in the target ``Experiment`` an error is
+        thrown. If your append operation requires new columns, use :func:`update_obs()`/:func:`update_var()` *before*
+        creating the registration map.
 
     Duplicate obs IDs:
         By default obs IDs (from ``obs_field_name``) across all inputs and the  existing ``Experiment`` must be globally

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -268,7 +268,7 @@ def register_anndatas(
     context: SOMATileDBContext | None = None,
     allow_duplicate_obs_ids: bool = False,
 ) -> ExperimentAmbientLabelMapping:
-    """Register AnnData objects to extend an existing SOMA Experiment.
+    """Register ``AnnData`` objects to extend an existing SOMA ``Experiment``.
 
     See :func:`register_h5ads()` for details.
     """

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -178,14 +178,26 @@ def register_h5ads(
     use_multiprocessing: bool = False,
     allow_duplicate_obs_ids: bool = False,
 ) -> ExperimentAmbientLabelMapping:
-    """Extends registration data from the baseline, already-written SOMA
-    experiment to include multiple H5AD input files. See ``from_h5ad`` and
-    ``from_anndata`` on-line help.
+    """Register H5AD files to extend an existing SOMA Experiment.
+
+    This function is the mandatory preparation step for appending one or more H5AD files to an existing SOMA Experiment.
+    It analyzes ``obs``/``var`` identifiers and schema elements across all inputs and the target ``Experiment`` to
+    compute a global ``ExperimentAmbientLabelMapping``. This "registration map" is required for appending new data via
+    :func:`from_anndata` or :func:`from_h5ad`. See ``from_h5ad`` and ``from_anndata`` for details.
+
+    Important Considerations for Append Mode
+    =========================================
+
+    Duplicates Handling
+    -------------------
 
     The registration process will raise an error if any `obs` IDs (from `obs_field_name`)
     are duplicated across the combination of all inputs and the target SOMA Experiment.
     You can set `allow_duplicate_obs_ids=True` to bypass this check if you are adding a
-    new Measurement to existing observations.
+    new ``Measurement`` to existing observations.
+
+    Multiprocessing Support
+    -----------------------
 
     If enabled via the ``use_multiprocessing`` parameter, this function will use multiprocessing
     to register each H5AD in parallel. In cases with many files, this can produce a performance

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -188,6 +188,24 @@ def register_h5ads(
     Important Considerations for Append Mode
     =========================================
 
+    Supported Workflows
+    -------------------
+
+    This function and the subsequent append workflow are designed for two primary scenarios:
+
+    1.  Concatenating multiple datasets where ``obs`` and ``var`` schemas are consistent across all inputs and the
+        target ``Experiment``.
+    2.  Adding a new ``Measurement`` for observations that *already exist* in the ``Experiment``.
+
+    The append workflow does NOT automatically evolve the schema of the ``obs`` DataFrame. Specifically, it does not add
+    new columns to the existing ``obs`` DataFrame if they are present in the input AnnDatas but not in the target
+    ``Experiment``.
+
+    If your append operation requires adding new ``obs`` columns, you must first add them to the existing ``obs``
+    DataFrame manually using ``tiledbsoma.io.update_obs()`` *before* running the creating the registration map. Failing
+    to do so will result in a ``SOMAError`` during the data write step (e.g., ``"Column name not found:
+    [new_column_name]"``).
+
     Duplicates Handling
     -------------------
 

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -201,7 +201,10 @@ def register_h5ads(
         By default obs IDs (from ``obs_field_name``) across all inputs and the  existing ``Experiment`` must be globally
         unique. If any duplicates are found, a ``SOMAError`` is raised to prevent unintentionally overwriting existing
         data, which is non-deterministic in multi-writer scenarios. Set ``allow_duplicate_obs_ids=True`` only when
-        adding a *new Measurement* for an existing set of observations (i.e., no new obs IDs).
+
+    New ``var`` IDs:
+        The append workflow automatically handles ``var`` IDs (from ``var_field_name``) that do not already exist in the target
+        ``Experiment``, assuming the input supplies all existing columns with compatible dtypes.
 
     Concurrency:
         If enabled via the ``use_multiprocessing`` parameter, this function will use multiprocessing to register each


### PR DESCRIPTION
**Issue and/or context:** SOMA-275

**Changes:** Update `register_h5ads()` docstrings to document the two supported append-mode workflows. I also reworded some of the narrative text for clarity.

**Notes for Reviewer:** This also restructures some of the additional narrative text to use indentation rather than underlines to separate sections, which aligns with Google style docstrings. 
