### PR TITLE
[r] Drop data.table as a dependency

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -30,7 +30,7 @@ Encoding: UTF-8
 Additional_repositories: https://tiledb-inc.r-universe.dev,
     https://bnprks.r-universe.dev/
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Depends:
     R (>= 4.1.0)

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -37,7 +37,6 @@ Depends:
 Imports:
     arrow (>= 19.0.1),
     bit64 (>= 4.6.0.1),
-    data.table,
     fs,
     glue,
     lifecycle,

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -6,6 +6,7 @@
 
 ## Changed
 
+- Removed `data.table` package dependency by leveraging `rlang::obj_address()` for generating ephemeral collection URIs.
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
 
 ## Deprecated

--- a/apis/r/R/ephemeral.R
+++ b/apis/r/R/ephemeral.R
@@ -294,7 +294,7 @@ EphemeralCollectionBase <- R6::R6Class(
       if (!missing(value)) {
         private$.read_only_error("uri")
       }
-      return(paste0("ephemeral-collection:", data.table::address(self)))
+      return(paste0("ephemeral-collection:", rlang::obj_address(self)))
     },
 
     #' @field members A list with the members of this collection

--- a/apis/r/R/zzz.R
+++ b/apis/r/R/zzz.R
@@ -12,23 +12,6 @@ NULL
 
 .pkgenv <- new.env(parent = emptyenv())
 
-#' Import Helper
-#'
-#' \code{R CMD check} tries to check use of all imported dependencies; however,
-#' it sometimes misses, such as in R6 methods. This function exists to satiate
-#' \code{R CMD check} by showing usage of imported dependencies.
-#'
-#' @return Invisibly returns \code{NULL}.
-#'
-#' @keywords internal
-#'
-#' @noRd
-#'
-.import_helper <- function() {
-  data.table::address
-  return(invisible(NULL))
-}
-
 ## .onLoad is called whether code from the package is used and the packages is 'loaded'. An
 ## example is calling `tiledbsoma::show_package_versions()`. So this is most elementary check,
 ## .onAttach is also called when the package is 'attached' via 'library(tiledbsoma)'

--- a/apis/r/man/BlockwiseSparseReadIter.Rd
+++ b/apis/r/man/BlockwiseSparseReadIter.Rd
@@ -8,7 +8,7 @@ Class that allows for blockwise read iteration of SOMA reads
 as sparse matrices.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "blockwise-matrix")
 dir.create(dir, recursive = TRUE)
 (exp <- load_dataset("soma-exp-pbmc-small", dir))

--- a/apis/r/man/BlockwiseTableReadIter.Rd
+++ b/apis/r/man/BlockwiseTableReadIter.Rd
@@ -8,7 +8,7 @@ Class that allows for blockwise read iteration of SOMA reads
 as Arrow \code{\link[arrow]{Table}s}.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "blockwise-table")
 dir.create(dir, recursive = TRUE)
 (exp <- load_dataset("soma-exp-pbmc-small", dir))

--- a/apis/r/man/CoordsStrider.Rd
+++ b/apis/r/man/CoordsStrider.Rd
@@ -40,7 +40,7 @@ as.list(strider)
 
 length(strider)
 
-\dontshow{if (requireNamespace("itertools", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("itertools", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 (strider <- CoordsStrider$new(start = 1L, end = 200L, stride = 60L))
 while (itertools::hasNext(strider)) {
   str(iterators::nextElem(strider))

--- a/apis/r/man/EphemeralCollection.Rd
+++ b/apis/r/man/EphemeralCollection.Rd
@@ -13,7 +13,7 @@ instead of on-disk.
 (col <- EphemeralCollection$new())
 col$soma_type
 
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "obs")
 dir.create(dir, recursive = TRUE)
 

--- a/apis/r/man/EphemeralExperiment.Rd
+++ b/apis/r/man/EphemeralExperiment.Rd
@@ -13,7 +13,7 @@ instead of on-disk.
 (exp <- EphemeralExperiment$new())
 exp$soma_type
 
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "obs")
 dir.create(dir, recursive = TRUE)
 

--- a/apis/r/man/SOMACollection.Rd
+++ b/apis/r/man/SOMACollection.Rd
@@ -41,7 +41,7 @@ at \code{parent_uri/child} automatically adds the child with key \code{"child"})
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-collection")
 
 (col <- SOMACollectionCreate(uri))

--- a/apis/r/man/SOMACollectionCreate.Rd
+++ b/apis/r/man/SOMACollectionCreate.Rd
@@ -46,7 +46,7 @@ Factory function to create a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-collection")
 
 (col <- SOMACollectionCreate(uri))

--- a/apis/r/man/SOMACollectionOpen.Rd
+++ b/apis/r/man/SOMACollectionOpen.Rd
@@ -40,7 +40,7 @@ Factory function to open a \link[tiledbsoma:SOMACollection]{SOMA collection}
 for reading (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-collection")
 
 (col <- SOMACollectionCreate(uri))

--- a/apis/r/man/SOMADataFrame.Rd
+++ b/apis/r/man/SOMADataFrame.Rd
@@ -10,7 +10,7 @@ contains a unique value for each row and is intended to act as a join key for
 other objects, such as \code{\link{SOMASparseNDArray}} (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-data-frame")
 df <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMADataFrameCreate.Rd
+++ b/apis/r/man/SOMADataFrameCreate.Rd
@@ -66,7 +66,7 @@ Factory function to create a \link[tiledbsoma:SOMADataFrame]{SOMA data frame}
 for writing (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-data-frame")
 df <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMADataFrameOpen.Rd
+++ b/apis/r/man/SOMADataFrameOpen.Rd
@@ -39,7 +39,7 @@ Factory function to open a \link[tiledbsoma:SOMADataFrame]{SOMA data frame}
 for reading (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-data-frame")
 df <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMADenseNDArray.Rd
+++ b/apis/r/man/SOMADenseNDArray.Rd
@@ -26,7 +26,7 @@ null value of the array type (e.g.,
 \code{\link[arrow:float32]{arrow::float32}()} defaults to 0.0).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-dense-array")
 mat <- matrix(stats::rnorm(100L ^ 2L), nrow = 100L, ncol = 100L)
 mat[1:3, 1:5]

--- a/apis/r/man/SOMADenseNDArrayCreate.Rd
+++ b/apis/r/man/SOMADenseNDArrayCreate.Rd
@@ -43,7 +43,7 @@ Factory function to create a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-dense-array")
 mat <- matrix(stats::rnorm(100L ^ 2L), nrow = 100L, ncol = 100L)
 mat[1:3, 1:5]

--- a/apis/r/man/SOMADenseNDArrayOpen.Rd
+++ b/apis/r/man/SOMADenseNDArrayOpen.Rd
@@ -40,7 +40,7 @@ Factory function to open a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-dense-array")
 mat <- matrix(stats::rnorm(100L ^ 2L), nrow = 100L, ncol = 100L)
 mat[1:3, 1:5]

--- a/apis/r/man/SOMAExperiment.Rd
+++ b/apis/r/man/SOMAExperiment.Rd
@@ -41,7 +41,7 @@ at \code{parent_uri/child} automatically adds the child with key \code{"child"})
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-experiment")
 obs <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAExperimentCreate.Rd
+++ b/apis/r/man/SOMAExperimentCreate.Rd
@@ -46,7 +46,7 @@ Factory function to create a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-experiment")
 obs <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAExperimentOpen.Rd
+++ b/apis/r/man/SOMAExperimentOpen.Rd
@@ -40,7 +40,7 @@ Factory function to open a \link[tiledbsoma:SOMAExperiment]{SOMA experiment}
 for reading (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-experiment")
 obs <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAMeasurement.Rd
+++ b/apis/r/man/SOMAMeasurement.Rd
@@ -41,7 +41,7 @@ at \code{parent_uri/child} automatically adds the child with key \code{"child"})
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-measurement")
 var <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAMeasurementCreate.Rd
+++ b/apis/r/man/SOMAMeasurementCreate.Rd
@@ -46,7 +46,7 @@ Factory function to create a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-measurement")
 var <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAMeasurementOpen.Rd
+++ b/apis/r/man/SOMAMeasurementOpen.Rd
@@ -41,7 +41,7 @@ Factory function to open a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-measurement")
 var <- data.frame(
   soma_joinid = bit64::seq.integer64(0L, 99L),

--- a/apis/r/man/SOMAOpen.Rd
+++ b/apis/r/man/SOMAOpen.Rd
@@ -39,7 +39,7 @@ Utility function to open the corresponding SOMA object given a URI
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "soma-open")
 dir.create(dir, recursive = TRUE)
 

--- a/apis/r/man/SOMASparseNDArray.Rd
+++ b/apis/r/man/SOMASparseNDArray.Rd
@@ -31,7 +31,7 @@ the object are overwritten and new index values are added
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-sparse-array")
 mat <- Matrix::rsparsematrix(100L, 100L, 0.7, repr = "T")
 mat[1:3, 1:5]

--- a/apis/r/man/SOMASparseNDArrayCreate.Rd
+++ b/apis/r/man/SOMASparseNDArrayCreate.Rd
@@ -53,7 +53,7 @@ Factory function to create a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-sparse-array")
 mat <- Matrix::rsparsematrix(100L, 100L, 0.7, repr = "T")
 mat[1:3, 1:5]

--- a/apis/r/man/SOMASparseNDArrayOpen.Rd
+++ b/apis/r/man/SOMASparseNDArrayOpen.Rd
@@ -40,7 +40,7 @@ Factory function to open a
 (lifecycle: maturing).
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-sparse-array")
 mat <- Matrix::rsparsematrix(100L, 100L, 0.7, repr = "T")
 mat[1:3, 1:5]

--- a/apis/r/man/SOMATileDBContext.Rd
+++ b/apis/r/man/SOMATileDBContext.Rd
@@ -7,7 +7,7 @@
 Context map for TileDB-backed SOMA objects
 }
 \examples{
-\dontshow{if (requireNamespace("tiledb", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("tiledb", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 (ctx <- SOMATileDBContext$new())
 ctx$get("sm.mem.reader.sparse_global_order.ratio_array_data")
 

--- a/apis/r/man/SparseReadIter.Rd
+++ b/apis/r/man/SparseReadIter.Rd
@@ -8,7 +8,7 @@
 a reads on \link{SOMASparseNDArray}.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "matrix-iter")
 dir.create(dir, recursive = TRUE)
 (exp <- load_dataset("soma-exp-pbmc-small", dir))

--- a/apis/r/man/TableReadIter.Rd
+++ b/apis/r/man/TableReadIter.Rd
@@ -9,7 +9,7 @@ a reads on \link{SOMASparseNDArray} and \link{SOMADataFrame}.
 Iteration chunks are retrieved as an Arrow \link[arrow]{Table}.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "table-iter")
 dir.create(dir, recursive = TRUE)
 (exp <- load_dataset("soma-exp-pbmc-small", dir))

--- a/apis/r/man/example-datasets.Rd
+++ b/apis/r/man/example-datasets.Rd
@@ -53,13 +53,13 @@ SOMA object.
 \examples{
 list_datasets()
 
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "pbmc-small")
 dir.create(dir, recursive = TRUE)
 dest <- extract_dataset("soma-exp-pbmc-small", dir)
 list.files(dest)
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 dir <- withr::local_tempfile(pattern = "pbmc_small")
 dir.create(dir, recursive = TRUE)
 (exp <- load_dataset("soma-exp-pbmc-small", dir))

--- a/apis/r/man/write_soma.Rd
+++ b/apis/r/man/write_soma.Rd
@@ -49,7 +49,7 @@ function and methods can be written for it to provide a high-level
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a Bioconductor S4 DataFrame object to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-data-frame")
 data("pbmc_small", package = "SeuratObject")
@@ -60,7 +60,7 @@ head(obs <- as(obs, "DataFrame"))
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a Bioconductor SelfHits object to a SOMA
 uri <- withr::local_tempfile(pattern = "hits")
 (hits <- S4Vectors::SelfHits(
@@ -74,14 +74,14 @@ uri <- withr::local_tempfile(pattern = "hits")
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a character vector to a SOMA
 uri <- withr::local_tempfile(pattern = "character")
 (sdf <- write_soma(letters, uri, soma_parent = NULL, relative = FALSE))
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a data.frame to a SOMA
 uri <- withr::local_tempfile(pattern = "data-frame")
 data("pbmc_small", package = "SeuratObject")
@@ -91,10 +91,10 @@ head(obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]])
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("BPCells", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("BPCells", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a BPCells `IterableMatrix` to a SOMA
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "matrix")
 mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
@@ -102,7 +102,7 @@ mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a dense S4 Matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-matrix")
 mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
@@ -110,7 +110,7 @@ mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a TsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "tsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "T")

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -200,7 +200,7 @@ as \link[tiledbsoma:SOMADataFrame]{data frames} to the
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 \donttest{
 uri <- withr::local_tempfile(pattern = "pbmc-small")
 

--- a/apis/r/man/write_soma.SingleCellExperiment.Rd
+++ b/apis/r/man/write_soma.SingleCellExperiment.Rd
@@ -101,7 +101,7 @@ the \code{\link[tiledbsoma:SOMAMeasurement]{measurement}} level.
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SingleCellExperiment", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SingleCellExperiment", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 \donttest{
 uri <- withr::local_tempfile(pattern = "single-cell-experiment")
 

--- a/apis/r/man/write_soma.SummarizedExperiment.Rd
+++ b/apis/r/man/write_soma.SummarizedExperiment.Rd
@@ -76,7 +76,7 @@ the \code{\link[tiledbsoma:SOMAMeasurement]{measurement}} level.
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SummarizedExperiment", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SummarizedExperiment", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 \donttest{
 uri <- withr::local_tempfile(pattern = "summarized-experiment")
 

--- a/apis/r/man/write_soma_objects.Rd
+++ b/apis/r/man/write_soma_objects.Rd
@@ -257,7 +257,7 @@ The array type is determined by \code{type}, or
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a Bioconductor S4 DataFrame object to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-data-frame")
 data("pbmc_small", package = "SeuratObject")
@@ -268,7 +268,7 @@ head(obs <- as(obs, "DataFrame"))
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("S4Vectors", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a Bioconductor SelfHits object to a SOMA
 uri <- withr::local_tempfile(pattern = "hits")
 (hits <- S4Vectors::SelfHits(
@@ -282,14 +282,14 @@ uri <- withr::local_tempfile(pattern = "hits")
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a character vector to a SOMA
 uri <- withr::local_tempfile(pattern = "character")
 (sdf <- write_soma(letters, uri, soma_parent = NULL, relative = FALSE))
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a data.frame to a SOMA
 uri <- withr::local_tempfile(pattern = "data-frame")
 data("pbmc_small", package = "SeuratObject")
@@ -299,10 +299,10 @@ head(obs <- suppressWarnings(SeuratObject::UpdateSeuratObject(pbmc_small))[[]])
 
 sdf$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("BPCells", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE) && requireNamespace("BPCells", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a BPCells `IterableMatrix` to a SOMA
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "matrix")
 mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
@@ -310,7 +310,7 @@ mat <- matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a dense S4 Matrix to a SOMA
 uri <- withr::local_tempfile(pattern = "s4-matrix")
 mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
@@ -318,7 +318,7 @@ mat <- Matrix::Matrix(stats::rnorm(25L), nrow = 5L, ncol = 5L)
 
 arr$close()
 \dontshow{\}) # examplesIf}
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 # Write a TsparseMatrix to a SOMA
 uri <- withr::local_tempfile(pattern = "tsparse-matrix")
 mat <- Matrix::rsparsematrix(5L, 5L, 0.3, repr = "T")

--- a/apis/r/man/write_soma_seurat_sub.Rd
+++ b/apis/r/man/write_soma_seurat_sub.Rd
@@ -272,7 +272,7 @@ as \link[tiledbsoma:SOMADataFrame]{data frames} to the
 }
 
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE) && requireNamespace("SeuratObject", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "seurat-sub")
 
 data("pbmc_small", package = "SeuratObject")


### PR DESCRIPTION
**Issue and/or context:** [SOMA-846]

**Changes:**

- Dropped `data.table` as a dependency
- Replaced `data.table::address()` with `rlang::obj_address()` in `EphemeralCollectionBase$uri` method
- Removed `.import_helper()` function from `zzz.R` (which was only needed to satisfy R CMD check for data.table usage)
- Updated roxygen2 and regenerated docs

**Notes for Reviewer:** The large line count in `man/` is a result of updating roxygen to 7.3.3 and regenerating docs.
