### PR TITLE
[r] Fix date parsing failure in `.deprecation_stage()`

### DIFF
--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -177,10 +177,11 @@
   # Defunct if:
   #   1. major version has been bumped, OR
   #   2. same major, minor diff >= 2, AND >= 12 weeks since deprecation release
-  is_defunct <- cur[["major"]] > dep[["major"]] ||
-    (cur[["major"]] == dep[["major"]] &&
-      (cur[["minor"]] - dep[["minor"]]) >= 2L &&
-      weeks_elapsed > 12L)
+  major_bump <- cur[["major"]] > dep[["major"]]
+  minor_gap <- (cur[["minor"]] - dep[["minor"]]) >= 2L
+  grace_period_over <- weeks_elapsed > 12L
+  is_defunct <- major_bump ||
+    (cur[["major"]] == dep[["major"]] && minor_gap && grace_period_over)
 
   if (is_defunct) "defunct" else "deprecate"
 }

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -66,10 +66,8 @@
       what = I(what),
       with = with,
       details = details,
-      # lifecycle tries to be clever when determining when to warn; however,
-      # it's actually pretty bad at it. It doesn't work well with R6 nor does
-      # it accurately track testthat usage. We need to force it
-      # to throw a deprecation warning
+      # lifecycle's default warning deduplication doesn't work well with R6
+      # or testthat, so force every call to produce a warning
       id = id %||% as.character(Sys.time()),
       always = always,
       env = env,

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -158,7 +158,9 @@
   # Get the known (or estimated) release date for the current version
   current_date <- .release_date(current, releases)
 
-  weeks <- as.double(
+  # Calculate the number of weeks between the current version's release date and
+  # the `when` release date
+  weeks_elapsed <- as.double(
     difftime(
       time1 = current_date,
       time2 = as.Date(releases[releases$Version == when, "Date"]),
@@ -167,28 +169,20 @@
     units = "weeks"
   )
 
-  .as_integer_version <- function(x) {
-    x <- vapply(
-      X = unlist(strsplit(as.character(x), split = "\\.")),
-      FUN = as.integer,
-      FUN.VALUE = integer(length = 1L)
-    )
-    if (length(x) > 4L) {
-      x <- x[1:4]
-    }
-    names(x) <- c("major", "minor", "patch", "devel")[seq_along(x)]
-    return(x)
-  }
-  cc <- .as_integer_version(current)
-  ww <- .as_integer_version(when)
-  defunct <- cc[["major"]] > ww[["major"]] || (
-    weeks > 12L &&
-      cc[["major"]] == ww[["major"]] && (cc[["minor"]] - ww[["minor"]]) >= 2L
-  )
-  if (defunct) {
-    return("defunct")
-  }
-  return("deprecate")
+  # Current version
+  cur <- .version_parts(current)
+  # When deprecation version
+  dep <- .version_parts(when)
+
+  # Defunct if:
+  #   1. major version has been bumped, OR
+  #   2. same major, minor diff >= 2, AND >= 12 weeks since deprecation release
+  is_defunct <- cur[["major"]] > dep[["major"]] ||
+    (cur[["major"]] == dep[["major"]] &&
+      (cur[["minor"]] - dep[["minor"]]) >= 2L &&
+      weeks_elapsed > 12L)
+
+  if (is_defunct) "defunct" else "deprecate"
 }
 
 # Helpers ----------------------------------------------------------------
@@ -288,4 +282,23 @@
 
   # Use the most recent file modification time as a fallback
   .pkg_install_date()
+}
+
+#' Parse a version into named major/minor/patch/devel components
+#' @param x A `package_version` or `numeric_version` object
+#' @return A named integer vector with elements `major`, `minor`, and
+#'   optionally `patch` and `devel`
+#' @noRd
+
+.version_parts <- function(x) {
+  parts <- vapply(
+    X = unlist(strsplit(as.character(x), split = "\\.")),
+    FUN = as.integer,
+    FUN.VALUE = integer(length = 1L)
+  )
+  if (length(parts) > 4L) {
+    parts <- parts[1:4]
+  }
+  names(parts) <- c("major", "minor", "patch", "devel")[seq_along(parts)]
+  parts
 }

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -134,11 +134,12 @@
   # Get list of releases
   releases <- .release_history()
 
-  # Check to see if the deprecation is scheduled for a future release
-  # If so, exit out
+  # If `when` is newer than all known releases, it's a future deprecation
   if (all(when > releases$Version)) {
     return(invisible(NULL))
   }
+
+  # Error if `when` is not in the release history
   if (!when %in% releases$Version) {
     stop(sprintf(
       fmt = "Unknown %s release: '%s'",
@@ -146,12 +147,14 @@
       as.character(when)
     ))
   }
-  # Get current package version
+
+  # Get current package version if major.minor format, rolling up dev versions
+  # to the next minor version if necessary
   current <- .tiledbsoma_deprecation_version()
   if (current < when) {
-    # Deprecation will happen in the future
     return(invisible(NULL))
   }
+
   # Get current package's release date
   if (current %in% releases$Version) {
     date <- as.POSIXlt(releases[releases$Version == current, "Date"], format = "%Y-%m-%d")

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -189,7 +189,7 @@
   }
   # Get current package's release date
   if (current %in% releases$Version) {
-    date <- as.POSIXlt(releases[releases$Version == current, "Date"])
+    date <- as.POSIXlt(releases[releases$Version == current, "Date"], format = "%Y-%m-%d")
   } else {
     date <- as.POSIXlt(read.dcf(
       system.file(
@@ -199,7 +199,7 @@
         mustWork = TRUE
       ),
       fields = "Date/Publication"
-    ))
+    ), format = "%Y-%m-%d")
     if (is.na(date)) {
       dates <- file.info(list.files(
         base::system.file(package = .pkgenv$pkgname),
@@ -212,7 +212,7 @@
   weeks <- as.double(
     difftime(
       time1 = date,
-      time2 = as.POSIXlt(x = releases[releases$Version == when, "Date"]),
+      time2 = as.POSIXlt(releases[releases$Version == when, "Date"], format = "%Y-%m-%d"),
       units = "weeks"
     ),
     units = "weeks"

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -1,4 +1,3 @@
-
 #' Signal a Deprecation
 #'
 #' Signal a deprecation/defunct stage using \CRANpkg{lifecycle}
@@ -131,42 +130,10 @@
   if (rlang::is_na(when)) {
     rlang::abort("'when' must be a valid version")
   }
+
   # Get list of releases
-  releases <- as.data.frame(read.dcf(system.file(
-    "extdata",
-    "releases.dcf",
-    package = .pkgenv$pkgname,
-    lib.loc = .pkgenv$libname,
-    mustWork = TRUE
-  )))
-  # Add fake release for current minor release if needed
-  mm <- unique(vapply(
-    X = releases$Version,
-    FUN = function(x) {
-      x <- unlist(strsplit(x = x, split = "\\."))
-      return(paste0(x[1:2], collapse = "."))
-    },
-    FUN.VALUE = character(length = 1L),
-    USE.NAMES = FALSE
-  ))
-  cmm <- unlist(strsplit(
-    x = as.character(utils::packageVersion(.pkgenv$pkgname)),
-    split = "\\."
-  ))
-  if (all(paste0(cmm[1:2], collapse = ".") > mm)) {
-    dates <- file.info(list.files(
-      base::system.file(package = .pkgenv$pkgname),
-      full.names = TRUE,
-      recursive = TRUE
-    ))$mtime
-    releases <- rbind(
-      releases,
-      data.frame(
-        Version = sprintf(fmt = "%s.%s.0", cmm[1L], cmm[2L]),
-        Date = format(as.POSIXlt(dates[which.max(dates)]), format = "%Y-%m-%d")
-      )
-    )
-  }
+  releases <- .release_history()
+
   # Check to see if the deprecation is scheduled for a future release
   # If so, exit out
   if (all(when > releases$Version)) {
@@ -237,4 +204,70 @@
     return("defunct")
   }
   return("deprecate")
+}
+
+# Helpers ----------------------------------------------------------------
+
+#' Read the release history from releases.dcf
+#'
+#' If the current package minor version is newer than all releases in
+#' releases.dcf (i.e., a dev build), a synthetic entry is added using the
+#' package's install timestamp as the release date.
+#' @return A data.frame with columns `Version` (character) and `Date`
+#'   (character, YYYY-MM-DD format)
+#' @noRd
+.release_history <- function() {
+  releases <- as.data.frame(read.dcf(system.file(
+    "extdata",
+    "releases.dcf",
+    package = .pkgenv$pkgname,
+    lib.loc = .pkgenv$libname,
+    mustWork = TRUE
+  )))
+
+  # Extract the set of known major.minor versions from the release history
+  known_minors <- unique(vapply(
+    X = releases$Version,
+    FUN = function(x) {
+      parts <- unlist(strsplit(x = x, split = "\\."))
+      paste0(parts[1:2], collapse = ".")
+    },
+    FUN.VALUE = character(length = 1L),
+    USE.NAMES = FALSE
+  ))
+
+  # Construct the current package's version in major.minor format
+  pkg_version <- as.character(utils::packageVersion(.pkgenv$pkgname))
+  pkg_parts <- unlist(strsplit(x = pkg_version, split = "\\."))
+  pkg_minor <- paste0(pkg_parts[1:2], collapse = ".")
+
+  # Add dummy release if current minor version is newer than all known minors
+  if (all(pkg_minor > known_minors)) {
+    releases <- rbind(
+      releases,
+      data.frame(
+        Version = sprintf(fmt = "%s.%s.0", pkg_parts[1L], pkg_parts[2L]),
+        Date = format(.pkg_install_date(), format = "%Y-%m-%d")
+      )
+    )
+  }
+
+  releases
+}
+
+#' Estimate the package installation date
+#'
+#' Uses the most recent file modification timestamp from package source files
+#' as an estimated released date. This is used when no official release
+#' date is available (e.g., dev builds installed from source).
+#' @return A `POSIXlt` date
+#' @noRd
+.pkg_install_date <- function() {
+  files <- list.files(
+    base::system.file(package = .pkgenv$pkgname),
+    full.names = TRUE,
+    recursive = TRUE
+  )
+  mod_times <- file.info(files)$mtime
+  as.POSIXlt(mod_times[which.max(mod_times)])
 }

--- a/apis/r/R/utils-deprecations.R
+++ b/apis/r/R/utils-deprecations.R
@@ -155,36 +155,18 @@
     return(invisible(NULL))
   }
 
-  # Get current package's release date
-  if (current %in% releases$Version) {
-    date <- as.POSIXlt(releases[releases$Version == current, "Date"], format = "%Y-%m-%d")
-  } else {
-    date <- as.POSIXlt(read.dcf(
-      system.file(
-        "DESCRIPTION",
-        package = .pkgenv$pkgname,
-        lib.loc = .pkgenv$libname,
-        mustWork = TRUE
-      ),
-      fields = "Date/Publication"
-    ), format = "%Y-%m-%d")
-    if (is.na(date)) {
-      dates <- file.info(list.files(
-        base::system.file(package = .pkgenv$pkgname),
-        full.names = TRUE,
-        recursive = TRUE
-      ))$mtime
-      date <- as.POSIXlt(dates[which.max(dates)])
-    }
-  }
+  # Get the known (or estimated) release date for the current version
+  current_date <- .release_date(current, releases)
+
   weeks <- as.double(
     difftime(
-      time1 = date,
-      time2 = as.POSIXlt(releases[releases$Version == when, "Date"], format = "%Y-%m-%d"),
+      time1 = current_date,
+      time2 = as.Date(releases[releases$Version == when, "Date"]),
       units = "weeks"
     ),
     units = "weeks"
   )
+
   .as_integer_version <- function(x) {
     x <- vapply(
       X = unlist(strsplit(as.character(x), split = "\\.")),
@@ -273,4 +255,37 @@
   )
   mod_times <- file.info(files)$mtime
   as.POSIXlt(mod_times[which.max(mod_times)])
+}
+
+#' Determine the release date for a version
+#'
+#' For known releases dates are retrieved from the release history. For unknown
+#' versions (e.g., dev builds), falls back to the DESCRIPTION Date/Publication
+#' field, then to the package's install timestamp.
+#' @param version A `package_version` or `numeric_version` object
+#' @param releases A data.frame from `.release_history()`
+#' @return A `Date` or `POSIXlt` object
+#' @noRd
+.release_date <- function(version, releases) {
+  if (version %in% releases$Version) {
+    return(as.Date(releases[releases$Version == version, "Date"]))
+  }
+
+  # Try the DESCRIPTION Date/Publication field first
+  date <- as.Date(read.dcf(
+    system.file(
+      "DESCRIPTION",
+      package = .pkgenv$pkgname,
+      lib.loc = .pkgenv$libname,
+      mustWork = TRUE
+    ),
+    fields = "Date/Publication"
+  ))
+
+  if (!is.na(date)) {
+    return(date)
+  }
+
+  # Use the most recent file modification time as a fallback
+  .pkg_install_date()
 }

--- a/apis/r/tests/testthat/test-utils-deprecations.R
+++ b/apis/r/tests/testthat/test-utils-deprecations.R
@@ -1,4 +1,37 @@
-test_that("input type validation", {
+# .deprecate() ----------------------------------------------------------
+
+test_that(".deprecate() validates inputs", {
+  # what must be a length-1 character string
+  expect_error(.deprecate(when = "1.0.0", what = 1))
+  expect_error(.deprecate(when = "1.0.0", what = c("a", "b")))
+  # dots must be empty
+  expect_error(.deprecate(when = "1.0.0", what = "foo()", extra = TRUE))
+})
+
+test_that(".deprecate() is silent for future deprecations", {
+  local_mocked_bindings(.deprecation_stage = function(...) NULL)
+  expect_silent(.deprecate(when = "99.0.0", what = "foo()"))
+})
+
+test_that(".deprecate() warns during deprecation stage", {
+  local_mocked_bindings(.deprecation_stage = function(...) "deprecate")
+  expect_warning(
+    .deprecate(when = "1.0.0", what = "foo()"),
+    class = "lifecycle_warning_deprecated"
+  )
+})
+
+test_that(".deprecate() errors during defunct stage", {
+  local_mocked_bindings(.deprecation_stage = function(...) "defunct")
+  expect_error(
+    .deprecate(when = "1.0.0", what = "foo()"),
+    class = "lifecycle_error_deprecated"
+  )
+})
+
+# .deprecation_stage() --------------------------------------------------
+
+test_that(".deprecation_stage() validates inputs", {
   # when must be string parseable as a version
   expect_error(.deprecation_stage(1))
   expect_error(.deprecation_stage(""))

--- a/apis/r/tests/testthat/test-utils-deprecations.R
+++ b/apis/r/tests/testthat/test-utils-deprecations.R
@@ -1,0 +1,58 @@
+test_that("input type validation", {
+  # when must be string parseable as a version
+  expect_error(.deprecation_stage(1))
+  expect_error(.deprecation_stage(""))
+  expect_error(
+    .deprecation_stage("not-a-version"),
+    "'when' must be a valid version"
+  )
+})
+
+test_that("future release returns NULL", {
+  # a version > than all known releases is assumed to be a future release
+  # so no deprecation is signaled
+  expect_null(.deprecation_stage("99.0.0"))
+})
+
+test_that("unknown release errors", {
+  # a version that's <= the latest release but not in releases.dcf is invalid
+  expect_error(.deprecation_stage("1.99.0"), "Unknown tiledbsoma release")
+})
+
+test_that("current version < when returns NULL", {
+  # if the current package version hasn't reached the deprecation version yet,
+  # no deprecation is signaled
+  local_mocked_bindings(.tiledbsoma_deprecation_version = function() {
+    package_version("1.16.0")
+  })
+  expect_null(.deprecation_stage("2.0.0"))
+})
+
+test_that("deprecate stage", {
+  # same major version and minor diff of 1 triggers deprecation warning
+  # (current=2.1.0, when=2.0.0)
+  local_mocked_bindings(.tiledbsoma_deprecation_version = function() {
+    package_version("2.1.0")
+  })
+  expect_equal(.deprecation_stage("2.0.0"), "deprecate")
+})
+
+test_that("defunct via major version bump", {
+  # a major version bump always triggers defunct (current=2.0.0, when=1.17.0)
+  local_mocked_bindings(.tiledbsoma_deprecation_version = function() {
+    package_version("2.0.0")
+  })
+  expect_equal(.deprecation_stage("1.17.0"), "defunct")
+})
+
+test_that("defunct via minor version + time", {
+  # within the same major version, defunct requires both:
+  #   - minor version diff >= 2
+  #   - >= 12 weeks between release dates
+  # 1.15.0 released 2024-12-17, 1.17.0 released 2025-05-21
+  # minor diff = 2, ~22 weeks apart (> 12 week threshold)
+  local_mocked_bindings(.tiledbsoma_deprecation_version = function() {
+    package_version("1.17.0")
+  })
+  expect_equal(.deprecation_stage("1.15.0"), "defunct")
+})


### PR DESCRIPTION
**Issue and/or context:** Addresses [CLOUD-3637](https://linear.app/tiledb/issue/CLOUD-3637).

The package's internal `.deprecation_stage()` function called `as.POSIXlt()` on date strings from `releases.dcf` (format: `YYYY-MM-DD`), which fails on a Conda-install of R 4.3.3  with `"character string is not in a standard unambiguous format"`.

**Changes:**

- Replaced `as.POSIXlt()` with `as.Date()` for calls that parse `YYYY-MM-DD` date strings (from `releases.dcf` and `DESCRIPTION`), which I validated works in the original environment and across R 4.(3|4|5).
- Added tests for both `.deprecate()` and `.deprecation_stage()`, which previously had zero direct test coverage.

**Notes for Reviewer:**  While adding tests I took the opportunity to clean up `.deprecation_stage()` by extracting helper functions and adding some comments, which should make the logic easier to follow. The core behavior is unchanged except for the date parsing fix.