### PR TITLE
Test macos arm64 wheels on macos-14

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -157,7 +157,7 @@ jobs:
           - platform: macosx_x86_64
             os: macos-15-intel
           - platform: macosx_arm64
-            os: macos-15
+            os: macos-14
           - wheel_suffix: manylinux_2_28_x86_64
             os: ubuntu-22.04
           - wheel_suffix: manylinux_2_28_aarch64
@@ -165,7 +165,7 @@ jobs:
           - wheel_suffix: macosx_13_0_x86_64
             os: macos-15-intel
           - wheel_suffix: macosx_13_0_arm64
-            os: macos-15
+            os: macos-14
           - python_name: "cp39"
             python_version: "3.9"
           - python_name: "cp310"


### PR DESCRIPTION
To try to reproduce what I'm seeing on my laptop (Sonoma 14.6.1). Jobs are failing due to failure to find the libtiledbsoma shared library. I don't understand how this is a dependency of the job, did I overlook a change that needs to be made to another workflow?

```
gmake[2]: *** [CMakeFiles/libtiledbsoma.dir/build.make:93: libtiledbsoma-prefix/src/libtiledbsoma-stamp/libtiledbsoma-configure] Error 1
  gmake[1]: *** [CMakeFiles/Makefile2:124: CMakeFiles/libtiledbsoma.dir/all] Error 2
  gmake: *** [Makefile:91: all] Error 2
  Traceback (most recent call last):
    File "/opt/python/cp312-cp312/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
  Checking: /project/dist/lib/libtiledbsoma.so exists: False
  Checking: /project/dist/lib64/libtiledbsoma.so exists: False
  Checking: /project/dist/lib/x86_64-linux-gnu/libtiledbsoma.so exists: False
  libtiledbsoma.so: cannot open shared object file: No such file or directory
```