### PR TITLE
[c++] Improve error messages when unable to open the TileDB object

### DIFF
--- a/apis/python/src/tiledbsoma/_exception.py
+++ b/apis/python/src/tiledbsoma/_exception.py
@@ -43,8 +43,8 @@ def is_does_not_exist_error(e: Exception) -> bool:
         or "Unrecognized array" in stre
         or "HTTP code 401" in stre
         or "HTTP code 404" in stre
-        or "[SOMAObject::open] " in stre
-        or "has TileDB type Invalid" in stre
+        or "not a valid TileDB" in stre
+        or "Unable to open" in stre
     )
 
 

--- a/libtiledbsoma/src/soma/soma_factory.cc
+++ b/libtiledbsoma/src/soma/soma_factory.cc
@@ -30,24 +30,8 @@ std::string get_soma_type_metadata_value(
             return get_soma_type_metadata_value_from_array(uri, ctx, timestamp);
         case Object::Type::Group:
             return get_soma_type_metadata_value_from_group(uri, ctx, timestamp);
-        case Object::Type::Invalid:
-            throw TileDBSOMAError(
-                fmt::format(
-                    "The object at URI '{}' has TileDB type Invalid ({}), which is neither Array ({}) nor Group ({})",
-                    uri,
-                    static_cast<int>(tiledb_type),
-                    static_cast<int>(Object::Type::Array),
-                    static_cast<int>(Object::Type::Group)));
         default:
-            throw TileDBSOMAError(
-                fmt::format(
-                    "The object at URI '{}' has unrecognized TileDB type ({}), which is neither Array ({}) nor Group "
-                    "({}) nor Invalid ({})",
-                    uri,
-                    static_cast<int>(tiledb_type),
-                    static_cast<int>(Object::Type::Array),
-                    static_cast<int>(Object::Type::Group),
-                    static_cast<int>(Object::Type::Invalid)));
+            throw TileDBSOMAError(fmt::format("The object at URI '{}' is not a valid TileDB array or group.", uri));
     }
 }
 

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -26,69 +26,101 @@ std::unique_ptr<SOMAObject> SOMAObject::open(
     std::shared_ptr<SOMAContext> ctx,
     std::optional<TimestampRange> timestamp,
     std::optional<std::string> soma_type) {
-    if (soma_type == std::nullopt) {
-        auto tiledb_type = Object::object(*ctx->tiledb_ctx(), std::string(uri)).type();
-        soma_type = util::soma_type_from_tiledb_type(tiledb_type);
+    auto tiledb_type = Object::Type::Invalid;
+    if (soma_type.has_value()) {
+        if (soma_type == "SOMAArray") {
+            tiledb_type = Object::Type::Array;
+        } else if (soma_type == "SOMAGroup") {
+            tiledb_type = Object::Type::Group;
+        } else {
+            throw TileDBSOMAError(fmt::format("Internal error: Invalid soma base type '{}'.", soma_type.value()));
+        }
+    } else {
+        tiledb_type = Object::object(*ctx->tiledb_ctx(), std::string(uri)).type();
     }
 
-    if (soma_type == "SOMAArray") {
-        auto array_ = SOMAArray::open(mode, uri, ctx, timestamp);
-        auto array_type = array_->type();
+    switch (tiledb_type) {
+        case Object::Type::Array: {
+            auto array_ = SOMAArray::open(mode, uri, ctx, timestamp);
+            auto array_type = array_->type();
 
-        if (!array_type.has_value())
-            throw TileDBSOMAError(fmt::format("[SOMAObject::open] SOMAArray '{}' has no type info", uri));
+            if (!array_type.has_value()) {
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "Unable to open the TileDB array at '{}'. The array is missing the required '{}' metadata "
+                        "key.",
+                        uri,
+                        SOMA_OBJECT_TYPE_KEY));
+            }
 
-        std::transform(array_type->begin(), array_type->end(), array_type->begin(), [](unsigned char c) {
-            return std::tolower(c);
-        });
+            std::transform(array_type->begin(), array_type->end(), array_type->begin(), [](unsigned char c) {
+                return std::tolower(c);
+            });
 
-        if (array_type == "somadataframe") {
-            return std::make_unique<SOMADataFrame>(*array_);
-        } else if (array_type == "somasparsendarray") {
-            return std::make_unique<SOMASparseNDArray>(*array_);
-        } else if (array_type == "somadensendarray") {
-            return std::make_unique<SOMADenseNDArray>(*array_);
-        } else if (array_type == "somapointclouddataframe") {
-            return std::make_unique<SOMAPointCloudDataFrame>(*array_);
-        } else if (array_type == "somageometrydataframe") {
-            return std::make_unique<SOMAGeometryDataFrame>(*array_);
-        } else {
-            throw TileDBSOMAError("[SOMAObject::open] Saw invalid SOMAArray type");
+            if (array_type == "somadataframe") {
+                return std::make_unique<SOMADataFrame>(*array_);
+            } else if (array_type == "somasparsendarray") {
+                return std::make_unique<SOMASparseNDArray>(*array_);
+            } else if (array_type == "somadensendarray") {
+                return std::make_unique<SOMADenseNDArray>(*array_);
+            } else if (array_type == "somapointclouddataframe") {
+                return std::make_unique<SOMAPointCloudDataFrame>(*array_);
+            } else if (array_type == "somageometrydataframe") {
+                return std::make_unique<SOMAGeometryDataFrame>(*array_);
+            } else {
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "Unable to open the TileDB array at '{}' with unrecognized SOMA array type '{}'.",
+                        uri,
+                        array_->type().value()));
+            }
         }
-    } else if (soma_type == "SOMAGroup") {
-        auto group_ = SOMAGroup::open(mode, uri, ctx, "", timestamp);
-        auto group_type = group_->type();
+        case Object::Type::Group: {
+            auto group_ = SOMAGroup::open(mode, uri, ctx, "", timestamp);
+            auto group_type = group_->type();
 
-        if (!group_type.has_value())
-            throw TileDBSOMAError(fmt::format("[SOMAObject::open] SOMAGroup '{}' has no type info", uri));
+            if (!group_type.has_value()) {
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "Unable to open the TileDB group at '{}'. The group is missing the required '{}' metadata "
+                        "key.",
+                        uri,
+                        SOMA_OBJECT_TYPE_KEY));
+            }
 
-        std::transform(group_type->begin(), group_type->end(), group_type->begin(), [](unsigned char c) {
-            return std::tolower(c);
-        });
+            std::transform(group_type->begin(), group_type->end(), group_type->begin(), [](unsigned char c) {
+                return std::tolower(c);
+            });
 
-        if (group_type == "somacollection") {
-            return std::make_unique<SOMACollection>(*group_);
-        } else if (group_type == "somaexperiment") {
-            return std::make_unique<SOMAExperiment>(*group_);
-        } else if (group_type == "somameasurement") {
-            return std::make_unique<SOMAMeasurement>(*group_);
-        } else if (group_type == "somascene") {
-            return std::make_unique<SOMAScene>(*group_);
-        } else if (group_type == "somamultiscaleimage") {
-            return std::make_unique<SOMAMultiscaleImage>(*group_);
-        } else {
-            throw TileDBSOMAError("[SOMAObject::open] Saw invalid SOMAGroup type");
+            if (group_type == "somacollection") {
+                return std::make_unique<SOMACollection>(*group_);
+            } else if (group_type == "somaexperiment") {
+                return std::make_unique<SOMAExperiment>(*group_);
+            } else if (group_type == "somameasurement") {
+                return std::make_unique<SOMAMeasurement>(*group_);
+            } else if (group_type == "somascene") {
+                return std::make_unique<SOMAScene>(*group_);
+            } else if (group_type == "somamultiscaleimage") {
+                return std::make_unique<SOMAMultiscaleImage>(*group_);
+            } else {
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "Unable to open the TileDB group at '{}' with unrecognized SOMA group type '{}'.",
+                        uri,
+                        group_->type().value()));
+            }
         }
+        default:
+            throw TileDBSOMAError(fmt::format("The object at URI '{}' is not a valid TileDB array or group.", uri));
     }
-
-    throw TileDBSOMAError("[SOMAObject::open] Invalid TileDB object passed to SOMAObject::open");
 }
 
 const std::optional<std::string> SOMAObject::type() {
     auto soma_object_type = this->get_metadata(SOMA_OBJECT_TYPE_KEY);
 
-    if (!soma_object_type.has_value())
+    if (!soma_object_type.has_value()) {
         return std::nullopt;
+    }
 
     const char* dtype = (const char*)std::get<MetadataInfo::value>(*soma_object_type);
     uint32_t sz = std::get<MetadataInfo::num>(*soma_object_type);


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-555

**Changes:**
Cleans up error messages when SOMA fails to open a TileDB object.
