### PR TITLE
[c++] Fix enumeration value check for MacOS builds

### DIFF
--- a/libtiledbsoma/src/soma/managed_query.h
+++ b/libtiledbsoma/src/soma/managed_query.h
@@ -950,7 +950,10 @@ class ManagedQuery {
                     shifted_indexes[i] = static_cast<DiskIndexType>(enumeration.index_of(enum_values[oi]).value());
                 } else {
                     shifted_indexes[i] = static_cast<DiskIndexType>(
-                        enumeration.index_of<ValueType>(enum_values[oi]).value());
+                        enumeration
+                            .index_of(
+                                std::string_view(reinterpret_cast<const char*>(&enum_values[oi]), sizeof(ValueType)))
+                            .value());
                 }
             }
         }


### PR DESCRIPTION
**Issue and/or context:** [tiledbsoma-feedstock Issue 369](https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/369)

**Changes:**
Use the `std::string_view` overload to check if value is present in an enumeration because of missing type definition after Xcode 16.3

**Notes for Reviewer:**
