### PR TITLE
[Backport Release 2.2] Update TileDB core to 2.30.0

### DIFF
--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p external
             # Please do not edit manually -- let scripts/update-tiledb-version.py update this
-          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-linux-x86_64-2.29.2-2cd33d3.tar.gz
+          wget --quiet https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-linux-x86_64-2.30.0-9b5305d.tar.gz
           tar -C external -xzf tiledb-*.tar.gz
           ls external/lib/
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- \[[#4324](https://github.com/single-cell-data/TileDB-SOMA/pull/4324)\] Update TileDB core version to [2.30.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.30.0).
 - \[[#4258](https://github.com/single-cell-data/TileDB-SOMA/pull/4258)\] Add optional schema validation to `tiledbsoma.io.add_X_layer`, which will generate an error if the provided matrix does not match the Experiment shape. Validation is enabled by default, for any dataset created with SOMA 1.15 or later.
 - \[[#4293](https://github.com/single-cell-data/TileDB-SOMA/pull/4293)\] The `SOMAObject` class is no longer a generic class over the handle `Wrapper` internal class.
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -1,3 +1,9 @@
+# tiledbsoma 2.2.0
+
+## Changed
+
+- Update TileDB core version to [2.30.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.30.0). ([#4324](https://github.com/single-cell-data/TileDB-SOMA/pull/4324))
+
 # tiledbsoma 2.1.2
 
 **Action required:** Users who ingested BPCells data with version 2.1.0 or 2.1.1 must re-ingest with this version to ensure data correctness.

--- a/apis/r/tools/get_tarball.R
+++ b/apis/r/tools/get_tarball.R
@@ -14,16 +14,16 @@ isLinux <- Sys.info()["sysname"] == "Linux"
 if (isMac) {
   arch <- system('uname -m', intern = TRUE)
   if (arch == "x86_64") {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-x86_64-2.29.2-2cd33d3.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-x86_64-2.30.0-9b5305d.tar.gz"
   } else if (arch == "arm64") {
-    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-arm64-2.29.2-2cd33d3.tar.gz"
+    url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-arm64-2.30.0-9b5305d.tar.gz"
   } else {
     stop(
       "Unsupported Mac architecture. Please have TileDB Core installed locally."
     )
   }
 } else if (isLinux) {
-  url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-linux-x86_64-2.29.2-2cd33d3.tar.gz"
+  url <- "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-linux-x86_64-2.30.0-9b5305d.tar.gz"
 } else {
   message(
     "Unsupported platform for downloading artifacts. Please have TileDB Core installed locally."

--- a/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsoma/cmake/Modules/FindTileDB_EP.cmake
@@ -38,8 +38,8 @@ else()
     # NB When updating the pinned URLs here, please also update in file apis/r/tools/get_tarball.R
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-windows-x86_64-2.29.2-2cd33d3.zip")
-          SET(DOWNLOAD_SHA1 "5dbe87d66ea3840cb40aa96f7211a0e1b5c9d314")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-windows-x86_64-2.30.0-9b5305d.zip")
+          SET(DOWNLOAD_SHA1 "de5baf2fe7bc8975ddc7988fb279f2bac7496715")
         elseif(APPLE) # OSX
 
           # Status quo as of 2023-05-18:
@@ -56,26 +56,26 @@ else()
           #   o CMAKE_SYSTEM_PROCESSOR is x86_64
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-x86_64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "ef68c7d86ae36b6126baf1ad824b4cae320a8ca1")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-x86_64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "2dd3f2920bb297fd1fda5b9915cff7073df78641")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-arm64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "c9cdc34f91d0d9cc6374974c7f9ede5133ff820a")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-arm64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "3f6fb0b4b8d603a3c92110cbf59f5460d4c8fdc3")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-x86_64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "ef68c7d86ae36b6126baf1ad824b4cae320a8ca1")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-x86_64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "2dd3f2920bb297fd1fda5b9915cff7073df78641")
           elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-macos-arm64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "c9cdc34f91d0d9cc6374974c7f9ede5133ff820a")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-macos-arm64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "3f6fb0b4b8d603a3c92110cbf59f5460d4c8fdc3")
           endif()
 
         else() # Linux
           if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-linux-arm64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "c175d860e0e4b42ae630f136724934c65c20bdd9")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-linux-arm64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "20c820eaa86536d8a433c7c8eb4ae267a59bed76")
           else()
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.29.2/tiledb-linux-x86_64-2.29.2-2cd33d3.tar.gz")
-            SET(DOWNLOAD_SHA1 "6c962b090c51506be9979294a21b65031a54e12e")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.30.0/tiledb-linux-x86_64-2.30.0-9b5305d.tar.gz")
+            SET(DOWNLOAD_SHA1 "1c91f12e5cb789eafb0696cfd77bacb78a8e9f5d")
           endif()
         endif()
 
@@ -98,8 +98,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.29.2.zip"
-          URL_HASH SHA1=3b3652d40d4177522970f84f3b8f21d7eabf9962
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.30.0.zip"
+          URL_HASH SHA1=fddca33c76819bcc3c4cfa1404c191cd7610235b
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
Backport updating TileDB core to version 2.30.0.