### PR TITLE
[c++] Remove std::format and unused param

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         # Pandas types changed between 1.x and 2.x. Our setup.py permits both, but for type-checking purposes we use the
         # Pandas 2.x types (e.g. `pd.Series[Any]`). See `_types.py` or https://github.com/single-cell-data/TileDB-SOMA/issues/2839
         # for more info.
-        - "pandas-stubs>=2"
+        - "pandas-stubs>=2,<3"
         - "somacore==1.0.29"
         - types-setuptools
       args: ["--config-file=apis/python/pyproject.toml", "apis/python/src", "apis/python/devtools"]

--- a/libtiledbsoma/src/common/arrow/utils.cc
+++ b/libtiledbsoma/src/common/arrow/utils.cc
@@ -18,10 +18,6 @@
 
 namespace tiledbsoma::common::arrow {
 
-namespace impl {
-constexpr std::array<char, 2> bool_dict({{0, 1}});
-}
-
 ArrowTable make_empty_arrow_table(std::string_view name, std::string_view format, size_t num_children = 0) {
     managed_unique_ptr<ArrowSchema> schema = make_managed_unique<ArrowSchema>();
     managed_unique_ptr<ArrowArray> array = make_managed_unique<ArrowArray>();


### PR DESCRIPTION
* Remove std::format calls
* Remove unused paramter