### PR TITLE
[python] Add medium_runner pytest mark to prevent macos OOM errors on CI

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -27,6 +27,7 @@ jobs:
           - os: macos-latest
             cc: clang
             cxx: clang++
+            extra_pytest_options: "-m 'not medium_runner'"
     uses: ./.github/workflows/test-python.yml
     with:
       os: ${{ matrix.os }}
@@ -34,6 +35,7 @@ jobs:
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
       report_codecov: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' }}
+      extra_pytest_options: ${{ matrix.extra_pytest_options }}
     secrets: inherit
 
   r-tests:

--- a/.github/workflows/ci-pr-python.yml
+++ b/.github/workflows/ci-pr-python.yml
@@ -25,6 +25,7 @@ jobs:
           - os: macos-latest
             cc: clang
             cxx: clang++
+            extra_pytest_options: "-m 'not medium_runner'"
     uses: ./.github/workflows/test-python.yml
     with:
       os: ${{ matrix.os }}
@@ -32,4 +33,5 @@ jobs:
       cc: ${{ matrix.cc }}
       cxx: ${{ matrix.cxx }}
       report_codecov: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' }}
+      extra_pytest_options: ${{ matrix.extra_pytest_options }}
     secrets: inherit

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,6 +21,9 @@ on:
       report_codecov:
         required: true
         type: boolean
+      extra_pytest_options:
+        required: false
+        type: string
 
 jobs:
 
@@ -79,7 +82,7 @@ jobs:
         # Setting PYTHONPATH ensures the tests load the in-tree source code under apis/python/src
         # instead of the copy we `pip install`ed to site-packages above. That's needed for the code
         # coverage analysis to work.
-        run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50
+        run: PYTHONPATH=$(pwd)/apis/python/src python -m pytest --cov=apis/python/src --cov-report=xml apis/python/tests -v --durations=20 --maxfail=50 ${{ inputs.extra_pytest_options }}
 
       - name: Report coverage to Codecov
         if: inputs.report_codecov

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -127,4 +127,5 @@ filterwarnings = ["ignore:Support for spatial types is experimental"]
 markers = [
     "slow: mark test as slow",
     "spatialdata: test of SpatialData integration",
+    "medium_runner: tests that are too large for the MacOS GitHub runners",
 ]

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -606,6 +606,7 @@ def test_null_obs(conftest_pbmc_small, tmp_path: Path):
             assert getter(k).nullable
 
 
+@pytest.mark.medium_runner
 def test_export_obsm_with_holes(soma_tiledb_context, h5ad_file_with_obsm_holes, tmp_path):
     adata = ad.read_h5ad(h5ad_file_with_obsm_holes.as_posix())
     original = adata.copy()
@@ -1301,6 +1302,7 @@ def test_from_anndata_byteorder_63459(tmp_path, conftest_pbmc_small):
         assert adata.uns["X"] == new_adata.uns["X"]
 
 
+@pytest.mark.medium_runner
 def test_soma_file_handling_65831_65864():
     context = tiledbsoma.SOMATileDBContext()
     if not TESTDATA.exists():

--- a/apis/python/tests/test_experiment_axis_delete.py
+++ b/apis/python/tests/test_experiment_axis_delete.py
@@ -35,6 +35,7 @@ from .test_experiment_query_spatial import soma_spatial_experiment  # noqa: F401
         "louvain == 'B cells' and n_genes < 500",
     ],
 )
+@pytest.mark.medium_runner
 def test_experiment_obs_axis_delete_from_pbmc3k(
     tmp_path, soma_tiledb_context, experiment_path, coords, value_filter
 ) -> None:

--- a/apis/python/tests/test_experiment_query.py
+++ b/apis/python/tests/test_experiment_query.py
@@ -522,6 +522,7 @@ def test_query_cleanup(soma_experiment: soma.Experiment):
     "n_obs,n_vars,obsp_layer_names,varp_layer_names,obsm_layer_names,varm_layer_names",
     [(1001, 99, ["foo"], ["bar"], ["baz"], ["quux"])],
 )
+@pytest.mark.medium_runner
 def test_experiment_query_obsp_varp_obsm_varm(soma_experiment):
     obs_slice = slice(3, 72)
     var_slice = slice(7, 21)
@@ -884,6 +885,7 @@ def test_empty_categorical_query(conftest_pbmc_small_exp):
         ['var_id not in ["S100A6", "CYBA", "NONESUCH"]', 1836],
     ],
 )
+@pytest.mark.medium_runner
 def test_experiment_query_historical(soma_tiledb_context, version, obs_params, var_params):
     """Checks that experiments written by older versions are still queryable."""
 
@@ -953,6 +955,7 @@ def test_experiment_query_historical(soma_tiledb_context, version, obs_params, v
 @pytest.mark.parametrize("obsp_layers", [(), ("connectivities",), ("distances",), ("connectivities", "distances")])
 @pytest.mark.parametrize("varp_layers", [()])
 @pytest.mark.parametrize("varm_layers", [(), ("PCs",)])
+@pytest.mark.medium_runner
 def test_annotation_matrix_slots(
     soma_tiledb_context, version, obsm_layers, obsp_layers, varm_layers, varp_layers
 ) -> None:

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1386,6 +1386,7 @@ def test_registration_lists_and_tuples(tmp_path, soma_tiledb_context):
         ["1.15.7", True],
     ],
 )
+@pytest.mark.medium_runner
 def test_extend_enmr_to_older_experiments_64521(tmp_path, soma_tiledb_context, version_and_shaped):
     version, _ = version_and_shaped
 

--- a/apis/python/tests/test_soma_experiment_versions.py
+++ b/apis/python/tests/test_soma_experiment_versions.py
@@ -13,6 +13,7 @@ from ._util import ROOT_DATA_DIR
     "name_and_expected_shape",
     [["pbmc3k_unprocessed", (2700, 13714)], ["pbmc3k_processed", (2638, 1838)]],
 )
+@pytest.mark.medium_runner
 def test_to_anndata(soma_tiledb_context, version, name_and_expected_shape):
     """Checks that experiments written by older versions are still readable,
     in the particular form of doing an outgest."""

--- a/apis/python/tests/test_sparse_nd_array.py
+++ b/apis/python/tests/test_sparse_nd_array.py
@@ -1793,6 +1793,7 @@ def test_iter(tmp_path: pathlib.Path):
         next(b)
 
 
+@pytest.mark.medium_runner
 def test_context_cleanup(tmp_path: pathlib.Path) -> None:
     arrow_tensor = create_random_tensor("table", (1,), np.float32(), density=1)
     with soma.SparseNDArray.create(tmp_path.as_uri(), type=pa.float64(), shape=(1,)) as write_arr:

--- a/apis/python/tests/test_update_matrix.py
+++ b/apis/python/tests/test_update_matrix.py
@@ -1,7 +1,10 @@
+import pytest
+
 import tiledbsoma
 import tiledbsoma.io
 
 
+@pytest.mark.medium_runner
 def test_update_matrix_X(conftest_pbmc3k_adata, tmp_path):
     output_path = tmp_path.as_posix()
 
@@ -33,6 +36,7 @@ def test_update_matrix_X(conftest_pbmc3k_adata, tmp_path):
 
 
 # Magical conftest.py fixture
+@pytest.mark.medium_runner
 def test_update_matrix_obsm(conftest_pbmc3k_adata, tmp_path):
     output_path = tmp_path.as_posix()
 


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-392

**Changes:**
This adds a pytest "medium_runner" tag that is used to filter tests for the MacOS runners. We can add/remove this mark to tests as we see what triggers the CI OOMs.