### PR TITLE
[python] Document current update obs/var limitation

### DIFF
--- a/apis/python/src/tiledbsoma/_experiment.py
+++ b/apis/python/src/tiledbsoma/_experiment.py
@@ -169,6 +169,13 @@ class Experiment(CollectionBase[SOMAObject]):
 
         Note: Deleting observations does not change the size of the current domain or possible enumeration values.
 
+        .. warning::
+
+            After deleting observations, :func:`~tiledbsoma.io.update_obs` cannot
+            cannot be used to update the remaining ``obs`` data. Deletion creates gaps in
+            ``soma_joinid`` values that ``update_obs`` does not currently handle.
+            Use :meth:`DataFrame.write` directly as a workaround.
+
         Args:
             coords:
                 A per-dimension ``Sequence`` of scalar, slice, sequence of scalar or
@@ -232,6 +239,13 @@ class Experiment(CollectionBase[SOMAObject]):
             ...     exp.var_axis_delete(value_filter="feature_biotype == 'gene'")
 
         Note: Deleting variables does not change the size of the current domain or possible enumeration values.
+
+        .. warning::
+
+            After deleting variables, :func:`~tiledbsoma.io.update_var` cannot
+            be used to update the remaining ``var`` data. Deletion creates gaps in
+            ``soma_joinid`` values that ``update_var`` does not currently handle.
+            Use :meth:`DataFrame.write` directly as a workaround.
 
         Args:
             coords:

--- a/apis/python/src/tiledbsoma/io/ingest.py
+++ b/apis/python/src/tiledbsoma/io/ingest.py
@@ -1412,6 +1412,13 @@ def update_obs(
         2. Modify values / add or drop columns while preserving row order.
         3. Pass the modified DataFrame as ``new_data``.
 
+    .. warning::
+
+        Currently this function does not work on Experiments that have had
+        observations deleted via :func:`obs_axis_delete`. Deletion creates gaps
+        in ``soma_joinid`` values, which causes an internal validation check to
+        fail. As a workaround, use :meth:`DataFrame.write` directly.
+
     Args:
         exp: :class:`Experiment` opened for write.
         new_data: A :class:`pandas.DataFrame` containing the final desired data for the existing ``obs`` DataFrame.
@@ -1449,6 +1456,13 @@ def update_var(
     """Replace the entire ``var`` DataFrame with the contents of a new :class:`pandas.DataFrame`.
 
     Analogous to ``update_obs``, but replaces the ``var`` DataFrame within a specific :class:`Measurement`. See :func:`update_obs` for details.
+
+    .. warning::
+
+        This function does not work on Experiments that have had variables
+        deleted via :func:`var_axis_delete`. Deletion creates gaps in
+        ``soma_joinid`` values, which causes an internal validation check to
+        fail. As a workaround, use :meth:`DataFrame.write` directly.
 
     Args:
         exp: :class:`Experiment` opened for write.


### PR DESCRIPTION
**Issue and/or context:** [SOMA-949]

**Changes:** Document that deletion creates gaps in `soma_joinid` values, which currently blocks updates via `update_obs` and `update_var` methods. 

**Notes for Reviewer:** Fixes for these limitations are in progress.
