### PR TITLE
[docs] Add 2.1.1 and 2.1.2 history/news to `main`

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- \[[#4309](https://github.com/single-cell-data/TileDB-SOMA/pull/4309)\] Update [TileDB core to 2.29.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.2).
 - \[[#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299)\] Use a global memory budget for read operations instead of a per column memory budget. The global memory budget allocates splits the budget per column depending on the type and characteristics of each column. Global memory budget is disabled by default under a feature flag and can be enabled by setting `soma.read.use_memory_pool`.
 
 ### Changed
@@ -25,6 +24,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 ### Security
+
+## [Release 2.1.2]
+
+Only R API updates in this release.
+
+## [Release 2.1.1]
+
+### Changed
+
+- \[[#4309](https://github.com/single-cell-data/TileDB-SOMA/pull/4309)\] Update [TileDB core to 2.29.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.2).
 
 ## [Release 2.1.0]
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -21,6 +21,20 @@
 
 ## Security
 
+# tiledbsoma 2.1.2
+
+**Action required:** Users who ingested BPCells data with version 2.1.0 or 2.1.1 must re-ingest with this version to ensure data correctness.
+
+## Fixed
+
+- Addressed bug in BPCells ingestion, where data ingested in an iterated manner would only be written at the top of the array. Ingestion now proceeds down the array for each iteration. ([#4317](https://github.com/single-cell-data/TileDB-SOMA/pull/4317))
+
+# tiledbsoma 2.1.1
+
+## Changed
+
+- Update TileDB core version to [2.29.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.2). ([#4309](https://github.com/single-cell-data/TileDB-SOMA/pull/4309))
+
 # tiledbsoma 2.1.0
 
 This release adds support for ingestion of BPCells-backed `Seurat` objects in `write_soma()`, adds warnings for new deprecations, and updates the TileDB core version to 2.29.1.


### PR DESCRIPTION
The release notes for 2.1.1 and 2.1.2 were added directly to the `release-2.1` branch. This adds the changes to `main`.