### PR TITLE
Clean-up soma_array header

### DIFF
--- a/libtiledbsoma/src/cli/cli.cc
+++ b/libtiledbsoma/src/cli/cli.cc
@@ -14,6 +14,7 @@
 #include "common/logging/impl/logger.h"
 #include "common/logging/logger.h"
 #include "soma/enums.h"
+#include "soma/managed_query.h"
 #include "soma/soma_array.h"
 #include "utils/arrow_adapter.h"
 

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -13,6 +13,7 @@
 
 #include "soma_dataframe.h"
 
+#include "../utils/arrow_adapter.h"
 #include "common/logging/impl/logger.h"
 #include "soma_coordinates.h"
 

--- a/libtiledbsoma/src/soma/soma_dense_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_dense_ndarray.cc
@@ -11,6 +11,7 @@
  *   This file defines the SOMADenseNDArray class.
  */
 #include "soma_dense_ndarray.h"
+#include "../utils/arrow_adapter.h"
 #include "soma_coordinates.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_geometry_dataframe.cc
@@ -12,6 +12,7 @@
  */
 
 #include "soma_geometry_dataframe.h"
+#include "../utils/arrow_adapter.h"
 #include "../utils/transformer.h"
 #include "../utils/util.h"
 #include "common/logging/impl/logger.h"

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <tiledb/tiledb>
 
+#include "../utils/common.h"
 #include "soma_context.h"
 
 namespace tiledbsoma {

--- a/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_point_cloud_dataframe.cc
@@ -13,7 +13,8 @@
 
 #include "soma_point_cloud_dataframe.h"
 #include <tiledb/tiledb>
-#include "utils/common.h"
+#include "../utils/arrow_adapter.h"
+#include "../utils/common.h"
 
 namespace tiledbsoma {
 using namespace tiledb;

--- a/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
+++ b/libtiledbsoma/src/soma/soma_sparse_ndarray.cc
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+#include "../utils/arrow_adapter.h"
 #include "common/logging/impl/logger.h"
 #include "soma_coordinates.h"
 

--- a/libtiledbsoma/src/utils/arrow_adapter.h
+++ b/libtiledbsoma/src/utils/arrow_adapter.h
@@ -22,6 +22,7 @@
 #include <tiledb/tiledb>
 #include <tiledb/tiledb_experimental>
 #include "../tiledb_adapter/platform_config.h"
+#include "common.h"
 
 // https://arrow.apache.org/docs/format/CDataInterface.html
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-listing-for-each-layout
@@ -73,9 +74,6 @@ class SOMACoordinateSpace;
 
 //     std::shared_ptr<ArrowBuffer> buffer_;
 // };
-
-template <typename T>
-using managed_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
 
 template <typename T, typename... Args>
     requires std::same_as<T, ArrowArray> || std::same_as<T, ArrowSchema>

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -14,12 +14,17 @@
 #ifndef TILEDBSOMA_COMMON_H
 #define TILEDBSOMA_COMMON_H
 
+#include <functional>
+#include <memory>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <string>
 #include <string_view>
 #include <tiledb/tiledb>
 
 namespace tiledbsoma {
+
+template <typename T>
+using managed_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
 
 template <typename T>
 concept is_data_buffer = std::same_as<std::unique_ptr<std::byte[]>, T> ||

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -291,9 +291,8 @@ TEST_CASE("SOMASparseNDArray: can_tiledbsoma_upgrade_shape", "[SOMASparseNDArray
     auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx);
     REQUIRE(snda->has_current_domain());
 
-    auto dom = snda->soma_domain_slot<int64_t>(dim_name);
-    REQUIRE(dom.first == 0);
-    REQUIRE(dom.second == dim_max);
+    auto shape = snda->shape();
+    REQUIRE(shape[0] - 1 == dim_max);
 
     std::vector<int64_t> newshape_wrong_dims({dim_max, 12});
     std::vector<int64_t> newshape_too_big({dim_max + 10});
@@ -346,11 +345,10 @@ TEST_CASE("SOMASparseNDArray: can_resize", "[SOMASparseNDArray]") {
     //   o Recall that the core current domain is mutable, up tp <= (max) domain
     // * The core (max) domain is huge
     //   o Recall that the core max domain is immutable
-    auto dom = snda->soma_domain_slot<int64_t>(dim_name);
-    auto mxd = snda->soma_maxdomain_slot<int64_t>(dim_name);
-    REQUIRE(dom != mxd);
-    REQUIRE(dom.first == 0);
-    REQUIRE(dom.second == dim_max);
+    auto shape = snda->shape();
+    auto max_shape = snda->maxshape();
+    REQUIRE(shape != max_shape);
+    REQUIRE(shape[0] - 1 == dim_max);
 
     std::vector<int64_t> newshape_wrong_dims({dim_max, 12});
     std::vector<int64_t> newshape_too_small({40});


### PR DESCRIPTION
Issues: Closes SOMA-853

Changes:
* Forward-declare many of the classes/structs used by the SOMAArray class
* Remove or inline unused/rarely-used functions
