### PR TITLE
[Backport to release-2.3] [r] Test coverage for duplicate key behavior in SOMA collections (#4378)

### DIFF
--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -15,9 +15,10 @@
 
 ## Fixed
 
-- `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
+- Fixed `SOMACollectionBase$set()` allowing replacement of existing members after reopening the collection. The method now consistently rejects duplicate keys both within the same session and across sessions. ([#4378](https://github.com/single-cell-data/TileDB-SOMA/pull/4378))
 - Fixed `SOMACollectionBase$remove()` incorrectly accessing `self$mode` instead of calling `self$mode()`.
 - Fixed collection member cache not properly handling DELETE mode.
+- `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 
 # tiledbsoma 2.2.0
 

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -165,6 +165,15 @@ SOMACollectionBase <- R6::R6Class(
     #' @description Add a new SOMA object to the collection
     #' (lifecycle: maturing).
     #'
+    #' This method adds an existing SOMA object to the collection under the
+    #' specified key. Replacing an existing key is not supported; attempting to
+    #' add an object with a key that already exists will raise an error.
+    #'
+    #' @note This method is not supported for Carrara (TileDB v3) URIs. For
+    #' Carrara collections, use the `add_new_*` methods instead, which create
+    #' child objects at nested URIs that are automatically registered with the
+    #' parent collection.
+    #'
     #' @param object SOMA object.
     #' @param name The name to use for the object; defaults to the basename of
     #' \code{object$uri}.
@@ -198,6 +207,14 @@ SOMACollectionBase <- R6::R6Class(
 
       # Default name to URI basename
       name <- name %||% basename(object$uri)
+
+      # Prevent replacing existing keys with new objects
+      if (name %in% self$names()) {
+        stop(
+          sprintf("replacing key '%s' is unsupported", name),
+          call. = FALSE
+        )
+      }
 
       # Determine whether to use relative URI
       relative <- relative %||% is_relative_uri(object$uri)

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -7,6 +7,12 @@
 Base class for objects containing persistent collection of SOMA
 objects, mapping string keys to any SOMA object (lifecycle: maturing).
 }
+\note{
+This method is not supported for Carrara (TileDB v3) URIs. For
+Carrara collections, use the \verb{add_new_*} methods instead, which create
+child objects at nested URIs that are automatically registered with the
+parent collection.
+}
 \section{Carrara (TileDB v3) behavior}{
 
 
@@ -124,6 +130,10 @@ Invisibly returns \code{self}.
 \subsection{Method \code{set()}}{
 Add a new SOMA object to the collection
 (lifecycle: maturing).
+
+This method adds an existing SOMA object to the collection under the
+specified key. Replacing an existing key is not supported; attempting to
+add an object with a key that already exists will raise an error.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SOMACollectionBase$set(object, name = NULL, relative = NULL)}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
* Test write_soma throws existingKeyWarning

* SOMACollection tests for duplicate key handling

* Update expected error for duplicate key handling

* Verify original child wasn't replaced

* Add tests for duplicate handling across sessions

* Prevent replacing existing keys across write sessions

* Update NEWS.md

* Update SOMACollection docs

* Remove empty line



---------


(cherry picked from commit 29ef58af0cd8dfdd2c909470155ea7d549f3fc75)
