### PR TITLE
 [Backport release 2.2] Update history/news/version for pre-release (#4346)

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 2.1.2
+Version: 2.2.0
 Authors@R: c(
     person(given = "Paul", family = "Hoffman",
            role = c("cre", "aut"), email = "tiledb-r@tiledb.com",

--- a/apis/r/inst/extdata/releases.dcf
+++ b/apis/r/inst/extdata/releases.dcf
@@ -1,3 +1,12 @@
+Version: 2.1.2
+Date: 2025-11-21
+
+Version: 2.1.1
+Date: 2025-11-13
+
+Version: 2.1.0
+Date: 2025-10-17
+
 Version: 2.0.0
 Date: 2025-10-06
 

--- a/apis/r/tests/testthat/test-11-reopen.R
+++ b/apis/r/tests/testthat/test-11-reopen.R
@@ -9,7 +9,8 @@ test_that("`reopen()` works on arrays", {
         schema = arrow::infer_schema(data.frame(
           soma_joinid = bit64::integer64(),
           int = integer()
-        ))
+        )),
+        domain = list(soma_joinid = c(1L, shape[1L]))
       ),
       SOMASparseNDArray = SOMASparseNDArrayCreate(
         uri,


### PR DESCRIPTION
Backport updates to R version number and few small related test fixes.