### PR TITLE
[ci] Remove github workflow tiledb-py pin

### DIFF
--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -74,7 +74,7 @@ jobs:
           CXX: ${{ matrix.cxx }}
 
       - name: Install dependencies
-        run: pip install --prefer-binary pytest typeguard 'tiledb<=0.34.0' tiledb.cloud
+        run: pip install --prefer-binary pytest typeguard tiledb tiledb.cloud
 
       - name: Show package versions
         run: python scripts/show-versions.py


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-373

**Changes:**
Remove pin that was temporarily needed while release process was underway for release 2.28.1.