### PR TITLE
[python] Clamp `extent` using max domain

### DIFF
--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -273,7 +273,7 @@ class DataFrame(SOMAArray, somacore.DataFrame):
                 index_column_name,
                 TileDBCreateOptions.from_platform_config(platform_config),
                 dtype,
-                slot_core_current_domain,
+                slot_core_max_domain,
             )
 
             # Necessary to avoid core array-creation error "Reduce domain max by
@@ -1099,7 +1099,7 @@ def _find_extent_for_domain(
     index_column_name: str,
     tiledb_create_write_options: TileDBCreateOptions,
     dtype: np.typing.DTypeLike | str,
-    slot_domain: tuple[Any, Any],
+    slot_max_domain: tuple[Any, Any],
 ) -> int | float | Literal["", b""]:
     """Helper function for _build_tiledb_schema. Returns a tile extent that is
     small enough for the index-column type, and that also fits within the
@@ -1135,7 +1135,7 @@ def _find_extent_for_domain(
     if dtype == "ascii" or np.dtype(dtype).kind in ("S", "U"):
         return ""
 
-    lo, hi = slot_domain
+    lo, hi = slot_max_domain
     if lo is None or hi is None:
         return extent
 

--- a/apis/python/src/tiledbsoma/_geometry_dataframe.py
+++ b/apis/python/src/tiledbsoma/_geometry_dataframe.py
@@ -215,7 +215,7 @@ class GeometryDataFrame(SpatialDataFrame, somacore.GeometryDataFrame):
                 index_column_name,
                 TileDBCreateOptions.from_platform_config(platform_config),
                 dtype,
-                slot_core_current_domain,
+                slot_core_max_domain,
             )
 
             # Necessary to avoid core array-creation error "Reduce domain max by

--- a/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
+++ b/apis/python/src/tiledbsoma/_point_cloud_dataframe.py
@@ -208,7 +208,7 @@ class PointCloudDataFrame(SpatialDataFrame, somacore.PointCloudDataFrame):
                 index_column_name,
                 TileDBCreateOptions.from_platform_config(platform_config),
                 dtype,
-                slot_core_current_domain,
+                slot_core_max_domain,
             )
 
             # Necessary to avoid core array-creation error "Reduce domain max by


### PR DESCRIPTION
**Issue and/or context:** [SOMA-416](https://linear.app/tiledb/issue/SOMA-416/python-dataframe-dimension-extent-set-incorrectly-when-domain-is-small)

**Changes:**
This PR uses max domain to clamp the dimension extent.

**Notes for Reviewer:**
Before the introduction of current domain the user specified domain was the max domain and the extend couldn't be larger that the domain. With the introduction of current domain the max domain is now set based on the datatype limits and the user specified domain in now the current domain.