### PR TITLE
Adding `.type` property for Sparse/DenseNDArrays

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4125](https://github.com/single-cell-data/TileDB-SOMA/pull/4125)\] Add delete mode specified by `mode='d'`.
 - \[[#4205](https://github.com/single-cell-data/TileDB-SOMA/pull/4205)\] Add `delete_cells` method to `SparseNDArray`, `DataFrame`, and `PointCloudDataFrame`.
+- \[[#4212](https://github.com/single-cell-data/TileDB-SOMA/pull/4212)\] Add `type` read-only property to `DenseNDArray` and `SparseNDArray`.
 
 ### Changed
 

--- a/apis/python/src/tiledbsoma/_common_nd_array.py
+++ b/apis/python/src/tiledbsoma/_common_nd_array.py
@@ -144,6 +144,21 @@ class NDArray(SOMAArray, somacore.NDArray):
         """
         return self._handle.tiledbsoma_has_upgraded_shape
 
+    @property
+    def type(self) -> pa.DataType:
+        """Returns the data type of the array's soma_data attribute.
+
+        This is a read-only property that provides direct access to the Arrow data type
+        of the array's data, equivalent to ``self.schema.field("soma_data").type``.
+
+        Lifecycle:
+            Maturing.
+
+        Returns:
+            The Arrow data type of the array's data.
+        """
+        return self.schema.field("soma_data").type
+
     @classmethod
     def _dim_capacity_and_extent(
         cls,

--- a/apis/python/tests/test_dense_nd_array.py
+++ b/apis/python/tests/test_dense_nd_array.py
@@ -39,6 +39,7 @@ def test_dense_nd_array_create_ok(tmp_path, shape: tuple[int, ...], element_type
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
+    assert a.type == element_type
     assert not a.schema.field("soma_data").nullable
 
     # Ensure read mode uses clib object

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -63,6 +63,7 @@ def test_sparse_nd_array_create_ok(tmp_path, shape: tuple[int, ...], element_typ
     for d in range(len(shape)):
         assert a.schema.field(f"soma_dim_{d}").type == pa.int64()
     assert a.schema.field("soma_data").type == element_type
+    assert a.type == element_type
     assert not a.schema.field("soma_data").nullable
 
     # Check with open binding


### PR DESCRIPTION
**Issue and/or context:**

SOMA SparseNDArray and DenseNDArray arrays are created with a specific data type (e.g., type=pa.float32), but there is no direct way to retrieve this type via the API. Users must currently inspect the underlying Arrow schema and infer the type from there.

**Changes:**
Adding a new `property` inside the NDArray class to be inherited by both Sparse and DenseNDArray classes.

**Notes for Reviewer:**
None