### PR TITLE
[r] Document SOMACollectionOpen()'s stricter type checking

### DIFF
--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -7,6 +7,7 @@
 ## Changed
 
 - Remove `data.table` package dependency by leveraging `rlang::obj_address()` for generating ephemeral collection URIs.
+- `SOMACollectionOpen()` now enforces strict type checking and will error if the URI points to a `SOMAExperiment`, `SOMAMeasurement`, or other collection subtype. Users should use the appropriate type-specific function (`SOMAExperimentOpen()`, `SOMAMeasurementOpen()`) or `SOMAOpen()`, which automatically resolves the correct subclass. ([#4443](https://github.com/single-cell-data/TileDB-SOMA/pull/4443))
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
 - Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
 

--- a/apis/r/R/Factory.R
+++ b/apis/r/R/Factory.R
@@ -409,6 +409,13 @@ SOMACollectionCreate <- function(
 #' Factory function to open a \link[tiledbsoma:SOMACollection]{SOMA collection}
 #' for reading (lifecycle: maturing).
 #'
+#' The \code{uri} must point to a \code{SOMACollection}. An error is raised if
+#' it points to a collection subtype such as
+#' \code{\link{SOMAExperiment}} or \code{\link{SOMAMeasurement}}. Use the
+#' corresponding type-specific factory function for those types, or use
+#' \code{\link{SOMAOpen}()} to automatically open any SOMA object with the
+#' appropriate type.
+#'
 #' @inheritParams SOMADataFrameOpen
 #' @param tiledb_timestamp Optional Datetime (POSIXct) for TileDB timestamp;
 #' defaults to the current time. If not \code{NULL}, all members accessed

--- a/apis/r/R/SOMAOpen.R
+++ b/apis/r/R/SOMAOpen.R
@@ -1,7 +1,11 @@
 #' Open a SOMA Object
 #'
 #' Utility function to open the corresponding SOMA object given a URI
-#' (lifecycle: maturing).
+#' (lifecycle: maturing). The SOMA type is automatically detected from stored
+#' metadata and the appropriate subclass is returned. This is a safe
+#' alternative to the type-specific factory functions (e.g.,
+#' \code{\link{SOMAExperimentOpen}()}) when you don't know the exact type
+#' stored at a URI.
 #'
 #' @inheritParams SOMACollectionOpen
 #' @param mode One of \dQuote{\code{READ}} or \dQuote{\code{WRITE}}

--- a/apis/r/R/utils-arrow.R
+++ b/apis/r/R/utils-arrow.R
@@ -254,7 +254,7 @@ check_arrow_data_types <- function(from, to) {
 
 #' Validate compatibility of Arrow schemas
 #'
-#' This is essentially a vectorized version of [`check_arrow_data_types`] that
+#' This is essentially a vectorized version of `check_arrow_data_types()` that
 #' checks the compatibility of each field in the schemas.
 #' @param from an [`arrow::Schema`]
 #' @param to an [`arrow::Schema`] with the same set of fields as `from`

--- a/apis/r/man/SOMACollectionOpen.Rd
+++ b/apis/r/man/SOMACollectionOpen.Rd
@@ -39,6 +39,14 @@ A \link[tiledbsoma:SOMACollection]{SOMA collection} stored at
 Factory function to open a \link[tiledbsoma:SOMACollection]{SOMA collection}
 for reading (lifecycle: maturing).
 }
+\details{
+The \code{uri} must point to a \code{SOMACollection}. An error is raised if
+it points to a collection subtype such as
+\code{\link{SOMAExperiment}} or \code{\link{SOMAMeasurement}}. Use the
+corresponding type-specific factory function for those types, or use
+\code{\link{SOMAOpen}()} to automatically open any SOMA object with the
+appropriate type.
+}
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 uri <- withr::local_tempfile(pattern = "soma-collection")

--- a/apis/r/man/SOMAOpen.Rd
+++ b/apis/r/man/SOMAOpen.Rd
@@ -36,7 +36,11 @@ A SOMA object
 }
 \description{
 Utility function to open the corresponding SOMA object given a URI
-(lifecycle: maturing).
+(lifecycle: maturing). The SOMA type is automatically detected from stored
+metadata and the appropriate subclass is returned. This is a safe
+alternative to the type-specific factory functions (e.g.,
+\code{\link{SOMAExperimentOpen}()}) when you don't know the exact type
+stored at a URI.
 }
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) withAutoprint(\{ # examplesIf}

--- a/apis/r/tests/testthat/test-carrara-01-create.R
+++ b/apis/r/tests/testthat/test-carrara-01-create.R
@@ -118,7 +118,7 @@ test_that("SOMACollection add_new_* methods", {
   # child2: SOMAExperiment
   child2_uri <- file.path(uri, "child2")
   SOMAExperimentCreate(child2_uri)$close()
-  child2 <- SOMACollectionOpen(child2_uri)
+  child2 <- SOMAExperimentOpen(child2_uri)
   expect_true(child2$exists())
   expect_equal(child2$soma_type, "SOMAExperiment")
   child2$close()
@@ -126,7 +126,7 @@ test_that("SOMACollection add_new_* methods", {
   # child3: SOMAMeasurement
   child3_uri <- file.path(uri, "child3")
   SOMAMeasurementCreate(child3_uri)$close()
-  child3 <- SOMACollectionOpen(child3_uri)
+  child3 <- SOMAMeasurementOpen(child3_uri)
   expect_true(child3$exists())
   expect_equal(child3$soma_type, "SOMAMeasurement")
   child3$close()


### PR DESCRIPTION
**Issue and/or context:** [SOMA-909]

This documents the breaking change introduced in [SOMA-909](https://linear.app/tiledb/issue/SOMA-909) where `SOMACollectionOpen()` now raises an error if the URI points to a `SOMAExperiment`, `SOMAMeasurement`, or other collection subtype.

**Changes:**

- Added a NEWS entry for the breaking change
- Updated `SOMACollectionOpen()` docs to explain the strict type-checking behavior and direct users to `SOMAExperimentOpen()`, `SOMAMeasurementOpen()`, or `SOMAOpen()` as appropriate
- Expanded `SOMAOpen()` docs to clarify that it auto-detects the SOMA type and returns the correct subclass, making it the safe choice when the type is unknown
- Fixed two tests in `test-carrara-01-create.R` that were opening `SOMAExperiment` and `SOMAMeasurement` URIs via `SOMACollectionOpen()`
- Minor: fixed a broken cross-reference in `utils-arrow.R` roxygen docs
