### PR TITLE
[python] Add delete cells methods to read-the-docs

### DIFF
--- a/doc/source/python-tiledbsoma-dataframe.rst
+++ b/doc/source/python-tiledbsoma-dataframe.rst
@@ -20,6 +20,7 @@
       ~DataFrame.close
       ~DataFrame.read
       ~DataFrame.write
+      ~DataFrame.delete_cells
       ~DataFrame.verify_open_for_writing
 
       ~DataFrame.keys

--- a/doc/source/python-tiledbsoma-experiment.rst
+++ b/doc/source/python-tiledbsoma-experiment.rst
@@ -38,6 +38,8 @@
       ~Experiment.add_new_sparse_ndarray
 
       ~Experiment.axis_query
+      ~Experiment.obs_axis_delete
+      ~Experiment.var_axis_delete
 
    .. rubric:: Attributes
 

--- a/doc/source/python-tiledbsoma-pointclouddataframe.rst
+++ b/doc/source/python-tiledbsoma-pointclouddataframe.rst
@@ -18,11 +18,12 @@
       ~PointCloudDataFrame.open
       ~PointCloudDataFrame.reopen
       ~PointCloudDataFrame.close
-      ~PointCloudDataFrame.verify_open_for_writing
 
       ~PointCloudDataFrame.keys
       ~PointCloudDataFrame.read
       ~PointCloudDataFrame.write
+      ~PointCloudDataFrame.delete_cells
+      ~PointCloudDataFrame.verify_open_for_writing
 
       ~PointCloudDataFrame.config_options_from_schema
       ~PointCloudDataFrame.non_empty_domain

--- a/doc/source/python-tiledbsoma-sparsendarray.rst
+++ b/doc/source/python-tiledbsoma-sparsendarray.rst
@@ -20,6 +20,7 @@
       ~SparseNDArray.close
       ~SparseNDArray.read
       ~SparseNDArray.write
+      ~SparseNDArray.delete_cells
       ~SparseNDArray.verify_open_for_writing
 
       ~SparseNDArray.non_empty_domain


### PR DESCRIPTION
**Issue and/or context:** Towards SOMA-475

**Changes:**
* Update read-the-docs generation to include new delete cell methods

