### PR TITLE
[python] Use importlib.metadata.version instead of __version__

### DIFF
--- a/apis/python/src/tiledbsoma/io/__init__.py
+++ b/apis/python/src/tiledbsoma/io/__init__.py
@@ -2,6 +2,9 @@
 #
 # Licensed under the MIT License.
 
+
+import importlib.metadata
+
 import anndata as ad
 import scipy
 from packaging.version import Version
@@ -32,8 +35,8 @@ from .shaping import (
 )
 
 # https://github.com/single-cell-data/TileDB-SOMA/issues/3920
-scipy_version = Version(scipy.__version__)
-anndata_version = Version(ad.__version__)
+scipy_version = Version(importlib.metadata.version("scipy"))
+anndata_version = Version(importlib.metadata.version("anndata"))
 if anndata_version >= Version("0.10.7") and anndata_version < Version("0.11.2") and scipy_version >= Version("1.15.0"):
     raise RuntimeError(
         f"anndata '{ad.__version__}' is incompatible with '{scipy.__version__}', and more generally, anndata 0.10.7-0.11.1 are incompatible with scipy 0.15. Please upgrade your anndata to >= 0.11.2, or downgrade your scipy to < 0.15.",


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-693

**Changes:**
Use `importlib.metadata` instead of `__version__` to get library versions.
