### PR TITLE
[c++] Update default log level to warn

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 2.3.99
+Version: 2.3.99.1
 Authors@R: c(
     person(given = "Paul", family = "Hoffman",
            role = c("cre", "aut"), email = "tiledb-r@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,7 @@
 ## Changed
 
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
+- Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
 
 ## Deprecated
 

--- a/libtiledbsoma/src/common/logging/impl/logger.cc
+++ b/libtiledbsoma/src/common/logging/impl/logger.cc
@@ -58,7 +58,7 @@ Logger::Logger() {
         console_sink->set_color(spdlog::level::critical, console_sink->red_bold);
 #endif
     }
-    set_level("INFO");
+    set_level("WARN");
     // Examples:
     // SPDLOG_LEVEL=trace name-of-program
     // SPDLOG_LEVEL=tiledbsoma=trace name-of-program


### PR DESCRIPTION
**Issue and/or context:** [SOMA-844]

**Changes:** Changes the default logging level in `libtiledbsoma` from `INFO` to `WARN` to reduce noise for users and in the R package's test outputs. The `INFO` log level outputs implementation details that are useful for debugging but not actionable for typical users, e.g.:

```log
[2026-01-26 14:09:47.651] [tiledbsoma] [Process: 93743] [Thread: 38614402] [info] [JoinIDCache] Loading obs joinids
[2026-01-26 14:09:47.739] [tiledbsoma] [Process: 93743] [Thread: 38614402] [info] [JoinIDCache] Loading var joinids
[2026-01-26 14:09:48.422] [tiledbsoma] [Process: 93743] [Thread: 38614402] [info] Adding assay 'RNA'
```

**Notes for Reviewer:** Python's `tiledbsoma.logging` module already defaults to `WARNING`. Changing the C++ default to `WARN` aligns both language APIs to the same default level.
