### PR TITLE
[py] Add `to_dict()` and `__repr__` to `PlatformConfig` and `PlatformSchemaConfig`

### DIFF
--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `PlatformConfig.dense_nd_array_dim_zstd_level` was incorrectly aliased to `sparse_nd_array_dim_zstd_level` and is now bound to the correct field.
+
 ### Security
 
 ## [2.3.0]

--- a/apis/python/HISTORY.md
+++ b/apis/python/HISTORY.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - \[[#4299](https://github.com/single-cell-data/TileDB-SOMA/pull/4299)\] Use a global memory budget for read operations instead of a per column memory budget. The global memory budget allocates splits the budget per column depending on the type and characteristics of each column. Global memory budget is disabled by default under a feature flag and can be enabled by setting `soma.read.use_memory_pool`.
 - \[[#4363](https://github.com/single-cell-data/TileDB-SOMA/pull/4363)\] Add new `SOMAContext` class that replaces the `SOMATileDBContext` class.
+- `PlatformConfig` and `PlatformSchemaConfig` now support `to_dict()` and have a readable `__repr__` for diagnostic logging.
 
 ### Changed
 

--- a/apis/python/src/tiledbsoma/_soma_array.py
+++ b/apis/python/src/tiledbsoma/_soma_array.py
@@ -34,7 +34,7 @@ class SOMAArray(SOMAObject):
 
     def schema_config_options(self) -> clib.PlatformSchemaConfig:
         """Returns metadata about the array schema that is not encompassed within
-        the Arrow Schema, in the form of a PlatformConfig.
+        the Arrow Schema, in the form of a PlatformSchemaConfig.
 
         Available attributes are:
             * capacity: int

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -1,5 +1,7 @@
 #include <tiledbsoma/tiledbsoma>
 
+#include <sstream>
+
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -166,7 +168,45 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def_readwrite("allows_duplicates", &PlatformConfig::allows_duplicates)
         .def_readwrite("tile_order", &PlatformConfig::tile_order)
         .def_readwrite("cell_order", &PlatformConfig::cell_order)
-        .def_readwrite("consolidate_and_vacuum", &PlatformConfig::consolidate_and_vacuum);
+        .def_readwrite("consolidate_and_vacuum", &PlatformConfig::consolidate_and_vacuum)
+        .def(
+            "to_dict",
+            [](const PlatformConfig& c) {
+                return py::dict(
+                    "dataframe_dim_zstd_level"_a = c.dataframe_dim_zstd_level,
+                    "sparse_nd_array_dim_zstd_level"_a = c.sparse_nd_array_dim_zstd_level,
+                    "dense_nd_array_dim_zstd_level"_a = c.dense_nd_array_dim_zstd_level,
+                    "write_X_chunked"_a = c.write_X_chunked,
+                    "goal_chunk_nnz"_a = c.goal_chunk_nnz,
+                    "remote_cap_nbytes"_a = c.remote_cap_nbytes,
+                    "capacity"_a = c.capacity,
+                    "offsets_filters"_a = c.offsets_filters,
+                    "validity_filters"_a = c.validity_filters,
+                    "allows_duplicates"_a = c.allows_duplicates,
+                    "tile_order"_a = c.tile_order,
+                    "cell_order"_a = c.cell_order,
+                    "attrs"_a = c.attrs,
+                    "dims"_a = c.dims,
+                    "consolidate_and_vacuum"_a = c.consolidate_and_vacuum);
+            })
+        .def("__repr__", [](const PlatformConfig& c) {
+            auto q = [](const std::optional<std::string>& v) { return v ? ("'" + *v + "'") : std::string("None"); };
+            std::ostringstream os;
+            os << "PlatformConfig("
+               << "dataframe_dim_zstd_level=" << c.dataframe_dim_zstd_level
+               << ", sparse_nd_array_dim_zstd_level=" << c.sparse_nd_array_dim_zstd_level
+               << ", dense_nd_array_dim_zstd_level=" << c.dense_nd_array_dim_zstd_level
+               << ", write_X_chunked=" << (c.write_X_chunked ? "True" : "False")
+               << ", goal_chunk_nnz=" << c.goal_chunk_nnz << ", remote_cap_nbytes=" << c.remote_cap_nbytes
+               << ", capacity=" << c.capacity << ", offsets_filters='" << c.offsets_filters << "'"
+               << ", validity_filters='" << c.validity_filters << "'"
+               << ", allows_duplicates=" << (c.allows_duplicates ? "True" : "False")
+               << ", tile_order=" << q(c.tile_order) << ", cell_order=" << q(c.cell_order) << ", attrs='" << c.attrs
+               << "'"
+               << ", dims='" << c.dims << "'"
+               << ", consolidate_and_vacuum=" << (c.consolidate_and_vacuum ? "True" : "False") << ")";
+            return os.str();
+        });
 
     py::class_<PlatformSchemaConfig>(m, "PlatformSchemaConfig")
         .def(py::init<>())
@@ -177,7 +217,33 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def_readwrite("dims", &PlatformSchemaConfig::dims)
         .def_readwrite("allows_duplicates", &PlatformSchemaConfig::allows_duplicates)
         .def_readwrite("tile_order", &PlatformSchemaConfig::tile_order)
-        .def_readwrite("cell_order", &PlatformSchemaConfig::cell_order);
+        .def_readwrite("cell_order", &PlatformSchemaConfig::cell_order)
+        .def(
+            "to_dict",
+            [](const PlatformSchemaConfig& c) {
+                return py::dict(
+                    "capacity"_a = c.capacity,
+                    "offsets_filters"_a = c.offsets_filters,
+                    "validity_filters"_a = c.validity_filters,
+                    "attrs"_a = c.attrs,
+                    "dims"_a = c.dims,
+                    "allows_duplicates"_a = c.allows_duplicates,
+                    "tile_order"_a = c.tile_order,
+                    "cell_order"_a = c.cell_order);
+            })
+        .def("__repr__", [](const PlatformSchemaConfig& c) {
+            auto q = [](const std::optional<std::string>& v) { return v ? ("'" + *v + "'") : std::string("None"); };
+            std::ostringstream os;
+            os << "PlatformSchemaConfig("
+               << "capacity=" << c.capacity << ", allows_duplicates=" << (c.allows_duplicates ? "True" : "False")
+               << ", tile_order=" << q(c.tile_order) << ", cell_order=" << q(c.cell_order) << ", offsets_filters='"
+               << c.offsets_filters << "'"
+               << ", validity_filters='" << c.validity_filters << "'"
+               << ", attrs='" << c.attrs << "'"
+               << ", dims='" << c.dims << "'"
+               << ")";
+            return os.str();
+        });
 
     m.def("_update_dataframe_schema", &SOMADataFrame::update_dataframe_schema);
 

--- a/apis/python/src/tiledbsoma/pytiledbsoma.cc
+++ b/apis/python/src/tiledbsoma/pytiledbsoma.cc
@@ -154,7 +154,7 @@ PYBIND11_MODULE(pytiledbsoma, m) {
         .def(py::init<>())
         .def_readwrite("dataframe_dim_zstd_level", &PlatformConfig::dataframe_dim_zstd_level)
         .def_readwrite("sparse_nd_array_dim_zstd_level", &PlatformConfig::sparse_nd_array_dim_zstd_level)
-        .def_readwrite("dense_nd_array_dim_zstd_level", &PlatformConfig::sparse_nd_array_dim_zstd_level)
+        .def_readwrite("dense_nd_array_dim_zstd_level", &PlatformConfig::dense_nd_array_dim_zstd_level)
         .def_readwrite("write_X_chunked", &PlatformConfig::write_X_chunked)
         .def_readwrite("goal_chunk_nnz", &PlatformConfig::goal_chunk_nnz)
         .def_readwrite("remote_cap_nbytes", &PlatformConfig::remote_cap_nbytes)

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -6,6 +6,7 @@ import pytest
 import tiledbsoma
 import tiledbsoma.io
 import tiledbsoma.options._tiledb_create_write_options as tco
+from tiledbsoma import pytiledbsoma as clib
 
 from ._util import assert_adata_equal
 
@@ -134,3 +135,13 @@ def test_dig_platform_config():
     # Unrecognized type (at tip)
     with pytest.raises(TypeError):
         tco._dig_platform_config({"a": {"b": "invalid"}}, int, ("a", "b"))
+
+
+def test_platform_config_dense_zstd_level_not_aliased():
+    """Regression: pytiledbsoma.cc:157 used to bind dense_nd_array_dim_zstd_level
+    to &PlatformConfig::sparse_nd_array_dim_zstd_level."""
+    cfg = clib.PlatformConfig()
+    cfg.sparse_nd_array_dim_zstd_level = 1
+    cfg.dense_nd_array_dim_zstd_level = 9
+    assert cfg.sparse_nd_array_dim_zstd_level == 1
+    assert cfg.dense_nd_array_dim_zstd_level == 9

--- a/apis/python/tests/test_platform_config.py
+++ b/apis/python/tests/test_platform_config.py
@@ -137,6 +137,90 @@ def test_dig_platform_config():
         tco._dig_platform_config({"a": {"b": "invalid"}}, int, ("a", "b"))
 
 
+def test_platform_schema_config_to_dict_keys():
+    cfg = clib.PlatformSchemaConfig()
+    d = cfg.to_dict()
+    assert type(d) is dict
+    assert set(d) == {
+        "capacity",
+        "offsets_filters",
+        "validity_filters",
+        "attrs",
+        "dims",
+        "allows_duplicates",
+        "tile_order",
+        "cell_order",
+    }
+
+
+def test_platform_schema_config_to_dict_values_match_attrs():
+    cfg = clib.PlatformSchemaConfig()
+    cfg.capacity = 1234
+    cfg.tile_order = "row-major"
+    d = cfg.to_dict()
+    assert d["capacity"] == 1234
+    assert d["tile_order"] == "row-major"
+    assert d["cell_order"] is None
+    assert isinstance(d["allows_duplicates"], bool)
+
+
+def test_platform_schema_config_to_dict_json_fields_parse(conftest_pbmc_small, tmp_path):
+    output_path = tmp_path.as_posix()
+    create_cfg = {
+        "capacity": 8888,
+        "offsets_filters": [
+            "RleFilter",
+            {"_type": "GzipFilter", "level": 7},
+            "NoOpFilter",
+        ],
+        "dims": {
+            "soma_dim_0": {"tile": 6, "filters": ["RleFilter"]},
+            "soma_dim_1": {"filters": []},
+        },
+        "attrs": {"soma_data": {"filters": ["NoOpFilter"]}},
+        "cell_order": "row-major",
+        "tile_order": "column-major",
+    }
+    tiledbsoma.io.from_anndata(
+        output_path,
+        conftest_pbmc_small,
+        "RNA",
+        platform_config={"tiledb": {"create": create_cfg}},
+    )
+    x_arr_uri = str(Path(output_path) / "ms" / "RNA" / "X" / "data")
+    with tiledbsoma.SparseNDArray.open(x_arr_uri) as x_arr:
+        cfg = x_arr.schema_config_options()
+        d = cfg.to_dict()
+        assert d["capacity"] == create_cfg["capacity"]
+        assert d["tile_order"] == create_cfg["tile_order"]
+        assert d["cell_order"] == create_cfg["cell_order"]
+        # JSON-string fields should parse cleanly
+        assert isinstance(json.loads(d["offsets_filters"]), list)
+        assert isinstance(json.loads(d["attrs"]), dict)
+        assert isinstance(json.loads(d["dims"]), dict)
+
+
+def test_platform_schema_config_repr():
+    cfg = clib.PlatformSchemaConfig()
+    r = repr(cfg)
+    assert r.startswith("PlatformSchemaConfig(")
+    assert r.endswith(")")
+    assert "capacity=" in r
+    assert "tile_order=None" in r
+
+
+def test_platform_config_to_dict_keys():
+    cfg = clib.PlatformConfig()
+    d = cfg.to_dict()
+    assert type(d) is dict
+    assert {"capacity", "tile_order", "consolidate_and_vacuum"} <= set(d)
+
+
+def test_platform_config_repr():
+    cfg = clib.PlatformConfig()
+    assert repr(cfg).startswith("PlatformConfig(")
+
+
 def test_platform_config_dense_zstd_level_not_aliased():
     """Regression: pytiledbsoma.cc:157 used to bind dense_nd_array_dim_zstd_level
     to &PlatformConfig::sparse_nd_array_dim_zstd_level."""


### PR DESCRIPTION
**Issue and/or context:** [SOMA-939]

The `PlatformConfig` and `PlatformSchemaConfig` attributes can only be viewed individually, with no convenient way to dump the full configuration for logging, diagnostics, etc. 

**Changes:**

- `PlatformConfig` and `PlatformSchemaConfig` now expose:
    - `to_dict()` returns a Python dict of all fields. 
    - `__repr__` provides a single-line representation showing each field. 

Example:

```py
import tempfile
from pprint import pprint

import pyarrow as pa

import tiledbsoma
from tiledbsoma import pytiledbsoma as clib

pc = clib.PlatformConfig()
print("\n\nrepr(pc):\n")
print(repr(pc))
print("\n\npc.to_dict():\n")
pprint(pc.to_dict())


with tempfile.TemporaryDirectory() as tmp:
    uri = f"{tmp}/sparse"
    tiledbsoma.SparseNDArray.create(uri, type=pa.float32(), shape=(100, 100)).close()
    with tiledbsoma.SparseNDArray.open(uri) as arr:
        cfg = arr.schema_config_options()
        print("\n\nrepr(cfg):\n")
        print(repr(cfg))
        print("\n\ncfg.to_dict():\n")
        pprint(cfg.to_dict())
```

Output:

```text
repr(pc):

PlatformConfig(dataframe_dim_zstd_level=3, sparse_nd_array_dim_zstd_level=3, dense_nd_array_dim_zstd_level=3, write_X_chunked=True, goal_chunk_nnz=100000000, remote_cap_nbytes=2400000000, capacity=100000, offsets_filters='["DOUBLE_DELTA", "BIT_WIDTH_REDUCTION", "ZSTD"]', validity_filters='', allows_duplicates=False, tile_order=None, cell_order=None, attrs='', dims='', consolidate_and_vacuum=False)


pc.to_dict():

{'allows_duplicates': False,
 'attrs': '',
 'capacity': 100000,
 'cell_order': None,
 'consolidate_and_vacuum': False,
 'dataframe_dim_zstd_level': 3,
 'dense_nd_array_dim_zstd_level': 3,
 'dims': '',
 'goal_chunk_nnz': 100000000,
 'offsets_filters': '["DOUBLE_DELTA", "BIT_WIDTH_REDUCTION", "ZSTD"]',
 'remote_cap_nbytes': 2400000000,
 'sparse_nd_array_dim_zstd_level': 3,
 'tile_order': None,
 'validity_filters': '',
 'write_X_chunked': True}


repr(cfg):

PlatformSchemaConfig(capacity=100000, allows_duplicates=False, tile_order='row-major', cell_order='row-major', offsets_filters='[{"COMPRESSION_LEVEL":-1,"COMPRESSION_REINTERPRET_DATATYPE":17,"name":"DOUBLE_DELTA"},{"BIT_WIDTH_MAX_WINDOW":256,"name":"BIT_WIDTH_REDUCTION"},{"COMPRESSION_LEVEL":-1,"name":"ZSTD"}]', validity_filters='[{"COMPRESSION_LEVEL":-1,"name":"RLE"}]', attrs='{"soma_data":{"filters":[{"COMPRESSION_LEVEL":-1,"name":"ZSTD"}]}}', dims='{"soma_dim_0":{"filters":[{"COMPRESSION_LEVEL":3,"name":"ZSTD"}],"tile":"2048"},"soma_dim_1":{"filters":[{"COMPRESSION_LEVEL":3,"name":"ZSTD"}],"tile":"2048"}}')


cfg.to_dict():

{'allows_duplicates': False,
 'attrs': '{"soma_data":{"filters":[{"COMPRESSION_LEVEL":-1,"name":"ZSTD"}]}}',
 'capacity': 100000,
 'cell_order': 'row-major',
 'dims': '{"soma_dim_0":{"filters":[{"COMPRESSION_LEVEL":3,"name":"ZSTD"}],"tile":"2048"},"soma_dim_1":{"filters":[{"COMPRESSION_LEVEL":3,"name":"ZSTD"}],"tile":"2048"}}',
 'offsets_filters': '[{"COMPRESSION_LEVEL":-1,"COMPRESSION_REINTERPRET_DATATYPE":17,"name":"DOUBLE_DELTA"},{"BIT_WIDTH_MAX_WINDOW":256,"name":"BIT_WIDTH_REDUCTION"},{"COMPRESSION_LEVEL":-1,"name":"ZSTD"}]',
 'tile_order': 'row-major',
 'validity_filters': '[{"COMPRESSION_LEVEL":-1,"name":"RLE"}]'}
```

**Notes for Reviewer:**

PR includes two other fixes:

- Fixed the `schema_config_options` docstring which incorrectly said the method returned a `PlatformConfig`, rather than a `PlatformSchemaConfig`.
- `PlatformConfig.dense_nd_array_dim_zstd_level` is now bound to the correct C++ member. 
 
