### PR TITLE
Fix python-dependency-variation with vcpkg addition

### DIFF
--- a/.github/workflows/python-dependency-variation.yml
+++ b/.github/workflows/python-dependency-variation.yml
@@ -51,6 +51,17 @@ jobs:
           fetch-depth: 0  # Required to fetch tags: https://github.com/actions/checkout/issues/2199
           fetch-tags: true  # Tags used for Python package version.
 
+      - name: Checkout vcpkg
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/vcpkg
+          path: vcpkg
+          
+      - name: Bootstrap vcpkg
+        run: |
+          ./vcpkg/bootstrap-vcpkg.sh
+          echo "CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
+
       - name: Show matrix OS
         run: echo "matrix.os:" ${{ matrix.os }}
 


### PR DESCRIPTION
**Issue and/or context:**
Failed CI job after merge.

https://github.com/single-cell-data/TileDB-SOMA/actions/runs/19143551127

**Changes:**

Fix python-dependency-variation with vcpkg addition

**Notes for Reviewer:**
