### PR TITLE
[python] Additional deprecation removals schedules for the 3.0.0 release

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Report coverage to Codecov
         if: inputs.report_codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           flags: python
           # Although Codecov isn't supposed to require an auth token for public repos like this one,

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for allowing a dimension in `shape` to be `None` in the `SparseNDArray`.
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for setting `domain=None` in the `create` method for `DataFrame`, `PointCloudDataFrame`, and `GeometryDataFrame`.
-- Remove the deprecated `"resume"` ingest mode from `tiledbsoma.io.from_h5ad`, `tiledbsoma.io.from_anndata`, `tiledbsoma.io.add_X_layer`, and `tiledbsoma.io.add_matrix_to_collection`. The recommended approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart from the original input files or a known-good backup.
-- Remove the deprecated behavior of deleting collection members in write mode (`mode="w"`). Use `mode="d"` instead.
+- \[[#4448](https://github.com/single-cell-data/TileDB-SOMA/pull/4448)\] Remove the deprecated `"resume"` ingest mode from `tiledbsoma.io.from_h5ad`, `tiledbsoma.io.from_anndata`, `tiledbsoma.io.add_X_layer`, and `tiledbsoma.io.add_matrix_to_collection`. The recommended approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart from the original input files or a known-good backup.
+- \[[#4448](https://github.com/single-cell-data/TileDB-SOMA/pull/4448)\] Remove the deprecated behavior of deleting collection members in write mode (`mode="w"`). Use `mode="d"` instead.
 
 ### Fixed
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for allowing a dimension in `shape` to be `None` in the `SparseNDArray`.
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for setting `domain=None` in the `create` method for `DataFrame`, `PointCloudDataFrame`, and `GeometryDataFrame`.
 - Remove the deprecated `"resume"` ingest mode from `tiledbsoma.io.from_h5ad`, `tiledbsoma.io.from_anndata`, `tiledbsoma.io.add_X_layer`, and `tiledbsoma.io.add_matrix_to_collection`. The recommended approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart from the original input files or a known-good backup.
+- Remove the deprecated behavior of deleting collection members in write mode (`mode="w"`). Use `mode="d"` instead.
 
 ### Fixed
 

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for allowing a dimension in `shape` to be `None` in the `SparseNDArray`.
 - \[[#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431)\] Remove deprecated support for setting `domain=None` in the `create` method for `DataFrame`, `PointCloudDataFrame`, and `GeometryDataFrame`.
+- Remove the deprecated `"resume"` ingest mode from `tiledbsoma.io.from_h5ad`, `tiledbsoma.io.from_anndata`, `tiledbsoma.io.add_X_layer`, and `tiledbsoma.io.add_matrix_to_collection`. The recommended approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart from the original input files or a known-good backup.
 
 ### Fixed
 

--- a/apis/python/devtools/ingestor
+++ b/apis/python/devtools/ingestor
@@ -43,12 +43,9 @@ def main():
         "--ingest-mode",
         help="""Write mode (the default) writes all data, creating new layers if the soma already exists.
 
-Resume mode skip data writes if data are within MBRs of the existing soma.
-This is useful for continuing after a partial/interrupted previous upload.
-
 Schema-only mode creates groups and array schema, without writing array data.
 This is useful as a prep-step for parallel append-ingest of multiple H5ADs to a single soma.""",
-        choices=["write", "schema_only", "schema-only", "resume"],
+        choices=["write", "schema_only", "schema-only"],
         default=["write"],
         nargs=1,
     )

--- a/apis/python/src/tiledbsoma/_soma_group.py
+++ b/apis/python/src/tiledbsoma/_soma_group.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable, Iterator
 from threading import Lock
 from typing import Any, Callable, Generic, TypeVar, cast
@@ -177,13 +176,6 @@ class SOMAGroup(SOMAObject, Generic[CollectionElementType]):
             if self.closed:
                 raise SOMAError(f"Cannot delete '{key!r}'. {self} is closed")
             if self.mode == "d":
-                self._handle.remove(key)
-            elif self.mode == "w":
-                warnings.warn(
-                    f"Deleting in write mode is deprecated. {self} should be reopened with mode='d'.",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
                 self._handle.remove(key)
             else:
                 raise SOMAError(

--- a/apis/python/src/tiledbsoma/_types.py
+++ b/apis/python/src/tiledbsoma/_types.py
@@ -59,7 +59,7 @@ Labels = Union[Sequence[str], PDIndex]
 
 NTuple = tuple[int, ...]
 
-IngestMode = Literal["write", "schema_only", "resume"]  # for static-analysis checks
+IngestMode = Literal["write", "schema_only"]  # for static-analysis checks
 INGEST_MODES = get_args(IngestMode)  # for run-time checks
 
 # Internal version of ``IngestMode`` that includes "update"; see ``IngestionParams``.

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -39,7 +39,6 @@ import pandas as pd
 import pyarrow as pa
 import scipy.sparse as sp
 from more_itertools import batched
-from typing_extensions import deprecated
 
 # As of anndata 0.11 we get a warning importing anndata.experimental.
 # But anndata.abc doesn't exist in anndata 0.10. And anndata 0.11 doesn't
@@ -70,7 +69,6 @@ from tiledbsoma._common_nd_array import NDArray
 from tiledbsoma._constants import SOMA_DATAFRAME_ORIGINAL_INDEX_NAME_JSON, SOMA_JOINID
 from tiledbsoma._core_options import PlatformConfig
 from tiledbsoma._exception import AlreadyExistsError, DoesNotExistError, SOMAError
-from tiledbsoma._soma_array import SOMAArray
 from tiledbsoma._soma_object import SOMAObject
 from tiledbsoma._tdb_handles import RawHandle
 from tiledbsoma._types import _INGEST_MODES, INGEST_MODES, IngestMode, NPNDArray, Path, _IngestMode
@@ -113,7 +111,6 @@ class IngestionParams:
 
     write_schema_no_data: bool
     error_if_already_exists: bool
-    skip_existing_nonempty_domain: bool
     appending: bool
 
     def __init__(
@@ -124,41 +121,23 @@ class IngestionParams:
         if ingest_mode == "schema_only":
             self.write_schema_no_data = True
             self.error_if_already_exists = False
-            self.skip_existing_nonempty_domain = False
             self.appending = False
 
         elif ingest_mode == "write":
             if label_mapping is None:
                 self.write_schema_no_data = False
                 self.error_if_already_exists = True
-                self.skip_existing_nonempty_domain = False
                 self.appending = False
             else:
                 # append mode, but, the user supplying non-null registration information suffices
                 # for us to understand "append"
                 self.write_schema_no_data = False
                 self.error_if_already_exists = False
-                self.skip_existing_nonempty_domain = False
-                self.appending = True
-
-        elif ingest_mode == "resume":
-            if label_mapping is None:
-                self.write_schema_no_data = False
-                self.error_if_already_exists = False
-                self.skip_existing_nonempty_domain = True
-                self.appending = False
-            else:
-                # resume-append mode, but, the user supplying non-null registration information
-                # suffices for us to understand "resume-append"
-                self.write_schema_no_data = False
-                self.error_if_already_exists = False
-                self.skip_existing_nonempty_domain = True
                 self.appending = True
 
         elif ingest_mode == "update":
             self.write_schema_no_data = False
             self.error_if_already_exists = False
-            self.skip_existing_nonempty_domain = False
             self.appending = False
 
         else:
@@ -363,20 +342,9 @@ def from_h5ad(
         ingest_mode: The ingestion type to perform:
 
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
-            - ``resume``: (deprecated) Adds data to an existing SOMA, skipping writing data
-              that was previously written. Useful for continuing after a partial
-              or interrupted ingestion operation.
             - ``schema_only``: Creates groups and the array schema, without
               writing any data to the array. Useful to prepare for appending
               multiple H5AD files to a single SOMA.
-
-          The 'resume' ingest_mode is deprecated and will be removed in a future version. The
-          current implementation has a known issue that can can cause multi-dataset appends to
-          not resume correctly.
-
-          The recommended and safest approach for recovering from a failed ingestion is to delete
-          the partially written SOMA Experiment and restart the ingestion process from the original
-          input files or a known-good backup.
 
         X_kind: Which type of matrix is used to store dense X data from the
           H5AD file: ``DenseNDArray`` or ``SparseNDArray``.
@@ -434,7 +402,6 @@ def from_h5ad(
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(f'expected ingest_mode to be one of {INGEST_MODES}; got "{ingest_mode}"')
-    _check_for_deprecated_modes(ingest_mode)
 
     if isinstance(input_path, ad.AnnData):
         raise TypeError("input path is an AnnData object -- did you want from_anndata?")
@@ -539,7 +506,7 @@ def from_anndata(
 
         raw_X_layer_name: SOMA array name for the AnnData's ``raw/X`` matrix.
 
-        ingest_mode: One of ``"write"``, ``"resume"`` (deprecated), or ``"schema_only"``.
+        ingest_mode: One of ``"write"`` or ``"schema_only"``.
           See :func:`from_h5ad` for details.
 
         use_relative_uri: Whether to use relative URIs for nested objects.
@@ -570,7 +537,6 @@ def from_anndata(
     """
     if ingest_mode not in INGEST_MODES:
         raise SOMAError(f'expected ingest_mode to be one of {INGEST_MODES}; got "{ingest_mode}"')
-    _check_for_deprecated_modes(ingest_mode)
 
     return _from_anndata(
         experiment_uri,
@@ -695,11 +661,6 @@ def _from_anndata(
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # MS
 
-    # For local disk and S3, this is the same as experiment.ms.uri.
-    # For ingest_mode="resume" on TileDB Cloud, experiment_uri will be of the form
-    # tiledb://namespace/s3://bucket/path/to/exp whereas experiment.ms.uri will
-    # be of the form tiledb://namespace/uuid. Only for the former is it suitable
-    # to append "/ms" so that is what we do here.
     experiment_ms_uri = f"{experiment_uri}/ms"
 
     with _create_or_open_collection(
@@ -1281,28 +1242,10 @@ def _write_dataframe_impl(
             raise ValueError("internal coding error: id_column_name unspecified")
         arrow_table = _extract_new_values_for_append(df_uri, arrow_table, filter_existing_joinids, context)
 
-    def check_for_containment(
-        df: pd.DataFrame,
-        soma_df: DataFrame,
-        ingestion_params: IngestionParams,
-    ) -> bool:
-        """For resume mode, check if the non-empty domain has already been written."""
-        if ingestion_params.skip_existing_nonempty_domain:
-            storage_ned = _read_nonempty_domain(soma_df)
-            dim_range = ((int(df.index.min()), int(df.index.max())),)
-            if _chunk_is_contained_in(dim_range, storage_ned):
-                logging.log_io(
-                    f"Skipped {df_uri}",
-                    _util.format_elapsed(s, f"SKIPPED {df_uri}"),
-                )
-                return True
-        return False
-
     if must_exist:
         # For update_obs, update_var, append_obs, and append_var, it's
         # an error situation if the dataframe doesn't already exist.
         soma_df = DataFrame.open(df_uri, "w", context=context)
-        check_for_containment(df, soma_df, ingestion_params)
 
     else:
         # We could (and used to) do:
@@ -1315,11 +1258,6 @@ def _write_dataframe_impl(
         # try create, doing the open if the create threw already-exists.
         # When the dataframe doesn't exist, this is just one round-trip request,
         # and when it does, it's two (as before).
-        #
-        # Note that for append/update, the dataframe must exist; but for
-        # resume mode, the dataframe may or may not exist. (The point of
-        # resume mode is to continue from a previous ingest which ended
-        # prematurely.)
         try:
             soma_df = DataFrame.create(
                 df_uri,
@@ -1337,7 +1275,6 @@ def _write_dataframe_impl(
             if ingestion_params.error_if_already_exists:
                 raise SOMAError(f"{df_uri} already exists") from e
             soma_df = DataFrame.open(df_uri, "w", context=context)
-            check_for_containment(df, soma_df, ingestion_params)
 
     if ingestion_params.write_schema_no_data:
         logging.log_io(
@@ -1429,7 +1366,6 @@ def _create_from_matrix(
             matrix,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=additional_metadata,
         )
     elif isinstance(soma_ndarray, SparseNDArray):  # SOMASparseNDArray
@@ -1438,7 +1374,6 @@ def _create_from_matrix(
             matrix,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=additional_metadata,
             axis_0_mapping=axis_0_mapping,
             axis_1_mapping=axis_1_mapping,
@@ -1687,7 +1622,6 @@ def update_matrix(
     )
 
     context = context._to_soma_context() if isinstance(context, SOMATileDBContext) else context
-    ingestion_params = IngestionParams("write", None)
 
     if isinstance(soma_ndarray, DenseNDArray):
         _write_matrix_to_denseNDArray(
@@ -1695,7 +1629,6 @@ def update_matrix(
             new_data,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=None,
         )
     elif isinstance(soma_ndarray, SparseNDArray):  # SOMASparseNDArray
@@ -1704,7 +1637,6 @@ def update_matrix(
             new_data,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=None,
             axis_0_mapping=AxisIDMapping.identity(new_data.shape[0]),
             axis_1_mapping=AxisIDMapping.identity(new_data.shape[1]),
@@ -1843,7 +1775,6 @@ def add_X_layer(
         Maturing.
     """
     exp.verify_open_for_writing()
-    _check_for_deprecated_modes(ingest_mode)
     context = context._to_soma_context() if isinstance(context, SOMATileDBContext) else context
     add_matrix_to_collection(
         exp,
@@ -1906,7 +1837,6 @@ def add_matrix_to_collection(
     """
     ingestion_params = IngestionParams(ingest_mode, None)
     context = context._to_soma_context() if isinstance(context, SOMATileDBContext) else context
-    _check_for_deprecated_modes(ingest_mode)
 
     # For local disk and S3, creation and storage URIs are identical.  For
     # cloud, creation URIs look like tiledb://namespace/s3://bucket/path/to/obj
@@ -1960,7 +1890,6 @@ def _write_matrix_to_denseNDArray(
     matrix: Matrix | h5py.Dataset,
     tiledb_create_options: TileDBCreateOptions,
     tiledb_write_options: TileDBWriteOptions,  # noqa: ARG001
-    ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
     """Write a matrix to an empty DenseNDArray."""
@@ -1969,27 +1898,6 @@ def _write_matrix_to_denseNDArray(
     # TileDB does not support big-endian so coerce to little-endian
     if isinstance(matrix, np.ndarray) and matrix.dtype.byteorder == ">":
         matrix = matrix.byteswap().view(matrix.dtype.newbyteorder("<"))
-
-    # There is a chunk-by-chunk already-done check for resume mode, below.
-    # This full-matrix-level check here might seem redundant, but in fact it's important:
-    # * By checking input bounds against storage NED here, we can see if the entire matrix
-    #   was already ingested and avoid even loading chunks;
-    # * By checking chunkwise we can catch the case where a matrix was already *partly*
-    #   ingested.
-    # * Of course, this also helps us catch already-completed writes in the non-chunked case.
-    # TODO: make sure we're not using an old timestamp for this
-    storage_ned = None
-    if ingestion_params.skip_existing_nonempty_domain:
-        # This lets us check for already-ingested chunks, when in resume-ingest mode.
-        storage_ned = _read_nonempty_domain(soma_ndarray)
-        matrix_bounds = [(0, int(n - 1)) for n in matrix.shape]  # Cast for lint in case np.int64
-        logging.log_io(
-            None,
-            f"Input bounds {tuple(matrix_bounds)} storage non-empty domain {storage_ned}",
-        )
-        if _chunk_is_contained_in(matrix_bounds, storage_ned):
-            logging.log_io(f"Skipped {soma_ndarray.uri}", f"SKIPPED WRITING {soma_ndarray.uri}")
-            return
 
     # Write all at once?
     if not tiledb_create_options.write_X_chunked:
@@ -2043,21 +1951,6 @@ def _write_matrix_to_denseNDArray(
 
         chunk = matrix[i:i2, :] if matrix.ndim == 2 else matrix[i:i2]
 
-        if ingestion_params.skip_existing_nonempty_domain and storage_ned is not None:
-            chunk_bounds = matrix_bounds
-            chunk_bounds[0] = (
-                int(i),
-                int(i2 - 1),
-            )  # Cast for lint in case np.int64
-            if _chunk_is_contained_in_axis(chunk_bounds, storage_ned, 0):
-                # Print doubly inclusive lo..hi like 0..17 and 18..31.
-                logging.log_io(
-                    "... %7.3f%% done" % chunk_percent,  # noqa: UP031
-                    "SKIP   chunk rows %d..%d of %d (%.3f%%)" % (i, i2 - 1, nrow, chunk_percent),  # noqa: UP031
-                )
-                i = i2
-                continue
-
         tensor = pa.Tensor.from_numpy(chunk) if isinstance(chunk, np.ndarray) else pa.Tensor.from_numpy(chunk.toarray())
         if matrix.ndim == 2:
             soma_ndarray.write((slice(i, i2 - 1), slice(0, ncol - 1)), tensor)
@@ -2077,20 +1970,6 @@ def _write_matrix_to_denseNDArray(
         i = i2
 
     return
-
-
-def _read_nonempty_domain(arr: SOMAArray) -> Any:  # noqa: ANN401
-    try:
-        return arr.non_empty_domain()
-    except (SOMAError, RuntimeError):
-        # This means that we're open in write-only mode.
-        # Reopen the array in read mode.
-        # TODO macOS throws RuntimeError instead of SOMAError
-        pass
-
-    cls = type(arr)
-    with cls.open(arr.uri, "r", platform_config=None, context=arr.context) as readarr:
-        return readarr.non_empty_domain()
 
 
 def _find_sparse_chunk_size(
@@ -2336,7 +2215,6 @@ def _write_matrix_to_sparseNDArray(
     matrix: Matrix,
     tiledb_create_options: TileDBCreateOptions,
     tiledb_write_options: TileDBWriteOptions,
-    ingestion_params: IngestionParams,
     additional_metadata: AdditionalMetadata,
     axis_0_mapping: AxisIDMapping,
     axis_1_mapping: AxisIDMapping,
@@ -2367,28 +2245,6 @@ def _write_matrix_to_sparseNDArray(
         }
 
         return pa.Table.from_pydict(pydict)
-
-    # There is a chunk-by-chunk already-done check for resume mode, below.
-    # This full-matrix-level check here might seem redundant, but in fact it's important:
-    # * By checking input bounds against storage NED here, we can see if the entire matrix
-    #   was already ingested and avoid even loading chunks;
-    # * By checking chunkwise we can catch the case where a matrix was already *partly*
-    #   ingested.
-    # * Of course, this also helps us catch already-completed writes in the non-chunked case.
-    # TODO: make sure we're not using an old timestamp for this
-    storage_ned = None
-    if ingestion_params.skip_existing_nonempty_domain:
-        # This lets us check for already-ingested chunks, when in resume-ingest mode.
-        # THIS IS A HACK AND ONLY WORKS BECAUSE WE ARE DOING THIS BEFORE ALL WRITES.
-        storage_ned = _read_nonempty_domain(soma_ndarray)
-        matrix_bounds = [(0, int(n - 1)) for n in matrix.shape]  # Cast for lint in case np.int64
-        logging.log_io(
-            None,
-            f"Input bounds {tuple(matrix_bounds)} storage non-empty domain {storage_ned}",
-        )
-        if _chunk_is_contained_in(matrix_bounds, storage_ned):
-            logging.log_io(f"Skipped {soma_ndarray.uri}", f"SKIPPED WRITING {soma_ndarray.uri}")
-            return
 
     add_metadata(soma_ndarray, additional_metadata)
 
@@ -2502,29 +2358,6 @@ def _write_matrix_to_sparseNDArray(
 
         chunk_percent = min(100, 100 * i2 / dim_max_size)
 
-        if ingestion_params.skip_existing_nonempty_domain and storage_ned is not None:
-            chunk_bounds = matrix_bounds
-            chunk_bounds[stride_axis] = (
-                int(i),
-                int(i2 - 1),
-            )  # Cast for lint in case np.int64
-            if _chunk_is_contained_in_axis(chunk_bounds, storage_ned, stride_axis):
-                # Print doubly inclusive lo..hi like 0..17 and 18..31.
-                logging.log_io(
-                    "... %7.3f%% done" % chunk_percent,  # noqa: UP031
-                    "SKIP   chunk rows %d..%d of %d (%.3f%%), nnz=%d, goal=%d"  # noqa: UP031
-                    % (
-                        i,
-                        i2 - 1,
-                        dim_max_size,
-                        chunk_percent,
-                        chunk_coo.nnz,
-                        tiledb_create_options.goal_chunk_nnz,
-                    ),
-                )
-                i = i2
-                continue
-
         # Print doubly inclusive lo..hi like 0..17 and 18..31.
         logging.log_io(
             None,
@@ -2553,55 +2386,6 @@ def _write_matrix_to_sparseNDArray(
             )
 
         i = i2
-
-
-def _chunk_is_contained_in(
-    chunk_bounds: Sequence[tuple[int, int]],
-    storage_nonempty_domain: Sequence[tuple[int | None, int | None]],
-) -> bool:
-    """Determines if a dim range is included within the array's non-empty domain.  Ranges are inclusive
-    on both endpoints.  This is a helper for resume-ingest mode.
-
-    We say "bounds" not "MBR" with the "M" for minimum: a sparse matrix might not _have_ any
-    elements for some initial/final rows or columns. Suppose an input array has shape 100 x 200, so
-    bounds ``((0, 99), (0, 199))`` -- and also suppose there are no matrix elements for column 1.
-    Also suppose the matrix has already been written to TileDB-SOMA storage. The TileDB non-empty
-    domain _is_ tight -- it'd say ``((0, 99), (3, 197))`` for example.  When we come back for a
-    resume-mode ingest, we'd see the input bounds aren't contained within the storage non-empty
-    domain, and erroneously declare that the data need to be rewritten.
-
-    This is why we take the stride axis as an argument. In resume mode, it's our contract with the
-    user that they declare they are retrying the exact same input file -- and we do our best to
-    fulfill their ask by checking the dimension being strided on.
-    """
-    if len(storage_nonempty_domain) == 0:
-        return False
-
-    if len(chunk_bounds) != len(storage_nonempty_domain):
-        raise SOMAError(
-            f"internal error: ingest data ndim {len(chunk_bounds)} != storage ndim {len(storage_nonempty_domain)}",
-        )
-    return all(_chunk_is_contained_in_axis(chunk_bounds, storage_nonempty_domain, i) for i in range(len(chunk_bounds)))
-
-
-def _chunk_is_contained_in_axis(
-    chunk_bounds: Sequence[tuple[int, int]],
-    storage_nonempty_domain: Sequence[tuple[int | None, int | None]],
-    stride_axis: int,
-) -> bool:
-    """Helper function for ``_chunk_is_contained_in``."""
-    if len(storage_nonempty_domain) == 0:
-        return False
-
-    storage_lo, storage_hi = storage_nonempty_domain[stride_axis]
-    if storage_lo is None or storage_hi is None:
-        # E.g. an array has had its schema created but no data written yet
-        return False
-
-    chunk_lo, chunk_hi = chunk_bounds[stride_axis]
-    if chunk_lo < storage_lo or chunk_lo > storage_hi:
-        return False
-    return not (chunk_hi < storage_lo or chunk_hi > storage_hi)
 
 
 def _maybe_ingest_uns(
@@ -2922,7 +2706,7 @@ def _ingest_uns_ndarray(
     context: SOMAContext | None,
     *,
     use_relative_uri: bool | None,
-    ingestion_params: IngestionParams,
+    ingestion_params: IngestionParams,  # noqa: ARG001
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
     data_protocol = coll.context.data_protocol(coll.uri)
@@ -2950,18 +2734,6 @@ def _ingest_uns_ndarray(
     except AlreadyExistsError:
         soma_arr = DenseNDArray.open(arr_uri, "w", context=context)
 
-    # If resume mode: don't re-write existing data. This is the user's explicit request
-    # that we not re-write things that have already been written.
-    if ingestion_params.skip_existing_nonempty_domain:
-        storage_ned = _read_nonempty_domain(soma_arr)
-        dim_range = ((0, value.shape[0] - 1),)
-        if _chunk_is_contained_in(dim_range, storage_ned):
-            logging.log_io(
-                f"Skipped {soma_arr.uri}",
-                f"Skipped {soma_arr.uri}",
-            )
-            return
-
     with soma_arr:
         _maybe_set(coll, key, soma_arr, use_relative_uri=use_relative_uri)
 
@@ -2970,7 +2742,6 @@ def _ingest_uns_ndarray(
             value,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=additional_metadata,
         )
 
@@ -2992,18 +2763,3 @@ def _concurrency_level(context: SOMAContext) -> int:
             int(context.config.get("soma.compute_concurrency_level", concurrency_level)),
         )
     return concurrency_level
-
-
-@deprecated(
-    """The 'resume' ingest_mode is deprecated and will be removed in a future version. The current implementation has a known issue that can can cause multi-dataset appends to not resume correctly.
-
-The recommended and safest approach for recovering from a failed ingestion is to delete the partially written SOMA Experiment and restart the ingestion process from the original input files or a known-good backup.""",
-    stacklevel=3,
-)
-def _resume_mode_is_deprecated() -> None:
-    pass
-
-
-def _check_for_deprecated_modes(ingest_mode: str) -> None:
-    if ingest_mode == "resume":
-        _resume_mode_is_deprecated()

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -2560,7 +2560,9 @@ def _ingest_uns_array(
             key,
             value,
             use_relative_uri=use_relative_uri,
-            **ingest_platform_ctx,
+            context=ingest_platform_ctx["context"],
+            additional_metadata=ingest_platform_ctx["additional_metadata"],
+            platform_config=ingest_platform_ctx["platform_config"],
         )
 
 
@@ -2706,7 +2708,6 @@ def _ingest_uns_ndarray(
     context: SOMAContext | None,
     *,
     use_relative_uri: bool | None,
-    ingestion_params: IngestionParams,  # noqa: ARG001
     additional_metadata: AdditionalMetadata = None,
 ) -> None:
     data_protocol = coll.context.data_protocol(coll.uri)

--- a/apis/python/src/tiledbsoma/io/spatial/ingest.py
+++ b/apis/python/src/tiledbsoma/io/spatial/ingest.py
@@ -285,9 +285,6 @@ def from_visium(
             Otherwise, it is ingested into channel-last format. Defaults to ``True``.
         ingest_mode: The ingestion type to perform:
             - ``write``: Writes all data, creating new layers if the SOMA already exists.
-            - ``resume``: Adds data to an existing SOMA, skipping writing data
-              that was previously written. Useful for continuing after a partial
-              or interrupted ingestion operation.
             - ``schema_only``: Creates groups and the array schema, without
               writing any data to the array. Useful to prepare for appending
               multiple H5AD files to a single SOMA.
@@ -717,7 +714,6 @@ def _write_X_layer(
             matrix,
             tiledb_create_options=TileDBCreateOptions.from_platform_config(platform_config),
             tiledb_write_options=TileDBWriteOptions.from_platform_config(platform_config),
-            ingestion_params=ingestion_params,
             additional_metadata=additional_metadata,
         )
     elif isinstance(soma_ndarray, SparseNDArray):  # SOMASparseNDArray

--- a/apis/python/tests/test_basic_anndata_io.py
+++ b/apis/python/tests/test_basic_anndata_io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import gc
 import json
 import random
@@ -90,12 +89,6 @@ def h5ad_file_X_none(request):
         ["write"],
         # Schema only:
         ["schema_only"],
-        # Schema only, then populate:
-        ["schema_only", "resume"],
-        # User writes data, then a subsequent write creates nothing new:
-        ["write", "resume"],
-        # "Resume" after no write at all does write new data:
-        ["resume"],
     ],
 )
 @pytest.mark.parametrize(
@@ -117,14 +110,13 @@ def test_import_anndata(conftest_pbmc_small, ingest_modes, X_kind, tmp_path):
     all2d = (slice(None), slice(None))  # keystroke-saver
 
     for ingest_mode in ingest_modes:
-        with pytest.deprecated_call() if ingest_mode == "resume" else contextlib.nullcontext():
-            uri = tiledbsoma.io.from_anndata(
-                output_path,
-                orig,
-                "RNA",
-                ingest_mode=ingest_mode,
-                X_kind=X_kind,
-            )
+        uri = tiledbsoma.io.from_anndata(
+            output_path,
+            orig,
+            "RNA",
+            ingest_mode=ingest_mode,
+            X_kind=X_kind,
+        )
         if ingest_mode != "schema_only":
             have_ingested = True
 
@@ -261,59 +253,6 @@ def test_named_X_layers(conftest_pbmc_small_h5ad_path, X_layer_name, tmp_path):
         else:
             assert X_layer_name in exp.ms["RNA"].X
             assert X_layer_name in exp.ms["raw"].X
-
-
-def _get_fragment_count(array_uri):
-    fragment_uri = Path(array_uri) / "__fragments"
-    return len(list(fragment_uri.iterdir())) if fragment_uri.exists() else 0
-
-
-@pytest.mark.parametrize(
-    "resume_mode_h5ad_file",
-    [
-        TESTDATA / "pbmc-small-x-dense.h5ad",
-        TESTDATA / "pbmc-small-x-csr.h5ad",
-        TESTDATA / "pbmc-small-x-csc.h5ad",
-    ],
-)
-def test_resume_mode(resume_mode_h5ad_file, tmp_path):
-    """
-    Makes sure resume-mode ingest after successful ingest of the same input data does not write
-    anything new
-    """
-    if not TESTDATA.exists():
-        raise RuntimeError(f"Missing directory '{TESTDATA}'. Try re-running `make data` from the project root.")
-
-    output_path1 = (tmp_path / "test_resume_mode_1_").as_posix()
-    tiledbsoma.io.from_h5ad(output_path1, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write")
-
-    output_path2 = (tmp_path / "test_resume_mode_2_").as_posix()
-    tiledbsoma.io.from_h5ad(output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="write")
-    with pytest.deprecated_call():
-        tiledbsoma.io.from_h5ad(output_path2, resume_mode_h5ad_file.as_posix(), "RNA", ingest_mode="resume")
-
-    exp1 = _factory.open(output_path1)
-    exp2 = _factory.open(output_path2)
-    with exp1, exp2:
-        assert _get_fragment_count(exp1.obs.uri) == _get_fragment_count(exp2.obs.uri)
-        assert _get_fragment_count(exp1.ms["RNA"].var.uri) == _get_fragment_count(exp2.ms["RNA"].var.uri)
-        assert _get_fragment_count(exp1.ms["RNA"].X["data"].uri) == _get_fragment_count(exp2.ms["RNA"].X["data"].uri)
-
-        meas1 = exp1.ms["RNA"]
-        meas2 = exp2.ms["RNA"]
-
-        if "obsm" in meas1:
-            for key in meas1.obsm:
-                assert _get_fragment_count(meas1.obsm[key].uri) == _get_fragment_count(meas2.obsm[key].uri)
-        if "varm" in meas1:
-            for key in meas1.varm:
-                assert _get_fragment_count(meas1.obsm[key].uri) == _get_fragment_count(meas2.obsm[key].uri)
-        if "obsp" in meas1:
-            for key in meas1.obsp:
-                assert _get_fragment_count(meas1.obsp[key].uri) == _get_fragment_count(meas2.obsp[key].uri)
-        if "varp" in meas1:
-            for key in meas1.varp:
-                assert _get_fragment_count(meas1.varm[key].uri) == _get_fragment_count(meas2.varm[key].uri)
 
 
 @pytest.mark.parametrize("use_relative_uri", [False, True, None])

--- a/apis/python/tests/test_collection.py
+++ b/apis/python/tests/test_collection.py
@@ -200,7 +200,7 @@ def test_delete_add_write_mode(soma_object, tmp_path: pathlib.Path):
         create["porkchop sandwiches"] = soma_object
 
     with soma.open(tmp_uri, "w", soma_type=soma.Collection) as update:
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(soma.SOMAError):
             del update["porkchop sandwiches"]
         # TEMPORARY: This should no longer raise once TileDB supports replacing
         # an existing group member.

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,11 +12,14 @@
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
 - Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
 
+## Defunct
+
+- The `SOMATileDBContext` class is defunct and calling its constructor now raises an error. Use the `SOMAContext` class instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
+- The `soma_context()` function is defunct and now raises an error when called. Use the `SOMAContext` class instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
+- The `tiledbsoma_ctx` parameter is defunct across all functions and methods, and passing it now raises an error. Use the `context` parameter instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
+
 ## Removed
 
-- Defunct `SOMATileDBContext` class. Use `SOMAContext` instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
-- Defunct `soma_context()` function. Use the `SOMAContext` class instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
-- Defunct `tiledbsoma_ctx` parameter in all functions and methods. Use the `context` parameter instead. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
 - Remove `SOMANDArrayBase$set_data_type()`, deprecated since 2.1.0. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
 - Remove deprecated support for removing collection-based class members in "WRITE" mode. Collections must now be in "DELETE" mode to remove members. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))
 - Remove deprecated support using `domain=NULL` in `SOMADataFrameCreate`. ([#4431](https://github.com/single-cell-data/TileDB-SOMA/pull/4431))


### PR DESCRIPTION
**Changes:**

* Add a defunct section to R NEWS. We have a deprecate, defunct, and remove stage in our deprecation policy. Adding an explicit defunct header to the news helps make it more clear what the current state is.
* Remove resume ingest mode (deprecated in 1.18.0).
* Remove straggling delete-in-write-mode warning.
