### PR TITLE
[python] Address new mypy errors

### DIFF
--- a/apis/python/src/tiledbsoma/_dask/load.py
+++ b/apis/python/src/tiledbsoma/_dask/load.py
@@ -135,7 +135,7 @@ def load_daskarray(
     obs_chunk_joinids, obs_chunk_sizes = chunk_ids_sizes(obs_ids, obs_chunk_size, nobs)
     var_chunk_joinids, var_chunk_sizes = chunk_ids_sizes(var_ids, var_chunk_size, nvar)
 
-    arr = np.empty((len(obs_chunk_joinids), len(var_chunk_joinids)), dtype=object)
+    arr: npt.NDArray = np.empty((len(obs_chunk_joinids), len(var_chunk_joinids)), dtype=object)
     for obs_chunk_idx, obs_chunk_ids in enumerate(obs_chunk_joinids):
         for var_chunk_idx, var_chunk_ids in enumerate(var_chunk_joinids):
             arr[obs_chunk_idx, var_chunk_idx] = (obs_chunk_ids, var_chunk_ids)

--- a/apis/python/src/tiledbsoma/io/spatial/_util.py
+++ b/apis/python/src/tiledbsoma/io/spatial/_util.py
@@ -24,7 +24,7 @@ def _expand_compressed_index_pointers(indptr: npt.NDArray, nval: int) -> npt.NDA
         indptr: Array of row/column pointers to be expanded.
         nval: Number of total non-zero values in the sparse matrix.
     """
-    indices = np.empty(nval, dtype=np.int64)
+    indices: npt.NDArray = np.empty(nval, dtype=np.int64)
     for index in range(len(indptr) - 1):
         indices[indptr[index] : indptr[index + 1]] = index
     return indices


### PR DESCRIPTION
Fix to mypy typing errors related to missing type annotations for `numpy.empty`.