### PR TITLE
[r] Skip tests using deprecated code in envs with lifecycle < 1.0.5

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -50,7 +50,6 @@ Imports:
     stats,
     tiledb (>= 0.34.0),
     tools,
-    lifecycle,
     utils
 LinkingTo:
     nanoarrow,

--- a/apis/r/tests/testthat/test-03-SOMATileDBContext.R
+++ b/apis/r/tests/testthat/test-03-SOMATileDBContext.R
@@ -18,6 +18,9 @@ test_that("SOMATileDBContext mechanics", {
 
 test_that("SOMATileDBContext SOMA mechanics", {
   skip_if(!extended_tests())
+  # lifecycle 1.0.4 emits a lifecycle_stage condition even when
+  # lifecycle_verbosity = "quiet", which causes expect_no_condition() to fail
+  skip_if_not_installed("lifecycle", minimum_version = "1.0.5")
   withr::local_options(lifecycle_verbosity = "quiet")
 
   ctx <- SOMATileDBContext$new()
@@ -52,6 +55,7 @@ test_that("SOMATileDBContext SOMA mechanics", {
 
 test_that("SOMATileDBContext TileDB mechanics", {
   skip_if(!extended_tests())
+  skip_if_not_installed("lifecycle", minimum_version = "1.0.5")
   withr::local_options(lifecycle_verbosity = "quiet")
 
   ctx <- SOMATileDBContext$new()
@@ -78,6 +82,7 @@ test_that("SOMATileDBContext TileDB mechanics", {
 
 test_that("SOMATileDBContext SOMA + TileDB mechanics", {
   skip_if(!extended_tests())
+  skip_if_not_installed("lifecycle", minimum_version = "1.0.5")
   withr::local_options(lifecycle_verbosity = "quiet")
 
   ctx <- SOMATileDBContext$new()


### PR DESCRIPTION
**Issue and/or context:** [SOMA-845]

**Changes:**

 1. `test-03-SOMATileDBContext.R`: Added `skip_if_not_installed("lifecycle", minimum_version = "1.0.5")` to test blocks that use `expect_no_condition()` with deprecation warnings.
 2. `DESCRIPTION`: Removed duplicate lifecycle entry.

**Notes for Reviewer:** In lifecycle 1.0.4, `deprecate_warn()` unconditionally called `signal_stage("deprecated", what)` before checking the lifecycle_verbosity option. This emitted a `lifecycle_stage` condition even when lifecycle_verbosity = "quiet". In 1.0.5, [the `signal_stage()` call was removed from `deprecate_warn()`](https://github.com/r-lib/lifecycle/pull/202/changes#diff-cbc97fa9edc3cf294a04a94e8e54814b51ab557fc83c9f789a1bd03f23b2eb6bL183), fixing the issue.
