### PR TITLE
[r] Update SCE Outgest tests to `sparseMatrix`

### DIFF
--- a/apis/r/tests/testthat/test-15-SCEOutgest.R
+++ b/apis/r/tests/testthat/test-15-SCEOutgest.R
@@ -77,14 +77,14 @@ test_that("Load SCE object from ExperimentQuery mechanics", {
       "connectivities",
       asSparse = TRUE
     ),
-    "dgCMatrix"
+    "sparseMatrix"
   )
   expect_identical(dim(graph), c(n_obs, n_obs))
   expect_identical(SingleCellExperiment::rowPairNames(obj), "network")
   expect_s4_class(SingleCellExperiment::rowPair(obj, "network"), "SelfHits")
   expect_s4_class(
     net <- SingleCellExperiment::rowPair(obj, "network", asSparse = TRUE),
-    "dgCMatrix"
+    "sparseMatrix"
   )
   expect_identical(dim(net), c(n_var, n_var))
   # Test named


### PR DESCRIPTION
Latest development version of SingleCellExperiment changes obps/varp return type to `TsparseMatrix` Change tests to general `sparseMatrix` to capture both `CsparseMatrix` and `TsparseMatrix`

Fixes [SOMA-932](https://linear.app/tiledb/issue/SOMA-932/adjust-sce-outgest-tests-to-check-for-sparsematrix-rather-than)