### PR TITLE
[Backport release 2.3][ci] Temporarily disable remote tests (#4366)

### DIFF
--- a/.github/workflows/python-remote-storage.yml
+++ b/.github/workflows/python-remote-storage.yml
@@ -1,16 +1,17 @@
 name: TileDB-SOMA Python CI (remote storage)
 
 on:
-  push:
-    branches:
-      - main
-      - 'release-*'
-  pull_request:
-    paths:
-      - "libtiledbsoma/**"
-      - "apis/python/**"
-      - "!**.md"
-      - '.github/workflows/python-remote-storage.yml'
+#  push:
+#    branches:
+#      - main
+#      - 'release-*'
+#  pull_request:
+#    paths:
+#      - "libtiledbsoma/**"
+#      - "apis/python/**"
+#      - "!**.md"
+#      - '.github/workflows/python-remote-storage.yml'
+#      - ".github/workflows/build-cpp.yml" # <-- The only build file
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Disable remote storage workflow on PR/push until the tokens are updated.

(cherry picked from commit 7a6fb0c2463ee351cdf56985a10a7a048a60ae7e)

