### PR TITLE
[python] Set the context in spatial import if not already set

### DIFF
--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -362,6 +362,8 @@ def from_visium(
     # - Create `ingest_ctx` for keyword args for creating SOMAGroup objects.
     # - Create `ingestion_platform_ctx` for keyword args for creating SOMAArray objects.
     if context is None:
+        if not SOMAContext.has_default():
+            SOMAContext.set_default()
         context = SOMAContext.get_default()
     elif isinstance(context, SOMATileDBContext):
         context = context._to_soma_context()


### PR DESCRIPTION
There was a bug in the `from_visium` ingestion where ingestion would fail if no `SOMAContext` was provided and no default `SOMAContext` was set.