### PR TITLE
[python] concurrency safe monkey patch for AnnData IO path

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4139](https://github.com/single-cell-data/tiledb-soma/pull/4139)\] [python] ExperimentAxisQuery.to_anndata would export obsm/varm as float32, regardless of the underlying SOMA data type. With this fix, the exported matrix will have the same data type as the original data.
 - \[[#4147](https://github.com/single-cell-data/TileDB-SOMA/pull/4147)\] [python] Fix a race condition in SOMA collection caching which would result in redundant object opens.
+- \[[#4223](https://github.com/single-cell-data/TileDB-SOMA/pull/4223)\] [python] Fix race condition in H5AD reading in the `tiledbsoma.io` module.
 
 ### Security
 

--- a/apis/python/src/tiledbsoma/io/_util.py
+++ b/apis/python/src/tiledbsoma/io/_util.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 import pathlib
 import sys
 from collections.abc import Iterator
-from contextlib import AbstractContextManager, contextmanager
-from unittest import mock
+from contextlib import contextmanager
 
 import anndata as ad
 import pyarrow as pa
@@ -41,7 +40,9 @@ _pa_type_to_str_fmt = {
 
 
 @contextmanager
-def read_h5ad(input_path: Path, *, mode: str = "r", ctx: SOMATileDBContext | None = None) -> Iterator[ad.AnnData]:
+def read_h5ad(
+    input_path: Path | str, *, mode: str | None = "r", ctx: SOMATileDBContext | None = None
+) -> Iterator[ad.AnnData]:
     """This lets us ingest H5AD with "r" (backed mode) from S3 URIs."""
     ctx = ctx or SOMATileDBContext()
     input_handle = CachingReader(
@@ -50,13 +51,12 @@ def read_h5ad(input_path: Path, *, mode: str = "r", ctx: SOMATileDBContext | Non
         cache_block_size=8 * 1024**2,
     )
     try:
-        with _hack_patch_anndata():
-            anndata = ad.read_h5ad(_FSPathWrapper(input_handle, input_path), mode)
-            yield anndata
+        adata = ad.read_h5ad(_FSPathWrapper(input_handle, input_path), mode)
+        yield adata
     finally:
         # This prevents a race condition with the REPL cleanup in ipython. See sc-65863
-        if anndata.file:
-            anndata.file.close()
+        if "adata" in locals() and adata.file:
+            adata.file.close()
         input_handle.close()
 
 
@@ -102,18 +102,30 @@ class _FSPathWrapper(pathlib.Path):
         return getattr(self._obj, name)
 
 
-# @typeguard_ignore
-def _hack_patch_anndata() -> AbstractContextManager[object]:
-    """Part Two of the ``_FSPathWrapper`` trick."""
+def _monkey_patch_anndata() -> None:
+    """Monkey patch the AnnData backed file manager to allow our path-like
+    wrapper class in addition to a str|Path.
 
-    @file_backing.AnnDataFileManager.filename.setter  # type: ignore[misc]
+    As this is a global change whenever tiledbsoma is imported, take
+    care to preserve original AnnData setter behavior in cases unrelated
+    to the above use.
+    """
+    original_setter = file_backing.AnnDataFileManager.filename.fset
+    original_getter = file_backing.AnnDataFileManager.filename.fget
+
     def filename(
         self: file_backing.AnnDataFileManager,
         filename: Path | _FSPathWrapper | None,
     ) -> None:
-        self._filename = filename
+        if isinstance(filename, _FSPathWrapper):
+            self._filename = filename
+        else:
+            original_setter(self, filename)
 
-    return mock.patch.object(file_backing.AnnDataFileManager, "filename", filename)
+    file_backing.AnnDataFileManager.filename = property(original_getter, filename)
+
+
+_monkey_patch_anndata()
 
 
 def get_arrow_str_format(pa_type: pa.DataType) -> str:

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1457,3 +1457,28 @@ def test_from_anndata_sketchy_key(tmp_path):
     tiledbsoma.io.from_anndata(exp_uri, adata, "../..")
     with tiledbsoma.Experiment.open(exp_uri) as E:
         assert E["ms"]["../.."].uri == f"file://{exp_uri}/ms/..%2F.."
+
+
+@pytest.mark.parametrize("backed", [None, "r"])
+def test_anndata_with_monkeypatch(conftest_pbmc_small_h5ad_path, backed):
+    """Confirm that the monkeypatch did not interfere with normal AnnData behavior"""
+    adata = ad.read_h5ad(conftest_pbmc_small_h5ad_path, backed=backed)
+    assert adata.shape == (80, 20)
+
+    adata = ad.read_h5ad(conftest_pbmc_small_h5ad_path.as_posix(), backed=backed)
+    assert adata.shape == (80, 20)
+
+    adata = ad.read_h5ad(str(conftest_pbmc_small_h5ad_path), backed=backed)
+    assert adata.shape == (80, 20)
+
+
+@pytest.mark.parametrize("backed", [None, "r"])
+def test_io_util_read_h5ad(conftest_pbmc_small_h5ad_path, backed):
+    with tiledbsoma.io._util.read_h5ad(conftest_pbmc_small_h5ad_path, mode=backed) as adata:
+        assert adata.shape == (80, 20)
+
+    with tiledbsoma.io._util.read_h5ad(f"file://{conftest_pbmc_small_h5ad_path!s}", mode=backed) as adata:
+        assert adata.shape == (80, 20)
+
+    with tiledbsoma.io._util.read_h5ad(str(conftest_pbmc_small_h5ad_path), mode=backed) as adata:
+        assert adata.shape == (80, 20)


### PR DESCRIPTION
SOMA-449 / #4219 demonstrate a race in the H5AD IO path for `tiledbsoma.io`. 

This race can occur with any storage system (it was reported against GCS, but testing revealed it against a local filesystem as well).