### PR TITLE
[r] Fix build when workspace path contains spaces

### DIFF
--- a/apis/r/tools/build_libtiledbsoma.sh.in
+++ b/apis/r/tools/build_libtiledbsoma.sh.in
@@ -14,7 +14,7 @@ cwd=`pwd`
 cd src/libtiledbsoma/build-lib
 
 ## The placeholder is filled in by check_cmake_and_git.R
-@cmake@ \
+"@cmake@" \
       -DDOWNLOAD_TILEDB_PREBUILT=ON \
       -DTILEDBSOMA_BUILD_CLI=OFF \
       -DTILEDBSOMA_ENABLE_TESTING=OFF \


### PR DESCRIPTION
**Issue and/or context:** Building the R package fails in working direcories that contain spaces in their filepaths.

**Changes:** Quotes the `@cmake@` placeholder to prevent unintentional path splitting.
