### PR TITLE
[r] Write ragged arrays relatively

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -55,6 +55,7 @@ LinkingTo:
     Rcpp,
     RcppInt64
 Suggests:
+    aws.s3,
     BPCells,
     datasets,
     iterators,

--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -55,7 +55,6 @@ LinkingTo:
     Rcpp,
     RcppInt64
 Suggests:
-    aws.s3,
     BPCells,
     datasets,
     iterators,

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -11,6 +11,7 @@
 - `SOMACollectionOpen()` now enforces strict type checking and will error if the URI points to a `SOMAExperiment`, `SOMAMeasurement`, or other collection subtype. Users should use the appropriate type-specific function (`SOMAExperimentOpen()`, `SOMAMeasurementOpen()`) or `SOMAOpen()`, which automatically resolves the correct subclass. ([#4443](https://github.com/single-cell-data/TileDB-SOMA/pull/4443))
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
 - Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
+- `SOMACollection$add_new_sparse_ndarray()` always adds relatively ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
 
 ## Defunct
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -13,6 +13,7 @@
 - Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
 - `SOMACollection$add_new_sparse_ndarray()` always adds relatively ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
 - `write_soma()` for `Seurat`, `SingleCellExperiment`, and `SummarizedExperiment` objects no longer allow passing arguments through the dots `...` ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
+- `write_soma()` for `Assay`, `Assay5`, `DimReduc`, `Graph`, and `SeuratCommand` objects pass `relative` through to other write calls ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
 
 ## Defunct
 

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -12,6 +12,7 @@
 - `ManagedQuery` reuses the same buffers for each incomplete read and allocates dedicated buffers when converting to Arrow. ([#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299))
 - Default log level changed from `info` to `warn` to reduce verbosity. Use `set_log_level("info")` or the `SPDLOG_LEVEL` environment variable to restore verbose logging. ([#4393](https://github.com/single-cell-data/TileDB-SOMA/pull/4393))
 - `SOMACollection$add_new_sparse_ndarray()` always adds relatively ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
+- `write_soma()` for `Seurat`, `SingleCellExperiment`, and `SummarizedExperiment` objects no longer allow passing arguments through the dots `...` ([#4450](https://github.com/single-cell-data/TileDB-SOMA/pull/4450))
 
 ## Defunct
 

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -381,6 +381,7 @@ SOMACollectionBase <- R6::R6Class(
     #' type of each element in the array.
     #' @param shape a vector of integers defining the shape of the array.
     #' @template param-platform-config
+    #' @param relative Add the sparse array relative to the collection
     #'
     #' @return Returns the newly-created array stored at \code{key}.
     #'
@@ -388,7 +389,8 @@ SOMACollectionBase <- R6::R6Class(
       key,
       type,
       shape,
-      platform_config = NULL
+      platform_config = NULL,
+      relative = TRUE
     ) {
       if (key %in% self$names()) {
         stop(sprintf("Member '%s' already exists", key), call. = FALSE)
@@ -402,7 +404,7 @@ SOMACollectionBase <- R6::R6Class(
         context = self$context,
         tiledb_timestamp = self$tiledb_timestamp # Cached value from $new()/SOMACollectionOpen
       )
-      private$.set_element(ndarr, key)
+      private$.set_element(ndarr, key, relative = relative)
       return(ndarr)
     },
 
@@ -499,7 +501,7 @@ SOMACollectionBase <- R6::R6Class(
     #
     # @return Invisibly returns self
     #
-    .set_element = function(object, name) {
+    .set_element = function(object, name, relative) {
       if (self$context$is_tiledbv3(self$uri)) {
         # Carrara requires member name to match URI basename
         if (basename(object$uri) != name) {
@@ -519,7 +521,7 @@ SOMACollectionBase <- R6::R6Class(
         private$.add_cache_member(name, object)
       } else {
         # v2: register with TileDB group
-        self$set(object, name, relative = TRUE)
+        self$set(object, name, relative = relative)
       }
       return(invisible(self))
     },

--- a/apis/r/R/SOMACollectionBase.R
+++ b/apis/r/R/SOMACollectionBase.R
@@ -519,7 +519,7 @@ SOMACollectionBase <- R6::R6Class(
         private$.add_cache_member(name, object)
       } else {
         # v2: register with TileDB group
-        self$set(object, name)
+        self$set(object, name, relative = TRUE)
       }
       return(invisible(self))
     },

--- a/apis/r/R/utils-seurat.R
+++ b/apis/r/R/utils-seurat.R
@@ -259,7 +259,7 @@
           expr = {
             arr <- write_soma(
               x = ldat,
-              uri = layer,
+              uri = if (relative) layer else file_path(X$uri, layer),
               soma_parent = X,
               sparse = TRUE,
               transpose = TRUE,
@@ -267,7 +267,8 @@
               shape = shape,
               key = layer,
               platform_config = platform_config,
-              context = context
+              context = context,
+              relative = relative
             )
             arr$set_metadata(type)
           },
@@ -297,7 +298,8 @@
       arr <- X$add_new_sparse_ndarray(
         key = layer,
         type = atype,
-        shape = as.integer(shape)
+        shape = as.integer(shape),
+        relative = relative
       )
       arr$.write_coordinates(coo)
       arr$set_metadata(.ragged_array_hint())
@@ -341,7 +343,7 @@
       tryCatch(
         expr = write_soma(
           x = mat,
-          uri = layer,
+          uri = if (relative) layer else file_path(X$uri, layer),
           soma_parent = X,
           sparse = TRUE,
           transpose = TRUE,
@@ -349,7 +351,8 @@
           shape = shape,
           key = layer,
           platform_config = platform_config,
-          context = context
+          context = context,
+          relative = relative
         ),
         error = function(err) {
           if (slot == 'data') {
@@ -372,12 +375,13 @@
   soma_info("Adding feature-level metadata")
   write_soma(
     x = var_df,
-    uri = 'var',
+    uri = if (relative) "var" else file_path(ms$uri, "var"),
     soma_parent = ms,
     key = 'var',
     ingest_mode = ingest_mode,
     platform_config = platform_config,
-    context = context
+    context = context,
+    relative = relative
   )
 
   # Check for any potentially-missed data

--- a/apis/r/R/utils-uris.R
+++ b/apis/r/R/utils-uris.R
@@ -42,9 +42,8 @@ uri_scheme_remove <- function(uri) {
 #'
 make_uri_relative <- function(uri, relative_to) {
   stopifnot(
-    "'uri' and 'relative_to' must be scalar character vectors" = is_scalar_character(
-      uri
-    ) &&
+    "'uri' and 'relative_to' must be scalar character vectors" =
+      is_scalar_character(uri) &&
       is_scalar_character(relative_to)
   )
 

--- a/apis/r/R/write_bioc.R
+++ b/apis/r/R/write_bioc.R
@@ -104,8 +104,10 @@ write_soma.Hits <- function(
 #'
 #' @inheritParams write_soma
 #' @inheritParams write_soma_objects
+#' @param x A \code{\link[SingleCellExperiment]{SingleCellExperiment}} object
 #' @param ms_name Name for resulting measurement; defaults to
 #' \code{\link[SingleCellExperiment]{mainExpName}(x)}.
+#' @template param-dots-reserved
 #'
 #' @inherit write_soma.SummarizedExperiment return sections
 #'
@@ -167,7 +169,15 @@ write_soma.SingleCellExperiment <- function(
 ) {
   check_package("SingleCellExperiment", version = .MINIMUM_SCE_VERSION())
   ingest_mode <- match.arg(arg = ingest_mode, choices = c("write", "resume"))
-  if ("shape" %in% names(args <- rlang::dots_list(...))) {
+  args <- rlang::dots_list(...)
+  if (length(args) && (length(args) > 1L || names(args) != "shape")) {
+    stop(
+      "The dots '...' must be empty when calling `write_soma() on a '",
+      class(x)[1L], "' object",
+      call. = FALSE
+    )
+  }
+  if ("shape" %in% names(args)) {
     shape <- args$shape
     stopifnot(
       "'shape' must be a vector of two postiive integers" = is.null(shape) ||
@@ -178,9 +188,8 @@ write_soma.SingleCellExperiment <- function(
   }
   ms_name <- ms_name %||% SingleCellExperiment::mainExpName(x)
 
-  uri <- NextMethod(
-    "write_soma",
-    x,
+  uri <- write_soma(
+    methods::as(x, "SummarizedExperiment"),
     uri = uri,
     ms_name = ms_name,
     ...,
@@ -188,6 +197,7 @@ write_soma.SingleCellExperiment <- function(
     platform_config = platform_config,
     context = context
   )
+
   experiment <- SOMAExperimentOpen(
     uri = uri,
     mode = "WRITE",
@@ -320,7 +330,9 @@ write_soma.SingleCellExperiment <- function(
 #'
 #' @inheritParams write_soma
 #' @inheritParams write_soma_objects
+#' @param x A \code{\link[SummarizedExperiment]{SummarizedExperiment}} object.
 #' @param ms_name Name for resulting measurement.
+#' @template param-dots-reserved
 #'
 #' @inherit write_soma return
 #'
@@ -389,7 +401,15 @@ write_soma.SummarizedExperiment <- function(
       !is.na(ms_name)
   )
   ingest_mode <- match.arg(arg = ingest_mode, choices = c("write", "resume"))
-  if ("shape" %in% names(args <- rlang::dots_list(...))) {
+  args <- rlang::dots_list(...)
+  if (length(args) && (length(args) > 1L || names(args) != "shape")) {
+    stop(
+      "The dots '...' must be empty when calling `write_soma() on a '",
+      class(x)[1L], "' object",
+      call. = FALSE
+    )
+  }
+  if ("shape" %in% names(args)) {
     shape <- args$shape
     stopifnot(
       "'shape' must be a vector of two postiive integers" = is.null(shape) ||

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -292,7 +292,7 @@ write_soma.DimReduc <- function(
   # Always write reductions as sparse arrays
   write_soma(
     x = SeuratObject::Embeddings(x),
-    uri = embed,
+    uri = if (relative) embed else file_path(obsm$uri, embed),
     soma_parent = obsm,
     sparse = TRUE,
     transpose = FALSE,
@@ -300,7 +300,8 @@ write_soma.DimReduc <- function(
     ingest_mode = ingest_mode,
     shape = demb,
     platform_config = platform_config,
-    context = context
+    context = context,
+    relative = relative
   )
 
   # Add feature loadings
@@ -379,7 +380,7 @@ write_soma.DimReduc <- function(
     # Always write reductions as sparse arrays
     write_soma(
       x = mat,
-      uri = ldgs,
+      uri = if (relative) ldgs else file_path(varm$uri, ldgs),
       soma_parent = varm,
       sparse = TRUE,
       transpose = FALSE,
@@ -387,7 +388,8 @@ write_soma.DimReduc <- function(
       ingest_mode = ingest_mode,
       shape = dload,
       platform_config = platform_config,
-      context = context
+      context = context,
+      relative = relative
     )
   }
 
@@ -476,7 +478,8 @@ write_soma.Graph <- function(
     ingest_mode = ingest_mode,
     shape = shape,
     platform_config = platform_config,
-    context = context
+    context = context,
+    relative = relative
   )
 
   return(invisible(soma_parent))
@@ -819,11 +822,10 @@ write_soma.SeuratCommand <- function(
   )
 
   key <- "seurat_commands"
-  uri <- uri %||% methods::slot(x, name = "name")
 
   # Create a group for command logs
   logs_uri <- .check_soma_uri(
-    key,
+    file_path(soma_parent$uri, key),
     soma_parent = soma_parent,
     relative = relative
   )
@@ -835,7 +837,7 @@ write_soma.SeuratCommand <- function(
       platform_config = platform_config,
       context = context
     )
-    soma_parent$add_new_collection(logs, key)
+    # soma_parent$add_new_collection(logs, key)
     logs
   } else {
     logs <- soma_parent$get(key)
@@ -858,6 +860,10 @@ write_soma.SeuratCommand <- function(
     logs
   }
   on.exit(logs$close(), add = TRUE, after = FALSE)
+  withCallingHandlers(
+    .register_soma_object(logs, soma_parent, key = key, relative = relative),
+    existingKeyWarning = .maybe_muffle
+  )
 
   # Encode parameters
   soma_info("Encoding parameters in the command log")
@@ -892,6 +898,11 @@ write_soma.SeuratCommand <- function(
   enc <- as.character(jsonlite::toJSON(xlist, null = "null", auto_unbox = TRUE))
 
   # Write out and return
+  uri <- uri %||% if (relative) {
+    methods::slot(x, name = "name")
+  } else {
+    file_path(logs$uri, methods::slot(x, name = "name"))
+  }
   sdf <- write_soma(
     x = enc,
     uri = uri,

--- a/apis/r/R/write_seurat.R
+++ b/apis/r/R/write_seurat.R
@@ -487,6 +487,7 @@ write_soma.Graph <- function(
 #' @inheritParams write_soma
 #' @inheritParams write_soma_objects
 #' @param x A \code{\link[SeuratObject]{Seurat}} object.
+#' @template param-dots-reserved
 #'
 #' @inherit write_soma return
 #'
@@ -546,7 +547,15 @@ write_soma.Seurat <- function(
       (is_scalar_character(uri) && nzchar(uri))
   )
   ingest_mode <- match.arg(arg = ingest_mode, choices = c("write", "resume"))
-  if ("shape" %in% names(args <- rlang::dots_list(...))) {
+  args <- rlang::dots_list(...)
+  if (length(args) && (length(args) > 1L || names(args) != "shape")) {
+    stop(
+      "The dots '...' must be empty when calling `write_soma() on a '",
+      class(x)[1L], "' object",
+      call. = FALSE
+    )
+  }
+  if ("shape" %in% names(args)) {
     shape <- args$shape
     stopifnot(
       "'shape' must be a vector of two postiive integers" = is.null(shape) ||

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -184,7 +184,7 @@ write_soma.data.frame <- function(
 ) {
   stopifnot(
     "'x' must be named" = is_named(x, allow_empty = FALSE),
-    "'x' must have at lease one row and one column" = dim(x) > 0L,
+    "'x' must have at least one row and one column" = dim(x) > 0L,
     "'df_index' must be a single character value" = is.null(df_index) ||
       (is_scalar_character(df_index) && nzchar(df_index)),
     "'index_column_names' must be a character vector" = is.character(
@@ -791,6 +791,7 @@ write_soma.TsparseMatrix <- function(
     "'axis' must be a single character value" = is_scalar_character(axis),
     "'prefix' must be a single character value" = is_scalar_character(prefix)
   )
+  x <- as.data.frame(x)
   axis <- match.arg(axis, choices = c("obs", "var", "index"))
   default <- switch(EXPR = axis, index = "index", paste0(axis, "_id"))
   index <- ""

--- a/apis/r/man/SOMACollectionBase.Rd
+++ b/apis/r/man/SOMACollectionBase.Rd
@@ -372,7 +372,8 @@ Add a new SOMA SparseNdArray to this collection
   key,
   type,
   shape,
-  platform_config = NULL
+  platform_config = NULL,
+  relative = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -394,6 +395,8 @@ object}
 
 \item{\code{platform_config}}{A \link[tiledbsoma:PlatformConfig]{platform configuration}
 object}
+
+\item{\code{relative}}{Add the sparse array relative to the collection}
 }
 \if{html}{\out{</div>}}
 }

--- a/apis/r/man/roxygen/templates/param-dots-reserved.R
+++ b/apis/r/man/roxygen/templates/param-dots-reserved.R
@@ -1,0 +1,1 @@
+#' @param ... Reserved for future use.

--- a/apis/r/man/write_soma.Seurat.Rd
+++ b/apis/r/man/write_soma.Seurat.Rd
@@ -19,7 +19,7 @@
 
 \item{uri}{URI for resulting SOMA object.}
 
-\item{...}{Arguments passed to other methods}
+\item{...}{Reserved for future use.}
 
 \item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
 \itemize{

--- a/apis/r/man/write_soma.SingleCellExperiment.Rd
+++ b/apis/r/man/write_soma.SingleCellExperiment.Rd
@@ -17,14 +17,14 @@ object to a SOMA}
 )
 }
 \arguments{
-\item{x}{An object.}
+\item{x}{A \code{\link[SingleCellExperiment]{SingleCellExperiment}} object}
 
 \item{uri}{URI for resulting SOMA object.}
 
 \item{ms_name}{Name for resulting measurement; defaults to
 \code{\link[SingleCellExperiment]{mainExpName}(x)}.}
 
-\item{...}{Arguments passed to other methods}
+\item{...}{Reserved for future use.}
 
 \item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
 \itemize{

--- a/apis/r/man/write_soma.SummarizedExperiment.Rd
+++ b/apis/r/man/write_soma.SummarizedExperiment.Rd
@@ -17,13 +17,13 @@ object to a SOMA}
 )
 }
 \arguments{
-\item{x}{An object.}
+\item{x}{A \code{\link[SummarizedExperiment]{SummarizedExperiment}} object.}
 
 \item{uri}{URI for resulting SOMA object.}
 
 \item{ms_name}{Name for resulting measurement.}
 
-\item{...}{Arguments passed to other methods}
+\item{...}{Reserved for future use.}
 
 \item{ingest_mode}{Ingestion mode when creating the SOMA; choose from:
 \itemize{

--- a/apis/r/tests/testthat/helper-remote.R
+++ b/apis/r/tests/testthat/helper-remote.R
@@ -1,4 +1,12 @@
-# Shared Remote Test Utilities ------------------------------------------
+# Shared Remote Test Utilities
+
+s3_tests <- function() {
+  envvars <- c("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_BUCKET")
+  return(
+    requireNamespace("aws.s3", quietly = TRUE) &&
+      all(nzchar(Sys.getenv(envvars)))
+  )
+}
 
 # Generate a unique ID for test assets
 generate_unique_id <- function(pattern = "") {

--- a/apis/r/tests/testthat/helper-remote.R
+++ b/apis/r/tests/testthat/helper-remote.R
@@ -1,13 +1,5 @@
 # Shared Remote Test Utilities
 
-s3_tests <- function() {
-  envvars <- c("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_BUCKET")
-  return(
-    requireNamespace("aws.s3", quietly = TRUE) &&
-      all(nzchar(Sys.getenv(envvars)))
-  )
-}
-
 # Generate a unique ID for test assets
 generate_unique_id <- function(pattern = "") {
   basename(tempfile(pattern = pattern))

--- a/apis/r/tests/testthat/helper-test-soma-objects.R
+++ b/apis/r/tests/testthat/helper-test-soma-objects.R
@@ -1,3 +1,17 @@
+
+collection_members <- function(collection) {
+  if (!inherits(collection, "SOMACollectionBase")) {
+    stop("'collection' must be a SOMACollection")
+  }
+  return(vapply(
+    X = collection$members,
+    FUN = `[[`,
+    FUN.VALUE = character(length = 1L),
+    "name",
+    USE.NAMES = FALSE
+  ))
+}
+
 # Returns the object created, populated, and closed (unless otherwise requested)
 create_and_populate_soma_dataframe <- function(
   uri,

--- a/apis/r/tests/testthat/test-14-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-14-SeuratIngest.R
@@ -589,6 +589,22 @@ test_that("Write Seurat with BPCells layers", {
   }
 })
 
+test_that("Write Seurat relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
+
+  pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
+  uri <- tempfile(pattern = SeuratObject::Project(pbmc_small))
+
+  for (i in c(TRUE, FALSE)) {
+    expect_error(
+      write_soma(pbmc_small, uri, relative = i),
+      regexp = "^The dots '\\.\\.\\.' must be empty when",
+      label = sprintf("write_soma.Seurat(relative = %s)", i)
+    )
+  }
+})
+
 test_that("Ragged array relative URIs (SOMA-906)", {
   skip_if(!extended_tests())
   skip_if_not_installed("tiledb", minimum_version = "0.34.0")

--- a/apis/r/tests/testthat/test-14-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-14-SeuratIngest.R
@@ -589,18 +589,12 @@ test_that("Write Seurat with BPCells layers", {
   }
 })
 
-test_that("Ragged array uploads to S3 (SOMA-906)", {
-  skip_if_not(
-    s3_tests(),
-    message = paste(
-      "Not running S3 tests; to run, please ensure {aws.s3} is installed and",
-      "the 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', and 'AWS_S3_BUCKET'",
-      "environment variables are set"
-    )
-  )
+test_that("Ragged array relative URIs (SOMA-906)", {
   skip_if(!extended_tests())
-  skip_if_not_installed("withr")
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
   skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
+  op <- options(Seurat.object.assay.calcn = FALSE)
+  on.exit(options(op), add = TRUE, after = FALSE)
   withr::local_options(Seurat.object.assay.calcn = FALSE)
 
   # Create and write a ragged `Seurat` object
@@ -621,50 +615,13 @@ test_that("Ragged array uploads to S3 (SOMA-906)", {
   )
   expect_no_condition(uri <- write_soma(obj, uri = tempfile("ragged-s3-")))
 
-  # Upload to S3
-  object_base <- basename(uri)
-  if (!suppressMessages(aws.s3::bucket_exists(Sys.getenv("AWS_S3_BUCKET")))) {
-    skip_if_not(
-      aws.s3::put_bucket(
-        Sys.getenv("AWS_S3_BUCKET"),
-        region = Sys.getenv("AWS_DEFAULT_REGION", unset = "us-east-1")
-      ),
-      message = "Failed to create S3 bucket for"
-    )
-    withr::defer(aws.s3::delete_bucket(Sys.getenv("AWS_S3_BUCKET")))
-  }
-  withr::defer({
-    contents <- aws.s3::get_bucket_df(
-      Sys.getenv("AWS_S3_BUCKET"),
-      prefix = object_base
-    )
-    aws.s3::delete_object(contents$Key, bucket = Sys.getenv("AWS_S3_BUCKET"))
-  })
-  for (f in list.files(uri, full.names = TRUE, recursive = TRUE)) {
-    skip_if_not(
-      aws.s3::put_object(
-        object = sub(
-          pattern = sprintf("^%s", uri),
-          replacement = object_base,
-          x = f
-        ),
-        bucket = Sys.getenv("AWS_S3_BUCKET"),
-        file = f
-      ),
-      message = sprintf(fmt = "Failed to upload '%s' to S3", f)
-    )
-  }
-
-  # Ensure that the members are all relative
-  s3_uri <- sprintf("s3://%s/%s", Sys.getenv("AWS_S3_BUCKET"), object_base)
-  expect_s3_class(exp <- SOMAExperimentOpen(s3_uri), "SOMAExperiment")
-  withr::defer(exp$close())
-  expect_type(members <- exp$ms$get("RNA")$X$members, "list")
-  expect_length(members, n = length(layers))
-  for (i in seq_along(members)) {
-    expect_true(
-      startsWith(members[[i]]$uri, sprintf("%s/", s3_uri)),
-      info = members[[i]]$name
-    )
+  # Check that the ragged arrays are relative to their group
+  expect_s3_class(exp <- SOMAExperimentOpen(uri), "SOMAExperiment")
+  on.exit(exp$close(), add = TRUE, after = FALSE)
+  group_uri <- exp$ms$get("RNA")$X$uri
+  grp <- tiledb::tiledb_group(group_uri, "READ")
+  on.exit(tiledb::tiledb_group_close(grp), add = TRUE, after = FALSE)
+  for (nm in names(layers)) {
+    expect_true(tiledb::tiledb_group_is_relative(grp, nm), info = nm)
   }
 })

--- a/apis/r/tests/testthat/test-14-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-14-SeuratIngest.R
@@ -154,6 +154,57 @@ test_that("Write Assay mechanics", {
   gc()
 })
 
+test_that("Write Assays relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  rna <- get_data("pbmc_small", package = "SeuratObject")[["RNA"]]
+  collection <- SOMACollectionCreate(tempfile("write-assay-relative-"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  # `relative = TRUE`
+  expect_s3_class(
+    ms <- write_soma(rna, soma_parent = collection, relative = TRUE),
+    "SOMAMeasurement"
+  )
+  on.exit(ms$close(), add = TRUE, after = FALSE)
+  ms$reopen("READ")
+  grp <- tiledb::tiledb_group(ms$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms)) {
+    expect_true(tiledb::tiledb_group_is_relative(grp, name = nm), info = nm)
+  }
+  x_grp <- tiledb::tiledb_group(ms$X$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(x_grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms$X)) {
+    expect_true(tiledb::tiledb_group_is_relative(x_grp, name = nm), info = nm)
+  }
+
+  # `relative = FALSE`
+  expect_s3_class(
+    ms_abs <- write_soma(
+      rna,
+      uri = tempfile("write-assay-absolute-"),
+      soma_parent = collection,
+      relative = FALSE
+    ),
+    "SOMAMeasurement"
+  )
+  on.exit(ms_abs$close(), add = TRUE, after = FALSE)
+  ms_abs$reopen("READ")
+  abs_grp <- tiledb::tiledb_group(ms_abs$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(abs_grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs)) {
+    expect_false(tiledb::tiledb_group_is_relative(abs_grp, name = nm), info = nm)
+  }
+  x_abs <- tiledb::tiledb_group(ms_abs$X$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(x_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs$X)) {
+    expect_false(tiledb::tiledb_group_is_relative(x_abs, name = nm), info = nm)
+  }
+})
+
 test_that("Write v5 in-memory Assay mechanics", {
   skip_if(!extended_tests())
   skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
@@ -246,6 +297,58 @@ test_that("Write v5 in-memory Assay mechanics", {
   }
 })
 
+test_that("Write v5 Assays relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  rna <- get_data("pbmc_small", package = "SeuratObject")[["RNA"]]
+  rna <- as(rna, "Assay5")
+  collection <- SOMACollectionCreate(tempfile("write-assay-v5-relative-"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  # `relative = TRUE`
+  expect_s3_class(
+    ms <- write_soma(rna, soma_parent = collection, relative = TRUE),
+    "SOMAMeasurement"
+  )
+  on.exit(ms$close(), add = TRUE, after = FALSE)
+  ms$reopen("READ")
+  grp <- tiledb::tiledb_group(ms$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms)) {
+    expect_true(tiledb::tiledb_group_is_relative(grp, name = nm), info = nm)
+  }
+  x_grp <- tiledb::tiledb_group(ms$X$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(x_grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms$X)) {
+    expect_true(tiledb::tiledb_group_is_relative(x_grp, name = nm), info = nm)
+  }
+
+  # `relative = FALSE`
+  expect_s3_class(
+    ms_abs <- write_soma(
+      rna,
+      uri = tempfile("write-assay-absolute-"),
+      soma_parent = collection,
+      relative = FALSE
+    ),
+    "SOMAMeasurement"
+  )
+  on.exit(ms_abs$close(), add = TRUE, after = FALSE)
+  ms_abs$reopen("READ")
+  abs_grp <- tiledb::tiledb_group(ms_abs$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(abs_grp), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs)) {
+    expect_false(tiledb::tiledb_group_is_relative(abs_grp, name = nm), info = nm)
+  }
+  x_abs <- tiledb::tiledb_group(ms_abs$X$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(x_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs$X)) {
+    expect_false(tiledb::tiledb_group_is_relative(x_abs, name = nm), info = nm)
+  }
+})
+
 test_that("Write DimReduc mechanics", {
   skip_if(!extended_tests())
   skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
@@ -322,6 +425,76 @@ test_that("Write DimReduc mechanics", {
   gc()
 })
 
+test_that("Write DimReducs relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
+  rna <- pbmc_small[["RNA"]]
+  pca <- pbmc_small[["pca"]]
+  fidx <- match(rownames(SeuratObject::Loadings(pca)), rownames(rna))
+  collection <- SOMACollectionCreate(tempfile("write-dimreduc-relative-"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  # `relative = TRUE`
+  ms_relative <- write_soma(rna, soma_parent = collection)
+  on.exit(ms_relative$close(), add = TRUE, after = FALSE)
+  expect_no_condition(write_soma(
+    pca,
+    soma_parent = ms_relative,
+    fidx = fidx,
+    nfeatures = nrow(rna),
+    relative = TRUE
+  ))
+  ms_relative$reopen("READ")
+  grp_rel <- tiledb::tiledb_group(ms_relative$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_rel), add = TRUE, after = FALSE)
+  expect_true(tiledb::tiledb_group_is_relative(grp_rel, name = "obsm"))
+  expect_true(tiledb::tiledb_group_is_relative(grp_rel, name = "varm"))
+  obsm_rel <- tiledb::tiledb_group(ms_relative$obsm$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(obsm_rel), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_relative$obsm)) {
+    expect_true(tiledb::tiledb_group_is_relative(obsm_rel, name = nm), info = nm)
+  }
+  varm_rel <- tiledb::tiledb_group(ms_relative$varm$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(varm_rel), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_relative$varm)) {
+    expect_true(tiledb::tiledb_group_is_relative(varm_rel, name = nm), info = nm)
+  }
+
+  # `relative = FALSE`
+  ms_abs <- write_soma(
+    rna,
+    uri = tempfile("write-dimreduc-absolute-"),
+    soma_parent = collection,
+    relative = FALSE
+  )
+  on.exit(ms_abs$close(), add = TRUE, after = FALSE)
+  expect_no_condition(write_soma(
+    pca,
+    soma_parent = ms_abs,
+    fidx = fidx,
+    nfeatures = nrow(rna),
+    relative = FALSE
+  ))
+  ms_abs$reopen("READ")
+  grp_abs <- tiledb::tiledb_group(ms_abs$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_abs), add = TRUE, after = FALSE)
+  expect_false(tiledb::tiledb_group_is_relative(grp_abs, name = "obsm"))
+  expect_false(tiledb::tiledb_group_is_relative(grp_abs, name = "varm"))
+  obsm_abs <- tiledb::tiledb_group(ms_abs$obsm$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(obsm_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs$obsm)) {
+    expect_false(tiledb::tiledb_group_is_relative(obsm_abs, name = nm), info = nm)
+  }
+  varm_abs <- tiledb::tiledb_group(ms_abs$varm$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(varm_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs$varm)) {
+    expect_false(tiledb::tiledb_group_is_relative(varm_abs, name = nm), info = nm)
+  }
+})
+
 test_that("Write Graph mechanics", {
   skip_if(!extended_tests())
   skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
@@ -346,6 +519,61 @@ test_that("Write Graph mechanics", {
   expect_error(write_soma(graph, collection = soma_parent))
 
   gc()
+})
+
+test_that("Write Graphs relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
+  rna <- pbmc_small[["RNA"]]
+  rna_snn <- pbmc_small[["RNA_snn"]]
+  collection <- SOMACollectionCreate(tempfile("write-graph-relative-"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  # `relative = TRUE`
+  ms_relative <- write_soma(rna, soma_parent = collection)
+  on.exit(ms_relative$close(), add = TRUE, after = FALSE)
+  expect_no_condition(write_soma(
+    rna_snn,
+    uri = "rna_snn",
+    soma_parent = ms_relative,
+    relative = TRUE
+  ))
+  ms_relative$reopen("READ")
+  grp_rel <- tiledb::tiledb_group(ms_relative$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_rel), add = TRUE, after = FALSE)
+  expect_true(tiledb::tiledb_group_is_relative(grp_rel, name = "obsp"))
+  obsp_rel <- tiledb::tiledb_group(ms_relative$obsp$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(obsp_rel), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_relative$obsp)) {
+    expect_true(tiledb::tiledb_group_is_relative(obsp_rel, name = nm), info = nm)
+  }
+
+  # `relative = FALSE`
+  ms_abs <- write_soma(
+    rna,
+    uri = tempfile("write-graph-absolute-"),
+    soma_parent = collection,
+    relative = FALSE
+  )
+  on.exit(ms_abs$close(), add = TRUE, after = FALSE)
+  expect_no_condition(write_soma(
+    rna_snn,
+    uri = tempfile("rna-snn-"),
+    soma_parent = ms_abs,
+    relative = FALSE
+  ))
+  ms_abs$reopen("READ")
+  grp_abs <- tiledb::tiledb_group(ms_abs$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_abs), add = TRUE, after = FALSE)
+  expect_false(tiledb::tiledb_group_is_relative(grp_abs, "obsp"))
+  obsp_abs <- tiledb::tiledb_group(ms_abs$obsp$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(obsp_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(ms_abs$obsp)) {
+    expect_false(tiledb::tiledb_group_is_relative(obsp_abs, name = nm), info = nm)
+  }
 })
 
 test_that("Write SeuratCommand mechanics", {
@@ -426,6 +654,46 @@ test_that("Write SeuratCommand mechanics", {
 
   uns$close()
   gc()
+})
+
+test_that("Write SeuratCommands relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  skip_if_not_installed("tiledb", minimum_version = "0.34.0")
+  skip_if_not_installed("SeuratObject", .MINIMUM_SEURAT_VERSION("c"))
+
+  pbmc_small <- get_data("pbmc_small", package = "SeuratObject")
+
+  # `relative = TRUE`
+  uns_rel <- SOMACollectionCreate(tempfile("write-command-relative-"))
+  on.exit(uns_rel$close(), add = TRUE, after = FALSE)
+  for (cmd in SeuratObject::Command(pbmc_small)) {
+    write_soma(pbmc_small[[cmd]], soma_parent = uns_rel, relative = TRUE)
+  }
+  uns_rel$reopen("READ")
+  grp_rel <- tiledb::tiledb_group(uns_rel$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_rel), add = TRUE, after = FALSE)
+  expect_true(tiledb::tiledb_group_is_relative(grp_rel, name = "seurat_commands"))
+  cmd_rel <- tiledb::tiledb_group(uns_rel$get("seurat_commands")$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(cmd_rel), add = TRUE, after = FALSE)
+  for (nm in collection_members(uns_rel$get("seurat_commands"))) {
+    expect_true(tiledb::tiledb_group_is_relative(cmd_rel, name = nm), info = nm)
+  }
+
+  # `relative = FALSE`
+  uns_abs <- SOMACollectionCreate(tempfile("write-command-relative-"))
+  on.exit(uns_abs$close(), add = TRUE, after = FALSE)
+  for (cmd in SeuratObject::Command(pbmc_small)) {
+    write_soma(pbmc_small[[cmd]], soma_parent = uns_abs, relative = FALSE)
+  }
+  uns_abs$reopen("READ")
+  grp_abs <- tiledb::tiledb_group(uns_abs$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(grp_abs), add = TRUE, after = FALSE)
+  expect_false(tiledb::tiledb_group_is_relative(grp_abs, name = "seurat_commands"))
+  cmd_abs <- tiledb::tiledb_group(uns_abs$get("seurat_commands")$uri, type = "READ")
+  on.exit(tiledb::tiledb_group_close(cmd_abs), add = TRUE, after = FALSE)
+  for (nm in collection_members(uns_abs$get("seurat_commands"))) {
+    expect_false(tiledb::tiledb_group_is_relative(cmd_abs, name = nm), info = nm)
+  }
 })
 
 test_that("Write Seurat mechanics", {
@@ -611,7 +879,6 @@ test_that("Ragged array relative URIs (SOMA-906)", {
   skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
   op <- options(Seurat.object.assay.calcn = FALSE)
   on.exit(options(op), add = TRUE, after = FALSE)
-  withr::local_options(Seurat.object.assay.calcn = FALSE)
 
   # Create and write a ragged `Seurat` object
   rna <- get_data("pbmc_small", package = "SeuratObject")[["RNA"]]

--- a/apis/r/tests/testthat/test-14-SeuratIngest.R
+++ b/apis/r/tests/testthat/test-14-SeuratIngest.R
@@ -588,3 +588,83 @@ test_that("Write Seurat with BPCells layers", {
     expect_identical(th, expected = "Matrix:dgCMatrix", info = lyr)
   }
 })
+
+test_that("Ragged array uploads to S3 (SOMA-906)", {
+  skip_if_not(
+    s3_tests(),
+    message = paste(
+      "Not running S3 tests; to run, please ensure {aws.s3} is installed and",
+      "the 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', and 'AWS_S3_BUCKET'",
+      "environment variables are set"
+    )
+  )
+  skip_if(!extended_tests())
+  skip_if_not_installed("withr")
+  skip_if_not_installed("SeuratObject", minimum_version = "5.0.2")
+  withr::local_options(Seurat.object.assay.calcn = FALSE)
+
+  # Create and write a ragged `Seurat` object
+  rna <- get_data("pbmc_small", package = "SeuratObject")[["RNA"]]
+  rna <- as(rna, "Assay5")
+  mat <- SeuratObject::LayerData(rna, "counts")
+  cells2 <- sprintf("%s.2", colnames(rna))
+  features2 <- sprintf("%s.2", rownames(rna))
+  layers <- list(
+    mat = mat,
+    cells2 = `colnames<-`(mat, cells2),
+    features2 = `rownames<-`(mat, features2),
+    c2f2 = `dimnames<-`(mat, list(features2, cells2))
+  )
+  expect_s4_class(
+    obj <- SeuratObject::CreateSeuratObject(SeuratObject::.CreateStdAssay(layers)),
+    "Seurat"
+  )
+  expect_no_condition(uri <- write_soma(obj, uri = tempfile("ragged-s3-")))
+
+  # Upload to S3
+  object_base <- basename(uri)
+  if (!suppressMessages(aws.s3::bucket_exists(Sys.getenv("AWS_S3_BUCKET")))) {
+    skip_if_not(
+      aws.s3::put_bucket(
+        Sys.getenv("AWS_S3_BUCKET"),
+        region = Sys.getenv("AWS_DEFAULT_REGION", unset = "us-east-1")
+      ),
+      message = "Failed to create S3 bucket for"
+    )
+    withr::defer(aws.s3::delete_bucket(Sys.getenv("AWS_S3_BUCKET")))
+  }
+  withr::defer({
+    contents <- aws.s3::get_bucket_df(
+      Sys.getenv("AWS_S3_BUCKET"),
+      prefix = object_base
+    )
+    aws.s3::delete_object(contents$Key, bucket = Sys.getenv("AWS_S3_BUCKET"))
+  })
+  for (f in list.files(uri, full.names = TRUE, recursive = TRUE)) {
+    skip_if_not(
+      aws.s3::put_object(
+        object = sub(
+          pattern = sprintf("^%s", uri),
+          replacement = object_base,
+          x = f
+        ),
+        bucket = Sys.getenv("AWS_S3_BUCKET"),
+        file = f
+      ),
+      message = sprintf(fmt = "Failed to upload '%s' to S3", f)
+    )
+  }
+
+  # Ensure that the members are all relative
+  s3_uri <- sprintf("s3://%s/%s", Sys.getenv("AWS_S3_BUCKET"), object_base)
+  expect_s3_class(exp <- SOMAExperimentOpen(s3_uri), "SOMAExperiment")
+  withr::defer(exp$close())
+  expect_type(members <- exp$ms$get("RNA")$X$members, "list")
+  expect_length(members, n = length(layers))
+  for (i in seq_along(members)) {
+    expect_true(
+      startsWith(members[[i]]$uri, sprintf("%s/", s3_uri)),
+      info = members[[i]]$name
+    )
+  }
+})

--- a/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
@@ -117,3 +117,30 @@ test_that("Resume-mode adds a second measurement to an existing experiment", {
   # Verify that the second measurement's X data is not all zeros (CX-279)
   expect_true(sum(mat2 != 0) > 0)
 })
+
+test_that("Write SummarizedExperiment relatively (SOMA-906)", {
+  skip_if(!extended_tests())
+  suppressWarnings(suppressMessages(skip_if_not_installed(
+    "SummarizedExperiment",
+    "1.28.0"
+  )))
+  skip_if_not_installed("pbmc3k")
+
+  se <- pbmc3k_sce()
+  var_df <- SummarizedExperiment::rowData(se)
+  features <- rownames(se)
+
+  se <- as(se, "SummarizedExperiment")
+  SummarizedExperiment::rowData(se) <- var_df
+  rownames(se) <- features
+
+  uri <- tempfile(pattern = "summarizedexperiment-relative-")
+
+  for (i in c(TRUE, FALSE)) {
+    expect_error(
+      write_soma(se, uri, relative = i, ms_name = "RNA"),
+      regexp = "^The dots '\\.\\.\\.' must be empty when",
+      label = sprintf("write_soma.SummarizedExperiment(relative = %s)", i)
+    )
+  }
+})

--- a/apis/r/tests/testthat/test-15-SingleCellExperimentIngest.R
+++ b/apis/r/tests/testthat/test-15-SingleCellExperimentIngest.R
@@ -101,3 +101,25 @@ test_that("SingleCellExperiment mainExpName mechanics", {
   expect_no_condition(experiment <- SOMAExperimentOpen(uri))
   expect_identical(experiment$ms$names(), ms_name2)
 })
+
+test_that("Write SingleCellExperiment relatively (SOMA-906)", {
+  skip_if(!extended_tests() || covr_tests())
+  skip_if_not_installed("pbmc3k")
+  suppressWarnings(suppressMessages(skip_if_not_installed(
+    "SingleCellExperiment",
+    .MINIMUM_SCE_VERSION("c")
+  )))
+
+  sce <- pbmc3k_sce()
+  SingleCellExperiment::mainExpName(sce) <- "RNA"
+
+  uri <- tempfile(pattern = "singlecellexperiment-relative-")
+
+  for (i in c(TRUE, FALSE)) {
+    expect_error(
+      write_soma(sce, uri, relative = i, ms_name = "RNA"),
+      regexp = "^The dots '\\.\\.\\.' must be empty when",
+      label = sprintf("write_soma.SingleCellExperiment(relative = %s)", i)
+    )
+  }
+})


### PR DESCRIPTION
Calling `write_soma()` on a `Seurat` v5 object with ragged arrays using an absolute file URI (eg. `/home/user/directory`) resulted in the SOMA NDArrays for the ragged `Seurat` matrices having absolute URIs instead of the intuitive relative arrays. This PR changes URI setting to be relative in this case

Modified SOMA methods:
 - `SOMACollectionBase$add_new_sparse_ndarray()`: now takes a parameter `relative`; defaults to `TRUE`
 - `write_soma()` methods for `Seurat`, `SingleCellExperiment`, and `SummarizedExperiment`: disallow passing arguments via `...`
 - `write_soma()` methods for `Assay`, `Assay5`, `DimReduc`, `Graph`, and `SeuratCommand` properly pass `relative` to other write-methods

Fixes [SOMA-906](https://linear.app/tiledb/issue/SOMA-906/r-mixed-uri-types-in-somaexperiments-created-via-write-seurat)