### PR TITLE
[ci/python] Add marks to additional tests to prevent OOM on macos runner

### DIFF
--- a/apis/python/tests/test_experiment_axis_delete.py
+++ b/apis/python/tests/test_experiment_axis_delete.py
@@ -109,6 +109,7 @@ def test_experiment_obs_axis_delete_from_pbmc3k(
         "var_id in ['PRDX1', 'TMED5', 'CDA', 'C1QA', 'C1QC', 'C1QB', 'ZNF436']",
     ],
 )
+@pytest.mark.medium_runner
 def test_experiment_var_axis_delete_from_pbmc3k(
     tmp_path, soma_tiledb_context, experiment_path, coords, value_filter
 ) -> None:

--- a/apis/python/tests/test_to_anndata_dask.py
+++ b/apis/python/tests/test_to_anndata_dask.py
@@ -129,6 +129,7 @@ sweep_queries = pytest.mark.parametrize(
 @sweep_queries
 @pytest.mark.parametrize("obs_chunk_size", [20, 30, 80, 100])
 @pytest.mark.parametrize("var_chunk_size", [3, 10, 20])
+@pytest.mark.medium_runner
 def test_dask_query_to_anndata(
     conftest_pbmc_small_exp: Experiment,
     obs_query: AxisQuery,
@@ -154,6 +155,7 @@ def test_dask_query_to_anndata(
     "obs_query,var_query,shape,nnz,obs_chunk_size,var_chunk_size",
     [(AxisQuery(), AxisQuery(), (80, 20), 1600, 20, 3)],
 )
+@pytest.mark.medium_runner
 def test_dask_query_to_anndata_timestamp(
     conftest_pbmc_small_exp_path: Path,
     obs_query: AxisQuery,
@@ -225,6 +227,7 @@ def test_dask_query_to_anndata_timestamp(
     "obs_query,var_query,shape,nnz,obs_chunk_size,var_chunk_size",
     [(AxisQuery(), AxisQuery(), (80, 20), 1600, 20, 3)],
 )
+@pytest.mark.medium_runner
 def test_dask_query_to_anndata_layers(
     conftest_pbmc_small_exp_path: Path,
     obs_query: AxisQuery,


### PR DESCRIPTION
Add marks to additional tests to prevent OOM on macos runner.