### PR TITLE
[r] Close measurement collection handle in SummarizedExperiment ingest path

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 2.3.99.3
+Version: 2.3.99.4
 Authors@R: c(
     person(given = "Paul", family = "Hoffman",
            role = c("cre", "aut"), email = "tiledb-r@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -29,6 +29,7 @@
 - Metadata values retrieved from collection-based classes (`SOMACollection`, `SOMAExperiment`, `SOMAMeasurement`) are no longer wrapped in a named list, consistent with array-based classes ([#4429](https://github.com/single-cell-data/TileDB-SOMA/pull/4429)).
 - [BREAKING] Use stored handle to access `SOMAArrayBase` properties rather than re-opening the `SOMAArrayBase`. Array properties can no longer be accessed on an unopened array. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
 - Use stored handle to read and write to `SOMASparseNDArray`, `SOMADenseNDArray`, and `SOMADataFrame` rather than re-opening the SOMA oobjects for each read/write. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
+- Properly close `ms` collection handle in `write_soma.SummarizedExperiment()`, ensuring that new measurements added to the ms collection are persisted to disk. ([#4452](https://github.com/single-cell-data/TileDB-SOMA/pull/4452))
 
 ## Security
 

--- a/apis/r/R/write_bioc.R
+++ b/apis/r/R/write_bioc.R
@@ -433,6 +433,7 @@ write_soma.SummarizedExperiment <- function(
     expr = .register_soma_object(expms, soma_parent = experiment, key = "ms"),
     existingKeyWarning = .maybe_muffle
   )
+  on.exit(expms$close(), add = TRUE, after = FALSE)
   ms_uri <- .check_soma_uri(uri = ms_name, soma_parent = expms)
   ms <- SOMAMeasurementCreate(
     uri = ms_uri,

--- a/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
@@ -66,3 +66,39 @@ test_that("Write SummarizedExperiment mechanics", {
   expect_error(write_soma(se, uri, 1))
   expect_error(write_soma(se, uri, TRUE))
 })
+
+test_that("Resume-mode adds a second measurement to an existing experiment", {
+  suppressWarnings(suppressMessages(skip_if_not_installed(
+    "SummarizedExperiment",
+    "1.28.0"
+  )))
+
+  n_obs <- 5L
+  obs <- S4Vectors::DataFrame(id = paste0("s", seq_len(n_obs)))
+  rownames(obs) <- obs$id
+
+  make_se <- function(n_var, prefix) {
+    x <- matrix(seq_len(n_obs * n_var), nrow = n_var, ncol = n_obs)
+    rownames(x) <- paste0(prefix, seq_len(n_var))
+    colnames(x) <- obs$id
+    var <- S4Vectors::DataFrame(id = rownames(x))
+    rownames(var) <- var$id
+    SummarizedExperiment::SummarizedExperiment(
+      assays = list(counts = x),
+      colData = obs,
+      rowData = var
+    )
+  }
+
+  se1 <- make_se(10L, "a")
+  se2 <- make_se(20L, "b")
+
+  uri <- withr::local_tempdir("multi-ms-se")
+  write_soma(se1, uri, ms_name = "ms1", ingest_mode = "write")
+  write_soma(se2, uri, ms_name = "ms2", ingest_mode = "resume")
+
+  exp <- SOMAExperimentOpen(uri)
+  on.exit(exp$close(), add = TRUE, after = FALSE)
+
+  expect_setequal(exp$ms$names(), c("ms1", "ms2"))
+})


### PR DESCRIPTION
**Issue and/or context:** [SOMA-951]

**Changes:**

- Close measurement collection handle in SummarizedExperiment ingest path that prevented new measurements from being registered in resume mode
- Add test for multi-measurement `SummarizedExperiment` ingestion

**Notes for reviewers:** The [initial CI failure](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/24894303302) was caused by a test that tripped a second issue in this code path, which is addressed separately in #4453. Once this is merged I'll migrate the test to that branch.
