### PR TITLE
[c++] Implement buffer resize and resubmission for read queries

### DIFF
--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(TILEDB_SOMA_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_transformers.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/array_buffers.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer_strategies.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/tiledb_adapter/value_filter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/tiledb_adapter/platform_config.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/arrow_adapter.cc
@@ -251,6 +252,7 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_coordinates.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/array_buffers.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/soma/column_buffer_strategies.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_array.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_group.h
   ${CMAKE_CURRENT_SOURCE_DIR}/soma/soma_column.h

--- a/libtiledbsoma/src/soma/array_buffers.cc
+++ b/libtiledbsoma/src/soma/array_buffers.cc
@@ -178,4 +178,9 @@ void ArrayBuffers::emplace(const std::string& name, std::shared_ptr<ColumnBuffer
     buffers_.emplace(name, buffer);
 }
 
+void ArrayBuffers::expand_buffers() {
+    for (const auto& [name, buffer] : buffers_) {
+        buffer->resize(buffer->max_size() * DEFAULT_BUFFER_EXPANSION_FACTOR);
+    }
+}
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/array_buffers.cc
+++ b/libtiledbsoma/src/soma/array_buffers.cc
@@ -99,7 +99,8 @@ void ArrayBuffers::emplace(const std::string& name, std::shared_ptr<ColumnBuffer
 }
 
 void ArrayBuffers::expand_buffers() {
-    for (const auto& [name, buffer] : buffers_) {
+    for (const auto& name : names_) {
+        std::shared_ptr<ReadColumnBuffer> buffer = at<ReadColumnBuffer>(name);
         buffer->resize(
             buffer->max_size() * DEFAULT_BUFFER_EXPANSION_FACTOR,
             buffer->max_num_cells() * DEFAULT_BUFFER_EXPANSION_FACTOR);

--- a/libtiledbsoma/src/soma/array_buffers.cc
+++ b/libtiledbsoma/src/soma/array_buffers.cc
@@ -32,11 +32,11 @@ bool ArrayBuffers::use_memory_pool(const std::shared_ptr<tiledb::Array>& array) 
 ArrayBuffers::ArrayBuffers(
     const std::vector<std::string>& names,
     const tiledb::Array& array,
-    std::shared_ptr<ColumnBufferAllocationStrategy> strategy)
+    std::unique_ptr<ColumnBufferAllocationStrategy> strategy)
     : names_(names)
     , strategy_(std::move(strategy)) {
     if (!strategy_) {
-        strategy_ = std::make_shared<BasicAllocationStrategy>(array);
+        strategy_ = std::make_unique<BasicAllocationStrategy>(array);
     }
 
     MemoryMode mode = ColumnBuffer::memory_mode(array.config());

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -38,7 +38,8 @@ class ArrayBuffers {
         const std::vector<std::string>& names,
         const tiledb::Array& array,
         std::unique_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
-    ArrayBuffers(const ArrayBuffers&) = default;
+
+    ArrayBuffers(const ArrayBuffers&) = delete;
     ArrayBuffers(ArrayBuffers&&) = default;
     ~ArrayBuffers() = default;
 

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -15,12 +15,13 @@
 #define ARRAY_BUFFERS_H
 
 #include <concepts>
+#include <functional>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
-
 #include <tiledb/tiledb>
 
 #include "../utils/common.h"
 #include "column_buffer.h"
+#include "column_buffer_strategies.h"
 
 namespace tiledbsoma {
 
@@ -30,12 +31,13 @@ class ArrayBuffers {
     inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 28;
     inline static const size_t DEFAULT_BUFFER_EXPANSION_FACTOR = 2;
     inline static const std::string CONFIG_KEY_USE_MEMORY_POOL = "soma.read.use_memory_pool";
-    inline static const std::string CONFIG_KEY_MEMORY_BUDGET = "soma.read.memory_budget";
-    inline static const std::string CONFIG_KEY_VAR_SIZED_FACTOR = "soma.read.var_size_factor";
 
    public:
     ArrayBuffers() = default;
-    ArrayBuffers(const std::vector<std::string>& names, const tiledb::Array& array);
+    ArrayBuffers(
+        const std::vector<std::string>& names,
+        const tiledb::Array& array,
+        std::unique_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
     ArrayBuffers(const ArrayBuffers&) = default;
     ArrayBuffers(ArrayBuffers&&) = default;
     ~ArrayBuffers() = default;
@@ -114,6 +116,8 @@ class ArrayBuffers {
 
     // Map: column name -> ColumnBuffer
     std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
+
+    std::unique_ptr<ColumnBufferAllocationStrategy> strategy_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -105,6 +105,8 @@ class ArrayBuffers {
      */
     static bool use_memory_pool(const std::shared_ptr<tiledb::Array>& array);
 
+    void expand_buffers();
+
    private:
     // A vector of column names that maintains the order the columns were added
     std::vector<std::string> names_;

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -37,9 +37,9 @@ class ArrayBuffers {
     ArrayBuffers(
         const std::vector<std::string>& names,
         const tiledb::Array& array,
-        std::unique_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
+        std::shared_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
 
-    ArrayBuffers(const ArrayBuffers&) = delete;
+    ArrayBuffers(const ArrayBuffers&) = default;
     ArrayBuffers(ArrayBuffers&&) = default;
     ~ArrayBuffers() = default;
 
@@ -118,7 +118,7 @@ class ArrayBuffers {
     // Map: column name -> ColumnBuffer
     std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
 
-    std::unique_ptr<ColumnBufferAllocationStrategy> strategy_;
+    std::shared_ptr<ColumnBufferAllocationStrategy> strategy_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -110,6 +110,11 @@ class ArrayBuffers {
      */
     static bool use_memory_pool(const std::shared_ptr<tiledb::Array>& array);
 
+    /**
+     * @brief Double the size of the allocated buffers. Any data already in the buffers 
+     * will be deleted. By default this function will allocate more memory than the 
+     * memory budget set by the user.
+     */
     void expand_buffers();
 
    private:
@@ -119,6 +124,7 @@ class ArrayBuffers {
     // Map: column name -> ColumnBuffer
     std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
 
+    // The allocation strategy used to split the available memory budget to the different columns.
     std::unique_ptr<ColumnBufferAllocationStrategy> strategy_;
 };
 

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -28,6 +28,7 @@ using namespace tiledb;
 
 class ArrayBuffers {
     inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 28;
+    inline static const size_t DEFAULT_BUFFER_EXPANSION_FACTOR = 2;
     inline static const std::string CONFIG_KEY_USE_MEMORY_POOL = "soma.read.use_memory_pool";
     inline static const std::string CONFIG_KEY_MEMORY_BUDGET = "soma.read.memory_budget";
     inline static const std::string CONFIG_KEY_VAR_SIZED_FACTOR = "soma.read.var_size_factor";

--- a/libtiledbsoma/src/soma/array_buffers.h
+++ b/libtiledbsoma/src/soma/array_buffers.h
@@ -28,7 +28,6 @@ namespace tiledbsoma {
 using namespace tiledb;
 
 class ArrayBuffers {
-    inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 28;
     inline static const size_t DEFAULT_BUFFER_EXPANSION_FACTOR = 2;
     inline static const std::string CONFIG_KEY_USE_MEMORY_POOL = "soma.read.use_memory_pool";
 
@@ -37,11 +36,13 @@ class ArrayBuffers {
     ArrayBuffers(
         const std::vector<std::string>& names,
         const tiledb::Array& array,
-        std::shared_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
+        std::unique_ptr<ColumnBufferAllocationStrategy> strategy = nullptr);
 
-    ArrayBuffers(const ArrayBuffers&) = default;
+    ArrayBuffers(const ArrayBuffers&) = delete;
     ArrayBuffers(ArrayBuffers&&) = default;
     ~ArrayBuffers() = default;
+
+    ArrayBuffers& operator=(const ArrayBuffers&) = delete;
 
     /**
      * @brief Return the buffer with the given name.
@@ -118,7 +119,7 @@ class ArrayBuffers {
     // Map: column name -> ColumnBuffer
     std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
 
-    std::shared_ptr<ColumnBufferAllocationStrategy> strategy_;
+    std::unique_ptr<ColumnBufferAllocationStrategy> strategy_;
 };
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -769,7 +769,7 @@ uint64_t ColumnBuffer::max_size() const {
 }
 
 uint64_t ColumnBuffer::max_num_cells() const {
-    return is_var_ ? max_size() / sizeof(uint64_t) : max_size() / tiledb::impl::type_size(type());
+    return is_var_ ? (offsets_.capacity() - 1) : max_size() / tiledb::impl::type_size(type());
 }
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -752,8 +752,7 @@ void ColumnBuffer::resize(uint64_t num_bytes, uint64_t num_cells, bool preserve_
         }
 
         if (is_nullable_) {
-            std::memcpy(
-                offsets_buffer.data(), offsets_.data(), std::min(num_cells + 1, num_cells_ + 1) * sizeof(uint64_t));
+            std::memcpy(offsets_buffer.data(), offsets_.data(), std::min(num_cells, num_cells_) * sizeof(uint64_t));
         }
     }
 

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -727,7 +727,7 @@ std::shared_ptr<ColumnBuffer> VectorColumnBuffer::alloc(
         name, type, num_cells, num_bytes, is_var, is_nullable, enumeration, is_ordered, mode);
 }
 
-void ColumnBuffer::resize(size_t num_bytes, size_t num_cells, bool preserve_data) {
+void ColumnBuffer::resize(uint64_t num_bytes, uint64_t num_cells, bool preserve_data) {
     std::vector<std::byte> data_buffer(num_bytes);
     std::vector<uint64_t> offsets_buffer;
     std::vector<uint8_t> validity_buffer;
@@ -764,11 +764,11 @@ void ColumnBuffer::resize(size_t num_bytes, size_t num_cells, bool preserve_data
     num_cells_ = std::min(num_cells_, num_cells);
 }
 
-size_t ColumnBuffer::max_size() const {
+uint64_t ColumnBuffer::max_size() const {
     return data_.capacity();
 }
 
-size_t ColumnBuffer::max_num_cells() const {
+uint64_t ColumnBuffer::max_num_cells() const {
     return is_var_ ? max_size() / sizeof(uint64_t) : max_size() / tiledb::impl::type_size(type());
 }
 

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -752,7 +752,7 @@ void ColumnBuffer::resize(uint64_t num_bytes, uint64_t num_cells, bool preserve_
         }
 
         if (is_nullable_) {
-            std::memcpy(offsets_buffer.data(), offsets_.data(), std::min(num_cells, num_cells_) * sizeof(uint64_t));
+            std::memcpy(validity_buffer.data(), validity_.data(), std::min(num_cells, num_cells_) * sizeof(uint8_t));
         }
     }
 

--- a/libtiledbsoma/src/soma/column_buffer.cc
+++ b/libtiledbsoma/src/soma/column_buffer.cc
@@ -727,7 +727,7 @@ std::shared_ptr<ColumnBuffer> VectorColumnBuffer::alloc(
         name, type, num_cells, num_bytes, is_var, is_nullable, enumeration, is_ordered, mode);
 }
 
-void ColumnBuffer::resize(uint64_t num_bytes, uint64_t num_cells, bool preserve_data) {
+void ColumnBuffer::resize(const uint64_t num_bytes, const uint64_t num_cells, const bool preserve_data) {
     std::vector<std::byte> data_buffer(num_bytes);
     std::vector<uint64_t> offsets_buffer;
     std::vector<uint8_t> validity_buffer;

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -292,7 +292,7 @@ class ColumnBuffer {
     /**
      * @brief Resize the internal buffers to the given size.
      */
-    void resize(size_t size, bool preserve_data = false);
+    void resize(size_t size, size_t num_cells, bool preserve_data = false);
 
    protected:
     size_t num_cells_;

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -297,14 +297,14 @@ class ColumnBuffer {
     virtual std::unique_ptr<IArrowBufferStorage> export_buffers();
 
     /**
-     * @brief Resize the internal buffers to the given size.
-     * 
-     * @param size Number of bytes to allocate for the data buffer.
-     * @param num_cells Number of cells the buffer should hold. 
-     *  For variable sized and nullable columns this dictates the size of the offsets and validity buffers.
-     * @param preserve_data If true, copy any data written in the old buffers to the new buffers.
+     * @brief Get max size of data buffer in bytes.
      */
-    void resize(const uint64_t size, const uint64_t num_cells, const bool preserve_data = false);
+    uint64_t max_size() const;
+
+    /**
+     * @brief Get the max number of cells the buffers can hold.
+     */
+    uint64_t max_num_cells() const;
 
    protected:
     size_t num_cells_;
@@ -432,6 +432,16 @@ class ReadColumnBuffer : public ColumnBuffer {
         ColumnBuffer::to_bitmap(validity(), bitmap);
     }
 
+    /**
+     * @brief Resize the internal buffers to the given size.
+     * 
+     * @param size Number of bytes to allocate for the data buffer.
+     * @param num_cells Number of cells the buffer should hold. 
+     *  For variable sized and nullable columns this dictates the size of the offsets and validity buffers.
+     * @param preserve_data If true, copy any data written in the old buffers to the new buffers.
+     */
+    virtual void resize(const uint64_t size, const uint64_t num_cells, const bool preserve_data = false) = 0;
+
     using ColumnBuffer::data;
     using ColumnBuffer::offsets;
     using ColumnBuffer::validity;
@@ -485,6 +495,8 @@ class CArrayColumnBuffer : public ReadColumnBuffer {
      * @brief Release ownership of the underyling offsets buffer to the caller and reallocate a new buffer with the same size.
      */
     std::unique_ptr<uint64_t[]> release_and_reallocate_offsets();
+
+    void resize(const uint64_t size, const uint64_t num_cells, const bool preserve_data = false) override;
 
     std::unique_ptr<IArrowBufferStorage> export_buffers() override;
 
@@ -561,6 +573,8 @@ class VectorColumnBuffer : public ReadColumnBuffer {
     std::span<std::byte> data() override;
     std::span<uint64_t> offsets() override;
     std::span<uint8_t> validity() override;
+
+    void resize(const uint64_t size, const uint64_t num_cells, const bool preserve_data = false) override;
 
     std::unique_ptr<IArrowBufferStorage> export_buffers() override;
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -298,8 +298,13 @@ class ColumnBuffer {
 
     /**
      * @brief Resize the internal buffers to the given size.
+     * 
+     * @param size Number of bytes to allocate for the data buffer.
+     * @param num_cells Number of cells the buffer should hold. 
+     *  For variable sized and nullable columns this dictates the size of the offsets and validity buffers.
+     * @param preserve_data If true, copy any data written in the old buffers to the new buffers.
      */
-    void resize(uint64_t size, uint64_t num_cells, bool preserve_data = false);
+    void resize(const uint64_t size, const uint64_t num_cells, const bool preserve_data = false);
 
    protected:
     size_t num_cells_;

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -89,6 +89,13 @@ class ColumnBuffer {
 
     virtual ~ColumnBuffer();
 
+    ColumnBuffer& operator=(const ColumnBuffer&) = delete;
+
+    /**
+     * @brief Attach this ColumnBuffer to a TileDB query.
+     *
+     * @param query TileDB query
+     */
     void attach(Query& query, std::optional<Subarray> subarray = std::nullopt);
 
     /**

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -292,7 +292,7 @@ class ColumnBuffer {
     /**
      * @brief Resize the internal buffers to the given size.
      */
-    void resize(size_t size, size_t num_cells, bool preserve_data = false);
+    void resize(uint64_t size, uint64_t num_cells, bool preserve_data = false);
 
    protected:
     size_t num_cells_;

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -103,7 +103,7 @@ class ColumnBuffer {
      *
      * @return size_t
      */
-    size_t size() const {
+    uint64_t size() const {
         return num_cells_;
     }
 
@@ -307,15 +307,15 @@ class ColumnBuffer {
     uint64_t max_num_cells() const;
 
    protected:
-    size_t num_cells_;
+    uint64_t num_cells_;
 
     // Data size which is calculated different for var vs non-var
-    size_t data_size_;
+    uint64_t data_size_;
 
-    size_t max_num_cells_;
+    uint64_t max_num_cells_;
 
     // Data size which is calculated different for var vs non-var
-    size_t max_data_size_;
+    uint64_t max_data_size_;
 
     MemoryMode mode_;
 

--- a/libtiledbsoma/src/soma/column_buffer.h
+++ b/libtiledbsoma/src/soma/column_buffer.h
@@ -289,6 +289,11 @@ class ColumnBuffer {
 
     virtual std::unique_ptr<IArrowBufferStorage> export_buffers();
 
+    /**
+     * @brief Resize the internal buffers to the given size.
+     */
+    void resize(size_t size, bool preserve_data = false);
+
    protected:
     size_t num_cells_;
 

--- a/libtiledbsoma/src/soma/column_buffer_strategies.cc
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.cc
@@ -1,0 +1,133 @@
+#include "column_buffer_strategies.h"
+
+#include "../utils/common.h"
+#include "../utils/logger.h"
+
+#include <stdexcept>
+
+namespace tiledbsoma {
+
+BasicAllocationStrategy::BasicAllocationStrategy(const tiledb::Array& array) {
+    const tiledb::Config config = array.config();
+
+    if (config.contains(CONFIG_KEY_INIT_BYTES)) {
+        auto value_str = config.get(CONFIG_KEY_INIT_BYTES.data());
+        try {
+            buffer_size = std::stoull(value_str);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(
+                fmt::format("[ColumnBuffer] Error parsing {}: '{}' ({})", CONFIG_KEY_INIT_BYTES, value_str, e.what()));
+        }
+    }
+}
+
+std::pair<size_t, size_t> BasicAllocationStrategy::get_buffer_sizes(
+    std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
+    return std::visit(
+        [&](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+
+            bool is_var = false;
+            if constexpr (std::is_same_v<T, tiledb::Attribute>) {
+                is_var = arg.variable_sized();
+            } else {
+                is_var = arg.cell_val_num() == TILEDB_VAR_NUM || arg.type() == TILEDB_STRING_ASCII ||
+                         arg.type() == TILEDB_STRING_UTF8;
+            }
+
+            size_t num_cells = is_var ? buffer_size / sizeof(uint64_t) :
+                                        buffer_size / tiledb::impl::type_size(arg.type());
+
+            return std::make_pair(buffer_size, num_cells);
+        },
+        column);
+}
+
+MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string> columns, const tiledb::Array& array) {
+    const tiledb::Config config = array.config();
+    const tiledb::ArraySchema schema = array.schema();
+
+    size_t memory_budget = 0;
+    if (config.contains(CONFIG_KEY_MEMORY_POOL_SIZE)) {
+        auto value_str = config.get(CONFIG_KEY_MEMORY_POOL_SIZE.data());
+        try {
+            memory_budget = std::stoull(value_str);
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[ArrayBuffers] Error parsing {}: '{}' ({})", CONFIG_KEY_MEMORY_POOL_SIZE, value_str, e.what()));
+        }
+    }
+
+    if (config.contains(CONFIG_KEY_VAR_SIZED_FACTOR)) {
+        auto value_str = config.get(CONFIG_KEY_VAR_SIZED_FACTOR.data());
+        try {
+            var_size_expansion_factor = std::max(1ull, std::stoull(value_str));
+        } catch (const std::exception& e) {
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[ArrayBuffers] Error parsing {}: '{}' ({})", CONFIG_KEY_VAR_SIZED_FACTOR, value_str, e.what()));
+        }
+    }
+
+    size_t weight = 0;
+    for (const auto& column : columns) {
+        if (schema.has_attribute(column)) {
+            tiledb::Attribute attr = schema.attribute(column);
+
+            if (!attr.variable_sized() && attr.cell_val_num() != 1) {
+                throw TileDBSOMAError("[compute_unit_buffer_size] Values per cell > 1 is not supported: " + column);
+            }
+
+            weight += attr.nullable() ? 1 : 0;
+            // If column has variable size add the offset array in the column budget
+            weight += attr.variable_sized() ? sizeof(uint64_t) * (1 + var_size_expansion_factor) :
+                                              tiledb::impl::type_size(attr.type());
+        }
+        // Else check if column is a TileDB dimension
+        else if (schema.domain().has_dimension(column)) {
+            tiledb::Dimension dim = schema.domain().dimension(column);
+
+            bool is_var = dim.cell_val_num() == TILEDB_VAR_NUM || dim.type() == TILEDB_STRING_ASCII ||
+                          dim.type() == TILEDB_STRING_UTF8;
+
+            if (!is_var && dim.cell_val_num() != 1) {
+                throw TileDBSOMAError("[compute_unit_buffer_size] Values per cell > 1 is not supported: " + column);
+            }
+
+            weight += (dim.type() == TILEDB_STRING_ASCII || dim.type() == TILEDB_STRING_UTF8) ?
+                          sizeof(uint64_t) * (1 + var_size_expansion_factor) :
+                          tiledb::impl::type_size(dim.type());
+        } else {
+            throw TileDBSOMAError(fmt::format("[compute_unit_buffer_size] Missing column name '{}'", column));
+        }
+    }
+
+    // Ensure minimum buffer size is multiple of 8
+    buffer_unit_size = (memory_budget / weight / 8) * 8;
+}
+
+std::pair<size_t, size_t> MemoryPoolAllocationStrategy::get_buffer_sizes(
+    std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
+    return std::visit(
+        [&](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+
+            bool is_var = false;
+            if constexpr (std::is_same_v<T, tiledb::Attribute>) {
+                is_var = arg.variable_sized();
+            } else {
+                is_var = arg.cell_val_num() == TILEDB_VAR_NUM || arg.type() == TILEDB_STRING_ASCII ||
+                         arg.type() == TILEDB_STRING_UTF8;
+            }
+
+            size_t column_budget = (is_var ? sizeof(uint64_t) * var_size_expansion_factor :
+                                             tiledb::impl::type_size(arg.type())) *
+                                   buffer_unit_size;
+            size_t num_cells = buffer_unit_size;
+
+            return std::make_pair(column_budget, num_cells);
+        },
+        column);
+}
+}  // namespace tiledbsoma

--- a/libtiledbsoma/src/soma/column_buffer_strategies.cc
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.cc
@@ -47,7 +47,7 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
     const tiledb::Config config = array.config();
     const tiledb::ArraySchema schema = array.schema();
 
-    size_t memory_budget = 0;
+    size_t memory_budget = DEFAULT_MEMORY_POOL;
     if (config.contains(CONFIG_KEY_MEMORY_POOL_SIZE)) {
         auto value_str = config.get(CONFIG_KEY_MEMORY_POOL_SIZE.data());
         try {
@@ -59,6 +59,7 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
         }
     }
 
+    var_size_expansion_factor = DEFAULT_VAR_SIZE_FACTOR;
     if (config.contains(CONFIG_KEY_VAR_SIZED_FACTOR)) {
         auto value_str = config.get(CONFIG_KEY_VAR_SIZED_FACTOR.data());
         try {

--- a/libtiledbsoma/src/soma/column_buffer_strategies.cc
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.cc
@@ -1,7 +1,7 @@
 #include "column_buffer_strategies.h"
 
 #include "../utils/common.h"
-#include "../utils/logger.h"
+#include "common/logging/impl/logger.h"
 
 #include <stdexcept>
 
@@ -16,7 +16,11 @@ BasicAllocationStrategy::BasicAllocationStrategy(const tiledb::Array& array) {
             buffer_size = std::stoull(value_str);
         } catch (const std::exception& e) {
             throw TileDBSOMAError(
-                fmt::format("[ColumnBuffer] Error parsing {}: '{}' ({})", CONFIG_KEY_INIT_BYTES, value_str, e.what()));
+                fmt::format(
+                    "[BasicAllocationStrategy] Error parsing {}: '{}' ({})",
+                    CONFIG_KEY_INIT_BYTES,
+                    value_str,
+                    e.what()));
         }
     }
 }
@@ -55,7 +59,10 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
         } catch (const std::exception& e) {
             throw TileDBSOMAError(
                 fmt::format(
-                    "[ArrayBuffers] Error parsing {}: '{}' ({})", CONFIG_KEY_MEMORY_POOL_SIZE, value_str, e.what()));
+                    "[MemoryPoolAllocationStrategy] Error parsing {}: '{}' ({})",
+                    CONFIG_KEY_MEMORY_POOL_SIZE,
+                    value_str,
+                    e.what()));
         }
     }
 
@@ -67,7 +74,10 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
         } catch (const std::exception& e) {
             throw TileDBSOMAError(
                 fmt::format(
-                    "[ArrayBuffers] Error parsing {}: '{}' ({})", CONFIG_KEY_VAR_SIZED_FACTOR, value_str, e.what()));
+                    "[MemoryPoolAllocationStrategy] Error parsing {}: '{}' ({})",
+                    CONFIG_KEY_VAR_SIZED_FACTOR,
+                    value_str,
+                    e.what()));
         }
     }
 
@@ -77,7 +87,7 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
             tiledb::Attribute attr = schema.attribute(column);
 
             if (!attr.variable_sized() && attr.cell_val_num() != 1) {
-                throw TileDBSOMAError("[compute_unit_buffer_size] Values per cell > 1 is not supported: " + column);
+                throw TileDBSOMAError("[MemoryPoolAllocationStrategy] Values per cell > 1 is not supported: " + column);
             }
 
             weight += attr.nullable() ? 1 : 0;
@@ -93,14 +103,14 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
                           dim.type() == TILEDB_STRING_UTF8;
 
             if (!is_var && dim.cell_val_num() != 1) {
-                throw TileDBSOMAError("[compute_unit_buffer_size] Values per cell > 1 is not supported: " + column);
+                throw TileDBSOMAError("[MemoryPoolAllocationStrategy] Values per cell > 1 is not supported: " + column);
             }
 
             weight += (dim.type() == TILEDB_STRING_ASCII || dim.type() == TILEDB_STRING_UTF8) ?
                           sizeof(uint64_t) * (1 + var_size_expansion_factor) :
                           tiledb::impl::type_size(dim.type());
         } else {
-            throw TileDBSOMAError(fmt::format("[compute_unit_buffer_size] Missing column name '{}'", column));
+            throw TileDBSOMAError(fmt::format("[MemoryPoolAllocationStrategy] Missing column name '{}'", column));
         }
     }
 

--- a/libtiledbsoma/src/soma/column_buffer_strategies.cc
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.cc
@@ -22,7 +22,7 @@ BasicAllocationStrategy::BasicAllocationStrategy(const tiledb::Array& array) {
 }
 
 std::pair<size_t, size_t> BasicAllocationStrategy::get_buffer_sizes(
-    std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
+    const std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
     return std::visit(
         [&](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
@@ -109,7 +109,7 @@ MemoryPoolAllocationStrategy::MemoryPoolAllocationStrategy(std::span<std::string
 }
 
 std::pair<size_t, size_t> MemoryPoolAllocationStrategy::get_buffer_sizes(
-    std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
+    const std::variant<tiledb::Attribute, tiledb::Dimension> column) const {
     return std::visit(
         [&](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;

--- a/libtiledbsoma/src/soma/column_buffer_strategies.h
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.h
@@ -33,6 +33,9 @@ class BasicAllocationStrategy : public ColumnBufferAllocationStrategy {
     size_t buffer_size = 1 << 30;
 };
 
+inline constexpr size_t DEFAULT_MEMORY_POOL = 1 << 30;
+inline constexpr size_t DEFAULT_VAR_SIZE_FACTOR = 2;
+
 class MemoryPoolAllocationStrategy : public ColumnBufferAllocationStrategy {
    public:
     MemoryPoolAllocationStrategy(std::span<std::string> columns, const tiledb::Array& array);
@@ -41,8 +44,8 @@ class MemoryPoolAllocationStrategy : public ColumnBufferAllocationStrategy {
         std::variant<tiledb::Attribute, tiledb::Dimension> column) const override;
 
    private:
-    size_t buffer_unit_size;
-    size_t var_size_expansion_factor;
+    size_t buffer_unit_size = 1 << 30;
+    size_t var_size_expansion_factor = 2;
 };
 }  // namespace tiledbsoma
 #endif

--- a/libtiledbsoma/src/soma/column_buffer_strategies.h
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.h
@@ -19,7 +19,7 @@ class ColumnBufferAllocationStrategy {
     virtual ~ColumnBufferAllocationStrategy() = default;
 
     virtual std::pair<size_t, size_t> get_buffer_sizes(
-        std::variant<tiledb::Attribute, tiledb::Dimension> column) const = 0;
+        const std::variant<tiledb::Attribute, tiledb::Dimension> column) const = 0;
 };
 
 class BasicAllocationStrategy : public ColumnBufferAllocationStrategy {
@@ -41,7 +41,7 @@ class MemoryPoolAllocationStrategy : public ColumnBufferAllocationStrategy {
     MemoryPoolAllocationStrategy(std::span<std::string> columns, const tiledb::Array& array);
 
     std::pair<size_t, size_t> get_buffer_sizes(
-        std::variant<tiledb::Attribute, tiledb::Dimension> column) const override;
+        const std::variant<tiledb::Attribute, tiledb::Dimension> column) const override;
 
    private:
     size_t buffer_unit_size = 1 << 30;

--- a/libtiledbsoma/src/soma/column_buffer_strategies.h
+++ b/libtiledbsoma/src/soma/column_buffer_strategies.h
@@ -1,0 +1,48 @@
+#ifndef COLUMN_BUFFER_STRATEGIES_H
+#define COLUMN_BUFFER_STRATEGIES_H
+
+#include <tiledb/tiledb>
+
+#include <span>
+#include <utility>
+#include <variant>
+
+namespace tiledbsoma {
+
+inline constexpr std::string_view CONFIG_KEY_INIT_BYTES = "soma.init_buffer_bytes";
+
+inline constexpr std::string_view CONFIG_KEY_MEMORY_POOL_SIZE{"soma.read.memory_budget"};
+inline constexpr std::string_view CONFIG_KEY_VAR_SIZED_FACTOR{"soma.read.var_size_factor"};
+
+class ColumnBufferAllocationStrategy {
+   public:
+    virtual ~ColumnBufferAllocationStrategy() = default;
+
+    virtual std::pair<size_t, size_t> get_buffer_sizes(
+        std::variant<tiledb::Attribute, tiledb::Dimension> column) const = 0;
+};
+
+class BasicAllocationStrategy : public ColumnBufferAllocationStrategy {
+   public:
+    BasicAllocationStrategy(const tiledb::Array& array);
+
+    std::pair<size_t, size_t> get_buffer_sizes(
+        std::variant<tiledb::Attribute, tiledb::Dimension> column) const override;
+
+   private:
+    size_t buffer_size = 1 << 30;
+};
+
+class MemoryPoolAllocationStrategy : public ColumnBufferAllocationStrategy {
+   public:
+    MemoryPoolAllocationStrategy(std::span<std::string> columns, const tiledb::Array& array);
+
+    std::pair<size_t, size_t> get_buffer_sizes(
+        std::variant<tiledb::Attribute, tiledb::Dimension> column) const override;
+
+   private:
+    size_t buffer_unit_size;
+    size_t var_size_expansion_factor;
+};
+}  // namespace tiledbsoma
+#endif

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -18,9 +18,9 @@
 
 #include <unordered_set>
 
+#include "column_buffer_strategies.h"
 #include "common/logging/impl/logger.h"
 #include "common/logging/logger.h"
-#include "column_buffer_strategies.h"
 #include "utils/common.h"
 #include "utils/util.h"
 

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -20,6 +20,7 @@
 
 #include "common/logging/impl/logger.h"
 #include "common/logging/logger.h"
+#include "column_buffer_strategies.h"
 #include "utils/common.h"
 #include "utils/util.h"
 
@@ -152,7 +153,8 @@ void ManagedQuery::setup_read() {
     LOG_TRACE("[ManagedQuery] allocate new buffers");
     if (!buffers_) {
         if (ArrayBuffers::use_memory_pool(array_)) {
-            buffers_ = std::make_shared<ArrayBuffers>(columns_, *array_);
+            buffers_ = std::make_shared<ArrayBuffers>(
+                columns_, *array_, std::make_unique<MemoryPoolAllocationStrategy>(columns_, *array_));
         } else {
             buffers_ = std::make_shared<ArrayBuffers>();
             for (auto& name : columns_) {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -154,7 +154,7 @@ void ManagedQuery::setup_read() {
     if (!buffers_) {
         if (ArrayBuffers::use_memory_pool(array_)) {
             buffers_ = std::make_shared<ArrayBuffers>(
-                columns_, *array_, std::make_unique<MemoryPoolAllocationStrategy>(columns_, *array_));
+                columns_, *array_, std::make_shared<MemoryPoolAllocationStrategy>(columns_, *array_));
         } else {
             buffers_ = std::make_shared<ArrayBuffers>();
             for (auto& name : columns_) {

--- a/libtiledbsoma/src/soma/managed_query.cc
+++ b/libtiledbsoma/src/soma/managed_query.cc
@@ -154,13 +154,9 @@ void ManagedQuery::setup_read() {
     if (!buffers_) {
         if (ArrayBuffers::use_memory_pool(array_)) {
             buffers_ = std::make_shared<ArrayBuffers>(
-                columns_, *array_, std::make_shared<MemoryPoolAllocationStrategy>(columns_, *array_));
+                columns_, *array_, std::make_unique<MemoryPoolAllocationStrategy>(columns_, *array_));
         } else {
-            buffers_ = std::make_shared<ArrayBuffers>();
-            for (auto& name : columns_) {
-                LOG_DEBUG(fmt::format("[ManagedQuery] [{}] Adding buffer for column '{}'", name_, name));
-                buffers_->emplace(name, VectorColumnBuffer::create(array_, name));
-            }
+            buffers_ = std::make_shared<ArrayBuffers>(columns_, *array_);
         }
     }
 

--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -53,6 +53,8 @@ class StatusAndException {
 
 class ManagedQuery {
    public:
+    inline static const size_t MAX_RETRIES = 3;
+
     //===================================================================
     //= public non-static
     //===================================================================
@@ -604,6 +606,8 @@ class ManagedQuery {
 
     // Query layout
     ResultOrder layout_ = ResultOrder::automatic;
+
+    size_t retries = 0;
 
     uint64_t _get_max_capacity(tiledb_datatype_t index_type);
 


### PR DESCRIPTION
**Issue and/or context:** [SOMA 796](https://linear.app/tiledb/issue/SOMA-796/check-query-incomplete-status-reason-and-cancel-if-not-completing)

**Changes:**
This PR introduces the following changes:
- Enable read buffer resize in case the read query returns zero results due to insufficient buffer size. Adds a retry limit for up to 3 times except for incomplete queries which return data.
- Refactor different memory allocation scheme selection to make `ArrayBuffers` generic.
- Extend the `ColumnBuffer` public API to report maximum capacity for reads