### PR TITLE
[python] Add function to cast for old versions of pyarrow

### DIFF
--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -42,6 +42,7 @@ from ._spatial_util import (
     process_spatial_df_region,
 )
 from ._types import OpenTimestamp
+from ._util import _cast_record_batch
 from .options import SOMATileDBContext
 from .options._util import build_clib_platform_config
 
@@ -566,7 +567,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         outline_transformer = clib.OutlineTransformer(coordinate_space_to_json(self._coord_space))
         for batch in batches:
             table = (
-                clib.TransformerPipeline(batch.cast(batch_schema, safe=True)).transform(outline_transformer).asTable()
+                clib.TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True)).transform(outline_transformer).asTable()
             )
             for subbatch in table.to_batches():
                 mq = ManagedQuery(self)._handle

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -567,7 +567,10 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         outline_transformer = clib.OutlineTransformer(coordinate_space_to_json(self._coord_space))
         for batch in batches:
             table = (
-                clib.TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True)).transform(outline_transformer).asTable()
+                clib
+                .TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True))
+                .transform(outline_transformer)
+                .asTable()
             )
             for subbatch in table.to_batches():
                 mq = ManagedQuery(self)._handle

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 from . import pytiledbsoma as clib
 from ._managed_query import ManagedQuery
 from ._soma_object import SOMAObject
-from ._util import _cast_domainish
+from ._util import _cast_domainish, _cast_record_batch
 
 
 class SOMAArray(SOMAObject):
@@ -155,12 +155,12 @@ class SOMAArray(SOMAObject):
             for batch in batches:
                 mq = ManagedQuery(self)._handle
                 mq.set_layout(clib.ResultOrder.unordered)
-                mq.submit_batch(batch.cast(batch_schema, safe=True))
+                mq.submit_batch(_cast_record_batch(batch, batch_schema, safe=True))
                 mq.finalize()
         else:
             # Single global order query - only finalize at the end.
             mq = ManagedQuery(self)._handle
             mq.set_layout(clib.ResultOrder.globalorder)
             for batch in batches[:-1]:
-                mq.submit_batch(batch.cast(batch_schema, safe=True))
+                mq.submit_batch(_cast_record_batch(batch, batch_schema, safe=True))
             mq.submit_and_finalize_batch(batches[-1])

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -381,3 +381,30 @@ def _df_set_index(
         if fallback_index_name is not None and fallback_index_name in df:
             df.set_index(fallback_index_name, inplace=True)
             df.index.name = None
+
+def _cast_record_batch(batch: pa.RecordBatch, target_schema: pa.Schema, safe=None, options=None):
+    """Cast a pyarrow ``RecordBatch`` to another schema.
+
+    ``RecordBatch.cast`` is added in pyarrow==1.16.0. If/when we upgrade our minimum version we can switch
+    to the arrow method.
+
+    This method is copied directly from pyarrow.
+    """
+    if batch.schema.names != target_schema.names:
+        raise ValueError(
+            f"Target schema's field names are not matching "
+            f"the record batch's field names: {batch.schema.names!r}, {target_schema.names!r}"
+        )
+
+    newcols = []
+    for index in range(batch.num_columns):
+        column = batch.column(index)
+        field = target_schema.field(index)
+        if not field.nullable and column.null_count > 0:
+            raise ValueError(
+                f"Casting field {field.name!r} with null values to non-nullable"
+            )
+        casted = column.cast(field.type, safe=safe, options=options)
+        newcols.append(casted)
+    return pa.RecordBatch.from_arrays(newcols, schema=target_schema)
+

--- a/apis/python/src/tiledbsoma/_util.py
+++ b/apis/python/src/tiledbsoma/_util.py
@@ -382,7 +382,8 @@ def _df_set_index(
             df.set_index(fallback_index_name, inplace=True)
             df.index.name = None
 
-def _cast_record_batch(batch: pa.RecordBatch, target_schema: pa.Schema, safe=None, options=None):
+
+def _cast_record_batch(batch: pa.RecordBatch, target_schema: pa.Schema, safe: bool = True) -> pa.RecordBatch:
     """Cast a pyarrow ``RecordBatch`` to another schema.
 
     ``RecordBatch.cast`` is added in pyarrow==1.16.0. If/when we upgrade our minimum version we can switch
@@ -401,10 +402,7 @@ def _cast_record_batch(batch: pa.RecordBatch, target_schema: pa.Schema, safe=Non
         column = batch.column(index)
         field = target_schema.field(index)
         if not field.nullable and column.null_count > 0:
-            raise ValueError(
-                f"Casting field {field.name!r} with null values to non-nullable"
-            )
-        casted = column.cast(field.type, safe=safe, options=options)
+            raise ValueError(f"Casting field {field.name!r} with null values to non-nullable")
+        casted = column.cast(field.type, safe=safe)
         newcols.append(casted)
     return pa.RecordBatch.from_arrays(newcols, schema=target_schema)
-


### PR DESCRIPTION
**Issue and/or context:** Closes SOMA-801

**Changes:**
Add function to do `pyarrow.RecordBatch` cast internally since `cast` method is not included in pyarrow version 11.0.0 (current minimum version).
