### PR TITLE
[python, C++] fix group handling issues

### DIFF
--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -149,7 +149,7 @@ class SOMAGroup(SOMAObject[_tdb_handles.SOMAGroupWrapper[Any]], Generic[Collecti
             uri=uri,
             uri_type=relative_type,
             name=key,
-            soma_type=clib_collection.type,
+            soma_type=soma_object.soma_type,
         )
         self._contents[key] = _CachedElement(
             entry=_tdb_handles.GroupEntry(soma_object.uri, soma_object._wrapper_type),

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -170,7 +170,7 @@ def test_collection_mapping(soma_object, tmp_path):
     assert list(k for k in c) == list(c.keys())
     assert len(c) == 1
     assert [k for k in c] == ["mumble"]
-    assert c.members() == {"mumble": (soma_object.uri, "SOMACollection")}
+    assert c.members() == {"mumble": (soma_object.uri, soma_object.soma_type)}
 
     # TEMPORARY: This should no longer raise an error once TileDB supports
     # replacing an existing group member.

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -192,11 +192,12 @@ bool SOMAGroup::has(const std::string& name) {
 }
 
 void SOMAGroup::set(const std::string& uri, URIType uri_type, const std::string& name, const std::string& soma_type) {
+    auto tiledb_type = this->tiledb_type_from_soma_type(soma_type);
     bool relative = uri_type == URIType::relative;
     if (uri_type == URIType::automatic) {
         relative = !((uri.find("://") != std::string::npos) || (uri.find("/") == 0));
     }
-    group_->add_member(uri, relative, name);
+    group_->add_member(uri, relative, name, tiledb_type);
     members_map_[name] = SOMAGroupEntry(uri, soma_type);
 }
 

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -183,7 +183,7 @@ class SOMAGroup : public SOMAObject {
      * @param uri of member to add
      * @param uri_type whether the given URI is automatic (default), absolute,
      * or relative
-     * @param name of member
+     * @param soma_type the soma_type of the member
      */
     void set(const std::string& uri, URIType uri_type, const std::string& name, const std::string& soma_type);
 

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -145,4 +145,25 @@ bool SOMAObject::check_type(std::string expected_type) {
     return soma_object_type == expected_type;
 };
 
+tiledb_object_t SOMAObject::tiledb_type_from_soma_type(const std::string& soma_type) {
+    const std::map<std::string, tiledb_object_t> typeMap = {
+        {"SOMAArray", tiledb_object_t::TILEDB_ARRAY},
+        {"SOMACollection", tiledb_object_t::TILEDB_GROUP},
+        {"SOMADataFrame", tiledb_object_t::TILEDB_ARRAY},
+        {"SOMADenseNDArray", tiledb_object_t::TILEDB_ARRAY},
+        {"SOMAExperiment", tiledb_object_t::TILEDB_GROUP},
+        {"SOMAGeometryDataFrame", tiledb_object_t::TILEDB_ARRAY},
+        {"SOMAGroup", tiledb_object_t::TILEDB_GROUP},
+        {"SOMAMeasurement", tiledb_object_t::TILEDB_GROUP},
+        {"SOMAMultiscaleImage", tiledb_object_t::TILEDB_GROUP},
+        {"SOMAPointCloudDataFrame", tiledb_object_t::TILEDB_ARRAY},
+        {"SOMAScene", tiledb_object_t::TILEDB_GROUP},
+        {"SOMASparseNDArray", tiledb_object_t::TILEDB_ARRAY},
+    };
+    const std::map<std::string, tiledb_object_t>::const_iterator iTileDBType = typeMap.find(soma_type);
+    if (iTileDBType == typeMap.end())
+        return tiledb_object_t::TILEDB_INVALID;
+    return iTileDBType->second;
+};
+
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -167,6 +167,11 @@ class SOMAObject {
      * must be opened in READ mode, otherwise the function will error out.
      */
     virtual uint64_t metadata_num() const = 0;
+
+    /**
+     * @brief Given a soma_type, return the underlying TileDB type.
+     */
+    static tiledb_object_t tiledb_type_from_soma_type(const std::string& soma_type);
 };
 }  // namespace tiledbsoma
 


### PR DESCRIPTION
Core team pointed out there is a performance deficiency in our calls to Group `add` -- we should be specifying the type of the object being added.  While this parameter is optional, not specifying it will incur a performance penalty.

While implementing this, I also noticed a bug in the `Collection.members` and `SOMAGroup._set_element` -- every member added to a Collection would be reported as soma_type==Collection by the `members` method. This was due to a typo in the group add call.

Summary of changes:
* TileDB object type now passed to Core Group.add
* `Collection.members` unit test now checks for the actual object type, rather than hard-coding "Collection"
* Fix SOMAGroup to correctly set collection member type.