### PR TITLE
[ci] Remove llvm from brew install on CI

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -e pipefail
           brew update
-          brew install automake llvm
+          brew install automake
 
       - name: "Setup for arm builds"
         # vcpkg source build requires this on ARM, for some reason; cf. https://github.com/NixOS/nixpkgs/issues/335868

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -46,14 +46,14 @@ jobs:
         run: |
           set -e pipefail
           brew update
-          brew install automake llvm
+          brew install automake
 
       - name: Checkout TileDB-SOMA
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Required to fetch tags: https://github.com/actions/checkout/issues/2199
           fetch-tags: true  # Tags used for Python package version.
-  
+
       - name: Download pre-built C++ library
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
**Issue and/or context:**
Mirroring a [similar change on TileDB-Py](https://github.com/TileDB-Inc/TileDB-Py/pull/2268/files)

**Changes:**
Remove llvm as a package that is installed by brew on CI.
