### PR TITLE
[r] Add `oldrel-2` to R test matrix configurations

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -68,6 +68,7 @@ jobs:
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
           - {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false}
+          - {os: ubuntu-latest, r: 'oldrel-2', report_codecov: false}
     uses: ./.github/workflows/test-r.yml
     with:
       os: ${{ matrix.config.os }}

--- a/.github/workflows/ci-pr-r.yml
+++ b/.github/workflows/ci-pr-r.yml
@@ -36,6 +36,7 @@ jobs:
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
           - {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false}
+          - {os: ubuntu-latest, r: 'oldrel-2', report_codecov: false}
     uses: ./.github/workflows/test-r.yml
     with:
       os: ${{ matrix.config.os }}


### PR DESCRIPTION
**Issue and/or context:** [SOMA-845]

**Changes:** Update both the PR workflow and the full CI workflow to add `oldrel-2`.

**Notes for Reviewer:** Added temporarily to try and reproduce a conda packaging test failure that occured on R v4.3.x, which isn't covered by the current test matrix.
