### PR TITLE
[r] Fix resume-mode writes to new/empty arrays

### DIFF
--- a/apis/r/DESCRIPTION
+++ b/apis/r/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     like those commonly used for single cell data analysis. It is documented at
     <https://github.com/single-cell-data>; a formal specification available is at
     <https://github.com/single-cell-data/SOMA/blob/main/abstract_specification.md>.
-Version: 2.3.99.4
+Version: 2.3.99.5
 Authors@R: c(
     person(given = "Paul", family = "Hoffman",
            role = c("cre", "aut"), email = "tiledb-r@tiledb.com",

--- a/apis/r/NEWS.md
+++ b/apis/r/NEWS.md
@@ -29,7 +29,8 @@
 - Metadata values retrieved from collection-based classes (`SOMACollection`, `SOMAExperiment`, `SOMAMeasurement`) are no longer wrapped in a named list, consistent with array-based classes ([#4429](https://github.com/single-cell-data/TileDB-SOMA/pull/4429)).
 - [BREAKING] Use stored handle to access `SOMAArrayBase` properties rather than re-opening the `SOMAArrayBase`. Array properties can no longer be accessed on an unopened array. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
 - Use stored handle to read and write to `SOMASparseNDArray`, `SOMADenseNDArray`, and `SOMADataFrame` rather than re-opening the SOMA oobjects for each read/write. ([#4414](https://github.com/single-cell-data/TileDB-SOMA/pull/4414))
-- Properly close `ms` collection handle in `write_soma.SummarizedExperiment()`, ensuring that new measurements added to the ms collection are persisted to disk. ([#4452](https://github.com/single-cell-data/TileDB-SOMA/pull/4452))
+- Properly close `ms` collection handle in `write_soma.SummarizedExperiment()`, ensuring that new measurements added to the `ms` collection are persisted to disk. ([#4452](https://github.com/single-cell-data/TileDB-SOMA/pull/4452))
+- Fix handling of empty arrays when calling `write_soma()` with `ingest_mode = "resume"`. ([#4443](https://github.com/single-cell-data/TileDB-SOMA/pull/4453))
 
 ## Security
 

--- a/apis/r/R/write_soma.R
+++ b/apis/r/R/write_soma.R
@@ -716,7 +716,13 @@ write_soma.TsparseMatrix <- function(
       j = bit64::as.integer64(methods::slot(x, "j")),
       x = methods::slot(x, "x")
     )
-    tbl <- tbl[-which(tbl$i %in% row_ids & tbl$j %in% col_ids), , drop = FALSE]
+
+    # Only subset the table if there are existing joinid matches
+    idx <- which(tbl$i %in% row_ids & tbl$j %in% col_ids)
+    if (length(idx) > 0) {
+      tbl <- tbl[-idx, , drop = FALSE]
+    }
+
     x <- if (nrow(tbl)) {
       Matrix::sparseMatrix(
         i = as.integer(tbl$i),

--- a/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
@@ -112,4 +112,8 @@ test_that("Resume-mode adds a second measurement to an existing experiment", {
   on.exit(exp$close(), add = TRUE, after = FALSE)
 
   expect_setequal(exp$ms$names(), c("ms1", "ms2"))
+
+  mat2 <- exp$ms$get("ms2")$X$get("counts")$read()$sparse_matrix()$concat()
+  # Verify that the second measurement's X data is not all zeros (CX-279)
+  expect_true(sum(mat2 != 0) > 0)
 })

--- a/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
+++ b/apis/r/tests/testthat/test-14-SummarizedExperimentIngest.R
@@ -58,6 +58,17 @@ test_that("Write SummarizedExperiment mechanics", {
     names(SummarizedExperiment::rowData(se))
   )
 
+  # Verify X data values round-trip correctly
+  for (assay in SummarizedExperiment::assayNames(se)) {
+    original <- SummarizedExperiment::assay(se, assay)
+    stored <- ms$X$get(assay)$read()$sparse_matrix()$concat()
+    expect_equal(
+      sum(stored != 0),
+      sum(original != 0),
+      label = sprintf("non-zero count for assay '%s'", assay)
+    )
+  }
+
   # Test ms_name assertions
   expect_error(write_soma(se, uri))
   expect_error(write_soma(se, uri, ""))

--- a/apis/r/tests/testthat/test-16-write-soma-resume.R
+++ b/apis/r/tests/testthat/test-16-write-soma-resume.R
@@ -314,6 +314,36 @@ test_that("Resume-mode sparse arrays", {
   gc()
 })
 
+test_that("Resume-mode sparse array to new URI preserves data", {
+  collection <- SOMACollectionCreate(tempfile(pattern = "sparse-new-resume"))
+  on.exit(collection$close(), add = TRUE, after = FALSE)
+
+  # Create a sparse matrix with known non-zero values
+  mat <- Matrix::rsparsematrix(10L, 8L, 0.5, repr = "T")
+
+  # Writing a new sparse array in "resume" mode should still write all data even
+  # if the array doesn't exist yet.
+  expect_s3_class(
+    ndarray <- write_soma(
+      mat,
+      uri = "new-array",
+      soma_parent = collection,
+      ingest_mode = "resume"
+    ),
+    "SOMASparseNDArray"
+  )
+  on.exit(ndarray$close(), add = TRUE, after = FALSE)
+
+  ndarray$reopen("READ")
+  result <- ndarray$read()$sparse_matrix()$concat()
+  expect_equal(
+    as.matrix(result),
+    as.matrix(mat),
+    label = "result",
+    expected.label = "mat"
+  )
+})
+
 test_that("Resume-mode dense arrays", {
   skip_if(!extended_tests())
   skip_if_not_installed("datasets")


### PR DESCRIPTION
**Issue and/or context:** [SOMA-952] When `ingest_mode = "resume"` is used and the target array is new or empty the coordinates check returns 0 causing the write to be skipped entirely.

**Changes:**  

- Added logic to handle empty coordinates in resume-mode's deduce logic within `write_soma.TsparseMatrix`.
- New "Resume-mode sparse array to new URI preserves data" test
 
**Notes for Reviewer:** This will be stacked on #4452 to add the missing test noted there.
