### PR TITLE
[python] Store array references until submit write

### DIFF
--- a/apis/python/src/tiledbsoma/_dense_nd_array.py
+++ b/apis/python/src/tiledbsoma/_dense_nd_array.py
@@ -366,8 +366,8 @@ class DenseNDArray(NDArray, somacore.DenseNDArray):
         mq = ManagedQuery(self, platform_config)
         mq._handle.set_layout(order)
         mq.set_coords(new_coords)
-        mq._handle.set_column_data("soma_data", input)
-        mq._handle.submit_write()
+        mq.set_column_data("soma_data", input)
+        mq.submit_write()
         mq._handle.finalize()
 
         tiledb_write_options = TileDBWriteOptions.from_platform_config(platform_config)

--- a/apis/python/src/tiledbsoma/_sparse_nd_array.py
+++ b/apis/python/src/tiledbsoma/_sparse_nd_array.py
@@ -389,23 +389,23 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             mq._handle.set_layout(layout)
 
             for i, c in enumerate(coords.T):
-                mq._handle.set_column_data(
+                mq.set_column_data(
                     f"soma_dim_{i}",
                     np.array(
                         c,
                         dtype=self.schema.field(f"soma_dim_{i}").type.to_pandas_dtype(),
                     ),
                 )
-            mq._handle.set_column_data(
+            mq.set_column_data(
                 "soma_data",
                 np.array(data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()),
             )
 
             if layout == clib.ResultOrder.unordered:
-                mq._handle.submit_write()
+                mq.submit_write()
                 mq._handle.finalize()
             else:
-                mq._handle.submit_and_finalize()
+                mq.submit_and_finalize()
 
             if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data
@@ -425,23 +425,23 @@ class SparseNDArray(NDArray, somacore.SparseNDArray):
             mq._handle.set_layout(layout)
 
             for i, c in enumerate([sp.row, sp.col]):
-                mq._handle.set_column_data(
+                mq.set_column_data(
                     f"soma_dim_{i}",
                     np.array(
                         c,
                         dtype=self.schema.field(f"soma_dim_{i}").type.to_pandas_dtype(),
                     ),
                 )
-            mq._handle.set_column_data(
+            mq.set_column_data(
                 "soma_data",
                 np.array(sp.data, dtype=self.schema.field("soma_data").type.to_pandas_dtype()),
             )
 
             if layout == clib.ResultOrder.unordered:
-                mq._handle.submit_write()
+                mq.submit_write()
                 mq._handle.finalize()
             else:
-                mq._handle.submit_and_finalize()
+                mq.submit_and_finalize()
 
             if write_options.consolidate_and_vacuum:
                 # Consolidate non-bulk data

--- a/apis/python/src/tiledbsoma/managed_query.cc
+++ b/apis/python/src/tiledbsoma/managed_query.cc
@@ -155,7 +155,7 @@ void load_managed_query(py::module& m) {
                 py::gil_scoped_release release;
                 try {
                     mq.setup_write_column(
-                        name, data.size(), (const void*)data_info.ptr, static_cast<uint64_t*>(nullptr), nullptr, true);
+                        name, data.size(), (const void*)data_info.ptr, static_cast<uint64_t*>(nullptr), nullptr, false);
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }


### PR DESCRIPTION
**Issue and/or context:**
#4311 aims to provide a zero copy write path but at the python side when setting individual columns with data the user can pass temporary objects which forces to always copy the data on that code path to avoid segfaults

**Changes:**
This PR stores the references of the object used to set individual columns until the query is submitted and disable memory copy from that code path.

**Notes for Reviewer:**
