### PR TITLE
[ci] Temporarily disable R-devel CI job

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -65,7 +65,8 @@ jobs:
       matrix:
         config:
           - {os: macos-latest, r: 'release', report_codecov: false}
-          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
+          # TODO(SOMA-941): re-enable once S4Vectors is compatible with R-devel
+          # - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
           #- {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false} # BPCells dep ggrepel not available
     uses: ./.github/workflows/test-r.yml

--- a/.github/workflows/ci-pr-r.yml
+++ b/.github/workflows/ci-pr-r.yml
@@ -33,7 +33,8 @@ jobs:
       matrix:
         config:
           - {os: macos-latest, r: 'release', report_codecov: false}
-          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
+          # TODO(SOMA-941): re-enable once S4Vectors is compatible with R-devel
+          # - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', report_codecov: false}
           - {os: ubuntu-latest, r: 'release', report_codecov: true}
           #- {os: ubuntu-latest, r: 'oldrel-1', report_codecov: false} # BPCells dep ggrepel not available
     uses: ./.github/workflows/test-r.yml


### PR DESCRIPTION
**Issue and/or context:** [SOMA-941]

R-devel (post-4.6.0) removed non-API C symbols (`PREXPR`, `PRENV`, `PRVALUE`) that Bioconductor's `S4Vectors` package depends on. This causes `S4Vectors.so` to fail to load with an `undefined symbol: PREXPR` error, breaking R package dependency installation in CI.

The fix is in S4Vectors 0.49.2 on the Bioconductor devel branch ([Bioconductor/S4Vectors#134](https://github.com/Bioconductor/S4Vectors/issues/134)) but has not yet reached the release channel.

**Changes:**

- Comment out the R-devel matrix entry in `ci-pr-r.yml` and `ci-full.yml`
- Each is tagged with `TODO(SOMA-941)` for easy discovery when it's time to re-enable

**Notes for Reviewer:** This failure is already present on `main` and is unrelated to any open PRs.