### PR TITLE
[r] Test coverage for duplicate key behavior in SOMA collections

### DIFF
--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -24,6 +24,7 @@
 
 ## Fixed
 
+- Fixed `SOMACollectionBase$set()` allowing replacement of existing members after reopening the collection. The method now consistently rejects duplicate keys both within the same session and across sessions. ([#4378](https://github.com/single-cell-data/TileDB-SOMA/pull/4378))
 - The SOMA Context is only cached as an environment variable when the function `soma_context` is called directly. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 - `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 - Fixed `SOMACollectionBase$remove()` incorrectly accessing `self$mode` instead of calling `self$mode()`.

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -165,6 +165,16 @@ SOMACollectionBase <- R6::R6Class(
     #' @description Add a new SOMA object to the collection
     #' (lifecycle: maturing).
     #'
+    #' This method adds an existing SOMA object to the collection under the
+
+    #' specified key. Replacing an existing key is not supported; attempting to
+    #' add an object with a key that already exists will raise an error.
+    #'
+    #' @note This method is not supported for Carrara (TileDB v3) URIs. For
+    #' Carrara collections, use the `add_new_*` methods instead, which create
+    #' child objects at nested URIs that are automatically registered with the
+    #' parent collection.
+    #'
     #' @param object SOMA object.
     #' @param name The name to use for the object; defaults to the basename of
     #' \code{object$uri}.

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -166,7 +166,6 @@ SOMACollectionBase <- R6::R6Class(
     #' (lifecycle: maturing).
     #'
     #' This method adds an existing SOMA object to the collection under the
-
     #' specified key. Replacing an existing key is not supported; attempting to
     #' add an object with a key that already exists will raise an error.
     #'

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -199,6 +199,14 @@ SOMACollectionBase <- R6::R6Class(
       # Default name to URI basename
       name <- name %||% basename(object$uri)
 
+      # Prevent replacing existing keys with new objects
+      if (name %in% self$names()) {
+        stop(
+          sprintf("replacing key '%s' is unsupported", name),
+          call. = FALSE
+        )
+      }
+
       # Determine whether to use relative URI
       relative <- relative %||% is_relative_uri(object$uri)
       if (!(isTRUE(relative) || isFALSE(relative))) {

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -7,6 +7,12 @@
 Base class for objects containing persistent collection of SOMA
 objects, mapping string keys to any SOMA object (lifecycle: maturing).
 }
+\note{
+This method is not supported for Carrara (TileDB v3) URIs. For
+Carrara collections, use the \verb{add_new_*} methods instead, which create
+child objects at nested URIs that are automatically registered with the
+parent collection.
+}
 \section{Carrara (TileDB v3) behavior}{
 
 
@@ -124,6 +130,10 @@ Invisibly returns \code{self}.
 \subsection{Method \code{set()}}{
 Add a new SOMA object to the collection
 (lifecycle: maturing).
+
+This method adds an existing SOMA object to the collection under the
+specified key. Replacing an existing key is not supported; attempting to
+add an object with a key that already exists will raise an error.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$set(object, name = NULL, relative = NULL)}\if{html}{\out{</div>}}
 }

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -199,8 +199,8 @@ test_that("SOMACollection set() rejects duplicate key in same session", {
   collection <- SOMACollectionCreate(uri)
   withr::defer(collection$close())
 
-  sdf1 <- create_and_populate_soma_dataframe(file.path(uri, "sdf1"))
-  sdf2 <- create_and_populate_soma_dataframe(file.path(uri, "sdf2"))
+  sdf1 <- create_and_populate_soma_dataframe(file.path(uri, "df1"), nrows = 5)
+  sdf2 <- create_and_populate_soma_dataframe(file.path(uri, "df2"), nrows = 10)
 
   collection$set(sdf1, name = "foo")
   expect_true("foo" %in% collection$names())
@@ -220,6 +220,12 @@ test_that("SOMACollection set() rejects duplicate key in same session", {
       shape = c(15, 15),
     )
   }, regexp = "Member 'foo' already exists")
+  collection$close()
+
+  # Verify original sdf1 is still there
+  collection <- SOMACollectionOpen(uri)
+  expect_s3_class(collection$get("foo"), "SOMADataFrame")
+  expect_equal(collection$get("foo")$read()$concat()$num_rows, 5)
 })
 
 test_that("SOMACollection set() rejects duplicate key after reopen", {

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -207,7 +207,7 @@ test_that("SOMACollection set() rejects duplicate key in same session", {
 
   expect_error(
     collection$set(sdf2, name = "foo"),
-    regexp = "Cannot add group member foo, a member with the same name or URI"
+    regexp = "replacing key 'foo' is unsupported"
   )
 
   expect_true("foo" %in% collection$names())

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -207,10 +207,19 @@ test_that("SOMACollection set() rejects duplicate key in same session", {
 
   expect_error(
     collection$set(sdf2, name = "foo"),
-    regexp = "replacing key 'foo' is unsupported"
+    regexp = "Cannot add group member foo, a member with the same name or URI"
   )
 
   expect_true("foo" %in% collection$names())
+
+  # Cannot add_new_* with existing key
+  expect_error({
+    collection$add_new_sparse_ndarray(
+      key = "foo",
+      type = arrow::int32(),
+      shape = c(15, 15),
+    )
+  }, regexp = "Member 'foo' already exists")
 })
 
 test_that("SOMACollection set() rejects duplicate key after reopen", {


### PR DESCRIPTION
## Issue and/or context

[SOMA-818](https://linear.app/tiledb/issue/SOMA-818/r-add-test-coverage-for-duplicate-key-behavior-in-soma-collections)

## Changes

Add test coverage for duplicate key handling in R SOMA collections via `write_soma()` and `SOMACollection$set()`.

- Added two new test cases for `SOMACollection$set()` to:
  - verify that attempting to add a member with an existing key within the same session throws an error and the original member is preserved
  - verify the same duplicate key rejection behavior persists after closing and reopening the collection
- Both tests also verify that `add_new_*` methods reject existing keys with "Member 'foo' already exists" error

- Added test case for `write_soma()` to:
  - verify that `write_soma()` emits an `existingKeyWarning` condition when attempting to register an object with a duplicate key (when `verbose = TRUE`)
  - confirm the original data was preserved and not replaced

## Notes for Reviewer

The new tests revealed a bug in R's `SOMACollectionBase$set()` method. The test at `test-06-SOMACollection.R:245` was expected to throw an error but it actually allowed replacing an existing member after reopening the collection (see test failure [here](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/21215626427/job/61036334902?pr=4378#step:7:524).

```r
collection$set(sdf1, name = "foo")
collection$close()
collection <- SOMACollectionOpen(uri, mode = "WRITE")
collection$set(sdf2, name = "foo")  # No error - silently allows replacement
```

This behavior differs from Python's `Collection.__setitem__()`, which correctly raises an error when attempting to add a duplicate key, both within the same session and after reopening the collection.

```python
collection["foo"] = obj1
collection["foo"] = obj2  # Raises SOMAError: "replacing key 'foo' is unsupported"
```
