### PR TITLE
[Backport to release 2.3] [r] Carrara Collections Support (#4368)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .vscode*
 .vs
 *.swp
@@ -79,6 +80,9 @@ apis/r/.Rproj*
 apis/r/*.Rproj
 apis/r/.Rhistory
 apis/r/tools/*.html
+apis/r/inst/tiledb/
+apis/r/inst/tiledbsoma/
+apis/r/tools/build_libtiledbsoma.sh
 
 # Coverage/codecov
 .coverage

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -4,6 +4,8 @@
 
 - A new `SOMAContext` method was added that replaces `SOMATileDBContext`. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 - New methods `set_default_context` and `get_default_context` for setting and getting the `SOMAContext`. ([#4364](https://github.com/single-cell-data/TileDB-SOMA/pull/4364))
+- Added `SOMAContext$is_tiledbv2()` and `SOMAContext$is_tiledbv3()` methods to check the data protocol for a given URI.
+- Added Carrara (TileDB v3) support for collection classes. Child objects created at nested Carrara URIs are automatically registered with their parent collection.
 
 ## Deprecated
 
@@ -14,6 +16,8 @@
 ## Fixed
 
 - `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
+- Fixed `SOMACollectionBase$remove()` incorrectly accessing `self$mode` instead of calling `self$mode()`.
+- Fixed collection member cache not properly handling DELETE mode.
 
 # tiledbsoma 2.2.0
 

--- a/apis/r/R/SOMAContext.R
+++ b/apis/r/R/SOMAContext.R
@@ -32,6 +32,18 @@ SOMAContext <- R6::R6Class(
     #'
     get_data_protocol = function(uri) {
       return(get_data_protocol_from_soma_context(private$.handle, uri))
+    },
+
+    #' @param uri A URI for a SOMA object
+    #' @return TRUE if the URI will use `tiledbv2` semantics.
+    is_tiledbv2 = function(uri) {
+      self$get_data_protocol(uri) == "tiledbv2"
+    },
+
+    #' @param uri A URI for a SOMA object
+    #' @return TRUE if the URI will use `tiledbv3` semantics.
+    is_tiledbv3 = function(uri) {
+      self$get_data_protocol(uri) == "tiledbv3"
     }
   ),
   active = list(

--- a/apis/r/R/utils-uris.R
+++ b/apis/r/R/utils-uris.R
@@ -73,3 +73,14 @@ make_uri_relative <- function(uri, relative_to) {
     start = uri_scheme_remove(relative_to)
   )
 }
+
+#' Detects whether a provided URI is a child relative URI to the parent.
+#' @noRd
+is_relative_uri <- function(uri) {
+  stopifnot(is_scalar_character(uri))
+  return(
+    !grepl("://", uri, fixed = TRUE) &&
+      !startsWith(uri, "/") &&
+      !startsWith(uri, "~")
+  )
+}

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -23,6 +23,23 @@ default platform configuration by passing a custom configuration to the
 \code{platform_config} argument.
 }
 
+\section{Carrara (TileDB v3) behavior}{
+
+
+When working with Carrara URIs (\verb{tiledb://workspace/teamspace/...}), child
+objects created at a URI nested under a parent collection are \strong{automatically
+added} as members of the parent. This means:
+
+\itemize{
+\item You do not need to call \code{add_new_collection()} after creating a child
+at a nested URI—the child is already a member.
+\item For backward compatibility, calling \code{add_new_collection()} on an
+already-registered child is a \strong{no-op} and will not cause an error.
+\item The member name must match the relative URI segment (e.g., creating
+at \code{parent_uri/child} automatically adds the child with key \code{"child"}).
+}
+}
+
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-collection")

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -7,6 +7,14 @@
 Base class for objects containing persistent collection of SOMA
 objects, mapping string keys to any SOMA object (lifecycle: maturing).
 }
+\section{Carrara (TileDB v3) behavior}{
+
+
+For Carrara URIs, child objects created at nested URIs are automatically
+added to the parent collection. Calling this method on an already-
+registered child is a \strong{no-op} for backward compatibility.
+}
+
 \seealso{
 Derived classes: \code{\link{SOMACollection}},
 \code{\link{SOMAMeasurement}},

--- a/apis/r/man/SOMAContext.Rd
+++ b/apis/r/man/SOMAContext.Rd
@@ -19,6 +19,8 @@ Context map for TileDB-SOMA objects
 \item \href{#method-SOMAContext-new}{\code{SOMAContext$new()}}
 \item \href{#method-SOMAContext-get_config}{\code{SOMAContext$get_config()}}
 \item \href{#method-SOMAContext-get_data_protocol}{\code{SOMAContext$get_data_protocol()}}
+\item \href{#method-SOMAContext-is_tiledbv2}{\code{SOMAContext$is_tiledbv2()}}
+\item \href{#method-SOMAContext-is_tiledbv3}{\code{SOMAContext$is_tiledbv3()}}
 \item \href{#method-SOMAContext-clone}{\code{SOMAContext$clone()}}
 }
 }
@@ -70,6 +72,44 @@ A character vector with the current config options set on the context.
 }
 \subsection{Returns}{
 The data protocol to use for the URI.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAContext-is_tiledbv2"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAContext-is_tiledbv2}{}}}
+\subsection{Method \code{is_tiledbv2()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAContext$is_tiledbv2(uri)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{uri}}{A URI for a SOMA object}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+TRUE if the URI will use \code{tiledbv2} semantics.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SOMAContext-is_tiledbv3"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMAContext-is_tiledbv3}{}}}
+\subsection{Method \code{is_tiledbv3()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SOMAContext$is_tiledbv3(uri)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{uri}}{A URI for a SOMA object}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+TRUE if the URI will use \code{tiledbv3} semantics.
 }
 }
 \if{html}{\out{<hr>}}

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -23,6 +23,23 @@ default platform configuration by passing a custom configuration to the
 \code{platform_config} argument.
 }
 
+\section{Carrara (TileDB v3) behavior}{
+
+
+When working with Carrara URIs (\verb{tiledb://workspace/teamspace/...}), child
+objects created at a URI nested under a parent collection are \strong{automatically
+added} as members of the parent. This means:
+
+\itemize{
+\item You do not need to call \code{add_new_collection()} after creating a child
+at a nested URI—the child is already a member.
+\item For backward compatibility, calling \code{add_new_collection()} on an
+already-registered child is a \strong{no-op} and will not cause an error.
+\item The member name must match the relative URI segment (e.g., creating
+at \code{parent_uri/child} automatically adds the child with key \code{"child"}).
+}
+}
+
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-experiment")

--- a/apis/r/man/SOMAMeasurement.Rd
+++ b/apis/r/man/SOMAMeasurement.Rd
@@ -23,6 +23,23 @@ default platform configuration by passing a custom configuration to the
 \code{platform_config} argument.
 }
 
+\section{Carrara (TileDB v3) behavior}{
+
+
+When working with Carrara URIs (\verb{tiledb://workspace/teamspace/...}), child
+objects created at a URI nested under a parent collection are \strong{automatically
+added} as members of the parent. This means:
+
+\itemize{
+\item You do not need to call \code{add_new_collection()} after creating a child
+at a nested URI—the child is already a member.
+\item For backward compatibility, calling \code{add_new_collection()} on an
+already-registered child is a \strong{no-op} and will not cause an error.
+\item The member name must match the relative URI segment (e.g., creating
+at \code{parent_uri/child} automatically adds the child with key \code{"child"}).
+}
+}
+
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-measurement")

--- a/apis/r/man/roxygen/templates/section-add-object-to-collection.R
+++ b/apis/r/man/roxygen/templates/section-add-object-to-collection.R
@@ -8,3 +8,18 @@
 #' configuration (see [`PlatformConfig`]). However, the user can override the
 #' default platform configuration by passing a custom configuration to the
 #' `platform_config` argument.
+#'
+#' @section Carrara (TileDB v3) behavior:
+#'
+#' When working with Carrara URIs (`tiledb://workspace/teamspace/...`), child
+#' objects created at a URI nested under a parent collection are **automatically
+#' added** as members of the parent. This means:
+#'
+#' \itemize{
+#'   \item You do not need to call `add_new_collection()` after creating a child
+#'     at a nested URI—the child is already a member.
+#'   \item For backward compatibility, calling `add_new_collection()` on an
+#'     already-registered child is a **no-op** and will not cause an error.
+#'   \item The member name must match the relative URI segment (e.g., creating
+#'     at `parent_uri/child` automatically adds the child with key `"child"`).
+#' }

--- a/apis/r/src/rinterface.cpp
+++ b/apis/r/src/rinterface.cpp
@@ -69,7 +69,7 @@ SEXP soma_array_reader(
     std::shared_ptr<tdbs::SOMAContext> somactx = ctxxp->ctxptr;
     std::stringstream ss;
     ss << "[soma_array_reader] Reading from " << uri;
-    tdbs::LOG_INFO(ss.str());
+    tdbs::LOG_DEBUG(ss.str());
 
     std::vector<std::string> column_names = {};
     if (!colnames.isNull()) {  // If we have column names, select them
@@ -107,13 +107,13 @@ SEXP soma_array_reader(
         std::stringstream ss;
         ss << "[soma_array_reader] Dimension " << dim.name() << " type " << tiledb::impl::to_str(dim.type())
            << " extent " << dim.tile_extent_to_str();
-        tdbs::LOG_INFO(ss.str());
+        tdbs::LOG_DEBUG(ss.str());
         name2dim.emplace(std::make_pair(dim.name(), std::make_shared<tiledb::Dimension>(dim)));
     }
 
     // If we have a query condition, apply it
     if (!qc.isNull()) {
-        tdbs::LOG_INFO("[soma_array_reader_impl] Applying query condition");
+        tdbs::LOG_DEBUG("[soma_array_reader_impl] Applying query condition");
         Rcpp::XPtr<tiledb::QueryCondition> qcxp(qc);
         mq.set_condition(*qcxp);
     }
@@ -147,7 +147,7 @@ SEXP soma_array_reader(
         std::stringstream ss;
         ss << "[soma_array_reader] Read complete with " << sr_data->get()->num_rows() << " rows and "
            << sr_data->get()->names().size() << " cols";
-        tdbs::LOG_INFO(ss.str());
+        tdbs::LOG_DEBUG(ss.str());
     }
     const std::vector<std::string> names = sr_data->get()->names();
     auto ncol = names.size();
@@ -169,7 +169,7 @@ SEXP soma_array_reader(
         {
             std::stringstream ss;
             ss << "[soma_array_reader] Accessing '" << names[i] << "' at pos " << i;
-            tdbs::LOG_INFO(ss.str());
+            tdbs::LOG_DEBUG(ss.str());
         }
         // now buf is a shared_ptr to ColumnBuffer
         auto buf = sr_data->get()->at(names[i]);
@@ -186,7 +186,7 @@ SEXP soma_array_reader(
             std::stringstream ss;
             ss << "[soma_array_reader] Incoming name " << std::string(pp.second->name) << " length "
                << pp.first->length;
-            tdbs::LOG_INFO(ss.str());
+            tdbs::LOG_DEBUG(ss.str());
         }
         if (pp.first->length > arr->length) {
             std::stringstream ss;
@@ -440,7 +440,7 @@ SEXP c_schema(const std::string& uri, Rcpp::XPtr<somactx_wrap_t> ctxxp) {
         std::stringstream ss;
         ss << "[c_schema] Accessing name '" << std::string(lib_retval->children[i]->name) << "' format '"
            << std::string(lib_retval->children[i]->format) << "' at position " << i;
-        tdbs::LOG_INFO(ss.str());
+        tdbs::LOG_DEBUG(ss.str());
         ArrowSchemaMove(lib_retval->children[i], sch->children[i]);
     }
 

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -37,7 +37,7 @@ void apply_dim_points(
                     mq->select_point<uint64_t>(nm, uv[i]);  // bonked when use with vector
                     std::stringstream ss;
                     ss << "[apply_dim_points] Applying dim point " << uv[i] << " on " << nm;
-                    tdbs::LOG_INFO(ss.str());
+                    tdbs::LOG_DEBUG(ss.str());
                     suitable = true;
                 }
             }
@@ -424,14 +424,14 @@ SEXP convert_domainish(const tdbs::ArrowTable& arrow_table) {
             ss << "[domainish] name {} format {} length {} lo {} hi {}" << std::string(arrow_schema->children[i]->name)
                << " format " << std::string(arrow_schema->children[i]->format) << " length "
                << arrow_array->children[i]->length << "lo " << lohi[0] << " hi " << lohi[1];
-            tdbs::LOG_INFO(ss.str());
+            tdbs::LOG_DEBUG(ss.str());
         } else {
             // Arrow semantics: non-variable-length: buffers 0,1 are validity &
             // data
             std::stringstream ss;
             ss << "[domainish] name " << std::string(arrow_schema->children[i]->name) << " format "
                << std::string(arrow_schema->children[i]->format) << " length " << arrow_array->children[i]->length;
-            tdbs::LOG_INFO(ss.str());
+            tdbs::LOG_DEBUG(ss.str());
         }
 
         ArrowArrayMove(arrow_array->children[i], arr->children[i]);

--- a/apis/r/tests/testthat/README-carrara.md
+++ b/apis/r/tests/testthat/README-carrara.md
@@ -1,0 +1,55 @@
+# Carrara Tests
+
+TileDB v3 aka Carrara introduces a new URL schema which supports relative paths and group membership lifecycle changes.
+
+This directory contains unit tests for Carrara-specific behavior in the R package.
+
+## Test Files
+
+- `test-carrara-01-create.R` - Tests for creating SOMA objects with Carrara URIs
+- `test-carrara-02-delete.R` - Tests for deleting SOMA objects
+- `test-carrara-03-uri-enforcement.R` - Tests for URI validation and enforcement
+- `test-carrara-04-error-handling.R` - Tests for error handling with Carrara operations
+
+## Running the Tests
+
+### Prerequisites
+
+- You have a user account in a Carrara deployment
+- You have set up your tiledb profile so that you can log into the account with a profile name
+- You have created a teamspace for testing use
+
+### Environment Variables
+
+Set the following environment variables:
+
+```bash
+export SOMA_TEST_CARRARA="true"                # Required to enable carrara tests
+export CARRARA_TEST_PROFILE="..."              # Profile name (default: "carrara")
+export CARRARA_TEST_WORKSPACE="..."            # Workspace name (default: "TileDB-Inc-Staging")
+export CARRARA_TEST_TEAMSPACE="..."            # Teamspace to use for tests (default: "aaron-dev")
+export CARRARA_TEST_FOLDER="..."               # Folder within teamspace (default: "remote_test")
+export TILEDB_REST_SERVER_ADDRESS="..."        # REST server URL (default: "https://api.staging.tiledb.io")
+```
+
+### Running Tests
+
+Run the carrara tests from the repository root:
+
+```bash
+# Run only carrara tests
+Rscript -e "testthat::test_local(path = 'apis/r', filter = 'carrara')"
+```
+
+Tests will be run within the specified workspace/teamspace, i.e., objects will be created at `tiledb://workspace/teamspace/folder/...`
+
+## Helper Functions
+
+The `helper-carrara.R` file provides utility functions for carrara tests:
+
+- `skip_if_no_carrara()` - Skips tests if `SOMA_TEST_CARRARA` is not set to "true"
+- `get_carrara_config()` - Returns configuration from environment variables
+- `with_carrara_env()` - Sets up carrara environment variables for a test scope
+- `get_base_uri()` - Builds the base URI for test objects
+- `carrara_array_path()` - Creates a unique array path with automatic cleanup
+- `carrara_group_path()` - Creates a unique group path with automatic cleanup

--- a/apis/r/tests/testthat/helper-carrara.R
+++ b/apis/r/tests/testthat/helper-carrara.R
@@ -1,0 +1,96 @@
+# Carrara Test Configuration and Helpers -----------------------------------
+
+# Generate a unique ID for test assets
+generate_unique_id <- function(pattern = "") {
+  basename(tempfile(pattern = pattern))
+}
+
+# Skip carrara tests unless explicitly enabled via environment variable
+skip_if_no_carrara <- function() {
+  if (Sys.getenv("SOMA_TEST_CARRARA", "false") != "true") {
+    skip("Carrara tests not enabled. Set SOMA_TEST_CARRARA=true to run.")
+  }
+}
+
+# Read from environment variables or use defaults
+get_carrara_config <- function() {
+  list(
+    profile = Sys.getenv("CARRARA_TEST_PROFILE", "carrara"),
+    workspace = Sys.getenv("CARRARA_TEST_WORKSPACE", "TileDB-Inc-Staging"),
+    teamspace = Sys.getenv("CARRARA_TEST_TEAMSPACE", "aaron-dev"),
+    folder = Sys.getenv("CARRARA_TEST_FOLDER", "remote_test"),
+    rest_server = Sys.getenv(
+      "TILEDB_REST_SERVER_ADDRESS",
+      "https://api.staging.tiledb.io"
+    )
+  )
+}
+
+# Set carrara-related environment variables and unset existing TILEDB_REST_TOKEN
+with_carrara_env <- function(env = parent.frame()) {
+    withr::local_envvar(list(
+      TILEDB_PROFILE_NAME = get_carrara_config()$profile,
+      TILEDB_REST_SERVER_ADDRESS = get_carrara_config()$rest_server,
+      TILEDB_REST_TOKEN = NA_character_
+  ), .local_envir = env)
+}
+
+# Build base URI for carrara tests
+get_base_uri <- function() {
+  cfg <- get_carrara_config()
+  sprintf("tiledb://%s/%s/%s", cfg$workspace, cfg$teamspace, cfg$folder)
+}
+
+# Create a unique carrara array path with automatic cleanup
+carrara_array_path <- function(env = parent.frame()) {
+
+  path <- file_path(
+    get_base_uri(),
+    generate_unique_id("tiledbsoma-r-")
+  )
+
+  # Register cleanup - delete array after test completes
+  withr::defer(
+    {
+      tryCatch(
+        tiledb::tiledb_vfs_remove_dir(path),
+        error = function(e) {
+          message("Failed to cleanup carrara array: ", path)
+        }
+      )
+    },
+    envir = env
+  )
+
+  path
+}
+
+# Create a unique carrara group path with automatic cleanup
+carrara_group_path <- function(env = parent.frame()) {
+  path <- file_path(
+    get_base_uri(),
+    generate_unique_id("tiledbsoma-r-group-")
+  )
+
+  # Recursively delete group after test completes
+  # Note: tiledb-r requires this specific sequence of operations
+  withr::defer(
+    {
+      tryCatch(
+        {
+          grp <- tiledb::tiledb_group(path)
+          tiledb::tiledb_group_close(grp)
+          grp <- tiledb::tiledb_group_open(grp, type = "MODIFY_EXCLUSIVE")
+          tiledb::tiledb_group_delete(grp = grp, uri = path, recursive = TRUE)
+          tiledb::tiledb_group_close(grp)
+        },
+        error = function(e) {
+          message("Failed to cleanup carrara group: ", path)
+        }
+      )
+    },
+    envir = env
+  )
+
+  path
+}

--- a/apis/r/tests/testthat/test-carrara-01-create.R
+++ b/apis/r/tests/testthat/test-carrara-01-create.R
@@ -1,0 +1,309 @@
+# Helper functions for Carrara tests --------------------------------------
+
+# Replacement helper that matches create_arrow_schema() and respects nullability
+create_arrow_table <- function(nrows = 10L, factors = FALSE) {
+  arrow::arrow_table(
+    soma_joinid = seq(bit64::as.integer64(0L), to = nrows - 1L),
+    int_column = seq.int(nrows) + 1000L,
+    float_column = seq(nrows) + 0.1,
+    string_column = as.character(seq.int(nrows) + 1000L),
+    schema = create_arrow_schema(FALSE)
+  )
+}
+
+# Tests for Carrara Object Creation -----------------------------------------
+
+test_that("SOMAContext detects data protocol", {
+  skip_if_no_carrara()
+  with_carrara_env()
+  ctx <- SOMAContext$new()
+
+  expect_equal(ctx$get_data_protocol("s3://foo/bar"), "tiledbv2")
+  expect_equal(ctx$get_data_protocol("tiledb://foo/bar/baz"), "tiledbv3")
+
+  expect_true(ctx$is_tiledbv2("s3://foo/bar"))
+  expect_false(ctx$is_tiledbv3("s3://foo/bar"))
+  expect_true(ctx$is_tiledbv3("tiledb://foo/bar/baz"))
+  expect_false(ctx$is_tiledbv2("tiledb://foo/bar/baz"))
+})
+
+test_that("SOMADataFrame creation", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_array_path()
+  tbl <- create_arrow_table()
+  domain <- list(soma_joinid = c(0L, 10L))
+
+  sdf0 <- SOMADataFrameCreate(
+    uri = uri,
+    schema = tbl$schema,
+    domain = domain
+  )
+
+  expect_no_error({
+    sdf0$write(tbl)
+    sdf0$close()
+  })
+  expect_true(sdf0$exists())
+
+  sdf1 <- SOMADataFrameOpen(uri)
+  expect_equal(sdf1$soma_type, "SOMADataFrame")
+  expect_equal(sdf1$domain(), domain)
+  expect_equal(sdf1$schema(), tbl$schema)
+
+  expect_equivalent(sdf1$read()$concat(), tbl)
+  sdf1$close()
+})
+
+test_that("SOMACollection creation", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri = uri)$close()
+
+  collection2 <- SOMACollectionOpen(uri)
+  # Testing equivalence because soma_type returns a named string for collections
+  expect_equivalent(collection2$soma_type, "SOMACollection")
+  expect_equal(length(collection2$names()), 0)
+  collection2$close()
+})
+
+test_that("SOMACollection add_new_* methods", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+
+  schema <- arrow::schema(
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+    arrow::field("A", arrow::int32())
+  )
+  domain <- list(soma_joinid = c(0L, 100L))
+  type <- arrow::float32()
+  shape <- c(99L, 101L)
+
+  children <- c(
+    "child1",
+    "child2",
+    "child3",
+    "child4",
+    "child5",
+    "child6",
+    "child7"
+  )
+
+  # Create collection
+  SOMACollectionCreate(uri = uri)$close()
+
+  # child1: SOMACollection
+  child1_uri <- file_path(uri, "child1")
+  child1 <- SOMACollectionCreate(child1_uri)
+
+  # For Carrara URIs children created at nested URIs are automatically added
+  # to the parent, so this is a no-op.
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  expect_no_error({
+    collection$add_new_collection(child1, "child1")
+  })
+
+  # Carrara requires that the member name matches the final segment of the URI
+  expect_error(
+    collection$add_new_collection(child1, "not_child1"),
+    "Member name `not_child1` must match the final segment of the URI"
+  )
+  collection$close()
+  child1$close()
+
+  # child2: SOMAExperiment
+  child2_uri <- file.path(uri, "child2")
+  SOMAExperimentCreate(child2_uri)$close()
+  child2 <- SOMACollectionOpen(child2_uri)
+  expect_true(child2$exists())
+  expect_equivalent(child2$soma_type, "SOMAExperiment")
+  child2$close()
+
+  # child3: SOMAMeasurement
+  child3_uri <- file.path(uri, "child3")
+  SOMAMeasurementCreate(child3_uri)$close()
+  child3 <- SOMACollectionOpen(child3_uri)
+  expect_true(child3$exists())
+  expect_equivalent(child3$soma_type, "SOMAMeasurement")
+  child3$close()
+
+  # child4: SOMACollection
+  child4_uri <- file.path(uri, "child4")
+  SOMACollectionCreate(child4_uri)$close()
+  child4 <- SOMACollectionOpen(child4_uri)
+  expect_true(child4$exists())
+  expect_equivalent(child4$soma_type, "SOMACollection")
+  child4$close()
+
+  # child5: SOMADataFrame
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  child5 <- collection$add_new_dataframe(
+    "child5",
+    schema = schema,
+    index_column_names = "soma_joinid",
+    domain = domain
+  )
+  child5$close()
+  collection$close()
+
+  # child6: SOMASparseNDArray
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  child6 <- collection$add_new_sparse_ndarray(
+    "child6",
+    type = type,
+    shape = shape
+  )
+  child6$close()
+  collection$close()
+
+  # child7: SOMADenseNDArray
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  child7 <- collection$add_new_dense_ndarray(
+    "child7",
+    type = type,
+    shape = shape
+  )
+  child7$close()
+  collection$close()
+
+  # Verify all children were added
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+
+  expect_equal(collection$length(), length(children))
+  expect_setequal(collection$names(), children)
+
+  # Verify types on retrieval
+  expect_equivalent(collection$get("child1")$soma_type, "SOMACollection")
+  expect_equivalent(collection$get("child2")$soma_type, "SOMAExperiment")
+  expect_equivalent(collection$get("child3")$soma_type, "SOMAMeasurement")
+  expect_equivalent(collection$get("child4")$soma_type, "SOMACollection")
+  expect_equivalent(collection$get("child5")$soma_type, "SOMADataFrame")
+  expect_equivalent(collection$get("child6")$soma_type, "SOMASparseNDArray")
+  expect_equivalent(collection$get("child7")$soma_type, "SOMADenseNDArray")
+
+  # Verify properties for child5, child6, child7
+  c5 <- collection$get("child5")
+  expect_equal(c5$schema(), schema)
+  expect_equal(c5$domain(), domain)
+  c5$close()
+
+  c6 <- collection$get("child6")
+  expect_equal(c6$shape(), bit64::as.integer64(shape))
+  c6$close()
+
+  c7 <- collection$get("child7")
+  expect_equal(c7$shape(), bit64::as.integer64(shape))
+  c7$close()
+
+  collection$close()
+
+  # Verify that all child URIs are relative
+  grp <- tiledb::tiledb_group(uri)
+  for (i in seq_len(tiledb::tiledb_group_member_count(grp)) - 1L) {
+    child_name <- tiledb::tiledb_group_member(grp, i)[3]
+    expect_true(tiledb::tiledb_group_is_relative(grp, child_name))
+  }
+  tiledb::tiledb_group_close(grp)
+})
+
+test_that("SOMACollection path encoding validation", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri = uri)$close()
+
+  # Test names with special characters
+  test_names <- c(
+    "my collection",           # spaces
+    "data_αβγ",                # unicode
+    "test-data_v1",            # hyphens and underscores
+    "name.with.dots",          # dots
+    "CamelCaseName"            # mixed case
+  )
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # Create child collections with special character names
+  for (name in test_names) {
+    child_uri <- file_path(uri, name)
+    SOMACollectionCreate(child_uri)$close()
+  }
+
+  collection$close()
+
+  # Verify all collections were created and names preserved
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+  expect_equal(collection$length(), length(test_names))
+  expect_setequal(collection$names(), test_names)
+
+  # Verify each collection can be opened and has correct type
+  for (name in test_names) {
+    child <- collection$get(name)
+    expect_equivalent(child$soma_type, "SOMACollection")
+    child$close()
+  }
+
+  collection$close()
+
+  # Test round-trip: create DataFrame with unicode name
+  unicode_df_uri <- file.path(uri, "dataframe_αβγ")
+  schema <- arrow::schema(
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+    arrow::field("value", arrow::int32())
+  )
+  domain <- list(soma_joinid = c(0L, 100L))
+
+  SOMADataFrameCreate(
+    uri = unicode_df_uri,
+    schema = schema,
+    domain = domain
+  )$close()
+
+  # Verify DataFrame with unicode name
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+  expect_true("dataframe_αβγ" %in% collection$names())
+
+  df <- collection$get("dataframe_αβγ")
+  expect_equivalent(df$soma_type, "SOMADataFrame")
+  df$close()
+
+  collection$close()
+})
+
+test_that("SOMACollection reflects carrara's implicit member addition", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri)$close()
+
+  # Create an NDArray child directly (not using add_new_*)
+  child_uri <- file_path(uri, "sparse_ndarray_A")
+  SOMASparseNDArrayCreate(
+    uri = child_uri,
+    type = arrow::int32(),
+    shape = c(10, 10)
+  )$close()
+
+  # Open collection and verify implicit addition
+  collection <- SOMACollectionOpen(uri)
+  expect_true("sparse_ndarray_A" %in% collection$names())
+  expect_true(collection$get("sparse_ndarray_A")$exists())
+  collection$close()
+
+  # Carrara does not support the set() operation
+  array_A <- SOMASparseNDArrayOpen(child_uri)
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  expect_error(
+    collection$set(array_A, "sparse_ndarray_A"),
+    class = "unsupportedOperationError"
+  )
+  collection$close()
+  array_A$close()
+})

--- a/apis/r/tests/testthat/test-carrara-02-delete.R
+++ b/apis/r/tests/testthat/test-carrara-02-delete.R
@@ -1,0 +1,89 @@
+# Tests for Carrara Member Deletion -----------------------------------------
+
+test_that("SOMACollection member deletion", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+
+  # Create collection with multiple member types
+  SOMACollectionCreate(uri = uri)$close()
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # Add different SOMA types as members
+  schema <- arrow::schema(
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+    arrow::field("value", arrow::int32())
+  )
+  domain <- list(soma_joinid = c(0L, 100L))
+  df <- collection$add_new_dataframe(
+    "test_dataframe",
+    schema = schema,
+    index_column_names = "soma_joinid",
+    domain = domain
+  )
+  df$close()
+
+  sparse <- collection$add_new_sparse_ndarray(
+    "test_sparse",
+    type = arrow::float32(),
+    shape = c(10L, 10L)
+  )
+  sparse$close()
+
+  dense <- collection$add_new_dense_ndarray(
+    "test_dense",
+    type = arrow::float32(),
+    shape = c(10L, 10L)
+  )
+  dense$close()
+
+  child_coll_uri <- file_path(uri, "test_collection")
+  child_coll <- SOMACollectionCreate(child_coll_uri)$close()
+
+  # Verify all members exist
+  expect_equal(collection$length(), 4)
+  expect_setequal(
+    collection$names(),
+    c("test_dataframe", "test_sparse", "test_dense", "test_collection")
+  )
+
+  collection$close()
+
+  # Test deletion of DataFrame
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  expect_no_error(collection$remove("test_dataframe"))
+  expect_equal(collection$length(), 3)
+  expect_false("test_dataframe" %in% collection$names())
+  collection$close()
+
+  # Test deletion of SparseNDArray
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  expect_no_error(collection$remove("test_sparse"))
+  expect_equal(collection$length(), 2)
+  expect_false("test_sparse" %in% collection$names())
+  collection$close()
+
+  # Test deletion of DenseNDArray
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  expect_no_error(collection$remove("test_dense"))
+  expect_equal(collection$length(), 1)
+  expect_false("test_dense" %in% collection$names())
+  collection$close()
+
+  # Test deletion of Collection
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  expect_no_error(collection$remove("test_collection"))
+  expect_equal(collection$length(), 0)
+  expect_false("test_collection" %in% collection$names())
+  collection$close()
+
+  # Test error when trying to remove non-existent member
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  expect_error(
+    collection$remove("nonexistent"),
+    "does not exist"
+  )
+  collection$close()
+})

--- a/apis/r/tests/testthat/test-carrara-03-uri-enforcement.R
+++ b/apis/r/tests/testthat/test-carrara-03-uri-enforcement.R
@@ -1,0 +1,129 @@
+# Tests for Carrara URI Enforcement -----------------------------------------
+
+test_that("SOMACollection member name vs URI enforcement", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri = uri)$close()
+
+  # Test 1: Verify error when member name doesn't match URI
+  child1_uri <- file_path(uri, "actual_name")
+  child1 <- SOMACollectionCreate(child1_uri)
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # This should fail because "wrong_name" doesn't match "actual_name"
+  expect_error(
+    collection$add_new_collection(child1, "wrong_name"),
+    "Member name `wrong_name` must match the final segment of the URI"
+  )
+
+  collection$close()
+  child1$close()
+
+  # Test 2: Verify success when member name matches URI
+  child2_uri <- file.path(uri, "correct_name")
+  child2 <- SOMACollectionCreate(child2_uri)
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # This should succeed because "correct_name" matches URI segment
+  expect_no_error(
+    collection$add_new_collection(child2, "correct_name")
+  )
+
+  expect_true("correct_name" %in% collection$names())
+  collection$close()
+  child2$close()
+
+  # Test 3: Verify enforcement with special characters in names
+  child3_uri <- file.path(uri, "name-with_special.chars")
+  child3 <- SOMACollectionCreate(child3_uri)
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # Should fail with wrong name
+  expect_error(
+    collection$add_new_collection(child3, "different_name"),
+    "Member name `different_name` must match the final segment of the URI"
+  )
+
+  # Should succeed with correct name
+  expect_no_error(
+    collection$add_new_collection(child3, "name-with_special.chars")
+  )
+
+  collection$close()
+  child3$close()
+
+  # Test 4: Verify enforcement works for all SOMA types
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+
+  # We already tested SOMACollection above, verify it's in the collection
+  expect_true("correct_name" %in% collection$names())
+  expect_true("name-with_special.chars" %in% collection$names())
+
+  collection$close()
+})
+
+test_that("Path separator in member name is rejected", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri = uri)$close()
+
+  # Member names containing path separators should fail with the Carrara because
+  # the intermediate path component doesn't exist
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  schema <- arrow::schema(
+    arrow::field("soma_joinid", arrow::int64(), nullable = FALSE),
+    arrow::field("value", arrow::int32())
+  )
+  domain <- list(soma_joinid = c(0L, 100L))
+
+  expect_error(
+    collection$add_new_dataframe(
+      "bad/key",
+      schema = schema,
+      index_column_names = "soma_joinid",
+      domain = domain
+    )
+  )
+
+  collection$close()
+})
+
+test_that("set() is not supported for Carrara collections", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri = uri)$close()
+
+  # Create a child array directly
+  child_uri <- file_path(uri, "child_array")
+  child <- SOMASparseNDArrayCreate(
+    uri = child_uri,
+    type = arrow::int32(),
+    shape = c(10, 10)
+  )
+
+  # set() should fail for Carrara regardless of whether the object exists
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  expect_error(
+    collection$set(child, "child_array"),
+    class = "unsupportedOperationError"
+  )
+
+  # Even with a different name, set() should fail (before name validation)
+  expect_error(
+    collection$set(child, "different_name"),
+    class = "unsupportedOperationError"
+  )
+
+  collection$close()
+  child$close()
+})

--- a/apis/r/tests/testthat/test-carrara-04-error-handling.R
+++ b/apis/r/tests/testthat/test-carrara-04-error-handling.R
@@ -1,0 +1,204 @@
+# Tests for Carrara Error Handling and Edge Cases --------------------------
+
+test_that("SOMACollection invalid operations", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+
+  # Opening non-existent URI should error
+  nonexistent_uri <- file_path(get_base_uri(), "does_not_exist")
+  expect_error(
+    SOMACollectionOpen(nonexistent_uri),
+    class = "error"
+  )
+
+  # Test 2: Adding duplicate member names should error
+  SOMACollectionCreate(uri = uri)$close()
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+
+  # Add first member
+  child1_uri <- file.path(uri, "duplicate_name")
+  SOMACollectionCreate(child1_uri)$close()
+
+  expect_true("duplicate_name" %in% collection$names())
+
+  # Attempt to add another member with same name should fail
+  child2_uri <- file.path(uri, "duplicate_name_v2")
+  child2 <- SOMACollectionCreate(child2_uri)
+
+  expect_error(
+    collection$add_new_collection(child2, "duplicate_name"),
+    class = "error"
+  )
+
+  child2$close()
+  collection$close()
+
+  # Test 3: Operations on closed objects should error
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+  collection$close()
+
+  # Attempting to use closed collection should error
+  expect_error(
+    collection$names(),
+    class = "error"
+  )
+})
+
+test_that("SOMACollection relative URI behavior", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  # Create nested collection structure
+  base_uri <- get_base_uri()
+  parent_uri <- file_path(base_uri, generate_unique_id("parent-"))
+  child_name <- "child_collection"
+  child_uri <- file.path(parent_uri, child_name)
+
+  # Register cleanup for parent (will recursively clean child)
+  withr::defer({
+    tryCatch(
+      {
+        grp <- tiledb::tiledb_group(parent_uri)
+        tiledb::tiledb_group_close(grp)
+        grp <- tiledb::tiledb_group_open(grp, type = "MODIFY_EXCLUSIVE")
+        tiledb::tiledb_group_delete(grp = grp, uri = parent_uri, recursive = TRUE)
+        tiledb::tiledb_group_close(grp)
+      },
+      error = function(e) {
+        message("Failed to cleanup: ", parent_uri)
+      }
+    )
+  })
+
+  # Create parent and child
+  SOMACollectionCreate(parent_uri)$close()
+  SOMACollectionCreate(child_uri)$close()
+
+  # Verify child is accessible from parent
+  parent <- SOMACollectionOpen(parent_uri, mode = "READ")
+  expect_true(child_name %in% parent$names())
+
+  # Verify we can open the child
+  child <- parent$get(child_name)
+  expect_equivalent(child$soma_type, "SOMACollection")
+  child$close()
+
+  parent$close()
+
+  # Verify child can be opened directly via its full URI
+  child_direct <- SOMACollectionOpen(child_uri, mode = "READ")
+  expect_equivalent(child_direct$soma_type, "SOMACollection")
+  child_direct$close()
+})
+
+test_that("SOMACollection delete member by name", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri)$close()
+
+  # Add members to the collection
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  collection$add_new_sparse_ndarray(
+    "array_to_delete",
+    type = arrow::int8(),
+    shape = c(10L)
+  )
+  collection$add_new_collection(
+    SOMACollectionCreate(file_path(uri, "collection_to_keep")),
+    "collection_to_keep"
+  )
+  collection$close()
+
+  # Verify both members exist
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+  expect_setequal(collection$names(), c("array_to_delete", "collection_to_keep"))
+  collection$close()
+
+  # Delete the array member
+  collection <- SOMACollectionOpen(uri, mode = "DELETE")
+  collection$remove("array_to_delete")
+  collection$close()
+
+  # Verify only the collection remains
+  collection <- SOMACollectionOpen(uri, mode = "READ")
+  expect_equal(collection$names(), "collection_to_keep")
+  collection$close()
+})
+
+test_that("Invalid nested storage paths are rejected", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+
+  # Attempting to create objects with nested storage URIs should fail
+  expect_error(
+    SOMACollectionCreate(file_path(uri, "s3://bucket/path"))
+  )
+
+  expect_error(
+    SOMASparseNDArrayCreate(
+      uri = file_path(uri, "s3://bucket/array"),
+      type = arrow::float32(),
+      shape = c(10, 11)
+    )
+  )
+})
+
+test_that("Opening nested child paths directly works", {
+  skip_if_no_carrara()
+  with_carrara_env()
+
+  uri <- carrara_group_path()
+  SOMACollectionCreate(uri)$close()
+
+  # Create nested structure: collection -> c1 -> c1.1 -> dnda1
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  collection$add_new_sparse_ndarray("snda1", type = arrow::int8(), shape = c(10, 11))
+  collection$add_new_collection(
+    SOMACollectionCreate(file_path(uri, "c1")),
+    "c1"
+  )
+  collection$close()
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  c1 <- collection$get("c1")
+  c1$add_new_collection(
+    SOMACollectionCreate(file_path(c1$uri, "c1.1")),
+    "c1.1"
+  )
+  c1$close()
+  collection$close()
+
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  c1 <- collection$get("c1")
+  c1_1 <- c1$get("c1.1")
+  c1_1$add_new_dense_ndarray("dnda1", type = arrow::int64(), shape = c(100, 10))
+  c1_1$close()
+  c1$close()
+  collection$close()
+
+  # Verify we can open each nested path directly
+  expect_equivalent(SOMACollectionOpen(uri)$soma_type, "SOMACollection")
+  expect_equal(
+    SOMASparseNDArrayOpen(file_path(uri, "snda1"))$soma_type,
+    "SOMASparseNDArray"
+  )
+  expect_equivalent(
+    SOMACollectionOpen(file_path(uri, "c1"))$soma_type,
+    "SOMACollection"
+  )
+  expect_equivalent(
+    SOMACollectionOpen(file_path(uri, "c1/c1.1"))$soma_type,
+    "SOMACollection"
+  )
+  expect_equal(
+    SOMADenseNDArrayOpen(file_path(uri, "c1/c1.1/dnda1"))$soma_type,
+    "SOMADenseNDArray"
+  )
+})


### PR DESCRIPTION
* Initital tests

* Reduce verbosity of internal diagnostic logging

* Format tests

* wip first light carrara test

* Additional dataframe tests

* Collection creation tests

* update add_new_collection for carrara compat

* Document carrara uri behavior in collection classes

* Add carrara uri checks to collection$set

* Add tests for collection$add_new_ methods

* add methods to check tiledbv2 and tiledbv3 semantics

* Formalize tests

* Remove dependency on uuid

* Breakup monolith test file

* Fix SOMACollection member cache for carrara child collections

[SOMA-797]

* Update handle retrieval for write/delete modes

* Fix Carrara member cache to handle delete mode and last member removal

- Skip cache refresh in delete mode to preserve uncommitted local changes
- Check cache initialization (!is.null) instead of length to prevent re-reading from server after removing the last member
- Open separate READ handle for both WRITE and DELETE modes when updating cache

* Add delete tests

* Test collection members are added via relative uris

* Block set() for Carrara collections

Add private .set_element() method that handles Carrara vs v2:
- Carrara: validates name/URI match, updates cache only (children are auto-registered when created at nested URIs)
- v2: delegates to public set() method
- Update add_new_* methods to use .set_element() instead of set()
- Add test verifying set() is blocked on carrara URIs

* Add carrara uri tests

* Add error handling tests

* Add tests for deletion by name

* Ignore additional R build artifacts

* Use new self$context

* Dev docs for carrara tests

* Update news

* Roxygenize

* Add missing carrara skip

* Ignore local .env files

* Ensure carrara tests use configured profile

* Rename readme for carrara tests

* Add missing carrara env to data protocol tests

* Apply suggestions from code review



---------


(cherry picked from commit e5a14aac1bca035c8ec2a40e33b5bfd3d83f3ac3)

**Issue and/or context:**

**Changes:**

**Notes for Reviewer:**
