### PR TITLE
[r] Remove internal forwarding of deprecated `tiledbsoma_ctx`

### DIFF
--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -74,7 +74,6 @@ SOMADataFrameCreate <- function(
   sdf <- SOMADataFrame$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context,
     tiledb_timestamp = tiledb_timestamp
   )
@@ -131,7 +130,6 @@ SOMADataFrameOpen <- function(
   sdf <- SOMADataFrame$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context,
     tiledb_timestamp = tiledb_timestamp
   )
@@ -186,7 +184,6 @@ SOMASparseNDArrayCreate <- function(
   snda <- SOMASparseNDArray$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context,
     tiledb_timestamp = tiledb_timestamp
   )
@@ -230,7 +227,6 @@ SOMASparseNDArrayOpen <- function(
   snda <- SOMASparseNDArray$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -283,7 +279,6 @@ SOMADenseNDArrayCreate <- function(
   dnda <- SOMADenseNDArray$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -318,7 +313,6 @@ SOMADenseNDArrayOpen <- function(
   dnda <- SOMADenseNDArray$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -366,7 +360,6 @@ SOMACollectionCreate <- function(
   coll <- SOMACollection$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -412,7 +405,6 @@ SOMACollectionOpen <- function(
   coll <- SOMACollection$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -472,7 +464,6 @@ SOMAMeasurementCreate <- function(
   meas <- SOMAMeasurement$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -516,7 +507,6 @@ SOMAMeasurementOpen <- function(
   meas <- SOMAMeasurement$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -576,7 +566,6 @@ SOMAExperimentCreate <- function(
   exp <- SOMAExperiment$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )
@@ -619,7 +608,6 @@ SOMAExperimentOpen <- function(
   exp <- SOMAExperiment$new(
     uri,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     tiledb_timestamp = tiledb_timestamp,
     context = context
   )

--- a/apis/r/R/SOMAOpen.R
+++ b/apis/r/R/SOMAOpen.R
@@ -59,7 +59,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     SOMADataFrame = SOMADataFrameOpen(
@@ -67,7 +66,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     SOMADenseNDArray = SOMADenseNDArrayOpen(
@@ -75,7 +73,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     SOMASparseNDArray = SOMASparseNDArrayOpen(
@@ -83,7 +80,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     SOMAExperiment = SOMAExperimentOpen(
@@ -91,7 +87,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     SOMAMeasurement = SOMAMeasurementOpen(
@@ -99,7 +94,6 @@ SOMAOpen <- function(
       mode = mode,
       platform_config = platform_config,
       context = context,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       tiledb_timestamp = tiledb_timestamp
     ),
     stop(

--- a/apis/r/R/datasets.R
+++ b/apis/r/R/datasets.R
@@ -111,12 +111,10 @@ load_dataset <- function(name, dir = tempdir(), tiledbsoma_ctx = NULL, context =
     metadata$soma_object_type %||% "",
     SOMAExperiment = SOMAExperimentOpen(
       dataset_uri,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       context = context
     ),
     SOMADataFrame = SOMADataFrameOpen(
       dataset_uri,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       context = context
     ),
     stop("The dataset is an unsupported SOMA object", call. = FALSE)

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -573,7 +573,6 @@ write_soma.Seurat <- function(
     uri = uri,
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context
   )
   on.exit(experiment$close(), add = TRUE, after = FALSE)
@@ -587,7 +586,6 @@ write_soma.Seurat <- function(
     uri = file_path(experiment$uri, "ms"),
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context
   )
   withCallingHandlers(
@@ -607,7 +605,6 @@ write_soma.Seurat <- function(
             soma_parent = expms,
             ingest_mode = ingest_mode,
             platform_config = platform_config,
-            tiledbsoma_ctx = tiledbsoma_ctx,
             context = context
           ),
           soma_parent = expms,
@@ -637,7 +634,6 @@ write_soma.Seurat <- function(
     key = 'obs',
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context
   )
 
@@ -700,7 +696,6 @@ write_soma.Seurat <- function(
         nfeatures = nfeatures,
         ingest_mode = ingest_mode,
         platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx,
         context = context
       ),
       error = err_to_warn
@@ -737,7 +732,6 @@ write_soma.Seurat <- function(
         soma_parent = ms,
         ingest_mode = ingest_mode,
         platform_config = platform_config,
-        tiledbsoma_ctx = tiledbsoma_ctx,
         context = context
       ),
       error = err_to_warn
@@ -759,7 +753,6 @@ write_soma.Seurat <- function(
     uri = file_path(experiment$uri, "uns"),
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    tiledbsoma_ctx = tiledbsoma_ctx,
     context = context
   )
   withCallingHandlers(
@@ -777,7 +770,6 @@ write_soma.Seurat <- function(
       soma_parent = expuns,
       ingest_mode = ingest_mode,
       platform_config = platform_config,
-      tiledbsoma_ctx = tiledbsoma_ctx,
       context = context
     )
   }


### PR DESCRIPTION
**Issue and/or context:**

Addresses [SOMA-832](https://linear.app/tiledb/issue/SOMA-832/r-remove-all-internal-usage-of-deprecated-tiledbsoma_ctx)

PR #4355 introduced `SOMAContext` and deprecated `tiledbsoma_ctx` / `SOMATileDBContext`. In this transition period user-facing functions accept `tiledbsoma_ctx`, call `get_soma_context()` to resolve it into a `SOMAContext`, and throw a deprecation warning. However, after resolution some functions were still forwarding the original `tiledbsoma_ctx` value to downstream internal calls. 

**Changes:**

- `Factory.R`: Removed `tiledbsoma_ctx = tiledbsoma_ctx` from all 12 `$new()` constructor calls (the resolved `context` is already being passed)
- `SOMAOpen.R`: Removed `tiledbsoma_ctx = tiledbsoma_ctx` from 6 factory `Open` calls (context already resolved by `get_soma_context()` at the top of `SOMAOpen()`)
- `datasets.R`: Removed `tiledbsoma_ctx = tiledbsoma_ctx` from 2 factory calls in `load_dataset()` (same pattern)
- `write_seurat.R`: Removed `tiledbsoma_ctx = tiledbsoma_ctx` from 8 internal calls within `write_soma.Seurat()` (context already resolved at function entry)

**What was not changed:**

- Exported functions still accept `tiledbsoma_ctx` (deprecation policy requires keeping it until defunct)
- `SOMAObject` still stores `private$.tiledbsoma_ctx` and the `$tiledbsoma_ctx` active binding still works

**Notes for reviewers:**

- Verified all remote tests (cloud/carrara) still pass.
