### PR TITLE
[Backport to release-2.3][python/r] Update R version and changelogs (#4387)

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 2.2.0
+Version: 2.3.0
 Authors@R: c(
     person(given = "Paul", family = "Hoffman",
            role = c("cre", "aut"), email = "tiledb-r@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,11 @@
 - Added `SOMAContext$is_tiledbv2()` and `SOMAContext$is_tiledbv3()` methods to check the data protocol for a given URI.
 - Added Carrara (TileDB v3) support for collection classes. Child objects created at nested Carrara URIs are automatically registered with their parent collection.
 
+## Changed
+
+- `SOMACollectionBase$set()` now throws an `unsupportedOperationError` for Carrara URIs since the Carrara data model does not support adding external objects to collections. Use `add_new_*` methods instead.
+- Reduced some internal diagnostic logging from INFO to DEBUG level.
+
 ## Deprecated
 
 - The function `soma_context` is deprecated. Use class `SOMAContext` instead. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
@@ -16,9 +21,9 @@
 ## Fixed
 
 - Fixed `SOMACollectionBase$set()` allowing replacement of existing members after reopening the collection. The method now consistently rejects duplicate keys both within the same session and across sessions. ([#4378](https://github.com/single-cell-data/TileDB-SOMA/pull/4378))
+- `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 - Fixed `SOMACollectionBase$remove()` incorrectly accessing `self$mode` instead of calling `self$mode()`.
 - Fixed collection member cache not properly handling DELETE mode.
-- `SOMATileDBContext` no longer replaces `sm.mem.reader.sparse_global_order.ratio_array_data` when set in the input config. ([#4355](https://github.com/single-cell-data/TileDB-SOMA/pull/4355))
 
 # tiledbsoma 2.2.0
 

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -430,7 +430,6 @@ SOMACollectionBase <- R6::R6Class(
         index_column_names = index_column_names,
         domain = domain,
         platform_config = platform_config %||% self$platform_config,
-        tiledbsoma_ctx = self$tiledbsoma_ctx,
         context = self$context,
         tiledb_timestamp = self$tiledb_timestamp # Cached value from $new()/SOMACollectionOpen
       )
@@ -459,7 +458,6 @@ SOMACollectionBase <- R6::R6Class(
         type = type,
         shape = shape,
         platform_config = platform_config %||% self$platform_config,
-        tiledbsoma_ctx = self$tiledbsoma_ctx,
         context = self$context,
         tiledb_timestamp = self$tiledb_timestamp
       )
@@ -493,7 +491,6 @@ SOMACollectionBase <- R6::R6Class(
         type = type,
         shape = shape,
         platform_config = platform_config %||% self$platform_config,
-        tiledbsoma_ctx = self$tiledbsoma_ctx,
         context = self$context,
         tiledb_timestamp = self$tiledb_timestamp # Cached value from $new()/SOMACollectionOpen
       )
@@ -816,7 +813,6 @@ SOMACollectionBase <- R6::R6Class(
         uri,
         mode = self$mode(),
         platform_config = self$platform_config,
-        tiledbsoma_ctx = self$tiledbsoma_ctx,
         context = self$context,
         tiledb_timestamp = self$tiledb_timestamp
       ))

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -56,14 +56,14 @@
     EXPR = .deprecation_stage(when = when) %||% "future",
     defunct = lifecycle::deprecate_stop(
       when = as.character(when),
-      what = what,
+      what = I(what),
       with = with,
       details = details,
       env = env
     ),
     deprecate = lifecycle::deprecate_warn(
       when = as.character(when),
-      what = what,
+      what = I(what),
       with = with,
       details = details,
       # lifecycle tries to be clever when determining when to warn; however,

--- a/apis/r/tests/testthat/test-03-SOMATileDBContext.R
+++ b/apis/r/tests/testthat/test-03-SOMATileDBContext.R
@@ -1,5 +1,8 @@
 test_that("SOMATileDBContext mechanics", {
   skip_if(!extended_tests())
+  # Suppress deprecation warnings since we're testing the deprecated class here
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   ctx <- SOMATileDBContext$new()
   expect_true(length(ctx) >= 1L)
   expect_identical(length(ctx), ctx$length())
@@ -15,6 +18,8 @@ test_that("SOMATileDBContext mechanics", {
 
 test_that("SOMATileDBContext SOMA mechanics", {
   skip_if(!extended_tests())
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   ctx <- SOMATileDBContext$new()
   ntiledb <- length(x = ctx$.__enclos_env__$private$.tiledb_ctx_names())
   expect_no_condition(ctx$set("member_uris_are_relative", TRUE))
@@ -47,6 +52,8 @@ test_that("SOMATileDBContext SOMA mechanics", {
 
 test_that("SOMATileDBContext TileDB mechanics", {
   skip_if(!extended_tests())
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   ctx <- SOMATileDBContext$new()
   tiledb_names <- ctx$.__enclos_env__$private$.tiledb_ctx_names()
   expect_identical(ctx$keys(), tiledb_names)
@@ -71,6 +78,8 @@ test_that("SOMATileDBContext TileDB mechanics", {
 
 test_that("SOMATileDBContext SOMA + TileDB mechanics", {
   skip_if(!extended_tests())
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   ctx <- SOMATileDBContext$new()
   tiledb_names <- ctx$.__enclos_env__$private$.tiledb_ctx_names()
   expect_error(

--- a/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
+++ b/apis/r/tests/testthat/test-06-SOMADenseNDArray.R
@@ -326,7 +326,12 @@ test_that("`SOMADenseNDArray$set_data_type()` deprecations", {
     }
   )
 
-  if (utils::packageVersion("tiledbsoma") >= "2.1.0") {
+  # Per POLICIES.md:
+  # deprecated in 2.1.0, defunct after two minor releases (2.3.0)
+  pkg_version <- utils::packageVersion("tiledbsoma")
+  if (pkg_version >= "2.3.0") {
+    lifecycle::expect_defunct(dnda$set_data_type(arrow::int16()))
+  } else if (pkg_version >= "2.1.0") {
     lifecycle::expect_deprecated(dnda$set_data_type(arrow::int16()))
   }
 })

--- a/apis/r/tests/testthat/test-10-SOMAArrayReader-Iterated.R
+++ b/apis/r/tests/testthat/test-10-SOMAArrayReader-Iterated.R
@@ -108,9 +108,9 @@ test_that("Iterated Interface from SOMA Classes", {
 
   # The read_complete et al. in this test case are designed to be verified
   # against 16MB buffer size, and the particular provided input dataset.
-  # The soma_context() is cached at the package level and passed that way
+  # The context is cached at the package level and passed that way
   # to the SOMADataFrame and SOMASparseNDArray classes
-  context_handle <- soma_context(c(soma.init_buffer_bytes = as.character(16777216)))
+  set_default_context(c(soma.init_buffer_bytes = as.character(16777216)), replace = TRUE)
 
   for (tc in test_cases) {
     sdf <- switch(


### PR DESCRIPTION
* Update Python history

* Update R NEWS and version number

* Prevent eval of `what` args in lifecycle::deprecate_* calls

Wrap `what` in `I()` to prevent unintended evaluation of R6 objects. For example: lifecycle::deprecate_warn(what="SOMAExperiment$tiledbsoma_ctx", when="2.3.0")

* Remove internal calls to deprecated self$tiledbsoma_ctx

SOMACollectionBase was calling self$tiledbsoma_ctx, which triggered the deprecation warning from the active bunding.

* Suppress deprecation warnings in SOMATileDBContext tests

Added `withr::local_options(lifecycle_verbosity = "quiet")` to suppress deprecation warnings since we're knowingly testing the deprecated class.

* Update iterated reader tests to leverage new set_default_context()

* Update deprecation handling for `set_data_type()`

- Adjusted tests for `set_data_type()` to reflect deprecation policy

---------


(cherry picked from commit 60406df290c9979186adbb6c2a8c6f29fd6c2e5e)

