### PR TITLE
[python] Update Carrara tests to use new SOMAContext

### DIFF
--- a/apis/python/remote_tests/carrara/conftest.py
+++ b/apis/python/remote_tests/carrara/conftest.py
@@ -37,21 +37,23 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session")
-def carrara_context() -> soma.SOMATileDBContext:
+def carrara_context() -> soma.SOMAContext:
     import tiledb.client
 
     tiledb.client.login(profile_name=PROFILE_NAME)
     assert tiledb.client.workspaces.get_workspace(tiledb.client.client.get_workspace_id()).name == WORKSPACE_NAME
-    return soma.SOMATileDBContext(tiledb_ctx=tiledb.Ctx())
+    soma.SOMAContext.set_default()
+    return soma.SOMAContext.create()
 
 
 @pytest.fixture
 def carrara_array_path() -> Generator[str, None, None]:
     """Fixture returns an Array path that will be recursively deleted after test finishes."""
+    import tiledb.client
     path = f"{BASE_URI}/{uuid4()}"
     yield path
 
-    tiledb.Array.delete_array(path)
+    tiledb.client.assets.delete_asset(path, delete_storage=True)
 
 
 @pytest.fixture

--- a/apis/python/remote_tests/carrara/conftest.py
+++ b/apis/python/remote_tests/carrara/conftest.py
@@ -50,6 +50,7 @@ def carrara_context() -> soma.SOMAContext:
 def carrara_array_path() -> Generator[str, None, None]:
     """Fixture returns an Array path that will be recursively deleted after test finishes."""
     import tiledb.client
+
     path = f"{BASE_URI}/{uuid4()}"
     yield path
 

--- a/apis/python/remote_tests/carrara/test_02_delete.py
+++ b/apis/python/remote_tests/carrara/test_02_delete.py
@@ -14,7 +14,6 @@ import pyarrow as pa
 import pytest
 
 import tiledbsoma as soma
-import tiledb
 
 from ._util import get_asset_info
 
@@ -51,6 +50,7 @@ def test_collection_delete_member_object(carrara_group_path: str, carrara_contex
     This tests the behavior when an object is deleted - does it correctly clean up parent group?.
     """
     import tiledb.client
+
     soma.Collection.create(carrara_group_path, context=carrara_context).close()
     with soma.Collection.open(carrara_group_path, mode="w", context=carrara_context) as C:
         C.add_new_sparse_ndarray("array", type=pa.int8(), shape=(10,))

--- a/apis/python/remote_tests/carrara/test_02_delete.py
+++ b/apis/python/remote_tests/carrara/test_02_delete.py
@@ -20,7 +20,7 @@ from ._util import get_asset_info
 
 
 @pytest.mark.carrara
-def test_collection_delete_member_by_name(carrara_group_path: str, carrara_context: soma.SOMATileDBContext) -> None:
+def test_collection_delete_member_by_name(carrara_group_path: str, carrara_context: soma.SOMAContext) -> None:
     """
     This tests the behavior when an object is removed from a group.
     1. create parent collection
@@ -42,14 +42,15 @@ def test_collection_delete_member_by_name(carrara_group_path: str, carrara_conte
     with soma.open(carrara_group_path, context=carrara_context) as C:
         assert set(C) == {"collection"}
 
-    assert not tiledb.array_exists(f"{carrara_group_path}/array", ctx=carrara_context.tiledb_ctx)
+    assert not soma.SparseNDArray.exists(f"{carrara_group_path}/array", context=carrara_context)
 
 
 @pytest.mark.carrara
-def test_collection_delete_member_object(carrara_group_path: str, carrara_context: soma.SOMATileDBContext) -> None:
+def test_collection_delete_member_object(carrara_group_path: str, carrara_context: soma.SOMAContext) -> None:
     """
     This tests the behavior when an object is deleted - does it correctly clean up parent group?.
     """
+    import tiledb.client
     soma.Collection.create(carrara_group_path, context=carrara_context).close()
     with soma.Collection.open(carrara_group_path, mode="w", context=carrara_context) as C:
         C.add_new_sparse_ndarray("array", type=pa.int8(), shape=(10,))
@@ -62,7 +63,7 @@ def test_collection_delete_member_object(carrara_group_path: str, carrara_contex
         array_asset_info = get_asset_info(C["array"].uri)
 
     # Delete the array object, which is a member of the parent group
-    tiledb.Array.delete_array(f"{carrara_group_path}/array", ctx=carrara_context.tiledb_ctx)
+    tiledb.client.assets.delete_asset(f"{carrara_group_path}/array", delete_storage=True)
 
     # verify that the parent group no longer contains the object, and that
     # the other objects still exist.

--- a/apis/python/remote_tests/carrara/test_03_io.py
+++ b/apis/python/remote_tests/carrara/test_03_io.py
@@ -32,9 +32,7 @@ def array_eq(a1, a2) -> bool:
     return False
 
 
-def test_soma_io_roundtrip(
-    small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMAContext
-) -> None:
+def test_soma_io_roundtrip(small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMAContext) -> None:
     soma.io.from_anndata(carrara_group_path, small_pbmc, measurement_name="RNA", context=carrara_context)
 
     with soma.open(carrara_group_path, context=carrara_context) as exp:

--- a/apis/python/remote_tests/carrara/test_03_io.py
+++ b/apis/python/remote_tests/carrara/test_03_io.py
@@ -33,7 +33,7 @@ def array_eq(a1, a2) -> bool:
 
 
 def test_soma_io_roundtrip(
-    small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMATileDBContext
+    small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMAContext
 ) -> None:
     soma.io.from_anndata(carrara_group_path, small_pbmc, measurement_name="RNA", context=carrara_context)
 
@@ -85,7 +85,7 @@ def test_soma_io_roundtrip(
 
 
 def test_soma_io_from_h5ad(
-    tmp_path: pathlib.Path, small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMATileDBContext
+    tmp_path: pathlib.Path, small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMAContext
 ) -> None:
     """Test ability to ingest an H5AD sourced from a Carrara asset URL."""
     import tiledb.client

--- a/apis/python/remote_tests/carrara/test_04_misc.py
+++ b/apis/python/remote_tests/carrara/test_04_misc.py
@@ -11,7 +11,7 @@ import tiledbsoma as soma
 import tiledbsoma.io
 
 
-def test_open(carrara_group_path: str, carrara_context: soma.SOMATileDBContext) -> None:
+def test_open(carrara_group_path: str, carrara_context: soma.SOMAContext) -> None:
     """Test that open works on direct paths to child objects."""
 
     soma.Collection.create(carrara_group_path, context=carrara_context).close()
@@ -33,7 +33,7 @@ def test_open(carrara_group_path: str, carrara_context: soma.SOMATileDBContext) 
 
 
 def test_experiment_axis_query(
-    small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMATileDBContext
+    small_pbmc: ad.AnnData, carrara_group_path: str, carrara_context: soma.SOMAContext
 ) -> None:
     """Very basic test that we can run an ExperimentAxisQuery against an Experiment."""
     soma.io.from_anndata(carrara_group_path, small_pbmc, measurement_name="RNA", context=carrara_context)


### PR DESCRIPTION
The Carrara tests were still using the newly deprecated `SOMATileDBContext`. Update to use `SOMAContext` class instead. While making this change, also switch to use `tiledb.client.assets.delete_asset` instead of `tiledb.Array.delete_array` to delete arrays.