### PR TITLE
[Backport to release 2.3]  [python] Add function to cast for old versions of pyarrow (#4367 )

### DIFF
--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -562,8 +562,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         outline_transformer = clib.OutlineTransformer(coordinate_space_to_json(self._coord_space))
         for batch in batches:
             table = (
-                clib
-                .TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True))
+                clib.TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True))
                 .transform(outline_transformer)
                 .asTable()
             )

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -42,6 +42,7 @@ from ._spatial_util import (
     process_spatial_df_region,
 )
 from ._types import OpenTimestamp
+from ._util import _cast_record_batch
 from .options import SOMATileDBContext
 from .options._util import build_clib_platform_config
 
@@ -561,7 +562,10 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
         outline_transformer = clib.OutlineTransformer(coordinate_space_to_json(self._coord_space))
         for batch in batches:
             table = (
-                clib.TransformerPipeline(batch.cast(batch_schema, safe=True)).transform(outline_transformer).asTable()
+                clib
+                .TransformerPipeline(_cast_record_batch(batch, batch_schema, safe=True))
+                .transform(outline_transformer)
+                .asTable()
             )
             for subbatch in table.to_batches():
                 mq = ManagedQuery(self)._handle

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 from . import pytiledbsoma as clib
 from ._managed_query import ManagedQuery
 from ._soma_object import SOMAObject
-from ._util import _cast_domainish
+from ._util import _cast_domainish, _cast_record_batch
 
 
 class SOMAArray(SOMAObject):
@@ -155,12 +155,12 @@ class SOMAArray(SOMAObject):
             for batch in batches:
                 mq = ManagedQuery(self)._handle
                 mq.set_layout(clib.ResultOrder.unordered)
-                mq.submit_batch(batch.cast(batch_schema, safe=True))
+                mq.submit_batch(_cast_record_batch(batch, batch_schema, safe=True))
                 mq.finalize()
         else:
             # Single global order query - only finalize at the end.
             mq = ManagedQuery(self)._handle
             mq.set_layout(clib.ResultOrder.globalorder)
             for batch in batches[:-1]:
-                mq.submit_batch(batch.cast(batch_schema, safe=True))
+                mq.submit_batch(_cast_record_batch(batch, batch_schema, safe=True))
             mq.submit_and_finalize_batch(batches[-1])


### PR DESCRIPTION
Add function to cast for old versions of pyarrow that do not yet have `RecordBatch.cast` implemented.

(cherry picked from commit d309274d098aa3ed0dd1ed7a18f4b313d8763982)


