### PR TITLE
[python] catch import error

### DIFF
--- a/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
+++ b/apis/python/src/tiledbsoma/options/_soma_tiledb_context.py
@@ -23,7 +23,7 @@ try:
     from tiledb import Ctx as TileDBCtx
 
     TILEDB_EXISTS = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     # If we set this to None, then the type hint TileDBCtx | None in the code
     # below will error out with:
     #   TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType'


### PR DESCRIPTION
We have code which prospectively attempts to import `tiledb` in order to determine if it should enable compatibility APIs with that package.  The code fails to handle a corner case which can occur with our namespaced packages, e.g.,
* tiledb.client or tiledb.cloud may be installed
* and tiledb is not installed
in some of these corner cases, an `ImportError` is thrown rather than a `ModuleNotFoundError`. 

This change just treats them as both a failure to find the `tiledb` package.