### PR TITLE
[c++] Remove another <format>

### DIFF
--- a/libtiledbsoma/src/common/arrow/utils.cc
+++ b/libtiledbsoma/src/common/arrow/utils.cc
@@ -7,7 +7,6 @@
  * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
  */
 
-#include <format>
 #include <numeric>
 #include <stdexcept>
 #include <unordered_map>


### PR DESCRIPTION
Another instance of "#include <format>". Found by CI here: https://github.com/TileDB-Inc/TileDB-Internal/actions/runs/21702368598/job/62585550897