### PR TITLE
Update community links in README.md (#4296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ TileDB-SOMA provides interoperability with existing Python or R data structures:
 
 ## Community
 
-- Please join the [TileDB Slack community](https://tiledb-community.slack.com/join/shared_invite/zt-ndq1ipwl-QcithaWG6j1BImtuQGSpag#/shared-invite/email) with dedicated channel `#genomics`.
+- Please join [TileDB's forum](https://forum.tiledb.com) for discussions and questions about TileDB-SOMA.
 - Please join the [CZI Slack community](https://cziscience.slack.com/join/shared_invite/zt-czl1kp2v-sgGpY4RxO3bPYmFg2XlbZA#/shared-invite/email), with dedicated
   channel `#cellxgene-census-users`.
 


### PR DESCRIPTION
- Replace Slack community link with TileDB's forum link

(cherry picked from commit e486ab11f53356bce5535fde2f27f106c3d9dce9)

