### PR TITLE
[python] Mark additional tests that use pbmc3k as requiring medium runner

### DIFF
--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -315,6 +315,7 @@ def test_resume_mode(resume_mode_h5ad_file, tmp_path):
 
 
 @pytest.mark.parametrize("use_relative_uri", [False, True, None])
+@pytest.mark.medium_runner
 def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri, tmp_path):
     output_path = tmp_path.as_posix()
 
@@ -357,6 +358,7 @@ def test_ingest_relative(conftest_pbmc3k_h5ad_path, use_relative_uri, tmp_path):
 
 
 @pytest.mark.parametrize("ingest_uns_keys", [["louvain_colors"], None])
+@pytest.mark.medium_runner
 def test_ingest_uns(
     tmp_path: Path,
     conftest_pbmc3k_h5ad_path,

--- a/apis/python/tests/test_registration_mappings.py
+++ b/apis/python/tests/test_registration_mappings.py
@@ -1222,6 +1222,7 @@ def test_enum_bit_width_append(tmp_path, all_at_once, nobs_a, nobs_b, soma_tiled
         assert readback_b == obs_ids_b
 
 
+@pytest.mark.medium_runner
 def test_multimodal_names(tmp_path, conftest_pbmc3k_adata, soma_tiledb_context):
     uri = tmp_path.as_posix()
 

--- a/apis/python/tests/test_update_dataframes.py
+++ b/apis/python/tests/test_update_dataframes.py
@@ -259,6 +259,7 @@ def test_change_counts(
 
 
 @pytest.mark.parametrize("separate_ingest", [False, True])
+@pytest.mark.medium_runner
 def test_update_non_null_to_null(soma_tiledb_context, tmp_path, conftest_pbmc3k_adata, separate_ingest):
     uri = tmp_path.as_uri()
 
@@ -305,6 +306,7 @@ def test_update_non_null_to_null(soma_tiledb_context, tmp_path, conftest_pbmc3k_
     verify_updates(uri, conftest_pbmc3k_adata.obs, conftest_pbmc3k_adata.var)
 
 
+@pytest.mark.medium_runner
 def test_enmr_add_drop_readd(soma_tiledb_context, tmp_path, conftest_pbmc3k_adata):
     uri = tmp_path.as_posix()
 


### PR DESCRIPTION
Add `medium_runner` mark to a few additional tests that have or will likely hit OOM on macos runners.
