### PR TITLE
[r] Add Carrara test coverage for duplicate key behavior

### DIFF
--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -835,7 +835,7 @@ write_soma.TsparseMatrix <- function(
       inherits(x = soma_parent, what = "SOMACollectionBase"),
     "'relative' must be a single logical value" = is_scalar_logical(relative)
   )
-  if (!isFALSE(relative)) {
+  if (isTRUE(relative)) {
     if (basename(uri) != uri) {
       warning("uri", call. = FALSE, immediate. = TRUE)
       uri <- basename(uri)

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -799,6 +799,35 @@ write_soma.TsparseMatrix <- function(
   return(x)
 }
 
+#' Validate and Resolve a SOMA URI
+#'
+#' Validates and resolves a URI for creating a new SOMA object. When `relative`
+#' is `TRUE`, the function ensures the URI contains only a basename (no path
+#' components) and constructs a full path relative to the parent collection.
+#' When `relative` is `FALSE`, it creates parent directories for local URIs.
+#'
+#' @param uri A single character string specifying the target URI or name.
+#' @param soma_parent A `SOMACollectionBase` object representing the parent
+#'   collection, or `NULL` for top-level objects.
+#' @param relative Logical; if `TRUE` (default), `uri` is treated as a relative
+#'   path and resolved against `soma_parent$uri`. If `FALSE`, `uri` is treated
+#'   as an absolute path.
+#'
+#' @return The resolved URI as a character string.
+#'
+#' @details
+#' When `relative = TRUE`:
+#' - If `uri` contains path separators, a warning is issued and only the
+#'   basename is used.
+#' - The resolved path is constructed by joining `soma_parent$uri` (or
+#'   `tools::R_user_dir("tiledbsoma")` if `soma_parent` is `NULL`) with the
+#'   basename.
+#'
+#' When `relative = FALSE`:
+#' - For local (non-remote) URIs, parent directories are created if they don't
+#'   exist.
+#'
+#' @noRd
 .check_soma_uri <- function(uri, soma_parent = NULL, relative = TRUE) {
   stopifnot(
     "'uri' must be a single character value" = is_scalar_character(uri),

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -821,8 +821,7 @@ write_soma.TsparseMatrix <- function(
 #'
 #' @details
 #' When `relative = TRUE`:
-#' - If `uri` contains path separators, a warning is issued and only the
-#'   basename is used.
+#' - If `uri` contains path separators, only the basename is used.
 #' - The resolved path is constructed by joining `soma_parent$uri` (or
 #'   `tools::R_user_dir("tiledbsoma")` if `soma_parent` is `NULL`) with the
 #'   basename.
@@ -843,7 +842,6 @@ write_soma.TsparseMatrix <- function(
   )
   if (isTRUE(relative)) {
     if (basename(uri) != uri) {
-      warning("uri", call. = FALSE, immediate. = TRUE)
       uri <- basename(uri)
     }
     uri <- file_path(soma_parent$uri %||% tools::R_user_dir("tiledbsoma"), uri)

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -809,6 +809,8 @@ write_soma.TsparseMatrix <- function(
 #' is `TRUE`, the function ensures the URI contains only a basename (no path
 #' components) and constructs a full path relative to the parent collection.
 #' When `relative` is `FALSE`, it creates parent directories for local URIs.
+#' For Carrara (TileDB v3) URIs, it also validates that `key` matches the URI
+#' basename.
 #'
 #' @param uri A single character string specifying the target URI or name.
 #' @param soma_parent A `SOMACollectionBase` object representing the parent
@@ -816,6 +818,8 @@ write_soma.TsparseMatrix <- function(
 #' @param relative Logical; if `TRUE` (default), `uri` is treated as a relative
 #'   path and resolved against `soma_parent$uri`. If `FALSE`, `uri` is treated
 #'   as an absolute path.
+#' @param key A single non-empty character string specifying the member name
+#'   within `soma_parent`, or `NULL`. Used to validate Carrara URI requirements.
 #'
 #' @return The resolved URI as a character string.
 #'
@@ -829,6 +833,11 @@ write_soma.TsparseMatrix <- function(
 #' When `relative = FALSE`:
 #' - For local (non-remote) URIs, parent directories are created if they don't
 #'   exist.
+#'
+#' For Carrara (TileDB v3) URIs:
+#' - When both `soma_parent` and `key` are provided, the function validates that
+#'   `key` matches the basename of the resolved `uri`. This is required by the
+#'   Carrara.
 #'
 #' @noRd
 .check_soma_uri <- function(uri, soma_parent = NULL, relative = TRUE, key = NULL) {

--- a/apis/r/tests/testthat/test-carrara-03-uri-enforcement.R
+++ b/apis/r/tests/testthat/test-carrara-03-uri-enforcement.R
@@ -79,7 +79,7 @@ test_that("write_soma rejects key that doesn't match URI basename", {
 
   df <- data.frame(a = 1:5, b = letters[1:5])
 
-  # key="df" but uri ends with "df1" - should error
+  # Error because key="df" but uri ends with "df1"
   expect_error(
     write_soma(
       df,
@@ -91,17 +91,27 @@ test_that("write_soma rejects key that doesn't match URI basename", {
   )
   expect_equal(collection$length(), 0L)
 
-  # When key matches URI basename, should succeed
-  sdf <- write_soma(
+  # Succeeds when key matches URI basename
+  sdf2 <- write_soma(
     df,
     uri = file_path(uri, "df2"),
     soma_parent = collection,
     key = "df2"
   )
-  sdf$close()
+  sdf2$close()
 
   expect_true("df2" %in% collection$names())
   expect_equal(collection$length(), 1L)
+
+  # URI basename is used when no key is provided
+  sdf3 <- write_soma(
+    df,
+    uri = file_path(uri, "df3"),
+    soma_parent = collection
+  )
+  sdf3$close()
+  expect_true("df3" %in% collection$names())
+  expect_equal(collection$length(), 2L)
 })
 
 

--- a/apis/r/tests/testthat/test-cloud-04-error-handling.R
+++ b/apis/r/tests/testthat/test-cloud-04-error-handling.R
@@ -26,3 +26,145 @@ test_that("Error handling for cloud operations", {
     class = "error"
   )
 })
+
+# Tests for Duplicate Key Handling --------------------------------------------
+
+test_that("SOMACollection set() rejects duplicate key in same session", {
+  skip_if_no_cloud()
+
+  uri <- cloud_path()
+  collection <- SOMACollectionCreate(uri)
+  withr::defer(collection$close())
+
+  # Create first dataframe
+  tbl <- arrow::arrow_table(
+    soma_joinid = bit64::as.integer64(0:4),
+    value = 1:5
+  )
+
+  sdf1_uri <- file_path(uri, "df1")
+  sdf1 <- SOMADataFrameCreate(sdf1_uri, tbl$schema, domain = list(soma_joinid = c(0L, 4L)))
+  sdf1$write(tbl)
+  sdf1$close()
+
+  # Create second dataframe
+  tbl2 <- arrow::arrow_table(
+    soma_joinid = bit64::as.integer64(0:9),
+    value = 6:15
+  )
+  sdf2_uri <- file_path(uri, "df2")
+  sdf2 <- SOMADataFrameCreate(sdf2_uri, tbl2$schema, domain = list(soma_joinid = c(0L, 9L)))
+  sdf2$write(tbl2)
+  sdf2$close()
+
+  # Set first with key "foo"
+  sdf1 <- SOMADataFrameOpen(sdf1_uri)
+  collection$set(sdf1, name = "foo")
+  expect_true("foo" %in% collection$names())
+
+  # Attempt to set second with same key - should fail
+  sdf2 <- SOMADataFrameOpen(sdf2_uri)
+  expect_error(
+    collection$set(sdf2, name = "foo"),
+    regexp = "replacing key 'foo' is unsupported"
+  )
+
+  # Attempt add_new_* with same key
+  expect_error(
+    collection$add_new_sparse_ndarray(key = "foo", type = arrow::int32(), shape = c(10, 10)),
+    regexp = "Member 'foo' already exists"
+  )
+
+  # Verify original still there
+  collection$close()
+  collection <- SOMACollectionOpen(uri)
+  expect_s3_class(collection$get("foo"), "SOMADataFrame")
+  expect_equal(collection$get("foo")$read()$concat()$num_rows, 5)
+})
+
+test_that("SOMACollection set() rejects duplicate key after reopen", {
+  skip_if_no_cloud()
+
+  uri <- cloud_path()
+  collection <- SOMACollectionCreate(uri)
+
+  # Create and add first dataframe
+  tbl <- arrow::arrow_table(
+    soma_joinid = bit64::as.integer64(0:4),
+    value = 1:5
+  )
+  sdf1_uri <- file_path(uri, "df1")
+  sdf1 <- SOMADataFrameCreate(sdf1_uri, tbl$schema, domain = list(soma_joinid = c(0L, 4L)))
+  sdf1$write(tbl)
+  sdf1$close()
+
+  sdf1 <- SOMADataFrameOpen(sdf1_uri)
+  collection$set(sdf1, name = "foo")
+  collection$close()
+
+  # Create second dataframe
+  tbl2 <- arrow::arrow_table(
+    soma_joinid = bit64::as.integer64(0:9),
+    value = 6:15
+  )
+  sdf2_uri <- file_path(uri, "df2")
+  sdf2 <- SOMADataFrameCreate(sdf2_uri, tbl2$schema, domain = list(soma_joinid = c(0L, 9L)))
+  sdf2$write(tbl2)
+  sdf2$close()
+
+  # Reopen and attempt duplicate
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  withr::defer(collection$close())
+
+  expect_true("foo" %in% collection$names())
+
+  sdf2 <- SOMADataFrameOpen(sdf2_uri)
+  expect_error(collection$set(sdf2, name = "foo"))
+
+  # Attempt add_new_* with same key after reopen
+  expect_error(
+    collection$add_new_sparse_ndarray(key = "foo", type = arrow::int32(), shape = c(10, 10)),
+    regexp = "Member 'foo' already exists"
+  )
+
+  # Verify original still there
+  collection$close()
+  collection <- SOMACollectionOpen(uri)
+  expect_s3_class(collection$get("foo"), "SOMADataFrame")
+  expect_equal(collection$get("foo")$read()$concat()$num_rows, 5)
+})
+
+test_that("write_soma throws existingKeyWarning for duplicate keys", {
+  skip_if_no_cloud()
+
+  uri <- cloud_path()
+  collection <- SOMACollectionCreate(uri)
+  withr::defer(collection$close())
+
+  df1 <- data.frame(a = 1:5, b = letters[1:5])
+  df2 <- data.frame(x = 6:10, y = letters[6:10])
+
+  # Write first object
+  sdf1 <- write_soma(df1, uri = file_path(uri, "df1"), soma_parent = collection, key = "foo")
+  sdf1$close()
+  expect_true("foo" %in% collection$names())
+
+  # Attempt to write another object with same key (verbose = TRUE)
+  expect_warning(
+    withr::with_options(
+      list(verbose = TRUE),
+      sdf2 <- write_soma(df2, uri = file_path(uri, "df2"), soma_parent = collection, key = "foo")
+    ),
+    class = "existingKeyWarning"
+  )
+
+  # Verify original data preserved
+  expect_equal(collection$length(), 1L)
+
+  collection$close()
+  collection <- SOMACollectionOpen(uri)
+  expect_identical(
+    collection$get("foo")$read()$concat()$a$as_vector(),
+    df1$a
+  )
+})


### PR DESCRIPTION
**Issue and context:** [SOMA-824] This is a follow-on to #4378, which added test coverage for duplicate key handling in the R package. This PR adds coverage specifically for Carrara.

**Changes:**

- `.check_soma_uri()`
  - added an optional `key` parameter used to ensure a collection member name matches the object's URI basename when writing to Carrara
  - this validation occurs before object creation to avoid leave the collection in an invalid state

- `test-carrara-03-uri-enforcement.R`
  - added tests verifying that `write_soma()` rejects mismatched key/URI combinations
  - verified that when `key` is omitted, the URI basename is correctly used as the member name
  - confirmed successful writes when key matches URI basename

- `test-carrara-04-error-handling.R`
  - added tests to verify`SOMACollection$add_new_*()` rejects duplicate keys before and after closing/reopening
  - added tests to verify `write_soma()` errors when attempting to write to an already-existing URI/key

**Notes for reviewer:** Also removed a warning from `.check_soma_uri()` that appears to be a debug leftover.