### PR TITLE
[c++] Remove `std::format` call

### DIFF
--- a/libtiledbsoma/src/soma/soma_context.cc
+++ b/libtiledbsoma/src/soma/soma_context.cc
@@ -78,7 +78,7 @@ void SOMAContext::validate_create_uri(const std::string_view uri) const {
     std::regex storage_uri_regex("^tiledb://.*/.*://.*$", std::regex_constants::ECMAScript);
     if (std::regex_match(uri.data(), storage_uri_regex)) {
         throw TileDBSOMAError(
-            std::format("Unsupported URI format '{}'. This format is not supported on TileDB Carrara.", uri));
+            fmt::format("Unsupported URI format '{}'. This format is not supported on TileDB Carrara.", uri));
     }
 }
 


### PR DESCRIPTION
**Issue and/or context:**

**Changes:**
Remove `std::format` call to preserve MacOS 11 compatibility

**Notes for Reviewer:**
