### PR TITLE
[r/ci] Replace P3M Bioc Mirror

### DIFF
--- a/.github/actions/setup-r/action.yaml
+++ b/.github/actions/setup-r/action.yaml
@@ -34,7 +34,7 @@ runs:
 
     - name: Configure Bioconductor
       run: |
-        echo 'utils::setRepositories(ind = 1:3)' | \
+        echo 'utils::setRepositories(ind = 1:3, addURLs = getOption("repos"))' | \
           tee -a "${HOME}/.Rprofile"
       shell: bash
 


### PR DESCRIPTION
P3M's Bioc mirror is down and hasn't been restored; remove the part of `setup-r/action.yaml` that configures the P3M Bioc mirror and use the default mirror instead

Fixes [SOMA-678](https://linear.app/tiledb/issue/SOMA-678/rci-replace-p3m-bioc-mirror)