### PR TITLE
[r] Fix `soma_type` inconsistency between arrays and collections

### DIFF
--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -16,6 +16,7 @@
 
 ## Fixed
 
+- Metadata values retrieved from collection-based classes (`SOMACollection`, `SOMAExperiment`, `SOMAMeasurement`) are no longer wrapped in a named list, consistent with array-based classes ([#4429](https://github.com/single-cell-data/TileDB-SOMA/pull/4429)).
 - [BREAKING] Use stored handle to access `SOMAArrayBase` properties rather than re-opening the `SOMAArrayBase`. Array properties can no longer be accessed on an unopened array. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
 - Use stored handle to read and write to `SOMASparseNDArray`, `SOMADenseNDArray`, and `SOMADataFrame` rather than re-opening the SOMA oobjects for each read/write. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
 

--- a/apis/r/R/RcppExports.R
+++ b/apis/r/R/RcppExports.R
@@ -5,7 +5,7 @@ createSchemaFromArrow <- function(uri, nasp, nadimap, nadimsp, sparse, datatype,
     invisible(.Call(`_tiledbsoma_createSchemaFromArrow`, uri, nasp, nadimap, nadimsp, sparse, datatype, pclst, ctxxp, tsvec))
 }
 
-createSchemaForDataFrame <- function(uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec = NULL) {
+createSchemaForDataFrame <- function(uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec) {
     invisible(.Call(`_tiledbsoma_createSchemaForDataFrame`, uri, nasp, index_column_names, index_column_domains, pclst, ctxxp, tsvec))
 }
 

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -164,7 +164,6 @@ SEXP _metadata_to_sexp(const tdbs::common::DataType v_type, const uint32_t v_num
 Rcpp::List c_group_get_metadata(Rcpp::XPtr<somagrp_wrap_t> xp) {
     check_xptr_tag<somagrp_wrap_t>(xp);  // throws if mismatched
     // unique pointer to SOMAGroup from external pointer wrapper
-    // 'members map': a map from string to pair of strings
     auto mm = xp->grpptr->get_metadata();
     auto n = mm.size();
     Rcpp::List lst(n);

--- a/apis/r/src/groups.cpp
+++ b/apis/r/src/groups.cpp
@@ -175,8 +175,7 @@ Rcpp::List c_group_get_metadata(Rcpp::XPtr<somagrp_wrap_t> xp) {
         // uint32_t, const void*>
         auto tpl = key.second;
         auto sxp = _metadata_to_sexp(std::get<0>(tpl), std::get<1>(tpl), std::get<2>(tpl));
-        Rcpp::List row = Rcpp::List::create(Rcpp::Named("name") = sxp);
-        lst[i] = row;
+        lst[i] = sxp;
         i++;
     }
     lst.attr("names") = names;

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -85,6 +85,52 @@ test_that("SOMACollection basics", {
   collection$close()
 })
 
+test_that("SOMACollection metadata", {
+  uri <- withr::local_tempdir("collection-metadata")
+  collection <- SOMACollectionCreate(uri)
+
+  # Check standard soma_type
+  expect_equal(collection$soma_type, "SOMACollection")
+
+  # Set metadata with different value types
+  md <- list(string_key = "abc", int_key = 42L, float_key = 3.14)
+  collection$set_metadata(md)
+
+  # Read individual keys while still open for write
+  expect_equal(collection$get_metadata("string_key"), "abc")
+  expect_equal(collection$get_metadata("int_key"), 42L)
+  expect_equal(collection$get_metadata("float_key"), 3.14)
+
+  # Read all metadata while still open for write
+  readmd <- collection$get_metadata()
+  expect_equal(readmd[["string_key"]], "abc")
+  expect_equal(readmd[["int_key"]], 42L)
+  expect_equal(readmd[["float_key"]], 3.14)
+  collection$close()
+
+  # Read metadata after reopening for read
+  collection <- SOMACollectionOpen(uri)
+  expect_equal(collection$soma_type, "SOMACollection")
+  readmd <- collection$get_metadata()
+  expect_equal(readmd[["string_key"]], "abc")
+  expect_equal(readmd[["int_key"]], 42L)
+  expect_equal(readmd[["float_key"]], 3.14)
+
+  # Non-existent key returns NULL
+  expect_null(collection$get_metadata("no_such_key"))
+  collection$close()
+
+  # Overwrite an existing key in a second write session
+  collection <- SOMACollectionOpen(uri, mode = "WRITE")
+  collection$set_metadata(list(string_key = "xyz"))
+  collection$close()
+
+  collection <- SOMACollectionOpen(uri)
+  expect_equal(collection$get_metadata("string_key"), "xyz")
+  expect_equal(collection$get_metadata("int_key"), 42L)
+  collection$close()
+})
+
 test_that("SOMACollection timestamped ops", {
   skip_if(!extended_tests())
   # Create a collection @ t0

--- a/apis/r/tests/testthat/test-06-SOMACollection.R
+++ b/apis/r/tests/testthat/test-06-SOMACollection.R
@@ -17,7 +17,7 @@ test_that("SOMACollection basics", {
     ),
     "GROUP"
   )
-  expect_true(collection$soma_type == "SOMACollection")
+  expect_equal(collection$soma_type, "SOMACollection")
   expect_true(collection$exists())
   expect_equal(collection$length(), 0)
   collection$close()
@@ -44,7 +44,7 @@ test_that("SOMACollection basics", {
 
   subcollection <- collection$get("subcollection")
   subcollection <- SOMACollectionOpen(subcollection$uri)
-  expect_true(subcollection$soma_type == "SOMACollection")
+  expect_equal(subcollection$soma_type, "SOMACollection")
   expect_true(subcollection$exists())
   subcollection$close()
 
@@ -57,7 +57,7 @@ test_that("SOMACollection basics", {
   )$close()
   df3 <- collection$get("new_df")
   df3 <- SOMADataFrameOpen(df3$uri)
-  expect_true(df3$soma_type == "SOMADataFrame")
+  expect_equal(df3$soma_type, "SOMADataFrame")
   df3$close()
 
   # Add new DenseNDArray to the collection
@@ -68,7 +68,7 @@ test_that("SOMACollection basics", {
   )$close()
   arr <- collection$get("nd_d_arr")
   arr <- SOMADenseNDArrayOpen(arr$uri)
-  expect_true(arr$soma_type == "SOMADenseNDArray")
+  expect_equal(arr$soma_type, "SOMADenseNDArray")
   arr$close()
 
   # Add new SparseNDArray to the collection
@@ -79,7 +79,7 @@ test_that("SOMACollection basics", {
   )$close()
   arr <- collection$get("nd_s_arr")
   arr <- SOMASparseNDArrayOpen(arr$uri)
-  expect_true(arr$soma_type == "SOMASparseNDArray")
+  expect_equal(arr$soma_type, "SOMASparseNDArray")
   arr$close()
 
   collection$close()

--- a/apis/r/tests/testthat/test-06-SOMADataFrame.R
+++ b/apis/r/tests/testthat/test-06-SOMADataFrame.R
@@ -84,7 +84,7 @@ test_that("Basic mechanics", {
 
   # Read back the data (ignore attributes)
   sdf <- SOMADataFrameOpen(uri)
-  expect_match(sdf$soma_type, "SOMADataFrame")
+  expect_equal(sdf$soma_type, "SOMADataFrame")
 
   expect_error(sdf$shape(), class = "notYetImplementedError")
   expect_warning(sdf$levels())
@@ -215,7 +215,7 @@ test_that("Basic mechanics with default index_column_names", {
   expect_s3_class(sdf, "SOMADataFrame")
   expect_true(sdf$exists())
   expect_true(dir.exists(uri))
-  expect_match(sdf$soma_type, "SOMADataFrame")
+  expect_equal(sdf$soma_type, "SOMADataFrame")
 
   # check for missing columns
   expect_error(

--- a/apis/r/tests/testthat/test-08-EphemeralCollection.R
+++ b/apis/r/tests/testthat/test-08-EphemeralCollection.R
@@ -10,7 +10,7 @@ test_that("Ephemeral Collection mechanics", {
   ))
   expect_false(collection$exists())
   expect_s3_class(collection$create(), collection$class())
-  expect_true(collection$soma_type == "SOMACollection")
+  expect_equal(collection$soma_type, "SOMACollection")
   expect_equal(collection$length(), 0)
 
   # Add a dataframe to the collection
@@ -24,7 +24,7 @@ test_that("Ephemeral Collection mechanics", {
   expect_error(collection$add_new_collection(collection, "collection"))
   expect_no_condition(collection$set(collection, "collection"))
   collection2 <- collection$get("collection")
-  expect_true(collection2$soma_type == "SOMACollection")
+  expect_equal(collection2$soma_type, "SOMACollection")
   expect_false(collection2$exists())
   expect_s3_class(df2 <- collection2$get("sdf"), "SOMADataFrame")
 
@@ -48,7 +48,7 @@ test_that("Ephemeral Collection mechanics", {
     "new_df"
   ))
   expect_s3_class(df3 <- collection$get("new_df"), "SOMADataFrame")
-  expect_true(df3$soma_type == "SOMADataFrame")
+  expect_equal(df3$soma_type, "SOMADataFrame")
   df3$close()
 
   # Add new DenseNdArray to the collection
@@ -66,7 +66,7 @@ test_that("Ephemeral Collection mechanics", {
     "nd_d_arr"
   ))
   expect_s3_class(arr <- collection$get("nd_d_arr"), "SOMADenseNDArray")
-  expect_true(arr$soma_type == "SOMADenseNDArray")
+  expect_equal(arr$soma_type, "SOMADenseNDArray")
   arr$close()
 
   # Add new SparseNdArray to the collection
@@ -84,6 +84,6 @@ test_that("Ephemeral Collection mechanics", {
     "nd_s_arr"
   ))
   expect_s3_class(arr <- collection$get("nd_s_arr"), "SOMASparseNDArray")
-  expect_true(arr$soma_type == "SOMASparseNDArray")
+  expect_equal(arr$soma_type, "SOMASparseNDArray")
   arr$close()
 })

--- a/apis/r/tests/testthat/test-carrara-01-create.R
+++ b/apis/r/tests/testthat/test-carrara-01-create.R
@@ -52,7 +52,7 @@ test_that("SOMADataFrame creation", {
   expect_equal(sdf1$domain(), domain)
   expect_equal(sdf1$schema(), tbl$schema)
 
-  expect_equivalent(sdf1$read()$concat(), tbl)
+  expect_equal(sdf1$read()$concat(), tbl)
   sdf1$close()
 })
 
@@ -64,8 +64,7 @@ test_that("SOMACollection creation", {
   SOMACollectionCreate(uri = uri)$close()
 
   collection2 <- SOMACollectionOpen(uri)
-  # Testing equivalence because soma_type returns a named string for collections
-  expect_equivalent(collection2$soma_type, "SOMACollection")
+  expect_equal(collection2$soma_type, "SOMACollection")
   expect_equal(length(collection2$names()), 0)
   collection2$close()
 })
@@ -121,7 +120,7 @@ test_that("SOMACollection add_new_* methods", {
   SOMAExperimentCreate(child2_uri)$close()
   child2 <- SOMACollectionOpen(child2_uri)
   expect_true(child2$exists())
-  expect_equivalent(child2$soma_type, "SOMAExperiment")
+  expect_equal(child2$soma_type, "SOMAExperiment")
   child2$close()
 
   # child3: SOMAMeasurement
@@ -129,7 +128,7 @@ test_that("SOMACollection add_new_* methods", {
   SOMAMeasurementCreate(child3_uri)$close()
   child3 <- SOMACollectionOpen(child3_uri)
   expect_true(child3$exists())
-  expect_equivalent(child3$soma_type, "SOMAMeasurement")
+  expect_equal(child3$soma_type, "SOMAMeasurement")
   child3$close()
 
   # child4: SOMACollection
@@ -137,7 +136,7 @@ test_that("SOMACollection add_new_* methods", {
   SOMACollectionCreate(child4_uri)$close()
   child4 <- SOMACollectionOpen(child4_uri)
   expect_true(child4$exists())
-  expect_equivalent(child4$soma_type, "SOMACollection")
+  expect_equal(child4$soma_type, "SOMACollection")
   child4$close()
 
   # child5: SOMADataFrame
@@ -178,13 +177,13 @@ test_that("SOMACollection add_new_* methods", {
   expect_setequal(collection$names(), children)
 
   # Verify types on retrieval
-  expect_equivalent(collection$get("child1")$soma_type, "SOMACollection")
-  expect_equivalent(collection$get("child2")$soma_type, "SOMAExperiment")
-  expect_equivalent(collection$get("child3")$soma_type, "SOMAMeasurement")
-  expect_equivalent(collection$get("child4")$soma_type, "SOMACollection")
-  expect_equivalent(collection$get("child5")$soma_type, "SOMADataFrame")
-  expect_equivalent(collection$get("child6")$soma_type, "SOMASparseNDArray")
-  expect_equivalent(collection$get("child7")$soma_type, "SOMADenseNDArray")
+  expect_equal(collection$get("child1")$soma_type, "SOMACollection")
+  expect_equal(collection$get("child2")$soma_type, "SOMAExperiment")
+  expect_equal(collection$get("child3")$soma_type, "SOMAMeasurement")
+  expect_equal(collection$get("child4")$soma_type, "SOMACollection")
+  expect_equal(collection$get("child5")$soma_type, "SOMADataFrame")
+  expect_equal(collection$get("child6")$soma_type, "SOMASparseNDArray")
+  expect_equal(collection$get("child7")$soma_type, "SOMADenseNDArray")
 
   # Verify properties for child5, child6, child7
   c5 <- collection$get("child5")
@@ -245,7 +244,7 @@ test_that("SOMACollection path encoding validation", {
   # Verify each collection can be opened and has correct type
   for (name in test_names) {
     child <- collection$get(name)
-    expect_equivalent(child$soma_type, "SOMACollection")
+    expect_equal(child$soma_type, "SOMACollection")
     child$close()
   }
 
@@ -270,7 +269,7 @@ test_that("SOMACollection path encoding validation", {
   expect_true("dataframe_αβγ" %in% collection$names())
 
   df <- collection$get("dataframe_αβγ")
-  expect_equivalent(df$soma_type, "SOMADataFrame")
+  expect_equal(df$soma_type, "SOMADataFrame")
   df$close()
 
   collection$close()

--- a/apis/r/tests/testthat/test-carrara-04-error-handling.R
+++ b/apis/r/tests/testthat/test-carrara-04-error-handling.R
@@ -83,14 +83,14 @@ test_that("SOMACollection relative URI behavior", {
 
   # Verify we can open the child
   child <- parent$get(child_name)
-  expect_equivalent(child$soma_type, "SOMACollection")
+  expect_equal(child$soma_type, "SOMACollection")
   child$close()
 
   parent$close()
 
   # Verify child can be opened directly via its full URI
   child_direct <- SOMACollectionOpen(child_uri, mode = "READ")
-  expect_equivalent(child_direct$soma_type, "SOMACollection")
+  expect_equal(child_direct$soma_type, "SOMACollection")
   child_direct$close()
 })
 
@@ -184,16 +184,16 @@ test_that("Opening nested child paths directly works", {
   collection$close()
 
   # Verify we can open each nested path directly
-  expect_equivalent(SOMACollectionOpen(uri)$soma_type, "SOMACollection")
+  expect_equal(SOMACollectionOpen(uri)$soma_type, "SOMACollection")
   expect_equal(
     SOMASparseNDArrayOpen(file_path(uri, "snda1"))$soma_type,
     "SOMASparseNDArray"
   )
-  expect_equivalent(
+  expect_equal(
     SOMACollectionOpen(file_path(uri, "c1"))$soma_type,
     "SOMACollection"
   )
-  expect_equivalent(
+  expect_equal(
     SOMACollectionOpen(file_path(uri, "c1/c1.1"))$soma_type,
     "SOMACollection"
   )

--- a/apis/r/tests/testthat/test-cloud-03-seurat-io.R
+++ b/apis/r/tests/testthat/test-cloud-03-seurat-io.R
@@ -33,7 +33,7 @@ test_that("Ingest Seurat object to cloud with write_soma", {
 
   # Verify measurement
   ms_rna <- exp$ms$get("RNA")
-  expect_equivalent(ms_rna$soma_type, "SOMAMeasurement")
+  expect_equal(ms_rna$soma_type, "SOMAMeasurement")
 
   # Verify var dataframe
   var_data <- ms_rna$var$read()$concat()

--- a/apis/system/tests/test_character_write_python_read_r.py
+++ b/apis/system/tests/test_character_write_python_read_r.py
@@ -22,4 +22,4 @@ class TestCharacterMetadataWritePythonReadR(TestWritePythonReadR):
         """
 
     def test_r_character(self, experiment):
-        self.r_assert(r"stopifnot(all(vapply(md, \(x) is.character(x$name), logical(1L))))")
+        self.r_assert(r"stopifnot(all(vapply(md, is.character, logical(1L))))")

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-coverage:
-  range: "90...95"
-
 ignore:
   - "apis/r/inst/tiledb/"
   - "apis/r/inst/tiledbsoma/include"
@@ -26,7 +23,19 @@ component_management:
         - libtiledbsoma/src/soma/**
         - libtiledbsoma/src/utils/**
 
+flags:
+  python:
+    paths:
+      - apis/python/src/
+    carryforward: true
+  r:
+    paths:
+      - apis/r/R/
+      - apis/r/src/
+    carryforward: true
+
 coverage:
+  range: "90...95"
   status:
     patch:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -35,4 +35,4 @@ coverage:
     project:
       default:
         target: 70
-        threshold: 100
+        threshold: "100%"


### PR DESCRIPTION
**Issue and/or context:** Collection types (SOMACollection, SOMAExperiment, SOMAMeasurement) returned a named string from `soma_type` and other metadata (e.g., `c(name = "SOMACollection")`), while array types returned an unnamed string. Resolves SOMA-803. 

**Changes:**

- Updated `c_group_get_metadata()` to store metadata values directly in the result list instead of wrapping them in a named sub-list
- Updated existing tests to remove permissive assertions that worked around the named character issue with stricter `expect_equal()` calls (i.e., removed patterns like `expect_equivalent(x$soma_type, ...)` and `expect_true(x$soma_type == ...)`)
- Added test coverage  `set_metadata()`/`get_metadata()` round-trips for SOMACollections similar to what we have in tiledbsoma-py
- Updated an interop test was using `x$name` to access metadata values, which depended on the old named-list wrapping. 

- Unrelated Codecov config fix: Added `carryforward: true` to the Python and R flags. Previously, R-only PRs (like this one) showed a project coverage drop because codecov was computing the total without Python's files. With carryforward, codecov will reuse the last known coverage for whichever flag didn't upload. 

**Notes for Reviewer:** Stricter test assertions and new metadata coverage was added *before* implementing the C++ fix. You can see an expected failures [here](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/22781706050/job/66090965508).


