### PR TITLE
[c++] Move column construction from ArrowAdapter to Column subclasses

### DIFF
--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -46,7 +46,28 @@ class SOMADimension : public SOMAColumn {
         ArrowArray* array,
         const std::string& soma_type,
         std::string_view type_metadata,
-        PlatformConfig platform_config);
+        const PlatformConfig& platform_config);
+
+    template <typename T>
+    static std::shared_ptr<SOMADimension> create(
+        std::shared_ptr<Context> ctx,
+        const std::string& name,
+        const std::string& soma_type,
+        const DimensionConfigAdapter<T>& dim_config,
+        const PlatformConfig& platform_config,
+        std::optional<tiledb_datatype_t> datatype = std::nullopt) {
+        FilterList filter_list = utils::create_dim_filter_list(name, platform_config, soma_type, ctx);
+        auto dim = datatype.has_value() ? dim_config.create_dimension(*ctx, name, datatype.value(), filter_list) :
+                                          dim_config.create_dimension(*ctx, name, filter_list);
+        return std::make_shared<SOMADimension>(SOMADimension(dim));
+    }
+
+    static std::shared_ptr<SOMADimension> create(
+        std::shared_ptr<Context> ctx,
+        const std::string& name,
+        const std::string& soma_type,
+        tiledb_datatype_t tiledb_type,
+        const PlatformConfig& platform_config);
 
     SOMADimension(Dimension dimension)
         : dimension(dimension) {

--- a/libtiledbsoma/src/soma/soma_geometry_column.h
+++ b/libtiledbsoma/src/soma/soma_geometry_column.h
@@ -56,7 +56,13 @@ class SOMAGeometryColumn : public SOMAColumn {
         const SOMACoordinateSpace& coordinate_space,
         const std::string& soma_type,
         std::string_view type_metadata,
-        PlatformConfig platform_config);
+        const PlatformConfig& platform_config);
+
+    static std::shared_ptr<SOMAGeometryColumn> create(
+        std::shared_ptr<Context> ctx,
+        const SOMACoordinateSpace& coordinate_space,
+        const std::vector<DimensionConfigAdapter<double_t>>& dim_configs,
+        const PlatformConfig& platform_config);
 
     SOMAGeometryColumn(std::vector<Dimension> dimensions, Attribute attribute, SOMACoordinateSpace coordinate_space)
         : dimensions(dimensions)

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -140,21 +140,6 @@ class ArrowAdapter {
         std::optional<std::pair<int64_t, int64_t>> timestamp_range = std::nullopt);
 
     /**
-     * @brief Get a TileDB dimension from an Arrow schema.
-     *
-     * @return std::pair<Dimension, bool> The TileDB dimension.
-     */
-    static Dimension tiledb_dimension_from_arrow_schema(
-        std::shared_ptr<Context> ctx,
-        ArrowSchema* schema,
-        ArrowArray* array,
-        std::string soma_type,
-        std::string_view type_metadata,
-        std::string prefix = std::string(),
-        std::string suffix = std::string(),
-        PlatformConfig platform_config = PlatformConfig());
-
-    /**
      * @brief Get a TileDB attribute with its enumeration from an Arrow schema.
      *
      * @return std::pair<Attribute, std::optional<Enumeration>>

--- a/libtiledbsoma/test/CMakeLists.txt
+++ b/libtiledbsoma/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(unit_soma
     unit_soma_coordinates.cc
     test_indexer.cc
     test_coordinate_value_filter.cc
+    test_platform_config.cc
     test_soma_object_basics.cc
     test_soma_column_selection.cc
 # TODO: uncomment when thread_pool is enabled

--- a/libtiledbsoma/test/test_platform_config.cc
+++ b/libtiledbsoma/test/test_platform_config.cc
@@ -1,0 +1,73 @@
+/**
+ * @file  test_soma_column_selection.cc
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ *
+ * @section DESCRIPTION
+ *
+ * This file manages tests for the SOMA column selection classes.
+ */
+
+#include "common.h"
+
+TEMPLATE_TEST_CASE_SIG(
+    "DimensionConfigAdapter: basic signed type with default tiledb type",
+    "[DimensionConfigAdpater][PlatformConfig]",
+    ((typename T, tiledb_datatype_t D), T, D),
+    (int8_t, TILEDB_INT8),
+    (int16_t, TILEDB_INT16),
+    (int32_t, TILEDB_INT32),
+    (int64_t, TILEDB_INT64),
+    (float_t, TILEDB_FLOAT32),
+    (double_t, TILEDB_FLOAT64)) {
+    std::array<T, 2> max_domain{10, 100};
+    std::array<T, 2> current_domain{10, 50};
+    T tile_extent{20};
+    DimensionConfigAdapter<T> dim_config(current_domain, max_domain, tile_extent);
+
+    Context ctx{};
+    std::string name{"index_column_0"};
+    FilterList filter_list{ctx};
+    tiledb::Dimension dim = dim_config.create_dimension(ctx, name, filter_list);
+    CHECK(dim.name() == name);
+    REQUIRE(dim.type() == D);
+    auto actual_max_domain = dim.domain<T>();
+    auto actual_tile_extent = dim.tile_extent<T>();
+    CHECK(actual_max_domain.first == max_domain[0]);
+    CHECK(actual_max_domain.second == max_domain[1]);
+    CHECK(actual_tile_extent == tile_extent);
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "DimensionConfigAdapter: basic signed types with specific tiledb types",
+    "[DimensionConfigAdpater][PlatformConfig]",
+    ((typename T, tiledb_datatype_t D), T, D),
+    (int8_t, TILEDB_INT8),
+    (int16_t, TILEDB_INT16),
+    (int32_t, TILEDB_INT32),
+    (int64_t, TILEDB_INT64),
+    (int64_t, TILEDB_DATETIME_SEC),
+    (int64_t, TILEDB_DATETIME_MS),
+    (int64_t, TILEDB_DATETIME_US),
+    (int64_t, TILEDB_DATETIME_NS),
+    (float_t, TILEDB_FLOAT32),
+    (double_t, TILEDB_FLOAT64)) {
+    std::array<T, 2> max_domain{10, 100};
+    std::array<T, 2> current_domain{10, 50};
+    T tile_extent{20};
+    DimensionConfigAdapter<T> dim_config(current_domain, max_domain, tile_extent);
+
+    Context ctx{};
+    std::string name{"index_column_0"};
+    FilterList filter_list{ctx};
+    tiledb::Dimension dim = dim_config.create_dimension(ctx, name, D, filter_list);
+    CHECK(dim.name() == name);
+    auto actual_max_domain = dim.domain<T>();
+    auto actual_tile_extent = dim.tile_extent<T>();
+    CHECK(actual_max_domain.first == max_domain[0]);
+    CHECK(actual_max_domain.second == max_domain[1]);
+    CHECK(actual_tile_extent == tile_extent);
+}


### PR DESCRIPTION
**Issue and/or context:** Towards SOMA-619

**Changes:**
This moves `SOMADimension` and `SOMAGeometyColumn` construction out of the ArrowAdapter class and into the respective column classes. This is in preparation for creating C++ constructors for SOMA arrays (e.g. `SOMADataFrame`, `SOMASparseNDArray`) without first creating intermediary arrow tables.