### PR TITLE
[c++/python/r] Move SOMADataFrame creation logic to C++

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -67,7 +67,7 @@ jobs:
           - {os: macos-latest, r: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
-          - {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false}
+          #- {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false} # BPCells dep ggrepel not available
     uses: ./.github/workflows/test-r.yml
     with:
       os: ${{ matrix.config.os }}

--- a/.github/workflows/ci-pr-r.yml
+++ b/.github/workflows/ci-pr-r.yml
@@ -35,7 +35,7 @@ jobs:
           - {os: macos-latest, r: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
-          - {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false}
+          #- {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false} # BPCells dep ggrepel not available
     uses: ./.github/workflows/test-r.yml
     with:
       os: ${{ matrix.config.os }}

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- \[[#4421](https://github.com/single-cell-data/TileDB-SOMA/pull/4421)\] Max domain for integral dimensions are changed for int32, int64 and uint64 columns and are now $(-2^{31} + 1, 2^{31} - 2)$, $(-2^{63} + 1, 2^{63} - 2)$ and $(0, 2^{63} - 2)$ respectively.
 - \[[#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299)\] `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow.
 - \[[#4294](https://github.com/single-cell-data/TileDB-SOMA/pull/4294)\] Use vcpkg instead of custom superbuild, for installing libtiledbsoma and its dependencies. Changes in CI workflows to use the prebuilt libtiledbsoma.
 - \[[#4363](https://github.com/single-cell-data/TileDB-SOMA/pull/4363)\] (BREAKING) The `context` property of a `SOMAObject` now returns a `SOMAContext` instead of a `SOMATileDBContext`.

--- a/apis/python/src/tiledbsoma/_dataframe.py
+++ b/apis/python/src/tiledbsoma/_dataframe.py
@@ -22,7 +22,7 @@ import somacore
 from somacore import options
 from typing_extensions import Self
 
-from . import _arrow_types, _util
+from . import _util
 from . import pytiledbsoma as clib
 from ._constants import SOMA_GEOMETRY, SOMA_JOINID
 from ._coordinate_selection import CoordinateValueFilters
@@ -208,106 +208,24 @@ class DataFrame(SOMAArray, somacore.DataFrame):
         Lifecycle:
             Maturing.
         """
-        schema = _canonicalize_schema(schema, index_column_names)
+        _util.check_type("schema", schema, (pa.Schema,))
 
-        # SOMA-to-core mappings:
-        #
-        # Before the current-domain feature was enabled (possible after core 2.25):
-        #
-        # * SOMA domain <-> core domain, AKA "max domain" which is a name we'll use for clarity
-        # * core current domain did not exist
-        #
-        # After the current-domain feature was enabled:
-        #
-        # * SOMA max_domain <-> core domain
-        # * SOMA domain <-> core current domain
-        #
-        # As far as the user is concerned, the SOMA-level domain is the only
-        # thing they see and care about. Before 2.25 support, it was immutable
-        # (since it was implemented by core domain). After 2.25 support, it is
-        # mutable/up-resizeable (since it is implemented by core current domain).
-
-        # At this point shift from API terminology "domain" to specifying a soma_ or core_
-        # prefix for these variables. This is crucial to avoid developer confusion.
-        soma_domain = domain
-        domain = None
-
-        if soma_domain is None:
+        soma_domain: list[tuple[Any, Any] | None] = []
+        if domain is None:
             warnings.warn(
                 "Setting ``domain=None`` is deprecated. Please specify the desired domain for the dataframe.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            soma_domain = tuple(None for _ in index_column_names)
+            soma_domain = [None for _ in index_column_names]
         else:
-            ndom = len(soma_domain)
-            nidx = len(index_column_names)
-            if ndom != nidx:
+            if len(index_column_names) != len(domain):
                 raise ValueError(
-                    f"if domain is specified, it must have the same length as index_column_names; got {ndom} != {nidx}",
+                    f"if domain is specified, it must have the same length as index_column_names; got {len(domain)} != {len(index_column_names)}",
                 )
 
-        index_column_schema = []
-        index_column_data = {}
-
-        for index_column_name, slot_soma_domain in zip(index_column_names, soma_domain):
-            pa_field = schema.field(index_column_name)
-            dtype = _arrow_types.tiledb_type_from_arrow_type(pa_field.type, is_indexed_column=True)
-
-            (slot_core_current_domain, saturated_cd) = _fill_out_slot_soma_domain(
-                slot_soma_domain,
-                False,
-                index_column_name,
-                pa_field.type,
-                dtype,
-            )
-            (slot_core_max_domain, saturated_md) = _fill_out_slot_soma_domain(
-                None,
-                True,
-                index_column_name,
-                pa_field.type,
-                dtype,
-            )
-
-            extent = _find_extent_for_domain(
-                index_column_name,
-                TileDBCreateOptions.from_platform_config(platform_config),
-                dtype,
-                slot_core_max_domain,
-            )
-
-            # Necessary to avoid core array-creation error "Reduce domain max by
-            # 1 tile extent to allow for expansion."
-            slot_core_current_domain = _revise_domain_for_extent(slot_core_current_domain, extent, saturated_cd)
-            slot_core_max_domain = _revise_domain_for_extent(slot_core_max_domain, extent, saturated_md)
-
-            if index_column_name == "soma_joinid":
-                lower = slot_core_current_domain[0]
-                upper = slot_core_current_domain[1]
-                if lower < 0 or upper < 0 or upper < lower:
-                    raise ValueError(
-                        f"domain for soma_joinid must be non-negative with lower <= upper; got ({lower}, {upper})",
-                    )
-
-            # Here is our Arrow data API for communicating schema info between
-            # Python/R and C++ libtiledbsoma:
-            #
-            # [0] core max domain lo
-            # [1] core max domain hi
-            # [2] core extent parameter
-            # If present, these next two signal to use the current-domain feature:
-            # [3] core current domain lo
-            # [4] core current domain hi
-
-            index_column_schema.append(pa_field)
-
-            index_column_data[pa_field.name] = [
-                *slot_core_max_domain,
-                extent,
-                *slot_core_current_domain,
-            ]
-
-        index_column_info = pa.RecordBatch.from_pydict(index_column_data, schema=pa.schema(index_column_schema))
+            for index_column_name, slot_soma_domain in zip(index_column_names, domain):
+                soma_domain.append(_cast_domain_to_cpp_type(slot_soma_domain, schema, index_column_name))
 
         plt_cfg = build_clib_platform_config(platform_config)
         context, tiledb_timestamp = _update_context_and_timestamp(context, tiledb_timestamp)
@@ -316,7 +234,8 @@ class DataFrame(SOMAArray, somacore.DataFrame):
             clib.SOMADataFrame.create(
                 uri,
                 schema=schema,
-                index_column_info=index_column_info,
+                index_column_names=index_column_names,
+                index_column_domains=soma_domain,
                 ctx=context._handle,
                 platform_config=plt_cfg,
                 timestamp=(0, timestamp_ms),
@@ -1093,6 +1012,24 @@ def _fill_out_slot_soma_domain(
         raise TypeError(f"Unsupported dtype {dtype}")
 
     return (slot_domain, saturated_range)
+
+
+def _cast_domain_to_cpp_type(
+    slot_domain: AxisDomain, schema: pa.Schema, index_column_name: str
+) -> tuple[Any, Any] | None:
+    if slot_domain is None:
+        return None
+
+    if index_column_name in schema.names:
+        domain_array = pa.RecordBatch.from_pydict(
+            {index_column_name: slot_domain}, pa.schema([schema.field(index_column_name)])
+        )
+
+        if isinstance(domain_array[0][0], pa.TimestampScalar):
+            return domain_array[0][0].value, domain_array[0][1].value
+        return domain_array[0][0].as_py(), domain_array[0][1].as_py()
+
+    return slot_domain[0], slot_domain[1]
 
 
 def _find_extent_for_domain(

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -17,12 +17,12 @@ using namespace pybind11::literals;  // to bring in the `_a` literal
 
 namespace tiledbsoma {
 
-std::any encode_domain(std::string_view format, py::object domain) {
-    auto encode_element = [&]<typename T>() -> std::any {
+DomainRange encode_domain(std::string_view format, py::object domain) {
+    auto encode_element = [&]<typename T>() -> DomainRange {
         if (domain.is_none()) {
-            return std::make_any<std::optional<std::pair<T, T>>>(std::nullopt);
+            return std::optional<std::pair<T, T>>();
         }
-        return std::make_any<std::optional<std::pair<T, T>>>(domain.cast<std::pair<T, T>>());
+        return std::make_optional<std::pair<T, T>>(domain.cast<std::pair<T, T>>());
     };
 
     switch (tiledbsoma::common::arrow::to_tiledb_format(format)) {

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -17,6 +17,53 @@ using namespace pybind11::literals;  // to bring in the `_a` literal
 
 namespace tiledbsoma {
 
+std::any encode_domain(std::string_view format, py::object domain) {
+    auto encode_element = [&]<typename T>() -> std::any {
+        if (domain.is_none()) {
+            return std::make_any<std::optional<std::pair<T, T>>>(std::nullopt);
+        }
+        return std::make_any<std::optional<std::pair<T, T>>>(domain.cast<std::pair<T, T>>());
+    };
+
+    switch (tiledbsoma::common::arrow::to_tiledb_format(format)) {
+        case TILEDB_UINT8:
+            return encode_element.template operator()<uint8_t>();
+        case TILEDB_UINT16:
+            return encode_element.template operator()<uint16_t>();
+        case TILEDB_UINT32:
+            return encode_element.template operator()<uint32_t>();
+        case TILEDB_UINT64:
+            return encode_element.template operator()<uint64_t>();
+        case TILEDB_INT8:
+            return encode_element.template operator()<int8_t>();
+        case TILEDB_INT16:
+            return encode_element.template operator()<int16_t>();
+        case TILEDB_INT32:
+            return encode_element.template operator()<int32_t>();
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_INT64:
+            return encode_element.template operator()<int64_t>();
+        case TILEDB_FLOAT32:
+            return encode_element.template operator()<float_t>();
+        case TILEDB_FLOAT64:
+            return encode_element.template operator()<double_t>();
+        case TILEDB_CHAR:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_BLOB:
+        case TILEDB_GEOM_WKT:
+        case TILEDB_GEOM_WKB:
+            return encode_element.template operator()<std::string>();
+        default:
+            throw py::type_error(
+                "[encode_domain] Unsupported type " +
+                tiledb::impl::type_to_str(tiledbsoma::common::arrow::to_tiledb_format(format)));
+    }
+}
+
 std::unordered_map<tiledb_datatype_t, std::string> _tdb_to_np_name_dtype = {
     {TILEDB_INT32, "int32"},
     {TILEDB_INT64, "int64"},

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -46,6 +46,8 @@ size_t sanitize_string(std::span<const T> string_raw, size_t num_elements) {
     return num_elements;
 }
 
+std::any encode_domain(std::string_view format, py::object domain);
+
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
 
 tiledb_datatype_t np_to_tdb_dtype(py::dtype type);

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -46,7 +46,7 @@ size_t sanitize_string(std::span<const T> string_raw, size_t num_elements) {
     return num_elements;
 }
 
-std::any encode_domain(std::string_view format, py::object domain);
+DomainRange encode_domain(std::string_view format, py::object domain);
 
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
 

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -69,11 +69,11 @@ void load_soma_dataframe(py::module& m) {
                     }
                 }
 
-                std::vector<std::any> domain;
+                std::vector<DomainRange> domain;
                 for (size_t i = 0; i < index_column_names.size(); ++i) {
                     if (index_column_names[i] == SOMA_JOINID) {
-                        domain.emplace_back(encode_domain(
-                            common::arrow::to_arrow_format(TILEDB_INT64), py::cast<py::list>(index_column_domains[i])));
+                        domain.emplace_back(
+                            encode_domain(common::arrow::to_arrow_format(TILEDB_INT64), index_column_domains[i]));
                         continue;
                     }
 

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -34,7 +34,8 @@ void load_soma_dataframe(py::module& m) {
             "create",
             [](std::string_view uri,
                py::object py_schema,
-               py::object index_column_info,
+               const std::vector<std::string>& index_column_names,
+               py::list index_column_domains,
                std::shared_ptr<SOMAContext> context,
                PlatformConfig platform_config,
                std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
@@ -68,24 +69,35 @@ void load_soma_dataframe(py::module& m) {
                     }
                 }
 
-                ArrowSchema index_column_schema;
-                ArrowArray index_column_array;
-                uintptr_t index_column_schema_ptr = (uintptr_t)(&index_column_schema);
-                uintptr_t index_column_array_ptr = (uintptr_t)(&index_column_array);
-                index_column_info.attr("_export_to_c")(index_column_array_ptr, index_column_schema_ptr);
+                std::vector<std::any> domain;
+                for (size_t i = 0; i < index_column_names.size(); ++i) {
+                    if (index_column_names[i] == SOMA_JOINID) {
+                        domain.emplace_back(encode_domain(
+                            common::arrow::to_arrow_format(TILEDB_INT64), py::cast<py::list>(index_column_domains[i])));
+                        continue;
+                    }
+
+                    for (int64_t j = 0; j < schema.n_children; ++j) {
+                        if (schema.children[j]->name == index_column_names[i]) {
+                            domain.emplace_back(encode_domain(schema.children[j]->format, index_column_domains[i]));
+                            break;
+                        }
+                    }
+                }
 
                 try {
                     SOMADataFrame::create(
                         uri,
                         common::arrow::make_managed_unique<ArrowSchema>(schema),
-                        common::arrow::ArrowTable(
-                            common::arrow::make_managed_unique<ArrowArray>(index_column_array),
-                            common::arrow::make_managed_unique<ArrowSchema>(index_column_schema)),
+                        index_column_names,
+                        domain,
                         context,
                         platform_config,
                         timestamp);
                 } catch (const std::out_of_range& e) {
                     throw py::type_error(e.what());
+                } catch (const std::range_error& e) {
+                    throw py::value_error(e.what());
                 } catch (const std::exception& e) {
                     TPY_ERROR_LOC(e.what());
                 }
@@ -93,7 +105,8 @@ void load_soma_dataframe(py::module& m) {
             "uri"_a,
             py::kw_only(),
             "schema"_a,
-            "index_column_info"_a,
+            "index_column_names"_a,
+            "index_column_domains"_a,
             "ctx"_a,
             "platform_config"_a,
             "timestamp"_a = py::none())

--- a/apis/python/src/tiledbsoma/soma_dataframe.cc
+++ b/apis/python/src/tiledbsoma/soma_dataframe.cc
@@ -77,11 +77,17 @@ void load_soma_dataframe(py::module& m) {
                         continue;
                     }
 
+                    bool index_found = false;
                     for (int64_t j = 0; j < schema.n_children; ++j) {
                         if (schema.children[j]->name == index_column_names[i]) {
                             domain.emplace_back(encode_domain(schema.children[j]->format, index_column_domains[i]));
+                            index_found = true;
                             break;
                         }
+                    }
+
+                    if (!index_found) {
+                        domain.emplace_back(DomainRange());
                     }
                 }
 

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2370,16 +2370,16 @@ def test_read_indexing(tmp_path, io):
                 next(sdf.read(**read_kwargs))
         else:
             table = next(sdf.read(**read_kwargs))
-            # Tiling can affect the order of the results thus we sort the results
-            assert sorted(table["A"].to_pylist()) == io["A"]
+            # Tiling can affect the order of the results thus we create a set of the results
+            assert set(table["A"].to_pylist()) == set(io["A"])
 
         if throws_ctx:
             with throws_ctx(throws):
                 next(sdf.read(**read_kwargs)).to_pandas()
         else:
             table = next(sdf.read(**read_kwargs)).to_pandas()
-            # Tiling can affect the order of the results thus we sort the results
-            assert sorted(table["A"].to_list()) == io["A"]
+            # Tiling can affect the order of the results thus we create a set of the results
+            assert set(table["A"].to_list()) == set(io["A"])
 
 
 @pytest.mark.parametrize("cfg", [{"soma.read.use_memory_pool": "false"}, {"soma.read.use_memory_pool": "true"}])

--- a/apis/python/tests/test_dataframe.py
+++ b/apis/python/tests/test_dataframe.py
@@ -2370,14 +2370,16 @@ def test_read_indexing(tmp_path, io):
                 next(sdf.read(**read_kwargs))
         else:
             table = next(sdf.read(**read_kwargs))
-            assert table["A"].to_pylist() == io["A"]
+            # Tiling can affect the order of the results thus we sort the results
+            assert sorted(table["A"].to_pylist()) == io["A"]
 
         if throws_ctx:
             with throws_ctx(throws):
                 next(sdf.read(**read_kwargs)).to_pandas()
         else:
             table = next(sdf.read(**read_kwargs)).to_pandas()
-            assert table["A"].to_list() == io["A"]
+            # Tiling can affect the order of the results thus we sort the results
+            assert sorted(table["A"].to_list()) == io["A"]
 
 
 @pytest.mark.parametrize("cfg", [{"soma.read.use_memory_pool": "false"}, {"soma.read.use_memory_pool": "true"}])

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -5,6 +5,10 @@ createSchemaFromArrow <- function(uri, nasp, nadimap, nadimsp, sparse, datatype,
     invisible(.Call(`_tiledbsoma_createSchemaFromArrow`, uri, nasp, nadimap, nadimsp, sparse, datatype, pclst, ctxxp, tsvec))
 }
 
+createSchemaForDataFrame <- function(uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec = NULL) {
+    invisible(.Call(`_tiledbsoma_createSchemaForDataFrame`, uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec))
+}
+
 createSchemaForNDArray <- function(uri, format, shape, soma_type, pclst, ctxxp, tsvec = NULL) {
     invisible(.Call(`_tiledbsoma_createSchemaForNDArray`, uri, format, shape, soma_type, pclst, ctxxp, tsvec))
 }

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -51,10 +51,6 @@ SOMADataFrame <- R6::R6Class(
       domain = NULL,
       platform_config = NULL
     ) {
-
-      # names <- sapply(as_nanoarrow_schema(schema)$children, "[[", "name")
-      # formats <- sapply(as_nanoarrow_schema(schema)$children, "[[", "format")
-
       envs <- unique(vapply(
         X = unique(sys.parents()),
         FUN = function(n) environmentName(environment(sys.function(n))),
@@ -69,8 +65,6 @@ SOMADataFrame <- R6::R6Class(
           call. = FALSE
         )
       }
-
-      schema <- private$validate_schema(schema, index_column_names)
 
       soma_domain <- domain;
       if (is.null(soma_domain)) {
@@ -95,65 +89,16 @@ SOMADataFrame <- R6::R6Class(
         }
       }
 
-      # attr_column_names <- setdiff(schema$names, index_column_names)
-      # stopifnot(
-      #   "At least one non-index column must be defined in the schema" = length(
-      #     attr_column_names
-      #   ) >
-      #     0
-      # )
-
-      # if ("soma_joinid" %in% index_column_names && !is.null(domain)) {
-      #   lower_bound <- domain[["soma_joinid"]][1]
-      #   upper_bound <- domain[["soma_joinid"]][2]
-      #   stopifnot(
-      #     "The lower bound for soma_joinid domain must be >= 0" = lower_bound >=
-      #       0,
-      #     "The upper bound for soma_joinid domain must be >= 0" = upper_bound >=
-      #       0,
-      #     "The upper bound for soma_joinid domain must be >= the lower bound" = upper_bound >=
-      #       lower_bound
-      #   )
-      # }
-
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
       tiledb_create_options <- TileDBCreateOptions$new(platform_config)
       tiledb_create_options$set("override_naming_restriction", getOption("tiledbsoma.write_soma.internal", default = FALSE))
-
-      # We currently pass domain and extent values in an arrow table (i.e. data.frame alike)
-      # where each dimension is one column (of the same type as in the schema followed by:
-      # * Before the new shape feature: three values for the domain pair and the extent;
-      # * After the new shape feature: five values for the maxdomain pair, extent, and domain.
-      # dom_ext_tbl <- get_domain_and_extent_dataframe(
-      #   schema,
-      #   ind_col_names = index_column_names,
-      #   domain = domain,
-      #   tdco = tiledb_create_options
-      # )
-
-      ## we transfer to the arrow table via a pair of array and schema pointers
-      # dnaap <- nanoarrow::nanoarrow_allocate_array()
-      # dnasp <- nanoarrow::nanoarrow_allocate_schema()
-      # arrow::as_record_batch(dom_ext_tbl)$export_to_c(dnaap, dnasp)
 
       ## we need a schema pointer to transfer the schema information
       nasp <- nanoarrow::nanoarrow_allocate_schema()
       schema$export_to_c(nasp)
 
       soma_debug("[SOMADataFrame$create] about to create schema from arrow")
-      # createSchemaFromArrow(
-      #   uri = self$uri,
-      #   nasp = nasp,
-      #   nadimap = dnaap,
-      #   nadimsp = dnasp,
-      #   sparse = TRUE,
-      #   datatype = "SOMADataFrame",
-      #   pclst = tiledb_create_options$to_list(FALSE),
-      #   ctxxp = private$.context$handle,
-      #   tsvec = self$.tiledb_timestamp_range
-      # )
-
       createSchemaForDataFrame(
         uri = self$uri,
         nasp = nasp,

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -119,6 +119,7 @@ SOMADataFrame <- R6::R6Class(
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
       tiledb_create_options <- TileDBCreateOptions$new(platform_config)
+      tiledb_create_options$set("override_naming_restriction", getOption("tiledbsoma.write_soma.internal", default = FALSE))
 
       # We currently pass domain and extent values in an arrow table (i.e. data.frame alike)
       # where each dimension is one column (of the same type as in the schema followed by:

--- a/apis/r/R/SOMADataFrame.R
+++ b/apis/r/R/SOMADataFrame.R
@@ -51,6 +51,10 @@ SOMADataFrame <- R6::R6Class(
       domain = NULL,
       platform_config = NULL
     ) {
+
+      # names <- sapply(as_nanoarrow_schema(schema)$children, "[[", "name")
+      # formats <- sapply(as_nanoarrow_schema(schema)$children, "[[", "format")
+
       envs <- unique(vapply(
         X = unique(sys.parents()),
         FUN = function(n) environmentName(environment(sys.function(n))),
@@ -68,38 +72,49 @@ SOMADataFrame <- R6::R6Class(
 
       schema <- private$validate_schema(schema, index_column_names)
 
-      if (is.null(domain)) {
+      soma_domain <- domain;
+      if (is.null(soma_domain)) {
         .deprecate(
           when = "2.1.0",
           what = "create(domain = 'must be a named list')",
         )
+
+        soma_domain <- vector(mode = 'list', length = length(index_column_names))
+        names(soma_domain) <- index_column_names
       }
-      if (!(is.null(domain) || .is_domain(domain, index_column_names))) {
+      if (!(is.null(soma_domain) || .is_domain(soma_domain, index_column_names))) {
         stop(
           "domain must be NULL or a named list, with values being 2-element vectors or NULL"
         )
+      } else {
+        # We cast all integer values to int64
+        for (name in index_column_names) {
+          if (is.integer(soma_domain[[name]])) {
+            soma_domain[[name]] <- as.integer64(soma_domain[[name]])
+          }
+        }
       }
 
-      attr_column_names <- setdiff(schema$names, index_column_names)
-      stopifnot(
-        "At least one non-index column must be defined in the schema" = length(
-          attr_column_names
-        ) >
-          0
-      )
+      # attr_column_names <- setdiff(schema$names, index_column_names)
+      # stopifnot(
+      #   "At least one non-index column must be defined in the schema" = length(
+      #     attr_column_names
+      #   ) >
+      #     0
+      # )
 
-      if ("soma_joinid" %in% index_column_names && !is.null(domain)) {
-        lower_bound <- domain[["soma_joinid"]][1]
-        upper_bound <- domain[["soma_joinid"]][2]
-        stopifnot(
-          "The lower bound for soma_joinid domain must be >= 0" = lower_bound >=
-            0,
-          "The upper bound for soma_joinid domain must be >= 0" = upper_bound >=
-            0,
-          "The upper bound for soma_joinid domain must be >= the lower bound" = upper_bound >=
-            lower_bound
-        )
-      }
+      # if ("soma_joinid" %in% index_column_names && !is.null(domain)) {
+      #   lower_bound <- domain[["soma_joinid"]][1]
+      #   upper_bound <- domain[["soma_joinid"]][2]
+      #   stopifnot(
+      #     "The lower bound for soma_joinid domain must be >= 0" = lower_bound >=
+      #       0,
+      #     "The upper bound for soma_joinid domain must be >= 0" = upper_bound >=
+      #       0,
+      #     "The upper bound for soma_joinid domain must be >= the lower bound" = upper_bound >=
+      #       lower_bound
+      #   )
+      # }
 
       # Parse the tiledb/create/ subkeys of the platform_config into a handy,
       # typed, queryable data structure.
@@ -109,30 +124,40 @@ SOMADataFrame <- R6::R6Class(
       # where each dimension is one column (of the same type as in the schema followed by:
       # * Before the new shape feature: three values for the domain pair and the extent;
       # * After the new shape feature: five values for the maxdomain pair, extent, and domain.
-      dom_ext_tbl <- get_domain_and_extent_dataframe(
-        schema,
-        ind_col_names = index_column_names,
-        domain = domain,
-        tdco = tiledb_create_options
-      )
+      # dom_ext_tbl <- get_domain_and_extent_dataframe(
+      #   schema,
+      #   ind_col_names = index_column_names,
+      #   domain = domain,
+      #   tdco = tiledb_create_options
+      # )
 
       ## we transfer to the arrow table via a pair of array and schema pointers
-      dnaap <- nanoarrow::nanoarrow_allocate_array()
-      dnasp <- nanoarrow::nanoarrow_allocate_schema()
-      arrow::as_record_batch(dom_ext_tbl)$export_to_c(dnaap, dnasp)
+      # dnaap <- nanoarrow::nanoarrow_allocate_array()
+      # dnasp <- nanoarrow::nanoarrow_allocate_schema()
+      # arrow::as_record_batch(dom_ext_tbl)$export_to_c(dnaap, dnasp)
 
       ## we need a schema pointer to transfer the schema information
       nasp <- nanoarrow::nanoarrow_allocate_schema()
       schema$export_to_c(nasp)
 
       soma_debug("[SOMADataFrame$create] about to create schema from arrow")
-      createSchemaFromArrow(
+      # createSchemaFromArrow(
+      #   uri = self$uri,
+      #   nasp = nasp,
+      #   nadimap = dnaap,
+      #   nadimsp = dnasp,
+      #   sparse = TRUE,
+      #   datatype = "SOMADataFrame",
+      #   pclst = tiledb_create_options$to_list(FALSE),
+      #   ctxxp = private$.context$handle,
+      #   tsvec = self$.tiledb_timestamp_range
+      # )
+
+      createSchemaForDataFrame(
         uri = self$uri,
         nasp = nasp,
-        nadimap = dnaap,
-        nadimsp = dnasp,
-        sparse = TRUE,
-        datatype = "SOMADataFrame",
+        index_column_names = index_column_names,
+        index_column_domains = soma_domain,
         pclst = tiledb_create_options$to_list(FALSE),
         ctxxp = private$.context$handle,
         tsvec = self$.tiledb_timestamp_range

--- a/apis/r/src/RcppExports.cpp
+++ b/apis/r/src/RcppExports.cpp
@@ -29,6 +29,22 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// createSchemaForDataFrame
+void createSchemaForDataFrame(const std::string& uri, naxpSchema nasp, Rcpp::CharacterVector index_column_names, Rcpp::List index_column_domains, Rcpp::List pclst, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
+RcppExport SEXP _tiledbsoma_createSchemaForDataFrame(SEXP uriSEXP, SEXP naspSEXP, SEXP index_column_namesSEXP, SEXP index_column_domainsSEXP, SEXP pclstSEXP, SEXP ctxxpSEXP, SEXP tsvecSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< naxpSchema >::type nasp(naspSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type index_column_names(index_column_namesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type index_column_domains(index_column_domainsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type pclst(pclstSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<somactx_wrap_t> >::type ctxxp(ctxxpSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::DatetimeVector> >::type tsvec(tsvecSEXP);
+    createSchemaForDataFrame(uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec);
+    return R_NilValue;
+END_RCPP
+}
 // createSchemaForNDArray
 void createSchemaForNDArray(const std::string& uri, const std::string& format, Rcpp::NumericVector shape, const std::string& soma_type, Rcpp::List pclst, Rcpp::XPtr<somactx_wrap_t> ctxxp, Rcpp::Nullable<Rcpp::DatetimeVector> tsvec);
 RcppExport SEXP _tiledbsoma_createSchemaForNDArray(SEXP uriSEXP, SEXP formatSEXP, SEXP shapeSEXP, SEXP soma_typeSEXP, SEXP pclstSEXP, SEXP ctxxpSEXP, SEXP tsvecSEXP) {
@@ -998,6 +1014,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledbsoma_createSchemaFromArrow", (DL_FUNC) &_tiledbsoma_createSchemaFromArrow, 9},
+    {"_tiledbsoma_createSchemaForDataFrame", (DL_FUNC) &_tiledbsoma_createSchemaForDataFrame, 7},
     {"_tiledbsoma_createSchemaForNDArray", (DL_FUNC) &_tiledbsoma_createSchemaForNDArray, 7},
     {"_tiledbsoma_writeArrayFromArrow", (DL_FUNC) &_tiledbsoma_writeArrayFromArrow, 7},
     {"_tiledbsoma_c_group_create", (DL_FUNC) &_tiledbsoma_c_group_create, 4},

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -152,6 +152,7 @@ void createSchemaForDataFrame(
     pltcfg.tile_order = Rcpp::as<std::string>(pclst["tile_order"]);
     pltcfg.attrs = Rcpp::as<std::string>(pclst["attrs"]);
     pltcfg.dims = Rcpp::as<std::string>(pclst["dims"]);
+    pltcfg.override_naming_restriction = Rcpp::as<bool>(pclst["override_naming_restriction"]);
 
     // shared pointer to SOMAContext from external pointer wrapper
     std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -233,11 +233,19 @@ void createSchemaForDataFrame(
             continue;
         }
 
+        bool column_found = false;
         for (int64_t j = 0; j < schema->n_children; ++j) {
             if (schema->children[j]->name == column) {
                 domains.emplace_back(encode_domain(schema->children[j]->format, index_column_domains[i]));
+                column_found = true;
                 break;
             }
+        }
+
+        if (!column_found) {
+            // If the index column is missing from schema just append an empty pair as domain.
+            // The C++ layer is responsible for catching the missing index column from schema and report back the proper error.
+            domains.emplace_back(tdbs::DomainRange());
         }
     }
 

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -126,6 +126,128 @@ void createSchemaFromArrow(
 }
 
 // [[Rcpp::export]]
+void createSchemaForDataFrame(
+    const std::string& uri,
+    naxpSchema nasp,
+    Rcpp::CharacterVector index_column_names,
+    Rcpp::List index_column_domains,
+    Rcpp::List pclst,
+    Rcpp::XPtr<somactx_wrap_t> ctxxp,
+    Rcpp::Nullable<Rcpp::DatetimeVector> tsvec) {
+    nanoarrow::UniqueSchema sp{nanoarrow_schema_from_xptr(nasp)};
+    auto schema = tdbs::common::arrow::make_managed_unique<ArrowSchema>();
+    sp.move(schema.get());
+
+    tdbs::PlatformConfig pltcfg;
+    pltcfg.dataframe_dim_zstd_level = Rcpp::as<int>(pclst["dataframe_dim_zstd_level"]);
+    pltcfg.sparse_nd_array_dim_zstd_level = Rcpp::as<int>(pclst["sparse_nd_array_dim_zstd_level"]);
+    pltcfg.dense_nd_array_dim_zstd_level = Rcpp::as<int>(pclst["dense_nd_array_dim_zstd_level"]);
+    pltcfg.write_X_chunked = Rcpp::as<bool>(pclst["write_X_chunked"]);
+    pltcfg.goal_chunk_nnz = Rcpp::as<double>(pclst["goal_chunk_nnz"]);
+    pltcfg.capacity = Rcpp::as<double>(pclst["capacity"]);
+    pltcfg.offsets_filters = Rcpp::as<std::string>(pclst["offsets_filters"]);
+    pltcfg.validity_filters = Rcpp::as<std::string>(pclst["validity_filters"]);
+    pltcfg.allows_duplicates = Rcpp::as<bool>(pclst["allows_duplicates"]);
+    pltcfg.cell_order = Rcpp::as<std::string>(pclst["cell_order"]);
+    pltcfg.tile_order = Rcpp::as<std::string>(pclst["tile_order"]);
+    pltcfg.attrs = Rcpp::as<std::string>(pclst["attrs"]);
+    pltcfg.dims = Rcpp::as<std::string>(pclst["dims"]);
+
+    // shared pointer to SOMAContext from external pointer wrapper
+    std::shared_ptr<tdbs::SOMAContext> sctx = ctxxp->ctxptr;
+    // shared pointer to TileDB Context from SOMAContext
+    std::shared_ptr<tiledb::Context> ctx = sctx->tiledb_ctx();
+
+    // optional timestamp range
+    std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(tsvec);
+
+    auto encode_domain = [&](std::string_view datatype, Rcpp::RObject domain) -> std::any {
+        auto encode = [&]<typename DomainType, typename ElementType>() -> std::any {
+            if (domain.isNULL()) {
+                return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(std::nullopt);
+            }
+
+            auto dom = Rcpp::as<std::vector<ElementType>>(domain);
+
+            if constexpr (std::is_integral_v<DomainType> || std::is_floating_point_v<DomainType>) {
+                if (domain.isObject()) {
+                    return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
+                        std::make_pair<DomainType, DomainType>(
+                            static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[0])),
+                            static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[1]))));
+                } else {
+                    return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
+                        std::make_pair<DomainType, DomainType>(
+                            static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
+                }
+            } else {
+                return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
+                    std::make_pair<DomainType, DomainType>(
+                        static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
+            }
+        };
+
+        switch (tdbs::common::arrow::to_tiledb_format(datatype)) {
+            case TILEDB_CHAR:
+            case TILEDB_STRING_ASCII:
+            case TILEDB_STRING_UTF8:
+            case TILEDB_BLOB:
+            case TILEDB_GEOM_WKT:
+            case TILEDB_GEOM_WKB:
+                return encode.template operator()<std::string, std::string>();
+            case TILEDB_INT8:
+                return encode.template operator()<int8_t, double_t>();
+            case TILEDB_UINT8:
+                return encode.template operator()<uint8_t, double_t>();
+            case TILEDB_INT16:
+                return encode.template operator()<int16_t, double_t>();
+            case TILEDB_UINT16:
+                return encode.template operator()<uint16_t, double_t>();
+            case TILEDB_INT32:
+                return encode.template operator()<int32_t, double_t>();
+            case TILEDB_UINT32:
+                return encode.template operator()<uint32_t, double_t>();
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+            case TILEDB_INT64:
+                return encode.template operator()<int64_t, double_t>();
+            case TILEDB_UINT64:
+                return encode.template operator()<uint64_t, double_t>();
+            case TILEDB_FLOAT32:
+                return encode.template operator()<float_t, double_t>();
+            case TILEDB_FLOAT64:
+                return encode.template operator()<double_t, double_t>();
+            default:
+                throw std::runtime_error(
+                    "[encode_domain] Unsupported type " +
+                    tiledb::impl::type_to_str(tdbs::common::arrow::to_tiledb_format(datatype)));
+        }
+    };
+
+    std::vector<std::any> domains;
+    for (size_t i = 0; i < index_column_names.size(); ++i) {
+        std::string column = Rcpp::as<std::string>(index_column_names[i]);
+        if (column == tdbs::SOMA_JOINID) {
+            domains.emplace_back(
+                encode_domain(tdbs::common::arrow::to_arrow_format(TILEDB_INT64), index_column_domains[i]));
+            continue;
+        }
+
+        for (int64_t j = 0; j < schema->n_children; ++j) {
+            if (schema->children[j]->name == column) {
+                domains.emplace_back(encode_domain(schema->children[j]->format, index_column_domains[i]));
+                break;
+            }
+        }
+    }
+
+    tdbs::SOMADataFrame::create(
+        uri, std::move(schema), Rcpp::as<std::vector<std::string>>(index_column_names), domains, sctx, pltcfg, tsrng);
+}
+
+// [[Rcpp::export]]
 void createSchemaForNDArray(
     const std::string& uri,
     const std::string& format,

--- a/apis/r/src/arrow.cpp
+++ b/apis/r/src/arrow.cpp
@@ -162,29 +162,26 @@ void createSchemaForDataFrame(
     // optional timestamp range
     std::optional<tdbs::TimestampRange> tsrng = makeTimestampRange(tsvec);
 
-    auto encode_domain = [&](std::string_view datatype, Rcpp::RObject domain) -> std::any {
-        auto encode = [&]<typename DomainType, typename ElementType>() -> std::any {
+    auto encode_domain = [&](std::string_view datatype, Rcpp::RObject domain) -> tdbs::DomainRange {
+        auto encode = [&]<typename DomainType, typename ElementType>() -> tdbs::DomainRange {
             if (domain.isNULL()) {
-                return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(std::nullopt);
+                return std::optional<std::pair<DomainType, DomainType>>();
             }
 
             auto dom = Rcpp::as<std::vector<ElementType>>(domain);
 
             if constexpr (std::is_integral_v<DomainType> || std::is_floating_point_v<DomainType>) {
                 if (domain.isObject()) {
-                    return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
-                        std::make_pair<DomainType, DomainType>(
-                            static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[0])),
-                            static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[1]))));
+                    return std::make_optional<std::pair<DomainType, DomainType>>(std::make_pair<DomainType, DomainType>(
+                        static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[0])),
+                        static_cast<DomainType>(*reinterpret_cast<int64_t*>(&dom[1]))));
                 } else {
-                    return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
-                        std::make_pair<DomainType, DomainType>(
-                            static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
+                    return std::make_optional<std::pair<DomainType, DomainType>>(std::make_pair<DomainType, DomainType>(
+                        static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
                 }
             } else {
-                return std::make_any<std::optional<std::pair<DomainType, DomainType>>>(
-                    std::make_pair<DomainType, DomainType>(
-                        static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
+                return std::make_optional<std::pair<DomainType, DomainType>>(std::make_pair<DomainType, DomainType>(
+                    static_cast<DomainType>(dom[0]), static_cast<DomainType>(dom[1])));
             }
         };
 
@@ -227,7 +224,7 @@ void createSchemaForDataFrame(
         }
     };
 
-    std::vector<std::any> domains;
+    std::vector<tdbs::DomainRange> domains;
     for (size_t i = 0; i < index_column_names.size(); ++i) {
         std::string column = Rcpp::as<std::string>(index_column_names[i]);
         if (column == tdbs::SOMA_JOINID) {

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -5,7 +5,7 @@ test_that("Basic mechanics", {
 
   expect_error(
     SOMADataFrameCreate(uri, asch, index_column_names = "qux", domain = list(qux = NULL)),
-    "Index column 'qux' missing"
+    "Missing index column 'qux' from schema"
   )
   if (dir.exists(uri)) {
     unlink(uri, recursive = TRUE)
@@ -198,7 +198,7 @@ test_that("Basic mechanics with default index_column_names", {
 
   expect_error(
     SOMADataFrameCreate(tempfile(), schema = asch, index_column_names = "qux", domain = list(qux = NULL)),
-    regexp = "Index column 'qux' missing"
+    regexp = "Missing index column 'qux' from schema"
   )
 
   if (dir.exists(uri)) {

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -4,8 +4,8 @@ test_that("Basic mechanics", {
   asch <- create_arrow_schema()
 
   expect_error(
-    SOMADataFrameCreate(uri, asch, index_column_names = "qux"),
-    "The following indexed field does not exist: qux"
+    SOMADataFrameCreate(uri, asch, index_column_names = "qux", domain = list(qux = NULL)),
+    "Index column 'qux' missing"
   )
   if (dir.exists(uri)) {
     unlink(uri, recursive = TRUE)
@@ -197,8 +197,8 @@ test_that("Basic mechanics with default index_column_names", {
   asch <- create_arrow_schema(foo_first = FALSE)
 
   expect_error(
-    SOMADataFrameCreate(tempfile(), schema = asch, index_column_names = "qux"),
-    regexp = "The following indexed field does not exist: qux"
+    SOMADataFrameCreate(tempfile(), schema = asch, index_column_names = "qux", domain = list(qux = NULL)),
+    regexp = "Index column 'qux' missing"
   )
 
   if (dir.exists(uri)) {
@@ -602,7 +602,7 @@ test_that("soma_ prefix is reserved", {
       index_column_names = "int_column",
       domain = list("int_column" = c(0, 0))
     ),
-    "Column names must not start with reserved prefix 'soma_'"
+    "DataFrame schema may not contain fields with name prefix 'soma_': got 'soma_foo'"
   )
 })
 
@@ -646,7 +646,7 @@ test_that("soma_joinid validations", {
       index_column_names = "int_column",
       domain = list("int_column" = c(0, 0))
     ),
-    "soma_joinid field must be of type Arrow int64"
+    "'soma_joinid' field must be of type Arrow int64 but is int32""
   )
 })
 

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -646,7 +646,7 @@ test_that("soma_joinid validations", {
       index_column_names = "int_column",
       domain = list("int_column" = c(0, 0))
     ),
-    "'soma_joinid' field must be of type Arrow int64 but is int32""
+    "'soma_joinid' field must be of type Arrow int64 but is int32"
   )
 })
 

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set_property(TARGET TILEDBSOMA_NANOARROW_OBJECT PROPERTY POSITION_INDEPENDENT_CO
 
 add_library(TILEDB_COMMON_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/common/arrow/arrow_buffer.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/arrow/decode.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/arrow/exporter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/arrow/utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/logging/impl/logger.cc

--- a/libtiledbsoma/src/common/arrow/decode.cc
+++ b/libtiledbsoma/src/common/arrow/decode.cc
@@ -1,0 +1,34 @@
+#include "decode.h"
+
+namespace tiledbsoma::common::arrow {
+    std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str) {
+        if (metadata_str == nullptr) {
+            return std::unordered_map<std::string, std::string>();
+        }
+
+        // Current offset in the metadata pointer
+        size_t offset = 0;
+        std::unordered_map<std::string, std::string> metadata_map;
+
+        int32_t element_count = reinterpret_cast<const int32_t*>(metadata_str)[0];
+        offset += sizeof(int32_t);
+
+        for (int32_t i = 0; i < element_count; ++i) {
+            int32_t key_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
+            offset += sizeof(int32_t);
+
+            std::string key(metadata_str + offset, key_size);
+            offset += key_size;
+
+            int32_t value_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
+            offset += sizeof(int32_t);
+
+            std::string value(metadata_str + offset, value_size);
+            offset += value_size;
+
+            metadata_map.emplace(std::move(key), std::move(value));
+        }
+
+        return metadata_map;
+    }
+}

--- a/libtiledbsoma/src/common/arrow/decode.cc
+++ b/libtiledbsoma/src/common/arrow/decode.cc
@@ -1,34 +1,34 @@
 #include "decode.h"
 
 namespace tiledbsoma::common::arrow {
-    std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str) {
-        if (metadata_str == nullptr) {
-            return std::unordered_map<std::string, std::string>();
-        }
+std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str) {
+    if (metadata_str == nullptr) {
+        return std::unordered_map<std::string, std::string>();
+    }
 
-        // Current offset in the metadata pointer
-        size_t offset = 0;
-        std::unordered_map<std::string, std::string> metadata_map;
+    // Current offset in the metadata pointer
+    size_t offset = 0;
+    std::unordered_map<std::string, std::string> metadata_map;
 
-        int32_t element_count = reinterpret_cast<const int32_t*>(metadata_str)[0];
+    int32_t element_count = reinterpret_cast<const int32_t*>(metadata_str)[0];
+    offset += sizeof(int32_t);
+
+    for (int32_t i = 0; i < element_count; ++i) {
+        int32_t key_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
         offset += sizeof(int32_t);
 
-        for (int32_t i = 0; i < element_count; ++i) {
-            int32_t key_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
-            offset += sizeof(int32_t);
+        std::string key(metadata_str + offset, key_size);
+        offset += key_size;
 
-            std::string key(metadata_str + offset, key_size);
-            offset += key_size;
+        int32_t value_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
+        offset += sizeof(int32_t);
 
-            int32_t value_size = reinterpret_cast<const int32_t*>(metadata_str + offset)[0];
-            offset += sizeof(int32_t);
+        std::string value(metadata_str + offset, value_size);
+        offset += value_size;
 
-            std::string value(metadata_str + offset, value_size);
-            offset += value_size;
-
-            metadata_map.emplace(std::move(key), std::move(value));
-        }
-
-        return metadata_map;
+        metadata_map.emplace(std::move(key), std::move(value));
     }
+
+    return metadata_map;
 }
+}  // namespace tiledbsoma::common::arrow

--- a/libtiledbsoma/src/common/arrow/decode.h
+++ b/libtiledbsoma/src/common/arrow/decode.h
@@ -14,7 +14,7 @@
 #include <unordered_map>
 
 namespace tiledbsoma::common::arrow {
-    std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str);
+std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str);
 }
 
 #endif

--- a/libtiledbsoma/src/common/arrow/decode.h
+++ b/libtiledbsoma/src/common/arrow/decode.h
@@ -1,0 +1,20 @@
+/**
+ * @file   decode.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ */
+
+#ifndef COMMON_ARROW_DECODE_H
+#define COMMON_ARROW_DECODE_H
+
+#include <string>
+#include <unordered_map>
+
+namespace tiledbsoma::common::arrow {
+    std::unordered_map<std::string, std::string> metadata_string_to_map(const char* metadata_str);
+}
+
+#endif

--- a/libtiledbsoma/src/soma/soma_attribute.cc
+++ b/libtiledbsoma/src/soma/soma_attribute.cc
@@ -13,6 +13,7 @@
 
 #include "soma_attribute.h"
 #include "../utils/arrow_adapter.h"
+#include "common/arrow/decode.h"
 #include "common/logging/impl/logger.h"
 
 namespace tiledbsoma {
@@ -56,11 +57,10 @@ std::shared_ptr<SOMAColumn> SOMAAttribute::deserialize(
 }
 
 std::shared_ptr<SOMAAttribute> SOMAAttribute::create(
-    std::shared_ptr<tiledb::Context> ctx,
-    ArrowSchema* schema,
-    std::string_view type_metadata,
-    PlatformConfig platform_config) {
-    auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(ctx, schema, type_metadata, platform_config);
+    std::shared_ptr<tiledb::Context> ctx, ArrowSchema* schema, PlatformConfig platform_config) {
+    auto metadata = common::arrow::metadata_string_to_map(schema->metadata);
+    auto attribute = ArrowAdapter::tiledb_attribute_from_arrow_schema(
+        ctx, schema, metadata[ARROW_DATATYPE_METADATA_KEY], platform_config);
 
     return std::make_shared<SOMAAttribute>(SOMAAttribute(attribute.first, attribute.second));
 }

--- a/libtiledbsoma/src/soma/soma_attribute.h
+++ b/libtiledbsoma/src/soma/soma_attribute.h
@@ -44,10 +44,7 @@ class SOMAAttribute : public SOMAColumn {
      * Create a ``SOMAAttribute`` shared pointer from an Arrow schema
      */
     static std::shared_ptr<SOMAAttribute> create(
-        std::shared_ptr<tiledb::Context> ctx,
-        ArrowSchema* schema,
-        std::string_view type_metadata,
-        PlatformConfig platform_config);
+        std::shared_ptr<tiledb::Context> ctx, ArrowSchema* schema, PlatformConfig platform_config);
 
     SOMAAttribute(tiledb::Attribute attribute, std::optional<tiledb::Enumeration> enumeration = std::nullopt)
         : attribute(attribute)

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -48,7 +48,7 @@ void SOMADataFrame::create(
     std::string_view uri,
     const common::arrow::managed_unique_ptr<ArrowSchema>& schema,
     std::span<const std::string> index_column_names,
-    std::span<const std::any> index_column_domains,
+    std::span<const DomainRange> index_column_domains,
     std::shared_ptr<SOMAContext> ctx,
     PlatformConfig platform_config,
     std::optional<TimestampRange> timestamp) {

--- a/libtiledbsoma/src/soma/soma_dataframe.cc
+++ b/libtiledbsoma/src/soma/soma_dataframe.cc
@@ -14,8 +14,14 @@
 #include "soma_dataframe.h"
 
 #include "../utils/arrow_adapter.h"
+#include "../utils/common.h"
 #include "common/logging/impl/logger.h"
+#include "soma_attribute.h"
 #include "soma_coordinates.h"
+#include "soma_dimension.h"
+
+#include <algorithm>
+#include <ranges>
 
 namespace tiledbsoma {
 using namespace tiledb;
@@ -34,6 +40,26 @@ void SOMADataFrame::create(
     std::optional<TimestampRange> timestamp) {
     auto [tiledb_schema, soma_schema_extension] = ArrowAdapter::tiledb_schema_from_arrow_schema(
         ctx->tiledb_ctx(), schema, index_columns, std::nullopt, "SOMADataFrame", true, platform_config, timestamp);
+
+    SOMAArray::create(ctx, uri, tiledb_schema, "SOMADataFrame", std::nullopt, timestamp);
+}
+
+void SOMADataFrame::create(
+    std::string_view uri,
+    const common::arrow::managed_unique_ptr<ArrowSchema>& schema,
+    std::span<const std::string> index_column_names,
+    std::span<const std::any> index_column_domains,
+    std::shared_ptr<SOMAContext> ctx,
+    PlatformConfig platform_config,
+    std::optional<TimestampRange> timestamp) {
+    tiledb::ArraySchema tiledb_schema = utils::create_dataframe_schema(
+        "SOMADataFrame",
+        schema.get(),
+        index_column_names,
+        index_column_domains,
+        ctx->tiledb_ctx(),
+        platform_config,
+        timestamp);
 
     SOMAArray::create(ctx, uri, tiledb_schema, "SOMADataFrame", std::nullopt, timestamp);
 }

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -70,7 +70,7 @@ class SOMADataFrame : public SOMAArray {
         std::string_view uri,
         const common::arrow::managed_unique_ptr<ArrowSchema>& schema,
         std::span<const std::string> index_column_names,
-        std::span<const std::any> index_column_domains,
+        std::span<const DomainRange> index_column_domains,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_dataframe.h
+++ b/libtiledbsoma/src/soma/soma_dataframe.h
@@ -14,8 +14,10 @@
 #ifndef SOMA_DATAFRAME
 #define SOMA_DATAFRAME
 
+#include <any>
 #include <filesystem>
 #include <optional>
+#include <span>
 
 #include "../common/soma_column_selection.h"
 #include "../tiledb_adapter/platform_config.h"
@@ -49,6 +51,26 @@ class SOMADataFrame : public SOMAArray {
         std::string_view uri,
         const common::arrow::managed_unique_ptr<ArrowSchema>& schema,
         const common::arrow::ArrowTable& index_columns,
+        std::shared_ptr<SOMAContext> ctx,
+        PlatformConfig platform_config = PlatformConfig(),
+        std::optional<TimestampRange> timestamp = std::nullopt);
+
+    /**
+     * @brief Create a SOMADataFrame object at the given URI.
+     *
+     * @param uri URI to create the SOMADataFrame
+     * @param schema Arrow schema
+     * @param index_columns The index column names with associated domains
+     * and tile extents per dimension
+     * @param ctx SOMAContext
+     * @param platform_config Optional config parameter dictionary
+     * @param timestamp Optional the timestamp range to write SOMA metadata info
+     */
+    static void create(
+        std::string_view uri,
+        const common::arrow::managed_unique_ptr<ArrowSchema>& schema,
+        std::span<const std::string> index_column_names,
+        std::span<const std::any> index_column_domains,
         std::shared_ptr<SOMAContext> ctx,
         PlatformConfig platform_config = PlatformConfig(),
         std::optional<TimestampRange> timestamp = std::nullopt);

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -228,6 +228,17 @@ std::shared_ptr<SOMADimension> SOMADimension::create(
     }
 }
 
+std::shared_ptr<SOMADimension> SOMADimension::create_soma_joinid(
+    std::shared_ptr<tiledb::Context> ctx, const std::string& soma_type, const PlatformConfig& platform_config) {
+    int64_t extent = utils::get_dim_extent<int64_t>(
+        SOMA_JOINID.data(), platform_config, 2048u, std::numeric_limits<int64_t>::max());
+
+    tiledb::Dimension dimension = tiledb::Dimension::create<int64_t>(
+        *ctx, SOMA_JOINID.data(), {{0, std::numeric_limits<int64_t>::max() - 1 - extent}}, extent);
+    dimension.set_filter_list(utils::create_dim_filter_list(SOMA_JOINID.data(), platform_config, soma_type, ctx));
+    return std::make_shared<SOMADimension>(dimension);
+}
+
 std::shared_ptr<SOMADimension> SOMADimension::create(
     std::shared_ptr<tiledb::Context> ctx,
     const std::string& name,

--- a/libtiledbsoma/src/soma/soma_dimension.cc
+++ b/libtiledbsoma/src/soma/soma_dimension.cc
@@ -149,6 +149,87 @@ std::shared_ptr<SOMADimension> SOMADimension::create(
 
 std::shared_ptr<SOMADimension> SOMADimension::create(
     std::shared_ptr<tiledb::Context> ctx,
+    ArrowSchema* schema,
+    const std::string& soma_type,
+    const PlatformConfig& platform_config) {
+    auto create_dimension = [&]<typename TMin, typename TMax = TMin>() -> std::shared_ptr<SOMADimension> {
+        TMin extent = utils::get_dim_extent<TMin>(
+            schema->name,
+            platform_config,
+            tiledb::impl::type_size(common::arrow::to_tiledb_format(schema->format)) == 1 ? 1u : 2048u,
+            static_cast<TMin>(std::numeric_limits<TMax>::max()));
+
+        auto datatype = common::arrow::to_tiledb_format(schema->format);
+        std::array<TMin, 2> domain;
+        switch (datatype) {
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+                domain[0] = std::numeric_limits<TMin>::lowest() + 1;
+                domain[1] = static_cast<TMin>(std::numeric_limits<TMax>::max()) - 1000000;
+                break;
+            case TILEDB_INT32:
+            case TILEDB_INT64:
+                domain[0] = std::numeric_limits<TMin>::lowest() + 1;
+                domain[1] = static_cast<TMin>(std::numeric_limits<TMax>::max()) - 1 - extent;
+                break;
+            default:
+                domain[0] = std::numeric_limits<TMin>::lowest();
+                domain[1] = static_cast<TMin>(std::numeric_limits<TMax>::max()) - 1 - extent;
+        }
+
+        tiledb::Dimension dimension = tiledb::Dimension::create(*ctx, schema->name, datatype, domain.data(), &extent);
+        dimension.set_filter_list(utils::create_dim_filter_list(schema->name, platform_config, soma_type, ctx));
+
+        return std::make_shared<SOMADimension>(dimension);
+    };
+
+    switch (common::arrow::to_tiledb_format(schema->format)) {
+        case TILEDB_CHAR:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_BLOB: {
+            tiledb::Dimension dimension = tiledb::Dimension::create(
+                *ctx, schema->name, TILEDB_STRING_ASCII, nullptr, nullptr);
+            dimension.set_filter_list(utils::create_dim_filter_list(schema->name, platform_config, soma_type, ctx));
+
+            return std::make_shared<SOMADimension>(dimension);
+        }
+        case TILEDB_INT8:
+            return create_dimension.template operator()<int8_t>();
+        case TILEDB_UINT8:
+            return create_dimension.template operator()<uint8_t>();
+        case TILEDB_INT16:
+            return create_dimension.template operator()<int16_t>();
+        case TILEDB_UINT16:
+            return create_dimension.template operator()<uint16_t>();
+        case TILEDB_INT32:
+            return create_dimension.template operator()<int32_t>();
+        case TILEDB_UINT32:
+            return create_dimension.template operator()<uint32_t>();
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_INT64:
+            return create_dimension.template operator()<int64_t>();
+        case TILEDB_UINT64:
+            return create_dimension.template operator()<uint64_t, int64_t>();
+        case TILEDB_FLOAT32:
+            return create_dimension.template operator()<float_t>();
+        case TILEDB_FLOAT64:
+            return create_dimension.template operator()<double_t>();
+        default:
+            throw TileDBSOMAError(
+                fmt::format(
+                    "[SOMADimension][create] Unsupported TileDB dimension: {} ",
+                    tiledb::impl::type_to_str(common::arrow::to_tiledb_format(schema->format))));
+    }
+}
+
+std::shared_ptr<SOMADimension> SOMADimension::create(
+    std::shared_ptr<tiledb::Context> ctx,
     const std::string& name,
     const std::string& soma_type,
     tiledb_datatype_t tiledb_type,

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -54,6 +54,9 @@ class SOMADimension : public SOMAColumn {
         const std::string& soma_type,
         const PlatformConfig& platform_config);
 
+    static std::shared_ptr<SOMADimension> create_soma_joinid(
+        std::shared_ptr<tiledb::Context> ctx, const std::string& soma_type, const PlatformConfig& platform_config);
+
     template <typename T>
     static std::shared_ptr<SOMADimension> create(
         std::shared_ptr<tiledb::Context> ctx,

--- a/libtiledbsoma/src/soma/soma_dimension.h
+++ b/libtiledbsoma/src/soma/soma_dimension.h
@@ -48,6 +48,12 @@ class SOMADimension : public SOMAColumn {
         std::string_view type_metadata,
         const PlatformConfig& platform_config);
 
+    static std::shared_ptr<SOMADimension> create(
+        std::shared_ptr<tiledb::Context> ctx,
+        ArrowSchema* schema,
+        const std::string& soma_type,
+        const PlatformConfig& platform_config);
+
     template <typename T>
     static std::shared_ptr<SOMADimension> create(
         std::shared_ptr<tiledb::Context> ctx,

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -443,8 +443,30 @@ ArraySchema create_dataframe_schema(
         throw std::range_error("At least one non-index column must be provided");
     }
 
+    if (arrow_schema->n_children) {
+        for (const auto& name : index_column_names) {
+            auto column_occurrences = std::count_if(
+                arrow_schema->children,
+                arrow_schema->children + arrow_schema->n_children,
+                [&](const auto child_schema) { return name == child_schema->name; });
+
+            if (column_occurrences == 0) {
+                // 'soma_joinid` will be added in the schema by default if missing
+                if (name != SOMA_JOINID) {
+                    throw std::range_error(fmt::format("Missing index column '{}' from schema", name));
+                }
+            } else if (column_occurrences != 1) {
+                throw std::range_error(fmt::format("Multiple columns found in schema for index column '{}'", name));
+            }
+        }
+    }
+
     if (index_column_names.size() != index_column_domains.size()) {
-        throw std::range_error("Size mismatch between list of index column names and domains");
+        throw std::range_error(
+            fmt::format(
+                "Size mismatch between list of index column names and domains; {} != {}",
+                index_column_names.size(),
+                index_column_domains.size()));
     }
 
     std::unordered_map<std::string, DomainRange> index_columns;
@@ -518,6 +540,7 @@ ArraySchema create_dataframe_schema(
     // We generate the additional schema metadata here to ensure that the
     // serialized column order matches the expected schema order
     for (const auto& column_name : index_column_names) {
+        // If a column is specified as `index column` but it isn't present in the schema the following call is expected to throw
         const auto column = util::find_column_by_name(columns, column_name);
 
         if (column->tiledb_dimensions().has_value()) {
@@ -596,9 +619,19 @@ ArraySchema create_dataframe_schema(
     for (const auto& column : columns | std::views::filter([](const auto& col) { return col->isIndexColumn(); })) {
         std::visit(
             [&](auto&& domain) {
-                using T = std::decay_t<decltype(domain)>::value_type::first_type;
+                using T = std::decay_t<decltype(domain)>;
 
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<T>(column, domain)}});
+                if constexpr (std::is_same_v<T, std::monostate>) {
+                    throw std::runtime_error(
+                        fmt::format(
+                            "Index column '{}' has no domain attached. This can be caused by the column not being "
+                            "present in the schema provided.",
+                            column->name()));
+                } else {
+                    using E = std::decay_t<decltype(domain)>::value_type::first_type;
+
+                    column->set_current_domain_slot(rect, {{decode_domain.template operator()<E>(column, domain)}});
+                }
             },
             index_columns[column->name()]);
     }

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -465,7 +465,7 @@ ArraySchema create_dataframe_schema(
         std::string_view format(arrow_schema->children[i]->format);
 
         // Verify no illegal use of soma_ prefix
-        if (name.starts_with("soma_")) {
+        if (!platform_config.override_naming_restriction && name.starts_with("soma_")) {
             if (name != SOMA_JOINID) {
                 throw std::range_error(
                     fmt::format(
@@ -496,15 +496,7 @@ ArraySchema create_dataframe_schema(
             }
 
             if (name == SOMA_JOINID) {
-                int64_t extent = utils::get_dim_extent<int64_t>(
-                    name.data(), platform_config, 2048, std::numeric_limits<int64_t>::max());
-
-                tiledb::Dimension dimension = tiledb::Dimension::create<int64_t>(
-                    *ctx, name.data(), {{0, std::numeric_limits<int64_t>::max() - extent - 1}}, extent);
-                dimension.set_filter_list(
-                    utils::create_dim_filter_list(name.data(), platform_config, soma_type.data(), ctx));
-
-                columns.push_back(std::make_shared<SOMADimension>(dimension));
+                columns.push_back(SOMADimension::create_soma_joinid(ctx, "SOMADataFrame", platform_config));
             } else {
                 columns.push_back(
                     SOMADimension::create(ctx, arrow_schema->children[i], "SOMADataFrame", platform_config));
@@ -518,13 +510,7 @@ ArraySchema create_dataframe_schema(
     if (std::none_of(
             columns.cbegin(), columns.cend(), [](const auto& column) { return column->name() == SOMA_JOINID; })) {
         if (index_columns.contains(SOMA_JOINID.data())) {
-            int64_t extent = utils::get_dim_extent<int64_t>(
-                SOMA_JOINID.data(), platform_config, 2048, std::numeric_limits<int64_t>::max());
-            tiledb::Dimension dimension = tiledb::Dimension::create<int64_t>(
-                *ctx, SOMA_JOINID.data(), {{0, std::numeric_limits<int64_t>::max() - 1 - extent}}, extent);
-            dimension.set_filter_list(
-                utils::create_dim_filter_list(SOMA_JOINID.data(), platform_config, "SOMADataFrame", ctx));
-            columns.push_back(std::make_shared<SOMADimension>(dimension));
+            columns.push_back(SOMADimension::create_soma_joinid(ctx, "SOMADataFrame", platform_config));
         } else {
             columns.push_back(
                 std::make_shared<SOMAAttribute>(tiledb::Attribute::create<int64_t>(

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -527,7 +527,9 @@ ArraySchema create_dataframe_schema(
         if (index_columns.contains(SOMA_JOINID.data())) {
             columns.push_back(SOMADimension::create_soma_joinid(ctx, "SOMADataFrame", platform_config));
         } else {
-            columns.push_back(
+            // If 'soma_joinid' is missing add it as the first attribute
+            columns.emplace(
+                columns.begin(),
                 std::make_shared<SOMAAttribute>(tiledb::Attribute::create<int64_t>(
                     *ctx,
                     SOMA_JOINID.data(),

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -432,7 +432,7 @@ ArraySchema create_dataframe_schema(
     std::string_view soma_type,
     ArrowSchema* arrow_schema,
     std::span<const std::string> index_column_names,
-    std::span<const std::any> index_column_domains,
+    std::span<const DomainRange> index_column_domains,
     std::shared_ptr<tiledb::Context> ctx,
     PlatformConfig platform_config,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
@@ -448,7 +448,7 @@ ArraySchema create_dataframe_schema(
             "[create_dataframe_schema] Size mismatch between list of index column names and domains");
     }
 
-    std::unordered_map<std::string, std::any> index_columns;
+    std::unordered_map<std::string, DomainRange> index_columns;
     for (size_t i = 0; i < index_column_names.size(); ++i) {
         if (index_columns.contains(index_column_names[i])) {
             throw std::range_error(
@@ -577,10 +577,10 @@ ArraySchema create_dataframe_schema(
     tiledb::CurrentDomain current_domain(*ctx);
     tiledb::NDRectangle rect(*ctx, domain);
 
-    auto decode_domain = [&index_columns]<typename T>(std::shared_ptr<SOMAColumn> column) -> std::any {
+    auto decode_domain = []<typename T>(
+                             std::shared_ptr<SOMAColumn> column, std::optional<std::pair<T, T>> domain) -> std::any {
         if constexpr (std::is_same_v<T, std::string>) {
-            auto current_domain = std::any_cast<std::optional<std::pair<T, T>>>(index_columns[column->name()])
-                                      .value_or(std::make_pair<T, T>("", ""));
+            auto current_domain = domain.value_or(std::make_pair<T, T>("", ""));
 
             if (current_domain.first != "" || current_domain.second != "") {
                 throw std::range_error("TileDB str and bytes index-column types do not support domain specification");
@@ -588,8 +588,7 @@ ArraySchema create_dataframe_schema(
 
             return std::make_any<std::array<std::string, 2>>(std::array<std::string, 2>{{"", ""}});
         } else {
-            auto current_domain = std::any_cast<std::optional<std::pair<T, T>>>(index_columns[column->name()])
-                                      .value_or(std::make_pair<T, T>(0, 0));
+            auto current_domain = domain.value_or(std::make_pair<T, T>(0, 0));
 
             if (column->name() == SOMA_JOINID) {
                 if (current_domain.first < 0) {
@@ -612,52 +611,59 @@ ArraySchema create_dataframe_schema(
     };
 
     for (const auto& column : columns | std::views::filter([](const auto& col) { return col->isIndexColumn(); })) {
-        switch (column->domain_type().value()) {
-            case TILEDB_UINT8:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint8_t>(column)}});
-                break;
-            case TILEDB_UINT16:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint16_t>(column)}});
-                break;
-            case TILEDB_UINT32:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint32_t>(column)}});
-                break;
-            case TILEDB_UINT64:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint64_t>(column)}});
-                break;
-            case TILEDB_INT8:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int8_t>(column)}});
-                break;
-            case TILEDB_INT16:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int16_t>(column)}});
-                break;
-            case TILEDB_INT32:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int32_t>(column)}});
-                break;
-            case TILEDB_DATETIME_SEC:
-            case TILEDB_DATETIME_MS:
-            case TILEDB_DATETIME_US:
-            case TILEDB_DATETIME_NS:
-            case TILEDB_INT64:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int64_t>(column)}});
-                break;
-            case TILEDB_FLOAT32:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<float_t>(column)}});
-                break;
-            case TILEDB_FLOAT64:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<double_t>(column)}});
-                break;
-            case TILEDB_CHAR:
-            case TILEDB_STRING_ASCII:
-            case TILEDB_STRING_UTF8:
-                column->set_current_domain_slot(rect, {{decode_domain.template operator()<std::string>(column)}});
-                break;
-            default:
-                throw std::runtime_error(
-                    fmt::format(
-                        "[create_dataframe_schema] Unsupported dimension type {} to set current domain",
-                        tiledb::impl::type_to_str(column->domain_type().value())));
-        }
+        std::visit(
+            [&](auto&& domain) {
+                using T = std::decay_t<decltype(domain)>::value_type::first_type;
+
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<T>(column, domain)}});
+            },
+            index_columns[column->name()]);
+        // switch (column->domain_type().value()) {
+        //     case TILEDB_UINT8:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint8_t>(column)}});
+        //         break;
+        //     case TILEDB_UINT16:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint16_t>(column)}});
+        //         break;
+        //     case TILEDB_UINT32:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint32_t>(column)}});
+        //         break;
+        //     case TILEDB_UINT64:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint64_t>(column)}});
+        //         break;
+        //     case TILEDB_INT8:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int8_t>(column)}});
+        //         break;
+        //     case TILEDB_INT16:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int16_t>(column)}});
+        //         break;
+        //     case TILEDB_INT32:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int32_t>(column)}});
+        //         break;
+        //     case TILEDB_DATETIME_SEC:
+        //     case TILEDB_DATETIME_MS:
+        //     case TILEDB_DATETIME_US:
+        //     case TILEDB_DATETIME_NS:
+        //     case TILEDB_INT64:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int64_t>(column)}});
+        //         break;
+        //     case TILEDB_FLOAT32:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<float_t>(column)}});
+        //         break;
+        //     case TILEDB_FLOAT64:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<double_t>(column)}});
+        //         break;
+        //     case TILEDB_CHAR:
+        //     case TILEDB_STRING_ASCII:
+        //     case TILEDB_STRING_UTF8:
+        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<std::string>(column)}});
+        //         break;
+        //     default:
+        //         throw std::runtime_error(
+        //             fmt::format(
+        //                 "[create_dataframe_schema] Unsupported dimension type {} to set current domain",
+        //                 tiledb::impl::type_to_str(column->domain_type().value())));
+        //}
     }
 
     current_domain.set_ndrectangle(rect);

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -14,11 +14,18 @@
 #include "platform_config.h"
 
 #include "../utils/common.h"
+#include "../utils/util.h"
 #include "common/arrow/utils.h"
 #include "common/logging/impl/logger.h"
 
+#include <algorithm>
 #include <limits>
+#include <ranges>
 #include <tiledb/tiledb_experimental>
+#include <unordered_map>
+
+#include "../soma/soma_attribute.h"
+#include "../soma/soma_dimension.h"
 
 using json = nlohmann::json;
 
@@ -412,6 +419,259 @@ ArraySchema create_nd_array_schema(
 
     for (size_t i = 0; i < shape.size(); ++i) {
         rect.set_range<int64_t>(i, 0, shape[i] - 1);
+    }
+
+    current_domain.set_ndrectangle(rect);
+    tiledb::ArraySchemaExperimental::set_current_domain(*ctx, schema, current_domain);
+    schema.check();
+
+    return schema;
+}
+
+ArraySchema create_dataframe_schema(
+    std::string_view soma_type,
+    ArrowSchema* arrow_schema,
+    std::span<const std::string> index_column_names,
+    std::span<const std::any> index_column_domains,
+    std::shared_ptr<tiledb::Context> ctx,
+    PlatformConfig platform_config,
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp) {
+    tiledb::ArraySchema schema = utils::create_base_tiledb_schema(ctx, platform_config, true, timestamp);
+    tiledb::Domain domain(*ctx);
+
+    if (index_column_names.empty()) {
+        throw std::range_error("[create_dataframe_schema] At least one non-index column must be provided");
+    }
+
+    if (index_column_names.size() != index_column_domains.size()) {
+        throw std::range_error(
+            "[create_dataframe_schema] Size mismatch between list of index column names and domains");
+    }
+
+    std::unordered_map<std::string, std::any> index_columns;
+    for (size_t i = 0; i < index_column_names.size(); ++i) {
+        if (index_columns.contains(index_column_names[i])) {
+            throw std::range_error(
+                fmt::format("[create_dataframe_schema] Duplicate index column found '{}'", index_column_names[i]));
+        }
+
+        index_columns.emplace(index_column_names[i], index_column_domains[i]);
+    }
+
+    std::vector<std::shared_ptr<SOMAColumn>> columns;
+
+    for (int64_t i = 0; i < arrow_schema->n_children; ++i) {
+        std::string_view name(arrow_schema->children[i]->name);
+        std::string_view format(arrow_schema->children[i]->format);
+
+        // Verify no illegal use of soma_ prefix
+        if (name.starts_with("soma_")) {
+            if (name != SOMA_JOINID) {
+                throw std::range_error(
+                    fmt::format(
+                        "[create_dataframe_schema] DataFrame schema may not contain fields with name prefix 'soma_': "
+                        "got '{}'",
+                        name));
+            }
+
+            if (name == SOMA_JOINID) {
+                if (common::arrow::to_tiledb_format(format) != TILEDB_INT64) {
+                    throw std::range_error(
+                        fmt::format(
+                            "[create_dataframe_schema] '{}' field must be of type Arrow int64 but is {}",
+                            SOMA_JOINID,
+                            common::arrow::to_arrow_readable(format)));
+                }
+            }
+        }
+
+        if (index_columns.contains(name.data())) {
+            if (arrow_schema->dictionary != nullptr) {
+                std::range_error(
+                    fmt::format(
+                        "[create_dataframe_schema] Cannot set index column '{}' to an enumeration. Index columns do "
+                        "not "
+                        "support enumerations.",
+                        name));
+            }
+
+            if (name == SOMA_JOINID) {
+                int64_t extent = utils::get_dim_extent<int64_t>(
+                    name.data(), platform_config, 2048, std::numeric_limits<int64_t>::max());
+
+                tiledb::Dimension dimension = tiledb::Dimension::create<int64_t>(
+                    *ctx, name.data(), {{0, std::numeric_limits<int64_t>::max() - extent - 1}}, extent);
+                dimension.set_filter_list(
+                    utils::create_dim_filter_list(name.data(), platform_config, soma_type.data(), ctx));
+
+                columns.push_back(std::make_shared<SOMADimension>(dimension));
+            } else {
+                columns.push_back(
+                    SOMADimension::create(ctx, arrow_schema->children[i], "SOMADataFrame", platform_config));
+            }
+        } else {
+            columns.push_back(SOMAAttribute::create(ctx, arrow_schema->children[i], platform_config));
+        }
+    }
+
+    // Inject missing required columns
+    if (std::none_of(
+            columns.cbegin(), columns.cend(), [](const auto& column) { return column->name() == SOMA_JOINID; })) {
+        if (index_columns.contains(SOMA_JOINID.data())) {
+            int64_t extent = utils::get_dim_extent<int64_t>(
+                SOMA_JOINID.data(), platform_config, 2048, std::numeric_limits<int64_t>::max());
+            tiledb::Dimension dimension = tiledb::Dimension::create<int64_t>(
+                *ctx, SOMA_JOINID.data(), {{0, std::numeric_limits<int64_t>::max() - 1 - extent}}, extent);
+            dimension.set_filter_list(
+                utils::create_dim_filter_list(SOMA_JOINID.data(), platform_config, "SOMADataFrame", ctx));
+            columns.push_back(std::make_shared<SOMADimension>(dimension));
+        } else {
+            columns.push_back(
+                std::make_shared<SOMAAttribute>(tiledb::Attribute::create<int64_t>(
+                    *ctx,
+                    SOMA_JOINID.data(),
+                    utils::create_attr_filter_list(SOMA_JOINID.data(), platform_config, ctx))));
+        }
+    }
+
+    if (static_cast<size_t>(std::count_if(columns.cbegin(), columns.cend(), [](const auto& col) {
+            return col->isIndexColumn();
+        })) != index_columns.size()) {
+        throw std::range_error("[create_dataframe_schema] Some index columns where not found in dataframe schema");
+    }
+
+    // Unit tests expect dimension order should match the index column schema
+    // and NOT the Arrow schema
+    // We generate the additional schema metadata here to ensure that the
+    // serialized column order matches the expected schema order
+    for (const auto& column_name : index_column_names) {
+        const auto column = util::find_column_by_name(columns, column_name);
+
+        if (column->tiledb_dimensions().has_value()) {
+            // Intermediate variable required to avoid lifetime issues
+            auto dimensions = column->tiledb_dimensions().value();
+            for (const auto& dimension : dimensions) {
+                domain.add_dimension(dimension);
+            }
+        }
+
+        if (column->tiledb_enumerations().has_value()) {
+            auto enumerations = column->tiledb_enumerations().value();
+            for (const auto& enumeration : enumerations) {
+                ArraySchemaExperimental::add_enumeration(*ctx, schema, enumeration);
+            }
+        }
+
+        if (column->tiledb_attributes().has_value()) {
+            auto attributes = column->tiledb_attributes().value();
+            for (const auto& attribute : attributes) {
+                schema.add_attribute(attribute);
+            }
+        }
+    }
+
+    for (const auto& column : columns | std::views::filter([](const auto& col) { return !col->isIndexColumn(); })) {
+        if (column->tiledb_enumerations().has_value()) {
+            auto enumerations = column->tiledb_enumerations().value();
+            for (const auto& enumeration : enumerations) {
+                ArraySchemaExperimental::add_enumeration(*ctx, schema, enumeration);
+            }
+        }
+
+        if (column->tiledb_attributes().has_value()) {
+            auto attributes = column->tiledb_attributes().value();
+            for (const auto& attribute : attributes) {
+                schema.add_attribute(attribute);
+            }
+        }
+    }
+
+    schema.set_domain(domain);
+
+    tiledb::CurrentDomain current_domain(*ctx);
+    tiledb::NDRectangle rect(*ctx, domain);
+
+    auto decode_domain = [&index_columns]<typename T>(std::shared_ptr<SOMAColumn> column) -> std::any {
+        if constexpr (std::is_same_v<T, std::string>) {
+            auto current_domain = std::any_cast<std::optional<std::pair<T, T>>>(index_columns[column->name()])
+                                      .value_or(std::make_pair<T, T>("", ""));
+
+            if (current_domain.first != "" || current_domain.second != "") {
+                throw std::range_error("TileDB str and bytes index-column types do not support domain specification");
+            }
+
+            return std::make_any<std::array<std::string, 2>>(std::array<std::string, 2>{{"", ""}});
+        } else {
+            auto current_domain = std::any_cast<std::optional<std::pair<T, T>>>(index_columns[column->name()])
+                                      .value_or(std::make_pair<T, T>(0, 0));
+
+            if (column->name() == SOMA_JOINID) {
+                if (current_domain.first < 0) {
+                    throw std::range_error(
+                        fmt::format(
+                            "[create_dataframe_schema] '{}' indices cannot be negative; got lower bound {}",
+                            SOMA_JOINID,
+                            current_domain.first));
+                } else if (current_domain.second < 0) {
+                    throw std::range_error(
+                        fmt::format(
+                            "[create_dataframe_schema] '{}' indices cannot be negative; got bound bound {}",
+                            SOMA_JOINID,
+                            current_domain.second));
+                }
+            }
+
+            return std::make_any<std::array<T, 2>>(std::array<T, 2>{{current_domain.first, current_domain.second}});
+        }
+    };
+
+    for (const auto& column : columns | std::views::filter([](const auto& col) { return col->isIndexColumn(); })) {
+        switch (column->domain_type().value()) {
+            case TILEDB_UINT8:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint8_t>(column)}});
+                break;
+            case TILEDB_UINT16:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint16_t>(column)}});
+                break;
+            case TILEDB_UINT32:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint32_t>(column)}});
+                break;
+            case TILEDB_UINT64:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint64_t>(column)}});
+                break;
+            case TILEDB_INT8:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int8_t>(column)}});
+                break;
+            case TILEDB_INT16:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int16_t>(column)}});
+                break;
+            case TILEDB_INT32:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int32_t>(column)}});
+                break;
+            case TILEDB_DATETIME_SEC:
+            case TILEDB_DATETIME_MS:
+            case TILEDB_DATETIME_US:
+            case TILEDB_DATETIME_NS:
+            case TILEDB_INT64:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<int64_t>(column)}});
+                break;
+            case TILEDB_FLOAT32:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<float_t>(column)}});
+                break;
+            case TILEDB_FLOAT64:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<double_t>(column)}});
+                break;
+            case TILEDB_CHAR:
+            case TILEDB_STRING_ASCII:
+            case TILEDB_STRING_UTF8:
+                column->set_current_domain_slot(rect, {{decode_domain.template operator()<std::string>(column)}});
+                break;
+            default:
+                throw std::runtime_error(
+                    fmt::format(
+                        "[create_dataframe_schema] Unsupported dimension type {} to set current domain",
+                        tiledb::impl::type_to_str(column->domain_type().value())));
+        }
     }
 
     current_domain.set_ndrectangle(rect);

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.cc
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.cc
@@ -440,19 +440,17 @@ ArraySchema create_dataframe_schema(
     tiledb::Domain domain(*ctx);
 
     if (index_column_names.empty()) {
-        throw std::range_error("[create_dataframe_schema] At least one non-index column must be provided");
+        throw std::range_error("At least one non-index column must be provided");
     }
 
     if (index_column_names.size() != index_column_domains.size()) {
-        throw std::range_error(
-            "[create_dataframe_schema] Size mismatch between list of index column names and domains");
+        throw std::range_error("Size mismatch between list of index column names and domains");
     }
 
     std::unordered_map<std::string, DomainRange> index_columns;
     for (size_t i = 0; i < index_column_names.size(); ++i) {
         if (index_columns.contains(index_column_names[i])) {
-            throw std::range_error(
-                fmt::format("[create_dataframe_schema] Duplicate index column found '{}'", index_column_names[i]));
+            throw std::range_error(fmt::format("Duplicate index column found '{}'", index_column_names[i]));
         }
 
         index_columns.emplace(index_column_names[i], index_column_domains[i]);
@@ -468,17 +466,14 @@ ArraySchema create_dataframe_schema(
         if (!platform_config.override_naming_restriction && name.starts_with("soma_")) {
             if (name != SOMA_JOINID) {
                 throw std::range_error(
-                    fmt::format(
-                        "[create_dataframe_schema] DataFrame schema may not contain fields with name prefix 'soma_': "
-                        "got '{}'",
-                        name));
+                    fmt::format("DataFrame schema may not contain fields with name prefix 'soma_': got '{}'", name));
             }
 
             if (name == SOMA_JOINID) {
                 if (common::arrow::to_tiledb_format(format) != TILEDB_INT64) {
                     throw std::range_error(
                         fmt::format(
-                            "[create_dataframe_schema] '{}' field must be of type Arrow int64 but is {}",
+                            "'{}' field must be of type Arrow int64 but is {}",
                             SOMA_JOINID,
                             common::arrow::to_arrow_readable(format)));
                 }
@@ -489,9 +484,7 @@ ArraySchema create_dataframe_schema(
             if (arrow_schema->dictionary != nullptr) {
                 std::range_error(
                     fmt::format(
-                        "[create_dataframe_schema] Cannot set index column '{}' to an enumeration. Index columns do "
-                        "not "
-                        "support enumerations.",
+                        "Cannot set index column '{}' to an enumeration. Index columns do not support enumerations.",
                         name));
             }
 
@@ -518,12 +511,6 @@ ArraySchema create_dataframe_schema(
                     SOMA_JOINID.data(),
                     utils::create_attr_filter_list(SOMA_JOINID.data(), platform_config, ctx))));
         }
-    }
-
-    if (static_cast<size_t>(std::count_if(columns.cbegin(), columns.cend(), [](const auto& col) {
-            return col->isIndexColumn();
-        })) != index_columns.size()) {
-        throw std::range_error("[create_dataframe_schema] Some index columns where not found in dataframe schema");
     }
 
     // Unit tests expect dimension order should match the index column schema
@@ -594,15 +581,11 @@ ArraySchema create_dataframe_schema(
                 if (current_domain.first < 0) {
                     throw std::range_error(
                         fmt::format(
-                            "[create_dataframe_schema] '{}' indices cannot be negative; got lower bound {}",
-                            SOMA_JOINID,
-                            current_domain.first));
+                            "'{}' indices cannot be negative; got lower bound {}", SOMA_JOINID, current_domain.first));
                 } else if (current_domain.second < 0) {
                     throw std::range_error(
                         fmt::format(
-                            "[create_dataframe_schema] '{}' indices cannot be negative; got bound bound {}",
-                            SOMA_JOINID,
-                            current_domain.second));
+                            "'{}' indices cannot be negative; got bound bound {}", SOMA_JOINID, current_domain.second));
                 }
             }
 
@@ -618,52 +601,6 @@ ArraySchema create_dataframe_schema(
                 column->set_current_domain_slot(rect, {{decode_domain.template operator()<T>(column, domain)}});
             },
             index_columns[column->name()]);
-        // switch (column->domain_type().value()) {
-        //     case TILEDB_UINT8:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint8_t>(column)}});
-        //         break;
-        //     case TILEDB_UINT16:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint16_t>(column)}});
-        //         break;
-        //     case TILEDB_UINT32:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint32_t>(column)}});
-        //         break;
-        //     case TILEDB_UINT64:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<uint64_t>(column)}});
-        //         break;
-        //     case TILEDB_INT8:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int8_t>(column)}});
-        //         break;
-        //     case TILEDB_INT16:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int16_t>(column)}});
-        //         break;
-        //     case TILEDB_INT32:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int32_t>(column)}});
-        //         break;
-        //     case TILEDB_DATETIME_SEC:
-        //     case TILEDB_DATETIME_MS:
-        //     case TILEDB_DATETIME_US:
-        //     case TILEDB_DATETIME_NS:
-        //     case TILEDB_INT64:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<int64_t>(column)}});
-        //         break;
-        //     case TILEDB_FLOAT32:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<float_t>(column)}});
-        //         break;
-        //     case TILEDB_FLOAT64:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<double_t>(column)}});
-        //         break;
-        //     case TILEDB_CHAR:
-        //     case TILEDB_STRING_ASCII:
-        //     case TILEDB_STRING_UTF8:
-        //         column->set_current_domain_slot(rect, {{decode_domain.template operator()<std::string>(column)}});
-        //         break;
-        //     default:
-        //         throw std::runtime_error(
-        //             fmt::format(
-        //                 "[create_dataframe_schema] Unsupported dimension type {} to set current domain",
-        //                 tiledb::impl::type_to_str(column->domain_type().value())));
-        //}
     }
 
     current_domain.set_ndrectangle(rect);

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.h
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.h
@@ -22,6 +22,7 @@
 
 #include <tiledb/tiledb>
 
+#include "../utils/common.h"
 #include "nanoarrow/nanoarrow.hpp"
 #include "nlohmann/json.hpp"
 
@@ -407,7 +408,7 @@ ArraySchema create_dataframe_schema(
     std::string_view soma_type,
     ArrowSchema* arrow_schema,
     std::span<const std::string> index_column_names,
-    std::span<const std::any> index_column_domains,
+    std::span<const DomainRange> index_column_domains,
     std::shared_ptr<tiledb::Context> ctx,
     PlatformConfig platform_config,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp);

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.h
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.h
@@ -14,6 +14,7 @@
 #ifndef SOMA_PLATFORM_CONFIG_H
 #define SOMA_PLATFORM_CONFIG_H
 
+#include <any>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -21,6 +22,7 @@
 
 #include <tiledb/tiledb>
 
+#include "nanoarrow/nanoarrow.hpp"
 #include "nlohmann/json.hpp"
 
 namespace tiledbsoma {
@@ -396,6 +398,14 @@ ArraySchema create_nd_array_schema(
     PlatformConfig platform_config,
     std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 
+ArraySchema create_dataframe_schema(
+    std::string_view soma_type,
+    ArrowSchema* arrow_schema,
+    std::span<const std::string> index_column_names,
+    std::span<const std::any> index_column_domains,
+    std::shared_ptr<tiledb::Context> ctx,
+    PlatformConfig platform_config,
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp);
 }  // namespace utils
 
 }  // namespace tiledbsoma

--- a/libtiledbsoma/src/tiledb_adapter/platform_config.h
+++ b/libtiledbsoma/src/tiledb_adapter/platform_config.h
@@ -154,6 +154,11 @@ struct PlatformConfig {
     /* Set whether the array should be consolidated and vacuumed after writing
      */
     bool consolidate_and_vacuum = false;
+
+    /**
+     * Set whether to allow arbitrary `soma_` prefixed columns
+     */
+    bool override_naming_restriction = false;
 };
 
 /** TileDB specific configuration options that can be read back from a single

--- a/libtiledbsoma/src/utils/arrow_adapter.cc
+++ b/libtiledbsoma/src/utils/arrow_adapter.cc
@@ -378,7 +378,7 @@ std::tuple<ArraySchema, nlohmann::json> ArrowAdapter::tiledb_schema_from_arrow_s
         }
 
         if (isattr) {
-            columns.push_back(SOMAAttribute::create(ctx, child, type_metadata, platform_config));
+            columns.push_back(SOMAAttribute::create(ctx, child, platform_config));
             LOG_DEBUG(fmt::format("[ArrowAdapter] adding attribute {}", child->name));
         }
     }

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -68,6 +68,7 @@ using TimestampRange = std::pair<uint64_t, uint64_t>;
 template <typename T>
 using DomainRangeEntry = std::optional<std::pair<T, T>>;
 using DomainRange = std::variant<
+    std::monostate,
     DomainRangeEntry<std::string>,
     DomainRangeEntry<int64_t>,
     DomainRangeEntry<uint64_t>,

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -16,10 +16,13 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 #include <string>
 #include <string_view>
 #include <tiledb/tiledb>
+#include <utility>
+#include <variant>
 
 namespace tiledbsoma {
 
@@ -61,6 +64,21 @@ using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };
 
 using TimestampRange = std::pair<uint64_t, uint64_t>;
+
+template <typename T>
+using DomainRangeEntry = std::optional<std::pair<T, T>>;
+using DomainRange = std::variant<
+    DomainRangeEntry<std::string>,
+    DomainRangeEntry<int64_t>,
+    DomainRangeEntry<uint64_t>,
+    DomainRangeEntry<double>,
+    DomainRangeEntry<int32_t>,
+    DomainRangeEntry<uint32_t>,
+    DomainRangeEntry<float>,
+    DomainRangeEntry<int16_t>,
+    DomainRangeEntry<uint16_t>,
+    DomainRangeEntry<int8_t>,
+    DomainRangeEntry<uint8_t>>;
 
 class TileDBSOMAError : public std::runtime_error {
    public:

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -79,7 +79,7 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
     auto column_it = std::find_if(columns.begin(), columns.end(), [&](auto col) { return col->name() == name; });
 
     if (column_it == columns.end()) {
-        throw TileDBSOMAError(fmt::format("[find_column_by_name] Index column '{}' missing", name));
+        throw TileDBSOMAError(fmt::format("Index column '{}' missing", name));
     }
 
     return *column_it;

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -79,11 +79,7 @@ std::shared_ptr<SOMAColumn> find_column_by_name(
     auto column_it = std::find_if(columns.begin(), columns.end(), [&](auto col) { return col->name() == name; });
 
     if (column_it == columns.end()) {
-        throw TileDBSOMAError(
-            fmt::format(
-                "[ArrowAdapter][tiledb_schema_from_arrow_schema] Index column "
-                "'{}' missing",
-                name));
+        throw TileDBSOMAError(fmt::format("[find_column_by_name] Index column '{}' missing", name));
     }
 
     return *column_it;

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -98,7 +98,6 @@ std::string get_enmr_label(ArrowSchema* index_schema, ArrowSchema* value_schema)
  */
 Enumeration get_enumeration(
     std::shared_ptr<Context> ctx_, std::shared_ptr<Array> array_, ArrowSchema* index_schema, ArrowSchema* value_schema);
-
 }  // namespace tiledbsoma::util
 
 #endif


### PR DESCRIPTION
**Issue and/or context:** [SOMA-864](https://linear.app/tiledb/issue/SOMA-864/dataframe-create-pushdown)

**Changes:**
This PR moves the `DataFrame` creation logic down to the common C++ layer and simplifies the R and Python implementations. Specifically
- Schema validation is now common for R and Python and implemented in C++.
- Max domains are now the same between R and Python. Because of R imposed restrictions the max domains for `int32`, `int64` and `uint64` columns are now narrower.
- Both Python and R implementations are now responsible to typecast the domain of column to the correct type before passing it to C++.

**Notes for Reviewer:**
