### PR TITLE
[python] Pin pandas to be less than 3.0.0

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -344,7 +344,7 @@ setuptools.setup(
         "attrs>=22.2",
         "more-itertools",
         "numpy",
-        "pandas",
+        "pandas<3.0.0",
         "pyarrow",
         "scanpy>=1.9.2",
         "scipy",


### PR DESCRIPTION
Add a temporary pin until we can fix test failures using `pandas==3.0.0` (see SOMA-826).