### PR TITLE
Substitute macos-13 runners with macos-15-intel

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -102,7 +102,7 @@ jobs:
         if: matrix.os == 'macos-15-intel'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.1'
+          xcode-version: '16.0'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         with:

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -66,7 +66,7 @@ jobs:
             # vcpkg source build requires this on ARM, for some reason; cf. https://github.com/NixOS/nixpkgs/issues/335868
             CIBW_ENVIRONMENT_LINUX: VCPKG_FORCE_SYSTEM_BINARIES=1
           - cibw_build: macosx_x86_64
-            os: macos-13
+            os: macos-15-intel
             cibw_archs_macos: x86_64
             wheel-name: macos-x86_64
           - cibw_build: macosx_arm64
@@ -99,7 +99,7 @@ jobs:
         with:
           xcode-version: '16.1'
       - name: Select XCode version for macos-x86_64
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.1'
@@ -156,7 +156,7 @@ jobs:
             os: ubuntu-24.04-arm
             arch: aarch64
           - wheel-name: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             arch: x86_64
           - wheel-name: macos-arm64
             os: macos-15


### PR DESCRIPTION
**Issue and/or context:**
The `macOS 13` runner image will be retired by `December 4th, 2025`. To raise awareness of the upcoming removal, jobs using `macOS 13` will temporarily fail during the scheduled brownout.

**Changes:**
- Changed the `macos-13` with `macos-15-intel` which is newly introduced label for environments that require the x86_64 (Intel) environment
- 
**Notes for Reviewer:**
