### PR TITLE
[c++] Throw error for unsupported filters

### DIFF
--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -153,6 +153,10 @@ json get_filter_list_json(tiledb::FilterList filter_list) {
                 // These filters have no options and are left empty
                 // intentionally
                 break;
+            default:
+                throw TileDBSOMAError(
+                    fmt::format(
+                        "Internal error: unrecognized filter type '{}'", tiledb::Filter::to_str(filter.filter_type())));
         }
         filter_list_as_json.emplace_back(filter_as_json);
     }


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-356

**Changes:**
Throw error if filter type is not caught in switch statement.