### PR TITLE
[c++/python/r] Expose custom `DataType` enum

### DIFF
--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -64,102 +64,103 @@ DomainRange encode_domain(std::string_view format, py::object domain) {
     }
 }
 
-std::unordered_map<tiledb_datatype_t, std::string> _tdb_to_np_name_dtype = {
-    {TILEDB_INT32, "int32"},
-    {TILEDB_INT64, "int64"},
-    {TILEDB_FLOAT32, "float32"},
-    {TILEDB_FLOAT64, "float64"},
-    {TILEDB_INT8, "int8"},
-    {TILEDB_UINT8, "uint8"},
-    {TILEDB_INT16, "int16"},
-    {TILEDB_UINT16, "uint16"},
-    {TILEDB_UINT32, "uint32"},
-    {TILEDB_UINT64, "uint64"},
-    {TILEDB_STRING_ASCII, "S"},
-    {TILEDB_STRING_UTF8, "U1"},
-    {TILEDB_CHAR, "S1"},
-    {TILEDB_DATETIME_YEAR, "M8[Y]"},
-    {TILEDB_DATETIME_MONTH, "M8[M]"},
-    {TILEDB_DATETIME_WEEK, "M8[W]"},
-    {TILEDB_DATETIME_DAY, "M8[D]"},
-    {TILEDB_DATETIME_HR, "M8[h]"},
-    {TILEDB_DATETIME_MIN, "M8[m]"},
-    {TILEDB_DATETIME_SEC, "M8[s]"},
-    {TILEDB_DATETIME_MS, "M8[ms]"},
-    {TILEDB_DATETIME_US, "M8[us]"},
-    {TILEDB_DATETIME_NS, "M8[ns]"},
-    {TILEDB_DATETIME_PS, "M8[ps]"},
-    {TILEDB_DATETIME_FS, "M8[fs]"},
-    {TILEDB_DATETIME_AS, "M8[as]"},
-    {TILEDB_TIME_HR, "m8[h]"},
-    {TILEDB_TIME_MIN, "m8[m]"},
-    {TILEDB_TIME_SEC, "m8[s]"},
-    {TILEDB_TIME_MS, "m8[ms]"},
-    {TILEDB_TIME_US, "m8[us]"},
-    {TILEDB_TIME_NS, "m8[ns]"},
-    {TILEDB_TIME_PS, "m8[ps]"},
-    {TILEDB_TIME_FS, "m8[fs]"},
-    {TILEDB_TIME_AS, "m8[as]"},
-    {TILEDB_BLOB, "V"},
-    {TILEDB_BOOL, "bool"},
+std::unordered_map<common::DataType, std::string> _tdb_to_np_name_dtype = {
+    {common::DataType::INT32, "int32"},
+    {common::DataType::INT64, "int64"},
+    {common::DataType::FLOAT32, "float32"},
+    {common::DataType::FLOAT64, "float64"},
+    {common::DataType::INT8, "int8"},
+    {common::DataType::UINT8, "uint8"},
+    {common::DataType::INT16, "int16"},
+    {common::DataType::UINT16, "uint16"},
+    {common::DataType::UINT32, "uint32"},
+    {common::DataType::UINT64, "uint64"},
+    {common::DataType::STRING_ASCII, "S"},
+    {common::DataType::STRING_UTF8, "U1"},
+    {common::DataType::CHAR, "S1"},
+    {common::DataType::DATETIME_YEAR, "M8[Y]"},
+    {common::DataType::DATETIME_MONTH, "M8[M]"},
+    {common::DataType::DATETIME_WEEK, "M8[W]"},
+    {common::DataType::DATETIME_DAY, "M8[D]"},
+    {common::DataType::DATETIME_HR, "M8[h]"},
+    {common::DataType::DATETIME_MIN, "M8[m]"},
+    {common::DataType::DATETIME_SEC, "M8[s]"},
+    {common::DataType::DATETIME_MS, "M8[ms]"},
+    {common::DataType::DATETIME_US, "M8[us]"},
+    {common::DataType::DATETIME_NS, "M8[ns]"},
+    {common::DataType::DATETIME_PS, "M8[ps]"},
+    {common::DataType::DATETIME_FS, "M8[fs]"},
+    {common::DataType::DATETIME_AS, "M8[as]"},
+    {common::DataType::TIME_HR, "m8[h]"},
+    {common::DataType::TIME_MIN, "m8[m]"},
+    {common::DataType::TIME_SEC, "m8[s]"},
+    {common::DataType::TIME_MS, "m8[ms]"},
+    {common::DataType::TIME_US, "m8[us]"},
+    {common::DataType::TIME_NS, "m8[ns]"},
+    {common::DataType::TIME_PS, "m8[ps]"},
+    {common::DataType::TIME_FS, "m8[fs]"},
+    {common::DataType::TIME_AS, "m8[as]"},
+    {common::DataType::BLOB, "V"},
+    {common::DataType::BOOL, "bool"},
 };
 
-std::unordered_map<std::string, tiledb_datatype_t> _np_name_to_tdb_dtype = {
-    {"int32", TILEDB_INT32},
-    {"int64", TILEDB_INT64},
-    {"float32", TILEDB_FLOAT32},
-    {"float64", TILEDB_FLOAT64},
-    {"int8", TILEDB_INT8},
-    {"uint8", TILEDB_UINT8},
-    {"int16", TILEDB_INT16},
-    {"uint16", TILEDB_UINT16},
-    {"uint32", TILEDB_UINT32},
-    {"uint64", TILEDB_UINT64},
-    {"datetime64[Y]", TILEDB_DATETIME_YEAR},
-    {"datetime64[M]", TILEDB_DATETIME_MONTH},
-    {"datetime64[W]", TILEDB_DATETIME_WEEK},
-    {"datetime64[D]", TILEDB_DATETIME_DAY},
-    {"datetime64[h]", TILEDB_DATETIME_HR},
-    {"datetime64[m]", TILEDB_DATETIME_MIN},
-    {"datetime64[s]", TILEDB_DATETIME_SEC},
-    {"datetime64[ms]", TILEDB_DATETIME_MS},
-    {"datetime64[us]", TILEDB_DATETIME_US},
-    {"datetime64[ns]", TILEDB_DATETIME_NS},
-    {"datetime64[ps]", TILEDB_DATETIME_PS},
-    {"datetime64[fs]", TILEDB_DATETIME_FS},
-    {"datetime64[as]", TILEDB_DATETIME_AS},
+std::unordered_map<std::string, common::DataType> _np_name_to_tdb_dtype = {
+    {"int32", common::DataType::INT32},
+    {"int64", common::DataType::INT64},
+    {"float32", common::DataType::FLOAT32},
+    {"float64", common::DataType::FLOAT64},
+    {"int8", common::DataType::INT8},
+    {"uint8", common::DataType::UINT8},
+    {"int16", common::DataType::INT16},
+    {"uint16", common::DataType::UINT16},
+    {"uint32", common::DataType::UINT32},
+    {"uint64", common::DataType::UINT64},
+    {"datetime64[Y]", common::DataType::DATETIME_YEAR},
+    {"datetime64[M]", common::DataType::DATETIME_MONTH},
+    {"datetime64[W]", common::DataType::DATETIME_WEEK},
+    {"datetime64[D]", common::DataType::DATETIME_DAY},
+    {"datetime64[h]", common::DataType::DATETIME_HR},
+    {"datetime64[m]", common::DataType::DATETIME_MIN},
+    {"datetime64[s]", common::DataType::DATETIME_SEC},
+    {"datetime64[ms]", common::DataType::DATETIME_MS},
+    {"datetime64[us]", common::DataType::DATETIME_US},
+    {"datetime64[ns]", common::DataType::DATETIME_NS},
+    {"datetime64[ps]", common::DataType::DATETIME_PS},
+    {"datetime64[fs]", common::DataType::DATETIME_FS},
+    {"datetime64[as]", common::DataType::DATETIME_AS},
     /* duration types map to timedelta */
-    {"timedelta64[h]", TILEDB_TIME_HR},
-    {"timedelta64[m]", TILEDB_TIME_MIN},
-    {"timedelta64[s]", TILEDB_TIME_SEC},
-    {"timedelta64[ms]", TILEDB_TIME_MS},
-    {"timedelta64[us]", TILEDB_TIME_US},
-    {"timedelta64[ns]", TILEDB_TIME_NS},
-    {"timedelta64[ps]", TILEDB_TIME_PS},
-    {"timedelta64[fs]", TILEDB_TIME_FS},
-    {"timedelta64[as]", TILEDB_TIME_AS},
-    {"bool", TILEDB_BOOL},
+    {"timedelta64[h]", common::DataType::TIME_HR},
+    {"timedelta64[m]", common::DataType::TIME_MIN},
+    {"timedelta64[s]", common::DataType::TIME_SEC},
+    {"timedelta64[ms]", common::DataType::TIME_MS},
+    {"timedelta64[us]", common::DataType::TIME_US},
+    {"timedelta64[ns]", common::DataType::TIME_NS},
+    {"timedelta64[ps]", common::DataType::TIME_PS},
+    {"timedelta64[fs]", common::DataType::TIME_FS},
+    {"timedelta64[as]", common::DataType::TIME_AS},
+    {"bool", common::DataType::BOOL},
 };
 
-py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
-    if (type == TILEDB_BLOB) {
+py::dtype tdb_to_np_dtype(common::DataType type, uint32_t cell_val_num) {
+    if (type == common::DataType::BLOB) {
         std::string base_str = "|V";
         if (cell_val_num < TILEDB_VAR_NUM)
             base_str += std::to_string(cell_val_num);
         return py::dtype(base_str);
     }
 
-    if (type == TILEDB_CHAR || type == TILEDB_STRING_UTF8 || type == TILEDB_STRING_ASCII) {
-        std::string base_str = (type == TILEDB_STRING_UTF8) ? "|U" : "|S";
+    if (type == common::DataType::CHAR || type == common::DataType::STRING_UTF8 ||
+        type == common::DataType::STRING_ASCII) {
+        std::string base_str = (type == common::DataType::STRING_UTF8) ? "|U" : "|S";
         if (cell_val_num < TILEDB_VAR_NUM)
             base_str += std::to_string(cell_val_num);
         return py::dtype(base_str);
     }
 
     if (cell_val_num == 1) {
-        if (type == TILEDB_STRING_UTF16 || type == TILEDB_STRING_UTF32)
+        if (type == common::DataType::STRING_UTF16 || type == common::DataType::STRING_UTF32)
             TPY_ERROR_LOC("Unimplemented UTF16 or UTF32 string conversion!");
-        if (type == TILEDB_STRING_UCS2 || type == TILEDB_STRING_UCS4)
+        if (type == common::DataType::STRING_UCS2 || type == common::DataType::STRING_UCS4)
             TPY_ERROR_LOC("Unimplemented UCS2 or UCS4 string conversion!");
 
         if (_tdb_to_np_name_dtype.count(type) == 1)
@@ -167,9 +168,9 @@ py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
     }
 
     if (cell_val_num == 2) {
-        if (type == TILEDB_FLOAT32)
+        if (type == common::DataType::FLOAT32)
             return py::dtype("complex64");
-        if (type == TILEDB_FLOAT64)
+        if (type == common::DataType::FLOAT64)
             return py::dtype("complex128");
     }
 
@@ -190,11 +191,11 @@ py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
     }
 
     TPY_ERROR_LOC(
-        "tiledb datatype not understood ('" + tiledb::impl::type_to_str(type) +
+        "tiledb datatype not understood ('" + std::string(common::getName(type)) +
         "', cell_val_num: " + std::to_string(cell_val_num) + ")");
 }
 
-tiledb_datatype_t np_to_tdb_dtype(py::dtype type) {
+common::DataType np_to_tdb_dtype(py::dtype type) {
     auto name = py::str(py::getattr(type, "name"));
     if (_np_name_to_tdb_dtype.count(name) == 1)
         return _np_name_to_tdb_dtype[name];
@@ -202,7 +203,7 @@ tiledb_datatype_t np_to_tdb_dtype(py::dtype type) {
     auto kind = py::str(py::getattr(type, "kind"));
 
     if (kind.is(py::str("S")))
-        return TILEDB_STRING_UTF8;
+        return common::DataType::STRING_UTF8;
     // Numpy encodes strings as UTF-32
     if (kind.is(py::str("U")))
         TPY_ERROR_LOC("[np_to_tdb_dtype] UTF-32 encoded strings are not supported");
@@ -216,11 +217,11 @@ tiledb_datatype_t np_to_tdb_dtype(py::dtype type) {
     TPY_ERROR_LOC(ss.str());
 }
 
-bool is_tdb_str(tiledb_datatype_t type) {
+bool is_tdb_str(common::DataType type) {
     switch (type) {
-        case TILEDB_STRING_ASCII:
-        case TILEDB_STRING_UTF8:
-        case TILEDB_CHAR:
+        case common::DataType::STRING_ASCII:
+        case common::DataType::STRING_UTF8:
+        case common::DataType::CHAR:
             return true;
         default:
             return false;
@@ -273,7 +274,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
     for (auto [key, val] : metadata_mapping) {
         auto [tdb_type, value_num, value] = val;
 
-        if (tdb_type == TILEDB_STRING_UTF8 || tdb_type == TILEDB_STRING_ASCII) {
+        if (tdb_type == common::DataType::STRING_UTF8 || tdb_type == common::DataType::STRING_ASCII) {
             // Empty strings stored as nullptr have a value_num of 1 and a \x00
             // value
             if (value_num == 1 && value == nullptr) {
@@ -282,7 +283,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
                 auto py_buf = py::array(py::dtype("|S1"), value_num, value);
                 results[py::str(key)] = py_buf.attr("tobytes")().attr("decode")("UTF-8");
             }
-        } else if (tdb_type == TILEDB_BLOB) {
+        } else if (tdb_type == common::DataType::BLOB) {
             py::dtype value_type = tdb_to_np_dtype(tdb_type, value_num);
             results[py::str(key)] = py::array(value_type, value_num, value).attr("item")(0);
         } else {
@@ -294,13 +295,13 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
 }
 
 void set_metadata(SOMAObject& soma_object, const std::string& key, py::array value, bool force) {
-    tiledb_datatype_t value_type = np_to_tdb_dtype(value.dtype());
+    common::DataType value_type = np_to_tdb_dtype(value.dtype());
 
     // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900:
     // Ensure that all Python and R write paths use UTF-8 for string
     // metadata values.
-    if (value_type == TILEDB_STRING_ASCII) {
-        value_type = TILEDB_STRING_UTF8;
+    if (value_type == common::DataType::STRING_ASCII) {
+        value_type = common::DataType::STRING_UTF8;
     }
 
     if (is_tdb_str(value_type) && value.size() > 1)
@@ -315,7 +316,7 @@ void set_metadata(SOMAObject& soma_object, const std::string& key, py::array val
     if (is_tdb_str(value_type) && value_num > 0) {
         // If an empty string is passed by default results in a NULL byte
         switch (value_type) {
-            case TILEDB_STRING_UTF8:
+            case common::DataType::STRING_UTF8:
                 value_num = sanitize_string(
                     std::span<const uint8_t>(static_cast<const uint8_t*>(value.data()), value_num), value_num);
 
@@ -324,8 +325,8 @@ void set_metadata(SOMAObject& soma_object, const std::string& key, py::array val
                 // No std::format in C++17, and, including logger/fmt headers
                 // is tetchy here.
                 std::stringstream ss;
-                ss << "[set_metadata] Unsupported string encoding '" << tiledb::impl::type_to_str(value_type)
-                   << "' for key '" << key << "'";
+                ss << "[set_metadata] Unsupported string encoding '" << common::getName(value_type) << "' for key '"
+                   << key << "'";
                 throw TileDBSOMAError(ss.str());
         }
     }

--- a/apis/python/src/tiledbsoma/common.cc
+++ b/apis/python/src/tiledbsoma/common.cc
@@ -65,102 +65,102 @@ DomainRange encode_domain(std::string_view format, py::object domain) {
 }
 
 std::unordered_map<common::DataType, std::string> _tdb_to_np_name_dtype = {
-    {common::DataType::INT32, "int32"},
-    {common::DataType::INT64, "int64"},
-    {common::DataType::FLOAT32, "float32"},
-    {common::DataType::FLOAT64, "float64"},
-    {common::DataType::INT8, "int8"},
-    {common::DataType::UINT8, "uint8"},
-    {common::DataType::INT16, "int16"},
-    {common::DataType::UINT16, "uint16"},
-    {common::DataType::UINT32, "uint32"},
-    {common::DataType::UINT64, "uint64"},
-    {common::DataType::STRING_ASCII, "S"},
-    {common::DataType::STRING_UTF8, "U1"},
-    {common::DataType::CHAR, "S1"},
-    {common::DataType::DATETIME_YEAR, "M8[Y]"},
-    {common::DataType::DATETIME_MONTH, "M8[M]"},
-    {common::DataType::DATETIME_WEEK, "M8[W]"},
-    {common::DataType::DATETIME_DAY, "M8[D]"},
-    {common::DataType::DATETIME_HR, "M8[h]"},
-    {common::DataType::DATETIME_MIN, "M8[m]"},
-    {common::DataType::DATETIME_SEC, "M8[s]"},
-    {common::DataType::DATETIME_MS, "M8[ms]"},
-    {common::DataType::DATETIME_US, "M8[us]"},
-    {common::DataType::DATETIME_NS, "M8[ns]"},
-    {common::DataType::DATETIME_PS, "M8[ps]"},
-    {common::DataType::DATETIME_FS, "M8[fs]"},
-    {common::DataType::DATETIME_AS, "M8[as]"},
-    {common::DataType::TIME_HR, "m8[h]"},
-    {common::DataType::TIME_MIN, "m8[m]"},
-    {common::DataType::TIME_SEC, "m8[s]"},
-    {common::DataType::TIME_MS, "m8[ms]"},
-    {common::DataType::TIME_US, "m8[us]"},
-    {common::DataType::TIME_NS, "m8[ns]"},
-    {common::DataType::TIME_PS, "m8[ps]"},
-    {common::DataType::TIME_FS, "m8[fs]"},
-    {common::DataType::TIME_AS, "m8[as]"},
-    {common::DataType::BLOB, "V"},
-    {common::DataType::BOOL, "bool"},
+    {common::DataType::int32, "int32"},
+    {common::DataType::int64, "int64"},
+    {common::DataType::float32, "float32"},
+    {common::DataType::float64, "float64"},
+    {common::DataType::int8, "int8"},
+    {common::DataType::uint8, "uint8"},
+    {common::DataType::int16, "int16"},
+    {common::DataType::uint16, "uint16"},
+    {common::DataType::uint32, "uint32"},
+    {common::DataType::uint64, "uint64"},
+    {common::DataType::string_ascii, "S"},
+    {common::DataType::string_utf8, "U1"},
+    {common::DataType::character, "S1"},
+    {common::DataType::datetime_year, "M8[Y]"},
+    {common::DataType::datetime_month, "M8[M]"},
+    {common::DataType::datetime_week, "M8[W]"},
+    {common::DataType::datetime_day, "M8[D]"},
+    {common::DataType::datetime_hr, "M8[h]"},
+    {common::DataType::datetime_min, "M8[m]"},
+    {common::DataType::datetime_sec, "M8[s]"},
+    {common::DataType::datetime_ms, "M8[ms]"},
+    {common::DataType::datetime_us, "M8[us]"},
+    {common::DataType::datetime_ns, "M8[ns]"},
+    {common::DataType::datetime_ps, "M8[ps]"},
+    {common::DataType::datetime_fs, "M8[fs]"},
+    {common::DataType::datetime_as, "M8[as]"},
+    {common::DataType::time_hr, "m8[h]"},
+    {common::DataType::time_min, "m8[m]"},
+    {common::DataType::time_sec, "m8[s]"},
+    {common::DataType::time_ms, "m8[ms]"},
+    {common::DataType::time_us, "m8[us]"},
+    {common::DataType::time_ns, "m8[ns]"},
+    {common::DataType::time_ps, "m8[ps]"},
+    {common::DataType::time_fs, "m8[fs]"},
+    {common::DataType::time_as, "m8[as]"},
+    {common::DataType::blob, "V"},
+    {common::DataType::boolean, "bool"},
 };
 
 std::unordered_map<std::string, common::DataType> _np_name_to_tdb_dtype = {
-    {"int32", common::DataType::INT32},
-    {"int64", common::DataType::INT64},
-    {"float32", common::DataType::FLOAT32},
-    {"float64", common::DataType::FLOAT64},
-    {"int8", common::DataType::INT8},
-    {"uint8", common::DataType::UINT8},
-    {"int16", common::DataType::INT16},
-    {"uint16", common::DataType::UINT16},
-    {"uint32", common::DataType::UINT32},
-    {"uint64", common::DataType::UINT64},
-    {"datetime64[Y]", common::DataType::DATETIME_YEAR},
-    {"datetime64[M]", common::DataType::DATETIME_MONTH},
-    {"datetime64[W]", common::DataType::DATETIME_WEEK},
-    {"datetime64[D]", common::DataType::DATETIME_DAY},
-    {"datetime64[h]", common::DataType::DATETIME_HR},
-    {"datetime64[m]", common::DataType::DATETIME_MIN},
-    {"datetime64[s]", common::DataType::DATETIME_SEC},
-    {"datetime64[ms]", common::DataType::DATETIME_MS},
-    {"datetime64[us]", common::DataType::DATETIME_US},
-    {"datetime64[ns]", common::DataType::DATETIME_NS},
-    {"datetime64[ps]", common::DataType::DATETIME_PS},
-    {"datetime64[fs]", common::DataType::DATETIME_FS},
-    {"datetime64[as]", common::DataType::DATETIME_AS},
+    {"int32", common::DataType::int32},
+    {"int64", common::DataType::int64},
+    {"float32", common::DataType::float32},
+    {"float64", common::DataType::float64},
+    {"int8", common::DataType::int8},
+    {"uint8", common::DataType::uint8},
+    {"int16", common::DataType::int16},
+    {"uint16", common::DataType::uint16},
+    {"uint32", common::DataType::uint32},
+    {"uint64", common::DataType::uint64},
+    {"datetime64[Y]", common::DataType::datetime_year},
+    {"datetime64[M]", common::DataType::datetime_month},
+    {"datetime64[W]", common::DataType::datetime_week},
+    {"datetime64[D]", common::DataType::datetime_day},
+    {"datetime64[h]", common::DataType::datetime_hr},
+    {"datetime64[m]", common::DataType::datetime_min},
+    {"datetime64[s]", common::DataType::datetime_sec},
+    {"datetime64[ms]", common::DataType::datetime_ms},
+    {"datetime64[us]", common::DataType::datetime_us},
+    {"datetime64[ns]", common::DataType::datetime_ns},
+    {"datetime64[ps]", common::DataType::datetime_ps},
+    {"datetime64[fs]", common::DataType::datetime_fs},
+    {"datetime64[as]", common::DataType::datetime_as},
     /* duration types map to timedelta */
-    {"timedelta64[h]", common::DataType::TIME_HR},
-    {"timedelta64[m]", common::DataType::TIME_MIN},
-    {"timedelta64[s]", common::DataType::TIME_SEC},
-    {"timedelta64[ms]", common::DataType::TIME_MS},
-    {"timedelta64[us]", common::DataType::TIME_US},
-    {"timedelta64[ns]", common::DataType::TIME_NS},
-    {"timedelta64[ps]", common::DataType::TIME_PS},
-    {"timedelta64[fs]", common::DataType::TIME_FS},
-    {"timedelta64[as]", common::DataType::TIME_AS},
-    {"bool", common::DataType::BOOL},
+    {"timedelta64[h]", common::DataType::time_hr},
+    {"timedelta64[m]", common::DataType::time_min},
+    {"timedelta64[s]", common::DataType::time_sec},
+    {"timedelta64[ms]", common::DataType::time_ms},
+    {"timedelta64[us]", common::DataType::time_us},
+    {"timedelta64[ns]", common::DataType::time_ns},
+    {"timedelta64[ps]", common::DataType::time_ps},
+    {"timedelta64[fs]", common::DataType::time_fs},
+    {"timedelta64[as]", common::DataType::time_as},
+    {"bool", common::DataType::boolean},
 };
 
 py::dtype tdb_to_np_dtype(common::DataType type, uint32_t cell_val_num) {
-    if (type == common::DataType::BLOB) {
+    if (type == common::DataType::blob) {
         std::string base_str = "|V";
         if (cell_val_num < TILEDB_VAR_NUM)
             base_str += std::to_string(cell_val_num);
         return py::dtype(base_str);
     }
 
-    if (type == common::DataType::CHAR || type == common::DataType::STRING_UTF8 ||
-        type == common::DataType::STRING_ASCII) {
-        std::string base_str = (type == common::DataType::STRING_UTF8) ? "|U" : "|S";
+    if (type == common::DataType::character || type == common::DataType::string_utf8 ||
+        type == common::DataType::string_ascii) {
+        std::string base_str = (type == common::DataType::string_utf8) ? "|U" : "|S";
         if (cell_val_num < TILEDB_VAR_NUM)
             base_str += std::to_string(cell_val_num);
         return py::dtype(base_str);
     }
 
     if (cell_val_num == 1) {
-        if (type == common::DataType::STRING_UTF16 || type == common::DataType::STRING_UTF32)
+        if (type == common::DataType::string_utf16 || type == common::DataType::string_utf32)
             TPY_ERROR_LOC("Unimplemented UTF16 or UTF32 string conversion!");
-        if (type == common::DataType::STRING_UCS2 || type == common::DataType::STRING_UCS4)
+        if (type == common::DataType::string_ucs2 || type == common::DataType::string_ucs4)
             TPY_ERROR_LOC("Unimplemented UCS2 or UCS4 string conversion!");
 
         if (_tdb_to_np_name_dtype.count(type) == 1)
@@ -168,9 +168,9 @@ py::dtype tdb_to_np_dtype(common::DataType type, uint32_t cell_val_num) {
     }
 
     if (cell_val_num == 2) {
-        if (type == common::DataType::FLOAT32)
+        if (type == common::DataType::float32)
             return py::dtype("complex64");
-        if (type == common::DataType::FLOAT64)
+        if (type == common::DataType::float64)
             return py::dtype("complex128");
     }
 
@@ -203,7 +203,7 @@ common::DataType np_to_tdb_dtype(py::dtype type) {
     auto kind = py::str(py::getattr(type, "kind"));
 
     if (kind.is(py::str("S")))
-        return common::DataType::STRING_UTF8;
+        return common::DataType::string_utf8;
     // Numpy encodes strings as UTF-32
     if (kind.is(py::str("U")))
         TPY_ERROR_LOC("[np_to_tdb_dtype] UTF-32 encoded strings are not supported");
@@ -219,9 +219,9 @@ common::DataType np_to_tdb_dtype(py::dtype type) {
 
 bool is_tdb_str(common::DataType type) {
     switch (type) {
-        case common::DataType::STRING_ASCII:
-        case common::DataType::STRING_UTF8:
-        case common::DataType::CHAR:
+        case common::DataType::string_ascii:
+        case common::DataType::string_utf8:
+        case common::DataType::character:
             return true;
         default:
             return false;
@@ -274,7 +274,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
     for (auto [key, val] : metadata_mapping) {
         auto [tdb_type, value_num, value] = val;
 
-        if (tdb_type == common::DataType::STRING_UTF8 || tdb_type == common::DataType::STRING_ASCII) {
+        if (tdb_type == common::DataType::string_utf8 || tdb_type == common::DataType::string_ascii) {
             // Empty strings stored as nullptr have a value_num of 1 and a \x00
             // value
             if (value_num == 1 && value == nullptr) {
@@ -283,7 +283,7 @@ py::dict meta(std::map<std::string, MetadataValue> metadata_mapping) {
                 auto py_buf = py::array(py::dtype("|S1"), value_num, value);
                 results[py::str(key)] = py_buf.attr("tobytes")().attr("decode")("UTF-8");
             }
-        } else if (tdb_type == common::DataType::BLOB) {
+        } else if (tdb_type == common::DataType::blob) {
             py::dtype value_type = tdb_to_np_dtype(tdb_type, value_num);
             results[py::str(key)] = py::array(value_type, value_num, value).attr("item")(0);
         } else {
@@ -300,8 +300,8 @@ void set_metadata(SOMAObject& soma_object, const std::string& key, py::array val
     // For https://github.com/single-cell-data/TileDB-SOMA/pull/2900:
     // Ensure that all Python and R write paths use UTF-8 for string
     // metadata values.
-    if (value_type == common::DataType::STRING_ASCII) {
-        value_type = common::DataType::STRING_UTF8;
+    if (value_type == common::DataType::string_ascii) {
+        value_type = common::DataType::string_utf8;
     }
 
     if (is_tdb_str(value_type) && value.size() > 1)
@@ -316,7 +316,7 @@ void set_metadata(SOMAObject& soma_object, const std::string& key, py::array val
     if (is_tdb_str(value_type) && value_num > 0) {
         // If an empty string is passed by default results in a NULL byte
         switch (value_type) {
-            case common::DataType::STRING_UTF8:
+            case common::DataType::string_utf8:
                 value_num = sanitize_string(
                     std::span<const uint8_t>(static_cast<const uint8_t*>(value.data()), value_num), value_num);
 

--- a/apis/python/src/tiledbsoma/common.h
+++ b/apis/python/src/tiledbsoma/common.h
@@ -50,7 +50,7 @@ DomainRange encode_domain(std::string_view format, py::object domain);
 
 py::dtype tdb_to_np_dtype(tiledb_datatype_t type, uint32_t cell_val_num);
 
-tiledb_datatype_t np_to_tdb_dtype(py::dtype type);
+common::DataType np_to_tdb_dtype(py::dtype type);
 
 bool is_tdb_str(tiledb_datatype_t type);
 

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -108,53 +108,55 @@ Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
     return (vec);
 }
 // helper function to convert_metadata
-SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
+SEXP _metadata_to_sexp(const tdbs::common::DataType v_type, const uint32_t v_num, const void* v) {
     // This supports a limited set of basic types as the metadata
     // annotation is not meant to support complete serialization
-    if (v_type == TILEDB_INT32) {
+    if (v_type == tdbs::common::DataType::INT32) {
         Rcpp::IntegerVector vec(v_num);
         std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
         return (vec);
-    } else if (v_type == TILEDB_FLOAT64) {
+    } else if (v_type == tdbs::common::DataType::FLOAT64) {
         Rcpp::NumericVector vec(v_num);
         std::memcpy(vec.begin(), v, v_num * sizeof(double));
         return (vec);
-    } else if (v_type == TILEDB_FLOAT32) {
+    } else if (v_type == tdbs::common::DataType::FLOAT32) {
         Rcpp::NumericVector vec(v_num);
         const float* fvec = static_cast<const float*>(v);
         size_t n = static_cast<size_t>(v_num);
         for (size_t i = 0; i < n; i++)
             vec[i] = static_cast<double>(fvec[i]);
         return (vec);
-    } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8) {
+    } else if (
+        v_type == tdbs::common::DataType::CHAR || v_type == tdbs::common::DataType::STRING_ASCII ||
+        v_type == tdbs::common::DataType::STRING_UTF8) {
         std::string s(static_cast<const char*>(v), v_num);
         return (Rcpp::wrap(s));
-    } else if (v_type == TILEDB_INT8) {
+    } else if (v_type == tdbs::common::DataType::INT8) {
         Rcpp::LogicalVector vec(v_num);
         const int8_t* ivec = static_cast<const int8_t*>(v);
         size_t n = static_cast<size_t>(v_num);
         for (size_t i = 0; i < n; i++)
             vec[i] = static_cast<bool>(ivec[i]);
         return (vec);
-    } else if (v_type == TILEDB_UINT8) {
+    } else if (v_type == tdbs::common::DataType::UINT8) {
         // Strictly speaking a check for under/overflow would be needed here
         // (and below) yet this is for metadata annotation (and not data
         // payload) so extreme ranges are less likely
         return copy_int_vector<uint8_t>(v_num, v);
-    } else if (v_type == TILEDB_INT16) {
+    } else if (v_type == tdbs::common::DataType::INT16) {
         return copy_int_vector<int16_t>(v_num, v);
-    } else if (v_type == TILEDB_UINT16) {
+    } else if (v_type == tdbs::common::DataType::UINT16) {
         return copy_int_vector<uint16_t>(v_num, v);
-    } else if (v_type == TILEDB_UINT32) {
+    } else if (v_type == tdbs::common::DataType::UINT32) {
         return copy_int_vector<uint32_t>(v_num, v);
-    } else if (v_type == TILEDB_INT64) {
+    } else if (v_type == tdbs::common::DataType::INT64) {
         std::vector<int64_t> iv(v_num);
         std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
         return Rcpp::toInteger64(iv);
-    } else if (v_type == TILEDB_UINT64) {
+    } else if (v_type == tdbs::common::DataType::UINT64) {
         return copy_int_vector<uint64_t>(v_num, v);
     } else {
-        Rcpp::stop("No support yet for TileDB data type %s", tiledb::impl::type_to_str(v_type));
+        Rcpp::stop("No support yet for TileDB data type %s", tdbs::common::getName(v_type));
     }
 }
 
@@ -221,15 +223,15 @@ void c_group_put_metadata(Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP o
         case REALSXP: {
             Rcpp::NumericVector v(obj);
             if (Rcpp::isInteger64(obj)) {
-                xp->grpptr->set_metadata(key, TILEDB_INT64, v.size(), v.begin());
+                xp->grpptr->set_metadata(key, tdbs::common::DataType::INT64, v.size(), v.begin());
             } else {
-                xp->grpptr->set_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
+                xp->grpptr->set_metadata(key, tdbs::common::DataType::FLOAT64, v.size(), v.begin());
             }
             break;
         }
         case INTSXP: {
             Rcpp::IntegerVector v(obj);
-            xp->grpptr->set_metadata(key, TILEDB_INT32, v.size(), v.begin());
+            xp->grpptr->set_metadata(key, tdbs::common::DataType::INT32, v.size(), v.begin());
             break;
         }
         case STRSXP: {
@@ -238,7 +240,7 @@ void c_group_put_metadata(Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP o
             // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
             // this best string type?
             // Use TILEDB_STRING_UTF8 for compatibility with Python API
-            xp->grpptr->set_metadata(key, TILEDB_STRING_UTF8, s.length(), s.c_str());
+            xp->grpptr->set_metadata(key, tdbs::common::DataType::STRING_UTF8, s.length(), s.c_str());
             break;
         }
         case LGLSXP: {  // experimental: map R logical (ie TRUE, FALSE, NA) to

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -111,15 +111,15 @@ Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
 SEXP _metadata_to_sexp(const tdbs::common::DataType v_type, const uint32_t v_num, const void* v) {
     // This supports a limited set of basic types as the metadata
     // annotation is not meant to support complete serialization
-    if (v_type == tdbs::common::DataType::INT32) {
+    if (v_type == tdbs::common::DataType::int32) {
         Rcpp::IntegerVector vec(v_num);
         std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
         return (vec);
-    } else if (v_type == tdbs::common::DataType::FLOAT64) {
+    } else if (v_type == tdbs::common::DataType::float64) {
         Rcpp::NumericVector vec(v_num);
         std::memcpy(vec.begin(), v, v_num * sizeof(double));
         return (vec);
-    } else if (v_type == tdbs::common::DataType::FLOAT32) {
+    } else if (v_type == tdbs::common::DataType::float32) {
         Rcpp::NumericVector vec(v_num);
         const float* fvec = static_cast<const float*>(v);
         size_t n = static_cast<size_t>(v_num);
@@ -127,33 +127,33 @@ SEXP _metadata_to_sexp(const tdbs::common::DataType v_type, const uint32_t v_num
             vec[i] = static_cast<double>(fvec[i]);
         return (vec);
     } else if (
-        v_type == tdbs::common::DataType::CHAR || v_type == tdbs::common::DataType::STRING_ASCII ||
-        v_type == tdbs::common::DataType::STRING_UTF8) {
+        v_type == tdbs::common::DataType::character || v_type == tdbs::common::DataType::string_ascii ||
+        v_type == tdbs::common::DataType::string_utf8) {
         std::string s(static_cast<const char*>(v), v_num);
         return (Rcpp::wrap(s));
-    } else if (v_type == tdbs::common::DataType::INT8) {
+    } else if (v_type == tdbs::common::DataType::int8) {
         Rcpp::LogicalVector vec(v_num);
         const int8_t* ivec = static_cast<const int8_t*>(v);
         size_t n = static_cast<size_t>(v_num);
         for (size_t i = 0; i < n; i++)
             vec[i] = static_cast<bool>(ivec[i]);
         return (vec);
-    } else if (v_type == tdbs::common::DataType::UINT8) {
+    } else if (v_type == tdbs::common::DataType::uint8) {
         // Strictly speaking a check for under/overflow would be needed here
         // (and below) yet this is for metadata annotation (and not data
         // payload) so extreme ranges are less likely
         return copy_int_vector<uint8_t>(v_num, v);
-    } else if (v_type == tdbs::common::DataType::INT16) {
+    } else if (v_type == tdbs::common::DataType::int16) {
         return copy_int_vector<int16_t>(v_num, v);
-    } else if (v_type == tdbs::common::DataType::UINT16) {
+    } else if (v_type == tdbs::common::DataType::uint16) {
         return copy_int_vector<uint16_t>(v_num, v);
-    } else if (v_type == tdbs::common::DataType::UINT32) {
+    } else if (v_type == tdbs::common::DataType::uint32) {
         return copy_int_vector<uint32_t>(v_num, v);
-    } else if (v_type == tdbs::common::DataType::INT64) {
+    } else if (v_type == tdbs::common::DataType::int64) {
         std::vector<int64_t> iv(v_num);
         std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
         return Rcpp::toInteger64(iv);
-    } else if (v_type == tdbs::common::DataType::UINT64) {
+    } else if (v_type == tdbs::common::DataType::uint64) {
         return copy_int_vector<uint64_t>(v_num, v);
     } else {
         Rcpp::stop("No support yet for TileDB data type %s", tdbs::common::getName(v_type));
@@ -223,15 +223,15 @@ void c_group_put_metadata(Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP o
         case REALSXP: {
             Rcpp::NumericVector v(obj);
             if (Rcpp::isInteger64(obj)) {
-                xp->grpptr->set_metadata(key, tdbs::common::DataType::INT64, v.size(), v.begin());
+                xp->grpptr->set_metadata(key, tdbs::common::DataType::int64, v.size(), v.begin());
             } else {
-                xp->grpptr->set_metadata(key, tdbs::common::DataType::FLOAT64, v.size(), v.begin());
+                xp->grpptr->set_metadata(key, tdbs::common::DataType::float64, v.size(), v.begin());
             }
             break;
         }
         case INTSXP: {
             Rcpp::IntegerVector v(obj);
-            xp->grpptr->set_metadata(key, tdbs::common::DataType::INT32, v.size(), v.begin());
+            xp->grpptr->set_metadata(key, tdbs::common::DataType::int32, v.size(), v.begin());
             break;
         }
         case STRSXP: {
@@ -240,7 +240,7 @@ void c_group_put_metadata(Rcpp::XPtr<somagrp_wrap_t> xp, std::string key, SEXP o
             // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is
             // this best string type?
             // Use TILEDB_STRING_UTF8 for compatibility with Python API
-            xp->grpptr->set_metadata(key, tdbs::common::DataType::STRING_UTF8, s.length(), s.c_str());
+            xp->grpptr->set_metadata(key, tdbs::common::DataType::string_utf8, s.length(), s.c_str());
             break;
         }
         case LGLSXP: {  // experimental: map R logical (ie TRUE, FALSE, NA) to

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -165,14 +165,14 @@ void set_metadata(
     auto soup = getObjectUniquePointer(is_array, OpenMode::soma_write, uri, sctx, tsvec);
 
     if (type == "character") {
-        const tdbs::common::DataType value_type = tdbs::common::DataType::STRING_UTF8;
+        const tdbs::common::DataType value_type = tdbs::common::DataType::string_utf8;
         std::string value = Rcpp::as<std::string>(valuesxp);
         std::stringstream ss;
         ss << "[set_metadata] key " << key << " value " << value << " is_array " << is_array << " type " << type;
         tdbs::common::logging::LOG_DEBUG(ss.str());
         soup->set_metadata(key, value_type, value.length(), (void*)value.c_str(), true);
     } else if (type == "integer64") {
-        const tdbs::common::DataType value_type = tdbs::common::DataType::INT64;
+        const tdbs::common::DataType value_type = tdbs::common::DataType::int64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
         std::stringstream ss;

--- a/apis/r/src/metadata.cpp
+++ b/apis/r/src/metadata.cpp
@@ -91,9 +91,9 @@ std::string get_metadata(std::string& uri, std::string& key, bool is_array, Rcpp
     }
     tdbs::MetadataValue val = *mv;
     auto dtype = std::get<0>(val);
-    auto txt = tiledb::impl::type_to_str(dtype);
+    auto txt = tdbs::common::getName(dtype);
     if (txt != "STRING_UTF8" && txt != "STRING_ASCII") {
-        Rcpp::stop("Currently unsupported type '%s'", txt.c_str());
+        Rcpp::stop("Currently unsupported type '%s'", txt.data());
     }
     auto len = std::get<1>(val);
     const void* ptr = std::get<2>(val);
@@ -165,14 +165,14 @@ void set_metadata(
     auto soup = getObjectUniquePointer(is_array, OpenMode::soma_write, uri, sctx, tsvec);
 
     if (type == "character") {
-        const tiledb_datatype_t value_type = TILEDB_STRING_UTF8;
+        const tdbs::common::DataType value_type = tdbs::common::DataType::STRING_UTF8;
         std::string value = Rcpp::as<std::string>(valuesxp);
         std::stringstream ss;
         ss << "[set_metadata] key " << key << " value " << value << " is_array " << is_array << " type " << type;
         tdbs::common::logging::LOG_DEBUG(ss.str());
         soup->set_metadata(key, value_type, value.length(), (void*)value.c_str(), true);
     } else if (type == "integer64") {
-        const tiledb_datatype_t value_type = TILEDB_INT64;
+        const tdbs::common::DataType value_type = tdbs::common::DataType::INT64;
         double dv = Rcpp::as<double>(valuesxp);
         int64_t value = Rcpp::fromInteger64(dv);
         std::stringstream ss;

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -712,20 +712,20 @@ Rcpp::List metadata_as_rlist(std::map<std::string, tiledbsoma::MetadataValue>& m
         auto dtype = std::get<0>(val);
         auto len = std::get<1>(val);
         const void* ptr = std::get<2>(val);
-        if (dtype == TILEDB_STRING_UTF8 || dtype == TILEDB_STRING_ASCII) {
+        if (dtype == tdbs::common::DataType::STRING_UTF8 || dtype == tdbs::common::DataType::STRING_ASCII) {
             auto str = std::string((char*)ptr, len);
             lst.push_back(str);
-        } else if (dtype == TILEDB_INT64) {
+        } else if (dtype == tdbs::common::DataType::INT64) {
             std::vector<int64_t> v(len);
             std::memcpy(&(v[0]), ptr, len * sizeof(int64_t));
             lst.push_back(Rcpp::toInteger64(v));
-        } else if (dtype == TILEDB_INT32) {
+        } else if (dtype == tdbs::common::DataType::INT32) {
             Rcpp::IntegerVector v(len);
             std::memcpy(v.begin(), ptr, len * sizeof(int32_t));
             lst.push_back(v);
         } else {
-            auto txt = tiledb::impl::type_to_str(dtype);
-            Rcpp::stop("Currently unsupported type '%s'", txt.c_str());
+            auto txt = tdbs::common::getName(dtype);
+            Rcpp::stop("Currently unsupported type '%s'", txt.data());
         }
     }
     lst.attr("names") = Rcpp::CharacterVector(namvec.begin(), namvec.end());

--- a/apis/r/src/rutilities.cpp
+++ b/apis/r/src/rutilities.cpp
@@ -712,14 +712,14 @@ Rcpp::List metadata_as_rlist(std::map<std::string, tiledbsoma::MetadataValue>& m
         auto dtype = std::get<0>(val);
         auto len = std::get<1>(val);
         const void* ptr = std::get<2>(val);
-        if (dtype == tdbs::common::DataType::STRING_UTF8 || dtype == tdbs::common::DataType::STRING_ASCII) {
+        if (dtype == tdbs::common::DataType::string_utf8 || dtype == tdbs::common::DataType::string_ascii) {
             auto str = std::string((char*)ptr, len);
             lst.push_back(str);
-        } else if (dtype == tdbs::common::DataType::INT64) {
+        } else if (dtype == tdbs::common::DataType::int64) {
             std::vector<int64_t> v(len);
             std::memcpy(&(v[0]), ptr, len * sizeof(int64_t));
             lst.push_back(Rcpp::toInteger64(v));
-        } else if (dtype == tdbs::common::DataType::INT32) {
+        } else if (dtype == tdbs::common::DataType::int32) {
             Rcpp::IntegerVector v(len);
             std::memcpy(v.begin(), ptr, len * sizeof(int32_t));
             lst.push_back(v);

--- a/libtiledbsoma/src/CMakeLists.txt
+++ b/libtiledbsoma/src/CMakeLists.txt
@@ -283,6 +283,11 @@ install(FILES
 )
 
 install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/datatype/datatype.h
+  DESTINATION "include/tiledbsoma/common/datatype"
+)
+
+install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/common/logging/logger.h
   DESTINATION "include/tiledbsoma/common/logging"
 )

--- a/libtiledbsoma/src/common/datatype/datatype.h
+++ b/libtiledbsoma/src/common/datatype/datatype.h
@@ -16,144 +16,144 @@ namespace tiledbsoma::common {
 using namespace std::string_view_literals;
 
 enum class DataType {
-    BOOL,
+    boolean,
     /** Integral types */
-    INT8,
-    INT16,
-    INT32,
-    INT64,
-    UINT8,
-    UINT16,
-    UINT32,
-    UINT64,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
     /** Floating point types */
-    FLOAT32,
-    FLOAT64,
+    float32,
+    float64,
     /** Temporal types */
-    DATETIME_YEAR,
-    DATETIME_MONTH,
-    DATETIME_WEEK,
-    DATETIME_DAY,
-    DATETIME_HR,
-    DATETIME_MIN,
-    DATETIME_SEC,
-    DATETIME_MS,
-    DATETIME_US,
-    DATETIME_NS,
-    DATETIME_PS,
-    DATETIME_FS,
-    DATETIME_AS,
-    TIME_HR,
-    TIME_MIN,
-    TIME_SEC,
-    TIME_MS,
-    TIME_US,
-    TIME_NS,
-    TIME_PS,
-    TIME_FS,
-    TIME_AS,
+    datetime_year,
+    datetime_month,
+    datetime_week,
+    datetime_day,
+    datetime_hr,
+    datetime_min,
+    datetime_sec,
+    datetime_ms,
+    datetime_us,
+    datetime_ns,
+    datetime_ps,
+    datetime_fs,
+    datetime_as,
+    time_hr,
+    time_min,
+    time_sec,
+    time_ms,
+    time_us,
+    time_ns,
+    time_ps,
+    time_fs,
+    time_as,
     /** String types */
-    CHAR,
-    STRING_ASCII,
-    STRING_UTF8,
-    STRING_UTF16,
-    STRING_UTF32,
-    STRING_UCS2,
-    STRING_UCS4,
+    character,
+    string_ascii,
+    string_utf8,
+    string_utf16,
+    string_utf32,
+    string_ucs2,
+    string_ucs4,
     /** Binary types */
-    BLOB,
+    blob,
     /** Geometry types */
-    GEOM_WKB,
-    GEOM_WKT
+    geom_wkb,
+    geom_wkt
 };
 
 constexpr std::string_view getName(DataType type) {
     switch (type) {
-        case DataType::BOOL:
+        case DataType::boolean:
             return "BOOL"sv;
-        case DataType::INT8:
+        case DataType::int8:
             return "INT8"sv;
-        case DataType::INT16:
+        case DataType::int16:
             return "INT16"sv;
-        case DataType::INT32:
+        case DataType::int32:
             return "INT32"sv;
-        case DataType::INT64:
+        case DataType::int64:
             return "INT64"sv;
-        case DataType::UINT8:
+        case DataType::uint8:
             return "UINT8"sv;
-        case DataType::UINT16:
+        case DataType::uint16:
             return "UINT16"sv;
-        case DataType::UINT32:
+        case DataType::uint32:
             return "UINT32"sv;
-        case DataType::UINT64:
+        case DataType::uint64:
             return "UINT64"sv;
-        case DataType::FLOAT32:
+        case DataType::float32:
             return "FLOAT32"sv;
-        case DataType::FLOAT64:
+        case DataType::float64:
             return "FLOAT64"sv;
-        case DataType::DATETIME_YEAR:
+        case DataType::datetime_year:
             return "DATETIME_YEAR"sv;
-        case DataType::DATETIME_MONTH:
+        case DataType::datetime_month:
             return "DATETIME_MONTH"sv;
-        case DataType::DATETIME_WEEK:
+        case DataType::datetime_week:
             return "DATETIME_WEEK"sv;
-        case DataType::DATETIME_DAY:
+        case DataType::datetime_day:
             return "DATETIME_DAY"sv;
-        case DataType::DATETIME_HR:
+        case DataType::datetime_hr:
             return "DATETIME_HR"sv;
-        case DataType::DATETIME_MIN:
+        case DataType::datetime_min:
             return "DATETIME_MIN"sv;
-        case DataType::DATETIME_SEC:
+        case DataType::datetime_sec:
             return "DATETIME_SEC"sv;
-        case DataType::DATETIME_MS:
+        case DataType::datetime_ms:
             return "DATETIME_MS"sv;
-        case DataType::DATETIME_US:
+        case DataType::datetime_us:
             return "DATETIME_US"sv;
-        case DataType::DATETIME_NS:
+        case DataType::datetime_ns:
             return "DATETIME_NS"sv;
-        case DataType::DATETIME_PS:
+        case DataType::datetime_ps:
             return "DATETIME_PS"sv;
-        case DataType::DATETIME_FS:
+        case DataType::datetime_fs:
             return "DATETIME_FS"sv;
-        case DataType::DATETIME_AS:
+        case DataType::datetime_as:
             return "DATETIME_AS"sv;
-        case DataType::TIME_HR:
+        case DataType::time_hr:
             return "TIME_HR"sv;
-        case DataType::TIME_MIN:
+        case DataType::time_min:
             return "TIME_MIN"sv;
-        case DataType::TIME_SEC:
+        case DataType::time_sec:
             return "TIME_SEC"sv;
-        case DataType::TIME_MS:
+        case DataType::time_ms:
             return "TIME_MS"sv;
-        case DataType::TIME_US:
+        case DataType::time_us:
             return "TIME_US"sv;
-        case DataType::TIME_NS:
+        case DataType::time_ns:
             return "TIME_NS"sv;
-        case DataType::TIME_PS:
+        case DataType::time_ps:
             return "TIME_PS"sv;
-        case DataType::TIME_FS:
+        case DataType::time_fs:
             return "TIME_FS"sv;
-        case DataType::TIME_AS:
+        case DataType::time_as:
             return "TIME_AS"sv;
-        case DataType::CHAR:
+        case DataType::character:
             return "CHAR"sv;
-        case DataType::STRING_ASCII:
+        case DataType::string_ascii:
             return "STRING_ASCII"sv;
-        case DataType::STRING_UTF8:
+        case DataType::string_utf8:
             return "STRING_UTF8"sv;
-        case DataType::STRING_UTF16:
+        case DataType::string_utf16:
             return "STRING_UTF16"sv;
-        case DataType::STRING_UTF32:
+        case DataType::string_utf32:
             return "STRING_UTF32"sv;
-        case DataType::STRING_UCS2:
+        case DataType::string_ucs2:
             return "STRING_UCS2"sv;
-        case DataType::STRING_UCS4:
+        case DataType::string_ucs4:
             return "STRING_UCS4"sv;
-        case DataType::BLOB:
+        case DataType::blob:
             return "BLOB"sv;
-        case DataType::GEOM_WKB:
+        case DataType::geom_wkb:
             return "GEOM_WKB"sv;
-        case DataType::GEOM_WKT:
+        case DataType::geom_wkt:
             return "GEOM_WKT"sv;
     }
 }

--- a/libtiledbsoma/src/common/datatype/datatype.h
+++ b/libtiledbsoma/src/common/datatype/datatype.h
@@ -10,7 +10,11 @@
 #ifndef COMMON_DATATYPE_H
 #define COMMON_DATATYPE_H
 
+#include <string_view>
+
 namespace tiledbsoma::common {
+using namespace std::string_view_literals;
+
 enum class DataType {
     BOOL,
     /** Integral types */
@@ -26,20 +30,133 @@ enum class DataType {
     FLOAT32,
     FLOAT64,
     /** Temporal types */
+    DATETIME_YEAR,
+    DATETIME_MONTH,
+    DATETIME_WEEK,
+    DATETIME_DAY,
+    DATETIME_HR,
+    DATETIME_MIN,
     DATETIME_SEC,
     DATETIME_MS,
     DATETIME_US,
     DATETIME_NS,
+    DATETIME_PS,
+    DATETIME_FS,
+    DATETIME_AS,
+    TIME_HR,
+    TIME_MIN,
+    TIME_SEC,
+    TIME_MS,
+    TIME_US,
+    TIME_NS,
+    TIME_PS,
+    TIME_FS,
+    TIME_AS,
     /** String types */
     CHAR,
     STRING_ASCII,
     STRING_UTF8,
+    STRING_UTF16,
+    STRING_UTF32,
+    STRING_UCS2,
+    STRING_UCS4,
     /** Binary types */
     BLOB,
     /** Geometry types */
     GEOM_WKB,
     GEOM_WKT
 };
+
+constexpr std::string_view getName(DataType type) {
+    switch (type) {
+        case DataType::BOOL:
+            return "BOOL"sv;
+        case DataType::INT8:
+            return "INT8"sv;
+        case DataType::INT16:
+            return "INT16"sv;
+        case DataType::INT32:
+            return "INT32"sv;
+        case DataType::INT64:
+            return "INT64"sv;
+        case DataType::UINT8:
+            return "UINT8"sv;
+        case DataType::UINT16:
+            return "UINT16"sv;
+        case DataType::UINT32:
+            return "UINT32"sv;
+        case DataType::UINT64:
+            return "UINT64"sv;
+        case DataType::FLOAT32:
+            return "FLOAT32"sv;
+        case DataType::FLOAT64:
+            return "FLOAT64"sv;
+        case DataType::DATETIME_YEAR:
+            return "DATETIME_YEAR"sv;
+        case DataType::DATETIME_MONTH:
+            return "DATETIME_MONTH"sv;
+        case DataType::DATETIME_WEEK:
+            return "DATETIME_WEEK"sv;
+        case DataType::DATETIME_DAY:
+            return "DATETIME_DAY"sv;
+        case DataType::DATETIME_HR:
+            return "DATETIME_HR"sv;
+        case DataType::DATETIME_MIN:
+            return "DATETIME_MIN"sv;
+        case DataType::DATETIME_SEC:
+            return "DATETIME_SEC"sv;
+        case DataType::DATETIME_MS:
+            return "DATETIME_MS"sv;
+        case DataType::DATETIME_US:
+            return "DATETIME_US"sv;
+        case DataType::DATETIME_NS:
+            return "DATETIME_NS"sv;
+        case DataType::DATETIME_PS:
+            return "DATETIME_PS"sv;
+        case DataType::DATETIME_FS:
+            return "DATETIME_FS"sv;
+        case DataType::DATETIME_AS:
+            return "DATETIME_AS"sv;
+        case DataType::TIME_HR:
+            return "TIME_HR"sv;
+        case DataType::TIME_MIN:
+            return "TIME_MIN"sv;
+        case DataType::TIME_SEC:
+            return "TIME_SEC"sv;
+        case DataType::TIME_MS:
+            return "TIME_MS"sv;
+        case DataType::TIME_US:
+            return "TIME_US"sv;
+        case DataType::TIME_NS:
+            return "TIME_NS"sv;
+        case DataType::TIME_PS:
+            return "TIME_PS"sv;
+        case DataType::TIME_FS:
+            return "TIME_FS"sv;
+        case DataType::TIME_AS:
+            return "TIME_AS"sv;
+        case DataType::CHAR:
+            return "CHAR"sv;
+        case DataType::STRING_ASCII:
+            return "STRING_ASCII"sv;
+        case DataType::STRING_UTF8:
+            return "STRING_UTF8"sv;
+        case DataType::STRING_UTF16:
+            return "STRING_UTF16"sv;
+        case DataType::STRING_UTF32:
+            return "STRING_UTF32"sv;
+        case DataType::STRING_UCS2:
+            return "STRING_UCS2"sv;
+        case DataType::STRING_UCS4:
+            return "STRING_UCS4"sv;
+        case DataType::BLOB:
+            return "BLOB"sv;
+        case DataType::GEOM_WKB:
+            return "GEOM_WKB"sv;
+        case DataType::GEOM_WKT:
+            return "GEOM_WKT"sv;
+    }
 }
+}  // namespace tiledbsoma::common
 
 #endif

--- a/libtiledbsoma/src/common/datatype/datatype.h
+++ b/libtiledbsoma/src/common/datatype/datatype.h
@@ -1,0 +1,45 @@
+/**
+ * @file   datatype.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ */
+
+#ifndef COMMON_DATATYPE_H
+#define COMMON_DATATYPE_H
+
+namespace tiledbsoma::common {
+enum class DataType {
+    BOOL,
+    /** Integral types */
+    INT8,
+    INT16,
+    INT32,
+    INT64,
+    UINT8,
+    UINT16,
+    UINT32,
+    UINT64,
+    /** Floating point types */
+    FLOAT32,
+    FLOAT64,
+    /** Temporal types */
+    DATETIME_SEC,
+    DATETIME_MS,
+    DATETIME_US,
+    DATETIME_NS,
+    /** String types */
+    CHAR,
+    STRING_ASCII,
+    STRING_UTF8,
+    /** Binary types */
+    BLOB,
+    /** Geometry types */
+    GEOM_WKB,
+    GEOM_WKT
+};
+}
+
+#endif

--- a/libtiledbsoma/src/common/datatype/utils.h
+++ b/libtiledbsoma/src/common/datatype/utils.h
@@ -24,91 +24,91 @@ using namespace std::string_view_literals;
 constexpr DataType tiledb_to_datatype(tiledb_datatype_t type) {
     switch (type) {
         case TILEDB_BOOL:
-            return DataType::BOOL;
+            return DataType::boolean;
         case TILEDB_INT8:
-            return DataType::INT8;
+            return DataType::int8;
         case TILEDB_INT16:
-            return DataType::INT16;
+            return DataType::int16;
         case TILEDB_INT32:
-            return DataType::INT32;
+            return DataType::int32;
         case TILEDB_INT64:
-            return DataType::INT64;
+            return DataType::int64;
         case TILEDB_UINT8:
-            return DataType::UINT8;
+            return DataType::uint8;
         case TILEDB_UINT16:
-            return DataType::UINT16;
+            return DataType::uint16;
         case TILEDB_UINT32:
-            return DataType::UINT32;
+            return DataType::uint32;
         case TILEDB_UINT64:
-            return DataType::UINT64;
+            return DataType::uint64;
         case TILEDB_FLOAT32:
-            return DataType::FLOAT32;
+            return DataType::float32;
         case TILEDB_FLOAT64:
-            return DataType::FLOAT64;
+            return DataType::float64;
         case TILEDB_DATETIME_YEAR:
-            return DataType::DATETIME_YEAR;
+            return DataType::datetime_year;
         case TILEDB_DATETIME_MONTH:
-            return DataType::DATETIME_MONTH;
+            return DataType::datetime_month;
         case TILEDB_DATETIME_WEEK:
-            return DataType::DATETIME_WEEK;
+            return DataType::datetime_week;
         case TILEDB_DATETIME_DAY:
-            return DataType::DATETIME_DAY;
+            return DataType::datetime_day;
         case TILEDB_DATETIME_HR:
-            return DataType::DATETIME_HR;
+            return DataType::datetime_hr;
         case TILEDB_DATETIME_MIN:
-            return DataType::DATETIME_MIN;
+            return DataType::datetime_min;
         case TILEDB_DATETIME_SEC:
-            return DataType::DATETIME_SEC;
+            return DataType::datetime_sec;
         case TILEDB_DATETIME_MS:
-            return DataType::DATETIME_MS;
+            return DataType::datetime_ms;
         case TILEDB_DATETIME_US:
-            return DataType::DATETIME_US;
+            return DataType::datetime_us;
         case TILEDB_DATETIME_NS:
-            return DataType::DATETIME_NS;
+            return DataType::datetime_ns;
         case TILEDB_DATETIME_PS:
-            return DataType::DATETIME_PS;
+            return DataType::datetime_ps;
         case TILEDB_DATETIME_FS:
-            return DataType::DATETIME_FS;
+            return DataType::datetime_fs;
         case TILEDB_DATETIME_AS:
-            return DataType::DATETIME_AS;
+            return DataType::datetime_as;
         case TILEDB_TIME_HR:
-            return DataType::TIME_HR;
+            return DataType::time_hr;
         case TILEDB_TIME_MIN:
-            return DataType::TIME_MIN;
+            return DataType::time_min;
         case TILEDB_TIME_SEC:
-            return DataType::TIME_SEC;
+            return DataType::time_sec;
         case TILEDB_TIME_MS:
-            return DataType::TIME_MS;
+            return DataType::time_ms;
         case TILEDB_TIME_US:
-            return DataType::TIME_US;
+            return DataType::time_us;
         case TILEDB_TIME_NS:
-            return DataType::TIME_NS;
+            return DataType::time_ns;
         case TILEDB_TIME_PS:
-            return DataType::TIME_PS;
+            return DataType::time_ps;
         case TILEDB_TIME_FS:
-            return DataType::TIME_FS;
+            return DataType::time_fs;
         case TILEDB_TIME_AS:
-            return DataType::TIME_AS;
+            return DataType::time_as;
         case TILEDB_CHAR:
-            return DataType::CHAR;
+            return DataType::character;
         case TILEDB_STRING_ASCII:
-            return DataType::STRING_ASCII;
+            return DataType::string_ascii;
         case TILEDB_STRING_UTF8:
-            return DataType::STRING_UTF8;
+            return DataType::string_utf8;
         case TILEDB_STRING_UTF16:
-            return DataType::STRING_UTF16;
+            return DataType::string_utf16;
         case TILEDB_STRING_UTF32:
-            return DataType::STRING_UTF32;
+            return DataType::string_utf32;
         case TILEDB_STRING_UCS2:
-            return DataType::STRING_UCS2;
+            return DataType::string_ucs2;
         case TILEDB_STRING_UCS4:
-            return DataType::STRING_UCS4;
+            return DataType::string_ucs4;
         case TILEDB_BLOB:
-            return DataType::BLOB;
+            return DataType::blob;
         case TILEDB_GEOM_WKB:
-            return DataType::GEOM_WKB;
+            return DataType::geom_wkb;
         case TILEDB_GEOM_WKT:
-            return DataType::GEOM_WKT;
+            return DataType::geom_wkt;
         default:
             throw std::invalid_argument("Unsupported datatype");
     }
@@ -118,91 +118,91 @@ constexpr DataType tiledb_to_datatype(tiledb_datatype_t type) {
 
 constexpr tiledb_datatype_t datatype_to_tiledb(DataType type) {
     switch (type) {
-        case DataType::BOOL:
+        case DataType::boolean:
             return TILEDB_BOOL;
-        case DataType::INT8:
+        case DataType::int8:
             return TILEDB_INT8;
-        case DataType::INT16:
+        case DataType::int16:
             return TILEDB_INT16;
-        case DataType::INT32:
+        case DataType::int32:
             return TILEDB_INT32;
-        case DataType::INT64:
+        case DataType::int64:
             return TILEDB_INT64;
-        case DataType::UINT8:
+        case DataType::uint8:
             return TILEDB_UINT8;
-        case DataType::UINT16:
+        case DataType::uint16:
             return TILEDB_UINT16;
-        case DataType::UINT32:
+        case DataType::uint32:
             return TILEDB_UINT32;
-        case DataType::UINT64:
+        case DataType::uint64:
             return TILEDB_UINT64;
-        case DataType::FLOAT32:
+        case DataType::float32:
             return TILEDB_FLOAT32;
-        case DataType::FLOAT64:
+        case DataType::float64:
             return TILEDB_FLOAT64;
-        case DataType::DATETIME_YEAR:
+        case DataType::datetime_year:
             return TILEDB_DATETIME_YEAR;
-        case DataType::DATETIME_MONTH:
+        case DataType::datetime_month:
             return TILEDB_DATETIME_MONTH;
-        case DataType::DATETIME_WEEK:
+        case DataType::datetime_week:
             return TILEDB_DATETIME_WEEK;
-        case DataType::DATETIME_DAY:
+        case DataType::datetime_day:
             return TILEDB_DATETIME_DAY;
-        case DataType::DATETIME_HR:
+        case DataType::datetime_hr:
             return TILEDB_DATETIME_HR;
-        case DataType::DATETIME_MIN:
+        case DataType::datetime_min:
             return TILEDB_DATETIME_MIN;
-        case DataType::DATETIME_SEC:
+        case DataType::datetime_sec:
             return TILEDB_DATETIME_SEC;
-        case DataType::DATETIME_MS:
+        case DataType::datetime_ms:
             return TILEDB_DATETIME_MS;
-        case DataType::DATETIME_US:
+        case DataType::datetime_us:
             return TILEDB_DATETIME_US;
-        case DataType::DATETIME_NS:
+        case DataType::datetime_ns:
             return TILEDB_DATETIME_NS;
-        case DataType::DATETIME_PS:
+        case DataType::datetime_ps:
             return TILEDB_DATETIME_PS;
-        case DataType::DATETIME_FS:
+        case DataType::datetime_fs:
             return TILEDB_DATETIME_FS;
-        case DataType::DATETIME_AS:
+        case DataType::datetime_as:
             return TILEDB_DATETIME_AS;
-        case DataType::TIME_HR:
+        case DataType::time_hr:
             return TILEDB_TIME_HR;
-        case DataType::TIME_MIN:
+        case DataType::time_min:
             return TILEDB_TIME_MIN;
-        case DataType::TIME_SEC:
+        case DataType::time_sec:
             return TILEDB_TIME_SEC;
-        case DataType::TIME_MS:
+        case DataType::time_ms:
             return TILEDB_TIME_MS;
-        case DataType::TIME_US:
+        case DataType::time_us:
             return TILEDB_TIME_US;
-        case DataType::TIME_NS:
+        case DataType::time_ns:
             return TILEDB_TIME_NS;
-        case DataType::TIME_PS:
+        case DataType::time_ps:
             return TILEDB_TIME_PS;
-        case DataType::TIME_FS:
+        case DataType::time_fs:
             return TILEDB_TIME_FS;
-        case DataType::TIME_AS:
+        case DataType::time_as:
             return TILEDB_TIME_AS;
-        case DataType::CHAR:
+        case DataType::character:
             return TILEDB_CHAR;
-        case DataType::STRING_ASCII:
+        case DataType::string_ascii:
             return TILEDB_STRING_ASCII;
-        case DataType::STRING_UTF8:
+        case DataType::string_utf8:
             return TILEDB_STRING_UTF8;
-        case DataType::STRING_UTF16:
+        case DataType::string_utf16:
             return TILEDB_STRING_UTF16;
-        case DataType::STRING_UTF32:
+        case DataType::string_utf32:
             return TILEDB_STRING_UTF32;
-        case DataType::STRING_UCS2:
+        case DataType::string_ucs2:
             return TILEDB_STRING_UCS2;
-        case DataType::STRING_UCS4:
+        case DataType::string_ucs4:
             return TILEDB_STRING_UCS4;
-        case DataType::BLOB:
+        case DataType::blob:
             return TILEDB_BLOB;
-        case DataType::GEOM_WKB:
+        case DataType::geom_wkb:
             return TILEDB_GEOM_WKB;
-        case DataType::GEOM_WKT:
+        case DataType::geom_wkt:
             return TILEDB_GEOM_WKT;
         default:
             throw std::invalid_argument("Unsupported datatype");
@@ -214,47 +214,47 @@ constexpr std::string_view datatype_to_arrow(DataType type, bool use_large = tru
     auto z = use_large ? "Z"sv : "z"sv;
 
     switch (type) {
-        case DataType::BOOL:
+        case DataType::boolean:
             return "b"sv;
-        case DataType::INT8:
+        case DataType::int8:
             return "c"sv;
-        case DataType::INT16:
+        case DataType::int16:
             return "s"sv;
-        case DataType::INT32:
+        case DataType::int32:
             return "i"sv;
-        case DataType::INT64:
+        case DataType::int64:
             return "l"sv;
-        case DataType::UINT8:
+        case DataType::uint8:
             return "C"sv;
-        case DataType::UINT16:
+        case DataType::uint16:
             return "S"sv;
-        case DataType::UINT32:
+        case DataType::uint32:
             return "I"sv;
-        case DataType::UINT64:
+        case DataType::uint64:
             return "L"sv;
-        case DataType::FLOAT32:
+        case DataType::float32:
             return "f"sv;
-        case DataType::FLOAT64:
+        case DataType::float64:
             return "g"sv;
-        case DataType::DATETIME_SEC:
+        case DataType::datetime_sec:
             return "tss:"sv;
-        case DataType::DATETIME_MS:
+        case DataType::datetime_ms:
             return "tsm:"sv;
-        case DataType::DATETIME_US:
+        case DataType::datetime_us:
             return "tsu:"sv;
-        case DataType::DATETIME_NS:
+        case DataType::datetime_ns:
             return "tsn:"sv;
-        case DataType::CHAR:
+        case DataType::character:
             return z;
-        case DataType::STRING_ASCII:
+        case DataType::string_ascii:
             return u;
-        case DataType::STRING_UTF8:
+        case DataType::string_utf8:
             return u;
-        case DataType::BLOB:
+        case DataType::blob:
             return z;
-        case DataType::GEOM_WKB:
+        case DataType::geom_wkb:
             return z;
-        case DataType::GEOM_WKT:
+        case DataType::geom_wkt:
             return u;
         default:
             throw std::invalid_argument("Unsuported type by Arrow");
@@ -263,9 +263,9 @@ constexpr std::string_view datatype_to_arrow(DataType type, bool use_large = tru
 
 constexpr std::optional<std::string_view> datatype_to_arrow_metadata(DataType type) {
     switch (type) {
-        case DataType::GEOM_WKB:
+        case DataType::geom_wkb:
             return "WKB"sv;
-        case DataType::GEOM_WKT:
+        case DataType::geom_wkt:
             return "WKT"sv;
         default:
             return std::nullopt;

--- a/libtiledbsoma/src/common/datatype/utils.h
+++ b/libtiledbsoma/src/common/datatype/utils.h
@@ -1,0 +1,21 @@
+/**
+ * @file   utils.h
+ *
+ * @section LICENSE
+ *
+ * Licensed under the MIT License.
+ * Copyright (c) TileDB, Inc. and The Chan Zuckerberg Initiative Foundation
+ */
+
+#ifndef COMMON_DATATYPE_UTILS_H
+#define COMMON_DATATYPE_UTILS_H
+
+#include "datatype.h"
+
+#include <tiledb/tiledb>
+
+namespace tiledbsoma::common {
+DataType tiledb_to_datatype(tiledb_datatype_t type);
+}
+
+#endif

--- a/libtiledbsoma/src/common/datatype/utils.h
+++ b/libtiledbsoma/src/common/datatype/utils.h
@@ -14,8 +14,292 @@
 
 #include <tiledb/tiledb>
 
-namespace tiledbsoma::common {
-DataType tiledb_to_datatype(tiledb_datatype_t type);
+#include <optional>
+#include <string_view>
+#include <tuple>
+
+namespace tiledbsoma::common::type {
+namespace impl {
+using namespace std::string_view_literals;
+constexpr DataType tiledb_to_datatype(tiledb_datatype_t type) {
+    switch (type) {
+        case TILEDB_BOOL:
+            return DataType::BOOL;
+        case TILEDB_INT8:
+            return DataType::INT8;
+        case TILEDB_INT16:
+            return DataType::INT16;
+        case TILEDB_INT32:
+            return DataType::INT32;
+        case TILEDB_INT64:
+            return DataType::INT64;
+        case TILEDB_UINT8:
+            return DataType::UINT8;
+        case TILEDB_UINT16:
+            return DataType::UINT16;
+        case TILEDB_UINT32:
+            return DataType::UINT32;
+        case TILEDB_UINT64:
+            return DataType::UINT64;
+        case TILEDB_FLOAT32:
+            return DataType::FLOAT32;
+        case TILEDB_FLOAT64:
+            return DataType::FLOAT64;
+        case TILEDB_DATETIME_YEAR:
+            return DataType::DATETIME_YEAR;
+        case TILEDB_DATETIME_MONTH:
+            return DataType::DATETIME_MONTH;
+        case TILEDB_DATETIME_WEEK:
+            return DataType::DATETIME_WEEK;
+        case TILEDB_DATETIME_DAY:
+            return DataType::DATETIME_DAY;
+        case TILEDB_DATETIME_HR:
+            return DataType::DATETIME_HR;
+        case TILEDB_DATETIME_MIN:
+            return DataType::DATETIME_MIN;
+        case TILEDB_DATETIME_SEC:
+            return DataType::DATETIME_SEC;
+        case TILEDB_DATETIME_MS:
+            return DataType::DATETIME_MS;
+        case TILEDB_DATETIME_US:
+            return DataType::DATETIME_US;
+        case TILEDB_DATETIME_NS:
+            return DataType::DATETIME_NS;
+        case TILEDB_DATETIME_PS:
+            return DataType::DATETIME_PS;
+        case TILEDB_DATETIME_FS:
+            return DataType::DATETIME_FS;
+        case TILEDB_DATETIME_AS:
+            return DataType::DATETIME_AS;
+        case TILEDB_TIME_HR:
+            return DataType::TIME_HR;
+        case TILEDB_TIME_MIN:
+            return DataType::TIME_MIN;
+        case TILEDB_TIME_SEC:
+            return DataType::TIME_SEC;
+        case TILEDB_TIME_MS:
+            return DataType::TIME_MS;
+        case TILEDB_TIME_US:
+            return DataType::TIME_US;
+        case TILEDB_TIME_NS:
+            return DataType::TIME_NS;
+        case TILEDB_TIME_PS:
+            return DataType::TIME_PS;
+        case TILEDB_TIME_FS:
+            return DataType::TIME_FS;
+        case TILEDB_TIME_AS:
+            return DataType::TIME_AS;
+        case TILEDB_CHAR:
+            return DataType::CHAR;
+        case TILEDB_STRING_ASCII:
+            return DataType::STRING_ASCII;
+        case TILEDB_STRING_UTF8:
+            return DataType::STRING_UTF8;
+        case TILEDB_STRING_UTF16:
+            return DataType::STRING_UTF16;
+        case TILEDB_STRING_UTF32:
+            return DataType::STRING_UTF32;
+        case TILEDB_STRING_UCS2:
+            return DataType::STRING_UCS2;
+        case TILEDB_STRING_UCS4:
+            return DataType::STRING_UCS4;
+        case TILEDB_BLOB:
+            return DataType::BLOB;
+        case TILEDB_GEOM_WKB:
+            return DataType::GEOM_WKB;
+        case TILEDB_GEOM_WKT:
+            return DataType::GEOM_WKT;
+        default:
+            throw std::invalid_argument("Unsupported datatype");
+    }
 }
+
+// DataType arrow_to_datatype(std::string_view type, std::string_view type_metadata);
+
+constexpr tiledb_datatype_t datatype_to_tiledb(DataType type) {
+    switch (type) {
+        case DataType::BOOL:
+            return TILEDB_BOOL;
+        case DataType::INT8:
+            return TILEDB_INT8;
+        case DataType::INT16:
+            return TILEDB_INT16;
+        case DataType::INT32:
+            return TILEDB_INT32;
+        case DataType::INT64:
+            return TILEDB_INT64;
+        case DataType::UINT8:
+            return TILEDB_UINT8;
+        case DataType::UINT16:
+            return TILEDB_UINT16;
+        case DataType::UINT32:
+            return TILEDB_UINT32;
+        case DataType::UINT64:
+            return TILEDB_UINT64;
+        case DataType::FLOAT32:
+            return TILEDB_FLOAT32;
+        case DataType::FLOAT64:
+            return TILEDB_FLOAT64;
+        case DataType::DATETIME_YEAR:
+            return TILEDB_DATETIME_YEAR;
+        case DataType::DATETIME_MONTH:
+            return TILEDB_DATETIME_MONTH;
+        case DataType::DATETIME_WEEK:
+            return TILEDB_DATETIME_WEEK;
+        case DataType::DATETIME_DAY:
+            return TILEDB_DATETIME_DAY;
+        case DataType::DATETIME_HR:
+            return TILEDB_DATETIME_HR;
+        case DataType::DATETIME_MIN:
+            return TILEDB_DATETIME_MIN;
+        case DataType::DATETIME_SEC:
+            return TILEDB_DATETIME_SEC;
+        case DataType::DATETIME_MS:
+            return TILEDB_DATETIME_MS;
+        case DataType::DATETIME_US:
+            return TILEDB_DATETIME_US;
+        case DataType::DATETIME_NS:
+            return TILEDB_DATETIME_NS;
+        case DataType::DATETIME_PS:
+            return TILEDB_DATETIME_PS;
+        case DataType::DATETIME_FS:
+            return TILEDB_DATETIME_FS;
+        case DataType::DATETIME_AS:
+            return TILEDB_DATETIME_AS;
+        case DataType::TIME_HR:
+            return TILEDB_TIME_HR;
+        case DataType::TIME_MIN:
+            return TILEDB_TIME_MIN;
+        case DataType::TIME_SEC:
+            return TILEDB_TIME_SEC;
+        case DataType::TIME_MS:
+            return TILEDB_TIME_MS;
+        case DataType::TIME_US:
+            return TILEDB_TIME_US;
+        case DataType::TIME_NS:
+            return TILEDB_TIME_NS;
+        case DataType::TIME_PS:
+            return TILEDB_TIME_PS;
+        case DataType::TIME_FS:
+            return TILEDB_TIME_FS;
+        case DataType::TIME_AS:
+            return TILEDB_TIME_AS;
+        case DataType::CHAR:
+            return TILEDB_CHAR;
+        case DataType::STRING_ASCII:
+            return TILEDB_STRING_ASCII;
+        case DataType::STRING_UTF8:
+            return TILEDB_STRING_UTF8;
+        case DataType::STRING_UTF16:
+            return TILEDB_STRING_UTF16;
+        case DataType::STRING_UTF32:
+            return TILEDB_STRING_UTF32;
+        case DataType::STRING_UCS2:
+            return TILEDB_STRING_UCS2;
+        case DataType::STRING_UCS4:
+            return TILEDB_STRING_UCS4;
+        case DataType::BLOB:
+            return TILEDB_BLOB;
+        case DataType::GEOM_WKB:
+            return TILEDB_GEOM_WKB;
+        case DataType::GEOM_WKT:
+            return TILEDB_GEOM_WKT;
+        default:
+            throw std::invalid_argument("Unsupported datatype");
+    }
+}
+
+constexpr std::string_view datatype_to_arrow(DataType type, bool use_large = true) {
+    auto u = use_large ? "U"sv : "u"sv;
+    auto z = use_large ? "Z"sv : "z"sv;
+
+    switch (type) {
+        case DataType::BOOL:
+            return "b"sv;
+        case DataType::INT8:
+            return "c"sv;
+        case DataType::INT16:
+            return "s"sv;
+        case DataType::INT32:
+            return "i"sv;
+        case DataType::INT64:
+            return "l"sv;
+        case DataType::UINT8:
+            return "C"sv;
+        case DataType::UINT16:
+            return "S"sv;
+        case DataType::UINT32:
+            return "I"sv;
+        case DataType::UINT64:
+            return "L"sv;
+        case DataType::FLOAT32:
+            return "f"sv;
+        case DataType::FLOAT64:
+            return "g"sv;
+        case DataType::DATETIME_SEC:
+            return "tss:"sv;
+        case DataType::DATETIME_MS:
+            return "tsm:"sv;
+        case DataType::DATETIME_US:
+            return "tsu:"sv;
+        case DataType::DATETIME_NS:
+            return "tsn:"sv;
+        case DataType::CHAR:
+            return z;
+        case DataType::STRING_ASCII:
+            return u;
+        case DataType::STRING_UTF8:
+            return u;
+        case DataType::BLOB:
+            return z;
+        case DataType::GEOM_WKB:
+            return z;
+        case DataType::GEOM_WKT:
+            return u;
+        default:
+            throw std::invalid_argument("Unsuported type by Arrow");
+    }
+}
+
+constexpr std::optional<std::string_view> datatype_to_arrow_metadata(DataType type) {
+    switch (type) {
+        case DataType::GEOM_WKB:
+            return "WKB"sv;
+        case DataType::GEOM_WKT:
+            return "WKT"sv;
+        default:
+            return std::nullopt;
+    }
+}
+}  // namespace impl
+
+enum class DataTypeFormat { SOMA, TILEDB, ARROW, ARROW_METADATA };
+
+template <DataTypeFormat Format, bool use_large = true>
+constexpr auto as(DataType type) {
+    if constexpr (Format == DataTypeFormat::SOMA) {
+        return type;
+    } else if constexpr (Format == DataTypeFormat::TILEDB) {
+        return impl::datatype_to_tiledb(type);
+    } else if constexpr (Format == DataTypeFormat::ARROW) {
+        return impl::datatype_to_arrow(type, use_large);
+    } else {
+        return impl::datatype_to_arrow_metadata(type);
+    }
+}
+
+template <DataTypeFormat Format, bool use_large = true>
+constexpr auto as(tiledb_datatype_t type) {
+    if constexpr (Format == DataTypeFormat::SOMA) {
+        return impl::tiledb_to_datatype(type);
+    } else if constexpr (Format == DataTypeFormat::TILEDB) {
+        return type;
+    } else if constexpr (Format == DataTypeFormat::ARROW) {
+        return impl::datatype_to_arrow(impl::tiledb_to_datatype(type), use_large);
+    } else {
+        return impl::datatype_to_arrow_metadata(impl::tiledb_to_datatype(type));
+    }
+}
+}  // namespace tiledbsoma::common::type
 
 #endif

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -19,6 +19,8 @@
 /** Defines whether the SOMAObject should be opened in read or write mode */
 enum class OpenMode { soma_read, soma_write, soma_delete };
 
+enum class ObjectType { INVALID, ARRAY, GROUP };
+
 /** Defines whether the result should be opened in row-major or column-major
  * order */
 enum class ResultOrder { automatic = 0, rowmajor, colmajor, unordered, global };

--- a/libtiledbsoma/src/soma/enums.h
+++ b/libtiledbsoma/src/soma/enums.h
@@ -19,7 +19,7 @@
 /** Defines whether the SOMAObject should be opened in read or write mode */
 enum class OpenMode { soma_read, soma_write, soma_delete };
 
-enum class ObjectType { INVALID, ARRAY, GROUP };
+enum class ObjectType { invalid, array, group };
 
 /** Defines whether the result should be opened in row-major or column-major
  * order */

--- a/libtiledbsoma/src/soma/soma_array.cc
+++ b/libtiledbsoma/src/soma/soma_array.cc
@@ -19,6 +19,8 @@
 #include "../utils/arrow_adapter.h"
 #include "../utils/util.h"
 #include "common/arrow/utils.h"
+#include "common/datatype/datatype.h"
+#include "common/datatype/utils.h"
 #include "common/logging/impl/logger.h"
 #include "common/query/managed_query.h"
 #include "coordinate_value_filters.h"
@@ -31,6 +33,7 @@
 
 namespace tiledbsoma {
 using namespace common::logging;
+using namespace common::type;
 
 //==================================================================
 // helper functions
@@ -78,7 +81,7 @@ std::map<std::string, MetadataValue> create_metadata_cache(tiledb::Array& array)
         uint32_t value_num;
         const void* value;
         array.get_metadata_from_index(idx, &key, &value_type, &value_num, &value);
-        MetadataValue mdval(value_type, value_num, value);
+        MetadataValue mdval(as<DataTypeFormat::SOMA>(value_type), value_num, value);
         std::pair<std::string, const MetadataValue> mdpair(key, mdval);
         metadata_cache.insert(mdpair);
     }
@@ -363,14 +366,14 @@ PlatformSchemaConfig SOMAArray::schema_config_options() const {
 }
 
 void SOMAArray::set_metadata(
-    const std::string& key, tiledb_datatype_t value_type, uint32_t value_num, const void* value, bool force) {
+    const std::string& key, common::DataType value_type, uint32_t value_num, const void* value, bool force) {
     if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
         throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be modified.");
 
     if (!force && key.compare(ENCODING_VERSION_KEY) == 0)
         throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be modified.");
 
-    arr_->put_metadata(key, value_type, value_num, value);
+    arr_->put_metadata(key, as<DataTypeFormat::TILEDB>(value_type), value_num, value);
 
     MetadataValue mdval(value_type, value_num, value);
     std::pair<std::string, const MetadataValue> mdpair(key, mdval);

--- a/libtiledbsoma/src/soma/soma_array.h
+++ b/libtiledbsoma/src/soma/soma_array.h
@@ -32,6 +32,7 @@ class ArraySchema;
 class ArraySchemaEvolution;
 class Enumeration;
 class CurrentDomain;
+class QueryCondition;
 }  // namespace tiledb
 
 struct ArrowArray;
@@ -289,7 +290,7 @@ class SOMAArray : public SOMAObject {
      * @param coord_filter Coordinate value filter defining the coordinates to delete.
      * @param value_filter Additional value filter to constrain the delete by.
      */
-    void delete_cells(const CoordinateValueFilters& coord_filters, const QueryCondition& value_filter);
+    void delete_cells(const CoordinateValueFilters& coord_filters, const tiledb::QueryCondition& value_filter);
 
     /**
      * @brief Get the TileDB ArraySchema. This should eventually
@@ -341,11 +342,7 @@ class SOMAArray : public SOMAObject {
      * @note The writes will take effect only upon closing the array.
      */
     void set_metadata(
-        const std::string& key,
-        tiledb_datatype_t value_type,
-        uint32_t value_num,
-        const void* value,
-        bool force = false);
+        const std::string& key, common::DataType value_type, uint32_t value_num, const void* value, bool force = false);
 
     /**
      * Delete a metadata key-value item from an open array. The array must
@@ -740,12 +737,12 @@ class SOMAArray : public SOMAObject {
      *
      * @param delete_cond The query condition that specifies which cells to delete.
      */
-    void delete_cells_impl(const QueryCondition& delete_cond);
+    void delete_cells_impl(const tiledb::QueryCondition& delete_cond);
 
     static tiledb::Array _create(
         std::shared_ptr<SOMAContext> ctx,
         std::string_view uri,
-        ArraySchema schema,
+        tiledb::ArraySchema schema,
         std::string_view soma_type,
         std::optional<std::string_view> soma_schema,
         std::optional<TimestampRange> timestamp);

--- a/libtiledbsoma/src/soma/soma_column.h
+++ b/libtiledbsoma/src/soma/soma_column.h
@@ -499,7 +499,7 @@ std::pair<std::string, std::string> SOMAColumn::core_domain_slot<std::string>() 
 
 template <>
 std::pair<std::string, std::string> SOMAColumn::core_current_domain_slot<std::string>(
-    const SOMAContext& ctx, Array& array) const;
+    const SOMAContext& ctx, tiledb::Array& array) const;
 
 template <>
 std::pair<std::string, std::string> SOMAColumn::core_current_domain_slot<std::string>(

--- a/libtiledbsoma/src/soma/soma_context.cc
+++ b/libtiledbsoma/src/soma/soma_context.cc
@@ -13,12 +13,39 @@
 #include <regex>
 #include <thread>
 
+#include <tiledb/tiledb>
+
 #include <thread_pool/thread_pool.h>
 #include "../utils/common.h"
 #include "common/logging/impl/logger.h"
 #include "soma_context.h"
 
 namespace tiledbsoma {
+
+SOMAContext::SOMAContext()
+    : ctx_(std::make_shared<tiledb::Context>(tiledb::Config({})))
+    , thread_pool_mutex_() {
+}
+
+SOMAContext::SOMAContext(std::map<std::string, std::string> tiledb_config)
+    : ctx_(std::make_shared<tiledb::Context>(tiledb::Config(tiledb_config)))
+    , thread_pool_mutex_() {
+}
+
+bool SOMAContext::operator==(const SOMAContext& other) const {
+    return ctx_ == other.ctx_;
+}
+
+std::shared_ptr<tiledb::Context> SOMAContext::tiledb_ctx() const {
+    return ctx_;
+}
+
+std::map<std::string, std::string> SOMAContext::tiledb_config() const {
+    std::map<std::string, std::string> cfg;
+    for (auto& it : ctx_->config())
+        cfg[it.first] = it.second;
+    return cfg;
+}
 
 std::shared_ptr<ThreadPool>& SOMAContext::thread_pool() {
     const std::lock_guard<std::mutex> lock(thread_pool_mutex_);

--- a/libtiledbsoma/src/soma/soma_context.h
+++ b/libtiledbsoma/src/soma/soma_context.h
@@ -15,15 +15,24 @@
 #define SOMA_CONTEXT
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
-#include <tiledb/tiledb>
+
+#pragma region Forward declarations
+
+namespace tiledb {
+class Config;
+class Context;
+}  // namespace tiledb
 
 namespace tiledbsoma {
 class ThreadPool;
+}  // namespace tiledbsoma
 
-using namespace tiledb;
+#pragma endregion
 
+namespace tiledbsoma {
 class SOMAContext {
     // Controls concurrency level for SOMA compute thread pool. Defaults to host
     // CPU count.
@@ -33,28 +42,15 @@ class SOMAContext {
     //===================================================================
     //= public non-static
     //===================================================================
-    SOMAContext()
-        : ctx_(std::make_shared<Context>(Config({})))
-        , thread_pool_mutex_() {};
+    SOMAContext();
 
-    SOMAContext(std::map<std::string, std::string> tiledb_config)
-        : ctx_(std::make_shared<Context>(Config(tiledb_config)))
-        , thread_pool_mutex_() {};
+    SOMAContext(std::map<std::string, std::string> tiledb_config);
 
-    bool operator==(const SOMAContext& other) const {
-        return ctx_ == other.ctx_;
-    }
+    bool operator==(const SOMAContext& other) const;
 
-    std::shared_ptr<Context> tiledb_ctx() const {
-        return ctx_;
-    }
+    std::shared_ptr<tiledb::Context> tiledb_ctx() const;
 
-    std::map<std::string, std::string> tiledb_config() const {
-        std::map<std::string, std::string> cfg;
-        for (auto& it : ctx_->config())
-            cfg[it.first] = it.second;
-        return cfg;
-    }
+    std::map<std::string, std::string> tiledb_config() const;
 
     std::shared_ptr<ThreadPool>& thread_pool();
 
@@ -79,7 +75,7 @@ class SOMAContext {
     //===================================================================
 
     // TileDB context
-    std::shared_ptr<Context> ctx_;
+    std::shared_ptr<tiledb::Context> ctx_;
 
     // Threadpool
     std::shared_ptr<ThreadPool> thread_pool_ = nullptr;

--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -19,6 +19,8 @@
 
 #include "soma_coordinates.h"
 
+#include "common/datatype/utils.h"
+
 using json = nlohmann::json;
 
 namespace nlohmann {
@@ -46,6 +48,7 @@ struct adl_serializer<tiledbsoma::SOMAAxis> {
 }  // namespace nlohmann
 
 namespace tiledbsoma {
+using namespace common::type;
 
 SOMACoordinateSpace::SOMACoordinateSpace()
     : axes_{{"x", std::nullopt}, {"y", std::nullopt}} {
@@ -114,15 +117,15 @@ SOMACoordinateSpace::SOMACoordinateSpace(
 }
 
 SOMACoordinateSpace SOMACoordinateSpace::from_metadata(
-    tiledb_datatype_t value_type, uint32_t value_num, const void* value) {
-    if (value_type != TILEDB_STRING_UTF8 && value_type != TILEDB_STRING_ASCII) {
+    common::DataType value_type, uint32_t value_num, const void* value) {
+    if (value_type != common::DataType::STRING_UTF8 && value_type != common::DataType::STRING_ASCII) {
         throw TileDBSOMAError(
             fmt::format(
                 "[SOMACoordinateSpace]: Unexpected datatype for coordinate space "
                 "metadata. Expected {} or {}; got {}",
-                tiledb::impl::type_to_str(TILEDB_STRING_UTF8),
-                tiledb::impl::type_to_str(TILEDB_STRING_ASCII),
-                tiledb::impl::type_to_str(value_type)));
+                common::getName(common::DataType::STRING_UTF8),
+                common::getName(common::DataType::STRING_ASCII),
+                common::getName(value_type)));
     }
     if (value == nullptr) {
         throw TileDBSOMAError(

--- a/libtiledbsoma/src/soma/soma_coordinates.cc
+++ b/libtiledbsoma/src/soma/soma_coordinates.cc
@@ -118,13 +118,13 @@ SOMACoordinateSpace::SOMACoordinateSpace(
 
 SOMACoordinateSpace SOMACoordinateSpace::from_metadata(
     common::DataType value_type, uint32_t value_num, const void* value) {
-    if (value_type != common::DataType::STRING_UTF8 && value_type != common::DataType::STRING_ASCII) {
+    if (value_type != common::DataType::string_utf8 && value_type != common::DataType::string_ascii) {
         throw TileDBSOMAError(
             fmt::format(
                 "[SOMACoordinateSpace]: Unexpected datatype for coordinate space "
                 "metadata. Expected {} or {}; got {}",
-                common::getName(common::DataType::STRING_UTF8),
-                common::getName(common::DataType::STRING_ASCII),
+                common::getName(common::DataType::string_utf8),
+                common::getName(common::DataType::string_ascii),
                 common::getName(value_type)));
     }
     if (value == nullptr) {

--- a/libtiledbsoma/src/soma/soma_coordinates.h
+++ b/libtiledbsoma/src/soma/soma_coordinates.h
@@ -19,6 +19,8 @@
 #include <vector>
 #include "../utils/common.h"
 
+#include "common/datatype/datatype.h"
+
 namespace tiledbsoma {
 
 struct SOMAAxis {
@@ -36,7 +38,7 @@ struct SOMAAxis {
 
 class SOMACoordinateSpace {
    public:
-    static SOMACoordinateSpace from_metadata(tiledb_datatype_t value_type, uint32_t value_num, const void* value);
+    static SOMACoordinateSpace from_metadata(common::DataType value_type, uint32_t value_num, const void* value);
 
     static SOMACoordinateSpace from_string(std::string_view metadata);
 

--- a/libtiledbsoma/src/soma/soma_factory.cc
+++ b/libtiledbsoma/src/soma/soma_factory.cc
@@ -19,16 +19,15 @@
 #include "soma_context.h"
 
 namespace tiledbsoma {
-using namespace tiledb;
 
 std::string get_soma_type_metadata_value(
     std::string_view uri, const SOMAContext& ctx, std::optional<TimestampRange> timestamp) {
-    auto tiledb_type = Object::object(*ctx.tiledb_ctx(), std::string(uri)).type();
+    auto tiledb_type = tiledb::Object::object(*ctx.tiledb_ctx(), std::string(uri)).type();
 
     switch (tiledb_type) {
-        case Object::Type::Array:
+        case tiledb::Object::Type::Array:
             return get_soma_type_metadata_value_from_array(uri, ctx, timestamp);
-        case Object::Type::Group:
+        case tiledb::Object::Type::Group:
             return get_soma_type_metadata_value_from_group(uri, ctx, timestamp);
         default:
             throw TileDBSOMAError(fmt::format("The object at URI '{}' is not a valid TileDB array or group.", uri));
@@ -38,9 +37,9 @@ std::string get_soma_type_metadata_value(
 std::string get_soma_type_metadata_value_from_array(
     std::string_view uri, const SOMAContext& ctx, std::optional<TimestampRange> timestamp) {
     auto temporal_policy = timestamp.has_value() ?
-                               TemporalPolicy(TimestampStartEnd, timestamp->first, timestamp->second) :
-                               TemporalPolicy();
-    Array array(*ctx.tiledb_ctx(), std::string(uri), TILEDB_READ, temporal_policy);
+                               tiledb::TemporalPolicy(tiledb::TimestampStartEnd, timestamp->first, timestamp->second) :
+                               tiledb::TemporalPolicy();
+    tiledb::Array array(*ctx.tiledb_ctx(), std::string(uri), TILEDB_READ, temporal_policy);
 
     // Get and return datatype.
     tiledb_datatype_t value_type{};
@@ -88,7 +87,7 @@ std::string get_soma_type_metadata_value_from_group(
         cfg["sm.group.timestamp_start"] = timestamp->first;
         cfg["sm.group.timestamp_end"] = timestamp->second;
     }
-    Group group(*ctx.tiledb_ctx(), std::string(uri), TILEDB_READ, cfg);
+    tiledb::Group group(*ctx.tiledb_ctx(), std::string(uri), TILEDB_READ, cfg);
 
     // Get and return datatype.
     tiledb_datatype_t value_type{};

--- a/libtiledbsoma/src/soma/soma_factory.h
+++ b/libtiledbsoma/src/soma/soma_factory.h
@@ -19,7 +19,6 @@
 #include <string>
 #include "../utils/common.h"
 
-using namespace tiledb;
 namespace tiledbsoma {
 
 class SOMAContext;

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -13,10 +13,13 @@
 
 #include "soma_group.h"
 #include "../utils/util.h"
+#include "common/datatype/datatype.h"
+#include "common/datatype/utils.h"
 #include "common/logging/impl/logger.h"
+#include "enums.h"
 
 namespace tiledbsoma {
-using namespace tiledb;
+using namespace common::type;
 
 //==================================================================
 // helper functions
@@ -30,7 +33,8 @@ std::map<std::string, MetadataValue> create_metadata_cache(Group& group) {
         uint32_t value_num;
         const void* value;
         group.get_metadata_from_index(idx, &key, &value_type, &value_num, &value);
-        metadata_cache[key] = MetadataValue(value_type, value_num, value);
+
+        metadata_cache[key] = MetadataValue(as<DataTypeFormat::SOMA>(value_type), value_num, value);
     }
     return metadata_cache;
 }
@@ -218,7 +222,7 @@ void SOMAGroup::set(const std::string& uri, URIType uri_type, const std::string&
     if (uri_type == URIType::automatic) {
         relative = !((uri.find("://") != std::string::npos) || (uri.find("/") == 0));
     }
-    group_->add_member(uri, relative, name, tiledb_type);
+    group_->add_member(uri, relative, name, tiledb_type == ObjectType::ARRAY ? TILEDB_ARRAY : TILEDB_GROUP);
     members_map_[name] = SOMAGroupEntry(uri, soma_type);
 }
 
@@ -239,14 +243,14 @@ std::optional<TimestampRange> SOMAGroup::timestamp() {
 }
 
 void SOMAGroup::set_metadata(
-    const std::string& key, tiledb_datatype_t value_type, uint32_t value_num, const void* value, bool force) {
+    const std::string& key, common::DataType value_type, uint32_t value_num, const void* value, bool force) {
     if (!force && key.compare(SOMA_OBJECT_TYPE_KEY) == 0)
         throw TileDBSOMAError(SOMA_OBJECT_TYPE_KEY + " cannot be modified.");
 
     if (!force && key.compare(ENCODING_VERSION_KEY) == 0)
         throw TileDBSOMAError(ENCODING_VERSION_KEY + " cannot be modified.");
 
-    group_->put_metadata(key, value_type, value_num, value);
+    group_->put_metadata(key, as<DataTypeFormat::TILEDB>(value_type), value_num, value);
     MetadataValue mdval(value_type, value_num, value);
     std::pair<std::string, const MetadataValue> mdpair(key, mdval);
     metadata_.insert(mdpair);

--- a/libtiledbsoma/src/soma/soma_group.cc
+++ b/libtiledbsoma/src/soma/soma_group.cc
@@ -222,7 +222,7 @@ void SOMAGroup::set(const std::string& uri, URIType uri_type, const std::string&
     if (uri_type == URIType::automatic) {
         relative = !((uri.find("://") != std::string::npos) || (uri.find("/") == 0));
     }
-    group_->add_member(uri, relative, name, tiledb_type == ObjectType::ARRAY ? TILEDB_ARRAY : TILEDB_GROUP);
+    group_->add_member(uri, relative, name, tiledb_type == ObjectType::array ? TILEDB_ARRAY : TILEDB_GROUP);
     members_map_[name] = SOMAGroupEntry(uri, soma_type);
 }
 

--- a/libtiledbsoma/src/soma/soma_group.h
+++ b/libtiledbsoma/src/soma/soma_group.h
@@ -23,6 +23,14 @@
 #include "enums.h"
 #include "soma_object.h"
 
+#pragma region Forward declarations
+
+namespace tiledbsoma::common {
+enum class DataType;
+}  // namespace tiledbsoma::common
+
+#pragma endregion
+
 namespace tiledbsoma {
 using namespace tiledb;
 
@@ -230,11 +238,7 @@ class SOMAGroup : public SOMAObject {
      * @note The writes will take effect only upon closing the array.
      */
     void set_metadata(
-        const std::string& key,
-        tiledb_datatype_t value_type,
-        uint32_t value_num,
-        const void* value,
-        bool force = false);
+        const std::string& key, common::DataType value_type, uint32_t value_num, const void* value, bool force = false);
 
     /**
      * Delete a metadata key-value item from an open group. The group must

--- a/libtiledbsoma/src/soma/soma_multiscale_image.cc
+++ b/libtiledbsoma/src/soma/soma_multiscale_image.cc
@@ -14,6 +14,8 @@
 #include "soma_multiscale_image.h"
 #include "soma_collection.h"
 
+#include "common/datatype/datatype.h"
+
 namespace tiledbsoma {
 using namespace tiledb;
 

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -4,6 +4,7 @@
 
 #include "../utils/util.h"
 #include "common/logging/impl/logger.h"
+#include "enums.h"
 #include "soma_array.h"
 #include "soma_collection.h"
 #include "soma_dataframe.h"
@@ -157,24 +158,24 @@ void SOMAObject::check_encoding_version() {
     }
 };
 
-tiledb_object_t SOMAObject::tiledb_type_from_soma_type(const std::string& soma_type) {
-    const std::map<std::string, tiledb_object_t> typeMap = {
-        {"SOMAArray", tiledb_object_t::TILEDB_ARRAY},
-        {"SOMACollection", tiledb_object_t::TILEDB_GROUP},
-        {"SOMADataFrame", tiledb_object_t::TILEDB_ARRAY},
-        {"SOMADenseNDArray", tiledb_object_t::TILEDB_ARRAY},
-        {"SOMAExperiment", tiledb_object_t::TILEDB_GROUP},
-        {"SOMAGeometryDataFrame", tiledb_object_t::TILEDB_ARRAY},
-        {"SOMAGroup", tiledb_object_t::TILEDB_GROUP},
-        {"SOMAMeasurement", tiledb_object_t::TILEDB_GROUP},
-        {"SOMAMultiscaleImage", tiledb_object_t::TILEDB_GROUP},
-        {"SOMAPointCloudDataFrame", tiledb_object_t::TILEDB_ARRAY},
-        {"SOMAScene", tiledb_object_t::TILEDB_GROUP},
-        {"SOMASparseNDArray", tiledb_object_t::TILEDB_ARRAY},
+ObjectType SOMAObject::tiledb_type_from_soma_type(const std::string& soma_type) {
+    const std::map<std::string, ObjectType> typeMap = {
+        {"SOMAArray", ObjectType::ARRAY},
+        {"SOMACollection", ObjectType::GROUP},
+        {"SOMADataFrame", ObjectType::ARRAY},
+        {"SOMADenseNDArray", ObjectType::ARRAY},
+        {"SOMAExperiment", ObjectType::GROUP},
+        {"SOMAGeometryDataFrame", ObjectType::ARRAY},
+        {"SOMAGroup", ObjectType::GROUP},
+        {"SOMAMeasurement", ObjectType::GROUP},
+        {"SOMAMultiscaleImage", ObjectType::GROUP},
+        {"SOMAPointCloudDataFrame", ObjectType::ARRAY},
+        {"SOMAScene", ObjectType::GROUP},
+        {"SOMASparseNDArray", ObjectType::ARRAY},
     };
-    const std::map<std::string, tiledb_object_t>::const_iterator iTileDBType = typeMap.find(soma_type);
+    const std::map<std::string, ObjectType>::const_iterator iTileDBType = typeMap.find(soma_type);
     if (iTileDBType == typeMap.end())
-        return tiledb_object_t::TILEDB_INVALID;
+        return ObjectType::INVALID;
     return iTileDBType->second;
 };
 

--- a/libtiledbsoma/src/soma/soma_object.cc
+++ b/libtiledbsoma/src/soma/soma_object.cc
@@ -160,22 +160,22 @@ void SOMAObject::check_encoding_version() {
 
 ObjectType SOMAObject::tiledb_type_from_soma_type(const std::string& soma_type) {
     const std::map<std::string, ObjectType> typeMap = {
-        {"SOMAArray", ObjectType::ARRAY},
-        {"SOMACollection", ObjectType::GROUP},
-        {"SOMADataFrame", ObjectType::ARRAY},
-        {"SOMADenseNDArray", ObjectType::ARRAY},
-        {"SOMAExperiment", ObjectType::GROUP},
-        {"SOMAGeometryDataFrame", ObjectType::ARRAY},
-        {"SOMAGroup", ObjectType::GROUP},
-        {"SOMAMeasurement", ObjectType::GROUP},
-        {"SOMAMultiscaleImage", ObjectType::GROUP},
-        {"SOMAPointCloudDataFrame", ObjectType::ARRAY},
-        {"SOMAScene", ObjectType::GROUP},
-        {"SOMASparseNDArray", ObjectType::ARRAY},
+        {"SOMAArray", ObjectType::array},
+        {"SOMACollection", ObjectType::group},
+        {"SOMADataFrame", ObjectType::array},
+        {"SOMADenseNDArray", ObjectType::array},
+        {"SOMAExperiment", ObjectType::group},
+        {"SOMAGeometryDataFrame", ObjectType::array},
+        {"SOMAGroup", ObjectType::group},
+        {"SOMAMeasurement", ObjectType::group},
+        {"SOMAMultiscaleImage", ObjectType::group},
+        {"SOMAPointCloudDataFrame", ObjectType::array},
+        {"SOMAScene", ObjectType::group},
+        {"SOMASparseNDArray", ObjectType::array},
     };
     const std::map<std::string, ObjectType>::const_iterator iTileDBType = typeMap.find(soma_type);
     if (iTileDBType == typeMap.end())
-        return ObjectType::INVALID;
+        return ObjectType::invalid;
     return iTileDBType->second;
 };
 

--- a/libtiledbsoma/src/soma/soma_object.h
+++ b/libtiledbsoma/src/soma/soma_object.h
@@ -19,10 +19,23 @@
 #include <filesystem>
 #include <map>
 #include <string>
-#include <tiledb/tiledb>
 
 #include "../utils/common.h"
+#include "enums.h"
 #include "soma_context.h"
+
+#pragma region Forward declarations
+
+namespace tiledb {
+class Config;
+class Context;
+}  // namespace tiledb
+
+namespace tiledbsoma::common {
+enum class DataType;
+}  // namespace tiledbsoma::common
+
+#pragma endregion
 
 namespace tiledbsoma {
 
@@ -101,7 +114,7 @@ class SOMAObject {
      */
     virtual void set_metadata(
         const std::string& key,
-        tiledb_datatype_t value_type,
+        common::DataType value_type,
         uint32_t value_num,
         const void* value,
         bool force = false) = 0;
@@ -176,7 +189,7 @@ class SOMAObject {
     /**
      * @brief Given a soma_type, return the underlying TileDB type.
      */
-    static tiledb_object_t tiledb_type_from_soma_type(const std::string& soma_type);
+    static ObjectType tiledb_type_from_soma_type(const std::string& soma_type);
 };
 }  // namespace tiledbsoma
 

--- a/libtiledbsoma/src/soma/soma_scene.cc
+++ b/libtiledbsoma/src/soma/soma_scene.cc
@@ -15,8 +15,11 @@
 #include "soma_collection.h"
 #include "utils/common.h"
 
+#include "common/datatype/datatype.h"
+#include "common/datatype/utils.h"
+
 namespace tiledbsoma {
-using namespace tiledb;
+using namespace common::type;
 
 //===================================================================
 //= public static

--- a/libtiledbsoma/src/tiledbsoma/tiledbsoma
+++ b/libtiledbsoma/src/tiledbsoma/tiledbsoma
@@ -20,6 +20,7 @@
 
 #include "common/soma_column_selection.h"
 #include "common/arrow/utils.h"
+#include "common/datatype/datatype.h"
 #include "common/logging/logger.h"
 #include "common/query/array_buffers.h"
 #include "common/query/column_buffer.h"

--- a/libtiledbsoma/src/utils/common.h
+++ b/libtiledbsoma/src/utils/common.h
@@ -24,6 +24,8 @@
 #include <utility>
 #include <variant>
 
+#include "common/datatype/datatype.h"
+
 namespace tiledbsoma {
 
 template <typename T>
@@ -60,7 +62,7 @@ const std::string TILEDB_SOMA_SCHEMA_COL_TYPE_KEY = "tiledb_column_type";
 const std::string TILEDB_SOMA_SCHEMA_COL_DIM_KEY = "tiledb_dimensions";
 const std::string TILEDB_SOMA_SCHEMA_COL_ATTR_KEY = "tiledb_attributes";
 
-using MetadataValue = std::tuple<tiledb_datatype_t, uint32_t, const void*>;
+using MetadataValue = std::tuple<common::DataType, uint32_t, const void*>;
 enum MetadataInfo { dtype = 0, num, value };
 
 using TimestampRange = std::pair<uint64_t, uint64_t>;

--- a/libtiledbsoma/src/utils/util.cc
+++ b/libtiledbsoma/src/utils/util.cc
@@ -11,9 +11,12 @@
  * This file defines utilities.
  */
 
-#include "utils/util.h"
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
 #include <cstring>
 #include "common/logging/impl/logger.h"
+#include "utils/util.h"
 
 namespace tiledbsoma::util {
 
@@ -91,19 +94,22 @@ std::string get_enmr_label(ArrowSchema* index_schema, ArrowSchema* value_schema)
     return std::string(index_schema->name) + "_" + format;
 }
 
-Enumeration get_enumeration(
-    std::shared_ptr<Context> ctx, std::shared_ptr<Array> arr, ArrowSchema* index_schema, ArrowSchema* value_schema) {
+tiledb::Enumeration get_enumeration(
+    std::shared_ptr<tiledb::Context> ctx,
+    std::shared_ptr<tiledb::Array> arr,
+    ArrowSchema* index_schema,
+    ArrowSchema* value_schema) {
     std::string new_way = util::get_enmr_label(index_schema, value_schema);
     std::string old_way = std::string(index_schema->name);
     try {
         // New-style names of the form {attr_name}_{arrow_format}, e.g. "foo_U"
         // for attributes written by tiledbsoma >= 1.16.0
-        return ArrayExperimental::get_enumeration(*ctx, *arr, new_way);
+        return tiledb::ArrayExperimental::get_enumeration(*ctx, *arr, new_way);
     } catch (const std::exception& e) {
         // Old-style names of the form {attr_name}, e.g. "foo"
         // for attributes written by tiledbsoma < 1.16.0
         try {
-            return ArrayExperimental::get_enumeration(*ctx, *arr, old_way);
+            return tiledb::ArrayExperimental::get_enumeration(*ctx, *arr, old_way);
         } catch (const std::exception& e) {
             throw TileDBSOMAError(
                 fmt::format(

--- a/libtiledbsoma/src/utils/util.h
+++ b/libtiledbsoma/src/utils/util.h
@@ -22,6 +22,16 @@
 #include "common.h"
 #include "nanoarrow/nanoarrow.hpp"
 
+#pragma region Forward declarations
+
+namespace tiledb {
+class Array;
+class Context;
+class Enumeration;
+}  // namespace tiledb
+
+#pragma endregion
+
 namespace tiledbsoma::util {
 
 using VarlenBufferPair = std::pair<std::string, std::vector<uint64_t>>;
@@ -96,8 +106,11 @@ std::string get_enmr_label(ArrowSchema* index_schema, ArrowSchema* value_schema)
  * tiledbsoma >= 1.16.0 as well as old-style names of the form {attr_name},
  * e.g. "foo" for attributes written by tiledbsoma < 1.16.0.
  */
-Enumeration get_enumeration(
-    std::shared_ptr<Context> ctx_, std::shared_ptr<Array> array_, ArrowSchema* index_schema, ArrowSchema* value_schema);
+tiledb::Enumeration get_enumeration(
+    std::shared_ptr<tiledb::Context> ctx_,
+    std::shared_ptr<tiledb::Array> array_,
+    ArrowSchema* index_schema,
+    ArrowSchema* value_schema);
 }  // namespace tiledbsoma::util
 
 #endif

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -344,7 +344,7 @@ TEST_CASE("SOMAArray: metadata", "[SOMAArray]") {
     auto soma_array = SOMAArray::open(OpenMode::soma_write, uri, ctx);
 
     int32_t val = 100;
-    soma_array->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_array->set_metadata("md", common::DataType::INT32, 1, &val);
     soma_array->close();
 
     // Read metadata
@@ -354,7 +354,7 @@ TEST_CASE("SOMAArray: metadata", "[SOMAArray]") {
     REQUIRE(soma_array->has_metadata("soma_encoding_version"));
     REQUIRE(soma_array->has_metadata("md"));
     auto mdval = soma_array->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_array->close();

--- a/libtiledbsoma/test/unit_soma_array.cc
+++ b/libtiledbsoma/test/unit_soma_array.cc
@@ -344,7 +344,7 @@ TEST_CASE("SOMAArray: metadata", "[SOMAArray]") {
     auto soma_array = SOMAArray::open(OpenMode::soma_write, uri, ctx);
 
     int32_t val = 100;
-    soma_array->set_metadata("md", common::DataType::INT32, 1, &val);
+    soma_array->set_metadata("md", common::DataType::int32, 1, &val);
     soma_array->close();
 
     // Read metadata
@@ -354,7 +354,7 @@ TEST_CASE("SOMAArray: metadata", "[SOMAArray]") {
     REQUIRE(soma_array->has_metadata("soma_encoding_version"));
     REQUIRE(soma_array->has_metadata("md"));
     auto mdval = soma_array->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_array->close();

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -258,7 +258,7 @@ TEST_CASE("SOMACollection: metadata") {
     auto soma_collection = SOMACollection::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_collection->set_metadata("md", common::DataType::INT32, 1, &val);
+    soma_collection->set_metadata("md", common::DataType::int32, 1, &val);
     soma_collection->close();
 
     // Read metadata
@@ -268,7 +268,7 @@ TEST_CASE("SOMACollection: metadata") {
     REQUIRE(soma_collection->has_metadata("soma_encoding_version"));
     REQUIRE(soma_collection->has_metadata("md"));
     auto mdval = soma_collection->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_collection->close();
@@ -313,7 +313,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     auto soma_experiment = SOMAExperiment::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_experiment->set_metadata("md", common::DataType::INT32, 1, &val);
+    soma_experiment->set_metadata("md", common::DataType::int32, 1, &val);
     soma_experiment->close();
 
     // Read metadata
@@ -324,7 +324,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
     REQUIRE(soma_experiment->has_metadata("md"));
     auto mdval = soma_experiment->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_experiment->close();
@@ -370,7 +370,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
     auto soma_measurement = SOMAMeasurement::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_measurement->set_metadata("md", common::DataType::INT32, 1, &val);
+    soma_measurement->set_metadata("md", common::DataType::int32, 1, &val);
     soma_measurement->close();
 
     // Read metadata
@@ -380,7 +380,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
     REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
     REQUIRE(soma_measurement->has_metadata("md"));
     auto mdval = soma_measurement->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_measurement->close();

--- a/libtiledbsoma/test/unit_soma_collection.cc
+++ b/libtiledbsoma/test/unit_soma_collection.cc
@@ -258,7 +258,7 @@ TEST_CASE("SOMACollection: metadata") {
     auto soma_collection = SOMACollection::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_collection->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_collection->set_metadata("md", common::DataType::INT32, 1, &val);
     soma_collection->close();
 
     // Read metadata
@@ -268,7 +268,7 @@ TEST_CASE("SOMACollection: metadata") {
     REQUIRE(soma_collection->has_metadata("soma_encoding_version"));
     REQUIRE(soma_collection->has_metadata("md"));
     auto mdval = soma_collection->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_collection->close();
@@ -313,7 +313,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     auto soma_experiment = SOMAExperiment::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_experiment->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_experiment->set_metadata("md", common::DataType::INT32, 1, &val);
     soma_experiment->close();
 
     // Read metadata
@@ -324,7 +324,7 @@ TEST_CASE("SOMAExperiment: metadata") {
     REQUIRE(soma_experiment->has_metadata("soma_encoding_version"));
     REQUIRE(soma_experiment->has_metadata("md"));
     auto mdval = soma_experiment->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_experiment->close();
@@ -370,7 +370,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
     auto soma_measurement = SOMAMeasurement::open(uri, OpenMode::soma_write, ctx, std::pair<uint64_t, uint64_t>(1, 1));
 
     int32_t val = 100;
-    soma_measurement->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_measurement->set_metadata("md", common::DataType::INT32, 1, &val);
     soma_measurement->close();
 
     // Read metadata
@@ -380,7 +380,7 @@ TEST_CASE("SOMAMeasurement: metadata") {
     REQUIRE(soma_measurement->has_metadata("soma_encoding_version"));
     REQUIRE(soma_measurement->has_metadata("md"));
     auto mdval = soma_measurement->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_measurement->close();

--- a/libtiledbsoma/test/unit_soma_coordinates.cc
+++ b/libtiledbsoma/test/unit_soma_coordinates.cc
@@ -81,7 +81,9 @@ TEST_CASE("SOMACoordinateSpace: from_metadata", "[metadata][spatial]") {
 
     // Check `from_metadata` creates the expected SOMACoordinateSpace.
     auto actual_coord_space = SOMACoordinateSpace::from_metadata(
-        TILEDB_STRING_ASCII, static_cast<uint32_t>(metadata.size()), static_cast<const void*>(metadata.c_str()));
+        common::DataType::STRING_ASCII,
+        static_cast<uint32_t>(metadata.size()),
+        static_cast<const void*>(metadata.c_str()));
     REQUIRE(actual_coord_space == expected_coord_space);
 }
 
@@ -115,7 +117,9 @@ TEST_CASE("SOMACoordinateSpace: mock metadata round-trip", "[metadata][spatial]"
     auto coord_json = coord_space.to_string();
 
     auto coord_space_result = SOMACoordinateSpace::from_metadata(
-        TILEDB_STRING_ASCII, static_cast<uint32_t>(coord_json.size()), static_cast<const void*>(coord_json.c_str()));
+        common::DataType::STRING_ASCII,
+        static_cast<uint32_t>(coord_json.size()),
+        static_cast<const void*>(coord_json.c_str()));
 
     REQUIRE(coord_space == coord_space_result);
 }

--- a/libtiledbsoma/test/unit_soma_coordinates.cc
+++ b/libtiledbsoma/test/unit_soma_coordinates.cc
@@ -81,7 +81,7 @@ TEST_CASE("SOMACoordinateSpace: from_metadata", "[metadata][spatial]") {
 
     // Check `from_metadata` creates the expected SOMACoordinateSpace.
     auto actual_coord_space = SOMACoordinateSpace::from_metadata(
-        common::DataType::STRING_ASCII,
+        common::DataType::string_ascii,
         static_cast<uint32_t>(metadata.size()),
         static_cast<const void*>(metadata.c_str()));
     REQUIRE(actual_coord_space == expected_coord_space);
@@ -117,7 +117,7 @@ TEST_CASE("SOMACoordinateSpace: mock metadata round-trip", "[metadata][spatial]"
     auto coord_json = coord_space.to_string();
 
     auto coord_space_result = SOMACoordinateSpace::from_metadata(
-        common::DataType::STRING_ASCII,
+        common::DataType::string_ascii,
         static_cast<uint32_t>(coord_json.size()),
         static_cast<const void*>(coord_json.c_str()));
 

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -302,7 +302,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: metadata", "[
     auto sdf = open(OpenMode::soma_write, TimestampRange(0, 2));
 
     int32_t val = 100;
-    sdf->set_metadata("md", common::DataType::INT32, 1, &val);
+    sdf->set_metadata("md", common::DataType::int32, 1, &val);
     sdf->close();
 
     // Read metadata
@@ -312,7 +312,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: metadata", "[
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
     REQUIRE(sdf->has_metadata("md"));
     auto mdval = sdf->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     sdf->close();

--- a/libtiledbsoma/test/unit_soma_dataframe.cc
+++ b/libtiledbsoma/test/unit_soma_dataframe.cc
@@ -302,7 +302,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: metadata", "[
     auto sdf = open(OpenMode::soma_write, TimestampRange(0, 2));
 
     int32_t val = 100;
-    sdf->set_metadata("md", TILEDB_INT32, 1, &val);
+    sdf->set_metadata("md", common::DataType::INT32, 1, &val);
     sdf->close();
 
     // Read metadata
@@ -312,7 +312,7 @@ TEST_CASE_METHOD(VariouslyIndexedDataFrameFixture, "SOMADataFrame: metadata", "[
     REQUIRE(sdf->has_metadata("soma_encoding_version"));
     REQUIRE(sdf->has_metadata("md"));
     auto mdval = sdf->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     sdf->close();

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -165,7 +165,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     auto dnda = SOMADenseNDArray::open(uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
 
     int32_t val = 100;
-    dnda->set_metadata("md", common::DataType::INT32, 1, &val);
+    dnda->set_metadata("md", common::DataType::int32, 1, &val);
     dnda->close();
 
     // Read metadata
@@ -175,7 +175,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
     REQUIRE(dnda->has_metadata("md"));
     auto mdval = dnda->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     dnda->close();

--- a/libtiledbsoma/test/unit_soma_dense_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_dense_ndarray.cc
@@ -165,7 +165,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     auto dnda = SOMADenseNDArray::open(uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
 
     int32_t val = 100;
-    dnda->set_metadata("md", TILEDB_INT32, 1, &val);
+    dnda->set_metadata("md", common::DataType::INT32, 1, &val);
     dnda->close();
 
     // Read metadata
@@ -175,7 +175,7 @@ TEST_CASE("SOMADenseNDArray: metadata", "[SOMADenseNDArray]") {
     REQUIRE(dnda->has_metadata("soma_encoding_version"));
     REQUIRE(dnda->has_metadata("md"));
     auto mdval = dnda->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     dnda->close();

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -173,7 +173,7 @@ TEST_CASE("SOMAGroup: metadata") {
     SOMAGroup::create(ctx, uri, "NONE", {}, TimestampRange(0, 2));
     auto soma_group = SOMAGroup::open(OpenMode::soma_write, uri, ctx, "metadata", TimestampRange(1, 1));
     int32_t val = 100;
-    soma_group->set_metadata("md", common::DataType::INT32, 1, &val);
+    soma_group->set_metadata("md", common::DataType::int32, 1, &val);
     soma_group->close();
 
     // Read metadata
@@ -183,7 +183,7 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(soma_group->has_metadata("soma_encoding_version"));
     REQUIRE(soma_group->has_metadata("md"));
     auto mdval = soma_group->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_group->close();

--- a/libtiledbsoma/test/unit_soma_group.cc
+++ b/libtiledbsoma/test/unit_soma_group.cc
@@ -173,7 +173,7 @@ TEST_CASE("SOMAGroup: metadata") {
     SOMAGroup::create(ctx, uri, "NONE", {}, TimestampRange(0, 2));
     auto soma_group = SOMAGroup::open(OpenMode::soma_write, uri, ctx, "metadata", TimestampRange(1, 1));
     int32_t val = 100;
-    soma_group->set_metadata("md", TILEDB_INT32, 1, &val);
+    soma_group->set_metadata("md", common::DataType::INT32, 1, &val);
     soma_group->close();
 
     // Read metadata
@@ -183,7 +183,7 @@ TEST_CASE("SOMAGroup: metadata") {
     REQUIRE(soma_group->has_metadata("soma_encoding_version"));
     REQUIRE(soma_group->has_metadata("md"));
     auto mdval = soma_group->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     soma_group->close();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -219,7 +219,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
 
     int32_t val = 100;
-    snda->set_metadata("md", TILEDB_INT32, 1, &val);
+    snda->set_metadata("md", common::DataType::INT32, 1, &val);
     snda->close();
 
     // Read metadata
@@ -229,7 +229,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     REQUIRE(snda->has_metadata("soma_encoding_version"));
     REQUIRE(snda->has_metadata("md"));
     auto mdval = snda->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == TILEDB_INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     snda->close();

--- a/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
+++ b/libtiledbsoma/test/unit_soma_sparse_ndarray.cc
@@ -219,7 +219,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     auto snda = SOMASparseNDArray::open(uri, OpenMode::soma_write, ctx, TimestampRange(0, 2));
 
     int32_t val = 100;
-    snda->set_metadata("md", common::DataType::INT32, 1, &val);
+    snda->set_metadata("md", common::DataType::int32, 1, &val);
     snda->close();
 
     // Read metadata
@@ -229,7 +229,7 @@ TEST_CASE("SOMASparseNDArray: metadata", "[SOMASparseNDArray]") {
     REQUIRE(snda->has_metadata("soma_encoding_version"));
     REQUIRE(snda->has_metadata("md"));
     auto mdval = snda->get_metadata("md");
-    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::INT32);
+    REQUIRE(std::get<MetadataInfo::dtype>(*mdval) == common::DataType::int32);
     REQUIRE(std::get<MetadataInfo::num>(*mdval) == 1);
     REQUIRE(*((const int32_t*)std::get<MetadataInfo::value>(*mdval)) == 100);
     snda->close();


### PR DESCRIPTION
**Issue and/or context:** Provide a `DataType` enum class to hide `tiledb_datatype_t` which can't be forward declared to avoid including TileDB headers from SOMA header files.

**Changes:**
This PR adds:
- a `DataType` enum class mirroring `tiledb_datatype_t` (except `TILEDB_ANY`)
- a set of constexpr functions to convert from `DataType` and `tiledb_datatype_t` to `DataType` and `tiledb_datatype_t` and arrow format

**Notes for Reviewer:**
